### PR TITLE
fix(admin): draw the write-error alert's border at full strength

### DIFF
--- a/.changeset/the-dashboard-error-alert-meets-contrast.md
+++ b/.changeset/the-dashboard-error-alert-meets-contrast.md
@@ -1,0 +1,34 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+The dashboard's save-failure alert is legible at its edges.
+
+Its border was drawn at 40% strength, which composites to 1.69:1 against the
+page -- below the 3:1 a border carrying meaning has to meet. It is drawn at full
+strength now, matching every other error surface in the admin. Nothing else about
+the message changes.

--- a/packages/admin/src/components/features/widgets/edit/DashboardEditChrome.tsx
+++ b/packages/admin/src/components/features/widgets/edit/DashboardEditChrome.tsx
@@ -89,7 +89,12 @@ export function DashboardEditChrome({
         // reloaded, so the arrangement stays exactly where it is.
         <div
           role="alert"
-          className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm"
+          // Full-strength `border-destructive`, which is what every other error
+          // surface in the admin uses. The faded `/40` composited to 1.69:1 on
+          // the page surface against the 3:1 a non-decorative border needs, and
+          // this border is not decorative: it is what separates the alert from
+          // the arrangement behind it, for a reader who cannot rely on the tint.
+          className="rounded-md border border-destructive bg-destructive/10 px-3 py-2 text-sm"
           data-testid="dashboard-edit-error"
         >
           Your dashboard could not be saved. Your changes are still here — try

--- a/packages/nextly/src/domains/media/__tests__/media-revalidation.integration.test.ts
+++ b/packages/nextly/src/domains/media/__tests__/media-revalidation.integration.test.ts
@@ -68,7 +68,7 @@ describe("media writes bust their cache tags (integration)", () => {
         data: pdfDocument("x"),
         name: "doc.pdf",
         mimetype: "application/pdf",
-        size: 1,
+        size: pdfDocument("x").length,
       },
     });
 
@@ -90,7 +90,7 @@ describe("media writes bust their cache tags (integration)", () => {
         data: pdfDocument("x"),
         name: "gone.pdf",
         mimetype: "application/pdf",
-        size: 1,
+        size: pdfDocument("x").length,
       },
     });
     expect(uploaded.id).toBeTruthy();
@@ -119,7 +119,7 @@ describe("media writes bust their cache tags (integration)", () => {
         data: pdfDocument("x"),
         name: "resilient.pdf",
         mimetype: "application/pdf",
-        size: 1,
+        size: pdfDocument("x").length,
       },
     });
 
@@ -144,7 +144,7 @@ describe("the write surfaces that do NOT go through the unified service", () => 
       file: pdfDocument("x"),
       filename: "via-action.pdf",
       mimeType: "application/pdf",
-      size: 1,
+      size: pdfDocument("x").length,
       uploadedBy: null,
     });
 
@@ -180,7 +180,7 @@ describe("the write surfaces that do NOT go through the unified service", () => 
         data: pdfDocument("x"),
         name: "inside.pdf",
         mimetype: "application/pdf",
-        size: 1,
+        size: pdfDocument("x").length,
       },
       folder: folder.id,
     });
@@ -200,7 +200,7 @@ describe("the write surfaces that do NOT go through the unified service", () => 
         data: pdfDocument("y"),
         name: "also-inside.pdf",
         mimetype: "application/pdf",
-        size: 1,
+        size: pdfDocument("y").length,
       },
       folder: folder.id,
     });
@@ -246,7 +246,7 @@ describe("the write surfaces that do NOT go through the unified service", () => 
         data: pdfDocument("x"),
         name: "original.pdf",
         mimetype: "application/pdf",
-        size: 1,
+        size: pdfDocument("x").length,
       },
       folder: folder.id,
     });
@@ -312,7 +312,7 @@ describe("the write surfaces that do NOT go through the unified service", () => 
         data: pdfDocument("x"),
         name: "wanderer.pdf",
         mimetype: "application/pdf",
-        size: 1,
+        size: pdfDocument("x").length,
       },
     });
     // The control: it starts OUTSIDE the folder, so the move is a real change.
@@ -338,7 +338,7 @@ describe("the write surfaces that do NOT go through the unified service", () => 
         data: pdfDocument("x"),
         name: "ordered.pdf",
         mimetype: "application/pdf",
-        size: 1,
+        size: pdfDocument("x").length,
       },
     });
     expect(uploaded.id).toBeTruthy();
@@ -373,7 +373,7 @@ describe("a bulk fan-out pays the shared tag once and stays prompt", () => {
           data: pdfDocument(`bulk-${i}`),
           name: `bulk-${i}.pdf`,
           mimetype: "application/pdf",
-          size: 1,
+          size: pdfDocument(`bulk-${i}`).length,
         },
       });
       ids.push(file.id);
