### PR TITLE
fix(nextly): bracket a contributed type by provenance, not by scanning it

### DIFF
--- a/.changeset/a-contributed-type-is-bracketed.md
+++ b/.changeset/a-contributed-type-is-bracketed.md
@@ -1,0 +1,42 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A generated type contributed by a plugin is bracketed before `| null` is added
+to it, and the bracket is placed where a comment cannot reach it.
+
+A plugin's `codegen.tsType` callback returns an arbitrary type expression. Two
+shapes bind looser than a union and captured it: a conditional attached the
+null to its FALSE branch, leaving the true branch rejecting a value the column
+can return, and a function type attached it to the RETURN rather than to the
+field.
+
+Bracketing is decided by where the expression came from rather than by
+inspecting it, so no formatting of the expression and no type-level syntax
+added later can change the answer. The closing bracket sits on its own line
+because `//` runs to the end of its line, and an expression ending in a
+comment would otherwise swallow it and leave a file that does not compile.

--- a/packages/nextly/src/domains/schema/services/__tests__/plugin-codegen.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/plugin-codegen.test.ts
@@ -78,7 +78,7 @@ describe("plugin field types in the TypeScript generator", () => {
       ]),
     ]);
 
-    expect(file.code).toContain("score?: Rating<5> | null;");
+    expect(file.code).toContain("score?: (Rating<5>) | null;");
     expect(file.code).toContain('import type { Rating } from "@acme/ratings";');
   });
 
@@ -216,7 +216,7 @@ describe("plugin field types in the TypeScript generator", () => {
 
     // An ordinary save relocates unmodelled options, so a callback reading the
     // raw field would silently start emitting the un-narrowed type.
-    expect(file.code).toContain("score?: Rating<7> | null;");
+    expect(file.code).toContain("score?: (Rating<7>) | null;");
   });
 
   it("imports nothing for a registered type no field uses", () => {

--- a/packages/nextly/src/domains/schema/services/__tests__/plugin-codegen.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/plugin-codegen.test.ts
@@ -78,7 +78,7 @@ describe("plugin field types in the TypeScript generator", () => {
       ]),
     ]);
 
-    expect(file.code).toContain("score?: (Rating<5>) | null;");
+    expect(file.code).toContain("score?: (\n    Rating<5>\n  ) | null;");
     expect(file.code).toContain('import type { Rating } from "@acme/ratings";');
   });
 
@@ -101,7 +101,7 @@ describe("plugin field types in the TypeScript generator", () => {
     ]);
 
     expect(file.code).toContain(
-      "payload?: (T extends string ? number : boolean) | null;"
+      "payload?: (\n    T extends string ? number : boolean\n  ) | null;"
     );
   });
 
@@ -119,7 +119,7 @@ describe("plugin field types in the TypeScript generator", () => {
       collection([{ name: "handler", type: "callback-thing" }]),
     ]);
 
-    expect(file.code).toContain("handler?: (() => number) | null;");
+    expect(file.code).toContain("handler?: (\n    () => number\n  ) | null;");
   });
 
   it("gives a user field its declared option under the declared name", () => {
@@ -216,7 +216,7 @@ describe("plugin field types in the TypeScript generator", () => {
 
     // An ordinary save relocates unmodelled options, so a callback reading the
     // raw field would silently start emitting the un-narrowed type.
-    expect(file.code).toContain("score?: (Rating<7>) | null;");
+    expect(file.code).toContain("score?: (\n    Rating<7>\n  ) | null;");
   });
 
   it("imports nothing for a registered type no field uses", () => {

--- a/packages/nextly/src/domains/schema/services/__tests__/plugin-codegen.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/plugin-codegen.test.ts
@@ -78,6 +78,9 @@ describe("plugin field types in the TypeScript generator", () => {
       ]),
     ]);
 
+    // Bracketed and broken across lines because the type came from a plugin:
+    // an arbitrary expression may bind looser than the union, and a trailing
+    // line comment would otherwise swallow the closing bracket.
     expect(file.code).toContain("score?: (\n    Rating<5>\n  ) | null;");
     expect(file.code).toContain('import type { Rating } from "@acme/ratings";');
   });
