### PR TITLE
fix(builder): check a font weight as CSS reads it, not as JavaScript converts it

### DIFF
--- a/.changeset/a-font-file-can-be-added-from-the-panel.md
+++ b/.changeset/a-font-file-can-be-added-from-the-panel.md
@@ -60,5 +60,6 @@ have succeeded, because the list sent is exactly the one the checker approves.
 
 Web font formats carry the `format()` keyword their `src` entries take, so the
 panel, the upload gate and the public byte route read one table instead of
-three; a descending weight range such as `900 100` is refused, since a browser
-drops the whole descriptor and matches the face at a weight nobody chose.
+three; a descending weight range such as `900 100` is refused, because it is a
+range no specification gives a meaning to — a browser parses and keeps it, so
+what the face then matches is left to the engine.

--- a/.changeset/a-weight-the-browser-reads.md
+++ b/.changeset/a-weight-the-browser-reads.md
@@ -31,7 +31,9 @@ A font weight is checked as CSS reads it rather than as JavaScript converts it.
 bound applied afterwards, while the string kept in the descriptor is still
 `0x190` — which CSS cannot parse, so the browser drops the declaration and
 matches the face at a weight nobody chose. The exponent and fraction forms CSS
-does accept, such as `1e3` and `.5e3`, still work.
+does accept, such as `1e3`, `.5e3` and `400.0`, still work. A decimal point
+with no digit after it is refused too: the tokenizer takes `400.` as `400`
+followed by a stray point, and the descriptor is dropped.
 
 Choosing the same font file twice in a row works. A file input is uncontrolled,
 so clearing the panel's own state left the element still holding the previous

--- a/.changeset/a-weight-the-browser-reads.md
+++ b/.changeset/a-weight-the-browser-reads.md
@@ -1,0 +1,40 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A font weight is checked as CSS reads it rather than as JavaScript converts it.
+`0x190` becomes 400 on the way through a numeric conversion and passes any
+bound applied afterwards, while the string kept in the descriptor is still
+`0x190` — which CSS cannot parse, so the browser drops the declaration and
+matches the face at a weight nobody chose. The exponent and fraction forms CSS
+does accept, such as `1e3` and `.5e3`, still work.
+
+Choosing the same font file twice in a row works. A file input is uncontrolled,
+so clearing the panel's own state left the element still holding the previous
+choice — and a browser raises no event for an unchanged selection, which left
+the Add button disabled while the picker displayed the very file just chosen.
+Adding one variable font's italic after its upright is that flow.

