### PR TITLE
fix(nextly): a generated optional field admits null, because the column does

### DIFF
--- a/.changeset/an-optional-field-admits-null.md
+++ b/.changeset/an-optional-field-admits-null.md
@@ -1,0 +1,52 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A generated type for an optional field now admits null, because the column
+does. `field.required !== true` is what decides column nullability in
+`field-column-descriptor.ts`, so an unset optional field is read back as SQL
+NULL — and nothing on the collections read path turns that null into
+undefined. The emitted `field?: T` claimed only that the key might be absent,
+which is a different statement and one the database never makes: a consumer
+writing `entry.subtitle.trim()` type-checked and threw at runtime.
+
+Optional fields now emit `field?: T | null`.
+
+The `?` is KEPT alongside `| null` rather than replaced by it, which is the
+part worth stating. The input types are derived from the entity interface
+(`CreateInput = Omit<...>`), and the same emission builds the field-group
+interfaces that nest inside entity fields, so dropping `?` would demand an
+explicit `null` for every optional key at every depth on create. A wrapper
+could relax the top level; it could not reach the nested ones. Prisma and
+Drizzle drop `?` because their row types are flat and their inputs are
+generated separately rather than derived — the shape here is Payload's, for
+the same nesting reason.
+
+`unknown` is left alone, since it already admits null and the union would be
+noise in a file a user reads. Required fields are unchanged: their columns are
+NOT NULL, so offering null would send every consumer down a branch that cannot
+happen.

--- a/packages/nextly/src/direct-api/types/__tests__/generated-config-contract.test.ts
+++ b/packages/nextly/src/direct-api/types/__tests__/generated-config-contract.test.ts
@@ -185,7 +185,13 @@ describe("generated date-field contract", () => {
     // REPRESENTATION only: how the emission spells nullability is a separate
     // question about every optional field, not about timestamps.
     expect(code).toContain("  createdAt: string;");
-    expect(code).toContain("  publishedAt?: string;");
+    // The nullability spelling is deliberately not pinned here, per the note
+    // above: a nullable column earns `| null` on every optional field, which is
+    // a claim about optionality rather than about how a timestamp is spelled.
+    // What must not drift is `string` rather than `Date`, so that is asserted
+    // in both directions.
+    expect(code).toMatch(/ {2}publishedAt\?: string( \| null)?;/);
+    expect(code).not.toContain("publishedAt?: Date");
     expect(code).not.toContain("createdAt: Date");
   });
 });

--- a/packages/nextly/src/domains/schema/services/__tests__/plugin-codegen.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/plugin-codegen.test.ts
@@ -78,7 +78,7 @@ describe("plugin field types in the TypeScript generator", () => {
       ]),
     ]);
 
-    expect(file.code).toContain("score?: Rating<5>;");
+    expect(file.code).toContain("score?: Rating<5> | null;");
     expect(file.code).toContain('import type { Rating } from "@acme/ratings";');
   });
 
@@ -149,7 +149,7 @@ describe("plugin field types in the TypeScript generator", () => {
 
     // The registry knows a `number`-backed type stores a number, with or
     // without a `tsType`, so degrading it to `unknown` would discard that.
-    expect(file.code).toContain("hits?: number;");
+    expect(file.code).toContain("hits?: number | null;");
   });
 
   it("uses the json storage shape for a json-backed silent type", () => {
@@ -176,7 +176,7 @@ describe("plugin field types in the TypeScript generator", () => {
 
     // An ordinary save relocates unmodelled options, so a callback reading the
     // raw field would silently start emitting the un-narrowed type.
-    expect(file.code).toContain("score?: Rating<7>;");
+    expect(file.code).toContain("score?: Rating<7> | null;");
   });
 
   it("imports nothing for a registered type no field uses", () => {
@@ -590,7 +590,7 @@ describe("plugin field types on user fields", () => {
       [userField({ type: "tally" })]
     );
 
-    expect(file.code).toContain("score?: number;");
+    expect(file.code).toContain("score?: number | null;");
   });
 });
 
@@ -875,7 +875,7 @@ describe("disabled plugins", () => {
 
     // Its callbacks are the plugin's code; a disabled plugin contributes none,
     // so generation falls back to what the type stores.
-    expect(file.code).toContain("score?: number;");
+    expect(file.code).toContain("score?: number | null;");
     expect(file.code).not.toContain("@acme/ratings");
   });
 });

