### PR TITLE
fix(nextly): read the registry spelling from the catalog in the bootstrap DDL

### DIFF
--- a/.changeset/registry-spelling-through-the-catalog.md
+++ b/.changeset/registry-spelling-through-the-catalog.md
@@ -1,0 +1,39 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The SQLite bootstrap reads the field-group registry's name from the catalog
+instead of writing it out.
+
+Six statements spelled `dynamic_components` as a literal. That is the spelling
+the storage migration renames, and the catalog in `schemas/storage-format.ts`
+is what makes that a rename rather than a search — a literal elsewhere is a
+copy the rename cannot reach. The repository gates on this, and the gate was
+failing on `main`.
+
+No behavioural change: the constant resolves to the same string today. What
+changes is that it will still resolve correctly after the registry moves.

--- a/packages/nextly/src/database/sqlite-core-tables.ts
+++ b/packages/nextly/src/database/sqlite-core-tables.ts
@@ -21,6 +21,8 @@
 // added to a schema and not here is a column the ORM writes and the table does
 // not have, and every insert naming it fails.
 
+import { STORAGE_FORMAT } from "../schemas/storage-format";
+
 /**
  * Return SQLite CREATE TABLE IF NOT EXISTS statements for all core Nextly
  * tables in foreign-key-safe order.
@@ -325,7 +327,7 @@ export function generateSqliteCoreTableStatements(): string[] {
       ON "dynamic_singles" ("created_at")`,
     `CREATE INDEX IF NOT EXISTS "dynamic_singles_updated_at_idx"
       ON "dynamic_singles" ("updated_at")`,
-    `CREATE TABLE IF NOT EXISTS "dynamic_components" (
+    `CREATE TABLE IF NOT EXISTS "${STORAGE_FORMAT.registryTable}" (
       "id" TEXT PRIMARY KEY NOT NULL,
       "slug" TEXT NOT NULL UNIQUE,
       "label" TEXT NOT NULL,
@@ -345,16 +347,16 @@ export function generateSqliteCoreTableStatements(): string[] {
       "created_at" INTEGER NOT NULL,
       "updated_at" INTEGER NOT NULL
     )`,
-    `CREATE INDEX IF NOT EXISTS "dynamic_components_source_idx"
-      ON "dynamic_components" ("source")`,
-    `CREATE INDEX IF NOT EXISTS "dynamic_components_migration_status_idx"
-      ON "dynamic_components" ("migration_status")`,
-    `CREATE INDEX IF NOT EXISTS "dynamic_components_created_by_idx"
-      ON "dynamic_components" ("created_by")`,
-    `CREATE INDEX IF NOT EXISTS "dynamic_components_created_at_idx"
-      ON "dynamic_components" ("created_at")`,
-    `CREATE INDEX IF NOT EXISTS "dynamic_components_updated_at_idx"
-      ON "dynamic_components" ("updated_at")`,
+    `CREATE INDEX IF NOT EXISTS "${STORAGE_FORMAT.registryTable}_source_idx"
+      ON "${STORAGE_FORMAT.registryTable}" ("source")`,
+    `CREATE INDEX IF NOT EXISTS "${STORAGE_FORMAT.registryTable}_migration_status_idx"
+      ON "${STORAGE_FORMAT.registryTable}" ("migration_status")`,
+    `CREATE INDEX IF NOT EXISTS "${STORAGE_FORMAT.registryTable}_created_by_idx"
+      ON "${STORAGE_FORMAT.registryTable}" ("created_by")`,
+    `CREATE INDEX IF NOT EXISTS "${STORAGE_FORMAT.registryTable}_created_at_idx"
+      ON "${STORAGE_FORMAT.registryTable}" ("created_at")`,
+    `CREATE INDEX IF NOT EXISTS "${STORAGE_FORMAT.registryTable}_updated_at_idx"
+      ON "${STORAGE_FORMAT.registryTable}" ("updated_at")`,
     // Content-version store. Columns match schemas/versions/sqlite.ts. The
     // durable-sequence unique index is created here too, not just the table:
     // once a fallback-created DB exists, later boots skip ensureCoreTables and


### PR DESCRIPTION
## main's required check is red, and this is mine

`Lint / Typecheck / Test / Build` is the only required check on `main`, and its most recent completed run failed at `245ef1fbf`. The failing step is **Storage-spelling gate (field-group storage format)**.

Reproduced on `origin/main`:

```
✗ registry table goes through the catalog (legacy spelling) (6 hit(s)):
    packages/nextly/src/database/sqlite-core-tables.ts:328  CREATE TABLE IF NOT EXISTS "dynamic_components" (
    packages/nextly/src/database/sqlite-core-tables.ts:349    ON "dynamic_components" ("source")
    ...
1 storage-spelling gate failure(s).
```

`git log -S` puts all six in `b0e7cd062` — **#1466, my own PR**. When I added the registry table to the bootstrap I wrote its name out six times instead of reading it from the catalog.

It was masked until now: every earlier completed run on `main` failed first on the `border-destructive/40` contrast test from #1463. #1477 fixed that at `245ef1fbf`, and this surfaced immediately underneath it.

## The fix

All six statements now read `${STORAGE_FORMAT.registryTable}`.

No behavioural change — the constant resolves to the same string today. What changes is that it keeps resolving correctly after the storage migration renames the registry, which is the whole point of the gate: the catalog is what makes that a rename rather than a search, and a literal elsewhere is a copy the rename cannot reach.

## Evidence

- `pnpm check:storage-format-literals` — **fails on `origin/main`, passes here**, so the change is what clears it
- `packages/nextly` unit `src/database` — 15 files, 177 tests
- sqlite integration `src/database src/cli` — 6 files, 47 tests
- `check-types` and eslint clean

## Why this is separate from #1471

#1471 rewrites much of this file and is nine review rounds deep. `main` is red now, and this repair is two lines plus an import — it should not wait behind that. I will rebase #1471 onto this once it lands.