--- a/packages/builder/src/fonts-panel.test.tsx
+++ b/packages/builder/src/fonts-panel.test.tsx
@@ -568,8 +568,12 @@ describe("adding a font file", () => {
      * The control. A check written as a list of JavaScript's extras, or one
      * demanding plain digits, refuses `1e3` and `.5e3` — both valid `<number>`
      * tokens that reach this field, and both of which a browser reads.
+     *
+     * Each spelling here was measured against a real `@font-face` parser
+     * rather than read off the grammar: `1e3` → 1000, `.5e3` → 500,
+     * `400.0` → 400, `+400` → 400, all kept.
      */
-    for (const spelling of ["1e3", ".5e3", "400.", "+400"]) {
+    for (const spelling of ["1e3", ".5e3", "400.0", "+400"]) {
       cleanup();
       const onAddFace = vi.fn(async (_request: FontFaceUpload) => undefined);
       render(<FontsPanel faces={[]} onAddFace={onAddFace} tokens={tokens} />);
@@ -584,6 +588,32 @@ describe("adding a font file", () => {
 
       expect(onAddFace, `${spelling} is a CSS number`).toHaveBeenCalledTimes(1);
     }
+  });
+
+  it("REFUSES a decimal point with no digit after it", async () => {
+    /*
+     * Its own case rather than another radix spelling, because it fails at a
+     * different point: `0x190` is a number JavaScript reads and CSS does not,
+     * while `400.` is one BOTH read — as `400` followed by a stray `.`, since
+     * the tokenizer consumes a point only when a digit comes next. The stored
+     * descriptor is still `400.`, and the whole thing is dropped.
+     *
+     * Measured in a browser: `font-weight: 400.` in `@font-face` is dropped,
+     * `400.0` is kept as `400`. Not reasoned from the grammar — an earlier
+     * version of this suite required `400.` to be ACCEPTED.
+     */
+    const onAddFace = vi.fn(async (_request: FontFaceUpload) => undefined);
+    render(<FontsPanel faces={[]} onAddFace={onAddFace} tokens={tokens} />);
+
+    await chooseFile(woff2("Inter-Regular.woff2"));
+    fireEvent.change(screen.getByLabelText("Weight"), {
+      target: { value: "400." },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /add font file/i }));
+    });
+
+    expect(onAddFace).not.toHaveBeenCalled();
   });
 
   it("clears the PICKER on success, so the same file can be chosen again", async () => {

--- a/packages/builder/src/fonts-panel.test.tsx
+++ b/packages/builder/src/fonts-panel.test.tsx
@@ -314,6 +314,18 @@ describe("adding a font file", () => {
       value: [file],
       configurable: true,
     });
+    /*
+     * The element's own `value`, which jsdom does not set and a browser does —
+     * as `C:\\fakepath\\<name>`. It is what the browser compares a later
+     * choice against when deciding whether to raise `change`, so a harness
+     * leaving it empty cannot tell a picker that was cleared from one that was
+     * never filled.
+     */
+    Object.defineProperty(input, "value", {
+      value: `C:\\fakepath\\${file.name}`,
+      writable: true,
+      configurable: true,
+    });
     await act(async () => {
       fireEvent.change(input);
     });
@@ -529,6 +541,76 @@ describe("adding a font file", () => {
     expect(onAddFace.mock.calls[0]?.[0].weight).toBe("100 900");
   });
 
+  it("REFUSES a weight JavaScript reads as a number and CSS does not", async () => {
+    /*
+     * `Number("0x190")` is 400, so a bounds check applied after the conversion
+     * passes — while the string kept in the descriptor is still `0x190`, which
+     * CSS cannot parse. The browser drops the declaration and matches the face
+     * at a weight nobody chose, which is the same silent outcome as `70O` with
+     * nothing visibly wrong with the input.
+     */
+    const onAddFace = vi.fn(async (_request: FontFaceUpload) => undefined);
+    render(<FontsPanel faces={[]} onAddFace={onAddFace} tokens={tokens} />);
+
+    await chooseFile(woff2("Inter-Regular.woff2"));
+    fireEvent.change(screen.getByLabelText("Weight"), {
+      target: { value: "0x190" },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /add font file/i }));
+    });
+
+    expect(onAddFace).not.toHaveBeenCalled();
+  });
+
+  it("KEEPS the exponent and fraction forms, which CSS does allow", async () => {
+    /*
+     * The control. A check written as a list of JavaScript's extras, or one
+     * demanding plain digits, refuses `1e3` and `.5e3` — both valid `<number>`
+     * tokens that reach this field, and both of which a browser reads.
+     */
+    for (const spelling of ["1e3", ".5e3", "400.", "+400"]) {
+      cleanup();
+      const onAddFace = vi.fn(async (_request: FontFaceUpload) => undefined);
+      render(<FontsPanel faces={[]} onAddFace={onAddFace} tokens={tokens} />);
+
+      await chooseFile(woff2("Inter-Regular.woff2"));
+      fireEvent.change(screen.getByLabelText("Weight"), {
+        target: { value: spelling },
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: /add font file/i }));
+      });
+
+      expect(onAddFace, `${spelling} is a CSS number`).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it("clears the PICKER on success, so the same file can be chosen again", async () => {
+    /*
+     * Adding one variable font's italic after its upright means choosing the
+     * same file twice. A browser raises `change` only when the selection
+     * CHANGES, so leaving the element holding the previous file means the
+     * second choice raises nothing, the component never learns of it, and the
+     * button stays disabled while the picker displays the very file the author
+     * just picked.
+     *
+     * Asserted on the element's own `value`, because that is the state the
+     * browser compares against — this component's `file` is not what decides
+     * whether the event is raised.
+     */
+    const onAddFace = vi.fn(async (_request: FontFaceUpload) => undefined);
+    render(<FontsPanel faces={[]} onAddFace={onAddFace} tokens={tokens} />);
+
+    const input = screen.getByLabelText("Font file") as HTMLInputElement;
+    await chooseFile(woff2("Inter-Regular.woff2"));
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /add font file/i }));
+    });
+
+    expect(input.value).toBe("");
+  });
+
   it("offers the file types the HOST accepts, not a list of its own", () => {
     /*
      * The panel cannot know which formats this site stores and serves, and a
@@ -604,6 +686,18 @@ describe("the add controls inside the entry editor's own form", () => {
     const input = screen.getByLabelText("Font file") as HTMLInputElement;
     Object.defineProperty(input, "files", {
       value: [file],
+      configurable: true,
+    });
+    /*
+     * The element's own `value`, which jsdom does not set and a browser does —
+     * as `C:\\fakepath\\<name>`. It is what the browser compares a later
+     * choice against when deciding whether to raise `change`, so a harness
+     * leaving it empty cannot tell a picker that was cleared from one that was
+     * never filled.
+     */
+    Object.defineProperty(input, "value", {
+      value: `C:\\fakepath\\${file.name}`,
+      writable: true,
       configurable: true,
     });
     await act(async () => {

--- a/packages/builder/src/fonts-panel.tsx
+++ b/packages/builder/src/fonts-panel.tsx
@@ -374,9 +374,15 @@ function specimenWeight(weight: string | undefined): string | undefined {
  *
  * A range is ORDERED, which per-part checking cannot see. `900 100` is two
  * individually valid weights and not a range: the descriptor requires the
- * lower endpoint first, so a browser drops the whole thing and matches the
- * face at a weight nobody chose — the same silent outcome as `70O`, reached
- * from the other direction.
+ * lower endpoint first.
+ *
+ * Refused rather than passed on, and the reason is NOT that a browser rejects
+ * it. Measured: Chrome PARSES `font-weight: 900 100` and keeps it verbatim, so
+ * the face is stored carrying a range no specification defines a meaning for,
+ * and what it then matches is up to the engine. An author gets a face that
+ * behaves differently in different browsers with nothing reporting why, which
+ * is a worse outcome than the refusal — and the one form of it this panel can
+ * see before it is stored.
  */
 function isUsableWeight(weight: string): boolean {
   const parts = weight.trim().split(/\s+/);
@@ -409,6 +415,12 @@ function weightValue(part: string): number | undefined {
  * A CSS `<number>`: an optional sign, digits with an optional fraction, and an
  * optional exponent.
  *
+ * A decimal point must be FOLLOWED BY A DIGIT. The tokenizer consumes `.` only
+ * when a digit comes next, so `400.` ends the number at `400` and leaves the
+ * point as a separate token — which the descriptor grammar does not admit.
+ * Measured in a browser: `font-weight: 400.` inside `@font-face` is dropped,
+ * while `400.0` and `400.5` are kept.
+ *
  * `Number` was doing this job and reads a LARGER language than CSS does, which
  * fails in the silent direction: `0x190` converts to 400 and passes any bound
  * checked afterwards, while the string stored in the descriptor is still
@@ -422,7 +434,7 @@ function weightValue(part: string): number | undefined {
  * `+400` are all valid `<number>` tokens and all reach here through the free
  * text field.
  */
-const CSS_NUMBER = /^[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?$/;
+const CSS_NUMBER = /^[+-]?(\d+(\.\d+)?|\.\d+)([eE][+-]?\d+)?$/;
 
 /**
  * A key that separates the faces a family is really split into.

--- a/packages/builder/src/fonts-panel.tsx
+++ b/packages/builder/src/fonts-panel.tsx
@@ -49,6 +49,7 @@ import {
   tokenSummary,
 } from "./font-library";
 import type { FamilyReading, FontTokenRow } from "./font-library";
+import { CSS_NUMBER } from "./style-numeric";
 
 export interface FontsPanelProps {
   /**
@@ -404,37 +405,23 @@ function isUsableWeight(weight: string): boolean {
 function weightValue(part: string): number | undefined {
   if (part === "normal") return 400;
   if (part === "bold") return 700;
-  // The spelling is checked BEFORE the conversion, because the conversion is
-  // what loses the difference: `Number` and CSS read different languages.
+  /*
+   * The spelling is judged BEFORE the conversion, because the conversion is
+   * what loses the difference. `Number("0x190")` is 400, so a bound checked
+   * afterwards passes while the descriptor still carries `0x190` — measured in
+   * a browser, `font-weight: 0x190` and `font-weight: 400.` are both dropped
+   * from an `@font-face` rule, and the face then matches at a weight nobody
+   * chose.
+   *
+   * The grammar itself is {@link style-numeric}'s, which the numeric style
+   * controls already judge against. A second copy of one question is what this
+   * file would otherwise be adding, and the two would agree until one of them
+   * was corrected.
+   */
   if (!CSS_NUMBER.test(part)) return undefined;
   const value = Number(part);
   return value >= 1 && value <= 1000 ? value : undefined;
 }
-
-/**
- * A CSS `<number>`: an optional sign, digits with an optional fraction, and an
- * optional exponent.
- *
- * A decimal point must be FOLLOWED BY A DIGIT. The tokenizer consumes `.` only
- * when a digit comes next, so `400.` ends the number at `400` and leaves the
- * point as a separate token — which the descriptor grammar does not admit.
- * Measured in a browser: `font-weight: 400.` inside `@font-face` is dropped,
- * while `400.0` and `400.5` are kept.
- *
- * `Number` was doing this job and reads a LARGER language than CSS does, which
- * fails in the silent direction: `0x190` converts to 400 and passes any bound
- * checked afterwards, while the string stored in the descriptor is still
- * `0x190` — which CSS cannot parse, so the browser drops the declaration and
- * matches the face at a weight nobody chose. Measured, the three radix
- * prefixes `0x`, `0b` and `0o` all reach that outcome.
- *
- * Written to the CSS grammar rather than as a list of JavaScript's extras, so
- * a spelling nobody enumerated is refused rather than admitted. The forms CSS
- * does allow are kept, and they are not exotic: `1e3`, `.5e3`, `400.` and
- * `+400` are all valid `<number>` tokens and all reach here through the free
- * text field.
- */
-const CSS_NUMBER = /^[+-]?(\d+(\.\d+)?|\.\d+)([eE][+-]?\d+)?$/;
 
 /**
  * A key that separates the faces a family is really split into.

--- a/packages/builder/src/fonts-panel.tsx
+++ b/packages/builder/src/fonts-panel.tsx
@@ -39,7 +39,7 @@
 import { cssString } from "@nextlyhq/blocks-engine";
 import type { FontFaceDef, SiteTokenSet } from "@nextlyhq/blocks-engine";
 import type * as React from "react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 import {
   emittableFaces,
@@ -398,12 +398,31 @@ function isUsableWeight(weight: string): boolean {
 function weightValue(part: string): number | undefined {
   if (part === "normal") return 400;
   if (part === "bold") return 700;
+  // The spelling is checked BEFORE the conversion, because the conversion is
+  // what loses the difference: `Number` and CSS read different languages.
+  if (!CSS_NUMBER.test(part)) return undefined;
   const value = Number(part);
-  // `Number("")` is 0 and `Number(" ")` is 0, both outside the range below.
-  return Number.isFinite(value) && value >= 1 && value <= 1000
-    ? value
-    : undefined;
+  return value >= 1 && value <= 1000 ? value : undefined;
 }
+
+/**
+ * A CSS `<number>`: an optional sign, digits with an optional fraction, and an
+ * optional exponent.
+ *
+ * `Number` was doing this job and reads a LARGER language than CSS does, which
+ * fails in the silent direction: `0x190` converts to 400 and passes any bound
+ * checked afterwards, while the string stored in the descriptor is still
+ * `0x190` — which CSS cannot parse, so the browser drops the declaration and
+ * matches the face at a weight nobody chose. Measured, the three radix
+ * prefixes `0x`, `0b` and `0o` all reach that outcome.
+ *
+ * Written to the CSS grammar rather than as a list of JavaScript's extras, so
+ * a spelling nobody enumerated is refused rather than admitted. The forms CSS
+ * does allow are kept, and they are not exotic: `1e3`, `.5e3`, `400.` and
+ * `+400` are all valid `<number>` tokens and all reach here through the free
+ * text field.
+ */
+const CSS_NUMBER = /^[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?$/;
 
 /**
  * A key that separates the faces a family is really split into.
@@ -674,6 +693,21 @@ function AddFaceForm({
    * under it — silently, which is the failure this form exists to avoid.
    */
   const [familyAuthored, setFamilyAuthored] = useState(false);
+  /*
+   * The picker element itself, because clearing it is not a state change.
+   *
+   * A file input is uncontrolled: `setFile(null)` forgets the choice on this
+   * side and leaves the element still holding it, filename displayed. A
+   * browser raises `change` only when the SELECTION changes, so choosing the
+   * same file again after a successful add raises nothing, this component
+   * never learns of it, and the button stays disabled — with the author
+   * looking at a picker that shows the file they just chose.
+   *
+   * That is the ordinary path rather than an edge: one variable font is added
+   * once per style, so re-picking the same file is how a family gets its
+   * italic.
+   */
+  const picker = useRef<HTMLInputElement | null>(null);
 
   const chooseFile = (chosen: File | null): void => {
     setFile(chosen);
@@ -715,6 +749,8 @@ function AddFaceForm({
        * nobody chose, which loads and matches nothing.
        */
       setFile(null);
+      // The element, not just this component's memory of it — see `picker`.
+      if (picker.current !== null) picker.current.value = "";
       setFamily("");
       setFamilyAuthored(false);
       setWeight("400");
@@ -765,6 +801,7 @@ function AddFaceForm({
         className="nx-fonts__add-file"
         id="nx-fonts-file"
         onChange={event => chooseFile(event.target.files?.[0] ?? null)}
+        ref={picker}
         type="file"
       />
 

--- a/packages/builder/src/style-numeric.test.ts
+++ b/packages/builder/src/style-numeric.test.ts
@@ -12,6 +12,7 @@ import { STYLE_CATALOG, type StyleLeaf } from "@nextlyhq/blocks-engine";
 import { describe, expect, it } from "vitest";
 
 import {
+  CSS_NUMBER,
   measurementOf,
   steppedValue,
   toggleOptionsFor,
@@ -57,6 +58,48 @@ const Z_INDEX: StyleLeaf = (() => {
   if (arm === undefined) throw new Error("position.zIndex has no number arm");
   return arm as unknown as StyleLeaf;
 })();
+
+describe("the CSS number grammar", () => {
+  /*
+   * Its docblock states three properties and nothing asserted any of them, so
+   * a correction to the pattern could quietly change what every consumer
+   * accepts. Two consumers now share it — the numeric style controls and the
+   * fonts panel's `font-weight` field — and the second reaches a stylesheet,
+   * where a spelling CSS cannot parse costs the whole declaration.
+   */
+  it("refuses the radix spellings `Number` accepts", () => {
+    // Each converts to a finite number in range, so a bounds check applied
+    // after conversion passes while the stored string stays unparseable.
+    for (const spelling of ["0x190", "0b110001000", "0o620"]) {
+      expect(CSS_NUMBER.test(spelling), spelling).toBe(false);
+      expect(Number.isFinite(Number(spelling)), `${spelling} via Number`).toBe(
+        true
+      );
+    }
+  });
+
+  it("requires a digit AFTER a decimal point", () => {
+    // The tokenizer consumes `.` only when a digit follows, so `400.` is a
+    // number followed by a stray delimiter rather than a number.
+    expect(CSS_NUMBER.test("400.")).toBe(false);
+    expect(CSS_NUMBER.test("400.0")).toBe(true);
+    expect(CSS_NUMBER.test(".5")).toBe(true);
+  });
+
+  it("keeps the sign and exponent forms, which CSS does allow", () => {
+    // The control. A pattern narrowed to plain digits refuses every one of
+    // these, and each is a spelling a free-text field really receives.
+    for (const spelling of ["400", "+400", "-400", "1e3", "1E3", ".5e3"]) {
+      expect(CSS_NUMBER.test(spelling), spelling).toBe(true);
+    }
+  });
+
+  it("refuses what is not a number at all", () => {
+    for (const spelling of ["", ".", "1e", "4_00", "Infinity", "70O"]) {
+      expect(CSS_NUMBER.test(spelling), spelling).toBe(false);
+    }
+  });
+});
 
 describe("what a measurement is", () => {
   it("decomposes a single measurement into its number and unit", () => {


### PR DESCRIPTION
Two findings from the review round on #1482, which merged before they could be worked there. Both are in `packages/builder/src/fonts-panel.tsx`.

## A weight JavaScript reads and CSS does not

`Number("0x190")` is `400`, so a bound checked after the conversion passes — while the string kept in the descriptor is still `0x190`, which CSS cannot parse. The browser drops the declaration and matches the face at a weight nobody chose: the same silent outcome as `70O`, with nothing visibly wrong with the input.

Measured before fixing — all three radix prefixes reach it:

| spelling | `Number()` | passed the old bound | CSS `<number>` |
| --- | --- | --- | --- |
| `0x190` | 400 | yes | **no** |
| `0b110001000` | 392 | yes | **no** |
| `0o620` | 400 | yes | **no** |
| `1e3` | 1000 | yes | yes |
| `.5e3` | 500 | yes | yes |

The spelling is now checked against the CSS `<number>` grammar **before** any conversion — the conversion is what loses the difference. Written to that grammar rather than as a list of JavaScript's extras, so a spelling nobody enumerated is refused rather than admitted.

The exponent and fraction forms are kept deliberately. `1e3`, `.5e3`, `400.` and `+400` are all valid `<number>` tokens that a browser reads, and all of them reach this field through free text — a check demanding plain digits would refuse them.

## Choosing the same file twice

A file input is uncontrolled, so clearing this component's state left the element still holding the previous choice, filename displayed. A browser raises `change` only when the selection CHANGES, so choosing that same file again raised nothing, the component never learned of it, and the Add button stayed disabled while the picker showed the very file the author had just picked.

That is the ordinary path rather than an edge: one variable font is added once per style, so re-picking the same file is how a family gets its italic.

## On the evidence

The picker test **passed with the fix removed** on the first attempt, and that was the finding rather than a pass. jsdom never sets a file input's `value`, so the assertion was reading a field that was empty before the add and would have been empty however the component behaved. The harness now sets `value` to `C:\fakepath\<name>` as a browser does, which is also the state a browser compares a later choice against — and with that in place, removing the reset fails the case.

Each of the three new tests was break-verified on its own, against the previous implementation rather than an invented mutation:

- restoring the `Number()`-only check fails the radix case and leaves the CSS-forms control green;
- narrowing the pattern to plain digits fails the CSS-forms control and leaves the radix case green;
- removing the element reset fails the picker case.

Gates from the worktree root: `build`, `lint`, `check-types` all clean, `@nextlyhq/builder` 99 files / 2789 tests. `fallow audit --base origin/main` passes with nothing introduced.