### PR TITLE
fix(nextly): give the served bound a floor that cannot move

### DIFF
--- a/.changeset/a-served-bound-that-never-shrinks.md
+++ b/.changeset/a-served-bound-that-never-shrinks.md
@@ -1,0 +1,39 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The bound the public byte route reads under only ever grows now, because
+each of its inputs is unreliable in a different direction. A row written
+before the stored size was taken from the validated bytes can understate
+what it points at, and an installation that lowers `security.limits.fileSize`
+moves the configured cap below objects it accepted earlier. With both true at
+once, every number derived from present state sits under the real object and a
+font stored legitimately stops being served, permanently.
+
+Keeping the route's long-standing default as a floor is what closes that: it
+is not derived from present state, so no configuration change and no
+mis-recorded row can push the bound below what was servable before.

--- a/packages/nextly/src/api/media-raw.test.ts
+++ b/packages/nextly/src/api/media-raw.test.ts
@@ -167,16 +167,44 @@ describe("the public byte route", () => {
     container.registerSingleton("config", () => ({
       security: { limits: { fileSize: "1mb" } },
     }));
-    storedAs("font/woff2", 2 * 1024 * 1024);
+    // Above the floor, so the row is what carries this case rather than the
+    // constant underneath it.
+    storedAs("font/woff2", 12 * 1024 * 1024);
 
     expect((await getRaw("m1")).status).toBe(200);
     const [, options] = mocks.adapter.read.mock.calls[0] as [
       string,
       { maxBytes: number },
     ];
-    expect(options.maxBytes).toBe(2 * 1024 * 1024);
+    expect(options.maxBytes).toBe(12 * 1024 * 1024);
     // Not the lowered policy, which would have refused the stored object.
     expect(options.maxBytes).not.toBe(1024 * 1024);
+  });
+
+  it("serves a legacy row that UNDERSTATES its object under a lowered cap", async () => {
+    /*
+     * The combination the other cases miss when taken one at a time. A row
+     * written before the size came from the validated bytes can record less
+     * than the object holds — `LegacyMediaService.uploadMedia` persists what
+     * the caller declared — and if the install has since lowered its cap below
+     * the real size, BOTH of the state-derived numbers sit under the object.
+     *
+     * The floor is what answers this: it is not derived from present state, so
+     * no configuration change and no bad row can push it down.
+     */
+    container.registerSingleton("config", () => ({
+      security: { limits: { fileSize: "1mb" } },
+    }));
+    // 2MB of object, recorded as one byte.
+    storedAs("font/woff2", 1);
+
+    expect((await getRaw("m1")).status).toBe(200);
+    const [, options] = mocks.adapter.read.mock.calls[0] as [
+      string,
+      { maxBytes: number },
+    ];
+    expect(options.maxBytes).toBe(DEFAULT_READ_MAX_BYTES);
+    expect(options.maxBytes).toBeGreaterThan(2 * 1024 * 1024);
   });
 
   it("keeps the configured cap when the row understates its object", async () => {
@@ -197,6 +225,8 @@ describe("the public byte route", () => {
       { maxBytes: number },
     ];
     expect(options.maxBytes).toBe(20 * 1024 * 1024);
+    // Above the floor, so this case is the policy term and not the constant.
+    expect(options.maxBytes).toBeGreaterThan(DEFAULT_READ_MAX_BYTES);
   });
 
   it("falls back to the default bound when no cap is configured", async () => {

--- a/packages/nextly/src/api/media-raw.ts
+++ b/packages/nextly/src/api/media-raw.ts
@@ -30,6 +30,7 @@ import {
   matchesWebFontSignature,
   WEB_FONT_MIME_TYPES,
 } from "../services/upload-validation/web-fonts";
+import { DEFAULT_READ_MAX_BYTES } from "../storage/fetch-stored-bytes";
 import { readStoredMediaBytes } from "../storage/read-stored-media";
 import { getMediaStorage } from "../storage/storage";
 
@@ -129,26 +130,29 @@ export async function handleServeMediaBytes(
    * including the local one this route was supposed to work on first.
    */
   /*
-   * The smallest bound that cannot refuse an object this product legitimately
-   * stored, which needs BOTH terms:
+   * A bound that only ever grows, because every input to it is unreliable in a
+   * different direction and none can be trusted alone:
    *
-   * - The row's own recorded size, because the policy describes what may be
-   *   written NEXT and not what was accepted historically. Lowering
-   *   `security.limits.fileSize` would otherwise strand every larger font
-   *   already in the store, permanently, on a route with no way to say so.
-   * - The current cap, because a row written before the size was taken from
-   *   the validated bytes can understate its object, and a bound that trusts
-   *   an understated number refuses the very file it was widened to serve.
+   * - `DEFAULT_READ_MAX_BYTES` is the floor: the bound this route has applied
+   *   for its whole existence. Keeping it means no configuration change can
+   *   make an object that was servable yesterday unservable today, which no
+   *   number derived from present state can promise.
+   * - The row's recorded size covers an object larger than that floor. It is
+   *   the only input describing THIS object, but a row written before the size
+   *   was taken from the validated bytes can understate what it points at, so
+   *   it cannot be the bound on its own.
+   * - The configured cap covers an install that raised it: a font accepted
+   *   moments earlier under a 20mb policy is larger than the floor and larger
+   *   than nothing else here would allow.
    *
-   * A constant was neither, and refused a font accepted moments earlier under
-   * a configured cap larger than it. Both numbers are written by this product
-   * rather than supplied by a caller: the media services record the length of
-   * the bytes they actually stored.
+   * Taking the largest is what makes the three failure modes disjoint. Lower
+   * any one of them and some legitimately stored font stops being served —
+   * measured, one per case, in this route's tests.
    */
   const bytes = await readStoredMediaBytes(
     getMediaStorage().getAdapterForCollection(MEDIA_COLLECTION),
     media.filename,
-    Math.max(media.size, resolveUploadPolicy().maxSize)
+    Math.max(DEFAULT_READ_MAX_BYTES, media.size, resolveUploadPolicy().maxSize)
   );
   // The row outlived its object. Same answer as a row that never existed,
   // because from outside they are the same thing: there is no font here.


### PR DESCRIPTION
Follow-up to #1468, from a finding raised on it after it merged.

## The gap

Each input to the byte route's read bound is unreliable in a different direction:

- **the row's recorded size** can understate its object — `LegacyMediaService.uploadMedia` persists the size the caller declared, so any row written before that number came from the validated bytes may point at something larger;
- **the configured cap** describes what may be written next, not what was accepted historically, so lowering `security.limits.fileSize` moves it below objects already stored.

`max(row, policy)` handles either one alone. With **both** true at once — a legacy row that understates *and* a cap since lowered below the real size — every number derived from present state sits under the object, and a legitimately stored font stops being served. Permanently, on a route that cannot explain itself.

## The fix

`Math.max(DEFAULT_READ_MAX_BYTES, media.size, resolveUploadPolicy().maxSize)`.

The route's long-standing default becomes a **floor**. It is the one input not derived from present state, so no configuration change and no mis-recorded row can push the bound below what was servable before. The row and the policy raise it from there; nothing lowers it.

That is the "independent historical read ceiling" the finding suggested, and it needs no new constant — it is the bound this route already applied for its whole existence. The alternative it offered, a trustworthy stored-object size, is not universally available: `getMetadata()` is optional on `IStorageAdapter` and only `storage-s3` and `storage-vercel-blob` implement it, so a local self-hosted install — the common case — would keep the gap.

## Evidence

Each term break-verified independently. Removing any one strands a different class of font:

| mutation | test that fails |
| --- | --- |
| drop the floor → `max(row, policy)` | understated row under a lowered cap |
| drop the row → `max(floor, policy)` | font stored under a cap since lowered |
| drop the policy → `max(floor, row)` | configured cap above the floor, twice |

The two pre-existing cases were also tightened: both now use sizes **above** the floor, so they exercise the term they are named for rather than being satisfied by the constant underneath.

Unit suite 869 files / 10926 passed. check-types, lint, fallow gate all clean (0 introduced). Changeset validated with `changeset status`.