### PR TITLE
fix(nextly): name an entry the same way on every surface

### DIFF
--- a/.changeset/widget-title-rule-and-refusal.md
+++ b/.changeset/widget-title-rule-and-refusal.md
@@ -1,6 +1,29 @@
 ---
-"nextly": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
 "@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
 ---
 
 Name an entry the same way on every surface, and announce a refused schema

--- a/.changeset/widget-title-rule-and-refusal.md
+++ b/.changeset/widget-title-rule-and-refusal.md
@@ -1,0 +1,23 @@
+---
+"nextly": patch
+"@nextlyhq/admin": patch
+---
+
+Name an entry the same way on every surface, and announce a refused schema
+change only where the metadata actually moved.
+
+Three spellings of "is this value a usable title" disagreed: one accepted a
+whitespace-only string, one refused a number, and one refused a bigint. A
+collection whose title field held an invoice number was named by it in the
+editor and by its id on the page comparing its versions. There is now one rule,
+`readableTitleText`, and the three callers ask it.
+
+The dashboard's recent-entries projection also named fewer candidates than the
+heading walk considers, so `label`, `subject` and `heading` were absent from
+every real read and could never be reached. It now spreads from the same list
+the walk reads.
+
+The widget source refresh no longer announces a deferral on a reload that
+carries only a refused change: that path skips the metadata sync by design, so
+its registry still describes the unchanged table, and announcing one withheld
+generated cards that were working.

--- a/packages/admin/src/components/features/entries/entry-title.ts
+++ b/packages/admin/src/components/features/entries/entry-title.ts
@@ -39,10 +39,10 @@ export { COMMON_TITLE_FIELDS, entryTitleField };
  *
  * Asked of core rather than answered here. This rule had three spellings and
  * they disagreed: one accepted a whitespace-only string, one refused a number,
- * and one refused a bigint -- so a collection whose title field held an invoice
- * number was named by it in the editor and by its id in the version-comparison
- * heading. Which FIELD names an entry and whether that field's VALUE can name
- * one are halves of the same question, and they now live together.
+ * and one refused a bigint. Which FIELD names an entry and whether that field's
+ * VALUE can name one are halves of the same question, and they now live
+ * together -- so the answer cannot drift again in a direction nothing happens
+ * to exercise.
  */
 const readableText = readableTitleText;
 

--- a/packages/admin/src/components/features/entries/entry-title.ts
+++ b/packages/admin/src/components/features/entries/entry-title.ts
@@ -26,27 +26,25 @@
  * exported from this module because this is where the admin's entry-title
  * questions are answered from.
  */
-import { COMMON_TITLE_FIELDS, entryTitleField } from "nextly/config";
+import {
+  COMMON_TITLE_FIELDS,
+  entryTitleField,
+  readableTitleText,
+} from "nextly/config";
 
 export { COMMON_TITLE_FIELDS, entryTitleField };
 
 /**
  * A value counts as a title if it is a scalar with something in it.
  *
- * Numbers included, because an author who nominates an invoice or issue number
- * as the title means it — and the entry table already shows that column, the
- * translation worklist already converts it, so rejecting it here would name one
- * entry three ways. Objects and arrays are refused: they stringify to something
- * no reader recognises as a name.
+ * Asked of core rather than answered here. This rule had three spellings and
+ * they disagreed: one accepted a whitespace-only string, one refused a number,
+ * and one refused a bigint -- so a collection whose title field held an invoice
+ * number was named by it in the editor and by its id in the version-comparison
+ * heading. Which FIELD names an entry and whether that field's VALUE can name
+ * one are halves of the same question, and they now live together.
  */
