### PR TITLE
fix(nextly): a create may omit the status, and the name stays reserved

### DIFF
--- a/.changeset/a-create-may-omit-the-status.md
+++ b/.changeset/a-create-may-omit-the-status.md
@@ -1,0 +1,44 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A generated create input may omit the publish status, and the lifecycle name is
+reserved against column-less fields too.
+
+The base artifacts state `status` as required because a read always carries one,
+and the create artifacts are derived from them — so requiring it there made the
+generated type and the generated validator reject an ordinary status-less
+create that the API accepts and stores as a draft. The create artifacts now
+drop it from the omit list and reintroduce it optional.
+
+A column-less field named `status` — a component, or a many-to-many — was
+accepted by config validation, because the column rules exempt fields that
+occupy no column and returned before the lifecycle check. Such a field keeps
+its declared name as its payload key, so the generated interface and schema
+declared `status` twice and the generated file did not compile. The name is now
+refused before that exemption, matched on the declared name, so a column-less
+`Status` stays a distinct member.

--- a/packages/nextly/src/collections/config/validate-config.ts
+++ b/packages/nextly/src/collections/config/validate-config.ts
@@ -576,6 +576,24 @@ function validateFields(
     // Everything below is about columns, so a field that occupies none is exempt. A component or
     // a many-to-many named `Title` takes over nothing: its values live in its own table and its
     // payload key stays `Title`, distinct from the system field's `title`.
+    // The lifecycle is emitted into the generated artifacts as well as into the
+    // table: the interface and the Zod schema each declare a `status` member
+    // under the column's own name. A column-less field keeps its DECLARED name
+    // as its payload key and as its generated member, so the two collide there
+    // even though they never share a column — and the column-based exemption
+    // immediately below cannot see that, because it is about columns.
+    //
+    // Matched on the declared name rather than the converted column, because
+    // that is the key the artifacts emit: a column-less `Status` stays a
+    // distinct member and is left alone.
+    if (lifecycleEnabled && isLifecycleSystemColumn(name, "collection")) {
+      errors.push({
+        path: `${path}[${index}].name`,
+        message: `Field name '${name}' is owned by the Draft/Published lifecycle and would be declared twice in the generated types. Rename the field, or turn the lifecycle off`,
+        code: "FIELD_NAME_LIFECYCLE_RESERVED",
+      });
+      return;
+    }
     if (!fieldProducesColumn(candidate)) return;
     // A field may take over `title` or `slug` — that is the documented "user wins" behaviour —
     // but only under the column's own name. `Title` reaches the same column while staying a

--- a/packages/nextly/src/collections/config/validate-config.ts
+++ b/packages/nextly/src/collections/config/validate-config.ts
@@ -31,6 +31,8 @@ import {
 } from "../../domains/schema/services/field-column-descriptor";
 import {
   isLifecycleSystemColumn,
+  lifecycleDeclaredNameMessage,
+  lifecycleReservesDeclaredName,
   isOwnableSystemColumn,
   isReservedSystemColumn,
 } from "../../lib/system-columns";
@@ -576,20 +578,10 @@ function validateFields(
     // Everything below is about columns, so a field that occupies none is exempt. A component or
     // a many-to-many named `Title` takes over nothing: its values live in its own table and its
     // payload key stays `Title`, distinct from the system field's `title`.
-    // The lifecycle is emitted into the generated artifacts as well as into the
-    // table: the interface and the Zod schema each declare a `status` member
-    // under the column's own name. A column-less field keeps its DECLARED name
-    // as its payload key and as its generated member, so the two collide there
-    // even though they never share a column — and the column-based exemption
-    // immediately below cannot see that, because it is about columns.
-    //
-    // Matched on the declared name rather than the converted column, because
-    // that is the key the artifacts emit: a column-less `Status` stays a
-    // distinct member and is left alone.
-    if (lifecycleEnabled && isLifecycleSystemColumn(name, "collection")) {
+    if (lifecycleReservesDeclaredName(name, "collection", lifecycleEnabled)) {
       errors.push({
         path: `${path}[${index}].name`,
-        message: `Field name '${name}' is owned by the Draft/Published lifecycle and would be declared twice in the generated types. Rename the field, or turn the lifecycle off`,
+        message: lifecycleDeclaredNameMessage(name),
         code: "FIELD_NAME_LIFECYCLE_RESERVED",
       });
       return;

--- a/packages/nextly/src/domains/dynamic-collections/__tests__/column-name-agreement.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/__tests__/column-name-agreement.test.ts
@@ -460,6 +460,32 @@ describe("the publish lifecycle owns its columns while it is on", () => {
     ).filter(e => e.code === "FIELD_NAME_LIFECYCLE_RESERVED").length;
   }
 
+  it("refuses a COLUMN-LESS status field too, because the artifacts declare one", () => {
+    // A many-to-many keeps its values in its own table, so the column-collision
+    // rule exempts it and returns before the column-based lifecycle check. The
+    // generated interface and the generated schema each still declare a
+    // `status` member under that name, so the field and the lifecycle are
+    // emitted twice and the generated file does not compile.
+    // `options.relationType` is what `usesJunctionTable` reads; a top-level
+    // `hasMany` still produces a column and would be caught by the ordinary
+    // column rule instead, leaving this case unexercised.
+    const manyToMany = [
+      {
+        type: "relationship",
+        name: "status",
+        relationTo: "tags",
+        options: { relationType: "manyToMany" },
+      },
+    ];
+
+    expect({
+      on: lifecycleErrors(manyToMany, true),
+      // The control: with the lifecycle off nothing emits a status member, so
+      // the name is ordinary and must stay accepted.
+      off: lifecycleErrors(manyToMany, false),
+    }).toEqual({ on: 1, off: 0 });
+  });
+
   it("refuses a status field only when the lifecycle is enabled", () => {
     // Measured across all three generators: with the lifecycle ON a `status` field duplicates the
     // column in the created table AND the diff's desired state, so the table cannot be created.

--- a/packages/nextly/src/domains/dynamic-collections/__tests__/column-name-agreement.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/__tests__/column-name-agreement.test.ts
@@ -23,9 +23,9 @@ import {
   type SupportedDialect,
 } from "../../schema/services/field-column-descriptor";
 import { defineCollection } from "../../../collections/config/define-collection";
+import { validateSingleConfig } from "../../../singles/config/validate-single";
 import { validateCollectionConfig } from "../../../collections/config/validate-config";
 import { defineSingle } from "../../../singles/config/define-single";
-import { validateSingleConfig } from "../../../singles/config/validate-single";
 import { DynamicCollectionSchemaService } from "../services/dynamic-collection-schema-service";
 
 /** Names that reach a column, including the shapes the Builder refuses but code paths allow. */
@@ -459,6 +459,36 @@ describe("the publish lifecycle owns its columns while it is on", () => {
       } as never).errors ?? []
     ).filter(e => e.code === "FIELD_NAME_LIFECYCLE_RESERVED").length;
   }
+
+  it("refuses a column-less status field on a SINGLE as well", () => {
+    // The Single validator carries the same column-less exemption and emits the
+    // same lifecycle member, so the collision is identical there. One rule,
+    // asked by both, rather than the check living only where it was first
+    // noticed.
+    const singleErrors = (fields: unknown[], status: boolean) =>
+      (
+        validateSingleConfig({
+          slug: "settings",
+          label: "Settings",
+          status,
+          fields,
+        } as never).errors ?? []
+      ).filter(e => e.code === "FIELD_NAME_LIFECYCLE_RESERVED").length;
+
+    const manyToMany = [
+      {
+        type: "relationship",
+        name: "status",
+        relationTo: "tags",
+        options: { relationType: "manyToMany" },
+      },
+    ];
+
+    expect({
+      on: singleErrors(manyToMany, true),
+      off: singleErrors(manyToMany, false),
+    }).toEqual({ on: 1, off: 0 });
+  });
 
   it("refuses a COLUMN-LESS status field too, because the artifacts declare one", () => {
     // A many-to-many keeps its values in its own table, so the column-collision

--- a/packages/nextly/src/domains/schema/services/generated-lifecycle.test.ts
+++ b/packages/nextly/src/domains/schema/services/generated-lifecycle.test.ts
@@ -99,3 +99,43 @@ describe("a Single", () => {
     expect(ts).toContain('  status: "draft" | "published";');
   });
 });
+
+describe("create inputs may omit the status", () => {
+  // The column is NOT NULL with a default of 'draft', so a create that says
+  // nothing about the lifecycle is accepted and stored as a draft. The base
+  // interface states it as REQUIRED because a read always carries one, and the
+  // create artifacts are derived from that interface -- so without this the
+  // generated type and validator would both reject `{ title: "A" }`, which the
+  // runtime accepts.
+  it("drops it from the TypeScript Omit and re-adds it optional", () => {
+    const ts = new TypeGenerator().generateTypesFile([collection(true)]).code;
+
+    expect(ts).toMatch(/CreateInput = Omit<\w+, [^>]*"status">/);
+    expect(ts).toMatch(/& \{ status\?: \w+\["status"\] \}/);
+  });
+
+  it("marks it partial in the Zod create schema", () => {
+    const zod = new ZodGenerator().generateSchema(collection(true)).code;
+
+    expect(zod).toContain("CreateInputSchema");
+    expect(zod).toContain(".partial({ status: true })");
+  });
+
+  it("leaves the create artifacts alone when there is no lifecycle", () => {
+    // The default state again: a collection without the lifecycle must not gain
+    // a status omission or a partial that names a member it does not have.
+    const ts = new TypeGenerator().generateTypesFile([collection()]).code;
+    const zod = new ZodGenerator().generateSchema(collection()).code;
+
+    expect(ts).not.toContain('"status"');
+    expect(zod).not.toContain(".partial({ status: true })");
+  });
+
+  it("still requires it on the base artifacts, which describe a read", () => {
+    const ts = new TypeGenerator().generateTypesFile([collection(true)]).code;
+    const zod = new ZodGenerator().generateSchema(collection(true)).code;
+
+    expect(ts).toContain('  status: "draft" | "published";');
+    expect(zod).toContain('  status: z.enum(["draft", "published"]),');
+  });
+});

--- a/packages/nextly/src/domains/schema/services/generated-lifecycle.ts
+++ b/packages/nextly/src/domains/schema/services/generated-lifecycle.ts
@@ -46,3 +46,16 @@ export function lifecycleStatusZodMember(): string {
   const values = LIFECYCLE_STATUSES.map(status => `"${status}"`).join(", ");
   return `  status: z.enum([${values}]),`;
 }
+
+/**
+ * How a generated create schema closes its `omit({...})` call.
+ *
+ * A create may omit the status and take the column's default, while the base
+ * schema requires it because a read always carries one — so the create schema
+ * marks that one key partial.
+ */
+export function lifecycleCreateSchemaClosing(record: {
+  status?: boolean;
+}): string {
+  return hasLifecycleStatus(record) ? `}).partial({ status: true });` : `});`;
+}

--- a/packages/nextly/src/domains/schema/services/type-generator.ts
+++ b/packages/nextly/src/domains/schema/services/type-generator.ts
@@ -1280,8 +1280,20 @@ ${properties}
       omitFields.push("createdAt", "updatedAt");
     }
 
+    // The lifecycle column is NOT NULL with a default, so a read always has a
+    // value and the interface states it as required. A CREATE may omit it and
+    // take the default, so it is dropped from the `Omit` and reintroduced as an
+    // optional member rather than inherited as a required one.
+    const createOmits = hasLifecycleStatus(collection)
+      ? [...omitFields, "status"]
+      : omitFields;
+    const createBase = `Omit<${interfaceName}, ${createOmits.map(f => `"${f}"`).join(" | ")}>`;
     lines.push(
-      `export type ${interfaceName}CreateInput = Omit<${interfaceName}, ${omitFields.map(f => `"${f}"`).join(" | ")}>;`
+      `export type ${interfaceName}CreateInput = ${
+        hasLifecycleStatus(collection)
+          ? `${createBase} & { status?: ${interfaceName}["status"] }`
+          : createBase
+      };`
     );
     lines.push("");
 

--- a/packages/nextly/src/domains/schema/services/zod-generator.ts
+++ b/packages/nextly/src/domains/schema/services/zod-generator.ts
@@ -40,6 +40,7 @@ import type { DynamicCollectionRecord } from "../../../schemas/dynamic-collectio
 import { fieldAdmitsNull } from "./field-nullability";
 import {
   hasLifecycleStatus,
+  lifecycleCreateSchemaClosing,
   lifecycleStatusZodMember,
 } from "./generated-lifecycle";
 import {
@@ -391,7 +392,7 @@ export class ZodGenerator {
     for (const field of omitFields) {
       lines.push(`  ${field}: true,`);
     }
-    lines.push(`});`);
+    lines.push(lifecycleCreateSchemaClosing(collection));
     lines.push("");
 
     // Update input schema (all optional except id)

--- a/packages/nextly/src/lib/system-columns.ts
+++ b/packages/nextly/src/lib/system-columns.ts
@@ -480,6 +480,36 @@ export function isLifecycleSystemColumn(
   );
 }
 
+/**
+ * Whether the lifecycle already emits a member under this DECLARED name.
+ *
+ * Distinct from the column question. A field that occupies no column — a
+ * component, a many-to-many — is exempt from every column rule because its
+ * values live in its own table, but it keeps its declared name as its payload
+ * key and as its member in the generated types and schemas. The lifecycle emits
+ * a member under the column's own name, so the two are declared twice there
+ * even though they never share a column.
+ *
+ * Matched on the declared name rather than the converted column, because that
+ * is the key the artifacts emit: a column-less `Status` stays a distinct member
+ * and is left alone, while a column-producing one is caught by the column rule.
+ *
+ * Stated once because both the collection and the Single validator ask it, and
+ * an answer written twice is one that can drift.
+ */
+export function lifecycleReservesDeclaredName(
+  name: string,
+  entity: SystemColumnEntity,
+  lifecycleEnabled: boolean
+): boolean {
+  return lifecycleEnabled && isLifecycleSystemColumn(name, entity);
+}
+
+/** The refusal both validators report for {@link lifecycleReservesDeclaredName}. */
+export function lifecycleDeclaredNameMessage(name: string): string {
+  return `Field name '${name}' is owned by the Draft/Published lifecycle and would be declared twice in the generated types. Rename the field, or turn the lifecycle off`;
+}
+
 /** The names a validator on `surface` refuses for an author's own field. */
 export function reservedSystemFieldNames(
   surface: ReservationSurface

--- a/packages/nextly/src/singles/config/validate-single.ts
+++ b/packages/nextly/src/singles/config/validate-single.ts
@@ -29,6 +29,8 @@ import {
 } from "../../domains/schema/services/field-column-descriptor";
 import {
   isLifecycleSystemColumn,
+  lifecycleDeclaredNameMessage,
+  lifecycleReservesDeclaredName,
   isOwnableSystemColumn,
   isReservedSystemColumn,
 } from "../../lib/system-columns";
@@ -357,6 +359,14 @@ function validateFields(
     // Everything below is about columns, so a field that occupies none is exempt. A component or
     // a many-to-many named `Title` takes over nothing: its values live in its own table and its
     // payload key stays `Title`, distinct from the system field's `title`.
+    if (lifecycleReservesDeclaredName(name, "single", lifecycleEnabled)) {
+      errors.push({
+        path: `${path}[${index}].name`,
+        message: lifecycleDeclaredNameMessage(name),
+        code: "FIELD_NAME_LIFECYCLE_RESERVED",
+      });
+      return;
+    }
     if (!fieldProducesColumn(candidate)) return;
     // A field may take over `title` or `slug` — the documented "user wins" behaviour — but only
     // under the column's own name. `Title` reaches the same column while staying a different


### PR DESCRIPTION
Follow-up to #1492. **This commit was stranded** — pushed after GitHub had computed #1492's merge, so that PR merged at head `2e65d189b` and these fixes never reached `main`.

**`main` currently carries the regression.** Verified by content, not by merge state:

```
on origin/main:  hasLifecycleStatus            1   ← the feature landed
on origin/main:  createOmits                   0   ← the fix did not
on origin/main:  lifecycleCreateSchemaClosing  0   ← nor did it
on origin/main:  isLifecycleSystemColumn(name) 0   ← nor did it
control:         validate-config.ts          744 lines, readable
```

So on `main` today, any collection with `status: true` generates a `CreateInput` and a `CreateInputSchema` that **require** `status` — rejecting an ordinary `{ title: "A" }` that the API accepts and stores as a draft.

## What it fixes

Both findings Codex raised on #1492, each a regression that PR introduced.

**P1 — create artifacts rejected what the API accepts.** The create artifacts *derive* from the base (`Omit` for TypeScript, `.omit()` for Zod), so stating `status` as required on the base made it required on create. The column is `NOT NULL DEFAULT 'draft'`, so the runtime accepts a status-less create.

The base artifacts still require it, because a read always carries one. The create artifacts drop it from the omit list and reintroduce it optional:

```ts
export type PostCreateInput = Omit<Post, "id" | "createdAt" | "updatedAt" | "status"> & { status?: Post["status"] };
export const PostCreateInputSchema = PostSchema.omit({ id: true, createdAt: true, updatedAt: true }).partial({ status: true });
```

This is the same read-versus-write split the nullable-column work settled, applied to a `NOT NULL` column: there the read shape gained `| null`, here the write shape loses a requirement.

**P2 — a column-less field named `status` collided.** `validateField` returns at `if (!fieldProducesColumn(candidate)) return;` before the lifecycle check. That exemption is right for column collisions — a component or many-to-many keeps its values in its own table — and wrong here, because a column-less field keeps its declared name as its payload key and the artifacts now emit a `status` member under that name, so it is declared twice and the generated file does not compile.

The name is refused before that exemption. The two checks stay separate because they answer different questions: a column-producing field collides on the **column**, a column-less one on the **artifact key**. Matching on the declared name rather than the converted column leaves a column-less `Status` alone as a distinct member, while a column-producing `Status` is still caught by the existing column rule.

## Evidence, including one test that was false coverage

**The P2 break-verify did not fail on the first attempt**, and the fixture was why: a `relationship` with a top-level `hasMany` still produces a column, so the *existing* column rule caught it and the new check was never exercised. `usesJunctionTable` reads `options.relationType`; with that shape, disabling the new check fails exactly one test, with a lifecycle-off control at zero.

- `vitest run src/domains/schema src/direct-api/types src/domains/dynamic-collections` — **1824 passed, 142 files**
- `pnpm --filter nextly check-types` — exit 0
- `pnpm --filter @nextlyhq/admin check-types` — exit 0
- `pnpm --filter nextly lint` — exit 0
- `fallow audit --base origin/main` — `warn`, `complexity_introduced: 0`; the remaining duplication is line-shift on pre-existing clones far from this diff

## No changeset

#1492 already carries the changeset for this behaviour across all 25 lockstep packages; this corrects the implementation shipped under it.