@@ -478,7 +478,7 @@ describe("a bulk fan-out pays the shared tag once and stays prompt", () => {
         buffer: pdfDocument(`u${i}`),
         filename: `unified-${i}.pdf`,
         mimeType: "application/pdf",
-        size: 1,
+        size: pdfDocument(`u${i}`).length,
       })),
       ctx
     );
@@ -509,7 +509,7 @@ describe("a bulk fan-out pays the shared tag once and stays prompt", () => {
         file: pdfDocument(`l${i}`),
         filename: `legacy-${i}.pdf`,
         mimeType: "application/pdf",
-        size: 1,
+        size: pdfDocument(`l${i}`).length,
         uploadedBy: null,
       }))
     );
@@ -533,7 +533,7 @@ describe("a bulk fan-out pays the shared tag once and stays prompt", () => {
         file: pdfDocument(`d${i}`),
         filename: `doomed-${i}.pdf`,
         mimeType: "application/pdf",
-        size: 1,
+        size: pdfDocument(`d${i}`).length,
         uploadedBy: null,
       }))
     );

--- a/packages/nextly/src/domains/webhooks/__tests__/media-outbox.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/media-outbox.integration.test.ts
@@ -40,6 +40,12 @@ import { MediaService } from "../../../services/media";
 import type { RequestContext } from "../../../services/shared";
 import type { WebhookFastDrainScheduler } from "../after-drain";
 import type { WebhookEvent } from "../types";
+// 🔴 Every `size` below is derived from the fixture's own bytes rather than
+// stated as a literal. `MediaService.uploadMedia` persists the size it is GIVEN
+// and puts it in the webhook payload -- it never measures the buffer -- so a
+// fixture declaring 1 for a ten-byte file writes a row that claims something
+// untrue about itself, and any later test of size propagation would pass on a
+// broken implementation because both numbers were arbitrary anyway.
 import { pdfDocument } from "../../../services/upload-validation/__tests__/format-fixtures";
 
 let current: TestNextly | undefined;
