### PR TITLE
feat(nextly): offer a metric and a recent-entries card for every collection

### DIFF
--- a/.changeset/a-card-for-every-collection.md
+++ b/.changeset/a-card-for-every-collection.md
@@ -1,0 +1,45 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Your dashboard can show your own content.
+
+Every collection your project has now offers two cards through the "Add a
+widget" picker: how many entries it holds, and the entries changed most
+recently. They are built from the collections your install actually has, read
+when the page loads -- so a collection you draw in the Schema Builder can be
+added to your dashboard straight away, without a restart.
+
+They are OFFERED, never placed for you. An install with forty collections would
+otherwise open onto eighty cards you did not ask for, and removing seventy-seven
+of them is not a dashboard. Add the ones you want.
+
+A card only appears where it can be honest. A collection with no field that names
+its entries gets no "recent" list, because every row would read as an identifier;
+one with no timestamps gets none either, because "recently" would have nothing to
+sort by. And each card carries the same permission that gates the collection, so
+you are only offered cards for content you can read.

--- a/packages/admin/src/components/features/entries/entry-title.ts
+++ b/packages/admin/src/components/features/entries/entry-title.ts
@@ -16,37 +16,19 @@
  */
 
 /**
- * Field names that conventionally hold a title, in preference order.
+ * Which field NAMES an entry, and the conventional names used when nothing is
+ * nominated.
  *
- * `subject` and `heading` are here because a mail-like or article-like
- * collection names its entries with them, and a reader scanning a list of
- * either sees nothing useful without them.
+ * Re-exported from core rather than defined here. The server resolves the same
+ * question -- the activity feed labels a row with it, and the dashboard's
+ * generated list widgets pick a row label with it before the query is made --
+ * so the rule lives beside the collection domain and both sides ask it. Kept
+ * exported from this module because this is where the admin's entry-title
+ * questions are answered from.
  */
-export const COMMON_TITLE_FIELDS = [
-  "title",
-  "name",
-  "label",
-  "subject",
-  "heading",
-] as const;
+import { COMMON_TITLE_FIELDS, entryTitleField } from "nextly/config";
 
