### PR TITLE
fix(admin): offer an api-key control only where the endpoint would agree

### DIFF
--- a/.changeset/api-key-controls-match-the-endpoint.md
+++ b/.changeset/api-key-controls-match-the-endpoint.md
@@ -1,0 +1,44 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The API Keys screen no longer offers controls the endpoint behind them will
+refuse.
+
+The list route was widened to admit `read-api-keys`, because the endpoint
+accepts that grant — but the page still rendered Create unconditionally and
+every active row still offered Edit and Revoke. A reader who could only view
+keys was shown three controls, each leading to a route or request that turns
+them away.
+
+Each control is now gated on the grants its own operation needs, derived from
+one declaration that mirrors the server's rule — the action's own grant, or the
+`update-api-keys` umbrella that reaches all four. Creating answers to
+`create-api-keys` or that umbrella, editing to `update-api-keys`, revoking to
+`delete-api-keys` or the umbrella. The table's two gates are required props
+rather than defaulted, so a call site cannot omit them and silently offer
+everything.

--- a/.changeset/api-key-controls-match-the-endpoint.md
+++ b/.changeset/api-key-controls-match-the-endpoint.md
@@ -35,10 +35,15 @@ every active row still offered Edit and Revoke. A reader who could only view
 keys was shown three controls, each leading to a route or request that turns
 them away.
 
-Each control is now gated on the grants its own operation needs, derived from
-one declaration that mirrors the server's rule — the action's own grant, or the
-`update-api-keys` umbrella that reaches all four. Creating answers to
-`create-api-keys` or that umbrella, editing to `update-api-keys`, revoking to
-`delete-api-keys` or the umbrella. The table's two gates are required props
-rather than defaulted, so a call site cannot omit them and silently offer
-everything.
+Each control is now gated on the grants its own operation needs, and the row
+itself follows the same gate as the Edit item rather than staying clickable
+into a route that refuses. The create route accepts what the endpoint accepts
+instead of the narrower grant alone.
+
+The rule behind all of them is declared once, in the package that enforces it:
+`nextly/config` exports the API-key policy, the endpoints authorise from it, and
+the admin's route guards and controls derive their grant slugs from the same
+declaration through `permissionSlug`. Writing that rule twice is what let the
+list route demand `update-api-keys` while the endpoint accepted `read-api-keys`.
+The table's two gates are required props rather than defaulted, so a call site
+cannot omit them and silently offer everything.

