### PR TITLE
test(nextly): take a media fixture's bytes and its size from one buffer

### DIFF
--- a/packages/nextly/src/domains/media/__tests__/media-revalidation.integration.test.ts
+++ b/packages/nextly/src/domains/media/__tests__/media-revalidation.integration.test.ts
@@ -25,6 +25,16 @@ import {
 } from "../../../plugins/test-nextly";
 import { pdfDocument } from "../../../services/upload-validation/__tests__/format-fixtures";
 
+// 🔴 ONE buffer per fixture, reused for both the uploaded bytes and the size
+// that describes them. `MediaService` persists the size it is GIVEN and puts it
+// in the webhook payload -- it never measures the buffer -- so a declared size
+// taken from a SEPARATE `pdfDocument(...)` call describes a throwaway. The two
+// agree today only because the helper happens to be deterministic; if it ever
+// gains call-dependent output they diverge silently, which is precisely the
+// guarantee this is here to make unbreakable.
+const PDF_X = pdfDocument("x");
+const PDF_Y = pdfDocument("y");
+
 let current: TestNextly | undefined;
 
 afterEach(async () => {
@@ -65,10 +75,10 @@ describe("media writes bust their cache tags (integration)", () => {
 
     const uploaded = await handle.nextly.media.upload({
       file: {
-        data: pdfDocument("x"),
+        data: PDF_X,
         name: "doc.pdf",
         mimetype: "application/pdf",
-        size: pdfDocument("x").length,
+        size: PDF_X.length,
       },
     });
 
@@ -87,10 +97,10 @@ describe("media writes bust their cache tags (integration)", () => {
 
     const uploaded = await handle.nextly.media.upload({
       file: {
-        data: pdfDocument("x"),
+        data: PDF_X,
         name: "gone.pdf",
         mimetype: "application/pdf",
-        size: pdfDocument("x").length,
+        size: PDF_X.length,
       },
     });
     expect(uploaded.id).toBeTruthy();
@@ -116,10 +126,10 @@ describe("media writes bust their cache tags (integration)", () => {
     // while it sits in storage.
     const uploaded = await handle.nextly.media.upload({
       file: {
-        data: pdfDocument("x"),
+        data: PDF_X,
         name: "resilient.pdf",
         mimetype: "application/pdf",
-        size: pdfDocument("x").length,
+        size: PDF_X.length,
       },
     });
 
@@ -141,10 +151,10 @@ describe("the write surfaces that do NOT go through the unified service", () => 
     const legacy = new LegacyMediaService(handle.adapter, console as never);
 
     const result = await legacy.uploadMedia({
-      file: pdfDocument("x"),
+      file: PDF_X,
       filename: "via-action.pdf",
       mimeType: "application/pdf",
-      size: pdfDocument("x").length,
+      size: PDF_X.length,
       uploadedBy: null,
     });
 
@@ -177,10 +187,10 @@ describe("the write surfaces that do NOT go through the unified service", () => 
     const folder = await unified.createFolder({ name: "doomed" }, ctx);
     const uploaded = await handle.nextly.media.upload({
       file: {
-        data: pdfDocument("x"),
+        data: PDF_X,
         name: "inside.pdf",
         mimetype: "application/pdf",
-        size: pdfDocument("x").length,
+        size: PDF_X.length,
       },
       folder: folder.id,
     });
@@ -197,10 +207,10 @@ describe("the write surfaces that do NOT go through the unified service", () => 
     // statement about a single-element list.
     const second = await handle.nextly.media.upload({
       file: {
-        data: pdfDocument("y"),
+        data: PDF_Y,
         name: "also-inside.pdf",
         mimetype: "application/pdf",
-        size: pdfDocument("y").length,
+        size: PDF_Y.length,
       },
       folder: folder.id,
     });
@@ -243,10 +253,10 @@ describe("the write surfaces that do NOT go through the unified service", () => 
 
     const original = await handle.nextly.media.upload({
       file: {
-        data: pdfDocument("x"),
+        data: PDF_X,
         name: "original.pdf",
         mimetype: "application/pdf",
-        size: pdfDocument("x").length,
+        size: PDF_X.length,
       },
       folder: folder.id,
     });
@@ -309,10 +319,10 @@ describe("the write surfaces that do NOT go through the unified service", () => 
 
     const uploaded = await handle.nextly.media.upload({
       file: {
-        data: pdfDocument("x"),
+        data: PDF_X,
         name: "wanderer.pdf",
         mimetype: "application/pdf",
-        size: pdfDocument("x").length,
+        size: PDF_X.length,
       },
     });
     // The control: it starts OUTSIDE the folder, so the move is a real change.
@@ -335,10 +345,10 @@ describe("the write surfaces that do NOT go through the unified service", () => 
     const { handle, flush } = await bootWithSpy();
     const uploaded = await handle.nextly.media.upload({
       file: {
-        data: pdfDocument("x"),
+        data: PDF_X,
         name: "ordered.pdf",
         mimetype: "application/pdf",
-        size: pdfDocument("x").length,
+        size: PDF_X.length,
       },
     });
     expect(uploaded.id).toBeTruthy();
@@ -368,12 +378,13 @@ describe("a bulk fan-out pays the shared tag once and stays prompt", () => {
   ): Promise<string[]> {
     const ids: string[] = [];
     for (let i = 0; i < count; i++) {
+      const pdf = pdfDocument(`bulk-${i}`);
       const file = await handle.nextly.media.upload({
         file: {
-          data: pdfDocument(`bulk-${i}`),
+          data: pdf,
           name: `bulk-${i}.pdf`,
           mimetype: "application/pdf",
-          size: pdfDocument(`bulk-${i}`).length,
+          size: pdf.length,
         },
       });
       ids.push(file.id);
@@ -474,12 +485,15 @@ describe("a bulk fan-out pays the shared tag once and stays prompt", () => {
 
     flush.mockClear();
     const result = await unified.bulkUpload(
-      [0, 1, 2].map(i => ({
-        buffer: pdfDocument(`u${i}`),
-        filename: `unified-${i}.pdf`,
-        mimeType: "application/pdf",
-        size: pdfDocument(`u${i}`).length,
-      })),
+      [0, 1, 2].map(i => {
+        const pdf = pdfDocument(`u${i}`);
+        return {
+          buffer: pdf,
+          filename: `unified-${i}.pdf`,
+          mimeType: "application/pdf",
+          size: pdf.length,
+        };
+      }),
       ctx
     );
 
@@ -505,13 +519,16 @@ describe("a bulk fan-out pays the shared tag once and stays prompt", () => {
 
     flush.mockClear();
     const result = await legacy.uploadMediaBulk(
-      [0, 1, 2].map(i => ({
-        file: pdfDocument(`l${i}`),
-        filename: `legacy-${i}.pdf`,
-        mimeType: "application/pdf",
-        size: pdfDocument(`l${i}`).length,
-        uploadedBy: null,
-      }))
+      [0, 1, 2].map(i => {
+        const pdf = pdfDocument(`l${i}`);
+        return {
+          file: pdf,
+          filename: `legacy-${i}.pdf`,
+          mimeType: "application/pdf",
+          size: pdf.length,
+          uploadedBy: null,
+        };
+      })
     );
 
     expect(result.successCount).toBe(3);
@@ -529,13 +546,16 @@ describe("a bulk fan-out pays the shared tag once and stays prompt", () => {
     const { handle, flush } = await bootWithSpy();
     const legacy = new LegacyMediaService(handle.adapter, console as never);
     const uploaded = await legacy.uploadMediaBulk(
-      [0, 1, 2].map(i => ({
-        file: pdfDocument(`d${i}`),
-        filename: `doomed-${i}.pdf`,
-        mimeType: "application/pdf",
-        size: pdfDocument(`d${i}`).length,
-        uploadedBy: null,
-      }))
+      [0, 1, 2].map(i => {
+        const pdf = pdfDocument(`d${i}`);
+        return {
+          file: pdf,
+          filename: `doomed-${i}.pdf`,
+          mimeType: "application/pdf",
+          size: pdf.length,
+          uploadedBy: null,
+        };
+      })
     );
     expect(uploaded.successCount).toBe(3);
     const ids = uploaded.results

--- a/packages/nextly/src/domains/webhooks/__tests__/media-outbox.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/media-outbox.integration.test.ts
@@ -48,6 +48,16 @@ import type { WebhookEvent } from "../types";
 // broken implementation because both numbers were arbitrary anyway.
 import { pdfDocument } from "../../../services/upload-validation/__tests__/format-fixtures";
 
+// 🔴 ONE buffer per fixture, reused for both the uploaded bytes and the size
+// that describes them. `MediaService` persists the size it is GIVEN and puts it
+// in the webhook payload -- it never measures the buffer -- so a declared size
+// taken from a SEPARATE `pdfDocument(...)` call describes a throwaway. The two
+// agree today only because the helper happens to be deterministic; if it ever
+// gains call-dependent output they diverge silently, which is precisely the
+// guarantee this is here to make unbreakable.
+const PDF_NOT_REALLY_AN_IMAGE = pdfDocument("not-really-an-image");
+const PDF_X = pdfDocument("x");
+
 let current: TestNextly | undefined;
 
 afterEach(async () => {
@@ -104,10 +114,10 @@ describe("webhook outbox capture — media (integration)", () => {
     const media = service(current!);
     const result = await media.uploadMedia(
       {
-        file: pdfDocument("not-really-an-image"),
+        file: PDF_NOT_REALLY_AN_IMAGE,
         filename: "doc.pdf",
         mimeType: "application/pdf",
-        size: pdfDocument("not-really-an-image").length,
+        size: PDF_NOT_REALLY_AN_IMAGE.length,
         uploadedBy: null,
       },
       { type: "user", id: "user-1" }
@@ -129,9 +139,9 @@ describe("webhook outbox capture — media (integration)", () => {
     // The row describes its own bytes truthfully. Asserted rather than left to
     // the fixture, so a future edit that puts a literal back here fails instead
     // of quietly restoring metadata nothing can rely on.
-    expect(result.data!.size).toBe(pdfDocument("not-really-an-image").length);
+    expect(result.data!.size).toBe(PDF_NOT_REALLY_AN_IMAGE.length);
     expect((env.data as { size?: number }).size).toBe(
-      pdfDocument("not-really-an-image").length
+      PDF_NOT_REALLY_AN_IMAGE.length
     );
   });
 
@@ -139,10 +149,10 @@ describe("webhook outbox capture — media (integration)", () => {
     const media = service(current!);
     const uploaded = await media.uploadMedia(
       {
-        file: pdfDocument("x"),
+        file: PDF_X,
         filename: "doc.pdf",
         mimeType: "application/pdf",
-        size: pdfDocument("x").length,
+        size: PDF_X.length,
         uploadedBy: null,
       },
       { type: "user", id: "user-1" }
@@ -169,10 +179,10 @@ describe("webhook outbox capture — media (integration)", () => {
     const media = service(current!);
     const uploaded = await media.uploadMedia(
       {
-        file: pdfDocument("x"),
+        file: PDF_X,
         filename: "doc.pdf",
         mimeType: "application/pdf",
-        size: pdfDocument("x").length,
+        size: PDF_X.length,
         uploadedBy: null,
       },
       { type: "user", id: "user-1" }
@@ -199,10 +209,10 @@ describe("webhook outbox capture — media (integration)", () => {
     const media = service(current!);
     const uploaded = await media.uploadMedia(
       {
-        file: pdfDocument("x"),
+        file: PDF_X,
         filename: "doc.pdf",
         mimeType: "application/pdf",
-        size: pdfDocument("x").length,
+        size: PDF_X.length,
         uploadedBy: null,
       },
       { type: "user", id: "user-1" }
@@ -233,10 +243,10 @@ describe("webhook outbox capture — media (integration)", () => {
     const media = service(current!);
     const uploaded = await media.uploadMedia(
       {
-        file: pdfDocument("x"),
+        file: PDF_X,
         filename: "doc.pdf",
         mimeType: "application/pdf",
-        size: pdfDocument("x").length,
+        size: PDF_X.length,
         uploadedBy: null,
       },
       { type: "user", id: "user-1" }
@@ -267,10 +277,10 @@ describe("webhook outbox capture — media (integration)", () => {
     await seedUser(current!, "editor-7");
     const uploaded = await nextly.media.upload({
       file: {
-        data: pdfDocument("x"),
+        data: PDF_X,
         name: "doc.pdf",
         mimetype: "application/pdf",
-        size: pdfDocument("x").length,
+        size: PDF_X.length,
       },
       user: { id: "editor-7" },
     });
@@ -302,10 +312,10 @@ describe("webhook outbox capture — media (integration)", () => {
     await seedUser(current!, "editor-7");
     const uploaded = await nextly.media.upload({
       file: {
-        data: pdfDocument("x"),
+        data: PDF_X,
         name: "doc.pdf",
         mimetype: "application/pdf",
-        size: pdfDocument("x").length,
+        size: PDF_X.length,
       },
       user: { id: "editor-7" },
     });
@@ -336,10 +346,10 @@ describe("webhook outbox capture — media (integration)", () => {
     });
     const uploaded = await nextly.media.upload({
       file: {
-        data: pdfDocument("x"),
+        data: PDF_X,
         name: "doc.pdf",
         mimetype: "application/pdf",
-        size: pdfDocument("x").length,
+        size: PDF_X.length,
       },
       user: { id: "editor-7" },
     });
@@ -371,10 +381,10 @@ describe("webhook outbox capture — media (integration)", () => {
     });
     const uploaded = await nextly.media.upload({
       file: {
-        data: pdfDocument("x"),
+        data: PDF_X,
         name: "doc.pdf",
         mimetype: "application/pdf",
-        size: pdfDocument("x").length,
+        size: PDF_X.length,
       },
       user: { id: "editor-7" },
     });
@@ -418,10 +428,10 @@ describe("webhook outbox capture — media (integration)", () => {
 
     await legacy.uploadMedia(
       {
-        file: pdfDocument("x"),
+        file: PDF_X,
         filename: "doc.pdf",
         mimeType: "application/pdf",
-        size: pdfDocument("x").length,
+        size: PDF_X.length,
         uploadedBy: null,
       },
       { type: "user", id: "user-1" }
@@ -442,10 +452,10 @@ describe("webhook outbox capture — media (integration)", () => {
 
     await current!.nextly.media.upload({
       file: {
-        data: pdfDocument("x"),
+        data: PDF_X,
         name: "doc.pdf",
         mimetype: "application/pdf",
-        size: pdfDocument("x").length,
+        size: PDF_X.length,
       },
       user: { id: "editor-7" },
     });
@@ -467,10 +477,10 @@ describe("webhook outbox capture — media (integration)", () => {
 
     const uploaded = await nextly.media.upload({
       file: {
-        data: pdfDocument("x"),
+        data: PDF_X,
         name: "doc.pdf",
         mimetype: "application/pdf",
-        size: pdfDocument("x").length,
+        size: PDF_X.length,
       },
       folder: folder.id,
       user: { id: "editor-7" },


### PR DESCRIPTION
Follow-up to a codex finding on #1477, which had already merged. Test-only, so no
changeset.

## What was wrong

Each fixture site called `pdfDocument(...)` **twice** — once for the uploaded
bytes and once for the declared size:

```ts
data: pdfDocument("x"),
size: pdfDocument("x").length,   // a DIFFERENT buffer
```

`MediaService.uploadMedia` persists the size it is given and puts that number in
the webhook payload; it never measures the buffer. So the metadata described a
throwaway rather than the bytes actually uploaded. The two agree today only
because the helper happens to be deterministic — and if it ever gains
call-dependent output they diverge silently, which is precisely the guarantee
#1477 set out to establish.

I had considered the local-variable form and dismissed it, reasoning that both
expressions were textually identical so they could not drift. That reasoning was
wrong in the way that matters: identical *expressions* are not the same *value*
unless the function is pure, and nothing in the fixture's contract promises that.
One buffer cannot disagree with its own length under any implementation.

## The change

- the three fixed markers become one module-level buffer each
  (`PDF_X`, `PDF_Y`, `PDF_NOT_REALLY_AN_IMAGE`)
- the four sites inside loops build theirs once per iteration, which meant
  turning three concise `map` callbacks into blocks

Nothing now derives a size from a buffer other than the one it describes —
checkable directly: every remaining `pdfDocument(` call is either a constant
declaration or a loop-local binding.

## Verification

- both media suites — **27/27**
- `nextly` unit suite — 870 files green in the pre-push hook
- `check-types` and `lint` clean; `fallow audit --base origin/main` pass, 0
  introduced findings
- **break-verified**: restoring a literal `size: 19` fails with
  `expected 19 to be 36`

One thing worth flagging for whoever reviews: my first attempt at this rewrite
replaced `pdfDocument("x")` inside the constant declarations too, producing
`const PDF_X = PDF_X;`. `check-types` caught it (`TS7022`, `TS2448`) and the
suites failed to collect. Repaired and re-verified from a clean state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved media integration test fixtures by reusing generated PDF data across upload scenarios.
  * Ensured uploaded file contents and declared sizes remain consistent in single, folder, bulk, legacy, and direct API test cases.
  * No changes to application functionality, API behavior, or user-visible media workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->