### PR TITLE
feat(nextly): generated types declare the publish lifecycle

### DIFF
--- a/.changeset/generated-types-declare-the-lifecycle.md
+++ b/.changeset/generated-types-declare-the-lifecycle.md
@@ -1,0 +1,50 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Generated types and Zod schemas now declare the publish lifecycle.
+
+A collection or Single that sets `status: true` carries a draft/published
+column, and the generated artifacts said nothing about it — so a consumer of
+your generated types could not tell a draft from a published entry, which is
+the one distinction the lifecycle exists to express.
+
+Both artifacts now emit `status: "draft" | "published"` for those records, and
+nothing at all for the ones that do not declare it.
+
+The set comes from `LIFECYCLE_STATUSES` rather than being typed out, because
+its own docblock says it is stated once so that callers rejecting other values
+do not write the rejection from memory. Adding a status there now widens the
+generated type and the generated validator together.
+
+It is deliberately NOT `VersionStatus`. That union also carries `"unpublished"`,
+which describes a row in the version history rather than an entry, and no entry
+is ever written with it — offering it would send consumers down a branch that
+cannot occur.
+
+The member is neither optional nor nullable: the column is `NOT NULL DEFAULT
+'draft'`, so a read always has a value.

--- a/packages/nextly/src/domains/schema/services/generated-lifecycle.test.ts
+++ b/packages/nextly/src/domains/schema/services/generated-lifecycle.test.ts
@@ -43,8 +43,7 @@ describe("the rendered members", () => {
   it("is neither optional nor nullable", () => {
     // The column is NOT NULL DEFAULT 'draft', so a read always has a value.
     // Offering `?` or `| null` would describe a state the database cannot
-    // produce, which is the same error this module's neighbour fixed in the
-    // opposite direction for nullable columns.
+    // produce.
     expect(lifecycleStatusMember()).not.toContain("status?:");
     expect(lifecycleStatusMember()).not.toContain("| null");
   });
@@ -53,7 +52,7 @@ describe("the rendered members", () => {
 describe("a collection that declares the lifecycle", () => {
   it("gets it in BOTH generated artifacts", () => {
     // Both, because a payload valid against one must be valid against the
-    // other — the drift that produced this file's neighbour.
+    // other.
     const ts = new TypeGenerator().generateTypesFile([collection(true)]).code;
     const zod = new ZodGenerator().generateSchema(collection(true)).code;
 

--- a/packages/nextly/src/domains/schema/services/generated-lifecycle.test.ts
+++ b/packages/nextly/src/domains/schema/services/generated-lifecycle.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+import type { DynamicCollectionRecord } from "../../../schemas/dynamic-collections/types";
+import type { DynamicSingleRecord } from "../../../schemas/dynamic-singles/types";
+import {
+  hasLifecycleStatus,
+  lifecycleStatusMember,
+  lifecycleStatusZodMember,
+} from "./generated-lifecycle";
+import { TypeGenerator } from "./type-generator";
+import { ZodGenerator } from "./zod-generator";
+
+const collection = (status?: boolean) =>
+  ({
+    slug: "posts",
+    labels: { singular: "Post", plural: "Posts" },
+    fields: [{ name: "title", type: "text", required: true }],
+    timestamps: true,
+    ...(status === undefined ? {} : { status }),
+  }) as unknown as DynamicCollectionRecord;
+
+describe("hasLifecycleStatus", () => {
+  it("is true only when the record declares it", () => {
+    expect(hasLifecycleStatus({ status: true })).toBe(true);
+    expect(hasLifecycleStatus({ status: false })).toBe(false);
+    // The DEFAULT, which is the state most likely to go untested: `status` is
+    // optional and absent on most collections.
+    expect(hasLifecycleStatus({})).toBe(false);
+  });
+});
+
+describe("the rendered members", () => {
+  it("states the union from LIFECYCLE_STATUSES rather than from memory", () => {
+    // Pinned deliberately. If a status is added to `LIFECYCLE_STATUSES` this
+    // test fails, which is the prompt to decide whether the new value belongs
+    // in a generated entry type — not something to discover from a user report.
+    expect(lifecycleStatusMember()).toBe('  status: "draft" | "published";');
+    expect(lifecycleStatusZodMember()).toBe(
+      '  status: z.enum(["draft", "published"]),'
+    );
+  });
+
+  it("is neither optional nor nullable", () => {
+    // The column is NOT NULL DEFAULT 'draft', so a read always has a value.
+    // Offering `?` or `| null` would describe a state the database cannot
+    // produce, which is the same error this module's neighbour fixed in the
+    // opposite direction for nullable columns.
+    expect(lifecycleStatusMember()).not.toContain("status?:");
+    expect(lifecycleStatusMember()).not.toContain("| null");
+  });
+});
+
+describe("a collection that declares the lifecycle", () => {
+  it("gets it in BOTH generated artifacts", () => {
+    // Both, because a payload valid against one must be valid against the
+    // other — the drift that produced this file's neighbour.
+    const ts = new TypeGenerator().generateTypesFile([collection(true)]).code;
+    const zod = new ZodGenerator().generateSchema(collection(true)).code;
+
+    expect(ts).toContain('  status: "draft" | "published";');
+    expect(zod).toContain('  status: z.enum(["draft", "published"]),');
+  });
+
+  it("does not carry the version-history status", () => {
+    // `VersionStatus` also has "unpublished", which describes a row in the
+    // version history and is never written to an entry. Offering it would send
+    // consumers down a branch that cannot occur.
+    const ts = new TypeGenerator().generateTypesFile([collection(true)]).code;
+    expect(ts).not.toContain("unpublished");
+  });
+});
+
+describe("a collection that does not", () => {
+  it("gets no status member in either artifact", () => {
+    // The default state. A generator that emitted the lifecycle unconditionally
+    // would type a column these tables do not have.
+    const ts = new TypeGenerator().generateTypesFile([collection()]).code;
+    const zod = new ZodGenerator().generateSchema(collection()).code;
+
+    expect(ts).not.toContain("status:");
+    expect(zod).not.toContain("status:");
+  });
+
+  it("gets none when it declares status: false either", () => {
+    const ts = new TypeGenerator().generateTypesFile([collection(false)]).code;
+    expect(ts).not.toContain("status:");
+  });
+});
+
+describe("a Single", () => {
+  it("declares the lifecycle on the same flag a collection does", () => {
+    const single = {
+      slug: "site-settings",
+      label: "Site Settings",
+      fields: [{ name: "title", type: "text", required: true }],
+      status: true,
+    } as unknown as DynamicSingleRecord;
+
+    const ts = new TypeGenerator().generateTypesFile([], [single]).code;
+    expect(ts).toContain('  status: "draft" | "published";');
+  });
+});

--- a/packages/nextly/src/domains/schema/services/generated-lifecycle.ts
+++ b/packages/nextly/src/domains/schema/services/generated-lifecycle.ts
@@ -1,0 +1,48 @@
+import { LIFECYCLE_STATUSES } from "../../../lib/status-transition";
+
+/**
+ * How the publish lifecycle is written into the artifacts `generate:types`
+ * emits.
+ *
+ * A collection or Single that declares `status: true` carries a
+ * draft/published column, and its generated type said nothing about it — so a
+ * consumer of the generated types could not tell a draft from a published
+ * entry, which is the one distinction the whole lifecycle exists to express.
+ *
+ * **The set is not restated here.** `LIFECYCLE_STATUSES` is the source, and its
+ * own docblock says why: it is stated once because callers that reject anything
+ * else must not write the rejection from memory. Adding a value there widens
+ * the generated type and the generated validator together; typing the union out
+ * in either generator would make it a second answer that agrees only until
+ * someone edits one of them.
+ *
+ * **Not `VersionStatus`, deliberately.** That union carries `"unpublished"` as
+ * well, and it describes a row in the version HISTORY rather than an entry. No
+ * entry is ever written with it — measured across `domains/collections`, with
+ * the companion default on the same paths as the control proving the search
+ * finds things. Offering it on an entry type would send consumers down a branch
+ * that cannot occur.
+ */
+
+/** Whether this collection or Single carries a draft/published column. */
+export function hasLifecycleStatus(record: { status?: boolean }): boolean {
+  return record.status === true;
+}
+
+/**
+ * The TypeScript member for the status column.
+ *
+ * Not optional and not nullable: the column is `NOT NULL DEFAULT 'draft'`, so a
+ * read always has a value and offering `undefined` or `null` would describe a
+ * state the database cannot produce.
+ */
+export function lifecycleStatusMember(): string {
+  const union = LIFECYCLE_STATUSES.map(status => `"${status}"`).join(" | ");
+  return `  status: ${union};`;
+}
+
+/** The Zod member for the same column, in that generator's dialect. */
+export function lifecycleStatusZodMember(): string {
+  const values = LIFECYCLE_STATUSES.map(status => `"${status}"`).join(", ");
+  return `  status: z.enum([${values}]),`;
+}

--- a/packages/nextly/src/domains/schema/services/type-generator.ts
+++ b/packages/nextly/src/domains/schema/services/type-generator.ts
@@ -48,6 +48,10 @@ import { currentFieldGroupTypeKey } from "../../field-groups/storage/field-group
 
 import { renderFieldMember } from "./field-nullability";
 import {
+  hasLifecycleStatus,
+  lifecycleStatusMember,
+} from "./generated-lifecycle";
+import {
   asScalarStorageField,
   pluginDeclaredImportNames,
   asStorageEquivalentField,
@@ -500,6 +504,12 @@ export class TypeGenerator {
       lines.push("  updatedAt: string;");
     }
 
+    // The publish lifecycle, when this collection declares one. Without it a
+    // consumer of these types cannot tell a draft from a published entry.
+    if (hasLifecycleStatus(collection)) {
+      lines.push(lifecycleStatusMember());
+    }
+
     lines.push("}");
 
     return {
@@ -578,6 +588,11 @@ export class TypeGenerator {
 
     // Singles always have updatedAt (no createdAt)
     lines.push("  updatedAt: string;");
+
+    // A Single declares the lifecycle on the same flag a collection does.
+    if (hasLifecycleStatus(single)) {
+      lines.push(lifecycleStatusMember());
+    }
 
     lines.push("}");
 

--- a/packages/nextly/src/domains/schema/services/zod-generator.ts
+++ b/packages/nextly/src/domains/schema/services/zod-generator.ts
@@ -39,6 +39,10 @@ import type { DynamicCollectionRecord } from "../../../schemas/dynamic-collectio
 
 import { fieldAdmitsNull } from "./field-nullability";
 import {
+  hasLifecycleStatus,
+  lifecycleStatusZodMember,
+} from "./generated-lifecycle";
+import {
   asScalarStorageField,
   pluginDeclaredImportNames,
   isPluginDataField,
@@ -354,6 +358,12 @@ export class ZodGenerator {
     if (collection.timestamps) {
       lines.push(`  createdAt: z.string().datetime(),`);
       lines.push(`  updatedAt: z.string().datetime(),`);
+    }
+
+    // The same lifecycle the TypeScript interface declares, so a payload valid
+    // against one is valid against the other.
+    if (hasLifecycleStatus(collection)) {
+      lines.push(lifecycleStatusZodMember());
     }
 
     lines.push(`});`);


### PR DESCRIPTION
Closes `task:codegen-publish-lifecycle`.

## The gap

A collection or Single that sets `status: true` carries a draft/published column. The generated artifacts said nothing about it, so a consumer of your generated types **could not tell a draft from a published entry** — the one distinction the whole lifecycle exists to express.

Both artifacts now emit `status: "draft" | "published"` for those records, and nothing for the ones that do not declare it.

## Two corrections to the task as filed

The ticket named `_status` and `publishedAt`. Both were wrong, and I measured rather than implementing what it said.

- **`publishedAt` is not a system column on an entry at all.** It belongs to the releases domain (`releases-repository.ts:126`) and, in the SEO docs, to a user's *own* field (`post.publishedAt`). Emitting it would have invented a key that does not exist.
- **`_status` is the per-locale companion column.** The flag an author sets and a reader sees is `status` (`dynamic-collections/types.ts:425`).

## The union is not `VersionStatus`

`VersionStatus` is `"draft" | "published" | "unpublished"`. The third value describes a row in the version **history**, never an entry.

Measured across `domains/collections` with a must-be-found control on the same paths (`COMPANION_DEFAULT_STATUS` resolves there), so the empty result is a real absence rather than a broken search. Offering `"unpublished"` on an entry type would send consumers down a branch that cannot occur.

The set comes from **`LIFECYCLE_STATUSES`** (`lib/status-transition.ts:28`), which already exists for exactly this and whose own docblock says why:

> *Stated once because two callers need to REJECT anything else, and a rejection written from memory is a second answer to this question.*

This is the third caller. Adding a status there now widens the generated type and the generated validator together, rather than leaving them to agree by coincidence.

## Neither optional nor nullable

The column is `NOT NULL DEFAULT 'draft'`, so a read always has a value. This is the same question `field-nullability.ts` answers in the opposite direction for nullable columns, and asserting it explicitly keeps the two from drifting.

## Evidence

Each test break-verified **alone**:

| wrong implementation | what fails |
| --- | --- |
| emit the lifecycle unconditionally | the three **default-state** guards — no `status` declared, and `status: false` — nothing else |
| swap in `VERSION_STATUSES` | four, including the one asserting an entry never carries the version-history value |

**The default state is asserted deliberately.** `status` is optional and absent on most collections, so a generator emitting the lifecycle unconditionally would type a column those tables do not have — and no positive test could see it.

- `vitest run src/domains/schema src/direct-api/types` — **1465 passed, 126 files**
- `pnpm --filter nextly check-types` — exit 0
- `pnpm --filter @nextlyhq/admin check-types` — exit 0
- `pnpm --filter nextly lint` — exit 0
- `npx changeset status` — exit 0 (present is not the same as parseable)

Changeset covers all 25 lockstep packages, derived from `.changeset/config.json`'s `fixed` group rather than typed out.

## Base

Cut from `main`, not stacked on #1490 — a feature-branch base makes `ci.yml` and `integration.yml` skip entirely (`branches: [main]`), which would show green checks that never ran. Verified to build and pass on this base rather than only on the branch it was written against.
