### PR TITLE
fix(nextly): import the storage-format catalog once in the bootstrap DDL

### DIFF
--- a/.changeset/one-storage-format-import.md
+++ b/.changeset/one-storage-format-import.md
@@ -1,0 +1,33 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The SQLite bootstrap module imports the storage-format catalog once.
+
+Two changes landed within seconds of each other, each adding the same import at
+a different line. Neither conflicted, so git kept both and the package stopped
+building on `TS2300: Duplicate identifier 'STORAGE_FORMAT'`.

--- a/packages/nextly/src/database/sqlite-core-tables.ts
+++ b/packages/nextly/src/database/sqlite-core-tables.ts
@@ -23,8 +23,6 @@ import { STORAGE_FORMAT } from "../schemas/storage-format";
 // added to a schema and not here is a column the ORM writes and the table does
 // not have, and every insert naming it fails.
 
-import { STORAGE_FORMAT } from "../schemas/storage-format";
-
 /**
  * Return SQLite CREATE TABLE IF NOT EXISTS statements for all core Nextly
  * tables in foreign-key-safe order.


### PR DESCRIPTION
## main does not build

`packages/nextly` fails on:

```
src/database/sqlite-core-tables.ts(1,10):  error TS2300: Duplicate identifier 'STORAGE_FORMAT'.
src/database/sqlite-core-tables.ts(26,10): error TS2300: Duplicate identifier 'STORAGE_FORMAT'.
```

Both the required `Lint / Typecheck / Test / Build` check and all three
`Integration` legs are failing on `main` at `56bf9c1f4`.

## Cause — and it is mine

#1484 and #1471 each added the same import to the same file, at different
lines. They merged eleven seconds apart. Neither conflicted, because git sees
two unrelated insertions, so it kept both.

Each PR's CI was green. Neither could have caught this: a PR is tested merged
with `main` **as it was**, never with the other PR in flight. Two changes that
are individually correct and jointly broken produce no signal until they are
both on `main`.

## The fix

Keep the import at the top of the file, drop the duplicate that sat between the
file docblock and the function docblock. One line removed.

## Evidence

- `pnpm --filter nextly build` — **fails on `origin/main`, passes here**
- `pnpm --filter nextly check-types` — clean
- `pnpm check:storage-format-literals` — passes, so the spelling gate that
  #1484 repaired stays repaired
- `src/database` unit — 15 files, 184 tests
- sqlite integration `src/database src/cli` — 7 files, 50 tests
- eslint clean

## Worth recording

This is the third distinct way `main` went red today, and the second where a
green PR was not evidence about the tree it would land in. The other two were a
contrast test masking a second failure underneath it, and a storage-spelling
gate that only became visible once the first was fixed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused internal reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->