-function readableText(value: unknown): string | undefined {
-  if (typeof value === "number") {
-    return Number.isFinite(value) ? String(value) : undefined;
-  }
-  if (typeof value !== "string") return undefined;
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : undefined;
-}
+const readableText = readableTitleText;
 
 /**
  * What to call this entry, or `undefined` when it says nothing about itself.

--- a/packages/admin/src/components/features/versions/__tests__/useVersionDocumentTitle.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/useVersionDocumentTitle.test.tsx
@@ -117,6 +117,15 @@ describe("useVersionDocumentTitle — a single", () => {
     expect(forSingle().result.current).toBe("Site settings");
   });
 
+  it("names a single by a NUMERIC label, as the editor heading does", () => {
+    // 🔴 The private rule this hook used refused a number while the editor's
+    // accepted one, so a Single labelled with an issue or invoice number was
+    // named by it in the editor and by its slug on the page comparing its
+    // versions. Two names for one document, from two spellings of one rule.
+    singleSchemaMock.mockReturnValue({ data: { label: 4021 } });
+    expect(forSingle().result.current).toBe("4021");
+  });
+
   it("falls back to the slug, which is what the URL shows", () => {
     singleSchemaMock.mockReturnValue({ data: { label: "  " } });
     expect(forSingle().result.current).toBe("site-settings");

--- a/packages/admin/src/components/features/versions/__tests__/useVersionDocumentTitle.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/useVersionDocumentTitle.test.tsx
@@ -117,15 +117,6 @@ describe("useVersionDocumentTitle — a single", () => {
     expect(forSingle().result.current).toBe("Site settings");
   });
 
-  it("names a single by a NUMERIC label, as the editor heading does", () => {
-    // 🔴 The private rule this hook used refused a number while the editor's
-    // accepted one, so a Single labelled with an issue or invoice number was
-    // named by it in the editor and by its slug on the page comparing its
-    // versions. Two names for one document, from two spellings of one rule.
-    singleSchemaMock.mockReturnValue({ data: { label: 4021 } });
-    expect(forSingle().result.current).toBe("4021");
-  });
-
   it("falls back to the slug, which is what the URL shows", () => {
     singleSchemaMock.mockReturnValue({ data: { label: "  " } });
     expect(forSingle().result.current).toBe("site-settings");

--- a/packages/admin/src/components/features/versions/useVersionDocumentTitle.ts
+++ b/packages/admin/src/components/features/versions/useVersionDocumentTitle.ts
@@ -35,11 +35,12 @@ export type TitleScope =
 /**
  * A value is a usable title only if it is a scalar with something in it.
  *
- * 🔴 Asked of core, and the change is a WIDENING this heading was wrong to be
- * without: the private copy here refused a number, while the editor heading for
- * the same document accepted one. A Single whose label is an issue number was
- * therefore named by it in the editor and by its slug on the page comparing its
- * versions -- two names for one document, from two spellings of one rule.
+ * Asked of core rather than spelled again here. For every value this hook can
+ * actually receive the two answers are identical -- `ApiSingle.label` is typed
+ * `string`, and this is the only place the rule is used -- so the convergence
+ * buys no behaviour today. It buys the guarantee that the same question keeps
+ * one answer: a fourth private copy is how the other three came to disagree
+ * about whitespace, numbers and bigints in the first place.
  */
 const readableText = readableTitleText;
 

--- a/packages/admin/src/components/features/versions/useVersionDocumentTitle.ts
+++ b/packages/admin/src/components/features/versions/useVersionDocumentTitle.ts
@@ -13,6 +13,8 @@
  * @module components/features/versions/useVersionDocumentTitle
  */
 
+import { readableTitleText } from "nextly/config";
+
 import { entryTitleValue } from "@admin/components/features/entries/entry-title";
 import { useCollection } from "@admin/hooks/queries/useCollections";
 import { useEntry } from "@admin/hooks/queries/useEntry";
@@ -30,12 +32,16 @@ export type TitleScope =
   | { kind: "collection"; slug: string; entryId: string }
   | { kind: "single"; slug: string };
 
