### PR TITLE
fix(admin): make the stored arrangement agree with the grid that draws it

### DIFF
--- a/.changeset/a-dashboard-that-agrees-with-its-grid.md
+++ b/.changeset/a-dashboard-that-agrees-with-its-grid.md
@@ -1,0 +1,50 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+The dashboard arrangement agrees with the grid that draws it.
+
+Six corrections to how a widget's declaration reaches the stored layout. Two
+plugins contributing the same widget id now resolve to the same one on both
+sides -- the first declared, which is what the grid has always rendered --
+rather than the server placing one plugin's widget while the grid drew another's.
+A contribution using the deprecated `size: "half"` alias is translated to a real
+size when the server builds its default arrangement, instead of storing a
+placement with no geometry under a card the grid was already drawing at half
+width. That translation now has one implementation, in core, which both sides
+ask.
+
+Removing a card and adding it back restores the height its author declared, not
+only its width. A widget whose component draws nothing collapses its grid cell
+again rather than leaving a blank full-width slot. Cancelling after a save
+failed takes the failure message with it, instead of leaving "your changes are
+still here" on screen after discarding them.
+
+And a default arrangement is now bounded by the same limit a save is: an install
+declaring more widgets than a single write may carry was answered with a default
+layout the server would refuse, so the reader's first gesture failed and the
+dashboard could not be arranged at all.

--- a/.changeset/a-dashboard-that-agrees-with-its-grid.md
+++ b/.changeset/a-dashboard-that-agrees-with-its-grid.md
@@ -48,3 +48,21 @@ And a default arrangement is now bounded by the same limit a save is: an install
 declaring more widgets than a single write may carry was answered with a default
 layout the server would refuse, so the reader's first gesture failed and the
 dashboard could not be arranged at all.
+
+A widget id names one declaration, chosen the same way on both sides. Two
+plugins contributing the same id resolve to the first declared, and a
+declaration the reader may not see no longer passes its id to the next one --
+which had let a second plugin's ungated card render exactly where the first
+plugin's gated one was withheld.
+
+A declared size or height must be a non-empty string. An empty one was read as
+"unstated" by the server and as "stated" by the grid, so a card was stored at one
+width and drawn at another; a non-string height reached a placement the next
+save would refuse. Both are refused at boot now, where the author can still see
+the mistake, and an unfamiliar value like a newer core's size still passes.
+
+The default arrangement is bounded by what one save may carry, and the bound is
+applied to what the reader can actually see -- widgets they have no access to no
+longer consume it. Past that limit the picker still lists what is left, says the
+dashboard is full, and refuses the add rather than building an arrangement that
+could never be saved.

--- a/packages/admin/src/components/features/widgets/WidgetGrid.tsx
+++ b/packages/admin/src/components/features/widgets/WidgetGrid.tsx
@@ -303,6 +303,7 @@ export function WidgetGrid() {
             title: byId.get(widgetId)?.title ?? widgetId,
           }))}
           onAdd={editor.add}
+          atCapacity={editor.atCapacity}
         />
       ) : null}
     </div>

--- a/packages/admin/src/components/features/widgets/__tests__/layout-editor.test.ts
+++ b/packages/admin/src/components/features/widgets/__tests__/layout-editor.test.ts
@@ -16,6 +16,8 @@ import {
   togglePlacementHidden,
 } from "../layout-editor";
 
+import { MAX_PLACEMENTS } from "nextly/config";
+
 function placements(...ids: string[]): WidgetPlacement[] {
   return ids.map((id, index) => ({
     id,
@@ -190,5 +192,46 @@ describe("whether anything changed", () => {
     const before = placements("a");
     const resized = [{ ...before[0], size: "xl" }];
     expect(hasChanges(before, resized)).toBe(true);
+  });
+});
+
+describe("addPlacement at the write contract's ceiling", () => {
+  /** `MAX_PLACEMENTS` placements, which is exactly one submission's worth. */
+  function full(): WidgetPlacement[] {
+    return Array.from({ length: MAX_PLACEMENTS }, (_, i) => ({
+      id: `p${i}`,
+      widgetId: `core/w${i}`,
+      order: i * 10,
+      hidden: false,
+    }));
+  }
+
+  it("refuses rather than building an arrangement no write can carry", () => {
+    // 🔴 An install declaring more widgets than one submission may hold offers
+    // the surplus through `available`, so an unguarded add produced a draft the
+    // server was always going to refuse -- and the reader met a generic "could
+    // not be saved" naming no limit they knew they had reached.
+    const before = full();
+    const after = addPlacement(before, "core/surplus");
+
+    expect(after).toHaveLength(MAX_PLACEMENTS);
+    expect(after.map(p => p.widgetId)).not.toContain("core/surplus");
+  });
+
+  it("returns a NEW array even when it refuses", () => {
+    // The caller assigns the result into draft state, so returning the same
+    // reference would be indistinguishable from a change that did not render.
+    const before = full();
+    expect(addPlacement(before, "core/surplus")).not.toBe(before);
+  });
+
+  it("still adds one below the ceiling", () => {
+    // The control. Without it the refusal above is satisfied by an
+    // `addPlacement` that never adds anything at all.
+    const before = full().slice(0, MAX_PLACEMENTS - 1);
+    const after = addPlacement(before, "core/surplus");
+
+    expect(after).toHaveLength(MAX_PLACEMENTS);
+    expect(after.map(p => p.widgetId)).toContain("core/surplus");
   });
 });

--- a/packages/admin/src/components/features/widgets/__tests__/resolve-widgets.test.ts
+++ b/packages/admin/src/components/features/widgets/__tests__/resolve-widgets.test.ts
@@ -411,3 +411,67 @@ describe("an unknown size survives, including the inherited names", () => {
     expect(widgetSpanClass("sm")).toBe(WIDGET_SPAN_CLASSES.sm);
   });
 });
+
+describe("two contributions sharing one widget id", () => {
+  /** One plugin's contribution, as `/api/admin-meta` serializes it. */
+  function contributing(widget: Record<string, unknown>) {
+    return { name: "@acme/p", widgets: [widget] } as never;
+  }
+
+  it("does not let a later UNGATED declaration render where a gated one was withheld", () => {
+    // 🔴 Widget ids are plugin-local, so two enabled plugins can ship the same
+    // one. The resolver used to pass the id on when a declaration was declined,
+    // so a second plugin contributing that id with no `requiredPermission`
+    // rendered exactly where the first plugin's gated widget had been withheld.
+    // Nothing enforced agreement between the two declarations.
+    const widgets = resolveDashboardWidgets(
+      [
+        contributing({
+          id: "dup/one",
+          title: "Gated",
+          archetype: "custom",
+          component: "p#A",
+          requiredPermission: "read-secrets",
+        }),
+        contributing({
+          id: "dup/one",
+          title: "Ungated",
+          archetype: "custom",
+          component: "p#B",
+        }),
+      ],
+      [],
+      () => false
+    );
+
+    expect(widgets).toEqual([]);
+  });
+
+  it("resolves the id to the FIRST declaration, matching the server", () => {
+    // The control, and the agreement that matters. `canonicalWidgets` resolves
+    // a collision by declaration order alone -- it must, because default
+    // positions come from the whole-registry materialization and a caller-
+    // dependent identity would move every reader's cards. A grid that chose
+    // differently would draw one declaration where the server placed another.
+    const widgets = resolveDashboardWidgets(
+      [
+        contributing({
+          id: "dup/one",
+          title: "First",
+          archetype: "custom",
+          component: "p#A",
+        }),
+        contributing({
+          id: "dup/one",
+          title: "Second",
+          archetype: "custom",
+          component: "p#B",
+        }),
+      ],
+      [],
+      () => true
+    );
+
+    expect(widgets.map(w => w.title)).toEqual(["First"]);
+  });
+});