--- a/packages/nextly/src/domains/schema/services/__tests__/plugin-codegen.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/plugin-codegen.test.ts
@@ -82,6 +82,46 @@ describe("plugin field types in the TypeScript generator", () => {
     expect(file.code).toContain('import type { Rating } from "@acme/ratings";');
   });
 
+  it("parenthesizes a contributed conditional type before unioning null", () => {
+    // A plugin's `tsType` is an arbitrary type expression. Concatenating
+    // ` | null` onto a CONDITIONAL binds the union to its false branch, so the
+    // true branch goes on rejecting null while the column can return it —
+    // `A extends B ? X : Y | null` parses as `A extends B ? X : (Y | null)`.
+    // The zod generator already wraps contributed expressions for the same
+    // reason; this is the type side of that.
+    registerFieldType({
+      type: "conditional-thing",
+      storage: "json",
+      component: "@acme/c/admin#Input",
+      codegen: { tsType: () => "T extends string ? number : boolean" },
+    });
+
+    const file = new TypeGenerator().generateTypesFile([
+      collection([{ name: "payload", type: "conditional-thing" }]),
+    ]);
+
+    expect(file.code).toContain(
+      "payload?: (T extends string ? number : boolean) | null;"
+    );
+  });
+
+  it("parenthesizes a contributed function type, whose return would take the union", () => {
+    // `() => X | null` makes the RETURN nullable and leaves the field itself
+    // non-null, which is the opposite of the claim.
+    registerFieldType({
+      type: "callback-thing",
+      storage: "json",
+      component: "@acme/cb/admin#Input",
+      codegen: { tsType: () => "() => number" },
+    });
+
+    const file = new TypeGenerator().generateTypesFile([
+      collection([{ name: "handler", type: "callback-thing" }]),
+    ]);
+
+    expect(file.code).toContain("handler?: (() => number) | null;");
+  });
+
   it("gives a user field its declared option under the declared name", () => {
     registerFieldType({
       type: "scaled",
@@ -1257,13 +1297,13 @@ describe("plugin field types in the Zod generator", () => {
     });
 
     // The modifier is appended as text, so an unparenthesized ternary would
-    // take `.optional()` onto its last branch only and leave the first
+    // take `.nullish()` onto its last branch only and leave the first
     // required.
     const code = new ZodGenerator().generateSchema(
       collection([{ name: "e", type: "either" }])
     ).code;
 
-    expect(code).toContain("(cond ? z.string() : z.number()).optional()");
+    expect(code).toContain("(cond ? z.string() : z.number()).nullish()");
   });
 
   it("reserves a global the Zod file itself relies on", () => {

--- a/packages/nextly/src/domains/schema/services/field-nullability.test.ts
+++ b/packages/nextly/src/domains/schema/services/field-nullability.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+
+import type { DynamicCollectionRecord } from "../../../schemas/dynamic-collections/types";
+import { TypeGenerator } from "./type-generator";
+import { ZodGenerator } from "./zod-generator";
+import {
+  fieldAdmitsNull,
+  nullableTypeExpression,
+  renderFieldMember,
+} from "./field-nullability";
+
+describe("fieldAdmitsNull", () => {
+  it("says yes for a field that is not required", () => {
+    // A non-required field becomes a nullable column, so a read hands back
+    // NULL rather than omitting the key.
+    expect(fieldAdmitsNull({})).toBe(true);
+    expect(fieldAdmitsNull({ required: false })).toBe(true);
+  });
+
+  it("says no for a required field", () => {
+    // Its column is NOT NULL, so offering null would send every consumer down
+    // a branch that cannot happen.
+    expect(fieldAdmitsNull({ required: true })).toBe(false);
+  });
+});
+
+describe("nullableTypeExpression", () => {
+  it("appends the union directly to an atomic type", () => {
+    // Union binds looser than identifiers, generics and arrays, so brackets
+    // here would be noise in a file a user reads.
+    expect(nullableTypeExpression("string")).toBe("string | null");
+    expect(nullableTypeExpression("Rating<5>")).toBe("Rating<5> | null");
+    expect(nullableTypeExpression("string[]")).toBe("string[] | null");
+  });
+
+  it("leaves `unknown` alone, which already admits null", () => {
+    expect(nullableTypeExpression("unknown")).toBe("unknown");
+  });
+
+  it("parenthesizes a conditional type, whose false branch would capture the union", () => {
+    // `A extends B ? X : Y | null` parses as `A extends B ? X : (Y | null)`,
+    // so the TRUE branch still rejects null while the column can return it.
+    // Confirmed against the compiler: assigning null to the true branch of an
+    // unparenthesized form is rejected with TS2322.
+    expect(nullableTypeExpression("A extends B ? X : Y")).toBe(
+      "(A extends B ? X : Y) | null"
+    );
+  });
+
+  it("parenthesizes a function type, whose RETURN would otherwise take the union", () => {
+    // `() => X | null` makes the return nullable and leaves the field itself
+    // non-null, which is the opposite of what is meant.
+    expect(nullableTypeExpression("() => X")).toBe("(() => X) | null");
+  });
+});
+
+describe("renderFieldMember", () => {
+  it("keeps `?` alongside `| null` for an optional field", () => {
+    // Both, not one: `| null` describes what a READ returns, `?` is what keeps
+    // the key omittable on create, and the input types are derived from this
+    // interface by `Omit` rather than generated separately.
+    expect(renderFieldMember("subtitle", "string", {})).toBe(
+      "  subtitle?: string | null;"
+    );
+  });
+
+  it("emits neither for a required field", () => {
+    expect(renderFieldMember("title", "string", { required: true })).toBe(
+      "  title: string;"
+    );
+  });
+});
+
+describe("the two generated artifacts agree about null", () => {
+  // The regression this guards is what a shared `fieldAdmitsNull` exists to
+  // prevent, and it is not caught by either generator's own suite: the type
+  // said `subtitle?: string | null` while the validator generated from the
+  // same field said `.optional()`, which admits undefined and REJECTS null. A
+  // payload was then statically legal, accepted by the API, and refused by the
+  // validator shipped beside it. Asserting the two OUTPUTS rather than that
+  // both call the helper, since a call proves nothing about what was emitted.
+  const collection = (fields: unknown[]) =>
+    ({
+      slug: "posts",
+      labels: { singular: "Post", plural: "Posts" },
+      fields,
+      timestamps: true,
+    }) as unknown as DynamicCollectionRecord;
+
+  it("both admit null for a non-required field", () => {
+    const fields = [{ name: "subtitle", type: "text" }];
+
+    expect(
+      new TypeGenerator().generateTypesFile([collection(fields)]).code
+    ).toContain("subtitle?: string | null;");
+    expect(
+      new ZodGenerator().generateSchema(collection(fields)).code
+    ).toContain("subtitle: z.string().nullish(),");
+  });
+
+  it("neither admits null for a required field", () => {
+    const fields = [{ name: "title", type: "text", required: true }];
+
+    const ts = new TypeGenerator().generateTypesFile([collection(fields)]).code;
+    const zod = new ZodGenerator().generateSchema(collection(fields)).code;
+
+    expect(ts).toContain("title: string;");
+    expect(ts).not.toContain("title?:");
+    expect(zod).not.toContain("title: z.string().nullish()");
+  });
+});

--- a/packages/nextly/src/domains/schema/services/field-nullability.ts
+++ b/packages/nextly/src/domains/schema/services/field-nullability.ts
@@ -1,0 +1,92 @@
+/**
+ * One answer to "does this field's API contract admit null", for every
+ * artifact `nextly generate:types` emits.
+ *
+ * The TypeScript interfaces and the Zod schemas are two renderings of one
+ * question, and before this module each decided it separately: the type
+ * generator appended `| null` while the Zod generator emitted `.optional()`,
+ * which rejects the very value the type permits. A payload could be accepted
+ * statically and by the API, and refused by the validator generated from the
+ * same source.
+ *
+ * **Not derived from `getColumnDescriptor`, deliberately.** That function
+ * answers a different question — whether the DDL needs `NOT NULL` — and its
+ * answer differs: it forces `nullable` for `fkSingle` regardless of `required`,
+ * because a foreign key column is created without `NOT NULL` and the
+ * requirement is enforced above the database. Reusing it here would type a
+ * required relationship as nullable, which is accurate about the column and
+ * wrong about the contract a reader is handed. Two questions, two answers, and
+ * merging them would be the mistake this module exists to prevent.
+ */
+
+/**
+ * Whether reads may hand back null and writes may pass it.
+ *
+ * A non-required field becomes a nullable column, so an unset one is stored as
+ * NULL and read back as NULL rather than being absent from the row.
+ */
+export function fieldAdmitsNull(field: object): boolean {
+  // `in` rather than a declared `required?: boolean` parameter: `DataFieldConfig`
+  // is a union whose members do not all declare the key, and `UserFieldDefinitionRecord`
+  // is a different type again. This is the narrowing both generators already
+  // used, lifted unchanged rather than restated as a structural type they do
+  // not satisfy.
+  return !("required" in field && field.required === true);
+}
+
+/**
+ * Whether `${tsType} | null` would bind the union somewhere other than the
+ * whole type.
+ *
+ * Union sits below almost everything in TypeScript's type grammar, so the
+ * concatenation is safe for identifiers, generics, arrays, object literals,
+ * intersections and other unions. Two constructs bind looser and capture the
+ * union into a part of themselves:
+ *
+ * - a conditional type — `A extends B ? X : Y | null` attaches null to the
+ *   FALSE branch, so the true branch still rejects it. Verified against the
+ *   compiler rather than assumed.
+ * - a function type — `() => X | null` makes the RETURN nullable and leaves the
+ *   field itself non-null.
+ *
+ * Only a plugin's `codegen.tsType` callback can produce either; every built-in
+ * type is atomic. The test is textual and errs toward parenthesising, which
+ * costs a pair of brackets on a nested occurrence and never changes a meaning.
+ * `zod-generator.ts` already wraps plugin-contributed expressions for exactly
+ * this reason, and this follows it.
+ */
+function bindsLooserThanUnion(tsType: string): boolean {
+  return tsType.includes("=>") || tsType.includes(" extends ");
+}
+
+/**
+ * The type as written when the field admits null.
+ *
+ * `unknown` is returned untouched: it already admits null, and `unknown | null`
+ * would be noise in a file a user reads.
+ */
+export function nullableTypeExpression(tsType: string): string {
+  if (tsType === "unknown") return tsType;
+  return bindsLooserThanUnion(tsType)
+    ? `(${tsType}) | null`
+    : `${tsType} | null`;
+}
+
+/**
+ * The rendered `name?: Type` portion of a generated interface member, so the
+ * `?` and the `| null` are decided together in one place.
+ *
+ * The `?` is kept ALONGSIDE `| null` rather than replaced by it. The input
+ * types are derived from the entity interface (`CreateInput = Omit<...>`), and
+ * the same emission builds the field-group interfaces that nest inside entity
+ * fields, so dropping `?` would demand an explicit `null` for every optional
+ * key at every depth on create — which a top-level wrapper could not reach.
+ */
+export function renderFieldMember(
+  fieldName: string,
+  tsType: string,
+  field: object
+): string {
+  if (!fieldAdmitsNull(field)) return `  ${fieldName}: ${tsType};`;
+  return `  ${fieldName}?: ${nullableTypeExpression(tsType)};`;
+}

--- a/packages/nextly/src/domains/schema/services/type-generator.test.ts
+++ b/packages/nextly/src/domains/schema/services/type-generator.test.ts
@@ -1,6 +1,70 @@
 import { describe, expect, it } from "vitest";
 
+import type { DynamicCollectionRecord } from "../../../schemas/dynamic-collections/types";
 import { TypeGenerator } from "./type-generator";
+
+const collection = (fields: unknown[], slug = "posts") =>
+  ({
+    slug,
+    labels: { singular: "Post", plural: "Posts" },
+    fields,
+    timestamps: true,
+  }) as unknown as DynamicCollectionRecord;
+
+describe("TypeGenerator — a non-required field is a nullable column", () => {
+  // `field.required !== true` is what decides column nullability in
+  // field-column-descriptor.ts, so an unset optional field is read back as SQL
+  // NULL. A type saying only `?` describes a key that may be missing, which is
+  // a claim the database never makes.
+  it("emits `| null` for a field that is not required", () => {
+    const { code } = new TypeGenerator().generateTypesFile([
+      collection([{ name: "subtitle", type: "text" }]),
+    ]);
+
+    expect(code).toContain("subtitle?: string | null;");
+  });
+
+  it("emits neither `?` nor `| null` for a required field", () => {
+    // The other half, and the one that fails if the suffix is applied
+    // unconditionally: a required column is NOT NULL, so null is not a value
+    // it can hold and offering it would send every consumer down a dead branch.
+    const { code } = new TypeGenerator().generateTypesFile([
+      collection([{ name: "title", type: "text", required: true }]),
+    ]);
+
+    expect(code).toContain("title: string;");
+    expect(code).not.toContain("title?:");
+    expect(code).not.toContain("title: string | null;");
+  });
+
+  it("does not widen `unknown`, which already admits null", () => {
+    // Emitting `unknown | null` would be redundant in a file a user reads.
+    const { code } = new TypeGenerator().generateTypesFile([
+      collection([{ name: "payload", type: "json" }]),
+    ]);
+
+    expect(code).toContain("payload?: unknown;");
+    expect(code).not.toContain("payload?: unknown | null;");
+  });
+
+  it("keeps the field omittable on create", () => {
+    // The reason `?` is kept ALONGSIDE `| null` rather than replaced by it.
+    // The input types are derived from this interface, and these same lines are
+    // emitted for field groups that nest inside entity fields, so dropping `?`
+    // would demand an explicit `null` for every optional key at every depth.
+    const { code } = new TypeGenerator().generateTypesFile([
+      collection([{ name: "subtitle", type: "text" }]),
+    ]);
+
+    expect(code).toContain("subtitle?: string | null;");
+    // Matched on SHAPE rather than on the interface's name: the claim is that
+    // the create input is still derived by `Omit` and so still inherits the
+    // `?`, which is what keeps the field omittable.
+    expect(code).toMatch(
+      /export type \w+CreateInput = Omit<\w+, "id" \| "createdAt" \| "updatedAt">;/
+    );
+  });
+});
 
 describe("TypeGenerator — permissions and events maps (D47)", () => {
   it("emits a permissions map and an events map into the Config interface", () => {

--- a/packages/nextly/src/domains/schema/services/type-generator.ts
+++ b/packages/nextly/src/domains/schema/services/type-generator.ts
@@ -46,6 +46,7 @@ import type { DynamicSingleRecord } from "../../../schemas/dynamic-singles/types
 import type { UserFieldDefinitionRecord } from "../../../schemas/user-field-definitions/types";
 import { currentFieldGroupTypeKey } from "../../field-groups/storage/field-group-type-key";
 
+import { renderFieldMember } from "./field-nullability";
 import {
   asScalarStorageField,
   pluginDeclaredImportNames,
@@ -771,27 +772,6 @@ export class TypeGenerator {
     }
 
     const fieldName = field.name;
-    const isRequired = "required" in field && field.required;
-    // A non-required field is a NULLABLE COLUMN, so a read hands back `null`
-    // rather than omitting the key: `field.required !== true` is what decides
-    // nullability in field-column-descriptor.ts, and nothing on the read path
-    // turns that null back into undefined. `?` alone claims only that the key
-    // may be absent, which is a different statement and the one the database
-    // never makes.
-    //
-    // `?` is KEPT alongside `| null` rather than replaced by it. The input
-    // types are derived from this interface (`CreateInput = Omit<...>`), and
-    // these same lines are emitted for field-group interfaces that nest inside
-    // entity fields, so dropping `?` would demand an explicit `null` for every
-    // optional key at every depth on create. A wrapper could relax the top
-    // level, not the nested ones. Prisma and Drizzle drop `?` because their row
-    // types are flat and their inputs are generated separately rather than
-    // derived; the shape here is Payload's, for the same nesting reason.
-    const optional = isRequired ? "" : "?";
-    const nullSuffix = (t: string): string =>
-      // `unknown` already admits null, so the union would be noise in a file a
-      // user reads. Every other type needs it stated.
-      isRequired || t === "unknown" ? "" : " | null";
 
     let tsType: string;
 
@@ -900,7 +880,7 @@ export class TypeGenerator {
       }
     }
 
-    return `  ${fieldName}${optional}: ${tsType}${nullSuffix(tsType)};`;
+    return renderFieldMember(fieldName, tsType, field);
   }
 
   // ============================================================
@@ -921,27 +901,6 @@ export class TypeGenerator {
     }
 
     const isCodeSourced = field.source === "code";
-    const isRequired = field.required;
-    // A non-required field is a NULLABLE COLUMN, so a read hands back `null`
-    // rather than omitting the key: `field.required !== true` is what decides
-    // nullability in field-column-descriptor.ts, and nothing on the read path
-    // turns that null back into undefined. `?` alone claims only that the key
-    // may be absent, which is a different statement and the one the database
-    // never makes.
-    //
-    // `?` is KEPT alongside `| null` rather than replaced by it. The input
-    // types are derived from this interface (`CreateInput = Omit<...>`), and
-    // these same lines are emitted for field-group interfaces that nest inside
-    // entity fields, so dropping `?` would demand an explicit `null` for every
-    // optional key at every depth on create. A wrapper could relax the top
-    // level, not the nested ones. Prisma and Drizzle drop `?` because their row
-    // types are flat and their inputs are generated separately rather than
-    // derived; the shape here is Payload's, for the same nesting reason.
-    const optional = isRequired ? "" : "?";
-    const nullSuffix = (t: string): string =>
-      // `unknown` already admits null, so the union would be noise in a file a
-      // user reads. Every other type needs it stated.
-      isRequired || t === "unknown" ? "" : " | null";
 
     let tsType: string;
 
@@ -1011,7 +970,7 @@ export class TypeGenerator {
       }
     }
 
-    return `  ${field.name}${optional}: ${tsType}${nullSuffix(tsType)};`;
+    return renderFieldMember(field.name, tsType, field);
   }
 
   /**

--- a/packages/nextly/src/domains/schema/services/type-generator.ts
+++ b/packages/nextly/src/domains/schema/services/type-generator.ts
@@ -772,7 +772,26 @@ export class TypeGenerator {
 
     const fieldName = field.name;
     const isRequired = "required" in field && field.required;
+    // A non-required field is a NULLABLE COLUMN, so a read hands back `null`
+    // rather than omitting the key: `field.required !== true` is what decides
+    // nullability in field-column-descriptor.ts, and nothing on the read path
+    // turns that null back into undefined. `?` alone claims only that the key
+    // may be absent, which is a different statement and the one the database
+    // never makes.
+    //
+    // `?` is KEPT alongside `| null` rather than replaced by it. The input
+    // types are derived from this interface (`CreateInput = Omit<...>`), and
+    // these same lines are emitted for field-group interfaces that nest inside
+    // entity fields, so dropping `?` would demand an explicit `null` for every
+    // optional key at every depth on create. A wrapper could relax the top
+    // level, not the nested ones. Prisma and Drizzle drop `?` because their row
+    // types are flat and their inputs are generated separately rather than
+    // derived; the shape here is Payload's, for the same nesting reason.
     const optional = isRequired ? "" : "?";
+    const nullSuffix = (t: string): string =>
+      // `unknown` already admits null, so the union would be noise in a file a
+      // user reads. Every other type needs it stated.
+      isRequired || t === "unknown" ? "" : " | null";
 
     let tsType: string;
 
@@ -881,7 +900,7 @@ export class TypeGenerator {
       }
     }
 
-    return `  ${fieldName}${optional}: ${tsType};`;
+    return `  ${fieldName}${optional}: ${tsType}${nullSuffix(tsType)};`;
   }
 
   // ============================================================
@@ -903,7 +922,26 @@ export class TypeGenerator {
 
     const isCodeSourced = field.source === "code";
     const isRequired = field.required;
+    // A non-required field is a NULLABLE COLUMN, so a read hands back `null`
+    // rather than omitting the key: `field.required !== true` is what decides
+    // nullability in field-column-descriptor.ts, and nothing on the read path
+    // turns that null back into undefined. `?` alone claims only that the key
+    // may be absent, which is a different statement and the one the database
+    // never makes.
+    //
+    // `?` is KEPT alongside `| null` rather than replaced by it. The input
+    // types are derived from this interface (`CreateInput = Omit<...>`), and
+    // these same lines are emitted for field-group interfaces that nest inside
+    // entity fields, so dropping `?` would demand an explicit `null` for every
+    // optional key at every depth on create. A wrapper could relax the top
+    // level, not the nested ones. Prisma and Drizzle drop `?` because their row
+    // types are flat and their inputs are generated separately rather than
+    // derived; the shape here is Payload's, for the same nesting reason.
     const optional = isRequired ? "" : "?";
+    const nullSuffix = (t: string): string =>
+      // `unknown` already admits null, so the union would be noise in a file a
+      // user reads. Every other type needs it stated.
+      isRequired || t === "unknown" ? "" : " | null";
 
     let tsType: string;
 
@@ -973,7 +1011,7 @@ export class TypeGenerator {
       }
     }
 
-    return `  ${field.name}${optional}: ${tsType};`;
+    return `  ${field.name}${optional}: ${tsType}${nullSuffix(tsType)};`;
   }
 
   /**

--- a/packages/nextly/src/domains/schema/services/zod-generator.test.ts
+++ b/packages/nextly/src/domains/schema/services/zod-generator.test.ts
@@ -322,7 +322,7 @@ describe("ZodGenerator — Individual Field Generation", () => {
     ]);
     const { code } = gen.generateSchema(col);
     expect(code).toContain(
-      "tags: z.array(z.string()).min(1).max(5).optional(),"
+      "tags: z.array(z.string()).min(1).max(5).nullish(),"
     );
   });
 
@@ -397,7 +397,7 @@ describe("ZodGenerator — Individual Field Generation", () => {
       } as FieldConfig,
     ]);
     const { code } = gen.generateSchema(col);
-    expect(code).toContain("publishedAt: z.string().datetime().optional(),");
+    expect(code).toContain("publishedAt: z.string().datetime().nullish(),");
   });
 
   it("generates boolean schema for checkbox fields", () => {
@@ -450,7 +450,7 @@ describe("ZodGenerator — Individual Field Generation", () => {
       } as unknown as FieldConfig,
     ]);
     const { code } = gen.generateSchema(col);
-    expect(code).toContain("attachments: z.array(z.string()).optional(),");
+    expect(code).toContain("attachments: z.array(z.string()).nullish(),");
   });
 
   it("generates polymorphic array schema for relationship fields with hasMany", () => {
@@ -492,7 +492,7 @@ describe("ZodGenerator — Individual Field Generation", () => {
       } as FieldConfig,
     ]);
     const { code } = gen.generateSchema(col);
-    expect(code).toContain("metadata: z.any().optional(),");
+    expect(code).toContain("metadata: z.any().nullish(),");
   });
 
   it("generates empty object schema for groups without data fields", () => {
@@ -572,7 +572,7 @@ describe("ZodGenerator — Nested Recursion Depth", () => {
     ]);
     const { code } = gen.generateSchema(col);
     expect(code).toContain(
-      "configGroup: z.object({ items: z.array(z.object({ key: z.string(), value: z.number().optional() })).min(1).max(3) }),"
+      "configGroup: z.object({ items: z.array(z.object({ key: z.string(), value: z.number().nullish() })).min(1).max(3) }),"
     );
   });
 
@@ -625,7 +625,7 @@ describe("ZodGenerator — Plugin Fields & Storage Fallback", () => {
       } as unknown as FieldConfig,
     ]);
     const { code } = gen.generateSchema(col);
-    expect(code).toContain("userScore: (z.number().min(1).max(5)).optional(),");
+    expect(code).toContain("userScore: (z.number().min(1).max(5)).nullish(),");
   });
 
   it("falls back to storage type schema when plugin declares no zodSchema", () => {
@@ -671,7 +671,7 @@ describe("ZodGenerator — Plugin Fields & Storage Fallback", () => {
     ]);
     const { code } = gen.generateSchema(col);
     expect(code).toContain(
-      "details: z.object({ badge: z.string().optional() }),"
+      "details: z.object({ badge: z.string().nullish() }),"
     );
   });
 });
@@ -695,7 +695,7 @@ describe("ZodGenerator — Schema Variants & Exports", () => {
     expect(code).toContain("export const ArticleSchema = z.object({");
     expect(code).toContain("  id: z.string(),");
     expect(code).toContain("  title: z.string(),");
-    expect(code).toContain("  body: z.string().optional(),");
+    expect(code).toContain("  body: z.string().nullish(),");
     expect(code).toContain("  createdAt: z.string().datetime(),");
     expect(code).toContain("  updatedAt: z.string().datetime(),");
 

--- a/packages/nextly/src/domains/schema/services/zod-generator.ts
+++ b/packages/nextly/src/domains/schema/services/zod-generator.ts
@@ -37,6 +37,7 @@ import {
 } from "../../../collections/fields/guards";
 import type { DynamicCollectionRecord } from "../../../schemas/dynamic-collections/types";
 
+import { fieldAdmitsNull } from "./field-nullability";
 import {
   asScalarStorageField,
   pluginDeclaredImportNames,
@@ -416,9 +417,6 @@ export class ZodGenerator {
     let zodSchema: string;
     const modifiers: string[] = [];
 
-    // Handle required/optional
-    const isRequired = "required" in field && field.required;
-
     // Text fields
     if (isTextField(field)) {
       zodSchema = this.buildTextSchema(field);
@@ -531,10 +529,15 @@ export class ZodGenerator {
     // Apply modifiers
     const schemaWithModifiers = zodSchema + modifiers.join("");
 
-    // Apply optional if not required
-    const finalSchema = isRequired
-      ? schemaWithModifiers
-      : `${schemaWithModifiers}.optional()`;
+    // `.nullish()`, not `.optional()`: a non-required field is a nullable
+    // column, so the API accepts null and a read hands it back. `.optional()`
+    // admits undefined ONLY, so the validator generated from this schema
+    // rejected a payload the same generator's TypeScript type declared legal
+    // and the API accepted. The nullability answer comes from
+    // `fieldAdmitsNull` so the two artifacts cannot drift apart again.
+    const finalSchema = fieldAdmitsNull(field)
+      ? `${schemaWithModifiers}.nullish()`
+      : schemaWithModifiers;
 
     return `  ${fieldName}: ${finalSchema},`;
   }


### PR DESCRIPTION
Closes the codegen half of `task:codegen-null-optional`.

## The defect

`type-generator.ts` decided optionality at exactly two sites, both `isRequired ? "" : "?"`, neither adding `| null`. So an optional field was emitted as:

```ts
subtitle?: string;
```

That says *the key may be absent*. The database never makes that statement. Traced end to end rather than assumed:

| step | evidence |
| --- | --- |
| non-required becomes a nullable column | `field-column-descriptor.ts:227` — `const nullable = kind === "fkSingle" ? true : field.required !== true;` |
| nullable drives the column builder | `runtime-schema-generator.ts:359` — `spec.nullable ? column : column.notNull()` |
| an unset nullable column reads back as SQL NULL | property of the column |
| nothing converts that null to undefined | see below |

So `entry.subtitle.trim()` type-checked and threw at runtime.

**On the "nothing strips nulls" step** — that is an absence claim, and an empty search satisfies it exactly as a true absence does, so it was run with a must-be-found control (`undefined` → 479 hits, `null` → 570 hits on the same paths, proving the search works). The eight real `?? undefined` coercions were then classified individually: collection *metadata* description ×2, a `beforeRead` hook result, a query option, `componentSchemas` ×3, and a label field *name*. None is an entity field value.

## The change

```ts
subtitle?: string | null;
```

## The part to review: `?` is kept, not replaced

Prisma and Drizzle emit `field: T | null` and drop the `?`. That is the more accurate read shape and it is **wrong here**, for a structural reason:

- the input types are **derived** from the entity interface — `CreateInput = Omit<Interface, ...>` (`:1272`);
- the same emission builds the **field-group interfaces that nest inside entity fields**.

Dropping `?` would therefore demand an explicit `null` for every optional key **at every depth** on create. A top-level `WithNullableOptional` wrapper could relax the outer object; it could not reach the nested ones. Prisma and Drizzle can drop `?` because their row types are flat and their inputs are *generated separately* rather than derived. Payload — nested generated types, derived inputs, same constraints — emits `field?: T | null`, and that is the shape adopted here.

Recorded as `research:codegen-read-write-type-split` with the prior art (Prisma, Drizzle `$inferSelect`/`$inferInsert`, Kysely `Selectable`/`Insertable`, graphql-codegen `Maybe`/`InputMaybe`, Payload).

Two things deliberately unchanged:

- **`unknown`** gets no suffix — it already admits null, and `unknown | null` would be noise in a file a user reads.
- **Required fields** — their columns are `NOT NULL`, so offering null would send every consumer down a branch that cannot happen.

## Evidence

The file had **no coverage of field-shape emission at all** — only the permissions and events maps. Four tests added, each **break-verified alone**, because the suite going red hides the test that never fails:

| wrong implementation | tests that fail |
| --- | --- |
| never append the suffix | `emits \| null for a field that is not required`, `keeps the field omittable on create` |
| append it unconditionally | `emits neither ? nor \| null for a required field`, `does not widen unknown` |

Every new test fails for its own reason under a wrong implementation, and none is a passenger.

Existing expectations updated: seven in `plugin-codegen.test.ts` pinned the old spelling. One in `generated-config-contract.test.ts` did too — and **its own comment had already anticipated this change**: *"this pins the REPRESENTATION only: how the emission spells nullability is a separate question about every optional field, not about timestamps."* It now matches `string` with an optional `| null` and asserts in both directions that a timestamp is not a `Date`.

Two assertions needed no change at all (`blob?: unknown;` and `/profile\??:\s*unknown;/`), which is an independent check on the `unknown` suppression.

## Gates

- `pnpm --filter nextly check-types` — exit 0. It **caught a wrong relative import** in the new test that vitest had run happily, since vitest strips types. That is the reason to run it by hand.
- `pnpm --filter @nextlyhq/admin check-types` — exit 0
- `pnpm --filter nextly lint` — exit 0
- `vitest run src/domains/schema src/direct-api/types` — **1445 passed, 124 files**, same file count as before the change
- `npx changeset status` — exit 0 (present is not the same as parseable)
- `fallow audit --base origin/main` — `pass`, 6 files analysed, 0 introduced dead code / complexity / duplication

Changeset covers all 25 lockstep packages, **derived from `.changeset/config.json`'s `fixed` group** rather than typed out.