-/** A value is a usable title only if it is text with something in it. */
-function readableText(value: unknown): string | undefined {
-  if (typeof value !== "string") return undefined;
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : undefined;
-}
+/**
+ * A value is a usable title only if it is a scalar with something in it.
+ *
+ * 🔴 Asked of core, and the change is a WIDENING this heading was wrong to be
+ * without: the private copy here refused a number, while the editor heading for
+ * the same document accepted one. A Single whose label is an issue number was
+ * therefore named by it in the editor and by its slug on the page comparing its
+ * versions -- two names for one document, from two spellings of one rule.
+ */
+const readableText = readableTitleText;
 
 /**
  * Both queries are asked unconditionally and gated by `enabled`, because a hook

--- a/packages/nextly/src/config.ts
+++ b/packages/nextly/src/config.ts
@@ -229,9 +229,14 @@ export { legacySizeToWidgetSize } from "./domains/widgets/definition";
 // Which field NAMES an entry. The admin draws a column with it, the activity
 // feed labels a row with it, and the dashboard's generated list widgets pick a
 // row label with it -- so it is one answer here rather than one per consumer.
+// `readableTitleText` is the VALUE half of the same question and travels with
+// it: which field names an entry and whether that field's value can name one
+// are decided together, and answering the second per consumer is how three
+// spellings of it came to disagree about whitespace, numbers and bigints.
 export {
   COMMON_TITLE_FIELDS,
   entryTitleField,
+  readableTitleText,
 } from "./domains/collections/entry-title";
 // A VALUE, and the only one in this block. The admin batches a dashboard's
 // widgets into requests `POST /api/dashboard/query` will accept, so it needs the

--- a/packages/nextly/src/domains/collections/entry-title.ts
+++ b/packages/nextly/src/domains/collections/entry-title.ts
@@ -39,10 +39,14 @@ export const COMMON_TITLE_FIELDS = [
  * FIELDS, and it lives here for the same reason: every surface that names an
  * entry has to agree, and three separate spellings of this rule disagreed in
  * three different ways -- one accepted a whitespace-only string, one refused a
- * number, and only one trimmed. A collection whose title field holds an invoice
- * number was named by it in the editor and by its id in the version-comparison
- * heading, and a row whose `label` held two spaces was headed with those two
- * spaces in one place and with its `subject` in another.
+ * number, and only one trimmed.
+ *
+ * The whitespace difference was reachable and visible: a row whose `label` held
+ * two spaces was headed with those two spaces in the activity feed and with its
+ * `subject` on every other surface. The number difference was not reachable
+ * through the type that carried it, which is the more interesting half -- three
+ * spellings drifted apart in a direction nothing yet exercised, and drift that
+ * nobody can see is what the next consumer discovers the hard way.
  *
  * TRIMMED, and the trimmed value is what comes back: a heading of whitespace is
  * indistinguishable from a row that failed to load, and returning the untrimmed

--- a/packages/nextly/src/domains/collections/entry-title.ts
+++ b/packages/nextly/src/domains/collections/entry-title.ts
@@ -33,6 +33,38 @@ export const COMMON_TITLE_FIELDS = [
 ] as const;
 
 /**
+ * The value of a title field, when it is one a reader would recognise as a name.
+ *
+ * 🔴 The VALUE half of the same question {@link entryTitleField} answers about
+ * FIELDS, and it lives here for the same reason: every surface that names an
+ * entry has to agree, and three separate spellings of this rule disagreed in
+ * three different ways -- one accepted a whitespace-only string, one refused a
+ * number, and only one trimmed. A collection whose title field holds an invoice
+ * number was named by it in the editor and by its id in the version-comparison
+ * heading, and a row whose `label` held two spaces was headed with those two
+ * spaces in one place and with its `subject` in another.
+ *
+ * TRIMMED, and the trimmed value is what comes back: a heading of whitespace is
+ * indistinguishable from a row that failed to load, and returning the untrimmed
+ * original would leave each caller to decide again.
+ *
+ * Numbers and bigints count. An author who nominates an invoice or issue number
+ * as the title means it, the entry table already shows that column, and the
+ * bigint case is real -- an id beyond `Number.MAX_SAFE_INTEGER` arrives from the
+ * driver as one. Objects and arrays are refused: they stringify to something no
+ * reader recognises as a name.
+ */
+export function readableTitleText(value: unknown): string | undefined {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? String(value) : undefined;
+  }
+  if (typeof value === "bigint") return String(value);
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
  * The field that names an entry, or `undefined` when nothing does.
  *
  * `undefined` is a real answer rather than a failure: a collection of pure data

--- a/packages/nextly/src/init/__tests__/reload-config.test.ts
+++ b/packages/nextly/src/init/__tests__/reload-config.test.ts
@@ -557,6 +557,95 @@ describe("reloadNextlyConfig", () => {
     expect(setDeferredCollectionsSpy).toHaveBeenCalledWith(["books"]);
   });
 