@@ -100,6 +103,9 @@ describe("plugin field types in the TypeScript generator", () => {
       collection([{ name: "payload", type: "conditional-thing" }]),
     ]);
 
+    // Bracketed and broken across lines because the type came from a plugin:
+    // an arbitrary expression may bind looser than the union, and a trailing
+    // line comment would otherwise swallow the closing bracket.
     expect(file.code).toContain(
       "payload?: (\n    T extends string ? number : boolean\n  ) | null;"
     );
@@ -119,6 +125,9 @@ describe("plugin field types in the TypeScript generator", () => {
       collection([{ name: "handler", type: "callback-thing" }]),
     ]);
 
+    // Bracketed and broken across lines because the type came from a plugin:
+    // an arbitrary expression may bind looser than the union, and a trailing
+    // line comment would otherwise swallow the closing bracket.
     expect(file.code).toContain("handler?: (\n    () => number\n  ) | null;");
   });
 
@@ -216,6 +225,9 @@ describe("plugin field types in the TypeScript generator", () => {
 
     // An ordinary save relocates unmodelled options, so a callback reading the
     // raw field would silently start emitting the un-narrowed type.
+    // Bracketed and broken across lines because the type came from a plugin:
+    // an arbitrary expression may bind looser than the union, and a trailing
+    // line comment would otherwise swallow the closing bracket.
     expect(file.code).toContain("score?: (\n    Rating<7>\n  ) | null;");
   });
 

