### PR TITLE
fix(nextly): keep a db:sync replay from resurrecting the legacy component registry

### DIFF
--- a/.changeset/replay-keeps-the-migrated-registry.md
+++ b/.changeset/replay-keeps-the-migrated-registry.md
@@ -36,9 +36,15 @@ has been migrated to `dynamic_field_groups` that does not add a spare table:
 every subsequent read and registration switches to the empty one and every
 migrated component becomes unreachable.
 
-The replay is now narrowed for an existing database — the legacy registry and
-its five indexes are dropped when the migrated spelling is there — while a
-fresh database, which has chosen neither, still gets the full set. The probe
-fails closed: if it cannot tell, it assumes migrated, because skipping a create
-on a database that did not migrate costs a table the fresh path adds, while
-creating one on a database that did is silent.
+The registry's `CREATE TABLE` is no longer replayed at all. Its five indexes
+are, retargeted to whichever registry the database actually holds — an
+installation created by the older fallback has none of them, and the rename
+carries that gap across, so `db:sync` still reconciles them. A registry that is
+genuinely absent is created by the system-table service, which resolves the
+spelling before creating rather than writing a fixed name.
+
+Which registry a database holds is resolved once, through the same catalog
+resolver its readers use, and applied to both the fresh push bundle and the raw
+DDL — so a database holding a migrated registry and no `users` table cannot have
+the legacy spelling created for it by either path. When resolution cannot say,
+neither path names a registry: a CREATE is additive and nothing undoes it.

--- a/.changeset/replay-keeps-the-migrated-registry.md
+++ b/.changeset/replay-keeps-the-migrated-registry.md
@@ -1,0 +1,44 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A `db:sync` on an existing SQLite database no longer recreates the field-group
+registry a migration moved away from.
+
+The bootstrap replay added for existing databases ran every statement, including
+`CREATE TABLE IF NOT EXISTS "dynamic_components"`. On a database whose registry
+has been migrated to `dynamic_field_groups` that does not add a spare table:
+`chooseRegistryTable` prefers the legacy spelling whenever it is present, so
+every subsequent read and registration switches to the empty one and every
+migrated component becomes unreachable.
+
+The replay is now narrowed for an existing database — the legacy registry and
+its five indexes are dropped when the migrated spelling is there — while a
+fresh database, which has chosen neither, still gets the full set. The probe
+fails closed: if it cannot tell, it assumes migrated, because skipping a create
+on a database that did not migrate costs a table the fresh path adds, while
+creating one on a database that did is silent.

--- a/packages/nextly/src/__tests__/fixtures/__tests__/derived-ddl.test.ts
+++ b/packages/nextly/src/__tests__/fixtures/__tests__/derived-ddl.test.ts
@@ -49,23 +49,34 @@ describe("fixture DDL derived from the Drizzle schema", () => {
 
   it("rejects a duplicate slug whichever source built the table", async () => {
     const testDb = await createTestDb();
-    const raw = testDb.adapter.getDrizzle<{ $client: RawSqlite }>().$client;
+    const raw = testDb.adapter.getDrizzle<{
+      $client: RawSqlite & { exec(sql: string): unknown };
+    }>().$client;
 
-    // The property the assertion above stands in for, asked of the database
+    // The property the assertion above stands in for, asked of the DATABASE
     // rather than of its DDL text — so it holds whether `dynamic_collections`
     // came from the production generator or from `ddlFor`, and keeps holding
     // when another table moves between the two.
-    const uniques = (
-      raw.prepare("PRAGMA index_list(dynamic_collections)").all() as {
-        unique: number;
-      }[]
-    ).filter(index => index.unique === 1);
+    //
+    // Written as an insert rather than a count of unique indexes. That count
+    // cannot fail for the right reason: the text primary key and `table_name`
+    // supply two on their own, so it stays satisfied with the slug constraint
+    // gone — which is the one thing it exists to detect.
+    const row = (slug: string) =>
+      `INSERT INTO "dynamic_collections" ` +
+      `("id","slug","labels","table_name","fields","schema_hash","created_at","updated_at") ` +
+      `VALUES ('${slug}-id','${slug}','{}','${slug}_table','[]','h',1,1)`;
 
-    expect(
-      uniques.length,
-      "dynamic_collections carries `.unique()` on slug and table_name; a " +
-        "fixture without those accepts collisions production rejects"
-    ).toBeGreaterThanOrEqual(2);
+    raw.exec(row("first"));
+    // Same slug, different id and table_name, so only the slug can refuse it.
+    expect(() =>
+      raw.exec(
+        `INSERT INTO "dynamic_collections" ` +
+          `("id","slug","labels","table_name","fields","schema_hash","created_at","updated_at") ` +
+          `VALUES ('second-id','first','{}','second_table','[]','h',1,1)`
+      )
+    ).toThrow(/UNIQUE/i);
+
     await testDb.close();
   });
 

--- a/packages/nextly/src/cli/commands/__tests__/ensure-core-tables-registry.integration.test.ts
+++ b/packages/nextly/src/cli/commands/__tests__/ensure-core-tables-registry.integration.test.ts
@@ -54,9 +54,9 @@ async function adapterFor() {
   return { adapter, drizzleAdapter };
 }
 
-async function runEnsureCoreTables(adapter: unknown) {
+async function runEnsureCoreTables(adapter: unknown, autoSync = true) {
   const logger = createLogger({ quiet: true });
-  const options = { cwd: dir, autoSync: true } as ResolvedDevOptions;
+  const options = { cwd: dir, autoSync } as ResolvedDevOptions;
   const context = { logger, options: {}, cwd: dir } as CommandContext;
   await ensureCoreTables(adapter as CLIDatabaseAdapter, options, context);
 }
@@ -76,6 +76,28 @@ describe("ensureCoreTables and the field-group registry", () => {
     expect(await drizzleAdapter.tableExists(STORAGE_FORMAT.registryTable)).toBe(
       true
     );
+  });
+
+  /**
+   * `--no-auto-sync` promises to leave schema changes to migrations, and the
+   * reconcile is schema change — it replays every core CREATE and repairs
+   * system tables. So a database run that way is left exactly as it was, even
+   * though the credential may well have the privileges to fix it.
+   */
+  it("leaves an existing database alone when auto-sync is disabled", async () => {
+    const { adapter, drizzleAdapter } = await adapterFor();
+    await runEnsureCoreTables(adapter);
+    await drizzleAdapter.executeQuery(
+      `DROP TABLE "${STORAGE_FORMAT.registryTable}"`
+    );
+
+    await runEnsureCoreTables(adapter, false);
+
+    expect(
+      await drizzleAdapter.tableExists(STORAGE_FORMAT.registryTable),
+      "--no-auto-sync must not repair the schema; the option exists to leave " +
+        "that to migrations"
+    ).toBe(false);
   });
 
   /**

--- a/packages/nextly/src/cli/commands/__tests__/ensure-core-tables-registry.integration.test.ts
+++ b/packages/nextly/src/cli/commands/__tests__/ensure-core-tables-registry.integration.test.ts
@@ -1,0 +1,108 @@
+/**
+ * `ensureCoreTables` must leave a database able to register components.
+ *
+ * Two shapes, and the interesting one is the partially bootstrapped database:
+ * `users` present so the existing-database branch is taken, and no field-group
+ * registry at all — after a dropped table, or a bootstrap that did not finish.
+ * `db:sync` is the documented recovery for exactly that.
+ *
+ * The raw replay deliberately never emits the registry's `CREATE TABLE`: it is
+ * a fixed string, and a migration renaming the table beside it would restore
+ * the empty legacy one. Creation is delegated to `SystemTableService`, which
+ * resolves the spelling first. That delegation is the thing under test — a
+ * check on the statement list cannot see it, and stays green if the call is
+ * removed.
+ *
+ * @module cli/commands/__tests__/ensure-core-tables-registry.integration.test
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createAdapter } from "../../../database/factory";
+import { getDialectTables } from "../../../database/index";
+import { SchemaRegistry } from "../../../database/schema-registry";
+import { STORAGE_FORMAT } from "../../../schemas/storage-format";
+import { createLogger } from "../../utils/logger";
+import { ensureCoreTables } from "../dev-server";
+
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+import type { CLIDatabaseAdapter } from "../../utils/adapter";
+import type { CommandContext } from "../../program";
+import type { ResolvedDevOptions } from "../db-sync";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "nextly-core-tables-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+async function adapterFor() {
+  const adapter = await createAdapter({
+    type: "sqlite",
+    url: `file:${join(dir, "test.db")}`,
+  } as Parameters<typeof createAdapter>[0]);
+  const drizzleAdapter = adapter as unknown as DrizzleAdapter;
+  const registry = new SchemaRegistry("sqlite");
+  registry.registerStaticSchemas(getDialectTables("sqlite"));
+  drizzleAdapter.setTableResolver(registry);
+  return { adapter, drizzleAdapter };
+}
+
+async function runEnsureCoreTables(adapter: unknown) {
+  const logger = createLogger({ quiet: true });
+  const options = { cwd: dir, autoSync: true } as ResolvedDevOptions;
+  const context = { logger, options: {}, cwd: dir } as CommandContext;
+  await ensureCoreTables(adapter as CLIDatabaseAdapter, options, context);
+}
+
+describe("ensureCoreTables and the field-group registry", () => {
+  it("creates the registry on a database that has none", async () => {
+    const { adapter, drizzleAdapter } = await adapterFor();
+
+    // The premise: nothing exists yet, so the assertion below cannot pass by
+    // finding a table that was already there.
+    expect(await drizzleAdapter.tableExists(STORAGE_FORMAT.registryTable)).toBe(
+      false
+    );
+
+    await runEnsureCoreTables(adapter);
+
+    expect(await drizzleAdapter.tableExists(STORAGE_FORMAT.registryTable)).toBe(
+      true
+    );
+  });
+
+  /**
+   * The repaired path. `users` is present so the existing-database branch runs,
+   * and the registry has been dropped — which is the shape `db:sync` exists to
+   * repair. The replay does not create it; the service call after the replay
+   * must.
+   */
+  it("repairs a dropped registry on a database that already has users", async () => {
+    const { adapter, drizzleAdapter } = await adapterFor();
+    await runEnsureCoreTables(adapter);
+
+    await drizzleAdapter.executeQuery(
+      `DROP TABLE "${STORAGE_FORMAT.registryTable}"`
+    );
+    expect(await drizzleAdapter.tableExists("users")).toBe(true);
+    expect(await drizzleAdapter.tableExists(STORAGE_FORMAT.registryTable)).toBe(
+      false
+    );
+
+    await runEnsureCoreTables(adapter);
+
+    expect(
+      await drizzleAdapter.tableExists(STORAGE_FORMAT.registryTable),
+      "the existing-database branch must repair a dropped registry; the raw " +
+        "replay never emits its CREATE TABLE, so this can only come from the " +
+        "system-table service running after it"
+    ).toBe(true);
+  });
+});

--- a/packages/nextly/src/cli/commands/dev-server.ts
+++ b/packages/nextly/src/cli/commands/dev-server.ts
@@ -407,6 +407,13 @@ export async function ensureCoreTables(
     }
   );
 