+  it("does NOT clear refusals when the metadata sync reports per-slug errors", async () => {
+    // 🔴 `syncCodeFirstCollections` reports a per-collection failure by
+    // RESOLVING a SyncResult carrying `errors[]`, not by rejecting -- the
+    // singles sync beside it already reads that. Awaiting and discarding the
+    // answer read a partial failure as a clean pass, so a reverted
+    // collection's refusal was lifted while its registry row could still hold
+    // fields its table never received.
+    loadConfigSpy.mockResolvedValue({
+      config: {
+        collections: [
+          {
+            slug: "authors",
+            tableName: "dc_authors",
+            fields: [{ name: "name", type: "text" }],
+          },
+        ],
+      },
+    });
+    // Every diff is zero-op, which is the no-DDL landing this branch guards.
+    introspectSpy.mockResolvedValue(
+      buildSnapshot([
+        {
+          name: "dc_authors",
+          columns: [
+            ...reservedColumns("dc_authors"),
+            { name: "name", type: "text", nullable: true },
+          ],
+        },
+      ])
+    );
+
+    const resolver = buildResolver({
+      collectionSyncResult: {
+        created: [],
+        updated: [],
+        unchanged: [],
+        errors: [{ slug: "authors", error: "write failed" }],
+      },
+    });
+    const { reloadNextlyConfig } = await import("../reload-config");
+    await reloadNextlyConfig({ resolver });
+
+    // The control that this reload took the no-DDL landing at all.
+    expect(pipelineApplySpy).not.toHaveBeenCalled();
+    expect(setDeferredCollectionsSpy).not.toHaveBeenCalled();
+  });
+
+  it("DOES clear refusals when that same sync reports no errors", async () => {
+    // The control the refusal above needs: without it, "do not clear on error"
+    // is satisfied by a branch that stopped clearing at all, which would leave
+    // every refusal standing for the life of the process.
+    loadConfigSpy.mockResolvedValue({
+      config: {
+        collections: [
+          {
+            slug: "authors",
+            tableName: "dc_authors",
+            fields: [{ name: "name", type: "text" }],
+          },
+        ],
+      },
+    });
+    introspectSpy.mockResolvedValue(
+      buildSnapshot([
+        {
+          name: "dc_authors",
+          columns: [
+            ...reservedColumns("dc_authors"),
+            { name: "name", type: "text", nullable: true },
+          ],
+        },
+      ])
+    );
+
+    const resolver = buildResolver({
+      collectionSyncResult: {
+        created: [],
+        updated: [],
+        unchanged: ["authors"],
+        errors: [],
+      },
+    });
+    const { reloadNextlyConfig } = await import("../reload-config");
+    await reloadNextlyConfig({ resolver });
+
+    expect(pipelineApplySpy).not.toHaveBeenCalled();
+    expect(setDeferredCollectionsSpy).toHaveBeenCalledWith([]);
+  });
+
   it("publishes NOTHING when the reload carries only a refusal", async () => {
     // 🔴 A reload whose only change is refused never reaches the metadata sync:
     // `hasChanges` stays false, and the metadata-only landing is gated on

--- a/packages/nextly/src/init/__tests__/reload-config.test.ts
+++ b/packages/nextly/src/init/__tests__/reload-config.test.ts
@@ -120,6 +120,10 @@ describe("reloadNextlyConfig", () => {
     introspectSpy.mockReset();
     warnSpy.mockReset();
     errorSpy.mockReset();
+    // Its call history is what several assertions read, and it lives at module
+    // scope: without this, one test's publish satisfies the next one's
+    // expectation and a "not called" assertion can never hold.
+    setDeferredCollectionsSpy.mockReset();
     pipelineApplySpy.mockResolvedValue({
       success: true,
       statementsExecuted: 1,
@@ -551,6 +555,46 @@ describe("reloadNextlyConfig", () => {
     await reloadNextlyConfig({ resolver: buildResolver() });
 
     expect(setDeferredCollectionsSpy).toHaveBeenCalledWith(["books"]);
+  });
+
+  it("publishes NOTHING when the reload carries only a refusal", async () => {
+    // 🔴 A reload whose only change is refused never reaches the metadata sync:
+    // `hasChanges` stays false, and the metadata-only landing is gated on
+    // `!deferredSchemaChange` exactly so that refused `fields` are not
+    // persisted. The registry therefore still describes the unchanged table, so
+    // nothing is ahead of anything -- and announcing a deferral here would
+    // withhold cards that work, for the rest of the session.
+    loadConfigSpy.mockResolvedValue({
+      config: {
+        collections: [
+          {
+            slug: "books",
+            tableName: "dc_books",
+            fields: [{ name: "active", type: "checkbox" }],
+          },
+        ],
+      },
+    });
+    // The live `active` column is text; the config declares a checkbox. That is
+    // the type change the gate refuses, and it is the ONLY change in the batch.
+    introspectSpy.mockResolvedValue(
+      buildSnapshot([
+        {
+          name: "dc_books",
+          columns: [
+            ...reservedColumns("dc_books"),
+            { name: "active", type: "text", nullable: true },
+          ],
+        },
+      ])
+    );
+
+    const { reloadNextlyConfig } = await import("../reload-config");
+    await reloadNextlyConfig({ resolver: buildResolver() });
+
+    // The control that this reload took the no-DDL path rather than applying.
+    expect(pipelineApplySpy).not.toHaveBeenCalled();
+    expect(setDeferredCollectionsSpy).not.toHaveBeenCalled();
   });
 
   it("publishes an EMPTY refusal set when everything applied", async () => {

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -1883,33 +1883,6 @@ async function applyReload(opts?: {
     }
   }
 
-  // 🔴 Published BEFORE either branch below returns, and on every reload, so the
-  // set describes THIS reload rather than whichever one last got far enough to
-  // say something. A reload that refuses a collection's DDL still writes that
-  // collection's new field list to the registry, because the sync payload is
-  // built from the whole config -- so anything deciding what a query may NAME
-  // has to know the difference between metadata that landed and metadata that
-  // merely persisted. Nothing else carries that: `migration_status` is written
-  // by paths that never deferred anything, which is what makes it unable to
-  // answer this.
-  //
-  // Replacing the set rather than adding to it is what makes a later successful
-  // reload clear a refusal, with nobody having to remember to.
-  //
-  // Imported dynamically rather than at the top of the module: this file sits in
-  // `init/` and the widget source refresh reaches the DI container, so a static
-  // edge from here would add to the import cycles the repository already
-  // carries. The call is on an async path that has already awaited several
-  // times, so the cost is a resolved module lookup.
-  const { setDeferredCollections } = await import(
-    "../domains/widgets/collection-sources"
-  );
-  setDeferredCollections(
-    [...deferredEntities]
-      .filter(entity => entity.startsWith("collection:"))
-      .map(entity => entity.slice("collection:".length))
-  );
-
   // No schema (DDL) changes to apply. Registry-only metadata (versions,
   // localized, status, labels, description) can still have changed, and it does
   // not surface as a schema diff — so run the idempotent metadata sync before
@@ -1954,6 +1927,24 @@ async function applyReload(opts?: {
         newConfig,
         logger
       );
+      // Every diff was zero-op and the sync ran, so the stored field lists and
+      // the physical tables are in step: nothing is ahead of its table, and a
+      // refusal recorded by an earlier reload is over. Gated on the sync having
+      // SUCCEEDED -- a failed one leaves the metadata wherever it was, which is
+      // not a statement that anything caught up.
+      //
+      // The mirror of this is the deliberate absence of any publish on the
+      // OTHER `!hasChanges` path. There the sync is skipped precisely so that
+      // refused `fields` are not persisted, so nothing moved ahead of its table
+      // and nothing landed either. Replacing the set there would clear a
+      // refusal an earlier reload correctly recorded, and take working cards
+      // away for the rest of the session.
+      if (synced.collections) {
+        const { setDeferredCollections } = await import(
+          "../domains/widgets/collection-sources"
+        );
+        setDeferredCollections([]);
+      }
       // Publish each scope's (possibly toggled) recording policy ONLY when that
       // scope's metadata sync succeeded — a `webhooks` change surfaces as no
       // schema diff, so this is the path a live opt-out/opt-in toggle flows
@@ -2333,6 +2324,28 @@ async function applyReload(opts?: {
           // Non-fatal: migration status is metadata only.
         }
       }
+
+      // 🔴 Published HERE, on the path where the metadata sync actually ran,
+      // and not before the branch above. The sync writes the new field list for
+      // every configured collection, so a collection whose DDL this reload
+      // refused now has metadata its table never received -- that, and only
+      // that, is what a consumer deciding what a query may NAME has to be told.
+      //
+      // Computing it earlier looked equivalent and was not: a reload carrying
+      // ONLY a refused change never reaches this sync at all, so its registry
+      // still describes the unchanged table, and announcing a deferral for it
+      // would withhold cards that work.
+      //
+      // Replacing the set is what lets a later reload lift a refusal: every
+      // collection not named here had its DDL applied in the same pass.
+      const { setDeferredCollections } = await import(
+        "../domains/widgets/collection-sources"
+      );
+      setDeferredCollections(
+        [...deferredEntities]
+          .filter(entity => entity.startsWith("collection:"))
+          .map(entity => entity.slice("collection:".length))
+      );
     } catch {
       // Non-fatal: DDL was applied; metadata sync failed. The next boot
       // or HMR cycle will retry via registerServices.

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -190,6 +190,27 @@ type ComponentDef = {
 };
 
 /**
+ * The slugs a metadata sync REFUSED, read defensively from an untyped result.
+ *
+ * `syncCodeFirstCollections` resolves rather than rejecting on a per-collection
+ * failure, so a caller that only catches sees a partial failure as a success.
+ * Read through a guard for the same reason its sibling below is: the surface
+ * this module holds is duck-typed, and a fake may resolve anything at all.
+ */
+function syncFailedSlugs(result: unknown): string[] {
+  if (typeof result !== "object" || result === null) return [];
+  const errors = (result as { errors?: unknown }).errors;
+  if (!Array.isArray(errors)) return [];
+  return errors
+    .map(entry =>
+      typeof entry === "object" && entry !== null
+        ? (entry as { slug?: unknown }).slug
+        : undefined
+    )
+    .filter((slug): slug is string => typeof slug === "string");
+}
+
+/**
  * The slugs a metadata sync rewrote, read defensively from an untyped result.
  *
  * `SyncResult.updated` names the rows that went through `updateCollection`,
@@ -466,7 +487,25 @@ async function syncCodeFirstMetadataOnly(
       "collectionRegistryService"
     )) as CollectionRegistrySurface;
     const payload = buildCollectionSyncPayload(newConfig.collections ?? []);
-    if (payload.length > 0) await registry.syncCodeFirstCollections(payload);
+    // 🔴 The RESULT decides, not merely the absence of a throw. This sync
+    // reports a per-collection failure by resolving a `SyncResult` carrying
+    // `errors[]`, exactly as the singles sync below does -- so awaiting it and
+    // discarding the answer read a partial failure as a clean pass. Anything
+    // gated on `collections` then acted on metadata that had not landed: the
+    // recording policies would publish against a stale field tree, and the
+    // refusal set would be cleared while a reverted collection's registry row
+    // still held fields its table never received.
+    const result =
+      payload.length > 0
+        ? await registry.syncCodeFirstCollections(payload)
+        : undefined;
+    const failed = syncFailedSlugs(result);
+    if (failed.length > 0) {
+      collections = false;
+      logger?.warn(
+        `[Nextly HMR] metadata-only collection sync failed for ${failed.join(", ")}`
+      );
+    }
   } catch (err) {
     collections = false;
     logger?.warn(

--- a/packages/nextly/src/lib/entry-heading.test.ts
+++ b/packages/nextly/src/lib/entry-heading.test.ts
@@ -22,6 +22,23 @@ describe("entryHeading", () => {
     expect(entryHeading({ title: "T", name: "N" }, null, "id-1")).toBe("T");
   });
 
+  it("skips a WHITESPACE-ONLY candidate and keeps walking", () => {
+    // 🔴 The value rule is shared for this reason. A blank heading is
+    // indistinguishable from a row that failed to load, and the entry surfaces
+    // trim before accepting -- so a `label` holding two spaces was a blank
+    // heading in the activity feed and the meaningful `subject` everywhere
+    // else. Same entry, two names.
+    expect(
+      entryHeading({ label: "   ", subject: "Re: hello" }, null, "id-1")
+    ).toBe("Re: hello");
+    // The nominated field gets the same treatment: nominating it does not make
+    // whitespace a name.
+    expect(entryHeading({ headline: "  " }, "headline", "id-1")).toBe("id-1");
+    // And an accepted value comes back TRIMMED, so the two surfaces render the
+    // same characters rather than differing by leading space.
+    expect(entryHeading({ title: "  Ada  " }, null, "id-1")).toBe("Ada");
+  });
+
   it("walks the SAME conventional names the field-level rule accepts", () => {
     // 🔴 One question, one answer. The rule that decides which column a list or
     // a generated card SELECTS accepts `label`, `subject` and `heading` beside

--- a/packages/nextly/src/lib/entry-heading.ts
+++ b/packages/nextly/src/lib/entry-heading.ts
@@ -19,7 +19,10 @@
  * @module lib/entry-heading
  */
 
-import { COMMON_TITLE_FIELDS } from "../domains/collections/entry-title";
+import {
+  COMMON_TITLE_FIELDS,
+  readableTitleText,
+} from "../domains/collections/entry-title";
 
 /**
  * The first candidate that is a usable heading, else `fallback`.
@@ -56,10 +59,8 @@ export function entryHeading<TFallback extends string | undefined>(
     ...COMMON_TITLE_FIELDS.map(name => data[name]),
   ];
   for (const candidate of candidates) {
-    if (typeof candidate === "string" && candidate.length > 0) return candidate;
-    if (typeof candidate === "number" || typeof candidate === "bigint") {
-      return String(candidate);
-    }
+    const text = readableTitleText(candidate);
+    if (text !== undefined) return text;
   }
   return fallback;
 }

--- a/packages/nextly/src/services/dashboard/__tests__/recent-entries.test.ts
+++ b/packages/nextly/src/services/dashboard/__tests__/recent-entries.test.ts
@@ -295,6 +295,20 @@ describe("recent entry headings", () => {
     ).toBe("Fallback title");
   });
 
+  it("PROJECTS every candidate the walk considers, not just title and name", async () => {
+    // 🔴 The projection and the walk are one mechanism in two places. The walk
+    // gained `label`, `subject` and `heading`; a projection still naming only
+    // `title` and `name` leaves those absent from every real read, so the walk
+    // looks widened and cannot reach them -- the dead-code state this file's
+    // projecting mock exists to catch, wearing a different shape.
+    expect(
+      await headingFor({ id: "p7", subject: "Re: hello", updatedAt: "" })
+    ).toBe("Re: hello");
+    expect(
+      await headingFor({ id: "p8", label: "Invoice 4021", updatedAt: "" })
+    ).toBe("Invoice 4021");
+  });
+
   it("keeps an ordinary string title", async () => {
     expect(
       await headingFor({ id: "p6", title: "Real title", updatedAt: "" })

--- a/packages/nextly/src/services/dashboard/dashboard-service.ts
+++ b/packages/nextly/src/services/dashboard/dashboard-service.ts
@@ -22,6 +22,7 @@ import type { SqlParam } from "@nextlyhq/adapter-drizzle/types";
 import { container } from "../../di/container";
 import { getNextly } from "../../direct-api/nextly";
 import type { CountArgs, FindArgs } from "../../direct-api/types";
+import { COMMON_TITLE_FIELDS } from "../../domains/collections/entry-title";
 import { entryHeading } from "../../lib/entry-heading";
 import { BaseService } from "../base-service";
 import type { Logger } from "../shared";
@@ -724,8 +725,8 @@ export class DashboardService extends BaseService {
         // That is not "the lifecycle filter handles locales correctly"; it
         // is that NO filter is applied, so none can be wrong for either.
         status: "all",
-        // `entryHeading`'s fallback chain is
-        // `data[titleField] ?? data.title ?? data.name`, but the Direct
+        // `entryHeading` walks the nominated field and then every conventional
+        // name in `COMMON_TITLE_FIELDS`, but the Direct
         // API's `select` is a real projection (`applyFieldSelection` in
         // `collection-query-service.ts` keeps only `id`, the system
         // timestamps, and whatever key is named here) -- so `title` and
@@ -734,13 +735,19 @@ export class DashboardService extends BaseService {
         // real read, and the chain can never do anything but return the id:
         // dead code that only "worked" in a test handing the resolver an
         // unprojected row. Selecting a field twice when `titleField` already
-        // IS `title` or `name` is harmless -- every value here is `true`.
+        // IS one of them is harmless -- every value here is `true`.
+        //
+        // 🔴 SPREAD from the same list the walk reads, not written out. A
+        // projection that names fewer candidates than the walk considers is
+        // the dead-code state above wearing a different shape: the walk looks
+        // widened and every candidate it gained is missing from the row.
         select: {
           id: true,
           updatedAt: true,
           [titleField]: true,
-          title: true,
-          name: true,
+          ...Object.fromEntries(
+            COMMON_TITLE_FIELDS.map(name => [name, true] as const)
+          ),
           ...(coll.hasStatus ? { status: true } : {}),
         },
       });


### PR DESCRIPTION
Three fixes that share a cause: a question with more than one implementation.

## A commit stranded by the #1483 merge

`dde5dedbe` was pushed while GitHub was computing that merge, so it landed on the branch and not on `main`. Verified by CONTENT with a must-be-found control rather than by merge state: the marker is absent from merge commit `9a4bfb5fe` and present on the branch tip.

It is recovered here as the first commit. Without it, `main` announces a schema refusal on a reload that carries **only** a refused change — a path that skips the metadata sync by design (`if (!deferredSchemaChange)`, with a comment saying syncing there "would persist `fields` that disagree with the physical table"). Its registry still describes the unchanged table, so nothing is ahead of anything, and announcing a deferral withheld generated cards that were working for the rest of the session.

The announcement now happens only where the sync actually ran:

| Path | Publishes |
| --- | --- |
| After a successful apply | the refused collections — exactly those whose metadata advanced without DDL |
| Metadata-only landing | an empty set, gated on the sync having succeeded |
| Refused, no DDL | nothing — clearing here would drop a refusal an earlier reload correctly recorded |

## One rule for whether a value can name an entry

Three spellings, disagreeing in three different ways:

| implementation | whitespace-only | number | bigint |
| --- | --- | --- | --- |
| `entry-title.readableText` | rejects | accepts | rejects |
| `useVersionDocumentTitle.readableText` | rejects | **rejects** | rejects |
| `entryHeading` inline walk | **accepts** | accepts | accepts |

**Only the whitespace difference was reachable**, and codex was right to press on that — an earlier revision of this description claimed the number difference was user-visible and it is not. `ApiSingle.label` is typed `string`, and the version heading is the only caller of the copy that refused numbers, so no supported Single can produce one. The test asserting that has been removed rather than reworded: a green from an impossible input reads as coverage.

What IS reachable: a row whose `label` held two spaces was headed with those two spaces in the activity feed and with its `subject` everywhere else. And a rule with four spellings drifts in directions nothing happens to exercise until a consumer finds one — which is what this finding was an instance of, so the convergence stays on that ground.

`readableTitleText` now lives beside `entryTitleField` — which FIELD names an entry and whether that field's VALUE can name one are halves of one question — and all three callers ask it. The bigint case is real: an id past `MAX_SAFE_INTEGER` arrives from the driver as one.

## A projection that had drifted from its walk

`dashboard-service` names its fallback candidates explicitly, because the Direct API's `select` is a real projection and an unnamed candidate is simply absent from the row. Its own comment says so — an unprojected chain is "dead code that only 'worked' in a test handing the resolver an unprojected row".

The walk gained `label`, `subject` and `heading`; the projection stayed at `title` and `name`. Those three could never be reached. It now spreads from the same list the walk reads.

## Verification

Every behaviour change is break-verified against a wrong implementation rather than a mutation, and each break moved only its own test:

- restoring the unconditional pre-branch publish → fails `publishes NOTHING when the reload carries only a refusal`
- restoring the private untrimmed walk → fails `skips a WHITESPACE-ONLY candidate and keeps walking`
- narrowing the projection to `title`/`name` → fails `PROJECTS every candidate the walk considers`
- discarding the sync result again → fails `does NOT clear refusals when the metadata sync reports per-slug errors`, and only that one

Gates, each status read on its own line rather than through a pipe: `nextly` check-types 0, lint 0, **871 files / 11035 tests**; `admin` check-types 0, lint 0, **391 files / 3821 tests**; comment convention 0 across all six touched directories; `fallow audit --base origin/main` **passes** with every `*_introduced` at 0 over 12 changed files.

A pre-push run failed six files at `Test timed out in 10000ms` under turbo's concurrent build — none of them a file this branch touches. Re-run alone: 6 files / 157 tests, exit 0. Load, not a regression.

## Deliberately not here

- **Per-row title fallback in generated cards** (codex, open on #1483). Real. The fix needs `WidgetSource` to carry ordered title *candidates* rather than one resolved field, plus a renderer change — a published-type change that wants its own review. `dashboard-service` already demonstrates the pattern to copy.
- **A fourth copy of the title list** in `collection-bulk-service`, missing `heading`, so duplicating an entry titled by that field yields a copy indistinguishable from its original. Converged, then reverted: that harness builds its own mutation service, so there is no seam to assert the outcome on, and an unverified change is worse than a filed one.