--- a/packages/nextly/src/domains/schema/services/field-nullability.test.ts
+++ b/packages/nextly/src/domains/schema/services/field-nullability.test.ts
@@ -52,10 +52,9 @@ describe("nullableTypeExpression", () => {
   });
 
   it("brackets a contributed expression a syntax scan would have missed", () => {
-    // The case that retired the previous implementation: it tested for the
-    // literal `" extends "`, so a conditional formatted across lines went
-    // through unbracketed. Nothing about the formatting reaches the decision
-    // now.
+    // Bracketing is decided by provenance, so how the expression is formatted
+    // never reaches the decision: a conditional written across lines is
+    // bracketed exactly as a single-line one is.
     expect(
       nullableTypeExpression("T extends\n  U ? X : Y", { contributed: true })
     ).toBe("(\n    T extends\n  U ? X : Y\n  ) | null");

--- a/packages/nextly/src/domains/schema/services/field-nullability.test.ts
+++ b/packages/nextly/src/domains/schema/services/field-nullability.test.ts
@@ -37,20 +37,35 @@ describe("nullableTypeExpression", () => {
     expect(nullableTypeExpression("unknown")).toBe("unknown");
   });
 
-  it("parenthesizes a conditional type, whose false branch would capture the union", () => {
-    // `A extends B ? X : Y | null` parses as `A extends B ? X : (Y | null)`,
-    // so the TRUE branch still rejects null while the column can return it.
-    // Confirmed against the compiler: assigning null to the true branch of an
-    // unparenthesized form is rejected with TS2322.
-    expect(nullableTypeExpression("A extends B ? X : Y")).toBe(
-      "(A extends B ? X : Y) | null"
+  it("brackets a contributed expression, whatever its shape", () => {
+    // Provenance, not syntax. `A extends B ? X : Y | null` attaches null to the
+    // FALSE branch, so the true branch still rejects it; `() => X | null` makes
+    // the RETURN nullable. Both are only reachable through a plugin, so the
+    // bracket is applied because the expression came from outside rather than
+    // because it matched a pattern — which is what a formatting change evades.
+    expect(
+      nullableTypeExpression("A extends B ? X : Y", { contributed: true })
+    ).toBe("(A extends B ? X : Y) | null");
+    expect(nullableTypeExpression("() => X", { contributed: true })).toBe(
+      "(() => X) | null"
     );
   });
 
-  it("parenthesizes a function type, whose RETURN would otherwise take the union", () => {
-    // `() => X | null` makes the return nullable and leaves the field itself
-    // non-null, which is the opposite of what is meant.
-    expect(nullableTypeExpression("() => X")).toBe("(() => X) | null");
+  it("brackets a contributed expression a syntax scan would have missed", () => {
+    // The case that retired the previous implementation: it tested for the
+    // literal `" extends "`, so a conditional formatted across lines went
+    // through unbracketed. Nothing about the formatting reaches the decision
+    // now.
+    expect(
+      nullableTypeExpression("T extends\n  U ? X : Y", { contributed: true })
+    ).toBe("(T extends\n  U ? X : Y) | null");
+  });
+
+  it("leaves a type this module built itself unbracketed", () => {
+    // Built-in types are atomic by construction, so brackets would be noise.
+    expect(nullableTypeExpression("Rating<5>", { contributed: false })).toBe(
+      "Rating<5> | null"
+    );
   });
 });
 

--- a/packages/nextly/src/domains/schema/services/field-nullability.test.ts
+++ b/packages/nextly/src/domains/schema/services/field-nullability.test.ts
@@ -45,9 +45,9 @@ describe("nullableTypeExpression", () => {
     // because it matched a pattern — which is what a formatting change evades.
     expect(
       nullableTypeExpression("A extends B ? X : Y", { contributed: true })
-    ).toBe("(A extends B ? X : Y) | null");
+    ).toBe("(\n    A extends B ? X : Y\n  ) | null");
     expect(nullableTypeExpression("() => X", { contributed: true })).toBe(
-      "(() => X) | null"
+      "(\n    () => X\n  ) | null"
     );
   });
 
@@ -58,7 +58,7 @@ describe("nullableTypeExpression", () => {
     // now.
     expect(
       nullableTypeExpression("T extends\n  U ? X : Y", { contributed: true })
-    ).toBe("(T extends\n  U ? X : Y) | null");
+    ).toBe("(\n    T extends\n  U ? X : Y\n  ) | null");
   });
 
   it("leaves a type this module built itself unbracketed", () => {
@@ -66,6 +66,19 @@ describe("nullableTypeExpression", () => {
     expect(nullableTypeExpression("Rating<5>", { contributed: false })).toBe(
       "Rating<5> | null"
     );
+  });
+
+  it("keeps the closing bracket out of a trailing line comment's reach", () => {
+    // `//` runs to the end of its line, so a bracket placed after a contributed
+    // expression on the SAME line would be commented out and the generated file
+    // would not compile.
+    const rendered = nullableTypeExpression("Foo // why", {
+      contributed: true,
+    });
+
+    const lastLine = rendered.split("\n").at(-1) ?? "";
+    expect(lastLine).toContain(") | null");
+    expect(lastLine).not.toContain("//");
   });
 });
 

--- a/packages/nextly/src/domains/schema/services/field-nullability.ts
+++ b/packages/nextly/src/domains/schema/services/field-nullability.ts
@@ -35,41 +35,33 @@ export function fieldAdmitsNull(field: object): boolean {
 }
 
 /**
- * Whether `${tsType} | null` would bind the union somewhere other than the
- * whole type.
- *
- * Union sits below almost everything in TypeScript's type grammar, so the
- * concatenation is safe for identifiers, generics, arrays, object literals,
- * intersections and other unions. Two constructs bind looser and capture the
- * union into a part of themselves:
- *
- * - a conditional type — `A extends B ? X : Y | null` attaches null to the
- *   FALSE branch, so the true branch still rejects it. Verified against the
- *   compiler rather than assumed.
- * - a function type — `() => X | null` makes the RETURN nullable and leaves the
- *   field itself non-null.
- *
- * Only a plugin's `codegen.tsType` callback can produce either; every built-in
- * type is atomic. The test is textual and errs toward parenthesising, which
- * costs a pair of brackets on a nested occurrence and never changes a meaning.
- * `zod-generator.ts` already wraps plugin-contributed expressions for exactly
- * this reason, and this follows it.
- */
-function bindsLooserThanUnion(tsType: string): boolean {
-  return tsType.includes("=>") || tsType.includes(" extends ");
-}
-
-/**
  * The type as written when the field admits null.
  *
  * `unknown` is returned untouched: it already admits null, and `unknown | null`
  * would be noise in a file a user reads.
+ *
+ * **`contributed` is about PROVENANCE, not syntax.** Union binds looser than
+ * almost everything, so concatenation is safe for every type this module
+ * builds itself. It is not safe for a type a plugin's `codegen.tsType`
+ * returned, which may be any expression: a conditional binds the union to its
+ * FALSE branch, leaving the true branch rejecting null, and a function type
+ * takes it onto the RETURN.
+ *
+ * An earlier version tested the expression for `=>` and `" extends "`. That is
+ * a scan over syntax, and it has the unbounded surface AGENTS.md warns about —
+ * a conditional formatted with a newline after `extends` slips straight
+ * through it, which is exactly how it was caught. Provenance is a boundary
+ * instead: an expression from outside is bracketed because of where it came
+ * from, so no formatting can evade it and no future type-level syntax can
+ * either. `zod-generator.ts` has always done this with its contributed
+ * expressions; this is the type side agreeing.
  */
-export function nullableTypeExpression(tsType: string): string {
+export function nullableTypeExpression(
+  tsType: string,
+  options: { contributed: boolean } = { contributed: false }
+): string {
   if (tsType === "unknown") return tsType;
-  return bindsLooserThanUnion(tsType)
-    ? `(${tsType}) | null`
-    : `${tsType} | null`;
+  return options.contributed ? `(${tsType}) | null` : `${tsType} | null`;
 }
 
 /**
@@ -85,8 +77,9 @@ export function nullableTypeExpression(tsType: string): string {
 export function renderFieldMember(
   fieldName: string,
   tsType: string,
-  field: object
+  field: object,
+  options: { contributed: boolean } = { contributed: false }
 ): string {
   if (!fieldAdmitsNull(field)) return `  ${fieldName}: ${tsType};`;
-  return `  ${fieldName}?: ${nullableTypeExpression(tsType)};`;
+  return `  ${fieldName}?: ${nullableTypeExpression(tsType, options)};`;
 }

--- a/packages/nextly/src/domains/schema/services/field-nullability.ts
+++ b/packages/nextly/src/domains/schema/services/field-nullability.ts
@@ -40,28 +40,33 @@ export function fieldAdmitsNull(field: object): boolean {
  * `unknown` is returned untouched: it already admits null, and `unknown | null`
  * would be noise in a file a user reads.
  *
- * **`contributed` is about PROVENANCE, not syntax.** Union binds looser than
- * almost everything, so concatenation is safe for every type this module
- * builds itself. It is not safe for a type a plugin's `codegen.tsType`
- * returned, which may be any expression: a conditional binds the union to its
- * FALSE branch, leaving the true branch rejecting null, and a function type
- * takes it onto the RETURN.
+ * `contributed` says the expression came from a plugin's `codegen.tsType`
+ * callback rather than from this module, and it decides two things.
  *
- * An earlier version tested the expression for `=>` and `" extends "`. That is
- * a scan over syntax, and it has the unbounded surface AGENTS.md warns about —
- * a conditional formatted with a newline after `extends` slips straight
- * through it, which is exactly how it was caught. Provenance is a boundary
- * instead: an expression from outside is bracketed because of where it came
- * from, so no formatting can evade it and no future type-level syntax can
- * either. `zod-generator.ts` has always done this with its contributed
- * expressions; this is the type side agreeing.
+ * **Brackets.** Union binds looser than almost everything, so concatenation is
+ * safe for every type built here. An arbitrary expression may bind looser
+ * still: a conditional attaches the union to its FALSE branch, leaving the true
+ * branch rejecting null, and a function type attaches it to the RETURN.
+ * Deciding by provenance rather than by inspecting the text means no formatting
+ * of the expression, and no type-level syntax added later, can change the
+ * answer.
+ *
+ * **A newline before the closing bracket.** A contributed expression may end in
+ * a line comment, and `//` runs to the end of its line, so `(Foo // why)` would
+ * swallow the bracket and leave a generated file that does not compile. The
+ * break puts the bracket beyond the comment's reach.
+ *
+ * `zod-generator.ts` brackets its own contributed expressions for the first of
+ * these reasons.
  */
 export function nullableTypeExpression(
   tsType: string,
   options: { contributed: boolean } = { contributed: false }
 ): string {
   if (tsType === "unknown") return tsType;
-  return options.contributed ? `(${tsType}) | null` : `${tsType} | null`;
+  return options.contributed
+    ? `(\n    ${tsType}\n  ) | null`
+    : `${tsType} | null`;
 }
 
 /**

--- a/packages/nextly/src/domains/schema/services/type-generator.ts
+++ b/packages/nextly/src/domains/schema/services/type-generator.ts
@@ -774,6 +774,10 @@ export class TypeGenerator {
     const fieldName = field.name;
 
     let tsType: string;
+    // Whether `tsType` came from a plugin rather than from this file. It is
+    // what decides bracketing when null is unioned on — see
+    // `nullableTypeExpression`.
+    let fromPlugin = false;
 
     // Text fields (supports hasMany for array of strings)
     if (isTextField(field)) {
@@ -861,6 +865,7 @@ export class TypeGenerator {
           imported: pluginDeclaredImportNames(field, "tsImports"),
         });
         tsType = contributed;
+        fromPlugin = true;
       } else {
         // No rendering of its own, but the registry still knows what it stores.
         // Re-entered as the storage primitive's built-in type so the branch
@@ -880,7 +885,9 @@ export class TypeGenerator {
       }
     }
 
-    return renderFieldMember(fieldName, tsType, field);
+    return renderFieldMember(fieldName, tsType, field, {
+      contributed: fromPlugin,
+    });
   }
 
   // ============================================================
@@ -903,6 +910,10 @@ export class TypeGenerator {
     const isCodeSourced = field.source === "code";
 
     let tsType: string;
+    // Whether `tsType` came from a plugin rather than from this file. It is
+    // what decides bracketing when null is unioned on — see
+    // `nullableTypeExpression`.
+    let fromPlugin = false;
 
     switch (field.type) {
       case "text":
@@ -955,6 +966,7 @@ export class TypeGenerator {
             imported: pluginDeclaredImportNames(field, "tsImports"),
           });
           tsType = contributed;
+          fromPlugin = true;
           break;
         }
         const storageType = pluginStorageFieldType(field);
@@ -970,7 +982,9 @@ export class TypeGenerator {
       }
     }
 
-    return renderFieldMember(field.name, tsType, field);
+    return renderFieldMember(field.name, tsType, field, {
+      contributed: fromPlugin,
+    });
   }
 
   /**

--- a/packages/nextly/src/domains/schema/services/type-generator.ts
+++ b/packages/nextly/src/domains/schema/services/type-generator.ts
@@ -781,6 +781,27 @@ export class TypeGenerator {
   }
 
   /**
+   * The rendered member for a field whose type a plugin states, or `undefined`
+   * when the plugin renders nothing of its own.
+   *
+   * Rendering here rather than returning a flag is what keeps the two callers
+   * from diverging: provenance is expressed by WHICH return runs, so there is
+   * no value to thread and none to forget. Every other path reaches the plain
+   * return at the end of its method, where the type was built in this file and
+   * needs no bracketing.
+   */
+  private contributedMember(
+    fieldName: string,
+    field: Parameters<typeof pluginTsType>[0]
+  ): string | undefined {
+    const contributed = this.adoptContributedType(field);
+    if (contributed === undefined) return undefined;
+    return renderFieldMember(fieldName, contributed, field, {
+      contributed: true,
+    });
+  }
+
+  /**
    * Generates a TypeScript type string for a single field.
    */
   private generateFieldType(
@@ -796,10 +817,6 @@ export class TypeGenerator {
     const fieldName = field.name;
 
     let tsType: string;
-    // Whether `tsType` came from a plugin rather than from this file. It is
-    // what decides bracketing when null is unioned on — see
-    // `nullableTypeExpression`.
-    let fromPlugin = false;
 
     // Text fields (supports hasMany for array of strings)
     if (isTextField(field)) {
@@ -879,10 +896,9 @@ export class TypeGenerator {
     // state its own rendering; asked once, because the callback is plugin code
     // and nothing requires it to be pure.
     else {
-      const contributed = this.adoptContributedType(field);
-      if (contributed !== undefined) {
-        tsType = contributed;
-        fromPlugin = true;
+      const member = this.contributedMember(fieldName, field);
+      if (member !== undefined) {
+        return member;
       } else {
         // No rendering of its own, but the registry still knows what it stores.
         // Re-entered as the storage primitive's built-in type so the branch
@@ -902,9 +918,7 @@ export class TypeGenerator {
       }
     }
 
-    return renderFieldMember(fieldName, tsType, field, {
-      contributed: fromPlugin,
-    });
+    return renderFieldMember(fieldName, tsType, field);
   }
 
   // ============================================================
@@ -927,10 +941,6 @@ export class TypeGenerator {
     const isCodeSourced = field.source === "code";
 
     let tsType: string;
-    // Whether `tsType` came from a plugin rather than from this file. It is
-    // what decides bracketing when null is unioned on — see
-    // `nullableTypeExpression`.
-    let fromPlugin = false;
 
     switch (field.type) {
       case "text":
@@ -975,11 +985,9 @@ export class TypeGenerator {
         // registry says it stores. `string` remains the fallback only for a
         // type nothing in the process knows about, which is what a UI-authored
         // field of a since-removed plugin type is.
-        const contributed = this.adoptContributedType(field);
-        if (contributed !== undefined) {
-          tsType = contributed;
-          fromPlugin = true;
-          break;
+        const member = this.contributedMember(field.name, field);
+        if (member !== undefined) {
+          return member;
         }
         const storageType = pluginStorageFieldType(field);
         const asStorage =
@@ -994,9 +1002,7 @@ export class TypeGenerator {
       }
     }
 
-    return renderFieldMember(field.name, tsType, field, {
-      contributed: fromPlugin,
-    });
+    return renderFieldMember(field.name, tsType, field);
   }
 
   /**

--- a/packages/nextly/src/domains/schema/services/type-generator.ts
+++ b/packages/nextly/src/domains/schema/services/type-generator.ts
@@ -759,6 +759,28 @@ export class TypeGenerator {
   // ============================================================
 
   /**
+   * The type a plugin states for this field, recorded as an emission so the
+   * imports it names reach the generated file.
+   *
+   * `undefined` means the plugin renders nothing of its own. That is also what
+   * tells a caller the type it ends up with was built here rather than
+   * contributed, so one call answers both what the type is and where it came
+   * from — and a change to what counts as contributed lands in one place.
+   */
+  private adoptContributedType(
+    field: Parameters<typeof pluginTsType>[0]
+  ): string | undefined {
+    const contributed = pluginTsType(field);
+    if (contributed === undefined) return undefined;
+    this.pluginExpressions.set(field, contributed);
+    this.pluginEmissions.push({
+      expression: contributed,
+      imported: pluginDeclaredImportNames(field, "tsImports"),
+    });
+    return contributed;
+  }
+
+  /**
    * Generates a TypeScript type string for a single field.
    */
   private generateFieldType(
@@ -857,13 +879,8 @@ export class TypeGenerator {
     // state its own rendering; asked once, because the callback is plugin code
     // and nothing requires it to be pure.
     else {
-      const contributed = pluginTsType(field);
+      const contributed = this.adoptContributedType(field);
       if (contributed !== undefined) {
-        this.pluginExpressions.set(field, contributed);
-        this.pluginEmissions.push({
-          expression: contributed,
-          imported: pluginDeclaredImportNames(field, "tsImports"),
-        });
         tsType = contributed;
         fromPlugin = true;
       } else {
@@ -958,13 +975,8 @@ export class TypeGenerator {
         // registry says it stores. `string` remains the fallback only for a
         // type nothing in the process knows about, which is what a UI-authored
         // field of a since-removed plugin type is.
-        const contributed = pluginTsType(field);
+        const contributed = this.adoptContributedType(field);
         if (contributed !== undefined) {
-          this.pluginExpressions.set(field, contributed);
-          this.pluginEmissions.push({
-            expression: contributed,
-            imported: pluginDeclaredImportNames(field, "tsImports"),
-          });
           tsType = contributed;
           fromPlugin = true;
           break;


### PR DESCRIPTION
Follow-up to #1488. **This commit was stranded**: it was pushed after GitHub had already computed #1488's merge, so the pull request merged at head `22ab1b93f` and this change never reached `main`.

Verified by content rather than by merge state:

```
on origin/main:  options.contributed ?      0 occurrences   (the fix is absent)
on origin/main:  includes(" extends ")      1 occurrence    (the defect is present)
control:         the file is readable       92 lines
```

## What it fixes

Codex's follow-up P2 on #1488, which was about the fix I made for its earlier P2. That version tested the expression for `=>` and the literal `" extends "`, so a conditional a plugin formatted with a newline after `extends` slipped through unbracketed and `| null` bound to its false branch again — the exact defect the check existed to close, reachable just by reformatting the input.

That is the failure mode `AGENTS.md` names: *a scan over syntax has an unbounded surface and can only ever be patched.*

## The change: a boundary, not a scan

The decision now turns on **where the expression came from**, not what it looks like.

- Every type this module builds is atomic by construction → no brackets.
- Anything a plugin's `codegen.tsType` returned → bracketed, because it came from outside.

No formatting can evade that, and no future type-level syntax can either. `zod-generator.ts` has always done exactly this with contributed expressions (`zodSchema = \`(${contributed})\``, with a comment naming the hazard); the type side now agrees with it instead of approximating it.

**The storage-fallback path is what proves the boundary is drawn in the right place.** A silent plugin type re-enters generation as its storage primitive, so the resulting type is built *here* and is correctly left unbracketed. I had wrongly updated two expectations to `(number) | null` and the suite corrected me.

## Evidence

Break-verified: ignoring provenance fails six tests, including the whitespace-formatted conditional that a syntax scan misses.

The control — that a type built here stays unbracketed — is deliberately asserted separately, because that break cannot fail it: an assertion of *absence* is satisfied by a change that removes brackets everywhere.

- `vitest run src/domains/schema src/direct-api/types` — **1458 passed, 125 files**
- `pnpm --filter nextly check-types` — exit 0
- `pnpm --filter nextly lint` — exit 0

## No changeset

#1488 already carries the changeset for this behaviour across all 25 lockstep packages; this corrects the implementation shipped under it rather than adding new surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated TypeScript typings for plugin-contributed fields by consistently wrapping complex expressions before adding nullable unions.
  * Preserved correct formatting for multiline conditional and function types, including trailing comments.
  * Improved handling of plugin-provided types while retaining fallback behavior when custom rendering is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->