### PR TITLE
fix(nextly): import the storage-format catalog once

### DIFF
--- a/.changeset/the-sqlite-bootstrap-compiles.md
+++ b/.changeset/the-sqlite-bootstrap-compiles.md
@@ -1,0 +1,34 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+The SQLite bootstrap compiles again.
+
+Its DDL imported the storage-format catalog twice, which TypeScript refuses --
+so the package did not build, and every check that compiles it failed. One
+import now. Nothing about what the bootstrap creates changes: both imports named
+the same catalog and the second was inert as well as illegal.

--- a/packages/nextly/src/database/sqlite-core-tables.ts
+++ b/packages/nextly/src/database/sqlite-core-tables.ts
@@ -23,8 +23,6 @@ import { STORAGE_FORMAT } from "../schemas/storage-format";
 // added to a schema and not here is a column the ORM writes and the table does
 // not have, and every insert naming it fails.
 
-import { STORAGE_FORMAT } from "../schemas/storage-format";
-
 /**
  * Return SQLite CREATE TABLE IF NOT EXISTS statements for all core Nextly
  * tables in foreign-key-safe order.


### PR DESCRIPTION
**`main` does not compile.** Every gating job is failing on it, including all
three integration legs, which run `check-types` before their suites.

## The error

`packages/nextly/src/database/sqlite-core-tables.ts` imports the catalog twice:

```
line  1: import { STORAGE_FORMAT } from "../schemas/storage-format";
line 26: import { STORAGE_FORMAT } from "../schemas/storage-format";
```

```
src/database/sqlite-core-tables.ts(1,10): error TS2300: Duplicate identifier 'STORAGE_FORMAT'.
src/database/sqlite-core-tables.ts(26,10): error TS2300: Duplicate identifier 'STORAGE_FORMAT'.
```

Introduced by **#1484**, which was itself the repair for the storage-spelling
gate that #1466 broke. That gate now passes — `Storage-spelling gate passed.` —
so this is the last thing between `main` and green.

## Verification, with the control in the right direction

| tree | `pnpm check-types` |
| --- | --- |
| `origin/main` as it stands | **TS2300 ×2** |
| this branch | clean |

The control is what makes that a claim rather than an observation: I restored
`main`'s copy of the file, watched the two errors come back, and restored mine.

- `nextly` unit suite — **870 files, 10952 tests**, 0 failures
- `check-types` and `lint` clean
- `node scripts/check-storage-format-literals.cjs` → `Storage-spelling gate passed.`

## No test, deliberately

The compiler is the test. A duplicate import cannot survive `check-types`, which
runs in the pre-push hook, in `ci.yml`, and in each of the three dialect legs —
so a regression here fails in four places before it reaches anyone. A unit test
asserting "this file imports the symbol once" would be a weaker instrument
than the one already gating it, and would read as coverage for a property the
compiler owns.

## No changeset

Nothing about the published behaviour changes: `STORAGE_FORMAT.registryTable`
resolves to the same string it did before, and the second import was inert as
well as illegal.