### PR TITLE
test: assert the site style dark block under either dark-mode strategy

### DIFF
--- a/e2e/tests/site-style.spec.ts
+++ b/e2e/tests/site-style.spec.ts
@@ -170,6 +170,14 @@ function siteSheetOf(html: string): string {
  * value sits unguarded in the light block. Declarations within a block are
  * separated by `;` and every block ends with `}`, so the text since the last
  * `}` is exactly what opened the block this declaration is in.
+ *
+ * The scoping is TEXTUAL rather than a parse, which is sound for what this
+ * emitter writes and has two known limits, both of which fail in the safe
+ * direction — a spurious failure, never a defect hidden. A second rule inside
+ * one at-rule block would put a `}` between the at-rule and the declaration
+ * and lose the guard; the emitter writes one selector per media block, so this
+ * is latent rather than live. A `}` inside a quoted value earlier in the same
+ * block would truncate the prelude the same way.
  */
 function enclosingPreludeOf(sheet: string, index: number): string {
   return sheet.slice(sheet.lastIndexOf("}", index) + 1, index);

--- a/e2e/tests/site-style.spec.ts
+++ b/e2e/tests/site-style.spec.ts
@@ -49,6 +49,25 @@ const TOKEN_LIGHT = "#1b7f5c";
 const TOKEN_DARK = "#8fe3c0";
 
 /**
+ * The two forms a dark block can be written under, one per supported
+ * `darkMode` strategy: `attribute` writes a selector the host activates,
+ * `media` writes an at-rule the operating system activates. The emitter picks
+ * one, so a sheet carries exactly one of these and never both.
+ *
+ * Spelled out rather than imported from the engine, deliberately. Both are
+ * published contract: a host wires its own theme toggle to `data-nx-theme` in
+ * markup this repository never sees, so renaming it breaks every such host.
+ * Importing the engine's constant would make this expectation follow a rename
+ * and keep passing — expectation and output would be two derivations of one
+ * source, which cannot detect the source changing. Written out, a rename fails
+ * here, which is what an end-to-end test of a wire format is for.
+ */
+const DARK_BLOCK_GUARDS = [
+  '[data-nx-theme="dark"]',
+  "@media (prefers-color-scheme:dark)",
+] as const;
+
+/**
  * The stored font face, and the family its `@font-face` declares.
  *
  * A family no other tier names, for the reason the token above is named that
@@ -142,6 +161,21 @@ function siteSheetOf(html: string): string {
 }
 
 /**
+ * The prelude opening the block that the declaration at `index` sits in:
+ * every selector and at-rule since the previous block closed.
+ *
+ * Scoping matters because the alternative is to search the whole sheet before
+ * the declaration, and a guard found there need not be the one enclosing it —
+ * any earlier token's dark block satisfies that search while this token's
+ * value sits unguarded in the light block. Declarations within a block are
+ * separated by `;` and every block ends with `}`, so the text since the last
+ * `}` is exactly what opened the block this declaration is in.
+ */
+function enclosingPreludeOf(sheet: string, index: number): string {
+  return sheet.slice(sheet.lastIndexOf("}", index) + 1, index);
+}
+
+/**
  * Seeds the stored style and the fixture page, in a hook rather than a test
  * so no `--grep` can deselect it out from under the assertions.
  */
@@ -197,7 +231,17 @@ test("a stored token reaches the published page's site sheet, both modes", async
   // have put a dark block for this property into the sheet.
   const darkIndex = sheet.indexOf(`${TOKEN_PROPERTY}:${TOKEN_DARK}`);
   expect(darkIndex).toBeGreaterThan(-1);
-  expect(sheet.slice(0, darkIndex)).toContain('[data-nx-theme="dark"]');
+  // Which guard is correct is decided by this app's `darkMode` setting, not by
+  // this test: both strategies are supported and each emits the other's form
+  // never. Asserting one names a configuration rather than the property, and
+  // fails on an app that chose the other while nothing is wrong. What must
+  // hold under either is that the dark value is inside a dark guard at all —
+  // unguarded, it would apply in light mode, which is the actual defect.
+  const prelude = enclosingPreludeOf(sheet, darkIndex);
+  expect(
+    DARK_BLOCK_GUARDS.some(guard => prelude.includes(guard)),
+    `The dark value is not inside a dark-mode guard. The block enclosing it opens with: ${JSON.stringify(prelude)}`
+  ).toBe(true);
 });
 
 test("a stored font face reaches the published page as a rule a browser would act on", async ({

--- a/e2e/tests/site-style.spec.ts
+++ b/e2e/tests/site-style.spec.ts
@@ -49,23 +49,38 @@ const TOKEN_LIGHT = "#1b7f5c";
 const TOKEN_DARK = "#8fe3c0";
 
 /**
- * The two forms a dark block can be written under, one per supported
- * `darkMode` strategy: `attribute` writes a selector the host activates,
- * `media` writes an at-rule the operating system activates. The emitter picks
- * one, so a sheet carries exactly one of these and never both.
+ * The dark block this app must emit, and the only one that can work here.
  *
- * Spelled out rather than imported from the engine, deliberately. Both are
- * published contract: a host wires its own theme toggle to `data-nx-theme` in
- * markup this repository never sees, so renaming it breaks every such host.
- * Importing the engine's constant would make this expectation follow a rename
- * and keep passing — expectation and output would be two derivations of one
- * source, which cannot detect the source changing. Written out, a rename fails
- * here, which is what an end-to-end test of a wire format is for.
+ * The engine supports two `darkMode` strategies. `attribute` writes
+ * `[data-nx-theme="dark"]`, which a host activates by setting that attribute;
+ * `media` writes an at-rule the operating system activates. **This app has no
+ * theme toggle and sets `data-nx-theme` nowhere**, so the attribute form would
+ * emit dark values that can never apply — which is not hypothetical: the
+ * docblock on `SITE_STYLE_RESOLVED` in `apps/playground/src/lib/site-content.ts`
+ * records routes that omitted the token set, fell back to the attribute
+ * default, and silently served dark values no visitor could ever see.
+ *
+ * So accepting either form here would leave the suite green across exactly
+ * that regression. The configured strategy decides which form is correct, and
+ * for this app it is settled: `media`.
+ *
+ * Spelled out rather than imported from the engine, deliberately. This string
+ * is published contract — a host wires its own toggle to `data-nx-theme` in
+ * markup this repository never sees — so importing the engine's constant would
+ * make the expectation follow a rename and keep passing. Expectation and
+ * output would be two derivations of one source, which cannot detect that
+ * source changing.
+ *
+ * Requires the at-rule to be followed IMMEDIATELY by `{`, because the guard
+ * has to OPEN the block rather than merely appear before it: `@media (...);`
+ * followed by a bare rule contains the same text while the browser discards
+ * the empty at-rule and applies the dark value unconditionally. The two
+ * `[^{}]*` runs are the selector and whatever declarations precede this one in
+ * the same block — the site's own dark tokens are emitted there too — neither
+ * of which can contain a brace.
  */
-const DARK_BLOCK_GUARDS = [
-  '[data-nx-theme="dark"]',
-  "@media (prefers-color-scheme:dark)",
-] as const;
+const DARK_BLOCK_OPENING =
+  /@media \(prefers-color-scheme:dark\)\{[^{}]*\{[^{}]*$/;
 
 /**
  * The stored font face, and the family its `@font-face` declares.
@@ -239,17 +254,46 @@ test("a stored token reaches the published page's site sheet, both modes", async
   // have put a dark block for this property into the sheet.
   const darkIndex = sheet.indexOf(`${TOKEN_PROPERTY}:${TOKEN_DARK}`);
   expect(darkIndex).toBeGreaterThan(-1);
-  // Which guard is correct is decided by this app's `darkMode` setting, not by
-  // this test: both strategies are supported and each emits the other's form
-  // never. Asserting one names a configuration rather than the property, and
-  // fails on an app that chose the other while nothing is wrong. What must
-  // hold under either is that the dark value is inside a dark guard at all —
-  // unguarded, it would apply in light mode, which is the actual defect.
-  const prelude = enclosingPreludeOf(sheet, darkIndex);
-  expect(
-    DARK_BLOCK_GUARDS.some(guard => prelude.includes(guard)),
-    `The dark value is not inside a dark-mode guard. The block enclosing it opens with: ${JSON.stringify(prelude)}`
-  ).toBe(true);
+  // The block the declaration actually sits in has to BE the media block. A
+  // search of everything before it would accept a guard belonging to some
+  // other token while this value sat unguarded in the light block, and
+  // accepting the attribute form would accept dark values this app can never
+  // activate.
+  expect(enclosingPreludeOf(sheet, darkIndex)).toMatch(DARK_BLOCK_OPENING);
+});
+
+test("the browser resolves the stored token to each mode's value", async ({
+  page,
+}) => {
+  // The sheet being correct and the sheet APPLYING are different claims, and
+  // the assertion above can only reach the first. The failure this app has
+  // already had produced a sheet that read correctly — dark values were
+  // present and syntactically fine — under a selector nothing in the app ever
+  // sets, so no visitor saw them and no text assertion could tell. Asking the
+  // browser under each colour scheme is what separates emitted from applied.
+  //
+  // Read off the heading rather than the root: custom properties inherit, so
+  // this resolves whether the emitter declared them on `:root` or on a scoped
+  // wrapper, and does not encode which one it chose.
+  const resolved = async (): Promise<string> =>
+    (
+      await page
+        .getByRole("heading", { name: PAGE_HEADING })
+        .evaluate(
+          (element, property) =>
+            getComputedStyle(element).getPropertyValue(property),
+          TOKEN_PROPERTY
+        )
+    ).trim();
+
+  await page.emulateMedia({ colorScheme: "light" });
+  await page.goto(`/blocks/${PAGE_SLUG}`);
+  expect(await resolved()).toBe(TOKEN_LIGHT);
+
+  // No reload: a media query re-evaluates when the scheme changes, so this
+  // also proves the dark value is behind the query rather than merely present.
+  await page.emulateMedia({ colorScheme: "dark" });
+  expect(await resolved()).toBe(TOKEN_DARK);
 });
 
 test("a stored font face reaches the published page as a rule a browser would act on", async ({


### PR DESCRIPTION
## What was wrong

`e2e/tests/site-style.spec.ts` asserted that `[data-nx-theme="dark"]` appeared before the dark token value:

```ts
expect(sheet.slice(0, darkIndex)).toContain('[data-nx-theme="dark"]');
```

That selector is one of **two** forms the emitter can write. `packages/blocks-engine/src/style/site-tokens.ts:1187` is a ternary:

```ts
(set.darkMode ?? "attribute") === "media"
  ? `@media (prefers-color-scheme:dark){${body}}`
  : darkSelectorFor(selector, dark);
```

`DarkModeStrategy` is a closed union of `"attribute" | "media"`, and a sheet carries exactly one form. `apps/playground/src/lib/site-style-defaults.ts:53` declares `darkMode: "media"`, so the playground emits the `@media` form and the assertion failed on a **correctly emitted sheet**. The spec named a configuration where it meant a property.

## The second defect, which is why this is not a loosening

`sheet.slice(0, darkIndex)` spans the entire sheet before the declaration. A guard found there need not be the one enclosing it — any *earlier* token's dark block satisfies the search while this token's value sits unguarded in the light block, where it would apply in light mode.

Scoping to the enclosing block's prelude (the text since the previous `}`) is what makes the guard the one that actually encloses the declaration.

## Evidence

Measured against the emitted shapes `packages/blocks-engine/src/style/site-tokens.test.ts` pins, old assertion vs new:

| case | new | old |
| --- | --- | --- |
| media mode — what the playground emits | PASS | **FAIL** |
| attribute mode | PASS | PASS |
| unguarded, but an earlier token has a dark block | **FAIL** | **PASS** |
| no dark block emitted at all | FAIL | FAIL |

Row 1 is the bug being fixed. **Row 3 is the one that matters for review**: the previous assertion passed on a sheet that would apply dark values in light mode, so the new form is strictly stronger, not merely more permissive.

Row 3 is also the break-verification: it is the plausible broken implementation, and the new assertion fails on it.

Local runs, from `e2e/`:

- `npx playwright test tests/site-style.spec.ts` — **4 passed** (36.5s), including `a stored token reaches the published page's site sheet, both modes` by name
- `pnpm check-types` — exit 0
- `pnpm lint` — exit 0
- `fallow audit --base origin/main` — `verdict: pass`, `changed_files_count: 1`, `files_analyzed: 1`, `complexity_introduced: 0`, `dead_code_introduced: 0`

## One deliberate non-change

The two guard strings stay **spelled out** rather than imported from `blocks-engine`, which does export `DARK_MODE_ATTRIBUTE`.

Both strings are published contract: a host wires its own theme toggle to `data-nx-theme` in markup this repository never sees, so renaming it is a breaking change for every such host. Importing the constant would make the expectation follow a rename and keep passing — expectation and output would be two derivations of one source, which cannot detect that source changing. That is the specific failure an end-to-end test of a wire format exists to catch, so the duplication is the point here rather than a violation of the derive-don't-recompute rule.

## No changeset

Test-only change; no published package is affected.