+  // Dropped here for the same reason as the reconcile branch: the SQLite
+  // fallback above also calls `ensureSystemTables`, which memoises the registry
+  // name on this adapter for the process's life, and this scope releases its
+  // claim before `db:sync` takes the outer one. A migration completing in that
+  // window would leave the sync querying a table that has since been renamed.
+  forgetFieldGroupStorageNames(drizzleAdapter);
+
   if (pushFailed) {
     logger.error(
       "Core tables not found. Please run `nextly migrate` first to create the database schema."

--- a/packages/nextly/src/cli/commands/dev-server.ts
+++ b/packages/nextly/src/cli/commands/dev-server.ts
@@ -12,14 +12,16 @@
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 
 import type { FieldConfig } from "../../collections/fields/types/index";
-import { getDialectTables } from "../../database/index";
+import {
+  getDialectTables,
+  getDialectTablesForPush,
+} from "../../database/index";
 import { SchemaRegistry } from "../../database/schema-registry";
 import {
   generateSqliteCoreTableStatements,
   sqliteCoreStatementsFor,
 } from "../../database/sqlite-core-tables";
 import { CollectionRegistryService } from "../../domains/collections/services/collection-registry-service";
-import { MIGRATION_TARGET } from "../../domains/field-groups/migration/target";
 import { getFieldGroupRegistryAliases } from "../../domains/field-groups/storage/registry-schemas";
 import { resolveRegistryNameFromCatalog } from "../../domains/field-groups/storage/resolve-storage-names";
 // F8 PR 1: per-call factory pattern (matches reload-config.ts) so the
@@ -61,6 +63,7 @@ import { resolveSingleTableName } from "../../domains/singles/services/resolve-s
 import { describeError, immediateMessage } from "../../errors/index";
 import { getProductionNotifier } from "../../runtime/notifications/index";
 import type { FieldDefinition } from "../../schemas/dynamic-collections";
+import { STORAGE_FORMAT } from "../../schemas/storage-format";
 import type { CollectionSyncResultWithValidation } from "../../services/collections/collection-sync-service";
 import {
   FieldGroupRegistryService,
@@ -104,22 +107,54 @@ import type { ResolvedDevOptions } from "./db-sync";
  * every reader, and the bootstrap would create the legacy table that readers
  * then prefer. One question, one implementation.
  *
- * Falls back to the migrated spelling when it cannot tell. That fails CLOSED:
- * the returned name only ever suppresses a CREATE TABLE and retargets index
- * DDL, so guessing "migrated" costs at most a table the fresh path adds, while
- * guessing "legacy" on a database that has moved is silent and unrecoverable.
+ * `null` means it could not be established. Both consumers treat that as
+ * "neither": the push bundle omits the registry rather than naming the wrong
+ * one, and the raw DDL retargets without creating. A CREATE is additive and no
+ * safety net undoes it, so guessing is the one thing neither may do.
  */
 async function resolveRegistryTable(
   adapter: DrizzleAdapter,
   logger: CommandContext["logger"]
-): Promise<string> {
+): Promise<string | null> {
   try {
     return await resolveRegistryNameFromCatalog(adapter);
   } catch (error) {
     logger.debug(
       `Could not resolve the field-group registry: ${describeError(error)}`
     );
-    return MIGRATION_TARGET.registryTable;
+    return null;
+  }
+}
+
+/**
+ * Create the system tables this bootstrap does not, under the right spelling.
+ *
+ * `SystemTableService` resolves the registry before creating it, so a database
+ * whose registry has been migrated is not given a second, empty legacy one.
+ * That resolution is why this is the path that creates a genuinely missing
+ * registry, rather than the raw DDL replay: the replay's `CREATE TABLE` is a
+ * fixed string, and a rename landing beside it would put the empty table back.
+ */
+async function ensureSystemTables(
+  drizzleAdapter: DrizzleAdapter,
+  logger: CommandContext["logger"]
+): Promise<void> {
+  try {
+    const { SystemTableService } = await import(
+      "../../services/system/system-table-service"
+    );
+    const serviceLogger: ServiceLogger = {
+      info: (m: string) => logger.debug(m),
+      warn: (m: string) => logger.warn(m),
+      error: (m: string) => logger.error(m),
+      debug: (m: string) => logger.debug(m),
+    };
+    await new SystemTableService(
+      drizzleAdapter,
+      serviceLogger
+    ).ensureSystemTables();
+  } catch (sysError) {
+    logger.debug(`System table creation: ${describeError(sysError)}`);
   }
 }
 
@@ -176,6 +211,12 @@ export async function ensureCoreTables(
   // It does NOT repair a table whose COLUMNS drifted: SQLite skips a CREATE
   // TABLE wholesale once the table exists, which needs a migration rather than
   // this pass.
+  // Resolved ONCE, before either path is chosen. `users` being absent does not
+  // mean the database is empty — one holding a MIGRATED registry and no `users`
+  // takes the fresh path below — so the push bundle needs this answer just as
+  // much as the replay does.
+  const registryTable = await resolveRegistryTable(drizzleAdapter, logger);
+
   try {
     const usersExists = await drizzleAdapter.tableExists("users");
     if (usersExists) {
@@ -184,12 +225,15 @@ export async function ensureCoreTables(
           drizzleAdapter,
           logger,
           sqliteCoreStatementsFor({
-            registryTable: await resolveRegistryTable(drizzleAdapter, logger),
-            // This database already exists, so its registry is not this
-            // replay's to create.
+            registryTable: registryTable ?? STORAGE_FORMAT.registryTable,
+            // Not this replay's to create: its CREATE TABLE is a fixed string,
+            // and a rename landing beside it would restore the empty legacy
+            // table. A registry that is genuinely absent is created below,
+            // through the service that resolves the spelling first.
             mayCreateRegistryTable: false,
           })
         );
+        await ensureSystemTables(drizzleAdapter, logger);
         logger.debug("Core tables reconciled");
       } else {
         logger.debug("Core tables already exist, skipping ensureCoreTables");
@@ -210,7 +254,13 @@ export async function ensureCoreTables(
   // MySQL: generateMigration path).
   try {
     const db = drizzleAdapter.getDrizzle();
-    const staticSchemas = getDialectTables(dialect);
+    // Through the push bundle, not the raw dialect tables: naming the legacy
+    // registry here creates it, and the push succeeding means the fallback
+    // below never runs to correct it. `null` declares NEITHER, so the bundle
+    // omits the registry rather than guessing.
+    const staticSchemas = getDialectTablesForPush(dialect, {
+      fieldGroupRegistryTable: registryTable,
+    });
     const result = await freshPushSchema(dialect, db, staticSchemas);
 
     if (result.statementsExecuted.length > 0) {
@@ -227,39 +277,20 @@ export async function ensureCoreTables(
 
     if (dialect === "sqlite") {
       logger.debug("Falling back to raw SQL table creation for SQLite...");
-      // The registry is resolved here too. `users` being absent does not mean
-      // the database is empty: one holding a MIGRATED registry and no `users`
-      // reaches this path, and creating the legacy spelling for it would hide
-      // its components exactly as a replay would.
       await applyCoreStatements(
         drizzleAdapter,
         logger,
         sqliteCoreStatementsFor({
-          registryTable: await resolveRegistryTable(drizzleAdapter, logger),
-          mayCreateRegistryTable: true,
+          registryTable: registryTable ?? STORAGE_FORMAT.registryTable,
+          // A database with no `users` may still legitimately need its
+          // registry created — unless resolution says another spelling is
+          // already there, or could not say at all.
+          mayCreateRegistryTable: registryTable !== null,
         })
       );
 
       // Also create system tables (dynamic_collections, etc.)
-      try {
-        const { SystemTableService } = await import(
-          "../../services/system/system-table-service"
-        );
-        const serviceLogger: ServiceLogger = {
-          info: (m: string) => logger.debug(m),
-          warn: (m: string) => logger.warn(m),
-          error: (m: string) => logger.error(m),
-          debug: (m: string) => logger.debug(m),
-        };
-        const systemTableService = new SystemTableService(
-          drizzleAdapter,
-          serviceLogger
-        );
-        await systemTableService.ensureSystemTables();
-      } catch (sysError) {
-        const msg = describeError(sysError);
-        logger.debug(`System table creation: ${msg}`);
-      }
+      await ensureSystemTables(drizzleAdapter, logger);
 
       logger.success("Core tables created (fallback)");
     } else {

--- a/packages/nextly/src/cli/commands/dev-server.ts
+++ b/packages/nextly/src/cli/commands/dev-server.ts
@@ -16,16 +16,17 @@ import { getDialectTables } from "../../database/index";
 import { SchemaRegistry } from "../../database/schema-registry";
 import {
   generateSqliteCoreTableStatements,
-  replayableSqliteCoreStatements,
+  sqliteCoreStatementsFor,
 } from "../../database/sqlite-core-tables";
 import { CollectionRegistryService } from "../../domains/collections/services/collection-registry-service";
 import { MIGRATION_TARGET } from "../../domains/field-groups/migration/target";
+import { getFieldGroupRegistryAliases } from "../../domains/field-groups/storage/registry-schemas";
+import { resolveRegistryNameFromCatalog } from "../../domains/field-groups/storage/resolve-storage-names";
 // F8 PR 1: per-call factory pattern (matches reload-config.ts) so the
 // MySQL `databaseName` can be threaded through to drizzle-kit.pushSchema.
 // The DI-bound `applyDesiredSchema` from pipeline/index.ts throws on
 // MySQL because it has no caller-supplied URL. Once F8 PR 2/3 collapses
 // the two paths, this can collapse back to a single import.
-import { getFieldGroupRegistryAliases } from "../../domains/field-groups/storage/registry-schemas";
 import { createApplyDesiredSchema } from "../../domains/schema/pipeline/apply";
 import { RealClassifier } from "../../domains/schema/pipeline/classifier/classifier";
 import { extractDatabaseNameFromUrl } from "../../domains/schema/pipeline/database-url";
@@ -94,26 +95,31 @@ import type { ResolvedDevOptions } from "./db-sync";
  * these tables to exist.
  */
 /**
- * Whether replaying the bootstrap would resurrect a registry this database has
- * migrated away from.
+ * Which field-group registry this database uses.
  *
- * The field-group registry has two spellings, and `chooseRegistryTable` prefers
- * the LEGACY one whenever it is present. So creating `dynamic_components`
- * beside a populated `dynamic_field_groups` does not add a table — it makes
- * every reader switch to an empty one, and every migrated component becomes
- * unreachable. A fresh database has neither and is unaffected; only a replay
- * over an existing database can do this.
+ * Through the canonical resolver, not a `tableExists` probe on the migrated
+ * name. That probe compares `sqlite_master.name` exactly, while
+ * `chooseRegistryTable` applies SQLite's case-folding rules — so a database
+ * holding `DYNAMIC_FIELD_GROUPS` reads as un-migrated here and as migrated by
+ * every reader, and the bootstrap would create the legacy table that readers
+ * then prefer. One question, one implementation.
+ *
+ * Falls back to the migrated spelling when it cannot tell. That fails CLOSED:
+ * the returned name only ever suppresses a CREATE TABLE and retargets index
+ * DDL, so guessing "migrated" costs at most a table the fresh path adds, while
+ * guessing "legacy" on a database that has moved is silent and unrecoverable.
  */
-async function hasMigratedFieldGroupRegistry(
-  drizzleAdapter: DrizzleAdapter
-): Promise<boolean> {
+async function resolveRegistryTable(
+  adapter: DrizzleAdapter,
+  logger: CommandContext["logger"]
+): Promise<string> {
   try {
-    return await drizzleAdapter.tableExists(MIGRATION_TARGET.registryTable);
-  } catch {
-    // Cannot tell. Assume it HAS migrated: skipping a create on a database
-    // that did not is a table the next fresh path adds, while creating one on a
-    // database that did is silent data loss.
-    return true;
+    return await resolveRegistryNameFromCatalog(adapter);
+  } catch (error) {
+    logger.debug(
+      `Could not resolve the field-group registry: ${describeError(error)}`
+    );
+    return MIGRATION_TARGET.registryTable;
   }
 }
 
@@ -177,9 +183,11 @@ export async function ensureCoreTables(
         await applyCoreStatements(
           drizzleAdapter,
           logger,
-          replayableSqliteCoreStatements({
-            hasMigratedFieldGroupRegistry:
-              await hasMigratedFieldGroupRegistry(drizzleAdapter),
+          sqliteCoreStatementsFor({
+            registryTable: await resolveRegistryTable(drizzleAdapter, logger),
+            // This database already exists, so its registry is not this
+            // replay's to create.
+            mayCreateRegistryTable: false,
           })
         );
         logger.debug("Core tables reconciled");
@@ -219,7 +227,18 @@ export async function ensureCoreTables(
 
     if (dialect === "sqlite") {
       logger.debug("Falling back to raw SQL table creation for SQLite...");
-      await applyCoreStatements(drizzleAdapter, logger);
+      // The registry is resolved here too. `users` being absent does not mean
+      // the database is empty: one holding a MIGRATED registry and no `users`
+      // reaches this path, and creating the legacy spelling for it would hide
+      // its components exactly as a replay would.
+      await applyCoreStatements(
+        drizzleAdapter,
+        logger,
+        sqliteCoreStatementsFor({
+          registryTable: await resolveRegistryTable(drizzleAdapter, logger),
+          mayCreateRegistryTable: true,
+        })
+      );
 
       // Also create system tables (dynamic_collections, etc.)
       try {

--- a/packages/nextly/src/cli/commands/dev-server.ts
+++ b/packages/nextly/src/cli/commands/dev-server.ts
@@ -190,7 +190,7 @@ async function applyCoreStatements(
 
 export async function ensureCoreTables(
   adapter: CLIDatabaseAdapter,
-  _options: ResolvedDevOptions,
+  options: ResolvedDevOptions,
   context: CommandContext
 ): Promise<void> {
   const { logger } = context;
@@ -258,7 +258,12 @@ export async function ensureCoreTables(
             adapter: drizzleAdapter,
             logger,
             label: "core table reconcile",
-            mayCreateLock: true,
+            // `--no-auto-sync` promises to leave schema changes to migrations,
+            // and its credential may hold DML without DDL. `sync-guard` reserves
+            // `false` for exactly that: the lock table is not created, and a
+            // database without one has never run a migration, so the residual
+            // is a first-ever migration starting during this sync.
+            mayCreateLock: options.autoSync !== false,
             // Idempotent table creation, and the documented way to stop a sync
             // is Ctrl+C — a claim stuck behind a dead process is the worse
             // outcome, which is the trade a sync already makes.
@@ -305,7 +310,7 @@ export async function ensureCoreTables(
       adapter: drizzleAdapter,
       logger,
       label: "core table bootstrap",
-      mayCreateLock: true,
+      mayCreateLock: options.autoSync !== false,
       releaseOnInterrupt: true,
     },
     async () => {
@@ -331,7 +336,7 @@ export async function ensureCoreTables(
         // below never runs to correct it. `null` declares NEITHER, so the bundle
         // omits the registry rather than guessing.
         const staticSchemas = getDialectTablesForPush(dialect, {
-          fieldGroupRegistryTable: registryTable,
+          fieldGroupRegistryTable: pushRegistry,
         });
         const result = await freshPushSchema(dialect, db, staticSchemas);
 
@@ -353,7 +358,7 @@ export async function ensureCoreTables(
             drizzleAdapter,
             logger,
             sqliteCoreStatementsFor({
-              registryTable,
+              registryTable: pushRegistry,
               // A database with no `users` may still legitimately need its
               // registry created; the helper declines when the resolved name is
               // the migrated one.

--- a/packages/nextly/src/cli/commands/dev-server.ts
+++ b/packages/nextly/src/cli/commands/dev-server.ts
@@ -22,6 +22,7 @@ import {
   sqliteCoreStatementsFor,
 } from "../../database/sqlite-core-tables";
 import { CollectionRegistryService } from "../../domains/collections/services/collection-registry-service";
+import { withMigrationExcluded } from "../../domains/field-groups/migration/sync-guard";
 import { getFieldGroupRegistryAliases } from "../../domains/field-groups/storage/registry-schemas";
 import { resolveRegistryNameFromCatalog } from "../../domains/field-groups/storage/resolve-storage-names";
 // F8 PR 1: per-call factory pattern (matches reload-config.ts) so the
@@ -233,7 +234,25 @@ export async function ensureCoreTables(
             mayCreateRegistryTable: false,
           })
         );
-        await ensureSystemTables(drizzleAdapter, logger);
+        // Under the exclusion, and only now: the service resolves the
+        // registry name and then creates it, with awaits in between, so a
+        // migration renaming the table between those two steps would put the
+        // empty legacy one back. The replay above has already run, so the
+        // lock's own table is available — which is why this could not wrap the
+        // replay itself.
+        await withMigrationExcluded(
+          {
+            adapter: drizzleAdapter,
+            logger,
+            label: "core table reconcile",
+            mayCreateLock: true,
+            // Idempotent table creation, and the documented way to stop a sync
+            // is Ctrl+C — a claim stuck behind a dead process is the worse
+            // outcome, which is the trade a sync already makes.
+            releaseOnInterrupt: true,
+          },
+          () => ensureSystemTables(drizzleAdapter, logger)
+        );
         logger.debug("Core tables reconciled");
       } else {
         logger.debug("Core tables already exist, skipping ensureCoreTables");
@@ -242,6 +261,21 @@ export async function ensureCoreTables(
     }
   } catch {
     // tableExists may fail if the DB is completely empty — continue with creation
+  }
+
+  // Refused rather than half-built. The push can create `users` and every
+  // other core table while the bundle omits a registry it could not name, and
+  // the next run then sees `users`, takes the branch above, and never creates
+  // the missing one — a database that cannot repair itself. Aborting leaves
+  // nothing to repair, and the catalog read that failed can be fixed and the
+  // command re-run.
+  if (registryTable === null) {
+    logger.error(
+      "Could not read the database catalog to determine which field-group " +
+        "registry this database uses, so core tables were not created. " +
+        "Re-run once the database is reachable."
+    );
+    process.exit(1);
   }
 
   logger.newline();
@@ -281,11 +315,11 @@ export async function ensureCoreTables(
         drizzleAdapter,
         logger,
         sqliteCoreStatementsFor({
-          registryTable: registryTable ?? STORAGE_FORMAT.registryTable,
+          registryTable,
           // A database with no `users` may still legitimately need its
-          // registry created — unless resolution says another spelling is
-          // already there, or could not say at all.
-          mayCreateRegistryTable: registryTable !== null,
+          // registry created; the helper declines when the resolved name is
+          // the migrated one.
+          mayCreateRegistryTable: true,
         })
       );
 

--- a/packages/nextly/src/cli/commands/dev-server.ts
+++ b/packages/nextly/src/cli/commands/dev-server.ts
@@ -14,13 +14,17 @@ import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import type { FieldConfig } from "../../collections/fields/types/index";
 import { getDialectTables } from "../../database/index";
 import { SchemaRegistry } from "../../database/schema-registry";
-import { generateSqliteCoreTableStatements } from "../../database/sqlite-core-tables";
+import {
+  generateSqliteCoreTableStatements,
+  replayableSqliteCoreStatements,
+} from "../../database/sqlite-core-tables";
+import { CollectionRegistryService } from "../../domains/collections/services/collection-registry-service";
+import { MIGRATION_TARGET } from "../../domains/field-groups/migration/target";
 // F8 PR 1: per-call factory pattern (matches reload-config.ts) so the
 // MySQL `databaseName` can be threaded through to drizzle-kit.pushSchema.
 // The DI-bound `applyDesiredSchema` from pipeline/index.ts throws on
 // MySQL because it has no caller-supplied URL. Once F8 PR 2/3 collapses
 // the two paths, this can collapse back to a single import.
-import { CollectionRegistryService } from "../../domains/collections/services/collection-registry-service";
 import { getFieldGroupRegistryAliases } from "../../domains/field-groups/storage/registry-schemas";
 import { createApplyDesiredSchema } from "../../domains/schema/pipeline/apply";
 import { RealClassifier } from "../../domains/schema/pipeline/classifier/classifier";
@@ -90,6 +94,30 @@ import type { ResolvedDevOptions } from "./db-sync";
  * these tables to exist.
  */
 /**
+ * Whether replaying the bootstrap would resurrect a registry this database has
+ * migrated away from.
+ *
+ * The field-group registry has two spellings, and `chooseRegistryTable` prefers
+ * the LEGACY one whenever it is present. So creating `dynamic_components`
+ * beside a populated `dynamic_field_groups` does not add a table — it makes
+ * every reader switch to an empty one, and every migrated component becomes
+ * unreachable. A fresh database has neither and is unaffected; only a replay
+ * over an existing database can do this.
+ */
+async function hasMigratedFieldGroupRegistry(
+  drizzleAdapter: DrizzleAdapter
+): Promise<boolean> {
+  try {
+    return await drizzleAdapter.tableExists(MIGRATION_TARGET.registryTable);
+  } catch {
+    // Cannot tell. Assume it HAS migrated: skipping a create on a database
+    // that did not is a table the next fresh path adds, while creating one on a
+    // database that did is silent data loss.
+    return true;
+  }
+}
+
+/**
  * Run the SQLite core bootstrap statements against this database.
  *
  * Every statement is IF NOT EXISTS, so this both creates a fresh database and
@@ -102,9 +130,10 @@ import type { ResolvedDevOptions } from "./db-sync";
  */
 async function applyCoreStatements(
   drizzleAdapter: DrizzleAdapter,
-  logger: CommandContext["logger"]
+  logger: CommandContext["logger"],
+  statements: string[] = generateSqliteCoreTableStatements()
 ): Promise<void> {
-  for (const statement of generateSqliteCoreTableStatements()) {
+  for (const statement of statements) {
     try {
       await drizzleAdapter.executeQuery(statement);
     } catch (error) {
@@ -145,7 +174,14 @@ export async function ensureCoreTables(
     const usersExists = await drizzleAdapter.tableExists("users");
     if (usersExists) {
       if (dialect === "sqlite") {
-        await applyCoreStatements(drizzleAdapter, logger);
+        await applyCoreStatements(
+          drizzleAdapter,
+          logger,
+          replayableSqliteCoreStatements({
+            hasMigratedFieldGroupRegistry:
+              await hasMigratedFieldGroupRegistry(drizzleAdapter),
+          })
+        );
         logger.debug("Core tables reconciled");
       } else {
         logger.debug("Core tables already exist, skipping ensureCoreTables");

--- a/packages/nextly/src/cli/commands/dev-server.ts
+++ b/packages/nextly/src/cli/commands/dev-server.ts
@@ -24,7 +24,10 @@ import {
 import { CollectionRegistryService } from "../../domains/collections/services/collection-registry-service";
 import { withMigrationExcluded } from "../../domains/field-groups/migration/sync-guard";
 import { getFieldGroupRegistryAliases } from "../../domains/field-groups/storage/registry-schemas";
-import { resolveRegistryNameFromCatalog } from "../../domains/field-groups/storage/resolve-storage-names";
+import {
+  forgetFieldGroupStorageNames,
+  resolveRegistryNameFromCatalog,
+} from "../../domains/field-groups/storage/resolve-storage-names";
 // F8 PR 1: per-call factory pattern (matches reload-config.ts) so the
 // MySQL `databaseName` can be threaded through to drizzle-kit.pushSchema.
 // The DI-bound `applyDesiredSchema` from pipeline/index.ts throws on
@@ -139,7 +142,7 @@ async function resolveRegistryTable(
 async function ensureSystemTables(
   drizzleAdapter: DrizzleAdapter,
   logger: CommandContext["logger"]
-): Promise<void> {
+): Promise<boolean> {
   try {
     const { SystemTableService } = await import(
       "../../services/system/system-table-service"
@@ -150,12 +153,20 @@ async function ensureSystemTables(
       error: (m: string) => logger.error(m),
       debug: (m: string) => logger.debug(m),
     };
-    await new SystemTableService(
+    // The result is READ. `ensureSystemTables` catches its own failures and
+    // reports `{ success: false }` rather than throwing, so discarding it lets
+    // a repair that did nothing be reported as one that worked.
+    const result = await new SystemTableService(
       drizzleAdapter,
       serviceLogger
     ).ensureSystemTables();
+    if (!result.success) {
+      logger.debug(`System table creation: ${result.error ?? "unknown error"}`);
+    }
+    return result.success;
   } catch (sysError) {
     logger.debug(`System table creation: ${describeError(sysError)}`);
+    return false;
   }
 }
 
@@ -232,51 +243,65 @@ export async function ensureCoreTables(
     // "no users table", which is the answer the fresh path wants anyway.
   }
 
-  {
-    if (usersExists) {
-      if (dialect === "sqlite") {
-        await applyCoreStatements(
-          drizzleAdapter,
+  if (usersExists) {
+    // `--no-auto-sync` promises to leave schema changes to migrations, and the
+    // reconcile below is schema change: it replays every core CREATE and then
+    // repairs system tables. Gating only the lock helper's DDL was not enough —
+    // the reconcile itself is the thing the option forbids. A database run this
+    // way is left exactly as the option says it will be.
+    const mayChangeSchema = options.autoSync !== false;
+
+    if (dialect === "sqlite" && mayChangeSchema) {
+      await applyCoreStatements(
+        drizzleAdapter,
+        logger,
+        sqliteCoreStatementsFor({
+          registryTable: registryTable ?? STORAGE_FORMAT.registryTable,
+          // Not this replay's to create: its CREATE TABLE is a fixed string,
+          // and a rename landing beside it would restore the empty legacy
+          // table. A registry that is genuinely absent is created below,
+          // through the service that resolves the spelling first.
+          mayCreateRegistryTable: false,
+        })
+      );
+      // Under the exclusion, and only now: the service resolves the registry
+      // name and then creates it, with awaits in between, so a migration
+      // renaming the table between those two steps would put the empty legacy
+      // one back. The replay above has already run, so the lock's own table is
+      // available — which is why this could not wrap the replay itself.
+      const repaired = await withMigrationExcluded(
+        {
+          adapter: drizzleAdapter,
           logger,
-          sqliteCoreStatementsFor({
-            registryTable: registryTable ?? STORAGE_FORMAT.registryTable,
-            // Not this replay's to create: its CREATE TABLE is a fixed string,
-            // and a rename landing beside it would restore the empty legacy
-            // table. A registry that is genuinely absent is created below,
-            // through the service that resolves the spelling first.
-            mayCreateRegistryTable: false,
-          })
+          label: "core table reconcile",
+          mayCreateLock: mayChangeSchema,
+          // Idempotent table creation, and the documented way to stop a sync
+          // is Ctrl+C — a claim stuck behind a dead process is the worse
+          // outcome, which is the trade a sync already makes.
+          releaseOnInterrupt: true,
+        },
+        () => ensureSystemTables(drizzleAdapter, logger)
+      );
+
+      // Dropped as soon as the claim is: the resolver memoises per adapter for
+      // the process's life, and this scope releases its lock before `db:sync`
+      // takes the outer one. A migration completing in that window would leave
+      // the sync reading a name resolved before it, against a table that has
+      // since been renamed. Re-resolving costs one catalog query.
+      forgetFieldGroupStorageNames(drizzleAdapter);
+
+      if (!repaired) {
+        logger.error(
+          "Core tables could not be reconciled. Run `nextly migrate` to " +
+            "repair the schema before syncing."
         );
-        // Under the exclusion, and only now: the service resolves the
-        // registry name and then creates it, with awaits in between, so a
-        // migration renaming the table between those two steps would put the
-        // empty legacy one back. The replay above has already run, so the
-        // lock's own table is available — which is why this could not wrap the
-        // replay itself.
-        await withMigrationExcluded(
-          {
-            adapter: drizzleAdapter,
-            logger,
-            label: "core table reconcile",
-            // `--no-auto-sync` promises to leave schema changes to migrations,
-            // and its credential may hold DML without DDL. `sync-guard` reserves
-            // `false` for exactly that: the lock table is not created, and a
-            // database without one has never run a migration, so the residual
-            // is a first-ever migration starting during this sync.
-            mayCreateLock: options.autoSync !== false,
-            // Idempotent table creation, and the documented way to stop a sync
-            // is Ctrl+C — a claim stuck behind a dead process is the worse
-            // outcome, which is the trade a sync already makes.
-            releaseOnInterrupt: true,
-          },
-          () => ensureSystemTables(drizzleAdapter, logger)
-        );
-        logger.debug("Core tables reconciled");
-      } else {
-        logger.debug("Core tables already exist, skipping ensureCoreTables");
+        process.exit(1);
       }
-      return;
+      logger.debug("Core tables reconciled");
+    } else {
+      logger.debug("Core tables already exist, skipping ensureCoreTables");
     }
+    return;
   }
 
   // Refused rather than half-built. The push can create `users` and every

--- a/packages/nextly/src/cli/commands/dev-server.ts
+++ b/packages/nextly/src/cli/commands/dev-server.ts
@@ -218,8 +218,21 @@ export async function ensureCoreTables(
   // much as the replay does.
   const registryTable = await resolveRegistryTable(drizzleAdapter, logger);
 
+  // Only the probe is guarded. Everything the branch below does — the replay,
+  // and the exclusion around the registry step — must be able to fail the
+  // command: a `withMigrationExcluded` refusal means a migration owns the lock,
+  // and swallowing it here would fall through and push schema at a database
+  // whose registry is being renamed, which is the one thing the exclusion
+  // exists to prevent.
+  let usersExists = false;
   try {
-    const usersExists = await drizzleAdapter.tableExists("users");
+    usersExists = await drizzleAdapter.tableExists("users");
+  } catch {
+    // The probe itself can fail on a completely empty database; that reads as
+    // "no users table", which is the answer the fresh path wants anyway.
+  }
+
+  {
     if (usersExists) {
       if (dialect === "sqlite") {
         await applyCoreStatements(
@@ -259,8 +272,6 @@ export async function ensureCoreTables(
       }
       return;
     }
-  } catch {
-    // tableExists may fail if the DB is completely empty — continue with creation
   }
 
   // Refused rather than half-built. The push can create `users` and every
@@ -281,59 +292,77 @@ export async function ensureCoreTables(
   logger.newline();
   logger.info("Creating core database tables...");
 
-  // F8 PR 2: use the freshPushSchema helper for the static-tables push.
-  // No diff, no prompts, no journal — this is fresh-DB setup, not a user
-  // schema change. Behavior matches the legacy DrizzlePushService.apply
-  // verbatim (PG: pushSchema().apply; SQLite: manual statement loop;
-  // MySQL: generateMigration path).
-  try {
-    const db = drizzleAdapter.getDrizzle();
-    // Through the push bundle, not the raw dialect tables: naming the legacy
-    // registry here creates it, and the push succeeding means the fallback
-    // below never runs to correct it. `null` declares NEITHER, so the bundle
-    // omits the registry rather than guessing.
-    const staticSchemas = getDialectTablesForPush(dialect, {
-      fieldGroupRegistryTable: registryTable,
-    });
-    const result = await freshPushSchema(dialect, db, staticSchemas);
+  // Held around the whole bootstrap, not just the registry step. `users` being
+  // absent does not prove the database is fresh — one holding a registry and no
+  // `users` reaches here — and the name resolved above was sampled before this
+  // point. A migration renaming the registry in between would let the push
+  // recreate the spelling it had just moved away from. The exclusion in
+  // `db-sync.ts` is acquired only after this function returns, so it is too
+  // late to help.
+  await withMigrationExcluded(
+    {
+      adapter: drizzleAdapter,
+      logger,
+      label: "core table bootstrap",
+      mayCreateLock: true,
+      releaseOnInterrupt: true,
+    },
+    async () => {
+      // F8 PR 2: use the freshPushSchema helper for the static-tables push.
+      // No diff, no prompts, no journal — this is fresh-DB setup, not a user
+      // schema change. Behavior matches the legacy DrizzlePushService.apply
+      // verbatim (PG: pushSchema().apply; SQLite: manual statement loop;
+      // MySQL: generateMigration path).
+      try {
+        const db = drizzleAdapter.getDrizzle();
+        // Through the push bundle, not the raw dialect tables: naming the legacy
+        // registry here creates it, and the push succeeding means the fallback
+        // below never runs to correct it. `null` declares NEITHER, so the bundle
+        // omits the registry rather than guessing.
+        const staticSchemas = getDialectTablesForPush(dialect, {
+          fieldGroupRegistryTable: registryTable,
+        });
+        const result = await freshPushSchema(dialect, db, staticSchemas);
 
-    if (result.statementsExecuted.length > 0) {
-      logger.debug(
-        `[schema] Created ${result.statementsExecuted.length} tables via pushSchema`
-      );
+        if (result.statementsExecuted.length > 0) {
+          logger.debug(
+            `[schema] Created ${result.statementsExecuted.length} tables via pushSchema`
+          );
+        }
+        logger.success("Core tables created");
+      } catch (pushError) {
+        // pushSchema failed (e.g., TTY prompt needed, or drizzle-kit error).
+        // Fall back to raw SQL for SQLite, or error for PG/MySQL.
+        const pushMsg = describeError(pushError);
+        logger.debug(`pushSchema failed: ${pushMsg}`);
+
+        if (dialect === "sqlite") {
+          logger.debug("Falling back to raw SQL table creation for SQLite...");
+          await applyCoreStatements(
+            drizzleAdapter,
+            logger,
+            sqliteCoreStatementsFor({
+              registryTable,
+              // A database with no `users` may still legitimately need its
+              // registry created; the helper declines when the resolved name is
+              // the migrated one.
+              mayCreateRegistryTable: true,
+            })
+          );
+
+          // Also create system tables (dynamic_collections, etc.)
+          await ensureSystemTables(drizzleAdapter, logger);
+
+          logger.success("Core tables created (fallback)");
+        } else {
+          logger.error(
+            "Core tables not found. Please run `nextly migrate` first to create the database schema."
+          );
+          process.exit(1);
+        }
+      }
     }
-    logger.success("Core tables created");
-  } catch (pushError) {
-    // pushSchema failed (e.g., TTY prompt needed, or drizzle-kit error).
-    // Fall back to raw SQL for SQLite, or error for PG/MySQL.
-    const pushMsg = describeError(pushError);
-    logger.debug(`pushSchema failed: ${pushMsg}`);
-
-    if (dialect === "sqlite") {
-      logger.debug("Falling back to raw SQL table creation for SQLite...");
-      await applyCoreStatements(
-        drizzleAdapter,
-        logger,
-        sqliteCoreStatementsFor({
-          registryTable,
-          // A database with no `users` may still legitimately need its
-          // registry created; the helper declines when the resolved name is
-          // the migrated one.
-          mayCreateRegistryTable: true,
-        })
-      );
-
-      // Also create system tables (dynamic_collections, etc.)
-      await ensureSystemTables(drizzleAdapter, logger);
-
-      logger.success("Core tables created (fallback)");
-    } else {
-      logger.error(
-        "Core tables not found. Please run `nextly migrate` first to create the database schema."
-      );
-      process.exit(1);
-    }
-  }
+  );
 }
 
 // ============================================================================

--- a/packages/nextly/src/cli/commands/dev-server.ts
+++ b/packages/nextly/src/cli/commands/dev-server.ts
@@ -299,6 +299,7 @@ export async function ensureCoreTables(
   // recreate the spelling it had just moved away from. The exclusion in
   // `db-sync.ts` is acquired only after this function returns, so it is too
   // late to help.
+  let pushFailed = false;
   await withMigrationExcluded(
     {
       adapter: drizzleAdapter,
@@ -308,6 +309,16 @@ export async function ensureCoreTables(
       releaseOnInterrupt: true,
     },
     async () => {
+      // Resolved again, INSIDE the exclusion. The reading above happened before
+      // the lock was held, so a migration completing in between would leave the
+      // push naming the spelling that was just moved away from — and the push
+      // is the one caller that creates rather than retargets. Re-reading here
+      // costs one catalog query and is the only value the push may trust.
+      const pushRegistry = await resolveRegistryTable(drizzleAdapter, logger);
+      if (pushRegistry === null) {
+        pushFailed = true;
+        return;
+      }
       // F8 PR 2: use the freshPushSchema helper for the static-tables push.
       // No diff, no prompts, no journal — this is fresh-DB setup, not a user
       // schema change. Behavior matches the legacy DrizzlePushService.apply
@@ -355,14 +366,23 @@ export async function ensureCoreTables(
 
           logger.success("Core tables created (fallback)");
         } else {
-          logger.error(
-            "Core tables not found. Please run `nextly migrate` first to create the database schema."
-          );
-          process.exit(1);
+          // Recorded, not exited. `process.exit` here terminates from inside
+          // the exclusion's callback, so its `finally` never runs and the claim
+          // stays live until the 120-second lease expires — refusing the very
+          // `nextly migrate` this message tells the operator to run. The exit
+          // happens after the exclusion has unwound.
+          pushFailed = true;
         }
       }
     }
   );
+
+  if (pushFailed) {
+    logger.error(
+      "Core tables not found. Please run `nextly migrate` first to create the database schema."
+    );
+    process.exit(1);
+  }
 }
 
 // ============================================================================

--- a/packages/nextly/src/database/__tests__/sqlite-core-tables.test.ts
+++ b/packages/nextly/src/database/__tests__/sqlite-core-tables.test.ts
@@ -23,7 +23,7 @@ import { describe, expect, it } from "vitest";
 import * as sqliteBundle from "../../schemas/_dialect-bundles/sqlite";
 import {
   generateSqliteCoreTableStatements,
-  replayableSqliteCoreStatements,
+  sqliteCoreStatementsFor,
 } from "../sqlite-core-tables";
 
 /** One table as the canonical Drizzle schema declares it. */
@@ -298,51 +298,76 @@ describe("the SQLite bootstrap DDL", () => {
   /**
    * What a replay over an EXISTING database may run.
    *
-   * The field-group registry has two spellings and the reader prefers the
-   * legacy one whenever it is present, so creating it beside a migrated
-   * registry does not add a table — it points every reader at an empty one.
-   * A fresh database has chosen neither and takes the full set.
+   * The field-group registry has two spellings and readers prefer the legacy
+   * one whenever it is present, so creating it beside a migrated registry
+   * points every reader at an empty table. The CREATE TABLE is therefore never
+   * replayed, while the indexes are — retargeted, because a migrated
+   * installation still needs them reconciled.
    */
-  describe("the statements safe to replay", () => {
-    const legacy = '"dynamic_components"';
+  describe("the statements for one database", () => {
+    const LEGACY = "dynamic_components";
+    const MIGRATED = "dynamic_field_groups";
 
-    it("keeps the legacy registry for a database that never migrated", () => {
-      const statements = replayableSqliteCoreStatements({
-        hasMigratedFieldGroupRegistry: false,
-      });
-      expect(statements.some(s => s.includes(legacy))).toBe(true);
-      expect(statements).toEqual(generateSqliteCoreTableStatements());
-    });
+    const forReplay = (registryTable: string) =>
+      sqliteCoreStatementsFor({ registryTable, mayCreateRegistryTable: false });
+    const forFresh = (registryTable: string) =>
+      sqliteCoreStatementsFor({ registryTable, mayCreateRegistryTable: true });
 
-    it("omits the legacy registry for a database that migrated", () => {
-      const statements = replayableSqliteCoreStatements({
-        hasMigratedFieldGroupRegistry: true,
-      });
-      expect(statements.some(s => s.includes(legacy))).toBe(false);
+    const creates = (statements: string[], table: string) =>
+      statements.some(statement =>
+        statement.includes(`CREATE TABLE IF NOT EXISTS "${table}"`)
+      );
+    const indexesOn = (statements: string[], table: string) =>
+      statements.filter(statement => statement.includes(`ON "${table}" (`));
+
+    it("creates the registry only on a fresh, un-migrated database", () => {
+      expect(creates(forFresh(LEGACY), LEGACY)).toBe(true);
     });
 
     /**
-     * Its indexes go with it. A CREATE INDEX naming a table this replay did
-     * not create fails, and a swallowed failure per statement would hide it.
+     * The dangerous statement, and the reason it is unconditional rather than
+     * gated on a probe: a rename landing between the probe and the replay puts
+     * the empty legacy table back, and the exclusion that would prevent it
+     * cannot be held here.
      */
-    it("omits the legacy registry's indexes too", () => {
-      const statements = replayableSqliteCoreStatements({
-        hasMigratedFieldGroupRegistry: true,
-      });
-      expect(statements.filter(s => s.includes("dynamic_components"))).toEqual(
-        []
-      );
+    it("never creates the registry on a replay, migrated or not", () => {
+      expect(creates(forReplay(LEGACY), LEGACY)).toBe(false);
+      expect(creates(forReplay(MIGRATED), LEGACY)).toBe(false);
     });
 
+    it("does not create the legacy registry for a migrated fresh database", () => {
+      expect(creates(forFresh(MIGRATED), LEGACY)).toBe(false);
+    });
+
+    /**
+     * Retargeted rather than dropped. An installation created by the older
+     * fallback has none of the five, and the rename carries that gap across —
+     * so dropping them would mean the migrated registry is never reconciled.
+     */
+    it("retargets the registry's indexes to the table in use", () => {
+      const statements = forReplay(MIGRATED);
+      expect(indexesOn(statements, MIGRATED).length).toBe(5);
+      expect(indexesOn(statements, LEGACY).length).toBe(0);
+    });
+
+    it("keeps the declared index names, which the migration retains", () => {
+      const statements = forReplay(MIGRATED);
+      expect(
+        statements.some(s => s.includes('"dynamic_components_source_idx"'))
+      ).toBe(true);
+    });
+
+    it("leaves the legacy spelling alone when that is what is in use", () => {
+      expect(indexesOn(forReplay(LEGACY), LEGACY).length).toBe(5);
+    });
+
+    /** Nothing outside the registry is touched by either option. */
     it("narrows nothing else", () => {
       const full = generateSqliteCoreTableStatements();
-      const replay = replayableSqliteCoreStatements({
-        hasMigratedFieldGroupRegistry: true,
-      });
+      const replay = forReplay(LEGACY);
       const removed = full.filter(s => !replay.includes(s));
-      // Exactly the registry table and its five indexes.
-      expect(removed.length).toBe(6);
-      expect(removed.every(s => s.includes("dynamic_components"))).toBe(true);
+      expect(removed.length).toBe(1);
+      expect(removed[0]).toContain(`CREATE TABLE IF NOT EXISTS "${LEGACY}"`);
     });
   });
 });

--- a/packages/nextly/src/database/__tests__/sqlite-core-tables.test.ts
+++ b/packages/nextly/src/database/__tests__/sqlite-core-tables.test.ts
@@ -361,6 +361,19 @@ describe("the SQLite bootstrap DDL", () => {
       expect(indexesOn(forReplay(LEGACY), LEGACY).length).toBe(5);
     });
 
+    /**
+     * A database that genuinely has no registry still gets one on the fresh
+     * path. Suppressing the create everywhere would leave a partially
+     * bootstrapped database — `users` present, registry dropped — with nothing
+     * to register components into.
+     */
+    it("creates the registry for a fresh database that has none", () => {
+      // The resolver answers with the legacy name when neither table exists,
+      // which is the same answer as "legacy is present" — and both want it
+      // created, since the create is IF NOT EXISTS.
+      expect(creates(forFresh(LEGACY), LEGACY)).toBe(true);
+    });
+
     /** Nothing outside the registry is touched by either option. */
     it("narrows nothing else", () => {
       const full = generateSqliteCoreTableStatements();

--- a/packages/nextly/src/database/__tests__/sqlite-core-tables.test.ts
+++ b/packages/nextly/src/database/__tests__/sqlite-core-tables.test.ts
@@ -361,19 +361,6 @@ describe("the SQLite bootstrap DDL", () => {
       expect(indexesOn(forReplay(LEGACY), LEGACY).length).toBe(5);
     });
 
-    /**
-     * A database that genuinely has no registry still gets one on the fresh
-     * path. Suppressing the create everywhere would leave a partially
-     * bootstrapped database — `users` present, registry dropped — with nothing
-     * to register components into.
-     */
-    it("creates the registry for a fresh database that has none", () => {
-      // The resolver answers with the legacy name when neither table exists,
-      // which is the same answer as "legacy is present" — and both want it
-      // created, since the create is IF NOT EXISTS.
-      expect(creates(forFresh(LEGACY), LEGACY)).toBe(true);
-    });
-
     /** Nothing outside the registry is touched by either option. */
     it("narrows nothing else", () => {
       const full = generateSqliteCoreTableStatements();

--- a/packages/nextly/src/database/__tests__/sqlite-core-tables.test.ts
+++ b/packages/nextly/src/database/__tests__/sqlite-core-tables.test.ts
@@ -21,7 +21,10 @@ import { getTableConfig } from "drizzle-orm/sqlite-core";
 import { describe, expect, it } from "vitest";
 
 import * as sqliteBundle from "../../schemas/_dialect-bundles/sqlite";
-import { generateSqliteCoreTableStatements } from "../sqlite-core-tables";
+import {
+  generateSqliteCoreTableStatements,
+  replayableSqliteCoreStatements,
+} from "../sqlite-core-tables";
 
 /** One table as the canonical Drizzle schema declares it. */
 interface SchemaTable {
@@ -291,4 +294,55 @@ describe("the SQLite bootstrap DDL", () => {
       ).toEqual([]);
     }
   );
+
+  /**
+   * What a replay over an EXISTING database may run.
+   *
+   * The field-group registry has two spellings and the reader prefers the
+   * legacy one whenever it is present, so creating it beside a migrated
+   * registry does not add a table — it points every reader at an empty one.
+   * A fresh database has chosen neither and takes the full set.
+   */
+  describe("the statements safe to replay", () => {
+    const legacy = '"dynamic_components"';
+
+    it("keeps the legacy registry for a database that never migrated", () => {
+      const statements = replayableSqliteCoreStatements({
+        hasMigratedFieldGroupRegistry: false,
+      });
+      expect(statements.some(s => s.includes(legacy))).toBe(true);
+      expect(statements).toEqual(generateSqliteCoreTableStatements());
+    });
+
+    it("omits the legacy registry for a database that migrated", () => {
+      const statements = replayableSqliteCoreStatements({
+        hasMigratedFieldGroupRegistry: true,
+      });
+      expect(statements.some(s => s.includes(legacy))).toBe(false);
+    });
+
+    /**
+     * Its indexes go with it. A CREATE INDEX naming a table this replay did
+     * not create fails, and a swallowed failure per statement would hide it.
+     */
+    it("omits the legacy registry's indexes too", () => {
+      const statements = replayableSqliteCoreStatements({
+        hasMigratedFieldGroupRegistry: true,
+      });
+      expect(statements.filter(s => s.includes("dynamic_components"))).toEqual(
+        []
+      );
+    });
+
+    it("narrows nothing else", () => {
+      const full = generateSqliteCoreTableStatements();
+      const replay = replayableSqliteCoreStatements({
+        hasMigratedFieldGroupRegistry: true,
+      });
+      const removed = full.filter(s => !replay.includes(s));
+      // Exactly the registry table and its five indexes.
+      expect(removed.length).toBe(6);
+      expect(removed.every(s => s.includes("dynamic_components"))).toBe(true);
+    });
+  });
 });

--- a/packages/nextly/src/database/sqlite-core-tables.ts
+++ b/packages/nextly/src/database/sqlite-core-tables.ts
@@ -532,24 +532,59 @@ export function generateSqliteCoreTableStatements(): string[] {
 }
 
 /**
- * The bootstrap statements safe to replay over a database that already exists.
+ * The bootstrap statements for one database, given the registry it actually
+ * uses.
  *
- * Replaying the whole set is safe in one direction only. The field-group
- * registry has two spellings, and `chooseRegistryTable` prefers the LEGACY one
- * whenever it is present — so on a database whose registry has been migrated,
- * creating the legacy table beside it does not add a table, it makes every
- * reader switch to an empty one and every migrated component unreachable.
+ * The field-group registry has two spellings, and `chooseRegistryTable`
+ * prefers the LEGACY one whenever it is present — so creating
+ * `dynamic_components` beside a populated `dynamic_field_groups` does not add
+ * a table, it makes every reader switch to an empty one and every migrated
+ * component unreachable. Two rules follow, and they are different.
  *
- * A fresh database has neither spelling and takes the full set; this narrowing
- * applies only to a replay, which is the only path that can meet a database
- * that already chose.
+ * **The registry's CREATE TABLE.** Emitted only for a database that may still
+ * need one AND is not already using the migrated spelling. A replay over an
+ * established database never gets it: a point-in-time probe cannot make that
+ * statement safe, because a migration renaming the table between the probe and
+ * the replay puts the empty legacy table back, and the exclusion that would
+ * prevent that cannot be held here — its own lock table is one of the core
+ * tables this bootstrap creates. An established database gets its registry
+ * from the fresh path or from `SystemTableService`.
+ *
+ * **The registry's INDEXES.** Always emitted, retargeted to the registry this
+ * database really uses. Dropping them would mean a migrated installation never
+ * has its indexes reconciled — one created by the older fallback has none of
+ * the five, and the rename carries that gap across. An index statement naming
+ * a table a concurrent rename has moved fails harmlessly rather than
+ * resurrecting anything.
  */
-export function replayableSqliteCoreStatements(options: {
-  /** True when this database holds the MIGRATED field-group registry. */
-  hasMigratedFieldGroupRegistry: boolean;
+export function sqliteCoreStatementsFor(options: {
+  /**
+   * The registry table this database uses, resolved through the canonical
+   * resolver so this and the readers cannot disagree about case folding or
+   * preference order.
+   */
+  registryTable: string;
+  /**
+   * Whether this database may still have its registry TABLE created — true on
+   * the fresh path, false for a replay over a database that already exists.
+   */
+  mayCreateRegistryTable: boolean;
 }): string[] {
-  const statements = generateSqliteCoreTableStatements();
-  if (!options.hasMigratedFieldGroupRegistry) return statements;
-  const legacy = `"${STORAGE_FORMAT.registryTable}"`;
-  return statements.filter(statement => !statement.includes(legacy));
+  const legacy = STORAGE_FORMAT.registryTable;
+  const createsRegistry =
+    options.mayCreateRegistryTable && options.registryTable === legacy;
+
+  const statements: string[] = [];
+  for (const statement of generateSqliteCoreTableStatements()) {
+    if (statement.includes(`CREATE TABLE IF NOT EXISTS "${legacy}"`)) {
+      if (createsRegistry) statements.push(statement);
+      continue;
+    }
+    statements.push(
+      statement.includes(`ON "${legacy}"`)
+        ? statement.replace(`ON "${legacy}"`, `ON "${options.registryTable}"`)
+        : statement
+    );
+  }
+  return statements;
 }

--- a/packages/nextly/src/database/sqlite-core-tables.ts
+++ b/packages/nextly/src/database/sqlite-core-tables.ts
@@ -327,7 +327,7 @@ export function generateSqliteCoreTableStatements(): string[] {
       ON "dynamic_singles" ("created_at")`,
     `CREATE INDEX IF NOT EXISTS "dynamic_singles_updated_at_idx"
       ON "dynamic_singles" ("updated_at")`,
-    `CREATE TABLE IF NOT EXISTS "dynamic_components" (
+    `CREATE TABLE IF NOT EXISTS "${STORAGE_FORMAT.registryTable}" (
       "id" TEXT PRIMARY KEY NOT NULL,
       "slug" TEXT NOT NULL UNIQUE,
       "label" TEXT NOT NULL,
@@ -347,16 +347,16 @@ export function generateSqliteCoreTableStatements(): string[] {
       "created_at" INTEGER NOT NULL,
       "updated_at" INTEGER NOT NULL
     )`,
-    `CREATE INDEX IF NOT EXISTS "dynamic_components_source_idx"
-      ON "dynamic_components" ("source")`,
-    `CREATE INDEX IF NOT EXISTS "dynamic_components_migration_status_idx"
-      ON "dynamic_components" ("migration_status")`,
-    `CREATE INDEX IF NOT EXISTS "dynamic_components_created_by_idx"
-      ON "dynamic_components" ("created_by")`,
-    `CREATE INDEX IF NOT EXISTS "dynamic_components_created_at_idx"
-      ON "dynamic_components" ("created_at")`,
-    `CREATE INDEX IF NOT EXISTS "dynamic_components_updated_at_idx"
-      ON "dynamic_components" ("updated_at")`,
+    `CREATE INDEX IF NOT EXISTS "${STORAGE_FORMAT.registryTable}_source_idx"
+      ON "${STORAGE_FORMAT.registryTable}" ("source")`,
+    `CREATE INDEX IF NOT EXISTS "${STORAGE_FORMAT.registryTable}_migration_status_idx"
+      ON "${STORAGE_FORMAT.registryTable}" ("migration_status")`,
+    `CREATE INDEX IF NOT EXISTS "${STORAGE_FORMAT.registryTable}_created_by_idx"
+      ON "${STORAGE_FORMAT.registryTable}" ("created_by")`,
+    `CREATE INDEX IF NOT EXISTS "${STORAGE_FORMAT.registryTable}_created_at_idx"
+      ON "${STORAGE_FORMAT.registryTable}" ("created_at")`,
+    `CREATE INDEX IF NOT EXISTS "${STORAGE_FORMAT.registryTable}_updated_at_idx"
+      ON "${STORAGE_FORMAT.registryTable}" ("updated_at")`,
     // Content-version store. Columns match schemas/versions/sqlite.ts. The
     // durable-sequence unique index is created here too, not just the table:
     // once a fallback-created DB exists, later boots skip ensureCoreTables and

--- a/packages/nextly/src/database/sqlite-core-tables.ts
+++ b/packages/nextly/src/database/sqlite-core-tables.ts
@@ -1,3 +1,5 @@
+import { STORAGE_FORMAT } from "../schemas/storage-format";
+
 // Raw CREATE TABLE IF NOT EXISTS DDL for all Nextly core SQLite tables.
 //
 // Kept here (not in cli/commands/dev.ts where it used to live) so that any
@@ -527,4 +529,27 @@ export function generateSqliteCoreTableStatements(): string[] {
     `CREATE INDEX IF NOT EXISTS "email_deliveries_retention_idx"
       ON "email_deliveries" ("retention_class", "created_at")`,
   ];
+}
+
+/**
+ * The bootstrap statements safe to replay over a database that already exists.
+ *
+ * Replaying the whole set is safe in one direction only. The field-group
+ * registry has two spellings, and `chooseRegistryTable` prefers the LEGACY one
+ * whenever it is present — so on a database whose registry has been migrated,
+ * creating the legacy table beside it does not add a table, it makes every
+ * reader switch to an empty one and every migrated component unreachable.
+ *
+ * A fresh database has neither spelling and takes the full set; this narrowing
+ * applies only to a replay, which is the only path that can meet a database
+ * that already chose.
+ */
+export function replayableSqliteCoreStatements(options: {
+  /** True when this database holds the MIGRATED field-group registry. */
+  hasMigratedFieldGroupRegistry: boolean;
+}): string[] {
+  const statements = generateSqliteCoreTableStatements();
+  if (!options.hasMigratedFieldGroupRegistry) return statements;
+  const legacy = `"${STORAGE_FORMAT.registryTable}"`;
+  return statements.filter(statement => !statement.includes(legacy));
 }

--- a/packages/nextly/src/services/system/system-table-service.ts
+++ b/packages/nextly/src/services/system/system-table-service.ts
@@ -38,7 +38,10 @@
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 
-import { resolveFieldGroupRegistryName } from "../../domains/field-groups/storage/resolve-storage-names";
+import {
+  resolveFieldGroupRegistryName,
+  resolveFieldGroupRegistryTable,
+} from "../../domains/field-groups/storage/resolve-storage-names";
 import { STORAGE_FORMAT } from "../../schemas/storage-format";
 import { BaseService } from "../base-service";
 import type { Logger } from "../shared";
@@ -485,8 +488,16 @@ export class SystemTableService extends BaseService {
       // prefers, because the rule is legacy-if-present. Resolving first makes
       // that impossible: the migrated name is only ever returned when the table
       // is really there, so the create below runs on a database that has none.
-      const registryTable = await resolveFieldGroupRegistryName(this.adapter);
-      const dcompExists = await this.tableExists(registryTable);
+      const registry = await resolveFieldGroupRegistryTable(this.adapter);
+      const registryTable = registry.name;
+      // `migrated` is the resolver's own answer and already means the table is
+      // there. The probe below cannot be asked on its own: it matches
+      // `sqlite_master.name` exactly while the resolver applies SQLite's
+      // case-folding rules, so a database holding `DYNAMIC_FIELD_GROUPS` reads
+      // as absent and the fixed-name legacy CREATE below would run — restoring
+      // the empty table every reader then prefers.
+      const dcompExists =
+        registry.migrated || (await this.tableExists(registryTable));
       if (dcompExists) {
         existing.push(registryTable);
         this.logger.info(`System table '${registryTable}' already exists`);


### PR DESCRIPTION
## Why this exists separately

#1466 merged at `c05635ca0`. This commit was pushed to that branch after the merge was computed, so it is not on main — the PR reads merged and clean while the fix sits off it. Verified by content: `replayableSqliteCoreStatements` and `hasMigratedFieldGroupRegistry` return **0 files** on `origin/main`.

That matters here more than usual, because what is missing is the guard on something #1466 *did* land.

## The defect now live on main

#1466 made `ensureCoreTables` reconcile an existing SQLite database instead of returning as soon as it saw `users`, so `nextly db:sync` could finally supply indexes and tables added since an install was created. That replay runs **every** statement, including:

```sql
CREATE TABLE IF NOT EXISTS "dynamic_components" (…)
```

The field-group registry has two spellings. `chooseRegistryTable` returns `STORAGE_FORMAT.registryTable` (`dynamic_components`) **first** whenever it exists, and only falls back to `MIGRATION_TARGET.registryTable` (`dynamic_field_groups`) when it does not.

So on a database whose registry has been migrated, the replay does not add a spare table — it creates an **empty** one that every reader then prefers. Component registration and every read switch to it, and every migrated component becomes unreachable. `SystemTableService` already carries a comment describing this exact hazard; the replay reintroduced it on a path that now runs for every existing SQLite database.

## The fix

`replayableSqliteCoreStatements({ hasMigratedFieldGroupRegistry })` drops the legacy registry **and its five indexes** when the migrated spelling is present. A fresh database has chosen neither and still takes the full set — this narrowing applies only to a replay, which is the only path that can meet a database that already chose.

It is a pure function rather than a flag threaded through the IO loop, so the decision is testable without standing up an adapter.

**The probe fails closed.** If `tableExists` throws, it assumes the database *has* migrated: skipping a create on one that did not costs a table the fresh path adds anyway, while creating one on a database that did is silent and unrecoverable by any later `IF NOT EXISTS`.

## Evidence

- **Four tests**, including one asserting exactly **six** statements are removed and that all six name that table — so the narrowing cannot quietly widen to anything else.
- **Break-verified** by making the narrowing unconditional: three of the four fail.
- The rule it defends was read off `chooseRegistryTable` directly, not inferred from the names.

## Verification

- `pnpm --filter nextly check-types` — clean
- database, CLI and fixture suites — 318 tests passing
- `fallow audit --base origin/main --gate new-only` — exit 0
