### PR TITLE
fix(builder): a preview refusal that cannot be fooled by a spelling

### DIFF
--- a/.changeset/a-preview-cannot-be-fooled-by-a-spelling.md
+++ b/.changeset/a-preview-cannot-be-fooled-by-a-spelling.md
@@ -1,0 +1,53 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The tokens panel refuses to preview a value carrying a `var()`, because a reference
+there resolves against the PANEL's own custom properties rather than the canvas's and
+would draw a colour or a size the published page does not have. It asked that question
+with a regex over the raw text.
+
+A CSS function token is an identifier immediately followed by `(`, and the identifier
+is read decoded — so `v\61 r(--nx-measure-wide)` is a `var()` to a browser and was not
+one to that regex. It was previewed, resolving against the admin `--nx-*` namespace,
+which resolves in the panel and which no published page emits. The preview was
+confidently wrong rather than merely absent, which is the failure the guard exists to
+prevent.
+
+`referencesCustomProperty` is a new export from `@nextlyhq/blocks-engine`. It parses
+the value and compares decoded function names, so it also sees a reference nested
+inside a `calc()` or inside a fallback, and it answers "yes" for a value it cannot
+parse — a caller is deciding whether to draw something, and declining to draw a value
+that would not have rendered costs nothing.
+
+It lives in the engine because the engine owns CSS semantics and already held every
+part. Three modules had answered this question three ways, on purpose: `contrast.ts`
+decodes, `dtcg.ts` reads raw and documents that a var() with an escaped name is then
+read as invalid rather than dynamic, and `css-value.ts` had the parser and the decoder
+but kept the comparison private. A fourth answer written in the panel would have been
+the defect rather than the fix — and the raw reading that is safe in `dtcg` fails in
+the opposite direction here, where unseen means drawn.

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -255,6 +255,7 @@ export {
   // decode it the same way, or `font\2d family` reads as a different property
   // here than it does in a browser.
   decodeIdentifier,
+  referencesCustomProperty,
   // The other direction, public for the same reason. A caller that decoded a
   // name to compare it has to escape it again before writing it back, or a name
   // holding a space or a quote is emitted as tokens the parser reads apart.

--- a/packages/blocks-engine/src/style/css-value.ts
+++ b/packages/blocks-engine/src/style/css-value.ts
@@ -1094,6 +1094,84 @@ function hasStringChild(children: Iterable<CssNode>): boolean {
  */
 const MAX_VALUE_NESTING = 32;
 
+/**
+ * Whether CSS would make a custom-property substitution anywhere in this value.
+ *
+ * The question, not a spelling. A function token is an identifier immediately
+ * followed by `(`, and the identifier is read DECODED — so `v\61 r(--brand)` IS
+ * a `var()` to a browser, and any reader matching the literal text `var(` says it
+ * is not. That gap is a known sanitiser-bypass shape rather than a curiosity: it
+ * is how `url(` and `expression(` filters were historically defeated.
+ *
+ * **Exported because the answer must not be re-derived per consumer.** The
+ * builder's tokens panel refuses to preview a value carrying a reference, since
+ * a `var()` there resolves against the PANEL's own `--nx-*` properties and would
+ * draw a colour the canvas does not have. It asked that question with a regex
+ * over the raw text, so an escaped spelling was previewed — precisely the false
+ * preview the guard exists to prevent.
+ *
+ * **Not the same choice `dtcg.ts` makes, deliberately.** That module reads the
+ * raw spelling on purpose, and says so: a `var()` with an escaped name is then
+ * read as invalid rather than dynamic, which is safe THERE because its grammar
+ * refuses the parentheses anyway. The two want opposite defaults — reading raw
+ * fails closed for dtcg and fails OPEN for a preview, where unseen means drawn.
+ *
+ * **An unparseable value answers `true`.** It cannot be shown not to substitute,
+ * and every caller is deciding whether to render something whose appearance would
+ * be wrong; declining to draw a value that would not have rendered anyway costs
+ * nothing, while drawing one that substitutes is the defect. Fail-closed is a
+ * property of the question rather than of this implementation.
+ *
+ * `env()` is excluded. It substitutes, but from user-agent values that are the
+ * same in a panel and on a canvas, so it cannot produce the disagreement this
+ * exists to catch.
+ */
+export function referencesCustomProperty(value: string): boolean {
+  const parsed = parseValue(value);
+  if (parsed === null) return true;
+  return walkForVarCall(parsed, 0);
+}
+
+function walkForVarCall(node: CssNode, depth: number): boolean {
+  // Depth-bounded for the reason the URL walk is: parsing and walking are both
+  // recursive, so a deeply nested value exhausts the stack. Answering TRUE at
+  // the cap keeps the refusal fail-closed rather than declaring a value clean
+  // because it was too deep to read.
+  if (depth >= MAX_VALUE_NESTING) return true;
+  // A fallback arrives as raw text rather than as parsed children, so a
+  // reference nested inside one — `var(--a, v\61 r(--b))` — is invisible to a
+  // walk that only descends `children`.
+  if (node.type === "Raw") return rawCarriesVarCall(node.value, depth);
+  if (isVarCall(node)) return true;
+  for (const child of childrenOf(node)) {
+    if (walkForVarCall(child, depth + 1)) return true;
+  }
+  return false;
+}
+
+/** Whether THIS node is the substitution, as CSS reads its name. */
+function isVarCall(node: CssNode): boolean {
+  return node.type === "Function" && identifierOf(node) === "var";
+}
+
+/** A `var()` fallback, which the parser hands back as unparsed text. */
+function rawCarriesVarCall(text: string, depth: number): boolean {
+  const inner = parseValue(text);
+  return inner !== null && walkForVarCall(inner, depth + 1);
+}
+
+/**
+ * The children a node carries, or none.
+ *
+ * Separated so the walk reads as one loop rather than a guard and a loop. A
+ * node whose `children` is absent or null is a leaf, and a leaf has nothing to
+ * descend into — which is the same answer as an empty list.
+ */
+function childrenOf(node: CssNode): Iterable<CssNode> {
+  if (!("children" in node) || node.children === null) return [];
+  return node.children;
+}
+
 /** True when a stored string is longer than any declaration should carry. */
 export function isOverlongValue(value: string): boolean {
   return value.length > MAX_VALUE_LENGTH;

--- a/packages/blocks-engine/src/style/references-custom-property.test.ts
+++ b/packages/blocks-engine/src/style/references-custom-property.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Whether CSS would substitute a custom property in a value.
+ *
+ * The question this answers is not "does the text contain `var(`". A CSS
+ * function token is an identifier immediately followed by `(`, and the
+ * identifier is read DECODED — so a spelling nobody would type by hand is a
+ * `var()` to a browser and is not one to a reader matching the literal text.
+ *
+ * These are written as a table of SPELLINGS against one expectation, because
+ * every defect in this area is one spelling reaching a reader that only knew
+ * another.
+ */
+import { describe, expect, it } from "vitest";
+
+import { referencesCustomProperty } from "./css-value";
+
+describe("a value that CSS would substitute into", () => {
+  it.each([
+    ["the plain spelling", "var(--brand)"],
+    ["a hex-escaped name", "v\\61 r(--brand)"],
+    ["an escaped name in capitals", "V\\41 R(--brand)"],
+    ["nested inside calc()", "calc(v\\61 r(--x) * 2)"],
+    [
+      "nested inside a FALLBACK, which arrives as raw text",
+      "var(--a, v\\61 r(--b))",
+    ],
+    ["a shadow whose colour is a reference", "0 1px 2px var(--shadow)"],
+  ])("is found: %s", (_label, value) => {
+    expect(referencesCustomProperty(value)).toBe(true);
+  });
+
+  it.each([
+    ["a length", "1rem"],
+    ["a hex colour", "#ffffff"],
+    ["a function that is not var()", "rgba(0, 0, 0, 0.2)"],
+    ["a shadow of plain parts", "0 1px 2px rgba(0,0,0,.2)"],
+    ["a font stack", "system-ui, sans-serif"],
+  ])("is not found: %s", (_label, value) => {
+    expect(referencesCustomProperty(value)).toBe(false);
+  });
+
+  it("does not report env(), which resolves the same everywhere", () => {
+    /*
+     * `env()` substitutes too, and it is deliberately NOT this question. Its
+     * values come from the user agent and are identical in a panel and on a
+     * canvas, so it cannot produce the disagreement this predicate exists to
+     * catch. Asserted rather than left implicit, because "any substitution"
+     * is the obvious wrong generalisation of the name.
+     */
+    expect(referencesCustomProperty("env(safe-area-inset-top)")).toBe(false);
+  });
+
+  it.each([")", "var(", "a; b", "@media"])(
+    "answers TRUE for %s, which it cannot parse",
+    value => {
+      /*
+       * Fail-closed, and the branch is reachable — these really do fail to
+       * parse, which is why they are listed rather than described. A caller is
+       * deciding whether to DRAW something; declining to draw a value that
+       * would not have rendered costs nothing, and drawing one that substitutes
+       * is the defect.
+       */
+      expect(referencesCustomProperty(value)).toBe(true);
+    }
+  );
+
+  it("is not satisfied by the raw spelling alone", () => {
+    /*
+     * The control that names the defect. A regex over the raw text — which is
+     * what the tokens panel used — agrees with this predicate on the plain
+     * spelling and disagrees on the escaped one. If a future implementation
+     * regressed to matching text, this is the case that separates them.
+     */
+    const raw = (value: string) => /var\s*\(/i.test(value);
+
+    expect(raw("var(--brand)")).toBe(referencesCustomProperty("var(--brand)"));
+    expect(raw("v\\61 r(--brand)")).toBe(false);
+    expect(referencesCustomProperty("v\\61 r(--brand)")).toBe(true);
+  });
+});

--- a/packages/builder/src/tokens-panel.test.tsx
+++ b/packages/builder/src/tokens-panel.test.tsx
@@ -1292,6 +1292,61 @@ describe("the panel explains itself and shows the whole set", () => {
     expect(slots.every(slot => slot.childElementCount === 0)).toBe(true);
   });
 
+  it("draws NOTHING for a reference spelled with a CSS escape", () => {
+    /*
+     * The same rule as the case above, asked of a spelling the old guard could
+     * not see.
+     *
+     * A CSS function token is an identifier immediately followed by `(`, read
+     * DECODED — so `v\61 r(--nx-measure-wide)` is a `var()` to a browser. The
+     * panel matched `/var\s*\(/i` against the RAW text, so this was previewed
+     * and resolved against the panel's own `--nx-*` properties, which is exactly
+     * the false preview the guard exists to prevent. The admin namespace is the
+     * point: it resolves HERE and no published page emits it, so the preview
+     * would have been confidently wrong rather than merely absent.
+     *
+     * The question is now asked of `referencesCustomProperty`, which parses and
+     * compares decoded function names, so a reference nested in a `calc()` or a
+     * fallback is caught too.
+     */
+    mount({
+      tokens: [
+        {
+          name: "size.escaped",
+          kind: "dimension",
+          values: { light: "v\\61 r(--nx-measure-wide)" },
+        },
+        {
+          name: "size.nested",
+          kind: "dimension",
+          values: { light: "calc(v\\61 r(--nx-measure-wide) * 2)" },
+        },
+      ],
+    });
+
+    expect(document.querySelector(".nx-tokens__bar")).toBeNull();
+    // The slot is still there and EMPTY, so the column does not go ragged —
+    // refusing to draw is not the same as dropping the row.
+    const slots = Array.from(document.querySelectorAll(".nx-tokens__preview"));
+    expect(slots.length).toBe(2);
+    expect(slots.every(slot => slot.childElementCount === 0)).toBe(true);
+  });
+
+  it("still draws a plain value, so the refusal is about references", () => {
+    /*
+     * The must-differ control. Every assertion above passes by finding nothing,
+     * so a change that stopped previewing dimensions entirely — or a predicate
+     * that answered TRUE for everything — would satisfy them all.
+     */
+    mount({
+      tokens: [
+        { name: "size.plain", kind: "dimension", values: { light: "2rem" } },
+      ],
+    });
+
+    expect(document.querySelector(".nx-tokens__bar")).not.toBeNull();
+  });
+
   it("draws no preview for a token the ENGINE refuses to write", () => {
     /*
      * Preview eligibility is the engine's verdict, not a second rule here. A

--- a/packages/builder/src/tokens-panel.tsx
+++ b/packages/builder/src/tokens-panel.tsx
@@ -35,6 +35,7 @@
  */
 import {
   TOKEN_KINDS,
+  referencesCustomProperty,
   tokenIdentity,
   type SiteToken,
   type SiteTokenSet,
@@ -1237,9 +1238,21 @@ function drawableValue(row: TokenRow): string | undefined {
    * engine writes a `var()` happily, but it resolves against the canvas's
    * custom properties and this panel has its own — so drawing it here would
    * show a value the page does not have.
+   *
+   * ASKED OF THE ENGINE, not matched here. This read `/var\s*\(/i` against the
+   * raw text, and a CSS function token is an identifier followed by `(` with the
+   * identifier read DECODED — so `v\61 r(--nx-measure-wide)` is a `var()` to a
+   * browser and was not one to that regex. It was previewed, resolving against
+   * this panel's own `--nx-*` properties, which is the exact false preview the
+   * guard exists to prevent.
+   *
+   * `referencesCustomProperty` parses and compares decoded function names, so it
+   * also sees a reference nested in a `calc()` or inside a fallback. A fourth
+   * hand-written answer to "is this a var()" — after `contrast.ts`, `dtcg.ts` and
+   * `css-value.ts` — is the defect rather than the fix.
    */
   const own = row.value.trim();
-  if (own === "" || /var\s*\(/i.test(own)) return undefined;
+  if (own === "" || referencesCustomProperty(own)) return undefined;
   return own;
 }
 


### PR DESCRIPTION
Closes the last of the three findings left on #1458.

## The defect

The tokens panel declines to preview a value carrying a `var()`, because a reference resolves against the **panel's** own custom properties rather than the canvas's and would draw something the published page does not have. It asked that question with `/var\s*\(/i` over the raw text.

A CSS function token is an identifier immediately followed by `(`, and the identifier is read **decoded**. Measured against the old guard:

```
REFUSED  var(--nx-measure-wide)
DRAWN    v\61 r(--nx-measure-wide)
DRAWN    V\41 R(--nx-x)
DRAWN    calc(v\61 r(--nx-x) * 2)
```

What got drawn resolved against the admin `--nx-*` namespace — which resolves *in the panel* and which no published page emits. So the preview was confidently wrong rather than merely absent, which is exactly the failure the guard exists to prevent.

## Why a new engine export rather than a better regex

The engine owns CSS semantics and already held every part: a css-tree value AST, `decodeIdentifier`, `asciiLower`, and a private `identifierOf` doing precisely this comparison on function names.

Three modules had already answered this question three ways, each on purpose:

| module | reads | why |
| --- | --- | --- |
| `contrast.ts` | decoded | `r\67 b(...)` IS `rgb(...)`; only the NAME may carry escapes |
| `dtcg.ts` | raw, deliberately | a `var()` with an escaped name reads as invalid, and its grammar refuses it anyway — fails **closed** |
| `css-value.ts` | decoded | has the parser and decoder, kept the comparison private |

The panel read raw like `dtcg` — and the identical choice fails in the **opposite** direction. There, unseen means refused; here, unseen means **drawn**. So this is not "copy dtcg", and a fourth hand-written answer in the builder would have been the defect rather than the fix.

`referencesCustomProperty(value: string): boolean` is named after the question, not a spelling. It also catches a reference nested inside a `calc()` or inside a **fallback** — a fallback arrives as unparsed text and is invisible to a walk that only descends children.

## Two decisions stated rather than left implicit

**An unparseable value answers `true`.** The branch is reachable rather than theoretical — `)`, `var(`, `a; b` and `@media` all reach it. A caller is deciding whether to *draw* something; declining to draw a value that would not have rendered costs nothing, while drawing one that substitutes is the defect.

**`env()` is excluded.** It substitutes, but from user-agent values identical in a panel and on a canvas, so it cannot produce the disagreement this exists to catch. Asserted, because "any substitution" is the obvious wrong generalisation of the name.

## Evidence

Break-verified by failing test name, in both directions:

```
restore the raw-text guard      -> x draws NOTHING for a reference spelled with a CSS escape
predicate answers TRUE always   -> x still draws a plain value, so the refusal is about references
                                   (plus 3 others — the control exists because every other
                                    assertion here passes by finding nothing)
```

The walk is four small functions rather than one. Written as a single function it came out at cyclomatic 10 / CRAP 31.6, which `fallow --gate new-only` attributed as **introduced** and failed on — correctly, since it was new code and not a line shifted by the edit. After decomposing: `complexity_introduced: 0`, `verdict: pass`.

1734 tests in `blocks-engine`, 2764 in `builder`; `check-types`, `lint`, `lint:design` and `build` all pass.