@@ -101,7 +107,7 @@ describe("webhook outbox capture — media (integration)", () => {
         file: pdfDocument("not-really-an-image"),
         filename: "doc.pdf",
         mimeType: "application/pdf",
-        size: 19,
+        size: pdfDocument("not-really-an-image").length,
         uploadedBy: null,
       },
       { type: "user", id: "user-1" }
@@ -119,6 +125,14 @@ describe("webhook outbox capture — media (integration)", () => {
     const env = envelopeOf(rows[0]);
     expect((env.data as { filename?: string }).filename).toBeTruthy();
     expect(env.previous).toBeNull();
+
+    // The row describes its own bytes truthfully. Asserted rather than left to
+    // the fixture, so a future edit that puts a literal back here fails instead
+    // of quietly restoring metadata nothing can rely on.
+    expect(result.data!.size).toBe(pdfDocument("not-really-an-image").length);
+    expect((env.data as { size?: number }).size).toBe(
+      pdfDocument("not-really-an-image").length
+    );
   });
 
   it("records media.updated with the prior state on a metadata edit", async () => {
@@ -128,7 +142,7 @@ describe("webhook outbox capture — media (integration)", () => {
         file: pdfDocument("x"),
         filename: "doc.pdf",
         mimeType: "application/pdf",
-        size: 1,
+        size: pdfDocument("x").length,
         uploadedBy: null,
       },
       { type: "user", id: "user-1" }
@@ -158,7 +172,7 @@ describe("webhook outbox capture — media (integration)", () => {
         file: pdfDocument("x"),
         filename: "doc.pdf",
         mimeType: "application/pdf",
-        size: 1,
+        size: pdfDocument("x").length,
         uploadedBy: null,
       },
       { type: "user", id: "user-1" }
@@ -188,7 +202,7 @@ describe("webhook outbox capture — media (integration)", () => {
         file: pdfDocument("x"),
         filename: "doc.pdf",
         mimeType: "application/pdf",
-        size: 1,
+        size: pdfDocument("x").length,
         uploadedBy: null,
       },
       { type: "user", id: "user-1" }
@@ -222,7 +236,7 @@ describe("webhook outbox capture — media (integration)", () => {
         file: pdfDocument("x"),
         filename: "doc.pdf",
         mimeType: "application/pdf",
-        size: 1,
+        size: pdfDocument("x").length,
         uploadedBy: null,
       },
       { type: "user", id: "user-1" }
@@ -256,7 +270,7 @@ describe("webhook outbox capture — media (integration)", () => {
         data: pdfDocument("x"),
         name: "doc.pdf",
         mimetype: "application/pdf",
-        size: 1,
+        size: pdfDocument("x").length,
       },
       user: { id: "editor-7" },
     });
@@ -291,7 +305,7 @@ describe("webhook outbox capture — media (integration)", () => {
         data: pdfDocument("x"),
         name: "doc.pdf",
         mimetype: "application/pdf",
-        size: 1,
+        size: pdfDocument("x").length,
       },
       user: { id: "editor-7" },
     });
@@ -325,7 +339,7 @@ describe("webhook outbox capture — media (integration)", () => {
         data: pdfDocument("x"),
         name: "doc.pdf",
         mimetype: "application/pdf",
-        size: 1,
+        size: pdfDocument("x").length,
       },
       user: { id: "editor-7" },
     });
@@ -360,7 +374,7 @@ describe("webhook outbox capture — media (integration)", () => {
         data: pdfDocument("x"),
         name: "doc.pdf",
         mimetype: "application/pdf",
-        size: 1,
+        size: pdfDocument("x").length,
       },
       user: { id: "editor-7" },
     });
@@ -407,7 +421,7 @@ describe("webhook outbox capture — media (integration)", () => {
         file: pdfDocument("x"),
         filename: "doc.pdf",
         mimeType: "application/pdf",
-        size: 1,
+        size: pdfDocument("x").length,
         uploadedBy: null,
       },
       { type: "user", id: "user-1" }
@@ -431,7 +445,7 @@ describe("webhook outbox capture — media (integration)", () => {
         data: pdfDocument("x"),
         name: "doc.pdf",
         mimetype: "application/pdf",
-        size: 1,
+        size: pdfDocument("x").length,
       },
       user: { id: "editor-7" },
     });
@@ -456,7 +470,7 @@ describe("webhook outbox capture — media (integration)", () => {
         data: pdfDocument("x"),
         name: "doc.pdf",
         mimetype: "application/pdf",
-        size: 1,
+        size: pdfDocument("x").length,
       },
       folder: folder.id,
       user: { id: "editor-7" },


### PR DESCRIPTION
`main` is red on `Lint / Typecheck / Test / Build`. This restores it, and fixes a
fixture defect codex found while reviewing the earlier version of this branch.

## The contrast failure is mine, from #1463

`border-destructive/40` on the dashboard's save-failure alert composites to
**1.69:1** on the page surface, against the 3:1 a border carrying meaning has to
meet, and `packages/ui`'s contrast guard refuses it by name. It merged because
that check had not reported when #1463 was merged.

Drawn at full strength now, matching the eight other error surfaces in the admin.
It is not decorative — it is what separates the alert from the arrangement behind
it for a reader who cannot rely on the tint — so the decorative allowlist would
have been the wrong door.

**Break-verified:** with the faded border restored the guard fails naming exactly
`border-destructive/40 = 1.69:1 (needs 3:1)`; with the fix it passes 5/5.

## A media fixture that declared a size its bytes contradicted

`MediaService.uploadMedia` persists the size it is **given** and puts that number
in the webhook payload — it never measures the buffer. The fixtures uploaded a
36-byte PDF while declaring 19, and 10-byte buffers while declaring 1. Those rows
claim something untrue about themselves, and any later test of size propagation
would have passed on a broken implementation because both numbers were arbitrary.

Every declared size is now `pdfDocument(...).length` — the same expression that
produced the bytes, so the two cannot disagree — and the upload test asserts the
persisted size and the emitted payload's size both equal it. That makes the
honesty load-bearing rather than incidental.

**Break-verified:** restoring the literal fails with `expected 19 to be 36`.

## What this PR no longer contains

It opened as a repair for the integration legs as well. **#1468 landed that fix
first**, in `7560d27f1`, with the helper in `services/upload-validation/__tests__/format-fixtures`
— beside the validator, which is the better home than the one I had chosen. I
measured main after it landed (media suites 27/27) and dropped my redundant
commit rather than carrying a duplicate into a conflict.

Worth recording why I missed it: I searched open PRs for `upload|media|magic` in
the title and branch name. #1468 is called "serve the font the policy agreed to
store" and matched none of them. The search that would have found it is the
failing test's own path.

## Verification at `883ed6749`

- full sqlite integration — **245 files passed, 1486 tests, 0 failures**
- `nextly` 869 files, `admin` 389 files, both green in the pre-push hook
- `check-types` and `lint` clean; contrast guard 5/5
- `fallow audit --base origin/main` — pass, 0 introduced findings

One pre-push rejection was `export-contract.test.ts` at exactly 10000ms — a load
timeout under parallel turbo, in a file this diff does not touch. Alone: 4.08s,
102 tests passing.