### PR TITLE
fix(nextly): read the sync's reported failures on the post-DDL path too

### DIFF
--- a/.changeset/post-ddl-sync-reported-errors.md
+++ b/.changeset/post-ddl-sync-reported-errors.md
@@ -1,0 +1,36 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Hold a collection's handlers back when the metadata sync REPORTS a failure
+after the DDL, not only when it throws.
+
+The sync answers a per-collection failure by resolving with `errors[]` rather
+than rejecting. The post-DDL landing read only the rejection, so a partial
+failure published handlers and recording policies against a field tree the
+registry had not accepted — the state the rejection branch beside it already
+existed to prevent, reached by the shape it did not catch.

--- a/packages/nextly/src/init/__tests__/reload-config.test.ts
+++ b/packages/nextly/src/init/__tests__/reload-config.test.ts
@@ -2233,6 +2233,79 @@ describe("reloadNextlyConfig", () => {
       expect(edited).not.toHaveBeenCalled();
     });
 
+    it("holds hooks back when the post-DDL sync REPORTS a failure rather than throwing", async () => {
+      // 🔴 The same sync answers two ways. A rejection was already handled; a
+      // per-collection failure RESOLVES with `errors[]`, and the post-DDL path
+      // read only the rejection -- so a partial failure published handlers
+      // against a field tree the registry had not accepted, which is exactly
+      // what the test above exists to prevent for the other shape.
+      const registry = getHookRegistry();
+      const original = vi.fn(() => undefined);
+      const edited = vi.fn(() => undefined);
+      const { reloadNextlyConfig } = await import("../reload-config");
+
+      // An additive second collection, so this reload reaches the POST-DDL
+      // landing rather than the metadata-only one. Without it the sync under
+      // test is not the one that runs.
+      const withAdditive = (hook: () => undefined) => ({
+        collections: [
+          settledCollection({ afterRead: [hook] }),
+          {
+            slug: "hookauthors",
+            tableName: "dc_hookauthors",
+            fields: [{ name: "name", type: "text" }],
+          },
+        ],
+      });
+      const settleBoth = (): void => {
+        introspectSpy.mockResolvedValue(
+          buildSnapshot([
+            {
+              name: TABLE,
+              columns: [
+                ...reservedColumns(TABLE),
+                { name: "body", type: "text", nullable: true },
+              ],
+            },
+            {
+              name: "dc_hookauthors",
+              columns: reservedColumns("dc_hookauthors"),
+            },
+          ])
+        );
+      };
+
+      settleBoth();
+      loadConfigSpy.mockResolvedValue({ config: withAdditive(original) });
+      await reloadNextlyConfig({ resolver: buildResolver() });
+      // The control: a healthy reload of the SAME shape installs the handler,
+      // so the assertion below is about the reported failure rather than about
+      // this path never publishing at all.
+      expect(registry.getHookCount("afterRead", SLUG)).toBe(1);
+
+      settleBoth();
+      loadConfigSpy.mockResolvedValue({ config: withAdditive(edited) });
+      await reloadNextlyConfig({
+        resolver: buildResolver({
+          collectionSyncResult: {
+            created: [],
+            updated: [],
+            unchanged: [],
+            errors: [{ slug: SLUG, error: "write failed" }],
+          },
+        }),
+      });
+
+      await registry.execute("afterRead", {
+        collection: SLUG,
+        operation: "read",
+        data: {},
+        context: {},
+      });
+      expect(original).toHaveBeenCalledTimes(1);
+      expect(edited).not.toHaveBeenCalled();
+    });
+
     it("holds hooks back when a metadata-only sync fails", async () => {
       // The no-DDL path has its own sync, and it keeps the prior snapshot for
       // whatever it could not persist -- so those entities still validate and

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -2385,6 +2385,21 @@ async function applyReload(opts?: {
           .filter(entity => entity.startsWith("collection:"))
           .map(entity => entity.slice("collection:".length))
       );
+
+      // 🔴 The same reading the metadata-only landing makes, because this is
+      // the same sync answering the same way. A per-collection failure RESOLVES
+      // with `errors[]` rather than rejecting, so a `catch` alone sees a partial
+      // failure as a clean pass -- and `collectionSynced` gates two things that
+      // must not act on metadata the registry did not accept: the recording
+      // policies, and the hook publication below. Both would then run against a
+      // field tree that is not the one stored.
+      const failedCollections = syncFailedSlugs(collectionSync);
+      if (failedCollections.length > 0) {
+        collectionSynced = false;
+        logger?.warn(
+          `[Nextly HMR] collection metadata sync failed for ${failedCollections.join(", ")}`
+        );
+      }
     } catch {
       // Non-fatal: DDL was applied; metadata sync failed. The next boot
       // or HMR cycle will retry via registerServices.


### PR DESCRIPTION
Carries forward a fix written while #1491 was being merged, and answers the second of the two findings codex raised on that PR after the merge was computed.

## The finding

The metadata-only landing learned to read `SyncResult.errors` in #1491; the post-DDL landing did not. Same sync, two call sites, one of them fixed — the fix was exhaustive within an assumed scope.

`syncCodeFirstCollections` reports a per-collection failure by RESOLVING with `errors[]` rather than rejecting. The post-DDL path set `collectionSynced = false` only in its `catch`, so a partial failure read as a clean pass. That flag gates two things which must not act on metadata the registry declined:

- `republishRecordingPolicies` — the new recording decision would apply against a field tree that is not the stored one
- the hook publication — handlers published against fields serialization still ignores

Both are exactly what the rejection branch beside it already exists to prevent, reached by the shape it did not catch.

## Verification

The new test drives the REPORTED shape rather than the thrown one, and takes two controls to be worth anything:

- an additive second collection, so the reload lands on the post-DDL path at all — without it the sync under test is not the one that runs
- the handler installed first through a healthy reload of the same shape, so the assertion is about the reported failure rather than about this path never publishing

Break-verified against the wrong implementation rather than a mutation: discarding the reported errors again fails `holds hooks back when the post-DDL sync REPORTS a failure rather than throwing`, and only that one.

Gates, each status read on its own line rather than through a pipe: check-types 0, lint 0, `reload-config` 67 tests passing, comment convention 0, `fallow audit --base origin/main` **pass** with every `*_introduced` at 0 over 3 changed files.

## Note on the other open finding

Codex also raised "preserve deferrals for collections removed from config" on #1491. I am contesting that one on the merged PR rather than acting on it here: `usableCollections` gates on the status label as well as the refusal set, and a row whose metadata is ahead of its table necessarily carries `pending` — `updateCollection` sets it on every field change, and the applied-marking excludes deferred slugs — so the stated consequence, cards becoming queryable again, does not follow. The measurement is in that thread.