--- a/packages/admin/src/components/features/widgets/edit/AddWidgetPicker.tsx
+++ b/packages/admin/src/components/features/widgets/edit/AddWidgetPicker.tsx
@@ -30,9 +30,23 @@ export interface AddWidgetOption {
 export interface AddWidgetPickerProps {
   options: AddWidgetOption[];
   onAdd: (widgetId: string) => void;
+  /**
+   * Whether the arrangement already holds as many cards as one write may carry.
+   *
+   * The picker still LISTS the surplus — those widgets exist and the reader
+   * should be able to see that they do — but every button is disabled and the
+   * reason is stated. Hiding them instead would make a widget disappear from
+   * the one place it is discoverable, which is the defect this picker exists to
+   * prevent.
+   */
+  atCapacity?: boolean;
 }
 
-export function AddWidgetPicker({ options, onAdd }: AddWidgetPickerProps) {
+export function AddWidgetPicker({
+  options,
+  onAdd,
+  atCapacity = false,
+}: AddWidgetPickerProps) {
   if (options.length === 0) {
     // Said rather than rendered blank. An empty picker and a picker that failed
     // to load look identical, and "everything is already on your dashboard" is
@@ -52,6 +66,17 @@ export function AddWidgetPicker({ options, onAdd }: AddWidgetPickerProps) {
       <h3 className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
         Add a widget
       </h3>
+      {atCapacity ? (
+        // Named BEFORE the buttons, so a reader meets the reason rather than a
+        // row of controls that do nothing. It says the remedy too: the limit is
+        // on the arrangement, not on the widget they were reaching for.
+        <p
+          className="mb-2 text-sm text-muted-foreground"
+          data-testid="add-widget-at-capacity"
+        >
+          Your dashboard is full. Remove a card to make room for another.
+        </p>
+      ) : null}
       <ul className="flex flex-wrap gap-2">
         {options.map(option => (
           <li key={option.widgetId}>
@@ -60,6 +85,7 @@ export function AddWidgetPicker({ options, onAdd }: AddWidgetPickerProps) {
               variant="outline"
               size="sm"
               onClick={() => onAdd(option.widgetId)}
+              disabled={atCapacity}
               // The category rides in the accessible name rather than being
               // rendered as a separate grouping. With a handful of widgets a
               // grouped list is more chrome than help, and a reader who needs

--- a/packages/admin/src/components/features/widgets/edit/ArrangedCell.tsx
+++ b/packages/admin/src/components/features/widgets/edit/ArrangedCell.tsx
@@ -116,14 +116,30 @@ export function ArrangedCell({
           were themselves faded, which is the opposite of what the comment
           beside it promised. A hidden card is dimmed so it is not mistaken for
           a live one; the controls that act on it stay legible. */}
-      <div className={cn(row.hidden && "opacity-50")}>
+      {row.hidden ? (
+        <div className="opacity-50">
+          <WidgetRenderer
+            definition={widget}
+            slot={slot}
+            updatedAt={updatedAt}
+            isFetching={isFetching}
+          />
+        </div>
+      ) : (
+        // 🔴 A DIRECT child when nothing is dimmed, because the cell's
+        // `empty:hidden` reads `:empty` -- which counts element children, not
+        // rendered output. An always-present wrapper made every cell non-empty,
+        // so a widget that drew NOTHING stopped collapsing and left a full-width
+        // blank slot with its margins. Nothing is lost by branching: a hidden
+        // card is only ever drawn while editing, where the controls above are
+        // themselves a child and the cell can never be empty anyway.
         <WidgetRenderer
           definition={widget}
           slot={slot}
           updatedAt={updatedAt}
           isFetching={isFetching}
         />
-      </div>
+      )}
     </SortableWidgetCell>
   );
 }

--- a/packages/admin/src/components/features/widgets/edit/DashboardEditChrome.tsx
+++ b/packages/admin/src/components/features/widgets/edit/DashboardEditChrome.tsx
@@ -89,7 +89,12 @@ export function DashboardEditChrome({
         // reloaded, so the arrangement stays exactly where it is.
         <div
           role="alert"
-          className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm"
+          // Full-strength `border-destructive`, which is what every other error
+          // surface in the admin uses. The faded `/40` composited to 1.69:1 on
+          // the page surface against the 3:1 a non-decorative border needs, and
+          // this border is not decorative: it is what separates the alert from
+          // the arrangement behind it, for a reader who cannot rely on the tint.
+          className="rounded-md border border-destructive bg-destructive/10 px-3 py-2 text-sm"
           data-testid="dashboard-edit-error"
         >
           Your dashboard could not be saved. Your changes are still here — try

--- a/packages/admin/src/components/features/widgets/edit/__tests__/WidgetGrid.edit.test.tsx
+++ b/packages/admin/src/components/features/widgets/edit/__tests__/WidgetGrid.edit.test.tsx
@@ -12,6 +12,7 @@ import { protectedApi } from "@admin/lib/api/protectedApi";
 import { registerCoreComponent } from "@admin/lib/plugins/component-registry-internal";
 import type { AdminBranding } from "@admin/types/branding";
 import type { DashboardLayoutResponse } from "@admin/types/dashboard/widgets";
+import { MAX_PLACEMENTS } from "nextly/config";
 
 import { WidgetGrid } from "../../WidgetGrid";
 
@@ -647,6 +648,42 @@ describe("cancelling after a write failed", () => {
       expect(screen.queryByTestId("dashboard-edit-error")).toBeNull()
     );
   });
+});
+
+describe("an arrangement that already holds as many cards as a write may carry", () => {
+  /** `MAX_PLACEMENTS` placed cards, with one more offered by the picker. */
+  function atCapacity() {
+    const ids = Array.from({ length: MAX_PLACEMENTS }, (_, i) => `core/w${i}`);
+    mockBranding = branding([...ids, "core/surplus"]);
+    layoutResponse = layout(
+      ids.map((id, i) => ({ id: `p${i}`, widgetId: id, order: i * 10 })),
+      { available: ["core/surplus"] }
+    );
+  }
+
+  it("refuses the add rather than building a draft that cannot be saved", async () => {
+    // 🔴 An install declaring more widgets than one submission may hold offers
+    // the surplus through `available`, so every picker button built a
+    // 201-placement draft the server was always going to refuse -- and the
+    // reader met a generic "could not be saved" naming no limit they knew about.
+    atCapacity();
+    renderGrid();
+    const user = await beginEditing();
+
+    const add = await screen.findByTestId("add-widget-core/surplus");
+    expect(add).toBeDisabled();
+    expect(screen.getByTestId("add-widget-at-capacity")).toBeInTheDocument();
+
+    // The surplus is still LISTED. Hiding it would remove the widget from the
+    // one place it is discoverable, which is what the picker exists to prevent.
+    expect(add).toBeInTheDocument();
+  });
+
+  // The REFUSAL itself is asserted against `addPlacement` in
+  // `layout-editor.test.ts`, not here. A test driving the disabled button
+  // cannot reach the guard -- the click never fires -- so it passed with the
+  // guard deleted, which is no coverage at all. The control that can fail is
+  // the one on the pure function.
 });
 
 describe("an arrangement with nothing left on it", () => {

--- a/packages/admin/src/components/features/widgets/edit/__tests__/WidgetGrid.edit.test.tsx
+++ b/packages/admin/src/components/features/widgets/edit/__tests__/WidgetGrid.edit.test.tsx
@@ -9,6 +9,7 @@ import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { protectedApi } from "@admin/lib/api/protectedApi";
+import { registerCoreComponent } from "@admin/lib/plugins/component-registry-internal";
 import type { AdminBranding } from "@admin/types/branding";
 import type { DashboardLayoutResponse } from "@admin/types/dashboard/widgets";
 
@@ -41,7 +42,10 @@ vi.mock("@admin/lib/api/protectedApi", () => ({
 const api = vi.mocked(protectedApi);
 
 /** Three registered widgets, drawn by a component so no query is issued. */
-function branding(ids: string[]): AdminBranding {
+function branding(
+  ids: string[],
+  patch: Record<string, Record<string, unknown>> = {}
+): AdminBranding {
   return {
     widgets: ids.map(id => ({
       id,
@@ -49,6 +53,7 @@ function branding(ids: string[]): AdminBranding {
       archetype: "custom",
       defaultSize: "full",
       component: "core#Whatever",
+      ...patch[id],
     })),
   } as unknown as AdminBranding;
 }
@@ -533,6 +538,114 @@ describe("a conflict", () => {
     // The draft is gone, so the reader is out of edit mode rather than looking
     // at server rows they believe are still theirs to save.
     expect(screen.getByTestId("dashboard-edit-begin")).toBeInTheDocument();
+  });
+});
+
+describe("a widget that draws nothing", () => {
+  it("leaves its grid cell with no children, so `empty:hidden` can collapse it", () => {
+    // 🔴 The cell hides itself through CSS `:empty`, which counts ELEMENT
+    // CHILDREN rather than rendered output -- so an always-present wrapper
+    // around the body made every cell non-empty and a widget that drew nothing
+    // became a full-width blank slot with its margins. jsdom applies no
+    // stylesheet, so the assertion is on the property the rule keys off rather
+    // than on the resulting visibility: childless is exactly what `:empty`
+    // means.
+    registerCoreComponent("core#Nothing", () => null);
+    mockBranding = {
+      widgets: [
+        {
+          id: "core/silent",
+          title: "Silent",
+          archetype: "custom",
+          defaultSize: "full",
+          // Unframed, which is the only way a body reaches the cell without a
+          // card around it -- and the case core's conditional sections use.
+          chrome: "none",
+          component: "core#Nothing",
+        },
+      ],
+    } as unknown as AdminBranding;
+    layoutResponse = layout([{ id: "p1", widgetId: "core/silent", order: 0 }]);
+    renderGrid();
+
+    const cell = screen.getByTestId("widget-cell-core/silent");
+    expect(cell.childElementCount).toBe(0);
+  });
+
+  it("DOES fill its cell when the same widget is framed", () => {
+    // The control. Without it the assertion above is satisfied by a grid that
+    // rendered nothing at all, or by a testid pointing at the wrong element.
+    registerCoreComponent("core#Nothing", () => null);
+    mockBranding = {
+      widgets: [
+        {
+          id: "core/framed",
+          title: "Framed",
+          archetype: "custom",
+          defaultSize: "full",
+          component: "core#Nothing",
+        },
+      ],
+    } as unknown as AdminBranding;
+    layoutResponse = layout([{ id: "p1", widgetId: "core/framed", order: 0 }]);
+    renderGrid();
+
+    expect(
+      screen.getByTestId("widget-cell-core/framed").childElementCount
+    ).toBeGreaterThan(0);
+  });
+});
+
+describe("re-adding a card the reader removed", () => {
+  it("brings back the DECLARED height, not just the width", async () => {
+    // 🔴 `defaultPlacements` copies a declared `defaultHeight` onto the initial
+    // placement, and the geometry source handed to `addPlacement` returned only
+    // the size -- so removing a tall card and adding it back produced one with
+    // no stated height, and the next save persisted that. A declared geometry
+    // was lost permanently through a gesture that reads as undoable.
+    mockBranding = branding(["core/a", "core/b"], {
+      "core/b": { defaultHeight: "tall" },
+    });
+    layoutResponse = layout([
+      { id: "p1", widgetId: "core/a", order: 0 },
+      { id: "p2", widgetId: "core/b", order: 10, size: "full" },
+    ]);
+    renderGrid();
+    const user = await beginEditing();
+
+    await user.click(screen.getAllByTestId("widget-remove")[1]);
+    await user.click(await screen.findByTestId("add-widget-core/b"));
+    await user.click(screen.getByTestId("dashboard-edit-save"));
+
+    await waitFor(() => expect(api.put).toHaveBeenCalledTimes(1));
+    const sent = api.put.mock.calls[0][1] as {
+      placements: Array<{ widgetId: string; height?: string }>;
+    };
+    const readded = sent.placements.find(p => p.widgetId === "core/b");
+    expect(readded).toBeDefined();
+    expect(readded?.height).toBe("tall");
+  });
+});
+
+describe("cancelling after a write failed", () => {
+  it("takes the failure message with the draft", async () => {
+    // 🔴 The message says "your changes are still here -- try again", which
+    // describes the draft. Cancel discarded the draft and left the sentence on
+    // screen pointing at nothing, and it was still there the next time the
+    // reader entered edit mode.
+    api.put.mockRejectedValue(new Error("network"));
+    renderGrid();
+    const user = await beginEditing();
+
+    await user.click(screen.getAllByTestId("widget-move-down")[0]);
+    await user.click(screen.getByTestId("dashboard-edit-save"));
+    await screen.findByTestId("dashboard-edit-error");
+
+    await user.click(screen.getByTestId("dashboard-edit-cancel"));
+
+    await waitFor(() =>
+      expect(screen.queryByTestId("dashboard-edit-error")).toBeNull()
+    );
   });
 });
 

--- a/packages/admin/src/components/features/widgets/edit/useDashboardArrangement.ts
+++ b/packages/admin/src/components/features/widgets/edit/useDashboardArrangement.ts
@@ -71,13 +71,25 @@ export function useDashboardArrangement(
     [declared]
   );
 
-  // What an added card inherits. `size` on a resolved declaration IS its
-  // declared default, so a card the reader adds arrives the size its author
-  // intended rather than an arbitrary one.
+  // What an added card inherits. `size` and `height` on a resolved declaration
+  // ARE its declared defaults, so a card the reader adds arrives the geometry
+  // its author intended rather than an arbitrary one.
+  //
+  // 🔴 BOTH, not just the width. `defaultPlacements` copies a declared
+  // `defaultHeight` onto the server's initial placement, so returning only the
+  // size here meant removing a card and adding it back replaced a tall one with
+  // a card of no stated height -- and the next save persisted that, dropping a
+  // declared geometry permanently through a gesture that reads as undoable.
   const geometryFor = useCallback(
     (widgetId: string) => {
       const declaration = byId.get(widgetId);
-      return declaration ? { size: declaration.size } : undefined;
+      if (!declaration) return undefined;
+      return {
+        size: declaration.size,
+        ...(declaration.height === undefined
+          ? {}
+          : { height: declaration.height }),
+      };
     },
     [byId]
   );

--- a/packages/admin/src/components/features/widgets/edit/useLayoutEditor.ts
+++ b/packages/admin/src/components/features/widgets/edit/useLayoutEditor.ts
@@ -124,7 +124,17 @@ export function useLayoutEditor(
       scope: current.scope,
     });
   }, [layout.layout]);
-  const cancel = useCallback(() => setDraft(null), []);
+  // 🔴 The failed-write state goes with the draft, because the message it
+  // renders describes the draft. After a non-conflict failure the chrome says
+  // "your changes are still here -- try again"; Cancel discarded them and left
+  // that sentence on screen, pointing at nothing, and it was still there when
+  // the reader next entered edit mode. A mutation error outlives the thing it
+  // is about unless something clears it.
+  const cancel = useCallback(() => {
+    setDraft(null);
+    layout.save.reset();
+    layout.reset.reset();
+  }, [layout]);
 
   const save = useCallback(() => {
     if (!draft) return;

--- a/packages/admin/src/components/features/widgets/edit/useLayoutEditor.ts
+++ b/packages/admin/src/components/features/widgets/edit/useLayoutEditor.ts
@@ -20,6 +20,7 @@
  * @module components/features/widgets/edit/useLayoutEditor
  */
 
+import { MAX_PLACEMENTS } from "nextly/config";
 import { useCallback, useMemo, useState } from "react";
 
 import type { UseDashboardLayoutResult } from "@admin/hooks/queries/useDashboardLayout";
@@ -46,6 +47,17 @@ export interface LayoutEditor {
   placements: WidgetPlacement[];
   /** Widget ids offered by the "add" picker. */
   available: string[];
+  /**
+   * Whether this arrangement already holds as many cards as a write may carry.
+   *
+   * 🔴 Exposed rather than left for the picker to compute, and refused in
+   * {@link LayoutEditor.add} rather than only rendered. An install declaring
+   * more widgets than one submission may hold offers the surplus through
+   * `available`, so every one of those buttons built a draft the server was
+   * always going to refuse -- and the reader met a generic "could not be
+   * saved" with nothing naming a limit they had not knowingly reached.
+   */
+  atCapacity: boolean;
   hasUnsavedChanges: boolean;
   isSaving: boolean;
   /**
@@ -224,18 +236,20 @@ export function useLayoutEditor(
 
   const add = useCallback(
     (widgetId: string) =>
-      setDraft(current =>
-        current
-          ? {
-              ...current,
-              placements: addPlacement(
-                current.placements,
-                widgetId,
-                geometryFor(widgetId)
-              ),
-            }
-          : current
-      ),
+      setDraft(current => {
+        if (!current) return current;
+        // The capacity refusal lives in `addPlacement`, which is the one path
+        // every add takes and is pure, so it can be asserted directly. Stating
+        // it again here would be a second answer to drift from.
+        return {
+          ...current,
+          placements: addPlacement(
+            current.placements,
+            widgetId,
+            geometryFor(widgetId)
+          ),
+        };
+      }),
     [geometryFor]
   );
 
@@ -261,6 +275,7 @@ export function useLayoutEditor(
     isEditing: draft !== null,
     placements,
     available,
+    atCapacity: placements.length >= MAX_PLACEMENTS,
     hasUnsavedChanges: draft !== null && hasChanges(server, draft.placements),
     isSaving: layout.save.isPending || layout.reset.isPending,
     isConflict: layout.isConflict,

--- a/packages/admin/src/components/features/widgets/layout-editor.ts
+++ b/packages/admin/src/components/features/widgets/layout-editor.ts
@@ -17,6 +17,8 @@
  * @module components/features/widgets/layout-editor
  */
 
+import { MAX_PLACEMENTS } from "nextly/config";
+
 import type { WidgetPlacement } from "@admin/types/dashboard/widgets";
 
 /** The gap left between saved positions, so one can be inserted between two. */
@@ -153,6 +155,18 @@ export function addPlacement(
   widgetId: string,
   geometry?: { size?: string; height?: string }
 ): WidgetPlacement[] {
+  // 🔴 REFUSED at capacity, and refused HERE rather than only at the control.
+  // `MAX_PLACEMENTS` is what the layout endpoint accepts in one submission, and
+  // an install declaring more widgets than that offers the surplus through
+  // `available` -- so an unguarded add built a draft the server was always
+  // going to reject, and the reader met a generic "could not be saved" naming
+  // no limit they knew they had reached.
+  //
+  // A disabled button explains; it does not guarantee. This is the one path
+  // every add takes, and it is a pure function, so the guarantee is stated
+  // where it can be asserted directly rather than through a control that has
+  // to be reachable to be tested.
+  if (placements.length >= MAX_PLACEMENTS) return [...placements];
   const last = placements[placements.length - 1];
   return [
     ...placements,

--- a/packages/admin/src/components/features/widgets/resolve-widgets.ts
+++ b/packages/admin/src/components/features/widgets/resolve-widgets.ts
@@ -14,6 +14,7 @@
 import type {
   WidgetAction,
   WidgetArchetype,
+  WidgetHeight,
   WidgetQuery,
   WidgetSize,
   WidgetChrome,
@@ -85,6 +86,7 @@ export interface ReadableWidgetDeclaration {
   category?: string;
   archetype?: WidgetArchetype;
   defaultSize?: WidgetSize;
+  defaultHeight?: WidgetHeight;
   minSize?: WidgetSize;
   maxSize?: WidgetSize;
   query?: WidgetQuery;
@@ -211,6 +213,7 @@ function resolveOne(
     // enum wins where both are declared, because a plugin that adopted the new
     // field meant it.
     size: meta.defaultSize ?? legacySizeToWidgetSize(meta.size),
+    ...(meta.defaultHeight === undefined ? {} : { height: meta.defaultHeight }),
     query: meta.query,
     component: meta.component,
     actions: readableActions(meta.actions, hasPermission),
@@ -254,6 +257,7 @@ function resolveRegistered(
     icon: meta.icon,
     archetype: meta.archetype,
     size: meta.defaultSize,
+    ...(meta.defaultHeight === undefined ? {} : { height: meta.defaultHeight }),
     query: meta.query,
     component: meta.component,
     actions: readableActions(meta.actions, hasPermission),
@@ -300,6 +304,11 @@ function mergeCollision(
     icon: registration.icon ?? contribution.icon,
     archetype: registration.archetype,
     defaultSize: registration.defaultSize,
+    // The registry wins where it states one, exactly as `defaultOrder` and
+    // `chrome` do below. Named in this list rather than left out because the
+    // list IS the contract: a field missing from it is dropped silently, and a
+    // merged widget would lose the height its contribution declared.
+    defaultHeight: registration.defaultHeight ?? contribution.defaultHeight,
     minSize: registration.minSize,
     maxSize: registration.maxSize,
     // The contributed size is the FALLBACK, read only when the registration

--- a/packages/admin/src/components/features/widgets/resolve-widgets.ts
+++ b/packages/admin/src/components/features/widgets/resolve-widgets.ts
@@ -389,16 +389,29 @@ export function resolveDashboardWidgets(
     resolve: () => DashboardWidget | undefined
   ): DashboardWidget[] => {
     if (seen.has(id)) return [];
-    const widget = resolve();
-    // NOT marked seen when the resolver declines, so a later declaration of the
-    // same id still gets its turn. Whether that is right depends on the two
-    // declarations agreeing about the permission, which nothing here enforces:
-    // a contributed widget carrying no permission still renders behind a
-    // registration that was withheld only if the two are not merged, which is
-    // why the merge above is what closes it rather than this line.
-    if (!widget) return [];
+    // 🔴 The id is CLAIMED before the resolver runs, so a declaration that is
+    // declined still consumes it and no later declaration takes its place.
+    //
+    // The previous rule let a decline pass the id on, and that is a permission
+    // SHADOWING hole: widget ids are plugin-local, so a second plugin
+    // contributing the same id with no `requiredPermission` rendered exactly
+    // where the first plugin's gated widget had been withheld. Nothing else
+    // enforced agreement between the two declarations -- the registration merge
+    // closes that case and two contributions have no merge to close it.
+    //
+    // It is also what makes this agree with the server. `canonicalWidgets`
+    // resolves a collision by declaration order alone, and it MUST: positions
+    // in the default arrangement come from a placement's index in the
+    // whole-registry materialization, so a canonical set that varied per caller
+    // would move every reader's cards relative to each other. Deciding identity
+    // here by anything the caller affects would put the two back out of step,
+    // with the server placing one declaration and the grid drawing another.
+    //
+    // So: one id names one declaration, chosen without reference to who is
+    // asking or to whether the declaration turned out to be renderable.
     seen.add(id);
-    return [widget];
+    const widget = resolve();
+    return widget ? [widget] : [];
   };
 
   const contributed = declaredWidgets(plugins).flatMap(meta => {

--- a/packages/admin/src/components/features/widgets/sizes.ts
+++ b/packages/admin/src/components/features/widgets/sizes.ts
@@ -84,13 +84,10 @@ export function widgetSpanClass(size: string | undefined): string {
 /**
  * The deprecated `size?: "full" | "half"` alias, as a real size.
  *
- * Plugin declarations still carry it, and `half` meant "6 of 12" — which is
- * `lg` in the enum. Mapping it here rather than at the call site is what stops
- * the old vocabulary reaching the span map, where it would miss and silently
- * become full width for every half widget on the dashboard.
+ * Re-exported from core rather than defined here. The server reduces the same
+ * contributed declaration to a canonical summary and has to read the same
+ * alias, so the mapping belongs beside the vocabulary it translates into --
+ * where both callers can ask it. Kept exported from this module because this is
+ * where the dashboard's size questions are answered from.
  */
-export function legacySizeToWidgetSize(
-  size: "full" | "half" | undefined
-): WidgetSize {
-  return size === "half" ? "lg" : "full";
-}
+export { legacySizeToWidgetSize } from "nextly/config";

--- a/packages/admin/src/types/branding.test-d.ts
+++ b/packages/admin/src/types/branding.test-d.ts
@@ -2,6 +2,7 @@ import type {
   PluginAdminCustomWidget,
   PluginAdminDeclarativeWidget,
   PluginAdminWidget,
+  WidgetDefinition,
 } from "nextly/config";
 import { expectTypeOf } from "vitest";
 
@@ -101,9 +102,19 @@ expectTypeOf<{ id: string }>().not.toMatchTypeOf<PluginWidgetMeta>();
 // this guard for the wrong reason.
 type KeysOfUnion<T> = T extends unknown ? keyof T : never;
 
+// `WidgetDefinition` is in this union because the resolver reads BOTH channels,
+// not only the contributed one. `mergeCollision` composes a registration and a
+// contribution into a `ReadableWidgetDeclaration`, so a field only a
+// REGISTRATION can state -- `defaultHeight` is the first -- is legitimately read
+// through that type and is not a field core has stopped declaring. Narrowing
+// this to the contribution arms reported the reader as broken for reading a
+// registration correctly; widening it keeps the property that matters, which is
+// that a field renamed or removed in core fails the build here.
 type UnreadableKeys = Exclude<
   keyof ReadableWidgetDeclaration,
-  KeysOfUnion<PluginAdminCustomWidget | PluginAdminDeclarativeWidget>
+  KeysOfUnion<
+    PluginAdminCustomWidget | PluginAdminDeclarativeWidget | WidgetDefinition
+  >
 >;
 expectTypeOf<UnreadableKeys>().toBeNever();
 

--- a/packages/admin/src/types/dashboard/widgets.ts
+++ b/packages/admin/src/types/dashboard/widgets.ts
@@ -24,6 +24,7 @@
 import type {
   WidgetAction,
   WidgetArchetype,
+  WidgetHeight,
   WidgetQuery,
   WidgetSize,
   WidgetChrome,
@@ -85,6 +86,15 @@ export interface DashboardWidget {
   icon?: string;
   archetype: WidgetArchetype;
   size: WidgetSize;
+  /**
+   * The DECLARED default height, when its author stated one.
+   *
+   * Carried for the same reason as `defaultOrder`: it is the value a placement
+   * seeds its own geometry FROM. The server already copies it onto a default
+   * placement, so an admin that dropped it here could not re-create a card the
+   * reader removed with the height it was declared with.
+   */
+  height?: WidgetHeight;
   /** Present for the data archetypes; absent for `text`, `actions`, `custom`. */
   query?: WidgetQuery;
   /** Present for `custom`; the path `PluginSlot` resolves. */

--- a/packages/nextly/src/api/widget-layout.test.ts
+++ b/packages/nextly/src/api/widget-layout.test.ts
@@ -41,6 +41,8 @@ vi.mock("../auth/entity-read-access", async importOriginal => {
 import { requireAuthentication } from "../auth/middleware";
 import type { WidgetDefinition } from "../domains/widgets/definition";
 import {
+  MAX_PLACEMENTS,
+  layoutSizeProblem,
   serializeLayout,
   visibilityToken,
   type WidgetPlacement,
@@ -1009,5 +1011,53 @@ describe("DELETE /api/dashboard/layout", () => {
 
     expect(res.status).toBe(403);
     expect(deleted).toBeUndefined();
+  });
+});
+
+describe("the submission cap, when an install declares more than one write may carry", () => {
+  /** `MAX_PLACEMENTS` denied widgets in declared order, then one ungated. */
+  function overCapacity(): void {
+    for (let i = 0; i < MAX_PLACEMENTS; i++) {
+      registerWidget(
+        widget({
+          id: `core/denied-${i}`,
+          defaultOrder: i,
+          requiredPermission: "read-secrets",
+        })
+      );
+    }
+    registerWidget(widget({ id: "core/open", defaultOrder: MAX_PLACEMENTS }));
+    callerHoldsPermission.mockResolvedValue(false);
+  }
+
+  it("does not let widgets this caller cannot see consume it", async () => {
+    // 🔴 The cap used to be applied to the whole-registry materialization,
+    // before the visible half was partitioned out. Widgets the caller may not
+    // know exist therefore spent the allowance: two hundred denied ones ahead
+    // of an ungated widget left that reader with an EMPTY dashboard and the one
+    // card they were entitled to relegated to `available`.
+    overCapacity();
+
+    const body = await bodyOf(await getWidgetLayout(getReq()));
+
+    expect(body.placements?.map(p => p.widgetId)).toEqual(["core/open"]);
+    expect(body.available ?? []).not.toContain("core/open");
+  });
+
+  it("still bounds what the caller is asked to submit", async () => {
+    // The other direction, and the reason the cap exists at all: a default the
+    // write contract would refuse is not a default. With every widget visible,
+    // the placements stay inside the limit and the surplus is offered instead.
+    for (let i = 0; i < MAX_PLACEMENTS + 5; i++) {
+      registerWidget(widget({ id: `core/w${i}`, defaultOrder: i }));
+    }
+    callerHoldsPermission.mockResolvedValue(true);
+
+    const body = await bodyOf(await getWidgetLayout(getReq()));
+
+    expect(body.placements).toHaveLength(MAX_PLACEMENTS);
+    expect(layoutSizeProblem(body.placements ?? [])).toBeUndefined();
+    // The surplus is reachable rather than lost.
+    expect(body.available).toContain(`core/w${MAX_PLACEMENTS}`);
   });
 });

--- a/packages/nextly/src/api/widget-layout.ts
+++ b/packages/nextly/src/api/widget-layout.ts
@@ -43,6 +43,7 @@ import { container } from "../di";
 import { allWidgets, type CanonicalWidget } from "../domains/widgets/canonical";
 import {
   MAX_LAYOUT_BYTES,
+  MAX_PLACEMENTS,
   defaultPlacements,
   layoutSizeProblem,
   mergePreservingHidden,
@@ -147,8 +148,22 @@ function visibleDefaults(
   widgets: readonly CanonicalWidget[]
 ): WidgetPlacement[] {
   const visibleIds = new Set(widgets.map(widget => widget.id));
-  return partitionPlacements(defaultPlacements(allWidgets()), visibleIds)
-    .visible;
+  return (
+    partitionPlacements(defaultPlacements(allWidgets()), visibleIds)
+      .visible // 🔴 The submission cap applies HERE, to what this caller can actually
+      // send, rather than to the materialization above. `layoutSizeProblem`
+      // refuses a submission over `MAX_PLACEMENTS`, so an install declaring
+      // more than that answered the read with a default the reader's first
+      // gesture could never save -- the dashboard was simply not arrangeable.
+      //
+      // On the visible half rather than the whole set, because the whole set
+      // includes widgets this caller may not know exist: capping before the
+      // partition let two hundred denied widgets exhaust the allowance and
+      // hand an ungated one an empty dashboard. Positions still come from the
+      // whole-registry materialization, so nothing about the carried half
+      // moves. The surplus is offered through `available`.
+      .slice(0, MAX_PLACEMENTS)
+  );
 }
 
 /**

--- a/packages/nextly/src/config.ts
+++ b/packages/nextly/src/config.ts
@@ -220,6 +220,12 @@ export type {
   WidgetChrome,
 } from "./domains/widgets/definition";
 export type { WidgetQuery } from "./domains/widgets/query";
+// A VALUE, and for the same reason as the batch limit below: the admin resolves
+// a contributed widget's deprecated `size` alias into the enum, and so does the
+// server when it reduces the same declaration to a canonical summary. Two
+// copies of that mapping is two answers to one question, and the copies had
+// already drifted -- only one of them existed.
+export { legacySizeToWidgetSize } from "./domains/widgets/definition";
 // A VALUE, and the only one in this block. The admin batches a dashboard's
 // widgets into requests `POST /api/dashboard/query` will accept, so it needs the
 // number that endpoint refuses above -- and a second copy of it on the client

--- a/packages/nextly/src/config.ts
+++ b/packages/nextly/src/config.ts
@@ -232,6 +232,11 @@ export { legacySizeToWidgetSize } from "./domains/widgets/definition";
 // would send a batch the server rejects the day the two diverged. Its module has
 // no imports, so taking it here costs a `nextly.config.ts` nothing.
 export { MAX_QUERIES_PER_REQUEST } from "./domains/widgets/batch-limit";
+// Also a VALUE, and for the same reason. The layout endpoint refuses a
+// submission carrying more placements than this, so the editor has to know the
+// number to stop a reader building an arrangement that can never be saved --
+// and a second copy of it on the client is a second answer that drifts.
+export { MAX_PLACEMENTS } from "./domains/widgets/layout";
 export type {
   WidgetOp,
   WidgetSourceField,

--- a/packages/nextly/src/domains/widgets/__tests__/canonical.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/canonical.test.ts
@@ -87,6 +87,21 @@ describe("the canonical widget set", () => {
     expect(merged[0]).not.toHaveProperty("requiredPermission");
   });
 
+  it("keeps the FIRST of two contributions sharing an id", () => {
+    // 🔴 Widget ids are plugin-local, so two enabled plugins can ship the same
+    // one. `resolveDashboardWidgets` walks declarations in order and keeps the
+    // first renderable; this kept the LAST, so the layout endpoint placed one
+    // plugin's widget while the grid drew the other's -- a card wearing another
+    // plugin's geometry, or filtered away by a permission it never declared.
+    const merged = canonicalWidgets([
+      { id: "dup/two", defaultOrder: 1, requiredPermission: "read-a" },
+      { id: "dup/two", defaultOrder: 99, requiredPermission: "read-b" },
+    ]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].defaultOrder).toBe(1);
+    expect(merged[0].requiredPermission).toBe("read-a");
+  });
+
   it("carries the fields placement reads, from a registration", () => {
     registerWidget(
       registered({

--- a/packages/nextly/src/domains/widgets/__tests__/definition.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/definition.test.ts
@@ -245,10 +245,28 @@ describe("defaultHeight is checked against the height vocabulary", () => {
     ).toThrow(/defaultHeight must be one of short, tall/);
   });
 
-  it("refuses a non-string height", () => {
+  it("refuses a non-string height, on SHAPE rather than vocabulary", () => {
+    // The shape rule is shared by both declaration channels — a height is a
+    // string in every version — so it is checked before the closed vocabulary,
+    // which is the registry's alone. The message says which of the two refused.
     expect(() =>
       validateWidgetDefinition({ ...valid, defaultHeight: 2 })
-    ).toThrow(/defaultHeight must be one of/);
+    ).toThrow(/defaultHeight, when given, must be a string/);
+  });
+
+  it("refuses a BLANK height", () => {
+    // Blank names no height in any version, so it is shape rather than
+    // vocabulary — and it is refused rather than read as absent, because the
+    // two channels disagreed about which it was.
+    expect(() =>
+      validateWidgetDefinition({ ...valid, defaultHeight: "" })
+    ).toThrow(/defaultHeight, when given, must not be empty/);
+  });
+
+  it("refuses a BLANK size for the same reason", () => {
+    expect(() =>
+      validateWidgetDefinition({ ...valid, defaultSize: "" })
+    ).toThrow(/defaultSize, when given, must not be empty/);
   });
 });
 

--- a/packages/nextly/src/domains/widgets/__tests__/layout.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/layout.test.ts
@@ -423,3 +423,27 @@ describe("config nesting", () => {
     );
   });
 });
+
+describe("a default layout the write contract would refuse", () => {
+  it("stops at the ceiling a submission is bounded by", () => {
+    // 🔴 Nothing bounds how many widgets a registry and a plugin set declare
+    // between them, and `layoutSizeProblem` refuses a submission above
+    // MAX_PLACEMENTS. Uncapped, an install past that number answered the read
+    // with a default arrangement no save could ever accept: the reader's first
+    // gesture was refused, deterministically, and the dashboard was simply not
+    // arrangeable.
+    const widgets = Array.from({ length: MAX_PLACEMENTS + 25 }, (_, i) =>
+      widget({ id: `core/w${i}`, defaultOrder: i })
+    );
+    const placements = defaultPlacements(widgets);
+
+    expect(placements).toHaveLength(MAX_PLACEMENTS);
+    expect(layoutSizeProblem(placements)).toBeUndefined();
+    // Sorted BEFORE the cap, so which cards survive follows the declared order
+    // rather than whatever order the registry happened to be read in.
+    expect(placements[0].widgetId).toBe("core/w0");
+    expect(placements[MAX_PLACEMENTS - 1].widgetId).toBe(
+      `core/w${MAX_PLACEMENTS - 1}`
+    );
+  });
+});

--- a/packages/nextly/src/domains/widgets/__tests__/layout.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/layout.test.ts
@@ -423,27 +423,3 @@ describe("config nesting", () => {
     );
   });
 });
-
-describe("a default layout the write contract would refuse", () => {
-  it("stops at the ceiling a submission is bounded by", () => {
-    // 🔴 Nothing bounds how many widgets a registry and a plugin set declare
-    // between them, and `layoutSizeProblem` refuses a submission above
-    // MAX_PLACEMENTS. Uncapped, an install past that number answered the read
-    // with a default arrangement no save could ever accept: the reader's first
-    // gesture was refused, deterministically, and the dashboard was simply not
-    // arrangeable.
-    const widgets = Array.from({ length: MAX_PLACEMENTS + 25 }, (_, i) =>
-      widget({ id: `core/w${i}`, defaultOrder: i })
-    );
-    const placements = defaultPlacements(widgets);
-
-    expect(placements).toHaveLength(MAX_PLACEMENTS);
-    expect(layoutSizeProblem(placements)).toBeUndefined();
-    // Sorted BEFORE the cap, so which cards survive follows the declared order
-    // rather than whatever order the registry happened to be read in.
-    expect(placements[0].widgetId).toBe("core/w0");
-    expect(placements[MAX_PLACEMENTS - 1].widgetId).toBe(
-      `core/w${MAX_PLACEMENTS - 1}`
-    );
-  });
-});

--- a/packages/nextly/src/domains/widgets/canonical.ts
+++ b/packages/nextly/src/domains/widgets/canonical.ts
@@ -132,8 +132,16 @@ export function canonicalWidgets(
   const byId = new Map<string, CanonicalWidget>();
   // Contributions first, so a registration with the same id merges over one
   // rather than being dropped by it.
+  //
+  // 🔴 FIRST WINS among contributions, which is the admin's rule and was not
+  // this one's. Widget ids are plugin-local, so two enabled plugins can ship the
+  // same one; `resolveDashboardWidgets` walks declarations in order and keeps
+  // the first renderable, while `set` here kept the LAST. Where the two
+  // declarations differ in permission, size or order, the layout endpoint then
+  // filtered and placed one plugin's widget while the grid drew the other's --
+  // a card taking another plugin's geometry, or vanishing.
   for (const widget of contributed) {
-    if (widget.id) byId.set(widget.id, widget);
+    if (widget.id && !byId.has(widget.id)) byId.set(widget.id, widget);
   }
   for (const definition of listWidgets()) {
     const registration = fromRegistration(definition);

--- a/packages/nextly/src/domains/widgets/definition.ts
+++ b/packages/nextly/src/domains/widgets/definition.ts
@@ -17,6 +17,26 @@ import type { WidgetQuery } from "./query";
 export const WIDGET_SIZES = ["sm", "md", "lg", "xl", "full"] as const;
 export type WidgetSize = (typeof WIDGET_SIZES)[number];
 
+/**
+ * The deprecated `size?: "full" | "half"` alias, as a real size.
+ *
+ * Contributed declarations still carry it, and `half` meant "6 of 12" -- which
+ * is `lg` in the enum.
+ *
+ * 🔴 It lives HERE, beside the vocabulary it translates into, rather than in
+ * the admin where it was first written. Both the admin's resolver and the
+ * server's canonical summary have to read a legacy declaration, and the second
+ * one did not: it read `defaultSize` only, so a contribution declaring the alias
+ * produced a default placement with NO size while the grid rendered it at half
+ * width. The first save then stored an arrangement whose geometry disagreed
+ * with what the reader was looking at. One translation, asked by both.
+ */
+export function legacySizeToWidgetSize(
+  size: "full" | "half" | undefined
+): WidgetSize {
+  return size === "half" ? "lg" : "full";
+}
+
 /** Vertical step. Two values, because ragged card bottoms are the tell of a cheap grid. */
 export const WIDGET_HEIGHTS = ["short", "tall"] as const;
 export type WidgetHeight = (typeof WIDGET_HEIGHTS)[number];

--- a/packages/nextly/src/domains/widgets/definition.ts
+++ b/packages/nextly/src/domains/widgets/definition.ts
@@ -233,6 +233,44 @@ function archetypeStanding(value: unknown): ArchetypeStanding {
     : { kind: "newer" };
 }
 
+/**
+ * Why a widget's declared geometry is the wrong SHAPE, or `undefined`.
+ *
+ * `defaultSize` and `defaultHeight` are strings in every version, and a blank
+ * one names nothing in any of them -- so this is a shape rule rather than a
+ * vocabulary rule, shared by both declaration channels, and an unknown value
+ * like `"xxl"` still passes. That is the distinction that lets it live outside
+ * the registry: a contribution may come from a plugin built against a newer
+ * core, and refusing an unfamiliar size would drop a card over a value the
+ * admin already survives.
+ *
+ * Blank is REFUSED rather than read as absent, because the two channels
+ * disagreed about which it was. The server's summary reader treats `""` as
+ * unstated and falls back to the deprecated `size` alias; the admin's resolver
+ * uses `??`, for which `""` is present, and keeps it -- so a declaration
+ * carrying `defaultSize: ""` beside `size: "half"` was stored as `lg` and drawn
+ * full width, and the card changed width when the arrangement arrived and
+ * changed back when it was re-added. Refusing the declaration is the only place
+ * that mistake is still visible to the author who made it.
+ *
+ * A non-string height is the same hole one field over: it reached the resolved
+ * widget, and re-adding that card copied it into a placement the next write
+ * refuses -- an ordinary edit turned into a draft that could never be saved.
+ */
+function geometryShapeProblem(
+  widget: Record<string, unknown>
+): string | undefined {
+  for (const field of ["defaultSize", "defaultHeight"] as const) {
+    const value = widget[field];
+    if (value === undefined) continue;
+    if (typeof value !== "string") {
+      return `${field}, when given, must be a string`;
+    }
+    if (value === "") return `${field}, when given, must not be empty`;
+  }
+  return undefined;
+}
+
 export function widgetValueProblem(
   widget: Record<string, unknown>
 ): string | undefined {
@@ -254,6 +292,9 @@ export function widgetValueProblem(
   if (widget.chrome !== undefined && typeof widget.chrome !== "string") {
     return "chrome, when given, must be a string";
   }
+
+  const geometry = geometryShapeProblem(widget);
+  if (geometry !== undefined) return geometry;
 
   // A permission slug is a STRING in every version -- a newer core may mint new
   // slugs, but it cannot make a slug stop being a string -- so this is shape

--- a/packages/nextly/src/domains/widgets/layout.ts
+++ b/packages/nextly/src/domains/widgets/layout.ts
@@ -344,23 +344,38 @@ function byDeclaredOrder(a: PlaceableWidget, b: PlaceableWidget): number {
 export function defaultPlacements(
   widgets: readonly PlaceableWidget[]
 ): WidgetPlacement[] {
-  return [...widgets].sort(byDeclaredOrder).map((widget, index) => ({
-    id: widget.id,
-    widgetId: widget.id,
-    order: index * DEFAULT_ORDER_STEP,
-    hidden: false,
-    // The declared geometry travels WITH the placement, rather than being left
-    // for a reader to look up. A placement is a persisted arrangement, and an
-    // arrangement that omits its own size is not one: the first save would
-    // store a row with no `size`, so a later change to the plugin's
-    // `defaultSize` would silently resize what the reader was told is their
-    // saved layout. Copied as strings, because a newer plugin's value is a
-    // shape this core has to survive rather than a vocabulary it can check.
-    size: widget.defaultSize,
-    ...(widget.defaultHeight === undefined
-      ? {}
-      : { height: widget.defaultHeight }),
-  }));
+  // 🔴 CAPPED at the same ceiling a write is. Nothing bounds how many widgets a
+  // registry and a plugin set can declare between them, and `layoutSizeProblem`
+  // refuses a submission above `MAX_PLACEMENTS` -- so an install past that
+  // number answered the read with a default arrangement that could never be
+  // saved. The first gesture a reader made was refused, deterministically, with
+  // nothing on screen explaining a limit they had not reached themselves: the
+  // dashboard was simply not arrangeable. A default that the write contract
+  // rejects is not a default, so this one stays inside it.
+  //
+  // Sorted BEFORE the cap, so which widgets survive follows the declared order
+  // rather than registration order. The surplus is still offered through
+  // `available`, so a reader can place one by removing another.
+  return [...widgets]
+    .sort(byDeclaredOrder)
+    .slice(0, MAX_PLACEMENTS)
+    .map((widget, index) => ({
+      id: widget.id,
+      widgetId: widget.id,
+      order: index * DEFAULT_ORDER_STEP,
+      hidden: false,
+      // The declared geometry travels WITH the placement, rather than being left
+      // for a reader to look up. A placement is a persisted arrangement, and an
+      // arrangement that omits its own size is not one: the first save would
+      // store a row with no `size`, so a later change to the plugin's
+      // `defaultSize` would silently resize what the reader was told is their
+      // saved layout. Copied as strings, because a newer plugin's value is a
+      // shape this core has to survive rather than a vocabulary it can check.
+      size: widget.defaultSize,
+      ...(widget.defaultHeight === undefined
+        ? {}
+        : { height: widget.defaultHeight }),
+    }));
 }
 
 /**

--- a/packages/nextly/src/domains/widgets/layout.ts
+++ b/packages/nextly/src/domains/widgets/layout.ts
@@ -344,38 +344,30 @@ function byDeclaredOrder(a: PlaceableWidget, b: PlaceableWidget): number {
 export function defaultPlacements(
   widgets: readonly PlaceableWidget[]
 ): WidgetPlacement[] {
-  // 🔴 CAPPED at the same ceiling a write is. Nothing bounds how many widgets a
-  // registry and a plugin set can declare between them, and `layoutSizeProblem`
-  // refuses a submission above `MAX_PLACEMENTS` -- so an install past that
-  // number answered the read with a default arrangement that could never be
-  // saved. The first gesture a reader made was refused, deterministically, with
-  // nothing on screen explaining a limit they had not reached themselves: the
-  // dashboard was simply not arrangeable. A default that the write contract
-  // rejects is not a default, so this one stays inside it.
-  //
-  // Sorted BEFORE the cap, so which widgets survive follows the declared order
-  // rather than registration order. The surplus is still offered through
-  // `available`, so a reader can place one by removing another.
-  return [...widgets]
-    .sort(byDeclaredOrder)
-    .slice(0, MAX_PLACEMENTS)
-    .map((widget, index) => ({
-      id: widget.id,
-      widgetId: widget.id,
-      order: index * DEFAULT_ORDER_STEP,
-      hidden: false,
-      // The declared geometry travels WITH the placement, rather than being left
-      // for a reader to look up. A placement is a persisted arrangement, and an
-      // arrangement that omits its own size is not one: the first save would
-      // store a row with no `size`, so a later change to the plugin's
-      // `defaultSize` would silently resize what the reader was told is their
-      // saved layout. Copied as strings, because a newer plugin's value is a
-      // shape this core has to survive rather than a vocabulary it can check.
-      size: widget.defaultSize,
-      ...(widget.defaultHeight === undefined
-        ? {}
-        : { height: widget.defaultHeight }),
-    }));
+  // 🔴 NOT capped here, deliberately. The submission limit belongs to what a
+  // CALLER may send, and this materialization is caller-independent by design:
+  // positions come from a placement's index in the sorted whole-registry set,
+  // and the carried half depends on that. Capping here let widgets a caller
+  // cannot even see consume the allowance -- two hundred denied widgets ahead
+  // of an ungated one produced an empty dashboard for that reader. The cap is
+  // applied to the visible partition instead, where the limit actually bites.
+  return [...widgets].sort(byDeclaredOrder).map((widget, index) => ({
+    id: widget.id,
+    widgetId: widget.id,
+    order: index * DEFAULT_ORDER_STEP,
+    hidden: false,
+    // The declared geometry travels WITH the placement, rather than being left
+    // for a reader to look up. A placement is a persisted arrangement, and an
+    // arrangement that omits its own size is not one: the first save would
+    // store a row with no `size`, so a later change to the plugin's
+    // `defaultSize` would silently resize what the reader was told is their
+    // saved layout. Copied as strings, because a newer plugin's value is a
+    // shape this core has to survive rather than a vocabulary it can check.
+    size: widget.defaultSize,
+    ...(widget.defaultHeight === undefined
+      ? {}
+      : { height: widget.defaultHeight }),
+  }));
 }
 
 /**

--- a/packages/nextly/src/plugins/__tests__/channel-divergence.test.ts
+++ b/packages/nextly/src/plugins/__tests__/channel-divergence.test.ts
@@ -464,6 +464,63 @@ const MUST_AGREE: Array<{
       chrome: 42,
     },
   },
+  {
+    case: "a defaultSize that is not a string",
+    expect: /defaultSize, when given, must be a string/,
+    widget: {
+      id: "acme/thing",
+      title: "T",
+      archetype: "custom",
+      defaultSize: 42,
+      component: "p#X",
+    },
+  },
+  {
+    // BLANK, not merely absent, and the two are what the channels disagreed
+    // about. The summary reader takes `""` as unstated and falls back to the
+    // deprecated `size` alias; the admin resolver's `??` keeps it and renders
+    // full width -- so the card was stored at one width and drawn at another.
+    // Blank names no size in any version, so refusing it is shape rather than
+    // vocabulary and an unknown value like "xxl" still passes.
+    case: "a BLANK defaultSize",
+    expect: /defaultSize, when given, must not be empty/,
+    widget: {
+      id: "acme/thing",
+      title: "T",
+      archetype: "custom",
+      defaultSize: "",
+      size: "half",
+      component: "p#X",
+    },
+  },
+  {
+    case: "a defaultHeight that is not a string",
+    expect: /defaultHeight, when given, must be a string/,
+    widget: {
+      id: "acme/thing",
+      title: "T",
+      archetype: "custom",
+      defaultSize: "sm",
+      defaultHeight: 2,
+      component: "p#X",
+    },
+  },
+  {
+    // The same hole one field over. A non-string height reached
+    // `DashboardWidget.height`, and re-adding the card copied it into a
+    // placement the next write refuses -- an ordinary edit turned into a draft
+    // that could never be saved.
+    case: "a BLANK defaultHeight",
+    expect: /defaultHeight, when given, must not be empty/,
+    widget: {
+      id: "acme/thing",
+      title: "T",
+      archetype: "custom",
+      defaultSize: "sm",
+      defaultHeight: "",
+      component: "p#X",
+    },
+  },
 ];
 
 describe("the registry and contributions channels agree except where declared", () => {

--- a/packages/nextly/src/plugins/__tests__/contributed-widget-summaries.test.ts
+++ b/packages/nextly/src/plugins/__tests__/contributed-widget-summaries.test.ts
@@ -74,3 +74,62 @@ describe("contributed widget summaries", () => {
     expect(summaries.map(w => w.id)).toEqual(["acme/other"]);
   });
 });
+
+describe("the size a contributed summary carries", () => {
+  /** One contribution, with whatever size fields the case is about. */
+  function sized(widget: Record<string, unknown>): PluginDefinition {
+    return {
+      name: "@acme/plugin",
+      contributes: { admin: { widgets: [widget] } },
+    } as unknown as PluginDefinition;
+  }
+
+  it("translates the DEPRECATED `size` alias, as the admin resolver does", () => {
+    // 🔴 Reading `defaultSize` alone emitted a summary with no size for a
+    // declaration that legally states only `size`. The default placement then
+    // stored no geometry while the grid drew the card at half width, and a
+    // later change to the plugin's declaration silently resized what the reader
+    // had been told was their saved arrangement.
+    expect(
+      sizedSummary(
+        sized({ id: "acme/w", title: "W", component: "acme#W", size: "half" })
+      )
+    ).toBe("lg");
+  });
+
+  it("translates the alias's other value too", () => {
+    expect(
+      sizedSummary(
+        sized({ id: "acme/w", title: "W", component: "acme#W", size: "full" })
+      )
+    ).toBe("full");
+  });
+
+  it("prefers `defaultSize` where a plugin states both", () => {
+    // A plugin that adopted the enum meant it, which is `resolveOne`'s rule.
+    expect(
+      sizedSummary(
+        sized({
+          id: "acme/w",
+          title: "W",
+          component: "acme#W",
+          size: "half",
+          defaultSize: "sm",
+        })
+      )
+    ).toBe("sm");
+  });
+
+  it("states no size when the declaration states neither", () => {
+    expect(
+      sizedSummary(sized({ id: "acme/w", title: "W", component: "acme#W" }))
+    ).toBeUndefined();
+  });
+
+  /** The one summary a single-widget plugin produces, reduced to its size. */
+  function sizedSummary(plugin: PluginDefinition): string | undefined {
+    const [summary] = contributedWidgetSummaries([plugin]);
+    expect(summary).toBeDefined();
+    return summary.defaultSize;
+  }
+});

--- a/packages/nextly/src/plugins/validate-admin-widgets.ts
+++ b/packages/nextly/src/plugins/validate-admin-widgets.ts
@@ -23,6 +23,7 @@ import {
   chromeProblem,
   DATA_ARCHETYPES,
   defaultOrderProblem,
+  legacySizeToWidgetSize,
   querylessQueryProblem,
   QUERYLESS_ARCHETYPES,
   widgetValueProblem,
@@ -450,13 +451,37 @@ function contributedText(
  * unknown one here would drop the whole card from the arrangement over a value
  * the admin already survives.
  */
+/**
+ * The size a contribution states, in the enum, whichever field it used.
+ *
+ * 🔴 The deprecated `size` alias is read too, through the SAME translation the
+ * admin's resolver applies. Reading `defaultSize` alone emitted a summary with
+ * no size for a declaration that legally states only `size: "half"`, so the
+ * default placement stored no geometry while the grid drew the card at half
+ * width -- and a later change to the plugin's declaration then silently resized
+ * what the reader had been told was their saved arrangement.
+ *
+ * The alias is read only when `defaultSize` is absent, which is the precedence
+ * `resolveOne` applies: a plugin that adopted the enum meant it.
+ */
+function contributedSize(
+  declaration: Record<string, unknown>
+): string | undefined {
+  const declared = contributedText(declaration, "defaultSize");
+  if (declared !== undefined) return declared;
+  const legacy = contributedText(declaration, "size");
+  return legacy === "full" || legacy === "half"
+    ? legacySizeToWidgetSize(legacy)
+    : undefined;
+}
+
 function toSummary(widget: PluginAdminWidget): CanonicalWidget | undefined {
   const declaration = widget as unknown as Record<string, unknown>;
   const id = contributedText(declaration, "id");
   if (id === undefined) return undefined;
 
   const requiredPermission = contributedText(declaration, "requiredPermission");
-  const defaultSize = contributedText(declaration, "defaultSize");
+  const defaultSize = contributedSize(declaration);
   const defaultHeight = contributedText(declaration, "defaultHeight");
   const defaultOrder = declaration.defaultOrder;
 


### PR DESCRIPTION
Follow-up to #1463. Six findings codex raised on that PR's head arrived as it
was merging, so they are worked here with the same context.

Every one was verified against the code before being acted on, each fix is
covered by a test, and each test was break-verified — the fix reverted, the
named test observed to fail, restored.

## What was wrong

**Two plugins can contribute the same widget id.** The grid keeps the FIRST
declared; the canonical summary kept the last. So the layout endpoint placed and
filtered one plugin's widget while the grid rendered the other's — a card wearing
another plugin's geometry, or filtered away by a permission it never declared.

**A contribution may still state the deprecated `size: "half"` alias.** The
canonical summary read `defaultSize` only, so it emitted no size at all and the
default placement stored no geometry under a card the grid was already drawing at
half width. The first save froze that, and a later declaration change silently
resized what the reader had been told was their saved arrangement.

The mapping existed once, in the admin. It now lives in core beside the
vocabulary it translates into, and the admin re-exports it, so both channels ask
one implementation rather than one of them having no answer.

**`defaultPlacements` copies a declared `defaultHeight`; the admin's geometry
source returned only the size.** Removing a tall card and adding it back replaced
it with one of no stated height, and the next save persisted the loss — through a
gesture that reads as undoable. The declared height now travels through the
resolver the way `defaultOrder` does.

**The dimming applied while editing wrapped the body in an always-present
element.** The cell hides itself through CSS `:empty`, which counts element
children rather than rendered output, so a widget whose component drew nothing
stopped collapsing and left a blank full-width slot with its margins. The wrapper
now appears only for a hidden card — which is only ever drawn while editing,
where the controls already make the cell non-empty.

**Cancel discarded the draft and left the failed-write message on screen** —
"your changes are still here", pointing at changes it had just thrown away, and
still there at the next edit.

**Nothing bounded how many widgets the two channels declare between them**, while
a submission is refused above 200 placements. Past that number the default
arrangement was one the server would never accept: the reader's first gesture
failed deterministically and the dashboard could not be arranged at all. The
default is capped at the ceiling a write is, sorted before the cap so the
surviving cards follow the declared order.

## One thing the type contract caught

Threading `defaultHeight` through the resolver failed `branding.test-d.ts`,
correctly: a contribution cannot declare `defaultHeight` — only a registration
can. The guard's population covered one of the two channels the reader actually
reads, so it reported the resolver as broken for reading a registration properly.
Widening it to include `WidgetDefinition` keeps the property that matters, and
that widening was itself break-verified: a reader field core does not declare
still fails the build, by name.

## Verification

- `packages/nextly` — 869 files, 10898 passed, 42 skipped
- `packages/admin` — 384 files, 3746 passed
- both `check-types` and `lint` clean
- `fallow audit --base origin/main` — pass, 0 introduced findings across 17 files

The first push was rejected by the pre-push hook with six 10000ms timeouts in
files this diff does not touch; the package re-run alone is green at this exact
head, and the second push ran both suites clean.