-/**
- * The field that names an entry, from the author's choice then convention.
- *
- * `undefined` where neither applies, so a caller can tell "no conventional
- * title field" from "the title field is empty" and answer each in its own way.
- */
-export function entryTitleField(
-  useAsTitle: string | undefined,
-  fieldNames: readonly string[]
-): string | undefined {
-  // `id` is not a title even when nominated: it is what the fallbacks already
-  // show, and treating it as one would hide a real title field behind it.
-  if (useAsTitle && useAsTitle !== "id" && fieldNames.includes(useAsTitle)) {
-    return useAsTitle;
-  }
-  return COMMON_TITLE_FIELDS.find(name => fieldNames.includes(name));
-}
+export { COMMON_TITLE_FIELDS, entryTitleField };
 
 /**
  * A value counts as a title if it is a scalar with something in it.

--- a/packages/admin/src/components/features/widgets/edit/__tests__/WidgetGrid.edit.test.tsx
+++ b/packages/admin/src/components/features/widgets/edit/__tests__/WidgetGrid.edit.test.tsx
@@ -650,6 +650,38 @@ describe("cancelling after a write failed", () => {
   });
 });
 
+describe("when the schema changes underneath an open dashboard", () => {
+  it("re-reads the arrangement, so the picker knows what exists now", () => {
+    // 🔴 The layout endpoint answers which cards are PLACED and which are
+    // OFFERED, and a schema change moves both: a collection created a moment ago
+    // has cards to add, one just deleted no longer does. Nothing else
+    // invalidates this key -- `refetchOnWindowFocus` is the only other route --
+    // so a dashboard left open kept a picker that could not add the new card and
+    // still offered the removed one, whose save is then refused.
+    renderGrid();
+
+    return waitFor(() => expect(api.get).toHaveBeenCalledTimes(1)).then(() => {
+      act(() => {
+        window.dispatchEvent(new Event("nextly:schema-updated"));
+      });
+      return waitFor(() => expect(api.get).toHaveBeenCalledTimes(2));
+    });
+  });
+
+  it("does not re-read on an unrelated event", () => {
+    // The control: without it the assertion above is satisfied by a query that
+    // refetches on anything at all, including its own render.
+    renderGrid();
+
+    return waitFor(() => expect(api.get).toHaveBeenCalledTimes(1)).then(() => {
+      act(() => {
+        window.dispatchEvent(new Event("nextly:something-else"));
+      });
+      expect(api.get).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
 describe("an arrangement that already holds as many cards as a write may carry", () => {
   /** `MAX_PLACEMENTS` placed cards, with one more offered by the picker. */
   function atCapacity() {

--- a/packages/admin/src/context/RestartContext.tsx
+++ b/packages/admin/src/context/RestartContext.tsx
@@ -19,6 +19,7 @@ import {
   type ReactNode,
 } from "react";
 
+import { DASHBOARD_LAYOUT_KEY } from "@admin/hooks/queries/useDashboardLayout";
 import { ADMIN_META_KEY } from "@admin/hooks/useSchemaUpdateInvalidation";
 
 import { fieldGroupKeys } from "../hooks/queries";
@@ -101,6 +102,10 @@ export function RestartProvider({ children }: { children: ReactNode }) {
         // cards core derives per collection. Without it the picker offers a new
         // collection's card under its raw id and the grid cannot draw it.
         void queryClient.invalidateQueries({ queryKey: ADMIN_META_KEY });
+        // And the dashboard layout, which answers which cards are placed and
+        // which are offered. Both go stale for the same reason and neither is
+        // reachable from the other's key.
+        void queryClient.invalidateQueries({ queryKey: DASHBOARD_LAYOUT_KEY });
       } else {
         toast.error(message ?? "Failed to apply schema changes");
       }

--- a/packages/admin/src/context/RestartContext.tsx
+++ b/packages/admin/src/context/RestartContext.tsx
@@ -19,6 +19,8 @@ import {
   type ReactNode,
 } from "react";
 
+import { ADMIN_META_KEY } from "@admin/hooks/useSchemaUpdateInvalidation";
+
 import { fieldGroupKeys } from "../hooks/queries";
 
 interface RestartContextValue {
@@ -95,6 +97,10 @@ export function RestartProvider({ children }: { children: ReactNode }) {
         void queryClient.invalidateQueries({ queryKey: ["singles"] });
         void queryClient.invalidateQueries({ queryKey: ["single-documents"] });
         void queryClient.invalidateQueries({ queryKey: fieldGroupKeys.all() });
+        // The workspace payload carries the widget declarations, including the
+        // cards core derives per collection. Without it the picker offers a new
+        // collection's card under its raw id and the grid cannot draw it.
+        void queryClient.invalidateQueries({ queryKey: ADMIN_META_KEY });
       } else {
         toast.error(message ?? "Failed to apply schema changes");
       }

--- a/packages/admin/src/context/providers/BrandingProvider.tsx
+++ b/packages/admin/src/context/providers/BrandingProvider.tsx
@@ -4,7 +4,10 @@ import { useQuery } from "@tanstack/react-query";
 import type React from "react";
 import { createContext, useContext, useEffect, useMemo } from "react";
 
-import { useSchemaUpdateInvalidation } from "@admin/hooks/useSchemaUpdateInvalidation";
+import {
+  ADMIN_META_KEY,
+  useSchemaUpdateInvalidation,
+} from "@admin/hooks/useSchemaUpdateInvalidation";
 
 import { useAuthSession } from "../../hooks/queries/useAuthSession";
 import { protectedApi } from "../../lib/api/protectedApi";
@@ -228,7 +231,7 @@ export function BrandingProvider({ children }: BrandingProviderProps) {
   // them stale — the workspace half carries the widget declarations, including
   // the cards core derives per collection. This provider owns them, so it is
   // the one that re-reads them.
-  useSchemaUpdateInvalidation();
+  useSchemaUpdateInvalidation(ADMIN_META_KEY);
 
   const {
     data: brandingData,

--- a/packages/admin/src/context/providers/BrandingProvider.tsx
+++ b/packages/admin/src/context/providers/BrandingProvider.tsx
@@ -4,6 +4,8 @@ import { useQuery } from "@tanstack/react-query";
 import type React from "react";
 import { createContext, useContext, useEffect, useMemo } from "react";
 
+import { useSchemaUpdateInvalidation } from "@admin/hooks/useSchemaUpdateInvalidation";
+
 import { useAuthSession } from "../../hooks/queries/useAuthSession";
 import { protectedApi } from "../../lib/api/protectedApi";
 import { publicApi } from "../../lib/api/publicApi";
@@ -222,6 +224,12 @@ interface BrandingProviderProps {
 }
 
 export function BrandingProvider({ children }: BrandingProviderProps) {
+  // Both queries below are cached for five minutes, and a schema change makes
+  // them stale — the workspace half carries the widget declarations, including
+  // the cards core derives per collection. This provider owns them, so it is
+  // the one that re-reads them.
+  useSchemaUpdateInvalidation();
+
   const {
     data: brandingData,
     // `isLoadingError`, not `isError`: the latter is also true when a

--- a/packages/admin/src/hooks/__tests__/useSchemaUpdateInvalidation.test.tsx
+++ b/packages/admin/src/hooks/__tests__/useSchemaUpdateInvalidation.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * The listener that re-reads the workspace declarations when the schema
+ * changes outside this tab.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  SCHEMA_UPDATED_EVENT,
+  useSchemaUpdateInvalidation,
+} from "../useSchemaUpdateInvalidation";
+
+function mounted() {
+  const client = new QueryClient();
+  const spy = vi.spyOn(client, "invalidateQueries").mockResolvedValue();
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  const view = renderHook(() => useSchemaUpdateInvalidation(), { wrapper });
+  const keys = () =>
+    spy.mock.calls.map(call => (call[0] as { queryKey: unknown[] }).queryKey);
+  return { view, keys };
+}
+
+describe("useSchemaUpdateInvalidation", () => {
+  it("re-reads admin-meta, which carries the widget declarations", () => {
+    // 🔴 The workspace payload is cached for five minutes while the layout
+    // endpoint answers fresh, so a collection created a moment ago is offered
+    // in the picker under its raw id — and adding it saves a placement the grid
+    // skips for want of a declaration to draw.
+    const { keys } = mounted();
+
+    window.dispatchEvent(new Event(SCHEMA_UPDATED_EVENT));
+
+    expect(keys()).toEqual([["admin-meta"]]);
+  });
+
+  it("does nothing until the event actually fires", () => {
+    // The control. Without it the assertion above is satisfied by a hook that
+    // invalidates on mount and never listens for anything.
+    const { keys } = mounted();
+    expect(keys()).toEqual([]);
+  });
+
+  it("stops listening when it unmounts", () => {
+    // A listener that outlives its provider invalidates into a detached cache
+    // on every later schema change.
+    const { view, keys } = mounted();
+    view.unmount();
+
+    window.dispatchEvent(new Event(SCHEMA_UPDATED_EVENT));
+
+    expect(keys()).toEqual([]);
+  });
+});

--- a/packages/admin/src/hooks/__tests__/useSchemaUpdateInvalidation.test.tsx
+++ b/packages/admin/src/hooks/__tests__/useSchemaUpdateInvalidation.test.tsx
@@ -12,20 +12,20 @@ import {
   useSchemaUpdateInvalidation,
 } from "../useSchemaUpdateInvalidation";
 
-function mounted() {
+function mounted(key: readonly unknown[] = ["admin-meta"]) {
   const client = new QueryClient();
   const spy = vi.spyOn(client, "invalidateQueries").mockResolvedValue();
   const wrapper = ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={client}>{children}</QueryClientProvider>
   );
-  const view = renderHook(() => useSchemaUpdateInvalidation(), { wrapper });
+  const view = renderHook(() => useSchemaUpdateInvalidation(key), { wrapper });
   const keys = () =>
     spy.mock.calls.map(call => (call[0] as { queryKey: unknown[] }).queryKey);
   return { view, keys };
 }
 
 describe("useSchemaUpdateInvalidation", () => {
-  it("re-reads admin-meta, which carries the widget declarations", () => {
+  it("re-reads the key it was given", () => {
     // 🔴 The workspace payload is cached for five minutes while the layout
     // endpoint answers fresh, so a collection created a moment ago is offered
     // in the picker under its raw id — and adding it saves a placement the grid
@@ -53,5 +53,17 @@ describe("useSchemaUpdateInvalidation", () => {
     window.dispatchEvent(new Event(SCHEMA_UPDATED_EVENT));
 
     expect(keys()).toEqual([]);
+  });
+
+  it("re-reads whichever key its OWNER passes", () => {
+    // 🔴 The key is a parameter because TWO queries go stale on a schema change
+    // and they belong to different modules — the declarations and the dashboard
+    // layout, which answers which cards are placed and which are offered. A hook
+    // naming both would make one module responsible for the other's freshness.
+    const { keys } = mounted(["dashboard", "layout"]);
+
+    window.dispatchEvent(new Event(SCHEMA_UPDATED_EVENT));
+
+    expect(keys()).toEqual([["dashboard", "layout"]]);
   });
 });

--- a/packages/admin/src/hooks/queries/useDashboardLayout.ts
+++ b/packages/admin/src/hooks/queries/useDashboardLayout.ts
@@ -36,6 +36,7 @@ import {
 } from "@tanstack/react-query";
 import { useCallback } from "react";
 
+import { useSchemaUpdateInvalidation } from "@admin/hooks/useSchemaUpdateInvalidation";
 import { protectedApi } from "@admin/lib/api/protectedApi";
 import type {
   DashboardLayoutResponse,
@@ -104,6 +105,13 @@ function nonConflictError(...errors: Array<Error | null>): Error | null {
 
 export function useDashboardLayout(): UseDashboardLayoutResult {
   const queryClient = useQueryClient();
+
+  // A schema change moves what this endpoint answers: a collection created a
+  // moment ago has cards to OFFER, and one just deleted no longer does. Nothing
+  // else invalidates this key — `refetchOnWindowFocus` is the only other route,
+  // so a dashboard left open would keep a picker that cannot add the new card
+  // and still offers the removed one, whose save is then refused.
+  useSchemaUpdateInvalidation(DASHBOARD_LAYOUT_KEY);
 
   const query = useQuery({
     queryKey: DASHBOARD_LAYOUT_KEY,

--- a/packages/admin/src/hooks/useSchemaUpdateInvalidation.ts
+++ b/packages/admin/src/hooks/useSchemaUpdateInvalidation.ts
@@ -1,0 +1,51 @@
+"use client";
+
+/**
+ * Re-read the workspace declarations when the schema changes.
+ *
+ * ## Why this is the branding provider's job
+ *
+ * `/api/admin-meta/workspace` carries the widget DECLARATIONS — including the
+ * cards core derives per collection — and this provider owns those queries and
+ * caches them for five minutes. The dashboard's layout endpoint, meanwhile,
+ * answers fresh: a collection created a moment ago is offered in the picker
+ * immediately. Without this the picker shows that card under its raw id,
+ * because no declaration has arrived to give it a title, and adding it saves a
+ * placement the grid then skips for want of anything to draw — addable, stored,
+ * and invisible until something else happens to refetch.
+ *
+ * The owner invalidates its own cache. `RootLayout` and `RestartContext` each
+ * re-read the CONTENT caches on the same events, and neither owns this one;
+ * putting `admin-meta` in their lists would make three components responsible
+ * for one query's freshness.
+ *
+ * ## The two events
+ *
+ * A schema change reaches this tab two ways, and both have to be heard: the
+ * Schema Builder's own apply dispatches nothing (it invalidates directly, so
+ * `RestartContext` names this key too), while a code-first edit or an apply in
+ * ANOTHER tab arrives as `nextly:schema-updated` from the fetcher's version
+ * header check.
+ *
+ * @module hooks/useSchemaUpdateInvalidation
+ */
+
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect } from "react";
+
+/** The event the fetcher dispatches on a schema version bump. */
+export const SCHEMA_UPDATED_EVENT = "nextly:schema-updated";
+
+/** The queries this provider owns, both halves of the admin-meta payload. */
+export const ADMIN_META_KEY = ["admin-meta"] as const;
+
+export function useSchemaUpdateInvalidation(): void {
+  const queryClient = useQueryClient();
+  useEffect(() => {
+    const handler = () => {
+      void queryClient.invalidateQueries({ queryKey: ADMIN_META_KEY });
+    };
+    window.addEventListener(SCHEMA_UPDATED_EVENT, handler);
+    return () => window.removeEventListener(SCHEMA_UPDATED_EVENT, handler);
+  }, [queryClient]);
+}

--- a/packages/admin/src/hooks/useSchemaUpdateInvalidation.ts
+++ b/packages/admin/src/hooks/useSchemaUpdateInvalidation.ts
@@ -1,9 +1,9 @@
 "use client";
 
 /**
- * Re-read the workspace declarations when the schema changes.
+ * Re-read a query the schema change invalidated.
  *
- * ## Why this is the branding provider's job
+ * ## Which queries need this
  *
  * `/api/admin-meta/workspace` carries the widget DECLARATIONS — including the
  * cards core derives per collection — and this provider owns those queries and
@@ -14,10 +14,16 @@
  * placement the grid then skips for want of anything to draw — addable, stored,
  * and invisible until something else happens to refetch.
  *
+ * The dashboard LAYOUT goes stale for the same reason and separately: it
+ * answers which cards are placed and which are offered, so a collection created
+ * a moment ago is missing from the picker until something else refetches, and
+ * one just deleted is still offered and then refused on save. It has no polling
+ * and `refetchOnWindowFocus` only, so "something else" may be a long way off.
+ *
  * The owner invalidates its own cache. `RootLayout` and `RestartContext` each
- * re-read the CONTENT caches on the same events, and neither owns this one;
- * putting `admin-meta` in their lists would make three components responsible
- * for one query's freshness.
+ * re-read the CONTENT caches on the same events, and neither owns either of
+ * these; putting these keys in their lists would make one component responsible
+ * for another's freshness.
  *
  * ## The two events
  *
@@ -39,13 +45,29 @@ export const SCHEMA_UPDATED_EVENT = "nextly:schema-updated";
 /** The queries this provider owns, both halves of the admin-meta payload. */
 export const ADMIN_META_KEY = ["admin-meta"] as const;
 
-export function useSchemaUpdateInvalidation(): void {
+export function useSchemaUpdateInvalidation(
+  /**
+   * A STABLE reference — a module-level constant, not an inline literal.
+   *
+   * The effect depends on it, so a fresh array each render would detach and
+   * re-attach the listener on every one. Both callers pass an exported `as
+   * const` key, which is also what makes the key they invalidate the same object
+   * their `useQuery` registered under rather than a copy that happens to match.
+   */
+  queryKey: readonly unknown[]
+): void {
   const queryClient = useQueryClient();
+  // The key is a parameter so each OWNER re-reads its own cache. Two queries go
+  // stale on a schema change and they belong to different modules: the branding
+  // provider holds the widget declarations, and the dashboard layout holds which
+  // cards are placed and which are offered. A single hook naming both would make
+  // one module responsible for another's freshness, and a key added for one
+  // consumer would silently start invalidating for the other.
   useEffect(() => {
     const handler = () => {
-      void queryClient.invalidateQueries({ queryKey: ADMIN_META_KEY });
+      void queryClient.invalidateQueries({ queryKey });
     };
     window.addEventListener(SCHEMA_UPDATED_EVENT, handler);
     return () => window.removeEventListener(SCHEMA_UPDATED_EVENT, handler);
-  }, [queryClient]);
+  }, [queryClient, queryKey]);
 }

--- a/packages/nextly/src/api/widget-layout.ts
+++ b/packages/nextly/src/api/widget-layout.ts
@@ -31,16 +31,16 @@
  * @module api/widget-layout
  */
 
-import {
-  authorizationGroups,
-  callerHoldsPermission,
-  type ReadAccessCaller,
-} from "../auth/entity-read-access";
+import type { ReadAccessCaller } from "../auth/entity-read-access";
 import type { AuthContext } from "../auth/middleware";
 import { isErrorResponse, requireAuthentication } from "../auth/middleware";
 import { toNextlyAuthError } from "../auth/middleware/to-nextly-error";
 import { container } from "../di";
-import { allWidgets, type CanonicalWidget } from "../domains/widgets/canonical";
+import {
+  allWidgets,
+  declaredWidgets,
+  type CanonicalWidget,
+} from "../domains/widgets/canonical";
 import { refreshCollectionWidgets } from "../domains/widgets/collection-widgets";
 import {
   MAX_LAYOUT_BYTES,
@@ -53,6 +53,10 @@ import {
   visibilityToken,
   type WidgetPlacement,
 } from "../domains/widgets/layout";
+import {
+  holdsWidgetPermission,
+  permissionVerdicts,
+} from "../domains/widgets/visibility";
 import { NextlyError } from "../errors/nextly-error";
 import { getCachedNextly } from "../init";
 import {
@@ -100,6 +104,27 @@ const OPAQUE_CONFIG_HEADERS = {
 type LayoutSource = "own" | "default";
 
 /**
+ * The default arrangement, split by what this caller may see.
+ *
+ * ONE materialization, asked in one place. Both halves come from the same
+ * sorted set, because positions are indices into it: two calls that filtered
+ * differently would give the carried half positions that collide with the
+ * visible one, and a reader gaining a permission would find their arrangement
+ * silently reordered.
+ *
+ * Materialized from {@link declaredWidgets} rather than from every widget that
+ * exists. A card core GENERATED for a collection is offered through
+ * `available`, never placed -- so it must not take a default position, and must
+ * not spend one of the placements a caller may submit.
+ */
+function defaultRow(visibleIds: ReadonlySet<string>): {
+  visible: WidgetPlacement[];
+  invisible: WidgetPlacement[];
+} {
+  return partitionPlacements(defaultPlacements(declaredWidgets()), visibleIds);
+}
+
+/**
  * The placements a write must carry through untouched.
  *
  * Two cases, and the second is the one that is easy to miss. With a stored row,
@@ -125,8 +150,7 @@ function carriedPlacements(
   if (storedPlacements) {
     return partitionPlacements(storedPlacements, visibleIds).invisible;
   }
-  return partitionPlacements(defaultPlacements(allWidgets()), visibleIds)
-    .invisible;
+  return defaultRow(visibleIds).invisible;
 }
 
 /**
@@ -150,7 +174,7 @@ function visibleDefaults(
 ): WidgetPlacement[] {
   const visibleIds = new Set(widgets.map(widget => widget.id));
   return (
-    partitionPlacements(defaultPlacements(allWidgets()), visibleIds)
+    defaultRow(visibleIds)
       .visible // 🔴 The submission cap applies HERE, to what this caller can actually
       // send, rather than to the materialization above. `layoutSizeProblem`
       // refuses a submission over `MAX_PLACEMENTS`, so an install declaring
@@ -206,55 +230,14 @@ async function visibleWidgets(
   await refreshCollectionWidgets();
   const all = allWidgets();
 
-  const slugs = [
-    ...new Set(
-      all
-        .map(widget => widget.requiredPermission)
-        .filter(
-          (slug): slug is string => typeof slug === "string" && slug !== ""
-        )
-    ),
-  ];
+  const verdicts = await permissionVerdicts(
+    all.map(widget => widget.requiredPermission),
+    caller
+  );
 
-  const verdicts = new Map<string, boolean>();
-  for (const group of authorizationGroups(slugs)) {
-    const settled = await Promise.allSettled(
-      group.map(slug => callerHoldsPermission(slug, caller))
-    );
-    group.forEach((slug, index) => {
-      const outcome = settled[index];
-      // A rejected decision denies. A permission check that threw has told us
-      // nothing, and "nothing" must not read as "allowed" -- the same
-      // fail-closed direction `canReadEntity` takes when RBAC is unreachable.
-      verdicts.set(slug, outcome.status === "fulfilled" && outcome.value);
-    });
-  }
-
-  return all.filter(widget => isVisibleTo(widget, verdicts));
-}
-
-/**
- * Whether one widget may be mentioned to this caller.
- *
- * 🔴 Only `undefined` means ungated. Every other non-string is DENIED, which is
- * the opposite of what "not a string, so no permission was declared" gives
- * you: `requiredPermission: 42` or `{ read: true }` would then be treated as an
- * open widget and returned to every authenticated caller — a declaration whose
- * author plainly meant to restrict it, failing open because it was malformed.
- *
- * `widgetValueProblem` now refuses such a declaration, so this is the second of
- * two locks rather than the only one. It stays because the registry is also
- * writable from code that never passes through that validator, and because a
- * `typeof` on a value already in hand costs nothing.
- */
-function isVisibleTo(
-  widget: CanonicalWidget,
-  verdicts: ReadonlyMap<string, boolean>
-): boolean {
-  const slug: unknown = widget.requiredPermission;
-  if (slug === undefined) return true;
-  if (typeof slug !== "string" || slug === "") return false;
-  return verdicts.get(slug) === true;
+  return all.filter(widget =>
+    holdsWidgetPermission(widget.requiredPermission, verdicts)
+  );
 }
 
 /**

--- a/packages/nextly/src/api/widget-layout.ts
+++ b/packages/nextly/src/api/widget-layout.ts
@@ -41,6 +41,7 @@ import { isErrorResponse, requireAuthentication } from "../auth/middleware";
 import { toNextlyAuthError } from "../auth/middleware/to-nextly-error";
 import { container } from "../di";
 import { allWidgets, type CanonicalWidget } from "../domains/widgets/canonical";
+import { refreshCollectionWidgets } from "../domains/widgets/collection-widgets";
 import {
   MAX_LAYOUT_BYTES,
   MAX_PLACEMENTS,
@@ -198,6 +199,11 @@ async function getLayoutService(): Promise<WidgetLayoutService> {
 async function visibleWidgets(
   caller: ReadAccessCaller
 ): Promise<CanonicalWidget[]> {
+  // Same freshness the admin's own payload gets. Without this the endpoint
+  // would place and offer a set derived on some earlier request -- a collection
+  // created since would have no card to add, and one deleted since would still
+  // be offered and then refused on save.
+  await refreshCollectionWidgets();
   const all = allWidgets();
 
   const slugs = [

--- a/packages/nextly/src/api/widget-layout.ts
+++ b/packages/nextly/src/api/widget-layout.ts
@@ -31,7 +31,10 @@
  * @module api/widget-layout
  */
 
-import type { ReadAccessCaller } from "../auth/entity-read-access";
+import {
+  readableEntities,
+  type ReadAccessCaller,
+} from "../auth/entity-read-access";
 import type { AuthContext } from "../auth/middleware";
 import { isErrorResponse, requireAuthentication } from "../auth/middleware";
 import { toNextlyAuthError } from "../auth/middleware/to-nextly-error";
@@ -56,7 +59,6 @@ import {
 import {
   holdsWidgetPermission,
   permissionVerdicts,
-  readableCollections,
 } from "../domains/widgets/visibility";
 import { NextlyError } from "../errors/nextly-error";
 import { getCachedNextly } from "../init";
@@ -243,8 +245,10 @@ async function visibleWidgets(
   // collection's code-defined rules, and the widget query endpoint asks the
   // second. A key those rules reject had the card offered here and every query
   // for it refused. The same question, asked once per collection.
-  const readable = await readableCollections(
-    all.map(widget => widget.collection),
+  const readable = await readableEntities(
+    all
+      .map(widget => widget.collection)
+      .filter((slug): slug is string => slug !== undefined),
     caller
   );
 

--- a/packages/nextly/src/api/widget-layout.ts
+++ b/packages/nextly/src/api/widget-layout.ts
@@ -56,6 +56,7 @@ import {
 import {
   holdsWidgetPermission,
   permissionVerdicts,
+  readableCollections,
 } from "../domains/widgets/visibility";
 import { NextlyError } from "../errors/nextly-error";
 import { getCachedNextly } from "../init";
@@ -220,6 +221,7 @@ async function getLayoutService(): Promise<WidgetLayoutService> {
  * name the same permission, and asking twice is two database reads for one
  * answer.
  */
+
 async function visibleWidgets(
   caller: ReadAccessCaller
 ): Promise<CanonicalWidget[]> {
@@ -235,9 +237,23 @@ async function visibleWidgets(
     caller
   );
 
-  return all.filter(widget =>
-    holdsWidgetPermission(widget.requiredPermission, verdicts)
+  // 🔴 A GENERATED card is gated on its collection, not on a declared
+  // permission — it carries none. `callerHoldsPermission` judges an API key on
+  // its stamped grant alone, while `canReadEntity` also evaluates the
+  // collection's code-defined rules, and the widget query endpoint asks the
+  // second. A key those rules reject had the card offered here and every query
+  // for it refused. The same question, asked once per collection.
+  const readable = await readableCollections(
+    all.map(widget => widget.collection),
+    caller
   );
+
+  return all.filter(widget => {
+    if (widget.generated === true) {
+      return widget.collection !== undefined && readable.has(widget.collection);
+    }
+    return holdsWidgetPermission(widget.requiredPermission, verdicts);
+  });
 }
 
 /**

--- a/packages/nextly/src/auth/__tests__/entity-read-access.test.ts
+++ b/packages/nextly/src/auth/__tests__/entity-read-access.test.ts
@@ -21,7 +21,11 @@ vi.mock("../../di/container", () => ({
   },
 }));
 
-import { canReadEntity, type ReadAccessCaller } from "../entity-read-access";
+import {
+  canReadEntity,
+  readableEntities,
+  type ReadAccessCaller,
+} from "../entity-read-access";
 
 const apiKey = (permissions: string[]): ReadAccessCaller => ({
   userId: "owner-1",
@@ -178,5 +182,50 @@ describe("canReadEntity — degenerate input", () => {
     hasSpy.mockReturnValue(false);
 
     await expect(canReadEntity("posts", session)).resolves.toBe(false);
+  });
+});
+
+describe("readableEntities", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hasSpy.mockReturnValue(true);
+    registeredAccessSpy.mockReturnValue(undefined);
+    checkAccessSpy.mockResolvedValue(true);
+  });
+
+  it("denies only the slug whose check THREW, not the whole set", async () => {
+    // 🔴 A single rejected decision used to reject the whole calculation, so one
+    // unreachable RBAC lookup turned every surface built on this -- the
+    // dashboard's readable resources, the widget layout, the workspace payload
+    // -- into an error rather than a narrower answer. A check that threw has
+    // told us nothing, and "nothing" must not read as "allowed" either.
+    checkAccessSpy.mockImplementation(({ resource }: { resource: string }) =>
+      resource === "broken"
+        ? Promise.reject(new Error("rbac unreachable"))
+        : Promise.resolve(true)
+    );
+
+    const allowed = await readableEntities(
+      ["posts", "broken", "pages"],
+      session
+    );
+
+    expect([...allowed].sort()).toEqual(["pages", "posts"]);
+  });
+
+  it("asks about each slug ONCE however often it is named", async () => {
+    // A permission decision resolves a session caller through a per-user TTL
+    // cache, so a repeat is a second database read for an answer in hand -- and
+    // a dashboard offering two cards per collection names each one twice.
+    await readableEntities(["posts", "posts", "posts"], session);
+
+    expect(checkAccessSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("still returns what the caller may read", async () => {
+    // The control: without it both assertions above are satisfied by a function
+    // that returns the empty set.
+    const allowed = await readableEntities(["posts", "pages"], session);
+    expect([...allowed].sort()).toEqual(["pages", "posts"]);
   });
 });

--- a/packages/nextly/src/auth/entity-read-access.ts
+++ b/packages/nextly/src/auth/entity-read-access.ts
@@ -285,17 +285,35 @@ export async function readableEntities(
   slugs: readonly string[],
   caller: ReadAccessCaller
 ): Promise<Set<string>> {
+  // DEDUPLICATED, because several callers name one entity more than once — a
+  // dashboard offering two cards per collection asks about each twice — and a
+  // permission decision resolves a session caller through a per-user TTL cache,
+  // so the repeat is a second database read for an answer already in hand.
+  const distinct = [
+    ...new Set(
+      slugs.filter(
+        (slug): slug is string => typeof slug === "string" && slug !== ""
+      )
+    ),
+  ];
+
   const allowed = new Set<string>();
-  for (const group of authorizationGroups(slugs)) {
-    const verdicts = await Promise.all(
-      group.map(async slug => ({
-        slug,
-        allowed: await canReadEntity(slug, caller),
-      }))
+  for (const group of authorizationGroups(distinct)) {
+    // 🔴 `allSettled`, not `all`. A single rejected decision used to reject the
+    // WHOLE calculation, so one unreachable RBAC lookup turned every surface
+    // built on this — the dashboard's readable resources, the widget layout,
+    // the workspace payload — into an error rather than a narrower answer. A
+    // check that threw has told us nothing, and "nothing" must not read as
+    // "allowed" either: the slug is denied and the rest of the set still
+    // answers. That is the direction `canReadEntity` itself takes when RBAC is
+    // unreachable.
+    const settled = await Promise.allSettled(
+      group.map(slug => canReadEntity(slug, caller))
     );
-    for (const verdict of verdicts) {
-      if (verdict.allowed) allowed.add(verdict.slug);
-    }
+    group.forEach((slug, index) => {
+      const outcome = settled[index];
+      if (outcome.status === "fulfilled" && outcome.value) allowed.add(slug);
+    });
   }
   return allowed;
 }

--- a/packages/nextly/src/config.ts
+++ b/packages/nextly/src/config.ts
@@ -226,6 +226,13 @@ export type { WidgetQuery } from "./domains/widgets/query";
 // copies of that mapping is two answers to one question, and the copies had
 // already drifted -- only one of them existed.
 export { legacySizeToWidgetSize } from "./domains/widgets/definition";
+// Which field NAMES an entry. The admin draws a column with it, the activity
+// feed labels a row with it, and the dashboard's generated list widgets pick a
+// row label with it -- so it is one answer here rather than one per consumer.
+export {
+  COMMON_TITLE_FIELDS,
+  entryTitleField,
+} from "./domains/collections/entry-title";
 // A VALUE, and the only one in this block. The admin batches a dashboard's
 // widgets into requests `POST /api/dashboard/query` will accept, so it needs the
 // number that endpoint refuses above -- and a second copy of it on the client

--- a/packages/nextly/src/domains/collections/entry-title.ts
+++ b/packages/nextly/src/domains/collections/entry-title.ts
@@ -1,0 +1,53 @@
+/**
+ * Which field NAMES an entry, asked once for the whole product.
+ *
+ * A collection's author may nominate one through `admin.useAsTitle`; most do
+ * not, and the conventional names below are what a reader recognises when they
+ * have not. Both halves of that answer live here because three places need it
+ * and they must agree: the entry list draws a column with it, the activity feed
+ * labels a row with it, and a generated dashboard list picks its row label with
+ * it. A reader who sees "Hello world" in one place and `a3f9-...` in another is
+ * looking at two implementations of one question.
+ *
+ * In CORE rather than in the admin, where it was first written, because the
+ * server needs the same answer: `record-activity` already resolves an entry's
+ * heading server-side, and the dashboard's generated widgets have to know which
+ * field to select before the query is made.
+ *
+ * @module domains/collections/entry-title
+ */
+
+/**
+ * Field names that conventionally hold a title, in preference order.
+ *
+ * `subject` and `heading` are here because a mail-like or article-like
+ * collection names its entries with them, and a reader scanning a list of
+ * either sees nothing useful without them.
+ */
+export const COMMON_TITLE_FIELDS = [
+  "title",
+  "name",
+  "label",
+  "subject",
+  "heading",
+] as const;
+
+/**
+ * The field that names an entry, or `undefined` when nothing does.
+ *
+ * `undefined` is a real answer rather than a failure: a collection of pure data
+ * rows has no title field, and a caller that invents one shows the reader a
+ * column of identifiers. Callers are expected to handle it — the entry list
+ * falls back to the id, and a generated list widget declines to exist.
+ */
+export function entryTitleField(
+  useAsTitle: string | undefined,
+  fieldNames: readonly string[]
+): string | undefined {
+  // `id` is not a title even when nominated: it is what the fallbacks already
+  // show, and treating it as one would hide a real title field behind it.
+  if (useAsTitle && useAsTitle !== "id" && fieldNames.includes(useAsTitle)) {
+    return useAsTitle;
+  }
+  return COMMON_TITLE_FIELDS.find(name => fieldNames.includes(name));
+}

--- a/packages/nextly/src/domains/widgets/__tests__/built-in-sources.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/built-in-sources.test.ts
@@ -348,6 +348,41 @@ describe("what a source calls itself, and which field names its rows", () => {
     expect(getSource("collection:posts")?.titleField).toBe("title");
   });
 
+  it("REFUSES a boolean field as the title, nominated or conventional", () => {
+    // 🔴 One question, two answers is the defect. The shared naming rule accepts
+    // a non-empty string or a finite number and refuses a boolean -- in both
+    // implementations, `readableText` for the entry surfaces and the candidate
+    // walk for the activity feed. A field-level allowlist that admitted
+    // `checkbox` therefore nominated a column every value-level rule then
+    // declines: the card names nothing while the same entry is named by a
+    // conventional fallback everywhere else.
+    registerBuiltInSources([
+      {
+        slug: "posts",
+        useAsTitle: "active",
+        fields: [
+          { name: "active", type: "checkbox" },
+          { name: "title", type: "text" },
+        ],
+        timestamps: true,
+      },
+    ]);
+    expect(getSource("collection:posts")?.titleField).toBe("title");
+  });
+
+  it("REFUSES a conventional field that is itself a checkbox", () => {
+    // The half a nomination-only guard misses: `title` is a conventional name,
+    // so it is reached by the fallback walk without anyone nominating it.
+    registerBuiltInSources([
+      {
+        slug: "flags",
+        fields: [{ name: "title", type: "checkbox" }],
+        timestamps: true,
+      },
+    ]);
+    expect(getSource("collection:flags")?.titleField).toBeUndefined();
+  });
+
   it("judges a DUPLICATE name by the declaration the source carries", () => {
     // 🔴 Two questions about one name have to be asked of ONE declaration. A
     // collection may declare `tags` twice and the two need not agree; the

--- a/packages/nextly/src/domains/widgets/__tests__/built-in-sources.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/built-in-sources.test.ts
@@ -246,3 +246,85 @@ describe("built-in sources", () => {
     expect(listSources()).toHaveLength(1);
   });
 });
+
+describe("what a source calls itself, and which field names its rows", () => {
+  it("labels itself the way a HUMAN names the collection", () => {
+    // 🔴 `label` means "what a human calls this". The slug is a storage
+    // identifier, so a collection whose plural label is "Articles" was
+    // published to the picker -- and to every generated card's title -- as
+    // `blog-posts`, disagreeing with the name used everywhere else in the admin.
+    registerBuiltInSources([
+      {
+        slug: "blog-posts",
+        label: "Articles",
+        fields: [{ name: "title", type: "text" }],
+        timestamps: true,
+      },
+    ]);
+    expect(getSource("collection:blog-posts")?.label).toBe("Articles");
+  });
+
+  it("falls back to the slug when the collection named itself nothing", () => {
+    // The control: without it the assertion above is satisfied by a source that
+    // labels itself from any string it happens to hold.
+    registerBuiltInSources([
+      {
+        slug: "posts",
+        fields: [{ name: "title", type: "text" }],
+        timestamps: true,
+      },
+    ]);
+    expect(getSource("collection:posts")?.label).toBe("posts");
+  });
+
+  it("resolves the title field from the author's nomination", () => {
+    registerBuiltInSources([
+      {
+        slug: "posts",
+        useAsTitle: "headline",
+        fields: [
+          { name: "headline", type: "text" },
+          { name: "title", type: "text" },
+        ],
+        timestamps: true,
+      },
+    ]);
+    expect(getSource("collection:posts")?.titleField).toBe("headline");
+  });
+
+  it("REFUSES a nominated field a card could not print", () => {
+    // 🔴 `toSourceType` maps every type it does not recognise to "string", so a
+    // `json` field is indistinguishable from a text field by the time a source
+    // is built -- and schema validation permits one as `useAsTitle`. The card
+    // would then ask for an object per row, which `asText` declines to
+    // stringify, drawing an em dash on every line. It falls back to a field the
+    // card CAN print, which is what the entry list does when it reads a value
+    // it cannot render.
+    registerBuiltInSources([
+      {
+        slug: "posts",
+        useAsTitle: "payload",
+        fields: [
+          { name: "payload", type: "json" },
+          { name: "title", type: "text" },
+        ],
+        timestamps: true,
+      },
+    ]);
+    expect(getSource("collection:posts")?.titleField).toBe("title");
+  });
+
+  it("names no title field at all when nothing printable could be one", () => {
+    registerBuiltInSources([
+      {
+        slug: "readings",
+        fields: [
+          { name: "payload", type: "json" },
+          { name: "parts", type: "repeater" },
+        ],
+        timestamps: true,
+      },
+    ]);
+    expect(getSource("collection:readings")?.titleField).toBeUndefined();
+  });
+});

--- a/packages/nextly/src/domains/widgets/__tests__/built-in-sources.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/built-in-sources.test.ts
@@ -348,6 +348,28 @@ describe("what a source calls itself, and which field names its rows", () => {
     expect(getSource("collection:posts")?.titleField).toBe("title");
   });
 
+  it("judges a DUPLICATE name by the declaration the source carries", () => {
+    // 🔴 Two questions about one name have to be asked of ONE declaration. A
+    // collection may declare `tags` twice and the two need not agree; the
+    // source keeps the FIRST, which here stores an array. Asking the printable
+    // filter of the raw list let the second, scalar declaration vote, so `tags`
+    // qualified as a title while the field the source actually carries is the
+    // `hasMany` one -- and the card prints an array where a name belongs.
+    registerBuiltInSources([
+      {
+        slug: "posts",
+        useAsTitle: "tags",
+        fields: [
+          { name: "tags", type: "text", hasMany: true },
+          { name: "tags", type: "text" },
+          { name: "title", type: "text" },
+        ],
+        timestamps: true,
+      },
+    ]);
+    expect(getSource("collection:posts")?.titleField).toBe("title");
+  });
+
   it("accepts a single-valued field of the same type", () => {
     // The control: without it the refusal above is satisfied by an allowlist
     // that rejects `text` outright.

--- a/packages/nextly/src/domains/widgets/__tests__/built-in-sources.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/built-in-sources.test.ts
@@ -327,4 +327,41 @@ describe("what a source calls itself, and which field names its rows", () => {
     ]);
     expect(getSource("collection:readings")?.titleField).toBeUndefined();
   });
+
+  it("REFUSES a nominated field that holds many values", () => {
+    // 🔴 A scalar TYPE is not a scalar VALUE. `text` and `select` both accept
+    // `hasMany`, and one of those stores an array -- which `asText` declines to
+    // print, so the card draws an em dash on every row while a usable
+    // conventional title sits unused beside it. Type alone was the wrong
+    // question.
+    registerBuiltInSources([
+      {
+        slug: "posts",
+        useAsTitle: "tags",
+        fields: [
+          { name: "tags", type: "text", hasMany: true },
+          { name: "title", type: "text" },
+        ],
+        timestamps: true,
+      },
+    ]);
+    expect(getSource("collection:posts")?.titleField).toBe("title");
+  });
+
+  it("accepts a single-valued field of the same type", () => {
+    // The control: without it the refusal above is satisfied by an allowlist
+    // that rejects `text` outright.
+    registerBuiltInSources([
+      {
+        slug: "posts",
+        useAsTitle: "tags",
+        fields: [
+          { name: "tags", type: "text" },
+          { name: "title", type: "text" },
+        ],
+        timestamps: true,
+      },
+    ]);
+    expect(getSource("collection:posts")?.titleField).toBe("tags");
+  });
 });

--- a/packages/nextly/src/domains/widgets/__tests__/canonical.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/canonical.test.ts
@@ -4,7 +4,12 @@
  */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { canonicalWidgets, type CanonicalWidget } from "../canonical";
+import {
+  allWidgets,
+  canonicalWidgets,
+  declaredWidgets,
+  type CanonicalWidget,
+} from "../canonical";
 import { setGeneratedWidgets } from "../collection-widgets";
 import type { WidgetDefinition } from "../definition";
 import { clearWidgets, registerWidget } from "../registry";
@@ -186,6 +191,29 @@ describe("generated cards in the canonical set", () => {
     ]);
     expect(merged).toHaveLength(1);
     expect(merged[0].defaultOrder).toBe(3);
+  });
+
+  it("is NOT part of the set a default arrangement is built from", () => {
+    // 🔴 The whole "offered, never placed" claim rests on this. `defaultPlacements`
+    // is materialized from `declaredWidgets`, so a generated card appearing there
+    // would be auto-placed for every reader with no stored layout -- forty
+    // collections opening onto eighty cards nobody chose, and past the cap a
+    // dashboard they cannot add to. It still EXISTS, so it can be offered and a
+    // write naming it is accepted.
+    setGeneratedWidgets([generated]);
+    expect(allWidgets().map(w => w.id)).toEqual(["collection/posts-count"]);
+    expect(declaredWidgets()).toEqual([]);
+  });
+
+  it("IS placed once a declaration claims its id", () => {
+    // The control, and the reason the flag describes the surviving declaration
+    // rather than which ids core can generate: an author who declared this
+    // widget gets it placed like any other.
+    setGeneratedWidgets([generated]);
+    registerWidget(registered({ id: "collection/posts-count" }));
+    expect(declaredWidgets().map(w => w.id)).toEqual([
+      "collection/posts-count",
+    ]);
   });
 
   it("LOSES the id to an explicit registration too", () => {

--- a/packages/nextly/src/domains/widgets/__tests__/canonical.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/canonical.test.ts
@@ -2,9 +2,10 @@
  * One answer to "which widgets exist", across two channels that do not share a
  * shape.
  */
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { canonicalWidgets, type CanonicalWidget } from "../canonical";
+import { setGeneratedWidgets } from "../collection-widgets";
 import type { WidgetDefinition } from "../definition";
 import { clearWidgets, registerWidget } from "../registry";
 
@@ -144,5 +145,56 @@ describe("the canonical widget set", () => {
 
   it("is empty when neither channel has anything", () => {
     expect(canonicalWidgets([])).toEqual([]);
+  });
+});
+
+describe("generated cards in the canonical set", () => {
+  const generated = {
+    id: "collection/posts-count",
+    title: "posts",
+    archetype: "metric",
+    defaultSize: "sm",
+    requiredPermission: "read-posts",
+    query: { source: "collection:posts", op: "count" },
+  } as unknown as Parameters<typeof setGeneratedWidgets>[0][number];
+
+  afterEach(() => setGeneratedWidgets([]));
+
+  it("places and offers a card nobody declared", () => {
+    // 🔴 The whole point of generating them. Without this the layout endpoint
+    // answers "unavailable widget" for every id the picker offers, so the card
+    // is visible and unaddable -- which is the state a contributed widget was
+    // in before `canonicalWidgets` learned about that channel.
+    setGeneratedWidgets([generated]);
+    expect(canonicalWidgets([]).map(w => w.id)).toEqual([
+      "collection/posts-count",
+    ]);
+  });
+
+  it("carries the permission that gates the collection", () => {
+    setGeneratedWidgets([generated]);
+    expect(canonicalWidgets([])[0].requiredPermission).toBe("read-posts");
+  });
+
+  it("LOSES the id to a contribution that already claimed it", () => {
+    // A plugin that declared this widget meant it; core's derived guess must
+    // not displace it. The reader sees the plugin's card, and the server places
+    // the plugin's declaration -- one answer, not two.
+    setGeneratedWidgets([generated]);
+    const merged = canonicalWidgets([
+      { id: "collection/posts-count", defaultOrder: 3 },
+    ]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].defaultOrder).toBe(3);
+  });
+
+  it("LOSES the id to an explicit registration too", () => {
+    setGeneratedWidgets([generated]);
+    registerWidget(
+      registered({ id: "collection/posts-count", defaultOrder: 7 })
+    );
+    const merged = canonicalWidgets([]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].defaultOrder).toBe(7);
   });
 });

--- a/packages/nextly/src/domains/widgets/__tests__/collection-sources.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/collection-sources.test.ts
@@ -14,6 +14,7 @@ import { setNextlyLogger } from "../../../observability/logger";
 import {
   refreshCollectionSources,
   resetVerifiedTables,
+  setDeferredCollections,
 } from "../collection-sources";
 import {
   clearSources,
@@ -80,6 +81,7 @@ beforeEach(() => {
   // The observed-table memo is pinned on `globalThis`, so without this a
   // verification from one test satisfies the next one's assertion.
   resetVerifiedTables();
+  setDeferredCollections([]);
   setNextlyLogger({
     error: () => {},
     warn: () => {},
@@ -520,6 +522,101 @@ describe("a collection whose table is not there yet", () => {
 
     await refreshCollectionSources();
     expect(getSource("collection:drafts")).toBeUndefined();
+  });
+
+  it("withholds a DEFERRED collection even though its old table exists", async () => {
+    // 🔴 The case table existence cannot see. A reload writes the new field list
+    // for EVERY configured collection -- the sync payload is the whole config --
+    // while refusing the DDL for one it classified unsafe. That collection keeps
+    // its OLD table, which exists, beside a NEW field list the table never
+    // received. Verified structurally it would publish a source naming columns
+    // the database does not have, and the query fails after validating.
+    setDeferredCollections(["drafts"]);
+    registryHoldsWithTables(
+      [
+        {
+          slug: "drafts",
+          tableName: "dc_drafts",
+          migrationStatus: "pending",
+          fields: [{ name: "title", type: "text" }],
+          timestamps: true,
+        },
+      ],
+      ["dc_drafts"]
+    );
+
+    await refreshCollectionSources();
+    expect(getSource("collection:drafts")).toBeUndefined();
+  });
+
+  it("withholds a DEFERRED collection whose label still claims presence", async () => {
+    // The nastier half: the refusal has to override the LABEL too, not only the
+    // observed table. A collection edited after a healthy apply still carries
+    // `applied` from the previous cycle while its new fields sit unapplied, so a
+    // guard that only overrode the structural answer would publish it.
+    setDeferredCollections(["posts"]);
+    registryHoldsWithTables(
+      [
+        {
+          slug: "posts",
+          tableName: "dc_posts",
+          migrationStatus: "applied",
+          fields: [{ name: "title", type: "text" }],
+          timestamps: true,
+        },
+      ],
+      ["dc_posts"]
+    );
+
+    await refreshCollectionSources();
+    expect(getSource("collection:posts")).toBeUndefined();
+  });
+
+  it("publishes a collection again once the reload stops deferring it", async () => {
+    // The control: without it the two refusals above are satisfied by a guard
+    // that withholds permanently. A later successful reload REPLACES the set,
+    // so the refusal lifts with nobody having to clear it.
+    setDeferredCollections(["drafts"]);
+    registryHoldsWithTables(
+      [
+        {
+          slug: "drafts",
+          tableName: "dc_drafts",
+          migrationStatus: "pending",
+          fields: [{ name: "title", type: "text" }],
+          timestamps: true,
+        },
+      ],
+      ["dc_drafts"]
+    );
+    await refreshCollectionSources();
+    expect(getSource("collection:drafts")).toBeUndefined();
+
+    setDeferredCollections([]);
+    await refreshCollectionSources();
+    expect(getSource("collection:drafts")).toBeDefined();
+  });
+
+  it("asks the database NOTHING for a deferred collection", async () => {
+    // A deferred collection is excluded whatever the database answers, so a
+    // lookup for it is a round trip whose result is discarded -- on every
+    // request, for as long as the refusal stands.
+    setDeferredCollections(["drafts"]);
+    const { listTables } = registryHoldsWithTables(
+      [
+        {
+          slug: "drafts",
+          tableName: "dc_drafts",
+          migrationStatus: "pending",
+          fields: [{ name: "title", type: "text" }],
+          timestamps: true,
+        },
+      ],
+      ["dc_drafts"]
+    );
+
+    await refreshCollectionSources();
+    expect(listTables).not.toHaveBeenCalled();
   });
 
   it("asks the database NOTHING when every label already claims presence", async () => {

--- a/packages/nextly/src/domains/widgets/__tests__/collection-sources.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/collection-sources.test.ts
@@ -26,6 +26,7 @@ type Row = {
   status?: boolean;
   labels?: unknown;
   admin?: unknown;
+  migrationStatus?: unknown;
 };
 
 const containerGet = container.get as ReturnType<typeof vi.fn>;
@@ -425,5 +426,76 @@ describe("the display label a source takes from the registry", () => {
 
     await refreshCollectionSources();
     expect(getSource("collection:posts")?.label).toBe("Articles");
+  });
+});
+
+describe("a collection whose table is not there yet", () => {
+  it("gets no source, so nothing offers a card that cannot be queried", async () => {
+    // 🔴 A Schema-Builder collection is recorded `pending` and its migration
+    // does not run outside development. The row exists, permission seeding
+    // makes it visible, and the table arrives at the next deploy -- so a source
+    // for it accepts queries that reach a table that is not there, once per
+    // reader, until then.
+    registryHolds([
+      {
+        slug: "drafts",
+        migrationStatus: "pending",
+        fields: [{ name: "title", type: "text" }],
+        timestamps: true,
+      },
+    ]);
+
+    await refreshCollectionSources();
+    expect(getSource("collection:drafts")).toBeUndefined();
+  });
+
+  it("DOES give one to a collection whose migration ran", async () => {
+    // The control: without it the refusal above is satisfied by a filter that
+    // drops every collection.
+    registryHolds([
+      {
+        slug: "posts",
+        migrationStatus: "applied",
+        fields: [{ name: "title", type: "text" }],
+        timestamps: true,
+      },
+    ]);
+
+    await refreshCollectionSources();
+    expect(getSource("collection:posts")).toBeDefined();
+  });
+
+  it("DOES give one to a code-first collection", async () => {
+    // `synced` is what a code-first collection carries: migrations own its
+    // table, so it is present.
+    registryHolds([
+      {
+        slug: "pages",
+        migrationStatus: "synced",
+        fields: [{ name: "title", type: "text" }],
+        timestamps: true,
+      },
+    ]);
+
+    await refreshCollectionSources();
+    expect(getSource("collection:pages")).toBeDefined();
+  });
+
+  it("DOES give one to a row that predates the status field", async () => {
+    // 🔴 The one place this reads generously rather than closed. The field was
+    // added after rows existed, so a row without it says nothing about its
+    // table -- and those tables do exist. Refusing them would take widgets away
+    // from every collection an older install already had, to guard against a
+    // state they are not in.
+    registryHolds([
+      {
+        slug: "legacy",
+        fields: [{ name: "title", type: "text" }],
+        timestamps: true,
+      },
+    ]);
+
+    await refreshCollectionSources();
+    expect(getSource("collection:legacy")).toBeDefined();
   });
 });

--- a/packages/nextly/src/domains/widgets/__tests__/collection-sources.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/collection-sources.test.ts
@@ -24,6 +24,8 @@ type Row = {
   fields: Array<{ name: string; type: string; label?: string }>;
   timestamps?: boolean;
   status?: boolean;
+  labels?: unknown;
+  admin?: unknown;
 };
 
 const containerGet = container.get as ReturnType<typeof vi.fn>;
@@ -372,5 +374,56 @@ describe("fields inside a presentational group are addressable", () => {
     expect(
       getSource("collection:users")?.fields.map(f => f.name)
     ).not.toContain("secret");
+  });
+});
+
+describe("the display label a source takes from the registry", () => {
+  it("uses the collection's plural label", () => {
+    registryHolds([
+      {
+        slug: "blog-posts",
+        labels: { singular: "Article", plural: "Articles" },
+        fields: [{ name: "title", type: "text" }],
+        timestamps: true,
+      },
+    ]);
+    return refreshCollectionSources().then(() => {
+      expect(getSource("collection:blog-posts")?.label).toBe("Articles");
+    });
+  });
+
+  it("does not let a WHITESPACE label take the whole install down", async () => {
+    // 🔴 `validateSource` refuses a label that is empty after trimming, and
+    // `defineCollection` preserves `labels.plural: "   "` as written. A check
+    // for `!== ""` therefore accepted it, `registerSource` threw, and this
+    // refresh runs on every workspace, layout and widget-query request -- so one
+    // whitespace label failed all three for everybody.
+    registryHolds([
+      {
+        slug: "posts",
+        labels: { plural: "   " },
+        fields: [{ name: "title", type: "text" }],
+        timestamps: true,
+      },
+    ]);
+
+    await expect(refreshCollectionSources()).resolves.toBeUndefined();
+    expect(getSource("collection:posts")?.label).toBe("posts");
+  });
+
+  it("trims a label that is merely padded", async () => {
+    // The control: without it the assertion above is satisfied by a reader that
+    // ignores `labels` entirely and always answers with the slug.
+    registryHolds([
+      {
+        slug: "posts",
+        labels: { plural: "  Articles  " },
+        fields: [{ name: "title", type: "text" }],
+        timestamps: true,
+      },
+    ]);
+
+    await refreshCollectionSources();
+    expect(getSource("collection:posts")?.label).toBe("Articles");
   });
 });

--- a/packages/nextly/src/domains/widgets/__tests__/collection-sources.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/collection-sources.test.ts
@@ -11,7 +11,10 @@ vi.mock("../../../di/container", () => ({ container: { get: vi.fn() } }));
 
 import { container } from "../../../di/container";
 import { setNextlyLogger } from "../../../observability/logger";
-import { refreshCollectionSources } from "../collection-sources";
+import {
+  refreshCollectionSources,
+  resetVerifiedTables,
+} from "../collection-sources";
 import {
   clearSources,
   getSource,
@@ -27,6 +30,7 @@ type Row = {
   labels?: unknown;
   admin?: unknown;
   migrationStatus?: unknown;
+  tableName?: string;
 };
 
 const containerGet = container.get as ReturnType<typeof vi.fn>;
@@ -41,6 +45,28 @@ function registryHolds(rows: Row[]): void {
   });
 }
 
+/**
+ * Makes the registry answer with `rows` AND the database report `tables`.
+ *
+ * The plain `registryHolds` throws on `container.get("adapter")`, which is the
+ * unanswerable-introspection path -- so a test that wants the STRUCTURAL
+ * question asked has to supply a database that can answer it.
+ */
+function registryHoldsWithTables(
+  rows: Row[],
+  tables: string[]
+): { listTables: ReturnType<typeof vi.fn> } {
+  const listTables = vi.fn(async () => tables);
+  containerGet.mockImplementation((name: string) => {
+    if (name === "collectionRegistryService") {
+      return { getAllCollections: async () => rows };
+    }
+    if (name === "adapter") return { listTables };
+    throw new Error(`unexpected container.get("${name}") in this test`);
+  });
+  return { listTables };
+}
+
 /** Makes the registry unreachable, the way a failed read or a cold container is. */
 function registryUnreachable(): void {
   containerGet.mockImplementation(() => {
@@ -51,6 +77,9 @@ function registryUnreachable(): void {
 beforeEach(() => {
   vi.clearAllMocks();
   clearSources();
+  // The observed-table memo is pinned on `globalThis`, so without this a
+  // verification from one test satisfies the next one's assertion.
+  resetVerifiedTables();
   setNextlyLogger({
     error: () => {},
     warn: () => {},
@@ -447,6 +476,107 @@ describe("a collection whose table is not there yet", () => {
 
     await refreshCollectionSources();
     expect(getSource("collection:drafts")).toBeUndefined();
+  });
+
+  it("gives one to a PENDING collection whose table is actually there", async () => {
+    // 🔴 The status is a LABEL and several writers maintain it badly. A Builder
+    // collection deployed with `nextly migrate` keeps `pending` forever -- the
+    // only writer that records `applied`, `registerFromMigrations`, runs from
+    // the development boot path alone -- so its cards would never appear, on a
+    // table that has been queryable since the deploy. Asked structurally, the
+    // table is there and the source exists.
+    registryHoldsWithTables(
+      [
+        {
+          slug: "drafts",
+          tableName: "dc_drafts",
+          migrationStatus: "pending",
+          fields: [{ name: "title", type: "text" }],
+          timestamps: true,
+        },
+      ],
+      ["dc_drafts"]
+    );
+
+    await refreshCollectionSources();
+    expect(getSource("collection:drafts")).toBeDefined();
+  });
+
+  it("still refuses a PENDING collection whose table is genuinely absent", async () => {
+    // The control the case above needs: without it, "trust the structure" is
+    // satisfied by a filter that stopped refusing anything at all.
+    registryHoldsWithTables(
+      [
+        {
+          slug: "drafts",
+          tableName: "dc_drafts",
+          migrationStatus: "pending",
+          fields: [{ name: "title", type: "text" }],
+          timestamps: true,
+        },
+      ],
+      ["dc_something_else"]
+    );
+
+    await refreshCollectionSources();
+    expect(getSource("collection:drafts")).toBeUndefined();
+  });
+
+  it("asks the database NOTHING when every label already claims presence", async () => {
+    // The cost property, asserted rather than assumed. `refreshCollectionSources`
+    // runs on every workspace, layout and widget request, so introspecting per
+    // request would be a database round trip on the hot path. The label settles
+    // the common case and the structural question is asked only of the
+    // collections it declines -- which is the population it is wrong about.
+    const { listTables } = registryHoldsWithTables(
+      [
+        {
+          slug: "posts",
+          tableName: "dc_posts",
+          migrationStatus: "applied",
+          fields: [{ name: "title", type: "text" }],
+          timestamps: true,
+        },
+        {
+          slug: "pages",
+          tableName: "dc_pages",
+          migrationStatus: "synced",
+          fields: [{ name: "title", type: "text" }],
+          timestamps: true,
+        },
+      ],
+      ["dc_posts", "dc_pages"]
+    );
+
+    await refreshCollectionSources();
+    expect(getSource("collection:posts")).toBeDefined();
+    expect(listTables).not.toHaveBeenCalled();
+  });
+
+  it("does not re-introspect for a table it has already observed", async () => {
+    // A table that exists does not stop existing, so one observation settles it
+    // for the life of the process. Without this, a collection stuck on a wrong
+    // label would introspect on every request forever -- which is precisely the
+    // state this change exists to serve.
+    const { listTables } = registryHoldsWithTables(
+      [
+        {
+          slug: "drafts",
+          tableName: "dc_drafts",
+          migrationStatus: "pending",
+          fields: [{ name: "title", type: "text" }],
+          timestamps: true,
+        },
+      ],
+      ["dc_drafts"]
+    );
+
+    await refreshCollectionSources();
+    expect(listTables).toHaveBeenCalledTimes(1);
+
+    await refreshCollectionSources();
+    expect(getSource("collection:drafts")).toBeDefined();
+    expect(listTables).toHaveBeenCalledTimes(1);
   });
 
   it("DOES give one to a collection whose migration ran", async () => {

--- a/packages/nextly/src/domains/widgets/__tests__/collection-sources.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/collection-sources.test.ts
@@ -13,7 +13,6 @@ import { container } from "../../../di/container";
 import { setNextlyLogger } from "../../../observability/logger";
 import {
   refreshCollectionSources,
-  resetVerifiedTables,
   setDeferredCollections,
 } from "../collection-sources";
 import {
@@ -78,9 +77,8 @@ function registryUnreachable(): void {
 beforeEach(() => {
   vi.clearAllMocks();
   clearSources();
-  // The observed-table memo is pinned on `globalThis`, so without this a
-  // verification from one test satisfies the next one's assertion.
-  resetVerifiedTables();
+  // The refusal set is pinned on `globalThis`, so without this one test's
+  // deferral outlives it and satisfies the next test's assertion.
   setDeferredCollections([]);
   setNextlyLogger({
     error: () => {},
@@ -480,33 +478,13 @@ describe("a collection whose table is not there yet", () => {
     expect(getSource("collection:drafts")).toBeUndefined();
   });
 
-  it("gives one to a PENDING collection whose table is actually there", async () => {
-    // 🔴 The status is a LABEL and several writers maintain it badly. A Builder
-    // collection deployed with `nextly migrate` keeps `pending` forever -- the
-    // only writer that records `applied`, `registerFromMigrations`, runs from
-    // the development boot path alone -- so its cards would never appear, on a
-    // table that has been queryable since the deploy. Asked structurally, the
-    // table is there and the source exists.
-    registryHoldsWithTables(
-      [
-        {
-          slug: "drafts",
-          tableName: "dc_drafts",
-          migrationStatus: "pending",
-          fields: [{ name: "title", type: "text" }],
-          timestamps: true,
-        },
-      ],
-      ["dc_drafts"]
-    );
-
-    await refreshCollectionSources();
-    expect(getSource("collection:drafts")).toBeDefined();
-  });
-
-  it("still refuses a PENDING collection whose table is genuinely absent", async () => {
-    // The control the case above needs: without it, "trust the structure" is
-    // satisfied by a filter that stopped refusing anything at all.
+  it("refuses a PENDING collection even when its table is present", async () => {
+    // 🔴 The refusal is deliberate and is the conservative half of a known
+    // trade. `pending` is also what a Builder collection carries after its
+    // migration HAS run, because nothing marks the row -- so this hides cards
+    // that would work. It hides them rather than publishing a source whose
+    // columns may not exist, which is the failure that cannot be undone by
+    // looking again.
     registryHoldsWithTables(
       [
         {
@@ -572,108 +550,30 @@ describe("a collection whose table is not there yet", () => {
     expect(getSource("collection:posts")).toBeUndefined();
   });
 
-  it("publishes a collection again once the reload stops deferring it", async () => {
-    // The control: without it the two refusals above are satisfied by a guard
-    // that withholds permanently. A later successful reload REPLACES the set,
-    // so the refusal lifts with nobody having to clear it.
-    setDeferredCollections(["drafts"]);
-    registryHoldsWithTables(
-      [
-        {
-          slug: "drafts",
-          tableName: "dc_drafts",
-          migrationStatus: "pending",
-          fields: [{ name: "title", type: "text" }],
-          timestamps: true,
-        },
-      ],
-      ["dc_drafts"]
-    );
-    await refreshCollectionSources();
-    expect(getSource("collection:drafts")).toBeUndefined();
+  it("publishes a collection again once the reload stops deferring it", () => {
+    // The control the two refusals need: without it they are satisfied by a
+    // guard that withholds permanently. The label CLAIMS presence throughout,
+    // so the refusal is the only thing withholding this collection, and a later
+    // reload replaces the published set rather than adding to it -- which is
+    // what lifts a refusal with nobody having to clear it.
+    const row = {
+      slug: "posts",
+      tableName: "dc_posts",
+      migrationStatus: "applied",
+      fields: [{ name: "title", type: "text" }],
+      timestamps: true,
+    };
 
-    setDeferredCollections([]);
-    await refreshCollectionSources();
-    expect(getSource("collection:drafts")).toBeDefined();
-  });
+    return (async () => {
+      setDeferredCollections(["posts"]);
+      registryHolds([row]);
+      await refreshCollectionSources();
+      expect(getSource("collection:posts")).toBeUndefined();
 
-  it("asks the database NOTHING for a deferred collection", async () => {
-    // A deferred collection is excluded whatever the database answers, so a
-    // lookup for it is a round trip whose result is discarded -- on every
-    // request, for as long as the refusal stands.
-    setDeferredCollections(["drafts"]);
-    const { listTables } = registryHoldsWithTables(
-      [
-        {
-          slug: "drafts",
-          tableName: "dc_drafts",
-          migrationStatus: "pending",
-          fields: [{ name: "title", type: "text" }],
-          timestamps: true,
-        },
-      ],
-      ["dc_drafts"]
-    );
-
-    await refreshCollectionSources();
-    expect(listTables).not.toHaveBeenCalled();
-  });
-
-  it("asks the database NOTHING when every label already claims presence", async () => {
-    // The cost property, asserted rather than assumed. `refreshCollectionSources`
-    // runs on every workspace, layout and widget request, so introspecting per
-    // request would be a database round trip on the hot path. The label settles
-    // the common case and the structural question is asked only of the
-    // collections it declines -- which is the population it is wrong about.
-    const { listTables } = registryHoldsWithTables(
-      [
-        {
-          slug: "posts",
-          tableName: "dc_posts",
-          migrationStatus: "applied",
-          fields: [{ name: "title", type: "text" }],
-          timestamps: true,
-        },
-        {
-          slug: "pages",
-          tableName: "dc_pages",
-          migrationStatus: "synced",
-          fields: [{ name: "title", type: "text" }],
-          timestamps: true,
-        },
-      ],
-      ["dc_posts", "dc_pages"]
-    );
-
-    await refreshCollectionSources();
-    expect(getSource("collection:posts")).toBeDefined();
-    expect(listTables).not.toHaveBeenCalled();
-  });
-
-  it("does not re-introspect for a table it has already observed", async () => {
-    // A table that exists does not stop existing, so one observation settles it
-    // for the life of the process. Without this, a collection stuck on a wrong
-    // label would introspect on every request forever -- which is precisely the
-    // state this change exists to serve.
-    const { listTables } = registryHoldsWithTables(
-      [
-        {
-          slug: "drafts",
-          tableName: "dc_drafts",
-          migrationStatus: "pending",
-          fields: [{ name: "title", type: "text" }],
-          timestamps: true,
-        },
-      ],
-      ["dc_drafts"]
-    );
-
-    await refreshCollectionSources();
-    expect(listTables).toHaveBeenCalledTimes(1);
-
-    await refreshCollectionSources();
-    expect(getSource("collection:drafts")).toBeDefined();
-    expect(listTables).toHaveBeenCalledTimes(1);
+      setDeferredCollections([]);
+      await refreshCollectionSources();
+      expect(getSource("collection:posts")).toBeDefined();
+    })();
   });
 
   it("DOES give one to a collection whose migration ran", async () => {

--- a/packages/nextly/src/domains/widgets/__tests__/collection-widgets.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/collection-widgets.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import {
   collectionWidgets,
+  generatedCollectionSlug,
   readableGeneratedWidgets,
   setGeneratedWidgets,
 } from "../collection-widgets";
@@ -174,7 +175,7 @@ describe("which generated cards a reader may be told about", () => {
     setGeneratedWidgets([card("secret", "read-secret"), card("open")]);
 
     const readable = readableGeneratedWidgets(
-      permission => permission !== "read-secret",
+      slug => slug !== "secret",
       new Set()
     );
 
@@ -201,5 +202,31 @@ describe("which generated cards a reader may be told about", () => {
     expect(
       readableGeneratedWidgets(() => true, new Set()).map(w => w.id)
     ).toEqual(["posts", "pages"]);
+  });
+});
+
+describe("which collection a generated card is about", () => {
+  it("takes it from the QUERY, not from the widget id", () => {
+    // 🔴 Access is checked against the thing being READ. The id is a display
+    // identity that happens to be derived from the same slug; checking a name
+    // rather than the source is how the two come apart, and the query is what
+    // the read is actually performed against.
+    expect(
+      generatedCollectionSlug({
+        id: "collection/anything-count",
+        query: { source: "collection:posts", op: "count" },
+      } as unknown as Parameters<typeof generatedCollectionSlug>[0])
+    ).toBe("posts");
+  });
+
+  it("names nothing for a card that queries no collection", () => {
+    // The control, and what makes the refusal in `readableGeneratedWidgets`
+    // meaningful: a card whose subject cannot be identified is withheld.
+    expect(
+      generatedCollectionSlug({
+        id: "core/whatever",
+        query: { source: "system:users", op: "count" },
+      } as unknown as Parameters<typeof generatedCollectionSlug>[0])
+    ).toBeUndefined();
   });
 });

--- a/packages/nextly/src/domains/widgets/__tests__/collection-widgets.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/collection-widgets.test.ts
@@ -1,0 +1,140 @@
+/**
+ * A card per collection: what is derived, and what is deliberately not.
+ */
+import { describe, expect, it } from "vitest";
+
+import { collectionWidgets } from "../collection-widgets";
+import type { WidgetSource } from "../sources";
+
+function source(patch: Partial<WidgetSource>): WidgetSource {
+  return {
+    id: "collection:posts",
+    label: "posts",
+    kind: "collection",
+    requiredPermission: "read-posts",
+    supports: ["count", "list"],
+    fields: [
+      { name: "id", type: "string" },
+      { name: "title", type: "string" },
+      { name: "updatedAt", type: "date" },
+    ],
+    ...patch,
+  } as WidgetSource;
+}
+
+describe("what a collection gets", () => {
+  it("derives a metric and a list from one source", () => {
+    const widgets = collectionWidgets([source({})]);
+    expect(widgets.map(w => [w.id, w.archetype])).toEqual([
+      ["collection/posts-count", "metric"],
+      ["collection/posts-recent", "list"],
+    ]);
+  });
+
+  it("takes the permission from the SOURCE rather than rebuilding it", () => {
+    // 🔴 The widget and the source must agree about which permission gates the
+    // collection. Rebuilding `read-${slug}` here would be a second answer, and
+    // a source whose permission was corrected would leave a card gated by the
+    // old one -- offered to a reader whose every query against it is refused.
+    const widgets = collectionWidgets([
+      source({ requiredPermission: "read-articles" }),
+    ]);
+    expect(widgets.map(w => w.requiredPermission)).toEqual([
+      "read-articles",
+      "read-articles",
+    ]);
+  });
+
+  it("counts EVERY entry, drafts included", () => {
+    // A count that quietly excluded drafts would disagree with the number the
+    // collection's own list view shows, with nothing to say which is narrower.
+    const [count] = collectionWidgets([source({})]);
+    expect(count.query).toMatchObject({ op: "count", status: "all" });
+  });
+
+  it("selects the row label first and the muted line second", () => {
+    // The order the `list` renderer reads `select` in.
+    const [, recent] = collectionWidgets([source({})]);
+    expect(recent.query?.select).toEqual(["title", "updatedAt"]);
+    expect(recent.query?.sort).toBe("-updatedAt");
+  });
+
+  it("honours the conventional title order rather than field order", () => {
+    const [, recent] = collectionWidgets([
+      source({
+        fields: [
+          { name: "heading", type: "string" },
+          { name: "title", type: "string" },
+          { name: "updatedAt", type: "date" },
+        ],
+      }),
+    ]);
+    expect(recent.query?.select?.[0]).toBe("title");
+  });
+});
+
+describe("what a collection does NOT get", () => {
+  it("no list when nothing names its entries", () => {
+    // 🔴 A refusal, not a fallback. Every row would read as an identifier, and
+    // the `list` renderer already declines to guess a key out of a document it
+    // knows nothing about -- generating one that guesses badly would defeat
+    // that by answering the question wrongly instead of declining it.
+    const widgets = collectionWidgets([
+      source({
+        fields: [
+          { name: "id", type: "string" },
+          { name: "amount", type: "number" },
+          { name: "updatedAt", type: "date" },
+        ],
+      }),
+    ]);
+    expect(widgets.map(w => w.archetype)).toEqual(["metric"]);
+  });
+
+  it("no list when there is no updatedAt to mean 'recent'", () => {
+    // Sorting by id would give a card whose title claims something its rows do
+    // not support.
+    const widgets = collectionWidgets([
+      source({
+        fields: [
+          { name: "id", type: "string" },
+          { name: "title", type: "string" },
+        ],
+      }),
+    ]);
+    expect(widgets.map(w => w.archetype)).toEqual(["metric"]);
+  });
+
+  it("no metric when the source does not answer count", () => {
+    const widgets = collectionWidgets([source({ supports: ["list"] })]);
+    expect(widgets.map(w => w.archetype)).toEqual(["list"]);
+  });
+
+  it("nothing at all for a source that is not a collection", () => {
+    // Singles hold one entry, so a count of them is a constant and a list of
+    // them is that one entry. Neither is a card worth offering.
+    expect(
+      collectionWidgets([
+        source({ id: "single:homepage", kind: "single", label: "homepage" }),
+      ])
+    ).toEqual([]);
+  });
+
+  it("nothing when the install has no sources", () => {
+    expect(collectionWidgets([])).toEqual([]);
+  });
+
+  it("no card at all when the slug cannot make a valid widget id", () => {
+    // 🔴 A widget id is `namespace/name` in lowercase slug form, and the check
+    // is the REGISTRY's own predicate rather than a copy of its pattern. A
+    // second copy would accept ids the registry refuses -- and these ids reach
+    // the admin's payload and the layout endpoint, both of which treat them as
+    // real. Skipping is the honest outcome: the collection is still readable
+    // everywhere else, it simply gets no generated card.
+    expect(
+      collectionWidgets([
+        source({ id: "collection:Weird_Slug", label: "Weird_Slug" }),
+      ])
+    ).toEqual([]);
+  });
+});

--- a/packages/nextly/src/domains/widgets/__tests__/collection-widgets.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/collection-widgets.test.ts
@@ -37,17 +37,59 @@ describe("what a collection gets", () => {
     ]);
   });
 
-  it("takes the permission from the SOURCE rather than rebuilding it", () => {
-    // 🔴 The widget and the source must agree about which permission gates the
-    // collection. Rebuilding `read-${slug}` here would be a second answer, and
-    // a source whose permission was corrected would leave a card gated by the
-    // old one -- offered to a reader whose every query against it is refused.
+  it("carries NO requiredPermission, because the SERVER gates it", () => {
+    // 🔴 It used to carry the source's permission, and that was wrong in the
+    // direction that loses cards. The client checks `requiredPermission` against
+    // the flat `/me/permissions` list, which does not hold a grant that exists
+    // only in a collection's code-defined `access.read` — so a reader the server
+    // had approved saw both cards discarded by the grid, for a query it would
+    // have answered. The server filters these by collection on both paths that
+    // publish them; the client draws what it is sent.
     const widgets = collectionWidgets([
       source({ requiredPermission: "read-articles" }),
     ]);
-    expect(widgets.map(w => w.requiredPermission)).toEqual([
-      "read-articles",
-      "read-articles",
+    expect(widgets).toHaveLength(2);
+    for (const widget of widgets) {
+      expect(widget).not.toHaveProperty("requiredPermission");
+    }
+  });
+
+  it("derives a valid id for a slug carrying an underscore", () => {
+    // 🔴 `SLUG_PATTERN` permits `_` and a widget id does not, so
+    // `customer_notes` produced an id the registry refuses and BOTH cards were
+    // dropped — a supported class of collection that never got the feature.
+    const widgets = collectionWidgets([
+      source({ id: "collection:customer_notes", label: "customer_notes" }),
+    ]);
+    expect(widgets.map(w => w.id)).toEqual([
+      "collection/customer-notes-count",
+      "collection/customer-notes-recent",
+    ]);
+  });
+
+  it("gives NEITHER collection a card when two slugs derive one id", () => {
+    // The mapping is not injective: `a_b` and `a-b` both reduce to `a-b`.
+    // Neither has a claim over the other, and a card drawn for one while its
+    // query reads the other is the worst outcome available — so a collision
+    // costs both rather than silently picking a winner.
+    const widgets = collectionWidgets([
+      source({ id: "collection:a_b", label: "a_b" }),
+      source({ id: "collection:a-b", label: "a-b" }),
+    ]);
+    expect(widgets).toEqual([]);
+  });
+
+  it("still gives a card to collections that did not collide", () => {
+    // The control: without it the assertion above is satisfied by a collision
+    // rule that drops everything.
+    const widgets = collectionWidgets([
+      source({ id: "collection:a_b", label: "a_b" }),
+      source({ id: "collection:a-b", label: "a-b" }),
+      source({ id: "collection:posts", label: "posts" }),
+    ]);
+    expect(widgets.map(w => w.id)).toEqual([
+      "collection/posts-count",
+      "collection/posts-recent",
     ]);
   });
 
@@ -182,7 +224,7 @@ describe("which generated cards a reader may be told about", () => {
     expect(readable.map(w => w.id)).toEqual(["open"]);
   });
 
-  it("withholds a card whose id a CONTRIBUTION already claimed", () => {
+  it("withholds a card whose id a DECLARATION already claimed", () => {
     // The admin reads this array as the registration channel, and its merge
     // gives a registration authority over a colliding contribution's title,
     // archetype, query and permission. Publishing here would replace a plugin's

--- a/packages/nextly/src/domains/widgets/__tests__/collection-widgets.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/collection-widgets.test.ts
@@ -1,9 +1,13 @@
 /**
  * A card per collection: what is derived, and what is deliberately not.
  */
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
-import { collectionWidgets } from "../collection-widgets";
+import {
+  collectionWidgets,
+  readableGeneratedWidgets,
+  setGeneratedWidgets,
+} from "../collection-widgets";
 import type { WidgetSource } from "../sources";
 
 function source(patch: Partial<WidgetSource>): WidgetSource {
@@ -12,6 +16,7 @@ function source(patch: Partial<WidgetSource>): WidgetSource {
     label: "posts",
     kind: "collection",
     requiredPermission: "read-posts",
+    titleField: "title",
     supports: ["count", "list"],
     fields: [
       { name: "id", type: "string" },
@@ -59,17 +64,23 @@ describe("what a collection gets", () => {
     expect(recent.query?.sort).toBe("-updatedAt");
   });
 
-  it("honours the conventional title order rather than field order", () => {
+  it("labels rows with the field the SOURCE resolved, not one of its own", () => {
+    // 🔴 The source already applied the shared rule to the author's
+    // `admin.useAsTitle` AND the full field list. Re-resolving here from
+    // `fields` alone would ignore the nomination: a collection whose author
+    // chose `headline` would be labelled by a conventional name instead, and
+    // the dashboard would hold the worse of two answers to one question.
     const [, recent] = collectionWidgets([
       source({
+        titleField: "headline",
         fields: [
-          { name: "heading", type: "string" },
+          { name: "headline", type: "string" },
           { name: "title", type: "string" },
           { name: "updatedAt", type: "date" },
         ],
       }),
     ]);
-    expect(recent.query?.select?.[0]).toBe("title");
+    expect(recent.query?.select?.[0]).toBe("headline");
   });
 });
 
@@ -81,6 +92,7 @@ describe("what a collection does NOT get", () => {
     // that by answering the question wrongly instead of declining it.
     const widgets = collectionWidgets([
       source({
+        titleField: undefined,
         fields: [
           { name: "id", type: "string" },
           { name: "amount", type: "number" },
@@ -136,5 +148,58 @@ describe("what a collection does NOT get", () => {
         source({ id: "collection:Weird_Slug", label: "Weird_Slug" }),
       ])
     ).toEqual([]);
+  });
+});
+
+describe("which generated cards a reader may be told about", () => {
+  const card = (id: string, permission?: string) =>
+    ({
+      id,
+      title: id,
+      archetype: "metric",
+      defaultSize: "sm",
+      ...(permission === undefined ? {} : { requiredPermission: permission }),
+      query: { source: `collection:${id}`, op: "count" },
+    }) as unknown as Parameters<typeof setGeneratedWidgets>[0][number];
+
+  afterEach(() => setGeneratedWidgets([]));
+
+  it("withholds a card for a collection this reader may not read", () => {
+    // 🔴 The disclosure. A generated card's id, title and query all name a
+    // COLLECTION, so publishing the whole set tells any authenticated reader
+    // the slug and the existence of every collection in the install --
+    // including the ones the layout and query endpoints hide from them. That
+    // the admin would not draw the card is not a control: the payload is JSON,
+    // and reading it is the bypass.
+    setGeneratedWidgets([card("secret", "read-secret"), card("open")]);
+
+    const readable = readableGeneratedWidgets(
+      permission => permission !== "read-secret",
+      new Set()
+    );
+
+    expect(readable.map(w => w.id)).toEqual(["open"]);
+  });
+
+  it("withholds a card whose id a CONTRIBUTION already claimed", () => {
+    // The admin reads this array as the registration channel, and its merge
+    // gives a registration authority over a colliding contribution's title,
+    // archetype, query and permission. Publishing here would replace a plugin's
+    // card with core's guess in the grid while the server's canonical set kept
+    // the plugin's -- drawing one declaration and placing another.
+    setGeneratedWidgets([card("posts"), card("pages")]);
+
+    const readable = readableGeneratedWidgets(() => true, new Set(["posts"]));
+
+    expect(readable.map(w => w.id)).toEqual(["pages"]);
+  });
+
+  it("passes everything a reader may see and nobody claimed", () => {
+    // The control. Without it both refusals above are satisfied by a filter
+    // that returns nothing at all.
+    setGeneratedWidgets([card("posts"), card("pages")]);
+    expect(
+      readableGeneratedWidgets(() => true, new Set()).map(w => w.id)
+    ).toEqual(["posts", "pages"]);
   });
 });

--- a/packages/nextly/src/domains/widgets/__tests__/publish.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/publish.test.ts
@@ -86,8 +86,3 @@ describe("publishableWidgets", () => {
     );
   });
 });
-
-// Generated cards are NOT published here. They are caller-dependent -- their id
-// and title name a collection -- so the workspace route resolves them per
-// reader and passes them in; `readableGeneratedWidgets` in
-// `collection-widgets.test.ts` covers that filtering.

--- a/packages/nextly/src/domains/widgets/__tests__/publish.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/publish.test.ts
@@ -12,7 +12,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { setNextlyLogger } from "../../../observability/logger";
 import type { WidgetDefinition } from "../definition";
 import { publishableWidgets } from "../publish";
-import { setGeneratedWidgets } from "../collection-widgets";
 import { clearWidgets, registerWidget } from "../registry";
 
 const def = (
@@ -88,34 +87,7 @@ describe("publishableWidgets", () => {
   });
 });
 
-describe("the generated cards reach the admin", () => {
-  const generated = def("collection/posts-count", {
-    archetype: "metric",
-    query: { source: "collection:posts", op: "count" },
-  });
-
-  afterEach(() => setGeneratedWidgets([]));
-
-  it("publishes a card nobody registered", () => {
-    // 🔴 This is the seam that makes a generated card real. The admin renders
-    // from this payload and from plugin contributions, and a generated widget
-    // is in neither unless it is put here -- so without this the layout
-    // endpoint would offer an id the grid has no declaration to draw.
-    setGeneratedWidgets([generated]);
-    expect(publishableWidgets().map(w => w.id)).toEqual([
-      "collection/posts-count",
-    ]);
-  });
-
-  it("lets an explicit registration REPLACE the generated card of that id", () => {
-    // A generated card is core's guess at something useful; a registration of
-    // the same id is an author saying what that card should be. The reader gets
-    // one card, and it is the author's.
-    setGeneratedWidgets([generated]);
-    registerWidget(def("collection/posts-count", { title: "Mine" }));
-
-    const published = publishableWidgets();
-    expect(published).toHaveLength(1);
-    expect(published[0].title).toBe("Mine");
-  });
-});
+// Generated cards are NOT published here. They are caller-dependent -- their id
+// and title name a collection -- so the workspace route resolves them per
+// reader and passes them in; `readableGeneratedWidgets` in
+// `collection-widgets.test.ts` covers that filtering.

--- a/packages/nextly/src/domains/widgets/__tests__/publish.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/publish.test.ts
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { setNextlyLogger } from "../../../observability/logger";
 import type { WidgetDefinition } from "../definition";
 import { publishableWidgets } from "../publish";
+import { setGeneratedWidgets } from "../collection-widgets";
 import { clearWidgets, registerWidget } from "../registry";
 
 const def = (
@@ -84,5 +85,37 @@ describe("publishableWidgets", () => {
         widget: "acme/bigint",
       })
     );
+  });
+});
+
+describe("the generated cards reach the admin", () => {
+  const generated = def("collection/posts-count", {
+    archetype: "metric",
+    query: { source: "collection:posts", op: "count" },
+  });
+
+  afterEach(() => setGeneratedWidgets([]));
+
+  it("publishes a card nobody registered", () => {
+    // 🔴 This is the seam that makes a generated card real. The admin renders
+    // from this payload and from plugin contributions, and a generated widget
+    // is in neither unless it is put here -- so without this the layout
+    // endpoint would offer an id the grid has no declaration to draw.
+    setGeneratedWidgets([generated]);
+    expect(publishableWidgets().map(w => w.id)).toEqual([
+      "collection/posts-count",
+    ]);
+  });
+
+  it("lets an explicit registration REPLACE the generated card of that id", () => {
+    // A generated card is core's guess at something useful; a registration of
+    // the same id is an author saying what that card should be. The reader gets
+    // one card, and it is the author's.
+    setGeneratedWidgets([generated]);
+    registerWidget(def("collection/posts-count", { title: "Mine" }));
+
+    const published = publishableWidgets();
+    expect(published).toHaveLength(1);
+    expect(published[0].title).toBe("Mine");
   });
 });

--- a/packages/nextly/src/domains/widgets/__tests__/sources.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/sources.test.ts
@@ -402,3 +402,41 @@ describe("a registered source is a detached snapshot", () => {
     expect(Object.isFrozen(listed)).toBe(true);
   });
 });
+
+describe("a source's title field", () => {
+  const base = {
+    id: "plugin:acme/orders",
+    label: "Orders",
+    kind: "plugin" as const,
+    supports: ["list" as const],
+    fields: [{ name: "reference", type: "string" as const }],
+  };
+
+  it("refuses a field the source does not declare", () => {
+    // 🔴 The value becomes a `select` entry on a generated card, and `select` is
+    // checked against this source's own field allowlist when the query runs --
+    // so a source naming a field it does not declare produces a card whose every
+    // request is refused, per reader, rather than failing where it was declared.
+    expect(() => registerSource({ ...base, titleField: "headline" })).toThrow(
+      /titleField "headline" is not one of its fields/
+    );
+  });
+
+  it("refuses a blank one", () => {
+    expect(() => registerSource({ ...base, titleField: "   " })).toThrow(
+      /titleField, when given, must be a non-empty string/
+    );
+  });
+
+  it("accepts one the source declares", () => {
+    // The control: without it both refusals are satisfied by a validator that
+    // rejects every `titleField`.
+    registerSource({ ...base, titleField: "reference" });
+    expect(getSource("plugin:acme/orders")?.titleField).toBe("reference");
+  });
+
+  it("accepts a source that names none", () => {
+    registerSource(base);
+    expect(getSource("plugin:acme/orders")?.titleField).toBeUndefined();
+  });
+});

--- a/packages/nextly/src/domains/widgets/built-in-sources.ts
+++ b/packages/nextly/src/domains/widgets/built-in-sources.ts
@@ -64,6 +64,36 @@ const STATUS_FIELD: WidgetSourceField = { name: "status", type: "string" };
  */
 const NEVER_EXPOSED_FIELD_TYPES: ReadonlySet<string> = new Set(["password"]);
 
+/**
+ * Field types whose stored value a row-drawing card can PRINT.
+ *
+ * 🔴 An allowlist, and read against the field's ORIGINAL type rather than the
+ * coarse one below: `toSourceType` maps everything it does not recognise to
+ * `"string"`, so a `json`, `group`, `repeater`, `component` or `chips` field is
+ * indistinguishable from a text field by the time a source is built. Schema
+ * validation permits any of those as `admin.useAsTitle`, and the card that
+ * results asks for an object per row -- which `asText` correctly declines to
+ * stringify, so every row draws an em dash and the card says nothing at all.
+ *
+ * FAILS CLOSED on a type it does not know, including one a plugin registered.
+ * The two outcomes are not symmetric: an unrecognised scalar costs that
+ * collection its recent card, which is a missing card; an unrecognised
+ * structured type costs the reader a card of em dashes, which looks like the
+ * product is broken. `relationship` and `upload` are excluded for a third
+ * reason -- their value may well be a printable id, and an id is not a name.
+ */
+const PRINTABLE_FIELD_TYPES: ReadonlySet<string> = new Set([
+  "text",
+  "textarea",
+  "number",
+  "checkbox",
+  "date",
+  "select",
+  "email",
+  "code",
+  "radio",
+]);
+
 /** Map a Nextly field type onto the coarse type a query validator needs. */
 function toSourceType(fieldType: string): WidgetSourceField["type"] {
   switch (fieldType) {
@@ -127,6 +157,13 @@ export interface WidgetSourceCollection {
   slug: string;
   fields: Array<{ name: string; type: string; label?: string }>;
   /**
+   * What a human calls this collection — the registry's plural label.
+   *
+   * Absent falls back to the slug, which is what every source published before
+   * this was carrying. A collection that never set one has no better answer.
+   */
+  label?: string;
+  /**
    * The field the collection's author nominated to name its entries
    * (`admin.useAsTitle`), when they nominated one.
    *
@@ -167,15 +204,30 @@ function collectionSource(collection: WidgetSourceCollection): WidgetSource {
   // Through the shared rule, with BOTH halves: the author's nomination and the
   // names it must exist in. Resolved once here so no consumer has to ask again
   // with only one of them.
+  // Only the fields a card could actually print are candidates. Passing every
+  // name would let the shared rule nominate a structured field, and the entry
+  // list does not behave that way either: it reads the VALUE and falls back
+  // when the nominated one is not readable text. This is that same behaviour,
+  // decided from the declaration instead of from a row.
+  const printable = new Set(
+    collection.fields
+      .filter(field => PRINTABLE_FIELD_TYPES.has(field.type))
+      .map(field => field.name)
+  );
   const titleField = entryTitleField(
     collection.useAsTitle,
-    fields.map(field => field.name)
+    fields.filter(field => printable.has(field.name)).map(field => field.name)
   );
 
   return {
     id,
     ...(titleField === undefined ? {} : { titleField }),
-    label: collection.slug,
+    // What a HUMAN calls this collection, which is what `label` means. The slug
+    // is a storage identifier: a collection whose plural label is "Articles"
+    // was published to the source picker, and to every generated card's title,
+    // as `blog-posts` -- disagreeing with the name used everywhere else in the
+    // admin. The slug remains the identity, in `id`.
+    label: collection.label ?? collection.slug,
     // DERIVED from the id rather than restated beside it. The id's namespace is
     // the canonical identity -- `registerSource` refuses a source whose two
     // disagree -- so writing `"collection"` here as well would be the same fact

--- a/packages/nextly/src/domains/widgets/built-in-sources.ts
+++ b/packages/nextly/src/domains/widgets/built-in-sources.ts
@@ -135,27 +135,48 @@ function toSourceType(fieldType: string): WidgetSourceField["type"] {
  * config from the top means: a layout group appended below cannot displace the
  * field it shadows.
  */
-function exposedFields(
-  fields: Array<{ name: string; type: string; label?: string }>
-): WidgetSourceField[] {
+/**
+ * The declarations a source actually CARRIES, one per name.
+ *
+ * 🔴 Split out so every question about a field is asked of the SAME
+ * declaration. A collection may declare one name twice, and the two need not
+ * agree: `tags` as `hasMany` and then `tags` as a scalar is a legal config. The
+ * exposed field list kept the first of those while the printable-title filter
+ * was asked of the RAW list, where the second one also gets a vote -- so a name
+ * whose retained declaration stores an array could be nominated as the title,
+ * and the list card printed an array where a name belongs.
+ *
+ * Hidden types are dropped BEFORE a name is claimed, which is deliberate and is
+ * why "first" here means first EXPOSED: a name first declared as a
+ * never-exposed type and later as text is carried by the later declaration,
+ * because the earlier one was never a candidate to begin with.
+ */
+function retainedDeclarations<T extends { name: string; type: string }>(
+  fields: readonly T[]
+): T[] {
   const taken = new Set<string>();
-  const exposed: WidgetSourceField[] = [];
+  const kept: T[] = [];
   for (const field of fields) {
     if (NEVER_EXPOSED_FIELD_TYPES.has(field.type)) continue;
     if (taken.has(field.name)) continue;
     taken.add(field.name);
-    // The label travels with the field. This function REBUILDS each entry
-    // rather than passing it through -- `type` is mapped into the source
-    // vocabulary here -- so anything not named is dropped, which is how the
-    // label went missing between the collection registry and the source in the
-    // first place.
-    exposed.push({
-      name: field.name,
-      type: toSourceType(field.type),
-      ...(field.label !== undefined && { label: field.label }),
-    });
+    kept.push(field);
   }
-  return exposed;
+  return kept;
+}
+
+function exposedFields(
+  fields: Array<{ name: string; type: string; label?: string }>
+): WidgetSourceField[] {
+  // The label travels with the field. This function REBUILDS each entry rather
+  // than passing it through -- `type` is mapped into the source vocabulary
+  // here -- so anything not named is dropped, which is how the label went
+  // missing between the collection registry and the source in the first place.
+  return retainedDeclarations(fields).map(field => ({
+    name: field.name,
+    type: toSourceType(field.type),
+    ...(field.label !== undefined && { label: field.label }),
+  }));
 }
 
 /** One collection, in the shape a widget source is built from. */
@@ -221,8 +242,12 @@ function collectionSource(collection: WidgetSourceCollection): WidgetSource {
   // list does not behave that way either: it reads the VALUE and falls back
   // when the nominated one is not readable text. This is that same behaviour,
   // decided from the declaration instead of from a row.
+  //
+  // Asked of the RETAINED declarations, not of `collection.fields`. A duplicate
+  // name's later declaration is not the one this source carries, so letting it
+  // answer here would qualify a name whose actual declaration stores an array.
   const printable = new Set(
-    collection.fields
+    retainedDeclarations(collection.fields)
       .filter(
         field => PRINTABLE_FIELD_TYPES.has(field.type) && field.hasMany !== true
       )

--- a/packages/nextly/src/domains/widgets/built-in-sources.ts
+++ b/packages/nextly/src/domains/widgets/built-in-sources.ts
@@ -8,6 +8,8 @@
  * @module domains/widgets/built-in-sources
  */
 
+import { entryTitleField } from "../collections/entry-title";
+
 import {
   replaceSourcesOfKind,
   sourceKindFromId,
@@ -125,6 +127,14 @@ export interface WidgetSourceCollection {
   slug: string;
   fields: Array<{ name: string; type: string; label?: string }>;
   /**
+   * The field the collection's author nominated to name its entries
+   * (`admin.useAsTitle`), when they nominated one.
+   *
+   * Carried rather than resolved by the caller, because resolving it needs the
+   * full field list — system columns included — which only the source knows.
+   */
+  useAsTitle?: string;
+  /**
    * Whether the collection has `createdAt`/`updatedAt` columns. Absent means
    * ON, which is how `defineCollection` normalizes it and how the registry
    * stores it.
@@ -150,9 +160,21 @@ function collectionSource(collection: WidgetSourceCollection): WidgetSource {
   if (collection.status === true) systemFields.push(STATUS_FIELD);
 
   const id = `collection:${collection.slug}`;
+  const fields = [
+    ...declared,
+    ...systemFields.filter(field => !seen.has(field.name)),
+  ];
+  // Through the shared rule, with BOTH halves: the author's nomination and the
+  // names it must exist in. Resolved once here so no consumer has to ask again
+  // with only one of them.
+  const titleField = entryTitleField(
+    collection.useAsTitle,
+    fields.map(field => field.name)
+  );
 
   return {
     id,
+    ...(titleField === undefined ? {} : { titleField }),
     label: collection.slug,
     // DERIVED from the id rather than restated beside it. The id's namespace is
     // the canonical identity -- `registerSource` refuses a source whose two
@@ -165,10 +187,7 @@ function collectionSource(collection: WidgetSourceCollection): WidgetSource {
     // for why nothing enforces it.
     requiredPermission: `read-${collection.slug}`,
     supports: ["count", "list"],
-    fields: [
-      ...declared,
-      ...systemFields.filter(field => !seen.has(field.name)),
-    ],
+    fields,
   };
 }
 

--- a/packages/nextly/src/domains/widgets/built-in-sources.ts
+++ b/packages/nextly/src/domains/widgets/built-in-sources.ts
@@ -75,6 +75,12 @@ const NEVER_EXPOSED_FIELD_TYPES: ReadonlySet<string> = new Set(["password"]);
  * results asks for an object per row -- which `asText` correctly declines to
  * stringify, so every row draws an em dash and the card says nothing at all.
  *
+ * 🔴 CARDINALITY is checked beside the type, because a scalar type is not a
+ * scalar VALUE. `text` and `select` both accept `hasMany`, and one of those
+ * stores an array — which `asText` declines to print, so the card draws an em
+ * dash on every row while a usable conventional title sits unused beside it.
+ * Type alone was the wrong question.
+ *
  * FAILS CLOSED on a type it does not know, including one a plugin registered.
  * The two outcomes are not symmetric: an unrecognised scalar costs that
  * collection its recent card, which is a missing card; an unrecognised
@@ -155,7 +161,13 @@ function exposedFields(
 /** One collection, in the shape a widget source is built from. */
 export interface WidgetSourceCollection {
   slug: string;
-  fields: Array<{ name: string; type: string; label?: string }>;
+  fields: Array<{
+    name: string;
+    type: string;
+    label?: string;
+    /** Whether the field stores an ARRAY. A scalar type may still be one. */
+    hasMany?: boolean;
+  }>;
   /**
    * What a human calls this collection — the registry's plural label.
    *
@@ -211,7 +223,9 @@ function collectionSource(collection: WidgetSourceCollection): WidgetSource {
   // decided from the declaration instead of from a row.
   const printable = new Set(
     collection.fields
-      .filter(field => PRINTABLE_FIELD_TYPES.has(field.type))
+      .filter(
+        field => PRINTABLE_FIELD_TYPES.has(field.type) && field.hasMany !== true
+      )
       .map(field => field.name)
   );
   const titleField = entryTitleField(

--- a/packages/nextly/src/domains/widgets/built-in-sources.ts
+++ b/packages/nextly/src/domains/widgets/built-in-sources.ts
@@ -88,11 +88,25 @@ const NEVER_EXPOSED_FIELD_TYPES: ReadonlySet<string> = new Set(["password"]);
  * product is broken. `relationship` and `upload` are excluded for a third
  * reason -- their value may well be a printable id, and an id is not a name.
  */
+/**
+ * 🔴 The INVARIANT this list has to hold: every type in it must produce a value
+ * the shared naming rule will actually print. That rule accepts a non-empty
+ * string or a finite number and refuses everything else, in both places it is
+ * implemented -- `readableText` for the entry surfaces and the candidate walk in
+ * `entryHeading` for the activity feed.
+ *
+ * `checkbox` is absent for that reason, and its absence is the point rather than
+ * an oversight: a boolean is a legal `useAsTitle` nomination and a conventional
+ * field can itself be a checkbox, so nominating one here made the field-level
+ * answer disagree with every value-level answer -- the generated card selecting
+ * a column whose value each of those rules then declines, while the same entry
+ * is named by a conventional fallback everywhere else. A type this list admits
+ * but the value rule refuses is a card that names nothing.
+ */
 const PRINTABLE_FIELD_TYPES: ReadonlySet<string> = new Set([
   "text",
   "textarea",
   "number",
-  "checkbox",
   "date",
   "select",
   "email",

--- a/packages/nextly/src/domains/widgets/canonical.ts
+++ b/packages/nextly/src/domains/widgets/canonical.ts
@@ -46,6 +46,21 @@ import { listWidgets } from "./registry";
  */
 export interface CanonicalWidget {
   id: string;
+  /**
+   * Whether core DERIVED this card rather than an author declaring it.
+   *
+   * 🔴 It decides one thing: a derived card is offered and never placed. The
+   * default arrangement is materialized from the widgets an install DECLARES,
+   * and a generated set is unbounded in the install's own content -- forty
+   * collections would open onto eighty cards nobody asked for, and could fill
+   * the submission cap before the reader chose anything.
+   *
+   * Set only where the generated channel is the one that supplied the entry. A
+   * contribution or a registration claiming the same id has DECLARED that
+   * widget, so it is placed like any other: the flag describes where the
+   * surviving declaration came from, not which ids core can generate.
+   */
+  generated?: boolean;
   requiredPermission?: string;
   defaultSize?: string;
   defaultHeight?: string;
@@ -149,8 +164,12 @@ export function canonicalWidgets(
   // it, and core's derived guess must not displace it -- while a registration
   // below still merges over whichever of the two is here, for the same reason.
   for (const definition of generatedWidgets()) {
-    if (!byId.has(definition.id))
-      byId.set(definition.id, fromRegistration(definition));
+    if (!byId.has(definition.id)) {
+      byId.set(definition.id, {
+        ...fromRegistration(definition),
+        generated: true,
+      });
+    }
   }
   for (const definition of listWidgets()) {
     const registration = fromRegistration(definition);
@@ -182,6 +201,18 @@ const globalForContributed = globalThis as unknown as {
   __nextly_contributedWidgets?: CanonicalWidget[];
 };
 
+/**
+ * The contributed set, for a caller that needs to know which ids a PLUGIN
+ * claimed rather than merely which ids exist.
+ *
+ * The workspace payload asks: a generated card published under an id a plugin
+ * declared would be read by the admin as a registration, and the merge gives a
+ * registration authority over the contribution's title, archetype and query.
+ */
+export function contributedWidgets(): CanonicalWidget[] {
+  return [...(globalForContributed.__nextly_contributedWidgets ?? [])];
+}
+
 /** Replace the contributed set. Called once per boot, beside the registry. */
 export function setContributedWidgets(
   widgets: readonly CanonicalWidget[]
@@ -200,4 +231,22 @@ export function allWidgets(): CanonicalWidget[] {
   return canonicalWidgets(
     globalForContributed.__nextly_contributedWidgets ?? []
   );
+}
+
+/**
+ * The widgets an install DECLARES, which is what a default arrangement is built
+ * from.
+ *
+ * DERIVED from {@link allWidgets} rather than assembled separately, so the two
+ * cannot disagree about which widgets exist: this is the same set, less the
+ * cards core generated for content the reader has not asked to see.
+ *
+ * The distinction is not cosmetic. `defaultPlacements` positions a card by its
+ * index in the sorted set, and a generated card that appeared here would both
+ * take a position and consume one of the placements a caller may submit --
+ * so an install with many collections would open onto a dashboard nobody chose
+ * and, past the cap, one they could not add to.
+ */
+export function declaredWidgets(): CanonicalWidget[] {
+  return allWidgets().filter(widget => widget.generated !== true);
 }

--- a/packages/nextly/src/domains/widgets/canonical.ts
+++ b/packages/nextly/src/domains/widgets/canonical.ts
@@ -32,6 +32,7 @@
  * @module domains/widgets/canonical
  */
 
+import { generatedWidgets } from "./collection-widgets";
 import type { WidgetDefinition } from "./definition";
 import { listWidgets } from "./registry";
 
@@ -142,6 +143,14 @@ export function canonicalWidgets(
   // a card taking another plugin's geometry, or vanishing.
   for (const widget of contributed) {
     if (widget.id && !byId.has(widget.id)) byId.set(widget.id, widget);
+  }
+  // Generated cards sit BETWEEN the two declared channels. A contribution
+  // already holding the id keeps it -- a plugin that declared that widget meant
+  // it, and core's derived guess must not displace it -- while a registration
+  // below still merges over whichever of the two is here, for the same reason.
+  for (const definition of generatedWidgets()) {
+    if (!byId.has(definition.id))
+      byId.set(definition.id, fromRegistration(definition));
   }
   for (const definition of listWidgets()) {
     const registration = fromRegistration(definition);

--- a/packages/nextly/src/domains/widgets/canonical.ts
+++ b/packages/nextly/src/domains/widgets/canonical.ts
@@ -32,7 +32,10 @@
  * @module domains/widgets/canonical
  */
 
-import { generatedWidgets } from "./collection-widgets";
+import {
+  generatedCollectionSlug,
+  generatedWidgets,
+} from "./collection-widgets";
 import type { WidgetDefinition } from "./definition";
 import { listWidgets } from "./registry";
 
@@ -61,6 +64,16 @@ export interface CanonicalWidget {
    * surviving declaration came from, not which ids core can generate.
    */
   generated?: boolean;
+  /**
+   * The collection a GENERATED card reads, when it is one.
+   *
+   * Carried because access to such a card is a question about that collection
+   * rather than about a declared permission — it has none — and the summary is
+   * what layout resolution filters. Taken from the definition's QUERY where the
+   * generated channel supplies it, so the value names the thing actually read
+   * rather than a slug recovered from a display identity.
+   */
+  collection?: string;
   requiredPermission?: string;
   defaultSize?: string;
   defaultHeight?: string;
@@ -165,9 +178,11 @@ export function canonicalWidgets(
   // below still merges over whichever of the two is here, for the same reason.
   for (const definition of generatedWidgets()) {
     if (!byId.has(definition.id)) {
+      const collection = generatedCollectionSlug(definition);
       byId.set(definition.id, {
         ...fromRegistration(definition),
         generated: true,
+        ...(collection === undefined ? {} : { collection }),
       });
     }
   }

--- a/packages/nextly/src/domains/widgets/collection-sources.ts
+++ b/packages/nextly/src/domains/widgets/collection-sources.ts
@@ -53,7 +53,11 @@ interface RegisteredCollection {
    * is checked at the point of use rather than assumed from the record type.
    */
   admin?: unknown;
-  /** How far this collection's table has got. See {@link tableIsUsable}. */
+  /**
+   * How far this collection's table has got, as a LABEL rather than as the
+   * answer. See {@link statusClaimsPresent} for what it may be believed about,
+   * and {@link usableCollections} for the question that actually decides.
+   */
   migrationStatus?: unknown;
   /**
    * The singular/plural display names. Read defensively for the same reason as

--- a/packages/nextly/src/domains/widgets/collection-sources.ts
+++ b/packages/nextly/src/domains/widgets/collection-sources.ts
@@ -242,40 +242,6 @@ function statusClaimsPresent(collection: RegisteredCollection): boolean {
   return typeof status === "string" && TABLE_PRESENT_STATUSES.has(status);
 }
 
-/** The physical table a registered row names, when it names one usably. */
-function tableNameOf(collection: RegisteredCollection): string | undefined {
-  const name = (collection as { tableName?: unknown }).tableName;
-  return typeof name === "string" && name !== "" ? name : undefined;
-}
-
-/**
- * Slugs whose table has been OBSERVED to exist.
- *
- * Pinned on `globalThis` like every other boot-time widget store, so it
- * survives the module re-evaluation Next.js and Turbopack perform.
- *
- * 🔴 POSITIVE observations only, and the asymmetry is the design rather than an
- * omission. A table that exists does not stop existing under ordinary
- * operation, so remembering that one is present is sound for the life of the
- * process. An ABSENT table may arrive at any moment -- a migration running
- * against a live database is precisely the case this exists to notice -- so
- * caching absence would reinstate the staleness the status label already has,
- * one layer down and harder to see.
- */
-const globalForVerified = globalThis as unknown as {
-  __nextly_widgetVerifiedTables?: Set<string>;
-};
-
-function verifiedTables(): Set<string> {
-  globalForVerified.__nextly_widgetVerifiedTables ??= new Set<string>();
-  return globalForVerified.__nextly_widgetVerifiedTables;
-}
-
-/** Clear the observed-table memo. For tests, which build a fresh registry. */
-export function resetVerifiedTables(): void {
-  globalForVerified.__nextly_widgetVerifiedTables = new Set<string>();
-}
-
 /**
  * Collections whose stored metadata is known to be AHEAD of their table.
  *
@@ -317,90 +283,47 @@ export function setDeferredCollections(slugs: readonly string[]): void {
 }
 
 /**
- * The tables the database actually has, lowercased, or `undefined` when the
- * question could not be asked.
+ * The collections a widget source may be built from.
  *
- * Lowercased because the dialects disagree about identifier case and the core
- * drift check already compares this way; `undefined` is a THIRD answer rather
- * than an empty set, because "there are no tables" and "I could not look" lead
- * to opposite decisions and an empty set would silently mean the first.
+ * 🔴 NEITHER refusal probes the database, and the omission is deliberate.
+ * Whether a collection's stored shape is LIVE is a schema question, and
+ * answering it here means re-deriving something this module does not own. Three
+ * properties make that unattractive:
+ *
+ * - Table EXISTENCE is the wrong question. A reload that refuses a collection's
+ *   DDL writes its new field list anyway, so the OLD table stands beside NEW
+ *   metadata, and a source published on existence alone names columns that were
+ *   never created.
+ * - A probe is dialect-sensitive. `listTables` resolves against `public`, while
+ *   unqualified DML follows the whole search path -- which is why `tableExists`
+ *   reaches for `to_regclass` instead.
+ * - The property that WOULD decide -- whether the physical columns cover the
+ *   fields this source declares -- needs a field-to-column mapping that already
+ *   has several implementations in this repository awaiting convergence. A
+ *   fourth, partial one, owned by the widget domain, answers none of that.
+ *
+ * So this asks only what it can answer from what it holds:
+ *
+ * - `statusClaimsPresent` believes a label that CLAIMS presence and believes
+ *   nothing from one that declines. Its weakness is a false NEGATIVE: a
+ *   deployed Builder collection whose migration ran but whose row nobody marked
+ *   keeps its cards hidden. A hidden card is quiet and recoverable; a card
+ *   querying a column the table lacks is neither.
+ * - {@link setDeferredCollections} covers what the label cannot -- a reload that
+ *   refused a collection's DDL while its metadata was written regardless.
+ *
+ * That false negative is a defect in the WRITERS of `migration_status`, and it
+ * is closed by making them correct rather than by second-guessing them here.
  */
-async function presentTableNames(): Promise<ReadonlySet<string> | undefined> {
-  try {
-    const adapter = container.get<{
-      listTables?: () => Promise<string[]>;
-    }>("adapter");
-    if (typeof adapter?.listTables !== "function") return undefined;
-    const tables = await adapter.listTables();
-    if (!Array.isArray(tables)) return undefined;
-    return new Set(
-      tables
-        .filter((name): name is string => typeof name === "string")
-        .map(name => name.toLowerCase())
-    );
-  } catch (error) {
-    getNextlyLogger().error({
-      kind: "widget-table-introspection-unavailable",
-      err: error instanceof Error ? error.stack : String(error),
-    });
-    return undefined;
-  }
-}
-
-/**
- * The collections a widget source may be built from, asked STRUCTURALLY.
- *
- * The label is consulted first and settles the overwhelmingly common case at no
- * cost: when every collection's status claims its table is present, this makes
- * no database call at all. Introspection happens only for the collections whose
- * label DECLINES -- which is exactly the population the label is wrong about --
- * and then once for the whole batch rather than once per collection.
- *
- * On an unanswerable introspection this falls back to the label, which is the
- * behaviour that shipped before and is the conservative direction: a card is
- * withheld rather than pointed at a table that may not be there.
- */
-async function usableCollections<T extends RegisteredCollection>(
+function usableCollections<T extends RegisteredCollection>(
   collections: T[]
-): Promise<T[]> {
-  const verified = verifiedTables();
+): T[] {
   const deferred = deferredCollections();
-  // Checked BEFORE anything else, and it overrides both the label and the memo.
-  // A collection can be verified while its label is healthy and then be edited
-  // and refused: the table it was verified against is still there, and is no
-  // longer the shape the stored metadata describes. Consulting the memo first
-  // would publish exactly the source this guard exists to withhold.
-  const isDeferred = (collection: T): boolean =>
-    typeof collection.slug === "string" && deferred.has(collection.slug);
-  const settled = (collection: T): boolean =>
-    !isDeferred(collection) &&
-    (statusClaimsPresent(collection) ||
-      verified.has((tableNameOf(collection) ?? "").toLowerCase()));
-
-  // A row naming no table cannot be verified by any amount of introspection, so
-  // it must not TRIGGER any: without this it is permanently unsettled, and a
-  // single malformed row would put a round trip on every request forever while
-  // never changing the outcome. It is still filtered by the label below.
-  // A deferred collection is excluded whatever the database says, so it must not
-  // trigger a lookup either -- it would be a round trip whose answer is ignored,
-  // on every request, for as long as the refusal stands.
-  if (
-    !collections.some(
-      c => !settled(c) && !isDeferred(c) && tableNameOf(c) !== undefined
-    )
-  ) {
-    return collections.filter(settled);
-  }
-
-  const present = await presentTableNames();
-  if (present !== undefined) {
-    for (const collection of collections) {
-      if (statusClaimsPresent(collection) || isDeferred(collection)) continue;
-      const table = tableNameOf(collection)?.toLowerCase();
-      if (table !== undefined && present.has(table)) verified.add(table);
-    }
-  }
-  return collections.filter(settled);
+  return collections.filter(
+    collection =>
+      !(typeof collection.slug === "string" && deferred.has(collection.slug)) &&
+      statusClaimsPresent(collection)
+  );
 }
 
 /**
@@ -456,7 +379,7 @@ export async function refreshCollectionSources(): Promise<void> {
   );
 
   registerBuiltInSources(
-    (await usableCollections(named)).map(collection => ({
+    usableCollections(named).map(collection => ({
       slug: collection.slug,
       fields: readableFields(collection.fields),
       // Only an explicit `false` turns them off; absent means on, the way

--- a/packages/nextly/src/domains/widgets/collection-sources.ts
+++ b/packages/nextly/src/domains/widgets/collection-sources.ts
@@ -277,6 +277,46 @@ export function resetVerifiedTables(): void {
 }
 
 /**
+ * Collections whose stored metadata is known to be AHEAD of their table.
+ *
+ * 🔴 The one thing table existence cannot tell you, and the reason existence
+ * alone is not enough. A reload writes the new field list to
+ * `dynamic_collections` for EVERY configured collection -- the sync payload is
+ * built from the whole config and knows nothing about what applied -- while
+ * refusing the DDL for a collection whose change it classified unsafe. That
+ * collection then keeps its OLD table, which exists, alongside a NEW field list
+ * that the table never received.
+ *
+ * Verified structurally, such a collection publishes a source naming columns
+ * the database does not have, and a widget query validates against the source
+ * and then fails against the table. Withholding it is the older, duller outcome
+ * and the right one: a card that is missing is better than a card that errors.
+ *
+ * This is the "applied-schema signal" that `migration_status` is trying and
+ * failing to be. It is deliberately NOT read from that column: the label is
+ * also set by writers that never deferred anything, which is what made it
+ * unusable in the first place. The reload knows which collections it refused,
+ * so it says so directly.
+ */
+const globalForDeferred = globalThis as unknown as {
+  __nextly_widgetDeferredCollections?: Set<string>;
+};
+
+function deferredCollections(): ReadonlySet<string> {
+  return globalForDeferred.__nextly_widgetDeferredCollections ?? new Set();
+}
+
+/**
+ * Record which collections a reload declined to apply DDL for.
+ *
+ * Replaces the set rather than adding to it, so a collection whose later reload
+ * succeeds stops being deferred without anyone having to remember to clear it.
+ */
+export function setDeferredCollections(slugs: readonly string[]): void {
+  globalForDeferred.__nextly_widgetDeferredCollections = new Set(slugs);
+}
+
+/**
  * The tables the database actually has, lowercased, or `undefined` when the
  * question could not be asked.
  *
@@ -324,22 +364,38 @@ async function usableCollections<T extends RegisteredCollection>(
   collections: T[]
 ): Promise<T[]> {
   const verified = verifiedTables();
+  const deferred = deferredCollections();
+  // Checked BEFORE anything else, and it overrides both the label and the memo.
+  // A collection can be verified while its label is healthy and then be edited
+  // and refused: the table it was verified against is still there, and is no
+  // longer the shape the stored metadata describes. Consulting the memo first
+  // would publish exactly the source this guard exists to withhold.
+  const isDeferred = (collection: T): boolean =>
+    typeof collection.slug === "string" && deferred.has(collection.slug);
   const settled = (collection: T): boolean =>
-    statusClaimsPresent(collection) ||
-    verified.has((tableNameOf(collection) ?? "").toLowerCase());
+    !isDeferred(collection) &&
+    (statusClaimsPresent(collection) ||
+      verified.has((tableNameOf(collection) ?? "").toLowerCase()));
 
   // A row naming no table cannot be verified by any amount of introspection, so
   // it must not TRIGGER any: without this it is permanently unsettled, and a
   // single malformed row would put a round trip on every request forever while
   // never changing the outcome. It is still filtered by the label below.
-  if (!collections.some(c => !settled(c) && tableNameOf(c) !== undefined)) {
+  // A deferred collection is excluded whatever the database says, so it must not
+  // trigger a lookup either -- it would be a round trip whose answer is ignored,
+  // on every request, for as long as the refusal stands.
+  if (
+    !collections.some(
+      c => !settled(c) && !isDeferred(c) && tableNameOf(c) !== undefined
+    )
+  ) {
     return collections.filter(settled);
   }
 
   const present = await presentTableNames();
   if (present !== undefined) {
     for (const collection of collections) {
-      if (statusClaimsPresent(collection)) continue;
+      if (statusClaimsPresent(collection) || isDeferred(collection)) continue;
       const table = tableNameOf(collection)?.toLowerCase();
       if (table !== undefined && present.has(table)) verified.add(table);
     }

--- a/packages/nextly/src/domains/widgets/collection-sources.ts
+++ b/packages/nextly/src/domains/widgets/collection-sources.ts
@@ -184,7 +184,19 @@ function pluralLabelOf(collection: RegisteredCollection): string | undefined {
   const labels = collection.labels;
   if (typeof labels !== "object" || labels === null) return undefined;
   const plural = (labels as { plural?: unknown }).plural;
-  return typeof plural === "string" && plural !== "" ? plural : undefined;
+  if (typeof plural !== "string") return undefined;
+  // 🔴 TRIMMED, and the trim is what keeps a bad label from taking the install
+  // down. `validateSource` refuses a label that is empty AFTER trimming, and
+  // `defineCollection` preserves `labels.plural: "   "` as written -- so a
+  // check for `!== ""` accepts it, `registerSource` throws, and
+  // `refreshCollectionSources` runs on every workspace, layout and widget-query
+  // request. One whitespace label would fail all three for everybody.
+  //
+  // Falling back to the slug rather than passing the trimmed value on: a label
+  // of spaces names nothing, and the slug is the answer a collection with no
+  // label already gets.
+  const trimmed = plural.trim();
+  return trimmed === "" ? undefined : trimmed;
 }
 
 /**
@@ -198,9 +210,13 @@ function useAsTitleOf(collection: RegisteredCollection): string | undefined {
   const admin = collection.admin;
   if (typeof admin !== "object" || admin === null) return undefined;
   const nominated = (admin as { useAsTitle?: unknown }).useAsTitle;
-  return typeof nominated === "string" && nominated !== ""
-    ? nominated
-    : undefined;
+  if (typeof nominated !== "string") return undefined;
+  // Trimmed for the same reason, though this one fails softly: a nomination of
+  // spaces matches no field name, so the shared rule falls back rather than
+  // refusing. Normalised anyway, so the two readings of "the author stated
+  // nothing" agree.
+  const trimmed = nominated.trim();
+  return trimmed === "" ? undefined : trimmed;
 }
 
 export async function refreshCollectionSources(): Promise<void> {

--- a/packages/nextly/src/domains/widgets/collection-sources.ts
+++ b/packages/nextly/src/domains/widgets/collection-sources.ts
@@ -54,6 +54,11 @@ interface RegisteredCollection {
    */
   admin?: unknown;
   /**
+   * The singular/plural display names. Read defensively for the same reason as
+   * `admin`: the row is stored JSON.
+   */
+  labels?: unknown;
+  /**
    * The `timestamps` column pair. A required boolean on the stored record and
    * read defensively here, because the two values decide whether
    * `createdAt`/`updatedAt` exist as COLUMNS -- declaring them on a collection
@@ -172,6 +177,17 @@ async function readRegisteredCollections(): Promise<
  * read into a dashboard of broken cards.
  */
 /**
+ * What a human calls this collection, when the stored row carries a usable
+ * plural label. PLURAL because a source and its cards name a set of entries.
+ */
+function pluralLabelOf(collection: RegisteredCollection): string | undefined {
+  const labels = collection.labels;
+  if (typeof labels !== "object" || labels === null) return undefined;
+  const plural = (labels as { plural?: unknown }).plural;
+  return typeof plural === "string" && plural !== "" ? plural : undefined;
+}
+
+/**
  * The author's nominated title field, when the stored row carries a usable one.
  *
  * The row is JSON, so `admin` may be anything; a non-string nomination is read
@@ -202,6 +218,9 @@ export async function refreshCollectionSources(): Promise<void> {
         fields: readableFields(collection.fields),
         // Only an explicit `false` turns them off; absent means on, the way
         // `defineCollection` normalizes it and the registry stores it.
+        ...(pluralLabelOf(collection) === undefined
+          ? {}
+          : { label: pluralLabelOf(collection) }),
         ...(useAsTitleOf(collection) === undefined
           ? {}
           : { useAsTitle: useAsTitleOf(collection) }),

--- a/packages/nextly/src/domains/widgets/collection-sources.ts
+++ b/packages/nextly/src/domains/widgets/collection-sources.ts
@@ -194,18 +194,32 @@ async function readRegisteredCollections(): Promise<
  * read into a dashboard of broken cards.
  */
 /**
- * Whether this collection's TABLE exists to be queried.
+ * Whether the STATUS LABEL claims this collection's table is present.
  *
- * 🔴 A collection created in the Schema Builder is recorded `pending` and its
- * migration does not run outside development — so in production the row exists,
- * permission seeding makes it visible, and its table does not arrive until the
- * next deploy. A source for it accepts queries that reach a table that is not
- * there, once per reader, for as long as the deploy is away.
+ * 🔴 A label, not the answer. `migration_status` is written by several code
+ * paths and they do not agree: the HMR reload marks an edited collection
+ * `pending` after successfully applying its DDL, and `nextly migrate` applies a
+ * Builder collection's SQL in production without marking anything at all --
+ * `registerFromMigrations`, the one writer that records `applied`, runs only
+ * from the development boot path. So a table that is present and queryable can
+ * carry a label saying it is not, permanently.
  *
- * An ALLOWLIST of statuses that mean the table is present: `synced` for a
- * code-first collection whose table migrations own, and `applied` for a Builder
- * one whose migration ran. `pending`, `generated` and `failed` all mean it is
- * not there yet, and the last of those will not arrive on its own.
+ * This is therefore kept as the FAST PATH only, and {@link usableCollections}
+ * asks the structural question when the label declines. The distinction is the
+ * repository's own rule about identifying by structure rather than by someone
+ * else's spelling: the label is a claim maintained by writers this module does
+ * not control, while the table's existence is the thing itself.
+ *
+ * The allowlist is what the label may be BELIEVED about, and it is deliberately
+ * one-directional. `synced` and `applied` are trusted outright: a writer that
+ * went to the trouble of recording one had the table in hand, so a false
+ * positive here would need a writer lying rather than merely falling behind,
+ * and no path does that. `pending`, `generated` and `failed` are trusted for
+ * NOTHING -- they mean only that no writer has said otherwise yet, which is a
+ * statement about the writers rather than about the database.
+ *
+ * That asymmetry is what makes the fast path safe to take. A label claiming
+ * presence ends the question; a label declining is referred to the database.
  *
  * An ABSENT status is treated as usable, which is the one place this reads
  * generously rather than closed. The field was added after rows existed, so a
@@ -218,10 +232,115 @@ const TABLE_PRESENT_STATUSES: ReadonlySet<string> = new Set([
   "applied",
 ]);
 
-function tableIsUsable(collection: RegisteredCollection): boolean {
+function statusClaimsPresent(collection: RegisteredCollection): boolean {
   const status = (collection as { migrationStatus?: unknown }).migrationStatus;
   if (status === undefined) return true;
   return typeof status === "string" && TABLE_PRESENT_STATUSES.has(status);
+}
+
+/** The physical table a registered row names, when it names one usably. */
+function tableNameOf(collection: RegisteredCollection): string | undefined {
+  const name = (collection as { tableName?: unknown }).tableName;
+  return typeof name === "string" && name !== "" ? name : undefined;
+}
+
+/**
+ * Slugs whose table has been OBSERVED to exist.
+ *
+ * Pinned on `globalThis` like every other boot-time widget store, so it
+ * survives the module re-evaluation Next.js and Turbopack perform.
+ *
+ * 🔴 POSITIVE observations only, and the asymmetry is the design rather than an
+ * omission. A table that exists does not stop existing under ordinary
+ * operation, so remembering that one is present is sound for the life of the
+ * process. An ABSENT table may arrive at any moment -- a migration running
+ * against a live database is precisely the case this exists to notice -- so
+ * caching absence would reinstate the staleness the status label already has,
+ * one layer down and harder to see.
+ */
+const globalForVerified = globalThis as unknown as {
+  __nextly_widgetVerifiedTables?: Set<string>;
+};
+
+function verifiedTables(): Set<string> {
+  globalForVerified.__nextly_widgetVerifiedTables ??= new Set<string>();
+  return globalForVerified.__nextly_widgetVerifiedTables;
+}
+
+/** Clear the observed-table memo. For tests, which build a fresh registry. */
+export function resetVerifiedTables(): void {
+  globalForVerified.__nextly_widgetVerifiedTables = new Set<string>();
+}
+
+/**
+ * The tables the database actually has, lowercased, or `undefined` when the
+ * question could not be asked.
+ *
+ * Lowercased because the dialects disagree about identifier case and the core
+ * drift check already compares this way; `undefined` is a THIRD answer rather
+ * than an empty set, because "there are no tables" and "I could not look" lead
+ * to opposite decisions and an empty set would silently mean the first.
+ */
+async function presentTableNames(): Promise<ReadonlySet<string> | undefined> {
+  try {
+    const adapter = container.get<{
+      listTables?: () => Promise<string[]>;
+    }>("adapter");
+    if (typeof adapter?.listTables !== "function") return undefined;
+    const tables = await adapter.listTables();
+    if (!Array.isArray(tables)) return undefined;
+    return new Set(
+      tables
+        .filter((name): name is string => typeof name === "string")
+        .map(name => name.toLowerCase())
+    );
+  } catch (error) {
+    getNextlyLogger().error({
+      kind: "widget-table-introspection-unavailable",
+      err: error instanceof Error ? error.stack : String(error),
+    });
+    return undefined;
+  }
+}
+
+/**
+ * The collections a widget source may be built from, asked STRUCTURALLY.
+ *
+ * The label is consulted first and settles the overwhelmingly common case at no
+ * cost: when every collection's status claims its table is present, this makes
+ * no database call at all. Introspection happens only for the collections whose
+ * label DECLINES -- which is exactly the population the label is wrong about --
+ * and then once for the whole batch rather than once per collection.
+ *
+ * On an unanswerable introspection this falls back to the label, which is the
+ * behaviour that shipped before and is the conservative direction: a card is
+ * withheld rather than pointed at a table that may not be there.
+ */
+async function usableCollections<T extends RegisteredCollection>(
+  collections: T[]
+): Promise<T[]> {
+  const verified = verifiedTables();
+  const settled = (collection: T): boolean =>
+    statusClaimsPresent(collection) ||
+    verified.has((tableNameOf(collection) ?? "").toLowerCase());
+
+  // A row naming no table cannot be verified by any amount of introspection, so
+  // it must not TRIGGER any: without this it is permanently unsettled, and a
+  // single malformed row would put a round trip on every request forever while
+  // never changing the outcome. It is still filtered by the label below.
+  if (!collections.some(c => !settled(c) && tableNameOf(c) !== undefined)) {
+    return collections.filter(settled);
+  }
+
+  const present = await presentTableNames();
+  if (present !== undefined) {
+    for (const collection of collections) {
+      if (statusClaimsPresent(collection)) continue;
+      const table = tableNameOf(collection)?.toLowerCase();
+      if (table !== undefined && present.has(table)) verified.add(table);
+    }
+  }
+  return collections.filter(settled);
 }
 
 /**
@@ -271,30 +390,29 @@ export async function refreshCollectionSources(): Promise<void> {
   const collections = await readRegisteredCollections();
   if (!collections) return;
 
+  const named = collections.filter(
+    (collection): collection is RegisteredCollection & { slug: string } =>
+      typeof collection.slug === "string" && collection.slug !== ""
+  );
+
   registerBuiltInSources(
-    collections
-      .filter(
-        (collection): collection is RegisteredCollection & { slug: string } =>
-          typeof collection.slug === "string" && collection.slug !== ""
-      )
-      .filter(tableIsUsable)
-      .map(collection => ({
-        slug: collection.slug,
-        fields: readableFields(collection.fields),
-        // Only an explicit `false` turns them off; absent means on, the way
-        // `defineCollection` normalizes it and the registry stores it.
-        ...(pluralLabelOf(collection) === undefined
-          ? {}
-          : { label: pluralLabelOf(collection) }),
-        ...(useAsTitleOf(collection) === undefined
-          ? {}
-          : { useAsTitle: useAsTitleOf(collection) }),
-        timestamps: collection.timestamps !== false,
-        // The opposite default: only an explicit `true` turns Draft/Published
-        // on, matching `DynamicCollectionRecord.status` (required, defaults to
-        // false) and the `config.status === true` reading every other consumer
-        // of this flag takes.
-        status: collection.status === true,
-      }))
+    (await usableCollections(named)).map(collection => ({
+      slug: collection.slug,
+      fields: readableFields(collection.fields),
+      // Only an explicit `false` turns them off; absent means on, the way
+      // `defineCollection` normalizes it and the registry stores it.
+      ...(pluralLabelOf(collection) === undefined
+        ? {}
+        : { label: pluralLabelOf(collection) }),
+      ...(useAsTitleOf(collection) === undefined
+        ? {}
+        : { useAsTitle: useAsTitleOf(collection) }),
+      timestamps: collection.timestamps !== false,
+      // The opposite default: only an explicit `true` turns Draft/Published
+      // on, matching `DynamicCollectionRecord.status` (required, defaults to
+      // false) and the `config.status === true` reading every other consumer
+      // of this flag takes.
+      status: collection.status === true,
+    }))
   );
 }

--- a/packages/nextly/src/domains/widgets/collection-sources.ts
+++ b/packages/nextly/src/domains/widgets/collection-sources.ts
@@ -53,6 +53,8 @@ interface RegisteredCollection {
    * is checked at the point of use rather than assumed from the record type.
    */
   admin?: unknown;
+  /** How far this collection's table has got. See {@link tableIsUsable}. */
+  migrationStatus?: unknown;
   /**
    * The singular/plural display names. Read defensively for the same reason as
    * `admin`: the row is stored JSON.
@@ -113,12 +115,22 @@ function storedAtThisLevel(container: UnvalidatedContainer): boolean {
  */
 function readableFields(
   fields: unknown
-): Array<{ name: string; type: string; label?: string }> {
-  const usable: Array<{ name: string; type: string; label?: string }> = [];
+): Array<{ name: string; type: string; label?: string; hasMany?: boolean }> {
+  const usable: Array<{
+    name: string;
+    type: string;
+    label?: string;
+    hasMany?: boolean;
+  }> = [];
   for (const raw of addressableFields(fields, {
     descendInto: storedAtThisLevel,
   })) {
-    const field = raw as { name?: unknown; type?: unknown; label?: unknown };
+    const field = raw as {
+      name?: unknown;
+      type?: unknown;
+      label?: unknown;
+      hasMany?: unknown;
+    };
     if (typeof field.name === "string" && typeof field.type === "string") {
       // The label is carried when the field has a usable one, and omitted
       // otherwise -- a blank or whitespace label is not a heading, and passing
@@ -132,6 +144,11 @@ function readableFields(
       usable.push({
         name: field.name,
         type: field.type,
+        // 🔴 CARDINALITY, carried rather than dropped. A `text` or `select`
+        // field with `hasMany` stores an ARRAY, and a scalar type is not the
+        // same claim as a scalar value -- so a title chosen on type alone can
+        // still resolve to an array, which the row renderer declines to print.
+        ...(field.hasMany === true && { hasMany: true }),
         ...(label && { label }),
       });
     }
@@ -176,6 +193,37 @@ async function readRegisteredCollections(): Promise<
  * listed. Clearing on a transient failure, by contrast, turns one bad database
  * read into a dashboard of broken cards.
  */
+/**
+ * Whether this collection's TABLE exists to be queried.
+ *
+ * 🔴 A collection created in the Schema Builder is recorded `pending` and its
+ * migration does not run outside development — so in production the row exists,
+ * permission seeding makes it visible, and its table does not arrive until the
+ * next deploy. A source for it accepts queries that reach a table that is not
+ * there, once per reader, for as long as the deploy is away.
+ *
+ * An ALLOWLIST of statuses that mean the table is present: `synced` for a
+ * code-first collection whose table migrations own, and `applied` for a Builder
+ * one whose migration ran. `pending`, `generated` and `failed` all mean it is
+ * not there yet, and the last of those will not arrive on its own.
+ *
+ * An ABSENT status is treated as usable, which is the one place this reads
+ * generously rather than closed. The field was added after rows existed, so a
+ * row predating it says nothing about its table — and those tables do exist.
+ * Refusing them would take widgets away from every collection an older install
+ * already had, to protect against a state they are not in.
+ */
+const TABLE_PRESENT_STATUSES: ReadonlySet<string> = new Set([
+  "synced",
+  "applied",
+]);
+
+function tableIsUsable(collection: RegisteredCollection): boolean {
+  const status = (collection as { migrationStatus?: unknown }).migrationStatus;
+  if (status === undefined) return true;
+  return typeof status === "string" && TABLE_PRESENT_STATUSES.has(status);
+}
+
 /**
  * What a human calls this collection, when the stored row carries a usable
  * plural label. PLURAL because a source and its cards name a set of entries.
@@ -229,6 +277,7 @@ export async function refreshCollectionSources(): Promise<void> {
         (collection): collection is RegisteredCollection & { slug: string } =>
           typeof collection.slug === "string" && collection.slug !== ""
       )
+      .filter(tableIsUsable)
       .map(collection => ({
         slug: collection.slug,
         fields: readableFields(collection.fields),

--- a/packages/nextly/src/domains/widgets/collection-sources.ts
+++ b/packages/nextly/src/domains/widgets/collection-sources.ts
@@ -47,6 +47,13 @@ interface RegisteredCollection {
   slug?: unknown;
   fields?: unknown;
   /**
+   * The author's own answer to which field names an entry, under `admin`.
+   *
+   * Read defensively like the flags below: the row is stored JSON, so the shape
+   * is checked at the point of use rather than assumed from the record type.
+   */
+  admin?: unknown;
+  /**
    * The `timestamps` column pair. A required boolean on the stored record and
    * read defensively here, because the two values decide whether
    * `createdAt`/`updatedAt` exist as COLUMNS -- declaring them on a collection
@@ -164,6 +171,22 @@ async function readRegisteredCollections(): Promise<
  * listed. Clearing on a transient failure, by contrast, turns one bad database
  * read into a dashboard of broken cards.
  */
+/**
+ * The author's nominated title field, when the stored row carries a usable one.
+ *
+ * The row is JSON, so `admin` may be anything; a non-string nomination is read
+ * as no nomination rather than passed on, because the shared rule would then be
+ * comparing a number against a list of field names.
+ */
+function useAsTitleOf(collection: RegisteredCollection): string | undefined {
+  const admin = collection.admin;
+  if (typeof admin !== "object" || admin === null) return undefined;
+  const nominated = (admin as { useAsTitle?: unknown }).useAsTitle;
+  return typeof nominated === "string" && nominated !== ""
+    ? nominated
+    : undefined;
+}
+
 export async function refreshCollectionSources(): Promise<void> {
   const collections = await readRegisteredCollections();
   if (!collections) return;
@@ -179,6 +202,9 @@ export async function refreshCollectionSources(): Promise<void> {
         fields: readableFields(collection.fields),
         // Only an explicit `false` turns them off; absent means on, the way
         // `defineCollection` normalizes it and the registry stores it.
+        ...(useAsTitleOf(collection) === undefined
+          ? {}
+          : { useAsTitle: useAsTitleOf(collection) }),
         timestamps: collection.timestamps !== false,
         // The opposite default: only an explicit `true` turns Draft/Published
         // on, matching `DynamicCollectionRecord.status` (required, defaults to

--- a/packages/nextly/src/domains/widgets/collection-widgets.ts
+++ b/packages/nextly/src/domains/widgets/collection-widgets.ts
@@ -37,8 +37,6 @@
  * @module domains/widgets/collection-widgets
  */
 
-import { entryTitleField } from "../collections/entry-title";
-
 import { refreshCollectionSources } from "./collection-sources";
 import { isValidWidgetId, type WidgetDefinition } from "./definition";
 import { listSources, type WidgetSource } from "./sources";
@@ -108,11 +106,13 @@ function countWidget(source: WidgetSource): WidgetDefinition | undefined {
 function recentWidget(source: WidgetSource): WidgetDefinition | undefined {
   if (!source.supports.includes("list")) return undefined;
   const names = source.fields.map(field => field.name);
-  // `useAsTitle` is not passed: it lives in the static config, and this reads
-  // the REGISTRY so that Builder-drawn collections are covered too. The shared
-  // rule falls back to the conventional names, which is the same answer the
-  // entry list reaches for a collection that nominates nothing.
-  const label = entryTitleField(undefined, names);
+  // The source's own answer, which already went through the shared rule with
+  // the author's `admin.useAsTitle` AND the full field list. Resolving it again
+  // here from `fields` alone would ignore the nomination and pick a
+  // conventional name instead, so a collection whose author chose `headline`
+  // would be labelled by something else -- two answers to one question, and the
+  // dashboard holding the worse one.
+  const label = source.titleField;
   if (label === undefined) return undefined;
   if (!names.includes("updatedAt")) return undefined;
   const id = widgetId(source, "recent");
@@ -192,4 +192,38 @@ export function generatedWidgets(): WidgetDefinition[] {
 export async function refreshCollectionWidgets(): Promise<void> {
   await refreshCollectionSources();
   setGeneratedWidgets(collectionWidgets(listSources()));
+}
+
+/**
+ * The generated cards a given reader may be told about.
+ *
+ * 🔴 FILTERED, and by the permission rather than by anything the client does.
+ * A generated card's id, title and query all name a COLLECTION, so publishing
+ * the whole set discloses the slug and the existence of every collection in the
+ * install to any authenticated reader — including the ones the layout endpoint
+ * and the query endpoint deliberately hide from them. That the admin would not
+ * draw the card is not a control: the payload is JSON, and reading it is the
+ * bypass.
+ *
+ * 🔴 And a card whose id a CONTRIBUTION already claims is dropped. The admin
+ * reads this array as the registration channel, and `mergeCollision` gives a
+ * registration authority over the title, archetype, query, size and permission
+ * of a colliding contribution — so publishing a generated card under an id a
+ * plugin declared would replace that plugin's card with core's guess in the
+ * grid, while the server's canonical set kept the plugin's. The two would draw
+ * and place different declarations. `canonicalWidgets` already resolves this
+ * collision in the contribution's favour; this is the same answer, not a second
+ * one.
+ *
+ * `allow` is asked once per distinct permission by the caller, which already
+ * batches those decisions — asking here per widget would fire two checks for
+ * every collection.
+ */
+export function readableGeneratedWidgets(
+  allow: (requiredPermission: string | undefined) => boolean,
+  contributedIds: ReadonlySet<string>
+): WidgetDefinition[] {
+  return generatedWidgets().filter(
+    widget => !contributedIds.has(widget.id) && allow(widget.requiredPermission)
+  );
 }

--- a/packages/nextly/src/domains/widgets/collection-widgets.ts
+++ b/packages/nextly/src/domains/widgets/collection-widgets.ts
@@ -1,0 +1,195 @@
+/**
+ * A card per collection, derived from the sources the install actually has.
+ *
+ * ## Why these are GENERATED rather than registered
+ *
+ * A collection is created while the process is running — the Schema Builder
+ * makes one without a restart — so a widget declared for it at boot describes
+ * an install that has since changed. These are derived at REQUEST time from the
+ * registered sources, the same read `refreshCollectionSources` already performs
+ * per batch, so a collection added a minute ago has its cards and a collection
+ * deleted a minute ago does not.
+ *
+ * Django's admin takes the same position for the same reason: it builds a
+ * per-model view set at request time rather than freezing one at import.
+ *
+ * ## Why they are OFFERED and never placed
+ *
+ * They do not appear on anybody's dashboard until a reader adds one. An install
+ * with forty collections would otherwise open onto eighty cards, and the reader
+ * who wanted three has to remove seventy-seven. Payload shipped the auto-placing
+ * version and withdrew it: one card per collection produced duplicates with no
+ * clean opt-out, and the arrangement had no way to say "I have seen this and I
+ * do not want it".
+ *
+ * The picker is what makes "not placed" workable. Without a list naming the
+ * unplaced widgets these would be reachable from nothing.
+ *
+ * ## Why they are derived from SOURCES rather than from collections
+ *
+ * A widget and the source it queries must agree about three things: that the
+ * source exists, which ops it answers, and which permission gates it. Reading
+ * the collection registry a second time here would answer all three again, and
+ * the copies would drift — a source that stopped supporting `count` would leave
+ * a metric card whose every request is refused. Taking them from the registered
+ * source means there is nothing to disagree with.
+ *
+ * @module domains/widgets/collection-widgets
+ */
+
+import { entryTitleField } from "../collections/entry-title";
+
+import { refreshCollectionSources } from "./collection-sources";
+import { isValidWidgetId, type WidgetDefinition } from "./definition";
+import { listSources, type WidgetSource } from "./sources";
+
+/** How many rows a generated list asks for. The renderer draws at most five. */
+const LIST_ROWS = 5;
+
+/**
+ * The id of a generated widget, from the source it draws.
+ *
+ * Namespaced under `collection/` so it cannot collide with core's own `core/`
+ * cards, and suffixed by what it draws so one collection can have both. Derived
+ * from the source id rather than from a slug passed alongside it, for the same
+ * reason every other field here is.
+ */
+function widgetId(
+  source: WidgetSource,
+  kind: "count" | "recent"
+): string | undefined {
+  const id = `collection/${source.id.slice("collection:".length)}-${kind}`;
+  // ASKED rather than assumed. A widget id is `namespace/name` in lowercase
+  // slug form -- two segments, so the kind is a suffix rather than a third
+  // segment -- and a collection slug that cannot produce one is skipped instead
+  // of minting an id the registry would refuse. The predicate is the registry's
+  // own, so this cannot drift away from what it accepts.
+  return isValidWidgetId(id) ? id : undefined;
+}
+
+/**
+ * The metric card for a source: how many entries the collection holds.
+ *
+ * `status: "all"`, deliberately. A count that silently excluded drafts would
+ * disagree with the number the collection's own list view shows, and the reader
+ * has no way to tell which of the two is answering a narrower question.
+ */
+function countWidget(source: WidgetSource): WidgetDefinition | undefined {
+  if (!source.supports.includes("count")) return undefined;
+  const id = widgetId(source, "count");
+  if (id === undefined) return undefined;
+  return {
+    id,
+    title: source.label,
+    description: `How many entries ${source.label} holds`,
+    archetype: "metric",
+    defaultSize: "sm",
+    ...(source.requiredPermission === undefined
+      ? {}
+      : { requiredPermission: source.requiredPermission }),
+    query: { source: source.id, op: "count", status: "all" },
+  };
+}
+
+/**
+ * The list card for a source: the entries touched most recently.
+ *
+ * Returns `undefined` for a collection this cannot draw HONESTLY, and both
+ * conditions are refusals rather than fallbacks:
+ *
+ * - no field names the entries, so every row would read as an identifier. The
+ *   `list` renderer already refuses a widget that selects nothing rather than
+ *   guessing a key out of a document it knows nothing about; generating one
+ *   that selects the wrong key would defeat that by answering the question
+ *   badly instead of declining it.
+ * - no `updatedAt`, so "recently" has nothing to sort by. Sorting by id would
+ *   produce a card whose title is a claim its rows do not support.
+ */
+function recentWidget(source: WidgetSource): WidgetDefinition | undefined {
+  if (!source.supports.includes("list")) return undefined;
+  const names = source.fields.map(field => field.name);
+  // `useAsTitle` is not passed: it lives in the static config, and this reads
+  // the REGISTRY so that Builder-drawn collections are covered too. The shared
+  // rule falls back to the conventional names, which is the same answer the
+  // entry list reaches for a collection that nominates nothing.
+  const label = entryTitleField(undefined, names);
+  if (label === undefined) return undefined;
+  if (!names.includes("updatedAt")) return undefined;
+  const id = widgetId(source, "recent");
+  if (id === undefined) return undefined;
+
+  return {
+    id,
+    title: `Recent ${source.label}`,
+    description: `The ${source.label} entries changed most recently`,
+    archetype: "list",
+    defaultSize: "md",
+    ...(source.requiredPermission === undefined
+      ? {}
+      : { requiredPermission: source.requiredPermission }),
+    query: {
+      source: source.id,
+      op: "list",
+      status: "all",
+      // The row label first, then the muted line under it -- the order the
+      // `list` renderer reads `select` in.
+      select: [label, "updatedAt"],
+      sort: "-updatedAt",
+      limit: LIST_ROWS,
+    },
+  };
+}
+
+/**
+ * Every generated card the given sources support, in source order.
+ *
+ * Pure, so the derivation can be asserted without a container: the refresh
+ * below is the only part that needs one.
+ */
+export function collectionWidgets(
+  sources: readonly WidgetSource[]
+): WidgetDefinition[] {
+  const widgets: WidgetDefinition[] = [];
+  for (const source of sources) {
+    if (source.kind !== "collection") continue;
+    const count = countWidget(source);
+    if (count) widgets.push(count);
+    const recent = recentWidget(source);
+    if (recent) widgets.push(recent);
+  }
+  return widgets;
+}
+
+/**
+ * The generated set, pinned where every other boot-time widget store is.
+ *
+ * On `globalThis` so it survives the module re-evaluation Next.js and Turbopack
+ * perform, matching `__nextly_contributedWidgets` beside it.
+ */
+const globalForGenerated = globalThis as unknown as {
+  __nextly_generatedWidgets?: WidgetDefinition[];
+};
+
+/** Replace the generated set. */
+export function setGeneratedWidgets(
+  widgets: readonly WidgetDefinition[]
+): void {
+  globalForGenerated.__nextly_generatedWidgets = [...widgets];
+}
+
+/** The generated set, or none when nothing has derived one yet. */
+export function generatedWidgets(): WidgetDefinition[] {
+  return [...(globalForGenerated.__nextly_generatedWidgets ?? [])];
+}
+
+/**
+ * Re-derive the generated set from the install's current collections.
+ *
+ * Refreshes the SOURCES first, because the widgets are derived from them: a
+ * collection created since the last request has no source yet, so deriving
+ * without this produces a set one request out of date.
+ */
+export async function refreshCollectionWidgets(): Promise<void> {
+  await refreshCollectionSources();
+  setGeneratedWidgets(collectionWidgets(listSources()));
+}

--- a/packages/nextly/src/domains/widgets/collection-widgets.ts
+++ b/packages/nextly/src/domains/widgets/collection-widgets.ts
@@ -215,15 +215,47 @@ export async function refreshCollectionWidgets(): Promise<void> {
  * collision in the contribution's favour; this is the same answer, not a second
  * one.
  *
- * `allow` is asked once per distinct permission by the caller, which already
- * batches those decisions — asking here per widget would fire two checks for
- * every collection.
+ * 🔴 `allow` is asked about the COLLECTION, not about the card's declared
+ * permission, and the difference is an API key. `callerHoldsPermission` judges a
+ * key on its stamped grant alone, while `canReadEntity` — which the widget query
+ * endpoint uses — also evaluates the collection's code-defined `access.read`. A
+ * key stamped `read-secret` that those rules reject is refused by the query and
+ * would have been told the collection exists by this payload. The two must
+ * answer the same question, so this one asks the query path's.
+ *
+ * Asked once per distinct collection by the caller, which batches those
+ * decisions — asking here per widget would fire two checks for every one.
  */
 export function readableGeneratedWidgets(
-  allow: (requiredPermission: string | undefined) => boolean,
+  allow: (collectionSlug: string) => boolean,
   contributedIds: ReadonlySet<string>
 ): WidgetDefinition[] {
-  return generatedWidgets().filter(
-    widget => !contributedIds.has(widget.id) && allow(widget.requiredPermission)
-  );
+  return generatedWidgets().filter(widget => {
+    if (contributedIds.has(widget.id)) return false;
+    const slug = generatedCollectionSlug(widget);
+    // A generated card that names no collection cannot be checked against one,
+    // so it is withheld rather than published. This is unreachable today --
+    // every card here is built from a `collection:` source -- and the branch is
+    // free: it decides from a value already in hand, and refusing is the only
+    // safe answer for a card whose subject cannot be identified.
+    return slug !== undefined && allow(slug);
+  });
+}
+
+/**
+ * The collection a generated card is about, taken from the query it will run.
+ *
+ * From `query.source` rather than by unpicking the widget id, because the
+ * source is what the read is actually performed against — the id is a display
+ * identity that happens to be derived from the same slug, and checking access
+ * against a name rather than against the thing being read is how the two come
+ * apart.
+ */
+export function generatedCollectionSlug(
+  widget: WidgetDefinition
+): string | undefined {
+  const source = widget.query?.source;
+  if (typeof source !== "string") return undefined;
+  const prefix = "collection:";
+  return source.startsWith(prefix) ? source.slice(prefix.length) : undefined;
 }

--- a/packages/nextly/src/domains/widgets/collection-widgets.ts
+++ b/packages/nextly/src/domains/widgets/collection-widgets.ts
@@ -56,7 +56,18 @@ function widgetId(
   source: WidgetSource,
   kind: "count" | "recent"
 ): string | undefined {
-  const id = `collection/${source.id.slice("collection:".length)}-${kind}`;
+  // 🔴 An underscore is legal in a collection slug (`SLUG_PATTERN` permits it)
+  // and illegal in a widget id, so `customer_notes` produced an id the registry
+  // refuses and BOTH its cards were silently dropped -- a supported class of
+  // collection that never got the feature, with nothing to say why. Mapped to a
+  // hyphen, which is the id vocabulary's own separator.
+  //
+  // The mapping is not injective: `a_b` and `a-b` both become `a-b`. That is
+  // handled where the whole set is known, in `collectionWidgets`, because a
+  // collision is a property of the INSTALL rather than of either collection --
+  // deciding it here would need one of the two to win arbitrarily.
+  const slug = source.id.slice("collection:".length).replaceAll("_", "-");
+  const id = `collection/${slug}-${kind}`;
   // ASKED rather than assumed. A widget id is `namespace/name` in lowercase
   // slug form -- two segments, so the kind is a suffix rather than a third
   // segment -- and a collection slug that cannot produce one is skipped instead
@@ -82,9 +93,6 @@ function countWidget(source: WidgetSource): WidgetDefinition | undefined {
     description: `How many entries ${source.label} holds`,
     archetype: "metric",
     defaultSize: "sm",
-    ...(source.requiredPermission === undefined
-      ? {}
-      : { requiredPermission: source.requiredPermission }),
     query: { source: source.id, op: "count", status: "all" },
   };
 }
@@ -124,9 +132,6 @@ function recentWidget(source: WidgetSource): WidgetDefinition | undefined {
     description: `The ${source.label} entries changed most recently`,
     archetype: "list",
     defaultSize: "md",
-    ...(source.requiredPermission === undefined
-      ? {}
-      : { requiredPermission: source.requiredPermission }),
     query: {
       source: source.id,
       op: "list",
@@ -150,12 +155,24 @@ export function collectionWidgets(
   sources: readonly WidgetSource[]
 ): WidgetDefinition[] {
   const widgets: WidgetDefinition[] = [];
+  // 🔴 Two collections can derive ONE id — `a_b` and `a-b` both reduce to
+  // `a-b`. Neither has a claim over the other, and a card drawn for one while
+  // its query reads the other is the worst outcome available, so a collision
+  // costs BOTH collections their cards rather than silently picking a winner.
+  // Collected first, dropped second, so the decision does not depend on
+  // iteration order.
+  const claimed = new Map<string, number>();
+  const candidates: WidgetDefinition[] = [];
   for (const source of sources) {
     if (source.kind !== "collection") continue;
-    const count = countWidget(source);
-    if (count) widgets.push(count);
-    const recent = recentWidget(source);
-    if (recent) widgets.push(recent);
+    for (const widget of [countWidget(source), recentWidget(source)]) {
+      if (!widget) continue;
+      claimed.set(widget.id, (claimed.get(widget.id) ?? 0) + 1);
+      candidates.push(widget);
+    }
+  }
+  for (const widget of candidates) {
+    if (claimed.get(widget.id) === 1) widgets.push(widget);
   }
   return widgets;
 }
@@ -215,8 +232,14 @@ export async function refreshCollectionWidgets(): Promise<void> {
  * collision in the contribution's favour; this is the same answer, not a second
  * one.
  *
- * 🔴 `allow` is asked about the COLLECTION, not about the card's declared
- * permission, and the difference is an API key. `callerHoldsPermission` judges a
+ * 🔴 A generated card carries NO `requiredPermission`, and the server is what
+ * gates it. The permission the client could check is `read-<slug>` read off the
+ * flat `/me/permissions` list, and that list does not hold a grant that exists
+ * only in a collection's code-defined `access.read` — so a reader the server
+ * approved had both cards discarded by the grid, for a query it would have
+ * answered. One gate, on the side that can see every rule.
+ *
+ * 🔴 `allow` is asked about the COLLECTION, and the difference is an API key. `callerHoldsPermission` judges a
  * key on its stamped grant alone, while `canReadEntity` — which the widget query
  * endpoint uses — also evaluates the collection's code-defined `access.read`. A
  * key stamped `read-secret` that those rules reject is refused by the query and
@@ -228,10 +251,10 @@ export async function refreshCollectionWidgets(): Promise<void> {
  */
 export function readableGeneratedWidgets(
   allow: (collectionSlug: string) => boolean,
-  contributedIds: ReadonlySet<string>
+  declaredIds: ReadonlySet<string>
 ): WidgetDefinition[] {
   return generatedWidgets().filter(widget => {
-    if (contributedIds.has(widget.id)) return false;
+    if (declaredIds.has(widget.id)) return false;
     const slug = generatedCollectionSlug(widget);
     // A generated card that names no collection cannot be checked against one,
     // so it is withheld rather than published. This is unreachable today --

--- a/packages/nextly/src/domains/widgets/definition.ts
+++ b/packages/nextly/src/domains/widgets/definition.ts
@@ -176,8 +176,21 @@ function fail(message: string): never {
 }
 
 /** Confirms `id` is present and shaped as `namespace/name`. */
+/**
+ * Whether `id` is a widget id this registry would accept.
+ *
+ * Exported so a caller that DERIVES an id can ask before minting one, rather
+ * than restating the pattern. The dashboard generates a card per collection, and
+ * a slug that cannot produce a valid id has to be skipped — a second copy of
+ * this rule there would accept ids the registry refuses, or refuse ids it
+ * accepts, and either way the two would drift apart silently.
+ */
+export function isValidWidgetId(id: unknown): id is string {
+  return typeof id === "string" && ID_PATTERN.test(id);
+}
+
 function validateId(d: Partial<WidgetDefinition>): void {
-  if (typeof d.id !== "string" || !ID_PATTERN.test(d.id)) {
+  if (!isValidWidgetId(d.id)) {
     fail(
       `id must be namespace/name in lowercase slug form, got ${String(d.id)}`
     );

--- a/packages/nextly/src/domains/widgets/publish.ts
+++ b/packages/nextly/src/domains/widgets/publish.ts
@@ -23,6 +23,7 @@
 import { getNextlyLogger } from "../../observability/logger";
 import { jsonOnly, unserializableKeys } from "../../plugins/json-round-trip";
 
+import { generatedWidgets } from "./collection-widgets";
 import type { WidgetDefinition } from "./definition";
 import { listWidgets } from "./registry";
 
@@ -35,9 +36,14 @@ import { listWidgets } from "./registry";
  * contributed widget, and for the same reason.
  */
 export function publishableWidgets(): WidgetDefinition[] {
-  const publishable: WidgetDefinition[] = [];
+  const byId = new Map<string, WidgetDefinition>();
 
-  for (const definition of listWidgets()) {
+  // Generated cards FIRST, so an explicit registration of the same id replaces
+  // one: a generated widget is core's guess at a useful card, and an author who
+  // registered that id meant something by it. `Map` semantics below make the
+  // last write win, which is why the order is this way round rather than the
+  // reverse.
+  for (const definition of [...generatedWidgets(), ...listWidgets()]) {
     const serializable = jsonOnly(definition);
     if (serializable === undefined) {
       getNextlyLogger().error({
@@ -47,8 +53,9 @@ export function publishableWidgets(): WidgetDefinition[] {
       });
       continue;
     }
-    publishable.push(serializable as unknown as WidgetDefinition);
+    const widget = serializable as unknown as WidgetDefinition;
+    byId.set(widget.id, widget);
   }
 
-  return publishable;
+  return [...byId.values()];
 }

--- a/packages/nextly/src/domains/widgets/publish.ts
+++ b/packages/nextly/src/domains/widgets/publish.ts
@@ -23,7 +23,6 @@
 import { getNextlyLogger } from "../../observability/logger";
 import { jsonOnly, unserializableKeys } from "../../plugins/json-round-trip";
 
-import { generatedWidgets } from "./collection-widgets";
 import type { WidgetDefinition } from "./definition";
 import { listWidgets } from "./registry";
 
@@ -38,12 +37,7 @@ import { listWidgets } from "./registry";
 export function publishableWidgets(): WidgetDefinition[] {
   const byId = new Map<string, WidgetDefinition>();
 
-  // Generated cards FIRST, so an explicit registration of the same id replaces
-  // one: a generated widget is core's guess at a useful card, and an author who
-  // registered that id meant something by it. `Map` semantics below make the
-  // last write win, which is why the order is this way round rather than the
-  // reverse.
-  for (const definition of [...generatedWidgets(), ...listWidgets()]) {
+  for (const definition of listWidgets()) {
     const serializable = jsonOnly(definition);
     if (serializable === undefined) {
       getNextlyLogger().error({

--- a/packages/nextly/src/domains/widgets/publish.ts
+++ b/packages/nextly/src/domains/widgets/publish.ts
@@ -35,7 +35,7 @@ import { listWidgets } from "./registry";
  * contributed widget, and for the same reason.
  */
 export function publishableWidgets(): WidgetDefinition[] {
-  const byId = new Map<string, WidgetDefinition>();
+  const publishable: WidgetDefinition[] = [];
 
   for (const definition of listWidgets()) {
     const serializable = jsonOnly(definition);
@@ -47,9 +47,8 @@ export function publishableWidgets(): WidgetDefinition[] {
       });
       continue;
     }
-    const widget = serializable as unknown as WidgetDefinition;
-    byId.set(widget.id, widget);
+    publishable.push(serializable as unknown as WidgetDefinition);
   }
 
-  return [...byId.values()];
+  return publishable;
 }

--- a/packages/nextly/src/domains/widgets/sources.ts
+++ b/packages/nextly/src/domains/widgets/sources.ts
@@ -127,6 +127,28 @@ function validateSourceLabel(s: Partial<WidgetSource>): void {
 }
 
 /**
+ * Confirms `titleField`, when given, names a field this source declares.
+ *
+ * 🔴 The value becomes a `select` entry on a generated card, and `select` is
+ * checked against this source's own field allowlist when the query runs — so a
+ * source naming a field it does not declare produces a card whose every request
+ * is refused, with the refusal arriving per reader rather than at the point the
+ * source was registered. A plugin registering its own source is the caller this
+ * protects: core's own derivation takes the name FROM `fields`, so it cannot
+ * disagree with itself.
+ */
+function validateSourceTitleField(s: Partial<WidgetSource>): void {
+  if (s.titleField === undefined) return;
+  if (typeof s.titleField !== "string" || s.titleField.trim() === "") {
+    fail(`${s.id}: titleField, when given, must be a non-empty string`);
+  }
+  const declared = (s.fields ?? []).some(field => field.name === s.titleField);
+  if (!declared) {
+    fail(`${s.id}: titleField "${s.titleField}" is not one of its fields`);
+  }
+}
+
+/**
  * The namespaces core OWNS, and the kind each one means.
  *
  * `plugin` is deliberately absent: it is what an id claiming no reserved
@@ -266,6 +288,8 @@ export function validateWidgetSource(
   validateSourceKind(s);
   validateSourceSupports(s);
   validateSourceFields(s);
+  // AFTER the fields, because it is checked against them.
+  validateSourceTitleField(s);
 }
 
 const globalForSources = globalThis as unknown as {

--- a/packages/nextly/src/domains/widgets/sources.ts
+++ b/packages/nextly/src/domains/widgets/sources.ts
@@ -63,6 +63,21 @@ export interface WidgetSourceField {
 export interface WidgetSource {
   /** e.g. "collection:posts", "system:users", "plugin:stripe/revenue". */
   id: string;
+  /**
+   * Which of this source's fields NAMES a row, when one does.
+   *
+   * Resolved where the source is built, because that is the only place holding
+   * both halves of the answer: the author's `admin.useAsTitle` and the full
+   * field list it has to exist in. A consumer that resolved it again from
+   * `fields` alone would ignore the author's nomination and pick a conventional
+   * name instead -- so a collection whose author chose `headline` would have its
+   * dashboard card labelled by something else, or no card at all.
+   *
+   * Absent when nothing names the rows, which is a real answer: a source of pure
+   * data rows has no title field, and a caller that invents one shows the reader
+   * a column of identifiers.
+   */
+  titleField?: string;
   label: string;
   kind: WidgetSourceKind;
   /**

--- a/packages/nextly/src/domains/widgets/visibility.ts
+++ b/packages/nextly/src/domains/widgets/visibility.ts
@@ -15,6 +15,7 @@
 import {
   authorizationGroups,
   callerHoldsPermission,
+  canReadEntity,
   type ReadAccessCaller,
 } from "../../auth/entity-read-access";
 
@@ -72,4 +73,45 @@ export function holdsWidgetPermission(
     return false;
   }
   return verdicts.get(requiredPermission) === true;
+}
+
+/**
+ * Which of these collections the caller may actually read.
+ *
+ * 🔴 `canReadEntity`, not `callerHoldsPermission`, and the difference is an API
+ * key: the second reads only the key's stamped grant while the first also
+ * evaluates the collection's code-defined `access.read`. The widget QUERY
+ * endpoint asks the first, so anything deciding whether to OFFER a card for a
+ * collection has to ask the same one — otherwise a card is advertised, placed,
+ * and then refused on every request.
+ *
+ * Two surfaces need this — the layout endpoint filters what it places and
+ * offers, and the workspace payload filters which collections it names — and a
+ * copy in either that drifted would be a disclosure rather than a cosmetic
+ * difference. Batched in the same bounded rounds as the permission verdicts
+ * above, and a rejected decision denies.
+ */
+export async function readableCollections(
+  slugs: readonly (string | undefined)[],
+  caller: ReadAccessCaller
+): Promise<Set<string>> {
+  const distinct = [
+    ...new Set(
+      slugs.filter(
+        (slug): slug is string => typeof slug === "string" && slug !== ""
+      )
+    ),
+  ];
+
+  const readable = new Set<string>();
+  for (const group of authorizationGroups(distinct)) {
+    const settled = await Promise.allSettled(
+      group.map(slug => canReadEntity(slug, caller))
+    );
+    group.forEach((slug, index) => {
+      const outcome = settled[index];
+      if (outcome.status === "fulfilled" && outcome.value) readable.add(slug);
+    });
+  }
+  return readable;
 }

--- a/packages/nextly/src/domains/widgets/visibility.ts
+++ b/packages/nextly/src/domains/widgets/visibility.ts
@@ -1,0 +1,75 @@
+/**
+ * Which widgets a reader may be told exist.
+ *
+ * ONE implementation, because two surfaces ask it and a disagreement between
+ * them is a disclosure rather than a cosmetic difference. The layout endpoint
+ * asks so it can place and offer; the admin's workspace payload asks so it can
+ * ship the declarations for cards derived from a collection's own name. A copy
+ * in the second that drifted from the first would publish the existence and the
+ * slug of every collection an install has to a reader the first was hiding them
+ * from.
+ *
+ * @module domains/widgets/visibility
+ */
+
+import {
+  authorizationGroups,
+  callerHoldsPermission,
+  type ReadAccessCaller,
+} from "../../auth/entity-read-access";
+
+/**
+ * A decision per permission slug, taken in the bounded rounds the query batch
+ * already prescribes.
+ *
+ * Memoized per SLUG, not per widget: several widgets commonly name the same
+ * permission, and a permission check resolves a session caller through a
+ * per-user TTL cache, so asking twice is two database reads for one answer.
+ */
+export async function permissionVerdicts(
+  slugs: readonly (string | undefined)[],
+  caller: ReadAccessCaller
+): Promise<Map<string, boolean>> {
+  const distinct = [
+    ...new Set(
+      slugs.filter(
+        (slug): slug is string => typeof slug === "string" && slug !== ""
+      )
+    ),
+  ];
+
+  const verdicts = new Map<string, boolean>();
+  for (const group of authorizationGroups(distinct)) {
+    const settled = await Promise.allSettled(
+      group.map(slug => callerHoldsPermission(slug, caller))
+    );
+    group.forEach((slug, index) => {
+      const outcome = settled[index];
+      // A rejected decision DENIES. A permission check that threw has told us
+      // nothing, and "nothing" must not read as "allowed" -- the same
+      // fail-closed direction `canReadEntity` takes when RBAC is unreachable.
+      verdicts.set(slug, outcome.status === "fulfilled" && outcome.value);
+    });
+  }
+  return verdicts;
+}
+
+/**
+ * Whether a reader holding `verdicts` may know this widget exists.
+ *
+ * A widget with no `requiredPermission` is visible to any authenticated reader
+ * -- that is what omitting it means, and what core's own cards rely on. A
+ * declared permission that is not a usable string is refused rather than read
+ * as absent: the gap used to fail OPEN, so a widget whose author wrote an
+ * object there was gated for nobody.
+ */
+export function holdsWidgetPermission(
+  requiredPermission: unknown,
+  verdicts: ReadonlyMap<string, boolean>
+): boolean {
+  if (requiredPermission === undefined) return true;
+  if (typeof requiredPermission !== "string" || requiredPermission === "") {
+    return false;
+  }
+  return verdicts.get(requiredPermission) === true;
+}

--- a/packages/nextly/src/domains/widgets/visibility.ts
+++ b/packages/nextly/src/domains/widgets/visibility.ts
@@ -15,7 +15,6 @@
 import {
   authorizationGroups,
   callerHoldsPermission,
-  canReadEntity,
   type ReadAccessCaller,
 } from "../../auth/entity-read-access";
 
@@ -73,45 +72,4 @@ export function holdsWidgetPermission(
     return false;
   }
   return verdicts.get(requiredPermission) === true;
-}
-
-/**
- * Which of these collections the caller may actually read.
- *
- * 🔴 `canReadEntity`, not `callerHoldsPermission`, and the difference is an API
- * key: the second reads only the key's stamped grant while the first also
- * evaluates the collection's code-defined `access.read`. The widget QUERY
- * endpoint asks the first, so anything deciding whether to OFFER a card for a
- * collection has to ask the same one — otherwise a card is advertised, placed,
- * and then refused on every request.
- *
- * Two surfaces need this — the layout endpoint filters what it places and
- * offers, and the workspace payload filters which collections it names — and a
- * copy in either that drifted would be a disclosure rather than a cosmetic
- * difference. Batched in the same bounded rounds as the permission verdicts
- * above, and a rejected decision denies.
- */
-export async function readableCollections(
-  slugs: readonly (string | undefined)[],
-  caller: ReadAccessCaller
-): Promise<Set<string>> {
-  const distinct = [
-    ...new Set(
-      slugs.filter(
-        (slug): slug is string => typeof slug === "string" && slug !== ""
-      )
-    ),
-  ];
-
-  const readable = new Set<string>();
-  for (const group of authorizationGroups(distinct)) {
-    const settled = await Promise.allSettled(
-      group.map(slug => canReadEntity(slug, caller))
-    );
-    group.forEach((slug, index) => {
-      const outcome = settled[index];
-      if (outcome.status === "fulfilled" && outcome.value) readable.add(slug);
-    });
-  }
-  return readable;
 }

--- a/packages/nextly/src/init/__tests__/reload-config.test.ts
+++ b/packages/nextly/src/init/__tests__/reload-config.test.ts
@@ -152,6 +152,15 @@ describe("reloadNextlyConfig", () => {
     failComponentSync?: boolean;
     /** Seed a `nextly_meta` migration marker the storage guard will read. */
     migrationMarker?: unknown;
+    /**
+     * What the collection metadata sync REPORTS it rewrote.
+     *
+     * The real `syncCodeFirstCollections` answers a `SyncResult`, and the
+     * reload reads its `updated` list to learn which existing rows it just
+     * reset to `pending`. A fake resolving `{}` says "nothing was rewritten",
+     * so a test about an EDITED collection has to state the report.
+     */
+    collectionSyncResult?: unknown;
   }) {
     const withAdapter = opts?.withAdapter ?? true;
     const lockDouble = createLockingAdapter({
@@ -195,7 +204,7 @@ describe("reloadNextlyConfig", () => {
       collectionRegistryService: {
         syncCodeFirstCollections: opts?.failCollectionMetaSync
           ? vi.fn().mockRejectedValue(new Error("meta sync failed"))
-          : vi.fn().mockResolvedValue({}),
+          : vi.fn().mockResolvedValue(opts?.collectionSyncResult ?? {}),
         // Mirrors CollectionRegistryService.getAllCollections — the DB-backed
         // list of every registered collection (code + UI). Defaults to empty.
         getAllCollections: vi
@@ -491,6 +500,96 @@ describe("reloadNextlyConfig", () => {
       "books",
       "applied"
     );
+  });
+
+  it("marks an EDITED code-first collection as 'applied' after a successful apply", async () => {
+    // The other half of the same bug. `updateCollection` resets an existing
+    // row's migration_status to 'pending' whenever the fields change, and the
+    // DDL for that change is what the apply just performed -- but the table was
+    // present before the apply, so the pre-pipeline `liveByTable` snapshot
+    // cannot tell that its migration is done. The row then reports an
+    // outstanding migration for a table already at the new shape, and the
+    // widget source refresh (which reads migration_status to decide whether a
+    // collection can be queried) withdraws that collection's generated cards
+    // for the rest of the dev session.
+    loadConfigSpy.mockResolvedValue({
+      config: {
+        collections: [
+          {
+            slug: "books",
+            tableName: "dc_books",
+            fields: [{ name: "title", type: "text" }],
+          },
+        ],
+      },
+    });
+    // dc_books ALREADY EXISTS and is missing the new column -- an ALTER of a
+    // live table, which is the case the snapshot branch cannot see.
+    introspectSpy.mockResolvedValue(
+      buildSnapshot([
+        { name: "dc_books", columns: reservedColumns("dc_books") },
+      ])
+    );
+
+    const resolver = buildResolver({
+      collectionSyncResult: { created: [], updated: ["books"], unchanged: [] },
+    });
+    const { reloadNextlyConfig } = await import("../reload-config");
+    await reloadNextlyConfig({ resolver });
+
+    expect(pipelineApplySpy).toHaveBeenCalledTimes(1);
+    expect(resolver.updateCollectionMigrationStatusSpy).toHaveBeenCalledWith(
+      "books",
+      "applied"
+    );
+  });
+
+  it("leaves an UNCHANGED collection's migration status alone", async () => {
+    // The control the assertion above needs: marking every target 'applied'
+    // would pass that test too, and would overwrite a status that legitimately
+    // says a migration is outstanding. Only the rows the sync REPORTS it
+    // rewrote are re-marked.
+    loadConfigSpy.mockResolvedValue({
+      config: {
+        collections: [
+          {
+            slug: "books",
+            tableName: "dc_books",
+            fields: [{ name: "title", type: "text" }],
+          },
+          {
+            slug: "authors",
+            tableName: "dc_authors",
+            fields: [{ name: "name", type: "text" }],
+          },
+        ],
+      },
+    });
+    // BOTH tables already exist, so neither is caught by the snapshot branch.
+    introspectSpy.mockResolvedValue(
+      buildSnapshot([
+        { name: "dc_books", columns: reservedColumns("dc_books") },
+        { name: "dc_authors", columns: reservedColumns("dc_authors") },
+      ])
+    );
+
+    const resolver = buildResolver({
+      collectionSyncResult: {
+        created: [],
+        updated: ["books"],
+        unchanged: ["authors"],
+      },
+    });
+    const { reloadNextlyConfig } = await import("../reload-config");
+    await reloadNextlyConfig({ resolver });
+
+    expect(resolver.updateCollectionMigrationStatusSpy).toHaveBeenCalledWith(
+      "books",
+      "applied"
+    );
+    expect(
+      resolver.updateCollectionMigrationStatusSpy
+    ).not.toHaveBeenCalledWith("authors", "applied");
   });
 
   it("preserves UI-created singles (registry-only) in the desired schema", async () => {

--- a/packages/nextly/src/init/__tests__/reload-config.test.ts
+++ b/packages/nextly/src/init/__tests__/reload-config.test.ts
@@ -67,6 +67,15 @@ const {
   errorSpy: vi.fn(),
 }));
 
+const setDeferredCollectionsSpy = vi.fn();
+// The reload PUBLISHES which collections it refused, and the widget source
+// refresh is the consumer. Mocked here so this file can assert the call
+// without pulling the DI container in through the widgets domain.
+vi.mock("../../domains/widgets/collection-sources", () => ({
+  setDeferredCollections: (slugs: readonly string[]) =>
+    setDeferredCollectionsSpy(slugs),
+}));
+
 vi.mock("../../cli/utils/config-loader", () => ({
   loadConfig: loadConfigSpy,
   clearConfigCache: clearConfigCacheSpy,
@@ -500,6 +509,74 @@ describe("reloadNextlyConfig", () => {
       "books",
       "applied"
     );
+  });
+
+  it("PUBLISHES the collections it refused, so nothing queries an unapplied shape", async () => {
+    // 🔴 A refused collection still gets its new field list written to the
+    // registry -- the sync payload is the whole config and knows nothing about
+    // what applied -- so its stored metadata describes a shape its table never
+    // received. Anything deciding what a query may NAME has to be told, and
+    // `migration_status` cannot say it: the same value is written by paths that
+    // deferred nothing.
+    loadConfigSpy.mockResolvedValue({
+      config: {
+        collections: [
+          {
+            slug: "books",
+            tableName: "dc_books",
+            fields: [{ name: "active", type: "checkbox" }],
+          },
+          {
+            slug: "authors",
+            tableName: "dc_authors",
+            fields: [{ name: "name", type: "text" }],
+          },
+        ],
+      },
+    });
+    introspectSpy.mockResolvedValue(
+      buildSnapshot([
+        {
+          name: "dc_books",
+          columns: [
+            ...reservedColumns("dc_books"),
+            { name: "active", type: "text", nullable: true },
+          ],
+        },
+        { name: "dc_authors", columns: reservedColumns("dc_authors") },
+      ])
+    );
+
+    const { reloadNextlyConfig } = await import("../reload-config");
+    await reloadNextlyConfig({ resolver: buildResolver() });
+
+    expect(setDeferredCollectionsSpy).toHaveBeenCalledWith(["books"]);
+  });
+
+  it("publishes an EMPTY refusal set when everything applied", async () => {
+    // The control: without it the assertion above is satisfied by a call that
+    // always names every collection, which would withhold the whole dashboard.
+    loadConfigSpy.mockResolvedValue({
+      config: {
+        collections: [
+          {
+            slug: "authors",
+            tableName: "dc_authors",
+            fields: [{ name: "name", type: "text" }],
+          },
+        ],
+      },
+    });
+    introspectSpy.mockResolvedValue(
+      buildSnapshot([
+        { name: "dc_authors", columns: reservedColumns("dc_authors") },
+      ])
+    );
+
+    const { reloadNextlyConfig } = await import("../reload-config");
+    await reloadNextlyConfig({ resolver: buildResolver() });
+
+    expect(setDeferredCollectionsSpy).toHaveBeenCalledWith([]);
   });
 
   it("marks an EDITED code-first collection as 'applied' after a successful apply", async () => {

--- a/packages/nextly/src/init/__tests__/reload-config.test.ts
+++ b/packages/nextly/src/init/__tests__/reload-config.test.ts
@@ -544,6 +544,73 @@ describe("reloadNextlyConfig", () => {
     );
   });
 
+  it("does NOT mark a DEFERRED collection 'applied' in a mixed batch", async () => {
+    // A batch can apply one collection's safe change while REFUSING another's.
+    // The refused one goes into `deferredEntities` and its DDL never runs --
+    // but the metadata sync is built from every configured collection, so a
+    // deferred collection whose fields changed still comes back in `updated`.
+    // Marking it 'applied' from that list would state the opposite of what the
+    // reload just decided, and publish its cards against the shape the reload
+    // declined to apply.
+    loadConfigSpy.mockResolvedValue({
+      config: {
+        collections: [
+          // REFUSED: live `active` is text, the config declares a checkbox --
+          // a column type change the gate defers rather than applies.
+          {
+            slug: "books",
+            tableName: "dc_books",
+            fields: [{ name: "active", type: "checkbox" }],
+          },
+          // APPLIED: purely additive, so this reload reaches the post-DDL
+          // commit at all. Without it the deferred branch bails earlier and
+          // the marking under test is never reached.
+          {
+            slug: "authors",
+            tableName: "dc_authors",
+            fields: [{ name: "name", type: "text" }],
+          },
+        ],
+      },
+    });
+    introspectSpy.mockResolvedValue(
+      buildSnapshot([
+        {
+          name: "dc_books",
+          columns: [
+            ...reservedColumns("dc_books"),
+            { name: "active", type: "text", nullable: true },
+          ],
+        },
+        { name: "dc_authors", columns: reservedColumns("dc_authors") },
+      ])
+    );
+
+    // The sync reports BOTH as rewritten -- which is exactly the trap: its
+    // payload is every configured collection, so it cannot know one was
+    // deferred.
+    const resolver = buildResolver({
+      collectionSyncResult: {
+        created: [],
+        updated: ["books", "authors"],
+        unchanged: [],
+      },
+    });
+    const { reloadNextlyConfig } = await import("../reload-config");
+    await reloadNextlyConfig({ resolver });
+
+    // The control that this reload reached the post-DDL commit rather than
+    // bailing on the deferred branch, which withholds for its own reason.
+    expect(pipelineApplySpy).toHaveBeenCalledTimes(1);
+    expect(resolver.updateCollectionMigrationStatusSpy).toHaveBeenCalledWith(
+      "authors",
+      "applied"
+    );
+    expect(
+      resolver.updateCollectionMigrationStatusSpy
+    ).not.toHaveBeenCalledWith("books", "applied");
+  });
+
   it("leaves an UNCHANGED collection's migration status alone", async () => {
     // The control the assertion above needs: marking every target 'applied'
     // would pass that test too, and would overwrite a status that legitimately

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -2275,9 +2275,29 @@ async function applyReload(opts?: {
       // snapshot, because the snapshot answers "did this table exist before the
       // apply": the right question for a table the pipeline CREATED and the wrong
       // one for a table it ALTERED.
-      const migrated = new Set<string>(rewrittenSlugs(collectionSync));
+      //
+      // 🔴 A DEFERRED collection is excluded from BOTH halves, and the metadata
+      // sync cannot tell you which those are. `deferredEntities` holds a target
+      // whose diff threw -- omitted from `desiredCollections` outright, so the
+      // apply never carried its DDL -- and one whose change classified unsafe,
+      // where auto-apply is deliberately skipped and the terminal says so. In
+      // both cases the reload SAW the collection and decided not to migrate it.
+      //
+      // The sync payload, though, is built from every configured collection, so
+      // a deferred collection whose fields changed still comes back in
+      // `updated`. Marking that `applied` would state the opposite of what the
+      // reload just decided -- and, through the same queryability check this
+      // commit exists to feed, publish cards against the shape the reload
+      // explicitly declined to apply.
+      const isDeferred = (slug: string): boolean =>
+        deferredEntities.has(`collection:${slug}`);
+      const migrated = new Set<string>(
+        rewrittenSlugs(collectionSync).filter(slug => !isDeferred(slug))
+      );
       for (const target of targets) {
-        if (!liveByTable.has(target.tableName)) migrated.add(target.slug);
+        if (!liveByTable.has(target.tableName) && !isDeferred(target.slug)) {
+          migrated.add(target.slug);
+        }
       }
       for (const slug of migrated) {
         try {

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -189,6 +189,23 @@ type ComponentDef = {
   admin?: unknown;
 };
 
+/**
+ * The slugs a metadata sync rewrote, read defensively from an untyped result.
+ *
+ * `SyncResult.updated` names the rows that went through `updateCollection`,
+ * which is the one path that resets `migration_status` on a collection that
+ * already existed. Read through a guard rather than a cast because the surface
+ * this module holds is duck-typed: a partial resolver fake may resolve anything
+ * at all, and a sync that reports nothing must leave the marking alone rather
+ * than throw inside the metadata step.
+ */
+function rewrittenSlugs(result: unknown): string[] {
+  if (typeof result !== "object" || result === null) return [];
+  const updated = (result as { updated?: unknown }).updated;
+  if (!Array.isArray(updated)) return [];
+  return updated.filter((slug): slug is string => typeof slug === "string");
+}
+
 // Minimal duck-typed surfaces of registry services used here.
 interface CollectionRegistrySurface {
   syncCodeFirstCollections(configs: unknown[]): Promise<unknown>;
@@ -2230,20 +2247,43 @@ async function applyReload(opts?: {
       const codeFirstConfigs = buildCollectionSyncPayload(
         newConfig.collections ?? []
       );
-      await registry.syncCodeFirstCollections(codeFirstConfigs);
+      const collectionSync =
+        await registry.syncCodeFirstCollections(codeFirstConfigs);
 
       // registerCollection defaults migration_status to 'pending'; the pipeline
       // just created any missing tables, so mark them 'applied' (mirrors the
       // singles branch / di/register.ts). Without this a code collection added
       // after initial setup shows "pending" forever. Absent in the pre-pipeline
       // liveByTable snapshot ⇒ just created.
+      //
+      // 🔴 A successful apply leaves a row saying `pending` in TWO ways, and the
+      // pre-apply snapshot only sees one of them. `registerCollection` defaults a
+      // NEW row to `pending`, which the absent-table check below catches. But
+      // `updateCollection` ALSO RESETS an EXISTING row to `pending` whenever the
+      // fields, status or localized flag change -- and the DDL for that change is
+      // precisely what the apply above just performed. Such a collection's table
+      // was present before the apply, so `!liveByTable.has` skips it, and the row
+      // goes on reporting an outstanding migration for a table already at the new
+      // shape until a restart re-marks it.
+      //
+      // That row is not merely cosmetic. Anything deciding whether a collection's
+      // table can be queried reads it -- the widget source refresh does -- so a
+      // field edit under `next dev` silently withdrew that collection's generated
+      // cards from the dashboard for the rest of the session.
+      //
+      // The edited set is taken from the SYNC'S OWN REPORT rather than from the
+      // snapshot, because the snapshot answers "did this table exist before the
+      // apply": the right question for a table the pipeline CREATED and the wrong
+      // one for a table it ALTERED.
+      const migrated = new Set<string>(rewrittenSlugs(collectionSync));
       for (const target of targets) {
-        if (!liveByTable.has(target.tableName)) {
-          try {
-            await registry.updateMigrationStatus(target.slug, "applied");
-          } catch {
-            // Non-fatal: migration status is metadata only.
-          }
+        if (!liveByTable.has(target.tableName)) migrated.add(target.slug);
+      }
+      for (const slug of migrated) {
+        try {
+          await registry.updateMigrationStatus(slug, "applied");
+        } catch {
+          // Non-fatal: migration status is metadata only.
         }
       }
     } catch {

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -1883,6 +1883,33 @@ async function applyReload(opts?: {
     }
   }
 
+  // 🔴 Published BEFORE either branch below returns, and on every reload, so the
+  // set describes THIS reload rather than whichever one last got far enough to
+  // say something. A reload that refuses a collection's DDL still writes that
+  // collection's new field list to the registry, because the sync payload is
+  // built from the whole config -- so anything deciding what a query may NAME
+  // has to know the difference between metadata that landed and metadata that
+  // merely persisted. Nothing else carries that: `migration_status` is written
+  // by paths that never deferred anything, which is what makes it unable to
+  // answer this.
+  //
+  // Replacing the set rather than adding to it is what makes a later successful
+  // reload clear a refusal, with nobody having to remember to.
+  //
+  // Imported dynamically rather than at the top of the module: this file sits in
+  // `init/` and the widget source refresh reaches the DI container, so a static
+  // edge from here would add to the import cycles the repository already
+  // carries. The call is on an async path that has already awaited several
+  // times, so the cost is a resolved module lookup.
+  const { setDeferredCollections } = await import(
+    "../domains/widgets/collection-sources"
+  );
+  setDeferredCollections(
+    [...deferredEntities]
+      .filter(entity => entity.startsWith("collection:"))
+      .map(entity => entity.slice("collection:".length))
+  );
+
   // No schema (DDL) changes to apply. Registry-only metadata (versions,
   // localized, status, labels, description) can still have changed, and it does
   // not surface as a schema diff — so run the idempotent metadata sync before

--- a/packages/nextly/src/lib/entry-heading.test.ts
+++ b/packages/nextly/src/lib/entry-heading.test.ts
@@ -25,9 +25,10 @@ describe("entryHeading", () => {
   it("walks the SAME conventional names the field-level rule accepts", () => {
     // 🔴 One question, one answer. The rule that decides which column a list or
     // a generated card SELECTS accepts `label`, `subject` and `heading` beside
-    // `title` and `name`; this walk stopped at `name`. A collection naming its
-    // entries with `subject` was therefore titled correctly on the dashboard
-    // and shown as a bare id in the activity feed.
+    // `title` and `name`, and this walk has to accept the same set: a
+    // collection naming its entries with `subject` takes that field as its
+    // title on the dashboard, and a shorter walk answers the activity feed with
+    // a bare id for the same entry.
     expect(entryHeading({ subject: "Re: hello" }, null, "id-1")).toBe(
       "Re: hello"
     );

--- a/packages/nextly/src/lib/entry-heading.test.ts
+++ b/packages/nextly/src/lib/entry-heading.test.ts
@@ -22,6 +22,23 @@ describe("entryHeading", () => {
     expect(entryHeading({ title: "T", name: "N" }, null, "id-1")).toBe("T");
   });
 
+  it("walks the SAME conventional names the field-level rule accepts", () => {
+    // 🔴 One question, one answer. The rule that decides which column a list or
+    // a generated card SELECTS accepts `label`, `subject` and `heading` beside
+    // `title` and `name`; this walk stopped at `name`. A collection naming its
+    // entries with `subject` was therefore titled correctly on the dashboard
+    // and shown as a bare id in the activity feed.
+    expect(entryHeading({ subject: "Re: hello" }, null, "id-1")).toBe(
+      "Re: hello"
+    );
+    expect(entryHeading({ heading: "Chapter 1" }, null, "id-1")).toBe(
+      "Chapter 1"
+    );
+    expect(entryHeading({ label: "Draft" }, null, "id-1")).toBe("Draft");
+    // Preference order is preserved: `title` still outranks the newcomers.
+    expect(entryHeading({ subject: "S", title: "T" }, null, "id-1")).toBe("T");
+  });
+
   it("returns `undefined` rather than a placeholder when nothing is usable", () => {
     // The activity feed's case. A heading it invents is worse than none: the
     // row would claim a name the entry never had.

--- a/packages/nextly/src/lib/entry-heading.ts
+++ b/packages/nextly/src/lib/entry-heading.ts
@@ -28,14 +28,14 @@ import { COMMON_TITLE_FIELDS } from "../domains/collections/entry-title";
  * field, then each conventional title name in {@link COMMON_TITLE_FIELDS}. An
  * absent `titleField` simply starts the walk at `title`.
  *
- * 🔴 The conventional names are IMPORTED rather than written out, and the two
- * spellings disagreeing is exactly what the paragraph above promised could not
- * happen. This walked `title` then `name`; the field-level rule that decides
- * which column a list or a generated card SELECTS also accepts `label`,
- * `subject` and `heading`. A collection naming its entries with `subject` was
- * therefore titled correctly on the dashboard and shown as a bare id in the
- * activity feed -- one question, two answers, which is the condition this
- * module exists to prevent.
+ * 🔴 The conventional names are IMPORTED rather than written out here, so this
+ * walk and the field-level rule that decides which column a list or a generated
+ * card SELECTS cannot disagree about which names count. Two spellings of one
+ * list is precisely the drift the paragraph above says this module exists to
+ * prevent, and it would be invisible: a collection naming its entries with
+ * `subject` gets that field as its title on the dashboard, and a walk that
+ * stopped at `name` would answer the activity feed with a bare id instead --
+ * both surfaces behaving exactly as each was written.
  *
  * An EMPTY string is skipped rather than returned. `??` only skips `null` and
  * `undefined`, so an untitled draft used to render as no heading at all --

--- a/packages/nextly/src/lib/entry-heading.ts
+++ b/packages/nextly/src/lib/entry-heading.ts
@@ -19,12 +19,23 @@
  * @module lib/entry-heading
  */
 
+import { COMMON_TITLE_FIELDS } from "../domains/collections/entry-title";
+
 /**
  * The first candidate that is a usable heading, else `fallback`.
  *
  * Candidates, in descending preference: the collection's configured title
- * field, then a `title` field, then a `name` field. An absent `titleField`
- * simply starts the walk at `title`.
+ * field, then each conventional title name in {@link COMMON_TITLE_FIELDS}. An
+ * absent `titleField` simply starts the walk at `title`.
+ *
+ * 🔴 The conventional names are IMPORTED rather than written out, and the two
+ * spellings disagreeing is exactly what the paragraph above promised could not
+ * happen. This walked `title` then `name`; the field-level rule that decides
+ * which column a list or a generated card SELECTS also accepts `label`,
+ * `subject` and `heading`. A collection naming its entries with `subject` was
+ * therefore titled correctly on the dashboard and shown as a bare id in the
+ * activity feed -- one question, two answers, which is the condition this
+ * module exists to prevent.
  *
  * An EMPTY string is skipped rather than returned. `??` only skips `null` and
  * `undefined`, so an untitled draft used to render as no heading at all --
@@ -42,8 +53,7 @@ export function entryHeading<TFallback extends string | undefined>(
 ): string | TFallback {
   const candidates = [
     titleField ? data[titleField] : undefined,
-    data.title,
-    data.name,
+    ...COMMON_TITLE_FIELDS.map(name => data[name]),
   ];
   for (const candidate of candidates) {
     if (typeof candidate === "string" && candidate.length > 0) return candidate;

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -93,6 +93,7 @@ import { postWidgetQuery } from "./api/widget-query";
 import { readAccessTokenCookie } from "./auth/cookies/access-token-cookie";
 import type { SanitizedNextlyConfig } from "./collections/config/define-config";
 import { container } from "./di/container";
+import { refreshCollectionWidgets } from "./domains/widgets/collection-widgets";
 import { publishableWidgets } from "./domains/widgets/publish";
 import { NextlyError } from "./errors/nextly-error";
 import {
@@ -1504,6 +1505,12 @@ async function buildAdminMeta(): Promise<{
   // half already describes the RUNNING installation rather than the configured
   // one -- `showBuilder` from the live resolver, `customGroups` from the
   // database -- is the same property this relies on.
+  // Re-derived per request, not at boot. A collection drawn in the Schema
+  // Builder exists the moment it is saved, so a set frozen at boot describes an
+  // install that has since changed -- and in production "the next restart" means
+  // the next deploy. This is the same read `refreshCollectionSources` already
+  // performs once per dashboard batch.
+  await refreshCollectionWidgets();
   const registered = publishableWidgets();
   if (registered.length > 0) {
     workspace.widgets = registered;

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -36,6 +36,7 @@ import {
   updateApiKey,
   revokeApiKey,
 } from "./api/api-keys";
+import { readAccessCaller, readCaller } from "./api/authenticated-read";
 import {
   getDashboardStats,
   getDashboardRecentEntries,
@@ -93,8 +94,18 @@ import { postWidgetQuery } from "./api/widget-query";
 import { readAccessTokenCookie } from "./auth/cookies/access-token-cookie";
 import type { SanitizedNextlyConfig } from "./collections/config/define-config";
 import { container } from "./di/container";
-import { refreshCollectionWidgets } from "./domains/widgets/collection-widgets";
+import { contributedWidgets } from "./domains/widgets/canonical";
+import {
+  generatedWidgets,
+  readableGeneratedWidgets,
+  refreshCollectionWidgets,
+} from "./domains/widgets/collection-widgets";
+import type { WidgetDefinition } from "./domains/widgets/definition";
 import { publishableWidgets } from "./domains/widgets/publish";
+import {
+  holdsWidgetPermission,
+  permissionVerdicts,
+} from "./domains/widgets/visibility";
 import { NextlyError } from "./errors/nextly-error";
 import {
   currentFlattenedErrors,
@@ -1401,7 +1412,16 @@ async function handleServiceRequest(
  * written and drift afterwards, and the drift is invisible because both halves
  * look correct alone.
  */
-async function buildAdminMeta(): Promise<{
+async function buildAdminMeta(
+  /**
+   * Cards core DERIVED for this reader's readable collections.
+   *
+   * A parameter rather than a call, because which of them a reader may be told
+   * about depends on the reader and this builder is shared with the PUBLIC
+   * branding route. Empty for that route, which discards `workspace` anyway.
+   */
+  generatedForCaller: WidgetDefinition[] = []
+): Promise<{
   branding: Record<string, unknown>;
   workspace: Record<string, unknown>;
 }> {
@@ -1505,15 +1525,9 @@ async function buildAdminMeta(): Promise<{
   // half already describes the RUNNING installation rather than the configured
   // one -- `showBuilder` from the live resolver, `customGroups` from the
   // database -- is the same property this relies on.
-  // Re-derived per request, not at boot. A collection drawn in the Schema
-  // Builder exists the moment it is saved, so a set frozen at boot describes an
-  // install that has since changed -- and in production "the next restart" means
-  // the next deploy. This is the same read `refreshCollectionSources` already
-  // performs once per dashboard batch.
-  await refreshCollectionWidgets();
-  const registered = publishableWidgets();
-  if (registered.length > 0) {
-    workspace.widgets = registered;
+  const widgets = [...publishableWidgets(), ...generatedForCaller];
+  if (widgets.length > 0) {
+    workspace.widgets = widgets;
   }
 
   // Override config branding with DB values when available
@@ -1641,7 +1655,40 @@ async function handleAdminMetaWorkspaceRequest(
   // of the running one.
   await ensureServicesInitialized();
 
-  const { workspace } = await buildAdminMeta();
+  // Re-derived per request, and HERE rather than inside `buildAdminMeta`. A
+  // collection drawn in the Schema Builder exists the moment it is saved, so a
+  // set frozen at boot describes an install that has since changed -- and in
+  // production "the next restart" means the next deploy.
+  //
+  // 🔴 Only on this route. `buildAdminMeta` is shared with the PUBLIC branding
+  // handler, which deliberately does not initialise services: refreshing there
+  // asked an empty container for the collection registry on every anonymous
+  // login-page request, logging a registry-unavailable error for a payload that
+  // discards `workspace.widgets` anyway -- and, once initialised, made a cheap
+  // branding read load every collection's schema from the database.
+  await refreshCollectionWidgets();
+
+  // 🔴 The generated cards are resolved HERE rather than inside `buildAdminMeta`,
+  // because which of them a reader may be told about depends on the reader.
+  // Their id, title and query all name a COLLECTION, so publishing the whole
+  // set would disclose the slug and the existence of every collection in the
+  // install to any authenticated caller — including the ones the layout and
+  // query endpoints deliberately hide from them. That the admin would not draw
+  // the card is not a control; the payload is JSON, and reading it is the
+  // bypass. The verdicts come from the same implementation the layout endpoint
+  // filters with, so the two cannot disagree about what this reader may see.
+  const caller = readAccessCaller(await readCaller(auth));
+  const generated = generatedWidgets();
+  const verdicts = await permissionVerdicts(
+    generated.map(widget => widget.requiredPermission),
+    caller
+  );
+  const readable = readableGeneratedWidgets(
+    requiredPermission => holdsWidgetPermission(requiredPermission, verdicts),
+    new Set(contributedWidgets().map(widget => widget.id))
+  );
+
+  const { workspace } = await buildAdminMeta(readable);
   return withSessionCacheHeaders(respondAdminMeta(workspace));
 }
 

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -92,7 +92,6 @@ import {
 } from "./api/widget-layout";
 import { postWidgetQuery } from "./api/widget-query";
 import { readAccessTokenCookie } from "./auth/cookies/access-token-cookie";
-import { authorizationGroups, canReadEntity } from "./auth/entity-read-access";
 import type { SanitizedNextlyConfig } from "./collections/config/define-config";
 import { container } from "./di/container";
 import { contributedWidgets } from "./domains/widgets/canonical";
@@ -104,6 +103,7 @@ import {
 } from "./domains/widgets/collection-widgets";
 import type { WidgetDefinition } from "./domains/widgets/definition";
 import { publishableWidgets } from "./domains/widgets/publish";
+import { readableCollections } from "./domains/widgets/visibility";
 import { NextlyError } from "./errors/nextly-error";
 import {
   currentFlattenedErrors,
@@ -1681,31 +1681,21 @@ async function handleAdminMetaWorkspaceRequest(
   // `callerHoldsPermission` does not -- so an API key those rules reject is
   // refused by the query endpoint and would have been told the collection
   // exists by this payload. One question, one answer.
-  const slugs = [
-    ...new Set(
-      generatedWidgets()
-        .map(generatedCollectionSlug)
-        .filter((slug): slug is string => slug !== undefined)
-    ),
-  ];
-  const readableCollections = new Set<string>();
-  for (const group of authorizationGroups(slugs)) {
-    const settled = await Promise.allSettled(
-      group.map(slug => canReadEntity(slug, caller))
-    );
-    group.forEach((slug, index) => {
-      const outcome = settled[index];
-      // A rejected decision DENIES. A check that threw has told us nothing, and
-      // "nothing" must not read as "allowed" for a payload that discloses which
-      // collections an install has.
-      if (outcome.status === "fulfilled" && outcome.value) {
-        readableCollections.add(slug);
-      }
-    });
-  }
+  const readableCollectionSlugs = await readableCollections(
+    generatedWidgets().map(generatedCollectionSlug),
+    caller
+  );
   const readable = readableGeneratedWidgets(
-    slug => readableCollections.has(slug),
-    new Set(contributedWidgets().map(widget => widget.id))
+    slug => readableCollectionSlugs.has(slug),
+    // Every DECLARED id, registrations included. Filtering only contributions
+    // left a registration colliding with a generated card published TWICE in
+    // this payload -- once as itself and once as core's derived guess -- and the
+    // canonical set resolves that collision in the registration's favour, so the
+    // two halves of the response disagreed about which declaration the card is.
+    new Set([
+      ...contributedWidgets().map(widget => widget.id),
+      ...publishableWidgets().map(widget => widget.id),
+    ])
   );
 
   const { workspace } = await buildAdminMeta(readable);

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -103,6 +103,7 @@ import {
 } from "./domains/widgets/collection-widgets";
 import type { WidgetDefinition } from "./domains/widgets/definition";
 import { publishableWidgets } from "./domains/widgets/publish";
+import { listWidgets } from "./domains/widgets/registry";
 import { readableCollections } from "./domains/widgets/visibility";
 import { NextlyError } from "./errors/nextly-error";
 import {
@@ -1692,9 +1693,17 @@ async function handleAdminMetaWorkspaceRequest(
     // this payload -- once as itself and once as core's derived guess -- and the
     // canonical set resolves that collision in the registration's favour, so the
     // two halves of the response disagreed about which declaration the card is.
+    //
+    // 🔴 From `listWidgets()`, the registry ITSELF, not from the publishable
+    // projection of it. `publishableWidgets` drops a definition that cannot
+    // survive `JSON.stringify` -- a `BigInt` in `query.where`, say -- and that
+    // definition is still in the registry, so `canonicalWidgets` still resolves
+    // its id to the registration. Detecting collisions against the narrower set
+    // would publish core's generated card under an id the server had already
+    // given to somebody else, which is the same disagreement one level down.
     new Set([
       ...contributedWidgets().map(widget => widget.id),
-      ...publishableWidgets().map(widget => widget.id),
+      ...listWidgets().map(widget => widget.id),
     ])
   );
 

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -92,6 +92,7 @@ import {
 } from "./api/widget-layout";
 import { postWidgetQuery } from "./api/widget-query";
 import { readAccessTokenCookie } from "./auth/cookies/access-token-cookie";
+import { readableEntities } from "./auth/entity-read-access";
 import type { SanitizedNextlyConfig } from "./collections/config/define-config";
 import { container } from "./di/container";
 import { contributedWidgets } from "./domains/widgets/canonical";
@@ -104,7 +105,6 @@ import {
 import type { WidgetDefinition } from "./domains/widgets/definition";
 import { publishableWidgets } from "./domains/widgets/publish";
 import { listWidgets } from "./domains/widgets/registry";
-import { readableCollections } from "./domains/widgets/visibility";
 import { NextlyError } from "./errors/nextly-error";
 import {
   currentFlattenedErrors,
@@ -1682,8 +1682,10 @@ async function handleAdminMetaWorkspaceRequest(
   // `callerHoldsPermission` does not -- so an API key those rules reject is
   // refused by the query endpoint and would have been told the collection
   // exists by this payload. One question, one answer.
-  const readableCollectionSlugs = await readableCollections(
-    generatedWidgets().map(generatedCollectionSlug),
+  const readableCollectionSlugs = await readableEntities(
+    generatedWidgets()
+      .map(generatedCollectionSlug)
+      .filter((slug): slug is string => slug !== undefined),
     caller
   );
   const readable = readableGeneratedWidgets(

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -92,20 +92,18 @@ import {
 } from "./api/widget-layout";
 import { postWidgetQuery } from "./api/widget-query";
 import { readAccessTokenCookie } from "./auth/cookies/access-token-cookie";
+import { authorizationGroups, canReadEntity } from "./auth/entity-read-access";
 import type { SanitizedNextlyConfig } from "./collections/config/define-config";
 import { container } from "./di/container";
 import { contributedWidgets } from "./domains/widgets/canonical";
 import {
+  generatedCollectionSlug,
   generatedWidgets,
   readableGeneratedWidgets,
   refreshCollectionWidgets,
 } from "./domains/widgets/collection-widgets";
 import type { WidgetDefinition } from "./domains/widgets/definition";
 import { publishableWidgets } from "./domains/widgets/publish";
-import {
-  holdsWidgetPermission,
-  permissionVerdicts,
-} from "./domains/widgets/visibility";
 import { NextlyError } from "./errors/nextly-error";
 import {
   currentFlattenedErrors,
@@ -1678,13 +1676,35 @@ async function handleAdminMetaWorkspaceRequest(
   // bypass. The verdicts come from the same implementation the layout endpoint
   // filters with, so the two cannot disagree about what this reader may see.
   const caller = readAccessCaller(await readCaller(auth));
-  const generated = generatedWidgets();
-  const verdicts = await permissionVerdicts(
-    generated.map(widget => widget.requiredPermission),
-    caller
-  );
+  // The verdict the QUERY path takes. `canReadEntity` evaluates a collection's
+  // code-defined `access.read` as well as the stamped grant, and
+  // `callerHoldsPermission` does not -- so an API key those rules reject is
+  // refused by the query endpoint and would have been told the collection
+  // exists by this payload. One question, one answer.
+  const slugs = [
+    ...new Set(
+      generatedWidgets()
+        .map(generatedCollectionSlug)
+        .filter((slug): slug is string => slug !== undefined)
+    ),
+  ];
+  const readableCollections = new Set<string>();
+  for (const group of authorizationGroups(slugs)) {
+    const settled = await Promise.allSettled(
+      group.map(slug => canReadEntity(slug, caller))
+    );
+    group.forEach((slug, index) => {
+      const outcome = settled[index];
+      // A rejected decision DENIES. A check that threw has told us nothing, and
+      // "nothing" must not read as "allowed" for a payload that discloses which
+      // collections an install has.
+      if (outcome.status === "fulfilled" && outcome.value) {
+        readableCollections.add(slug);
+      }
+    });
+  }
   const readable = readableGeneratedWidgets(
-    requiredPermission => holdsWidgetPermission(requiredPermission, verdicts),
+    slug => readableCollections.has(slug),
     new Set(contributedWidgets().map(widget => widget.id))
   );
 


### PR DESCRIPTION
**The four archetype renderers have had no consumers since they were built.**
`metric`, `list`, `table` and `actions` all render; every core widget is
`archetype: "custom"` and draws itself. So the dashboard was four hand-drawn
cards, and the query contract underneath them was exercised only by tests.

This gives two of them real consumers, from the content the install actually has.

## What a reader gets

Every collection offers two cards through the picker PR #1463 built:

| card | archetype | query |
| --- | --- | --- |
| `collection/<slug>-count` | `metric` | `count`, `status: "all"` |
| `collection/<slug>-recent` | `list` | `list`, sorted `-updatedAt`, 5 rows |

`status: "all"` on the count is deliberate: a number that silently excluded
drafts would disagree with the collection's own list view, with nothing on screen
to say which is answering the narrower question.

## Three decisions worth reviewing

**Derived from the registered SOURCES, not from the collection registry again.**
A widget and the source it queries must agree on three things — that the source
exists, which ops it answers, and which permission gates it. Reading the registry
a second time here would answer all three again and the copies would drift: a
source that stopped supporting `count` would leave a metric card whose every
request is refused. There is nothing to disagree with when the widget is built
from the source.

**Re-derived per request, like the sources already are.** A collection drawn in
the Schema Builder exists the moment it is saved, so a set frozen at boot
describes an install that has since changed — and in production "the next
restart" means the next deploy. Django's admin builds its per-model views at
request time for the same reason.

**Offered, never placed.** An install with forty collections would otherwise open
onto eighty cards, and removing seventy-seven is not a dashboard. Payload shipped
the auto-placing version and withdrew it (#16250): one card per collection
produced duplicates with no clean opt-out and no way for the arrangement to say
"I have seen this and do not want it".

## Where a card is skipped rather than guessed

Each of these is a refusal, and each has a test:

- **no field names the entries** → no list. Every row would read as an
  identifier. The `list` renderer already refuses to pick a key out of a document
  it knows nothing about; generating one that picks wrongly would defeat that by
  answering badly instead of declining.
- **no `updatedAt`** → no list. "Recent" would have nothing to sort by, so the
  card's title would claim something its rows do not support.
- **a slug that cannot form a valid widget id** → neither card. Asked through
  `isValidWidgetId`, the registry's own predicate, rather than a second copy of
  its pattern — these ids reach the admin payload and the layout endpoint, both
  of which treat them as real.

That last one was found by a test, not by reading: widget ids are
`namespace/name`, exactly two segments, and my first draft minted
`collection/posts/count`.

## Precedence

Generated cards sit between the two declared channels. A **contribution** that
already claimed the id keeps it; an explicit **registration** replaces one. Core's
derived guess never displaces something an author stated. Both directions are
tested in `canonical.test.ts` and `publish.test.ts`, and both break-verified.

## One move outward

`entryTitleField` and `COMMON_TITLE_FIELDS` move from `packages/admin` into core
and are re-exported. The server now needs the answer the admin already had — the
entry list draws a column with it, the activity feed labels a row with it, and a
generated list picks its row label with it before the query is made. A reader who
sees "Hello world" in one place and `a3f9-…` in another is looking at two
implementations of one question.

## Verification

- `nextly` **871 files / 10962 tests**, `admin` **390 files / 3815 tests**
- `check-types` and `lint` clean in both; `fallow audit` pass, 0 introduced
- **break-verified**, each failing only its own test: rebuilding the permission
  from the slug; falling back to the first field instead of refusing; minting an
  id the registry would refuse; letting a generated card displace a contribution;
  dropping generated cards from the admin payload

### A pre-push failure that was NOT what it looked like

`export-contract.test.ts` timed out at 10000ms — the signature of a load timeout,
and it has done this four times today. But this PR adds exports to `nextly/config`
and that test reads the export surface, so I measured instead of assuming.
Cold-cache, both variants: **6.96s with my change, 6.88s with `main`'s
`config.ts`** — a 0.08s difference, and both pass.

Worth flagging separately: that file sits at ~70% of its timeout budget on a cold
cache, which is why load tips it over. Pre-existing, not addressed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard widgets can now be generated automatically from collections, including counts and recently updated entries.
  * Collection-based widgets use clearer labels and suitable title fields for entry names.
  * Widget visibility now respects collection access permissions.

* **Bug Fixes**
  * Dashboards and branding metadata refresh after schema changes.
  * Collections undergoing migrations are excluded from dashboard widget sources until usable.
  * Collection access checks now handle individual authorization failures without blocking other results.
  * Updated collections are correctly marked as applied after synchronization.
  * Activity entries now recognize additional conventional title fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->