--- a/packages/admin/src/components/features/api-keys/ApiKeyTable.tsx
+++ b/packages/admin/src/components/features/api-keys/ApiKeyTable.tsx
@@ -302,10 +302,18 @@ export const ApiKeyTable: React.FC<ApiKeyTableProps> = ({
       columns={columns}
       rows={paginatedData}
       loading={isLoading}
-      onRowClick={key => {
-        // Only active keys are editable; revoked keys are read-only.
-        if (key.isActive) onEdit(key);
-      }}
+      onRowClick={
+        // The row is a second door to the same edit route, so it answers to
+        // the same grant as the Edit item. Without this a read-only viewer
+        // opens the editor by clicking the row — or by activating it from the
+        // keyboard — and is refused there. Revoked keys are read-only for
+        // everyone.
+        canEdit
+          ? key => {
+              if (key.isActive) onEdit(key);
+            }
+          : undefined
+      }
       primaryColumn="name"
       rowActions={rowActions}
       registryKey="api-keys"

--- a/packages/admin/src/components/features/api-keys/ApiKeyTable.tsx
+++ b/packages/admin/src/components/features/api-keys/ApiKeyTable.tsx
@@ -34,6 +34,15 @@ export interface ApiKeyTableProps {
   isLoading?: boolean;
   onEdit: (key: ApiKeyMeta) => void;
   onRevoke: (key: ApiKeyMeta) => void;
+  /**
+   * Whether this reader may edit a key, and revoke one.
+   *
+   * Required rather than defaulted: the list is now open to a reader holding
+   * only `read-api-keys`, and a default of `true` would leave every call site
+   * that forgets these offering actions the endpoint refuses.
+   */
+  canEdit: boolean;
+  canRevoke: boolean;
 }
 
 // ============================================================
@@ -111,6 +120,8 @@ export const ApiKeyTable: React.FC<ApiKeyTableProps> = ({
   isLoading = false,
   onEdit,
   onRevoke,
+  canEdit,
+  canRevoke,
 }) => {
   const [search, setSearch] = useState("");
   const { page, pageSize, setPage, setPageSize, resetPage } = usePagination();
@@ -248,23 +259,30 @@ export const ApiKeyTable: React.FC<ApiKeyTableProps> = ({
   const rowActions = useCallback(
     (key: ApiKeyMeta): RowAction<ApiKeyMeta>[] => {
       if (!key.isActive) return [];
-      return [
-        {
+      // Offered only where the endpoint behind them would agree. Editing
+      // answers to `update-api-keys`; revoking accepts `delete-api-keys` or
+      // that same umbrella.
+      const actions: RowAction<ApiKeyMeta>[] = [];
+      if (canEdit) {
+        actions.push({
           id: "edit",
           label: "Edit",
           icon: <Edit className="h-4 w-4" />,
           onSelect: () => onEdit(key),
-        },
-        {
+        });
+      }
+      if (canRevoke) {
+        actions.push({
           id: "revoke",
           label: "Revoke",
           icon: <Trash2 className="h-4 w-4" />,
           destructive: true,
           onSelect: () => onRevoke(key),
-        },
-      ];
+        });
+      }
+      return actions;
     },
-    [onEdit, onRevoke]
+    [onEdit, onRevoke, canEdit, canRevoke]
   );
 
   return (

--- a/packages/admin/src/components/features/api-keys/__tests__/ApiKeyTable.actions.test.tsx
+++ b/packages/admin/src/components/features/api-keys/__tests__/ApiKeyTable.actions.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+/**
+ * Which row actions the table offers, and to whom.
+ *
+ * The API-keys list is reachable by a reader holding only `read-api-keys`,
+ * because the endpoint behind it accepts that grant. Editing and revoking do
+ * not: each answers to its own grant or the `update-api-keys` umbrella. A row
+ * menu that offers them anyway sends the reader to a route that refuses them,
+ * which reads as the product being broken rather than as a permission they
+ * lack.
+ *
+ * @module components/features/api-keys/__tests__/ApiKeyTable.actions.test
+ */
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { render, screen, waitFor } from "@admin/__tests__/utils";
+import type { ApiKeyMeta } from "@admin/services/apiKeyApi";
+
+import { ApiKeyTable } from "../ApiKeyTable";
+
+/** The same shape the columns suite renders, so the table draws a real row. */
+const KEY: ApiKeyMeta = {
+  id: "abcdefgh123456",
+  name: "CI Deploy",
+  description: null,
+  keyPrefix: "nx_live_abcdef",
+  tokenType: "read-only",
+  role: null,
+  expiresAt: null,
+  lastUsedAt: null,
+  isActive: true,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+function renderTable(gates: { canEdit: boolean; canRevoke: boolean }) {
+  render(
+    <ApiKeyTable
+      data={[KEY]}
+      onEdit={vi.fn()}
+      onRevoke={vi.fn()}
+      canEdit={gates.canEdit}
+      canRevoke={gates.canRevoke}
+    />
+  );
+}
+
+/** Open the row's action menu, whatever the list view labels its trigger. */
+async function openRowMenu() {
+  // Radix sets pointer-events: none on the trigger under jsdom, which the
+  // default pointer check refuses; the click itself is what we need.
+  const user = userEvent.setup({ pointerEventsCheck: 0 });
+  const triggers = screen.getAllByRole("button");
+  for (const trigger of triggers) {
+    await user.click(trigger);
+    if (screen.queryByText("Edit") || screen.queryByText("Revoke")) return true;
+  }
+  return false;
+}
+
+describe("ApiKeyTable row actions", () => {
+  it("offers both to a reader holding the write grants", async () => {
+    renderTable({ canEdit: true, canRevoke: true });
+    // The positive control: these labels DO render when permitted, so their
+    // absence below is the gate and not a query that never matches.
+    expect(await openRowMenu()).toBe(true);
+    await waitFor(() => {
+      expect(screen.getByText("Edit")).toBeInTheDocument();
+      expect(screen.getByText("Revoke")).toBeInTheDocument();
+    });
+  });
+
+  it("offers neither to a read-only viewer", async () => {
+    renderTable({ canEdit: false, canRevoke: false });
+    await openRowMenu();
+    expect(screen.queryByText("Edit")).toBeNull();
+    expect(screen.queryByText("Revoke")).toBeNull();
+  });
+
+  /**
+   * The grants are separate: `delete-api-keys` revokes without editing, so the
+   * two controls cannot be gated together.
+   */
+  it("offers revoke alone to a reader who may only revoke", async () => {
+    renderTable({ canEdit: false, canRevoke: true });
+    await openRowMenu();
+    await waitFor(() => expect(screen.getByText("Revoke")).toBeInTheDocument());
+    expect(screen.queryByText("Edit")).toBeNull();
+  });
+});

--- a/packages/admin/src/components/features/api-keys/__tests__/ApiKeyTable.actions.test.tsx
+++ b/packages/admin/src/components/features/api-keys/__tests__/ApiKeyTable.actions.test.tsx
@@ -14,7 +14,7 @@
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
-import { render, screen, waitFor } from "@admin/__tests__/utils";
+import { render, screen, waitFor, within } from "@admin/__tests__/utils";
 import type { ApiKeyMeta } from "@admin/services/apiKeyApi";
 
 import { ApiKeyTable } from "../ApiKeyTable";
@@ -34,11 +34,14 @@ const KEY: ApiKeyMeta = {
   updatedAt: "2026-01-01T00:00:00.000Z",
 };
 
+const onEditSpy = vi.fn();
+
 function renderTable(gates: { canEdit: boolean; canRevoke: boolean }) {
+  onEditSpy.mockClear();
   render(
     <ApiKeyTable
       data={[KEY]}
-      onEdit={vi.fn()}
+      onEdit={onEditSpy}
       onRevoke={vi.fn()}
       canEdit={gates.canEdit}
       canRevoke={gates.canRevoke}
@@ -76,6 +79,31 @@ describe("ApiKeyTable row actions", () => {
     await openRowMenu();
     expect(screen.queryByText("Edit")).toBeNull();
     expect(screen.queryByText("Revoke")).toBeNull();
+  });
+
+  /**
+   * The row itself is a second door to the edit route. Gating only the menu
+   * item leaves a read-only viewer able to open the editor by clicking the
+   * row, or by activating it from the keyboard, and be refused there.
+   */
+  it("does not make rows activate the editor for a read-only viewer", async () => {
+    renderTable({ canEdit: false, canRevoke: false });
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    // Scoped to the table: this list also renders a card view, so an unscoped
+    // query matches the same key twice.
+    const table = screen.getByRole("table");
+    await user.click(within(table).getByText("CI Deploy"));
+    // The positive control below proves this query DOES reach a clickable row
+    // when permitted, so a silent no-op here is the gate rather than a miss.
+    expect(onEditSpy).not.toHaveBeenCalled();
+  });
+
+  it("activates the editor from the row when permitted", async () => {
+    renderTable({ canEdit: true, canRevoke: true });
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    const table = screen.getByRole("table");
+    await user.click(within(table).getByText("CI Deploy"));
+    expect(onEditSpy).toHaveBeenCalled();
   });
 
   /**

--- a/packages/admin/src/components/features/api-keys/__tests__/ApiKeyTable.columns.test.tsx
+++ b/packages/admin/src/components/features/api-keys/__tests__/ApiKeyTable.columns.test.tsx
@@ -51,7 +51,15 @@ beforeEach(() => localStorage.clear());
 describe("ApiKeyTable columns", () => {
   it("omits the header and cells of a column the stored choice hides", () => {
     seedStoredChoice(TOGGLEABLE.filter(name => name !== "id"));
-    render(<ApiKeyTable data={[KEY]} onEdit={vi.fn()} onRevoke={vi.fn()} />);
+    render(
+      <ApiKeyTable
+        data={[KEY]}
+        onEdit={vi.fn()}
+        onRevoke={vi.fn()}
+        canEdit
+        canRevoke
+      />
+    );
     const table = screen.getByRole("table");
     // The Type header is the positive control: a header this query CAN find
     // inside the table, so the ID absence below is the hidden column and not

--- a/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
+++ b/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
@@ -189,6 +189,9 @@ export function DualSidebar({ isMobile }: DualSidebarProps = {}) {
     ),
   });
 
+  // Shown while the grants are still resolving, like the rest of the rail. The
+  // alternative flashes: an entry appearing a moment after the page settles
+  // reads as the UI changing its mind, and the media route refuses on its own.
   const hasMediaSection = hasPermissionDataPending
     ? true
     : capabilities.canViewMedia;

--- a/packages/admin/src/components/layout/sidebar/__tests__/resolve-settings-landing.test.ts
+++ b/packages/admin/src/components/layout/sidebar/__tests__/resolve-settings-landing.test.ts
@@ -42,6 +42,10 @@ describe("resolveSettingsLanding", () => {
     );
   });
 
+  /**
+   * The unchanged case. General Settings answers to `manage-settings`, so this
+   * reader lands on the panel's first entry rather than being routed past it.
+   */
   it("still sends a settings manager to General", () => {
     expect(resolveSettingsLanding(only("manage-settings"))).toBe(
       ROUTES.SETTINGS
@@ -82,22 +86,37 @@ describe("resolveSettingsLanding", () => {
     );
   });
 
+  /**
+   * The webhooks route is an any-of over the three webhook grants, so reading
+   * alone opens it and the panel may offer it.
+   */
   it("sends a webhook reader to Webhooks", () => {
     expect(resolveSettingsLanding(only("read-webhooks"))).toBe(
       ROUTES.SETTINGS_WEBHOOKS
     );
   });
 
+  /**
+   * User Management sits in the panel but answers to its own grants, which the
+   * rail consults separately — so a reader holding only `read-users` still has
+   * a destination here.
+   */
   it("sends a user reader to Users", () => {
     expect(resolveSettingsLanding(only("read-users"))).toBe(ROUTES.USERS);
   });
 
+  /** The same for roles, which is a separate grant from users. */
   it("sends a role reader to Roles", () => {
     expect(resolveSettingsLanding(only("read-roles"))).toBe(
       ROUTES.SECURITY_ROLES
     );
   });
 
+  /**
+   * The fallthrough itself, asked directly. It is unreachable for anyone the
+   * panel admits — the assertions below prove that — so this pins the shape of
+   * the answer for a reader who holds nothing at all.
+   */
   it("falls back to the panel for a reader with no destination", () => {
     expect(resolveSettingsLanding(only())).toBe(ROUTES.SETTINGS);
   });

--- a/packages/admin/src/constants/navigation.ts
+++ b/packages/admin/src/constants/navigation.ts
@@ -15,7 +15,7 @@ import {
   Webhook,
   type LucideIcon,
 } from "../components/icons";
-import { API_KEY_ACTION_PERMISSIONS } from "../lib/permissions/api-key-actions";
+import { apiKeyGrantsFor } from "../lib/permissions/api-key-actions";
 
 import { ROUTES } from "./routes";
 
@@ -126,7 +126,7 @@ export type SidebarNavigation = NavigationItem[];
  * it. `create-api-keys` is deliberately absent — it opens the create form, not
  * the list this entry links to.
  */
-export const API_KEYS_LIST_PERMISSIONS = API_KEY_ACTION_PERMISSIONS.read;
+export const API_KEYS_LIST_PERMISSIONS = apiKeyGrantsFor("read");
 
 export const RELEASE_SECTION_PERMISSIONS = [
   "read-content-releases",

--- a/packages/admin/src/constants/navigation.ts
+++ b/packages/admin/src/constants/navigation.ts
@@ -15,6 +15,7 @@ import {
   Webhook,
   type LucideIcon,
 } from "../components/icons";
+import { API_KEY_ACTION_PERMISSIONS } from "../lib/permissions/api-key-actions";
 
 import { ROUTES } from "./routes";
 
@@ -125,10 +126,7 @@ export type SidebarNavigation = NavigationItem[];
  * it. `create-api-keys` is deliberately absent — it opens the create form, not
  * the list this entry links to.
  */
-export const API_KEYS_LIST_PERMISSIONS = [
-  "read-api-keys",
-  "update-api-keys",
-] as const;
+export const API_KEYS_LIST_PERMISSIONS = API_KEY_ACTION_PERMISSIONS.read;
 
 export const RELEASE_SECTION_PERMISSIONS = [
   "read-content-releases",

--- a/packages/admin/src/lib/permissions/api-key-actions.ts
+++ b/packages/admin/src/lib/permissions/api-key-actions.ts
@@ -1,0 +1,30 @@
+/**
+ * Which grants reach each API-key operation.
+ *
+ * Mirrors `requireApiKeyPermission` in `api/api-keys.ts`, which authorises
+ * every endpoint as an any-of: the action's own grant, OR `update-api-keys`.
+ * That umbrella is why this cannot be read off the slug names — `update`
+ * reaches all four, and `create`, `delete` and `read` reach only their own.
+ *
+ * Declared here so the admin gates on the same rule the server enforces. A
+ * control shown to someone the endpoint will refuse is not a permission bug,
+ * it is an interface offering an action that cannot happen.
+ *
+ * @module lib/permissions/api-key-actions
+ */
+export const API_KEY_ACTION_PERMISSIONS = {
+  read: ["read-api-keys", "update-api-keys"],
+  create: ["create-api-keys", "update-api-keys"],
+  update: ["update-api-keys"],
+  delete: ["delete-api-keys", "update-api-keys"],
+} as const satisfies Record<string, readonly string[]>;
+
+export type ApiKeyAction = keyof typeof API_KEY_ACTION_PERMISSIONS;
+
+/** Whether this reader may perform one API-key operation. */
+export function mayPerformApiKeyAction(
+  action: ApiKeyAction,
+  hasPermission: (slug: string) => boolean
+): boolean {
+  return API_KEY_ACTION_PERMISSIONS[action].some(hasPermission);
+}

--- a/packages/admin/src/lib/permissions/api-key-actions.ts
+++ b/packages/admin/src/lib/permissions/api-key-actions.ts
@@ -1,30 +1,31 @@
 /**
- * Which grants reach each API-key operation.
+ * Which grants reach each API-key operation, as the server defines them.
  *
- * Mirrors `requireApiKeyPermission` in `api/api-keys.ts`, which authorises
- * every endpoint as an any-of: the action's own grant, OR `update-api-keys`.
- * That umbrella is why this cannot be read off the slug names — `update`
- * reaches all four, and `create`, `delete` and `read` reach only their own.
+ * Derived from `nextly/config`, not restated here. The endpoints authorise
+ * every API-key operation as an any-of — the operation's own action, OR the
+ * `update-api-keys` umbrella that reaches all four — and three surfaces ask
+ * that same question: the endpoint enforcing it, the route deciding who may
+ * open a page, and the control deciding which buttons to render. They drifted
+ * once already, and the admin was the side that was wrong.
  *
- * Declared here so the admin gates on the same rule the server enforces. A
- * control shown to someone the endpoint will refuse is not a permission bug,
+ * A control shown to someone the endpoint will refuse is not a permission bug,
  * it is an interface offering an action that cannot happen.
  *
  * @module lib/permissions/api-key-actions
  */
-export const API_KEY_ACTION_PERMISSIONS = {
-  read: ["read-api-keys", "update-api-keys"],
-  create: ["create-api-keys", "update-api-keys"],
-  update: ["update-api-keys"],
-  delete: ["delete-api-keys", "update-api-keys"],
-} as const satisfies Record<string, readonly string[]>;
+import { apiKeyPermissionSlugsFor, type ApiKeyOperation } from "nextly/config";
 
-export type ApiKeyAction = keyof typeof API_KEY_ACTION_PERMISSIONS;
+export type { ApiKeyOperation };
+
+/** The grants that authorise one API-key operation, as any-of. */
+export function apiKeyGrantsFor(operation: ApiKeyOperation): string[] {
+  return apiKeyPermissionSlugsFor(operation);
+}
 
 /** Whether this reader may perform one API-key operation. */
 export function mayPerformApiKeyAction(
-  action: ApiKeyAction,
+  operation: ApiKeyOperation,
   hasPermission: (slug: string) => boolean
 ): boolean {
-  return API_KEY_ACTION_PERMISSIONS[action].some(hasPermission);
+  return apiKeyGrantsFor(operation).some(hasPermission);
 }

--- a/packages/admin/src/pages/dashboard/settings/api-keys/index.tsx
+++ b/packages/admin/src/pages/dashboard/settings/api-keys/index.tsx
@@ -14,7 +14,9 @@ import { QueryErrorBoundary } from "@admin/components/shared/query-error-boundar
 import { SearchBar } from "@admin/components/shared/search-bar";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
 import { useApiKeys } from "@admin/hooks/queries/useApiKeys";
+import { useCurrentUserPermissions } from "@admin/hooks/useCurrentUserPermissions";
 import { navigateTo } from "@admin/lib/navigation";
+import { mayPerformApiKeyAction } from "@admin/lib/permissions/api-key-actions";
 import type { ApiKeyMeta } from "@admin/services/apiKeyApi";
 
 // ============================================================
@@ -22,6 +24,7 @@ import type { ApiKeyMeta } from "@admin/services/apiKeyApi";
 // ============================================================
 
 const ApiKeysContent: React.FC = () => {
+  const { hasPermission } = useCurrentUserPermissions();
   // Fetch keys
   const { data, isLoading, isError, error } = useApiKeys();
 
@@ -80,6 +83,8 @@ const ApiKeysContent: React.FC = () => {
         isLoading={isLoading}
         onEdit={handleEdit}
         onRevoke={handleRevoke}
+        canEdit={mayPerformApiKeyAction("update", hasPermission)}
+        canRevoke={mayPerformApiKeyAction("delete", hasPermission)}
       />
 
       {/* Revoke dialog */}
@@ -97,6 +102,7 @@ const ApiKeysContent: React.FC = () => {
 // ============================================================
 
 const ApiKeysPage: React.FC = () => {
+  const { hasPermission } = useCurrentUserPermissions();
   return (
     <QueryErrorBoundary fallback={<PageErrorFallback />}>
       <PageContainer width="wide">
@@ -105,13 +111,19 @@ const ApiKeysPage: React.FC = () => {
           description="Manage secure access keys for API integrations"
           crumb="API Keys"
           actions={
-            <Button
-              size="md"
-              onClick={() => navigateTo(ROUTES.SETTINGS_API_KEYS_CREATE)}
-            >
-              <Plus className="h-4 w-4" />
-              <span>Create API Key</span>
-            </Button>
+            // The list is open to a reader holding only `read-api-keys`, and
+            // the create route answers to `create-api-keys` or the update
+            // umbrella. Offering the button to everyone admitted here would
+            // send a reader to a page that turns them away.
+            mayPerformApiKeyAction("create", hasPermission) ? (
+              <Button
+                size="md"
+                onClick={() => navigateTo(ROUTES.SETTINGS_API_KEYS_CREATE)}
+              >
+                <Plus className="h-4 w-4" />
+                <span>Create API Key</span>
+              </Button>
+            ) : undefined
           }
         >
           <ApiKeysContent />

--- a/packages/admin/src/pages/registry.ts
+++ b/packages/admin/src/pages/registry.ts
@@ -11,6 +11,7 @@ import {
   collectionContentSection,
   overridableBy,
 } from "../lib/navigation/section-resolvers";
+import { API_KEY_ACTION_PERMISSIONS } from "../lib/permissions/api-key-actions";
 import type { PageProps } from "../lib/routing";
 import type { RouteSection } from "../types/route-section";
 
@@ -465,7 +466,11 @@ export const routeConfig: Record<string, RouteConfig> = {
   [ROUTES.SETTINGS_API_KEYS_CREATE]: {
     component: CreateApiKeyPage,
     type: "private",
-    requiredPermission: "create-api-keys",
+    // The endpoint accepts `create-api-keys` OR the `update-api-keys`
+    // umbrella, so the route does too. Guarding on the narrower grant alone
+    // turned the Create control into a door that closed on a holder the API
+    // would have served.
+    requiredPermission: [...API_KEY_ACTION_PERMISSIONS.create],
     section: overridableBy("settings"),
   },
   [ROUTES.SETTINGS_API_KEYS_EDIT]: {

--- a/packages/admin/src/pages/registry.ts
+++ b/packages/admin/src/pages/registry.ts
@@ -11,7 +11,7 @@ import {
   collectionContentSection,
   overridableBy,
 } from "../lib/navigation/section-resolvers";
-import { API_KEY_ACTION_PERMISSIONS } from "../lib/permissions/api-key-actions";
+import { apiKeyGrantsFor } from "../lib/permissions/api-key-actions";
 import type { PageProps } from "../lib/routing";
 import type { RouteSection } from "../types/route-section";
 
@@ -470,7 +470,7 @@ export const routeConfig: Record<string, RouteConfig> = {
     // umbrella, so the route does too. Guarding on the narrower grant alone
     // turned the Create control into a door that closed on a holder the API
     // would have served.
-    requiredPermission: [...API_KEY_ACTION_PERMISSIONS.create],
+    requiredPermission: apiKeyGrantsFor("create"),
     section: overridableBy("settings"),
   },
   [ROUTES.SETTINGS_API_KEYS_EDIT]: {

--- a/packages/nextly/src/api/api-keys.ts
+++ b/packages/nextly/src/api/api-keys.ts
@@ -26,6 +26,10 @@ import { z } from "zod";
 import { isErrorResponse, requireAnyPermission } from "../auth/middleware";
 import { toNextlyAuthError } from "../auth/middleware/to-nextly-error";
 import { container } from "../di";
+import {
+  apiKeyPermissionsFor,
+  type ApiKeyOperation,
+} from "../domains/auth/api-key-policy";
 import type { ApiKeyService } from "../domains/auth/services/api-key-service";
 import { NextlyError } from "../errors/nextly-error";
 import { getCachedNextly } from "../init";
@@ -50,14 +54,11 @@ async function getApiKeyService(): Promise<ApiKeyService> {
   return container.get<ApiKeyService>("apiKeyService");
 }
 
-async function requireApiKeyPermission(
-  req: Request,
-  action: "create" | "read" | "update" | "delete"
-) {
-  return requireAnyPermission(req, [
-    { action, resource: "api-keys" },
-    { action: "update", resource: "api-keys" },
-  ]);
+async function requireApiKeyPermission(req: Request, action: ApiKeyOperation) {
+  // The policy is declared once, in `domains/auth/api-key-policy`, because the
+  // admin's route guards and controls gate on the same question and drifted
+  // from it before.
+  return requireAnyPermission(req, apiKeyPermissionsFor(action));
 }
 
 /**

--- a/packages/nextly/src/config.ts
+++ b/packages/nextly/src/config.ts
@@ -262,3 +262,14 @@ export {
 } from "./services/upload-validation/mime";
 export type { AcceptedFormat } from "./services/upload-validation/mime";
 export type { WebFontFormat } from "./services/upload-validation/web-fonts";
+
+// The API-key authorization policy. Exported here so the admin's route guards
+// and controls derive from the same declaration the endpoints enforce, rather
+// than restating the action-or-update umbrella a second time.
+export {
+  API_KEY_RESOURCE,
+  API_KEY_ACTION_POLICY,
+  apiKeyPermissionsFor,
+  apiKeyPermissionSlugsFor,
+  type ApiKeyOperation,
+} from "./domains/auth/api-key-policy";

--- a/packages/nextly/src/domains/auth/__tests__/api-key-policy.test.ts
+++ b/packages/nextly/src/domains/auth/__tests__/api-key-policy.test.ts
@@ -1,0 +1,89 @@
+/**
+ * The API-key authorization policy, and that both shapes come from it.
+ *
+ * The endpoints, the admin's route guards and the admin's controls all ask
+ * which grants reach one operation. When that rule was written twice they
+ * disagreed: the list route demanded `update-api-keys` while the endpoint
+ * accepted `read-api-keys`, so a reader who could fetch keys over the API was
+ * turned away from the page that shows them.
+ *
+ * @module domains/auth/__tests__/api-key-policy.test
+ */
+import { describe, expect, it } from "vitest";
+
+import { permissionSlug } from "../../../schemas/_zod/rbac";
+import {
+  API_KEY_ACTION_POLICY,
+  API_KEY_RESOURCE,
+  apiKeyPermissionSlugsFor,
+  apiKeyPermissionsFor,
+  type ApiKeyOperation,
+} from "../api-key-policy";
+
+const OPERATIONS: ApiKeyOperation[] = ["read", "create", "update", "delete"];
+
+describe("the API-key policy", () => {
+  /**
+   * The umbrella is the whole reason this cannot be read off the slug names.
+   * `update-api-keys` reaches every operation; the others reach only their own.
+   */
+  it("lets update reach every operation", () => {
+    for (const operation of OPERATIONS) {
+      expect(API_KEY_ACTION_POLICY[operation], operation).toContain("update");
+    }
+  });
+
+  it("lets each other action reach only its own operation", () => {
+    for (const operation of OPERATIONS) {
+      const others = API_KEY_ACTION_POLICY[operation].filter(
+        action => action !== "update"
+      );
+      expect(others, operation).toEqual(
+        operation === "update" ? [] : [operation]
+      );
+    }
+  });
+});
+
+describe("the two shapes the policy produces", () => {
+  it("names one resource in the permission objects", () => {
+    for (const operation of OPERATIONS) {
+      const permissions = apiKeyPermissionsFor(operation);
+      expect(permissions.length, operation).toBeGreaterThan(0);
+      expect(
+        permissions.every(p => p.resource === API_KEY_RESOURCE),
+        operation
+      ).toBe(true);
+    }
+  });
+
+  /**
+   * The slugs are the same permissions, composed through `permissionSlug` —
+   * which states that the string is built there and nowhere else, so a change
+   * to its shape reaches the admin too.
+   */
+  it("derives the slugs from the same actions", () => {
+    for (const operation of OPERATIONS) {
+      expect(apiKeyPermissionSlugsFor(operation), operation).toEqual(
+        apiKeyPermissionsFor(operation).map(p =>
+          permissionSlug(p.action, p.resource)
+        )
+      );
+    }
+  });
+
+  /**
+   * The property the whole module exists for, stated as an assertion rather
+   * than left to the two call sites: reading is authorised by read OR update.
+   */
+  it("authorises reading by read or update", () => {
+    expect(apiKeyPermissionSlugsFor("read").sort()).toEqual([
+      "read-api-keys",
+      "update-api-keys",
+    ]);
+  });
+
+  it("authorises editing by update alone", () => {
+    expect(apiKeyPermissionSlugsFor("update")).toEqual(["update-api-keys"]);
+  });
+});

--- a/packages/nextly/src/domains/auth/api-key-policy.ts
+++ b/packages/nextly/src/domains/auth/api-key-policy.ts
@@ -1,0 +1,56 @@
+import { permissionSlug } from "../../schemas/_zod/rbac";
+
+/** The RBAC resource every API-key permission names. */
+export const API_KEY_RESOURCE = "api-keys";
+
+/** The operations an API key supports, as the HTTP surface exposes them. */
+export type ApiKeyOperation = "read" | "create" | "update" | "delete";
+
+/**
+ * Which actions authorise each API-key operation.
+ *
+ * Every entry is the operation's own action plus `update`, which is the
+ * umbrella: a holder of `update-api-keys` may do anything to a key, so it
+ * appears beside each of the others and alone under `update`.
+ *
+ * Declared once because three surfaces ask the same question and must agree —
+ * the endpoints that enforce it, the admin routes that decide who may open a
+ * page, and the admin controls that decide which buttons to render. When they
+ * disagreed, the list route demanded `update-api-keys` while the endpoint
+ * accepted `read-api-keys`, so a reader who could fetch keys over the API was
+ * turned away from the page that displays them.
+ *
+ * @module domains/auth/api-key-policy
+ */
+export const API_KEY_ACTION_POLICY = {
+  read: ["read", "update"],
+  create: ["create", "update"],
+  update: ["update"],
+  delete: ["delete", "update"],
+} as const satisfies Record<ApiKeyOperation, readonly string[]>;
+
+/**
+ * The permissions that authorise one operation, for `requireAnyPermission`.
+ *
+ * Any-of: holding any one of them is enough.
+ */
+export function apiKeyPermissionsFor(
+  operation: ApiKeyOperation
+): { action: string; resource: string }[] {
+  return API_KEY_ACTION_POLICY[operation].map(action => ({
+    action,
+    resource: API_KEY_RESOURCE,
+  }));
+}
+
+/**
+ * The same permissions as slugs, for callers that hold grant strings.
+ *
+ * Through `permissionSlug`, which composes that string here and nowhere else,
+ * so a change to the slug shape reaches this too.
+ */
+export function apiKeyPermissionSlugsFor(operation: ApiKeyOperation): string[] {
+  return API_KEY_ACTION_POLICY[operation].map(action =>
+    permissionSlug(action, API_KEY_RESOURCE)
+  );
+}


### PR DESCRIPTION
## Why this exists separately

#1462 merged at `ff40d1e57`. This commit was pushed to that branch after the merge was computed, so it is not on main. Verified by content: `mayPerformApiKeyAction` and `API_KEY_ACTION_PERMISSIONS` return **0 files** on `origin/main`.

It is the follow-up to a finding raised on #1462, and it closes a gap that PR opened.

## The defect

#1462 widened `SETTINGS_API_KEYS` to admit `read-api-keys`, because the endpoint behind it already accepted that grant — `requireApiKeyPermission` authorises every API-key endpoint as an any-of: *the action's own grant, OR `update-api-keys`*. The route had been narrower than the API it fronts, so a reader who could fetch the list was turned away from the page that shows it.

That was right, and it left the page unguarded. `ApiKeysPage` rendered **Create** unconditionally, and `rowActions` returned **Edit** and **Revoke** for every active key. A reader admitted by the widened route was therefore offered three controls, each leading somewhere that refuses them — which reads as the product being broken rather than as a permission they do not hold.

## The fix

The server's rule is declared once, in `lib/permissions/api-key-actions.ts`, and the UI consumes it:

| control | grants |
|---|---|
| Create | `create-api-keys` or `update-api-keys` |
| Edit | `update-api-keys` |
| Revoke | `delete-api-keys` or `update-api-keys` |

The umbrella is why this cannot be read off the slug names: `update-api-keys` reaches all four operations, while the others reach only their own. `API_KEYS_LIST_PERMISSIONS` is now derived from that table's `read` entry rather than spelled a second time.

`canEdit` and `canRevoke` on `ApiKeyTable` are **required props, not defaulted**. A default of `true` would leave any call site that forgets them offering refused actions, which is the failure this change exists to remove — and the compiler immediately caught the one existing call site.

## Evidence

Three tests, each seen to fail for its intended reason:

- both controls offered when permitted — the positive control, so the absences below are the gate and not a query that never matches
- neither offered to a read-only viewer
- **revoke offered without edit**, because the grants are separate and the two controls cannot be gated together

Break-verified by ungating `rowActions`: two of the three fail.

## One thing this introduces, stated rather than left to be found

Reading permissions in this page closes an import cycle:

```
useCurrentUserPermissions → useRouter → lib/routing → pages/registry → settings/api-keys/index → back
```

The closing edge is `useCurrentUserPermissions → useRouter`, which exists only to gate the `/me/permissions` fetch on the route being private. `lib/routing.ts` imports the page registry — its own comment at line 58 says so — therefore **any** permission read inside that graph does this. `pages/dashboard/roles.tsx` and the two landing redirects already do; this is the fourth instance, not a new shape.

The repo carries this as `task:arch-circular-dependencies` (45 cycles), scheduled after the page-builder phase. Breaking it means removing `useRouter` from the permissions hook, which changes a widely-used signature.

I took the cycle over the alternative, which is leaving controls that 403. Happy to drop the gating instead if that trade is judged the wrong way round.

## Verification

- `pnpm --filter @nextlyhq/admin check-types` — clean
- api-keys, sidebar, hooks and pages suites — 464 tests passing
- `fallow audit`: `duplication_introduced` and `styling_introduced` 0. It reports the cycle above, and `DualSidebar` complexity — which is inherited (main: cyclomatic 39 / cognitive 68 / CRAP 1560) and reattributed because the function body changed.
