### PR TITLE
fix(blocks-react): declare the tokens a stored stylesheet resolves against

### DIFF
--- a/.changeset/a-card-declares-what-its-colours-resolve-against.md
+++ b/.changeset/a-card-declares-what-its-colours-resolve-against.md
@@ -1,0 +1,45 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A page rendered from a stored stylesheet drew its cards as hard boxes in the
+text colour, with no fill.
+
+A consumer with no write path compiles a page once, stores the CSS and hands it
+back to the renderer. That artifact still carries every `var(--site-*)` it was
+compiled with, and the renderer withheld the whole site sheet whenever the
+site's breakpoints were not stated — so nothing declared those custom
+properties. An unresolved `var()` makes its declaration invalid at
+computed-value time, which drops each property to its INITIAL value rather than
+the site's: `transparent` for a background, and `currentColor` for a border.
+
+The withholding guarded the block-default and named-class tiers, which are
+emitted under the at-rules a site's breakpoints imply. It reached the token tier
+as well, which declares `:root { --site-*: ... }` and reads no breakpoints at
+all. Those tiers are now separated, so a page compiled without stated
+breakpoints still receives the declarations its own CSS references, and pages
+that emit no stylesheet still receive nothing.

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -518,7 +518,7 @@ export type { StyleQuery, StyleSubject } from "./style/style-origin";
 
 // The stylesheet every page of a site shares, compiled once and addressed by its content.
 export type { SiteSheetArtifact, SiteSheetInput } from "./style/site-sheet";
-export { compileSiteSheet } from "./style/site-sheet";
+export { compileSiteSheet, compileSiteTokenSheet } from "./style/site-sheet";
 // `outranksEntry` is published beside `styleOrigin` because that function
 // cannot answer every form of the question it answers: it is asked once per
 // STATE, so comparing two states' winners falls to the caller. Published, that

--- a/packages/blocks-engine/src/style/site-sheet.ts
+++ b/packages/blocks-engine/src/style/site-sheet.ts
@@ -297,13 +297,27 @@ function emitContentWidth(
 }
 
 /**
- * Compile the stylesheet every page of a site shares.
+ * The tiers that do not read `breakpoints`: font faces, tokens, content width.
  *
- * Order is the cascade, so it is fixed: font faces, then tokens, then the block-type defaults,
- * then the named classes. A page's own sheet is appended after this one, which is what lets a
- * node's own value beat a class and a class beat a block default.
+ * Separated because these three are compilable when the site's breakpoints are unknown and the
+ * block-default tier below them is not. `emitTokenBlocks` declares its custom properties under
+ * `:root` and the only at-rule it can reach for is `(prefers-color-scheme:dark)`, which is a
+ * colour-scheme query rather than a width one — so no answer about breakpoints changes a byte of
+ * what this emits. A caller holding only a compiled artifact can therefore still be handed the
+ * declarations that artifact's `var()` references resolve against, which is the whole reason this
+ * boundary is drawn here rather than left inside {@link compileSiteSheet}.
  */
-export function compileSiteSheet(input: SiteSheetInput): SiteSheetArtifact {
+function compileBreakpointIndependentTiers(
+  input: Omit<SiteSheetInput, "breakpoints">
+): {
+  blocks: string[];
+  warnings: ValidationIssue[];
+  // Carried out rather than re-derived by the caller: this file resolves the prefix once
+  // precisely so the half that DECLARES `--site-*` and the half that REFERENCES it cannot
+  // disagree, and a second `input.tokenPrefix ?? input.tokens?.prefix` beside it would be the
+  // drift that guard exists to prevent.
+  tokenPrefix: string | undefined;
+} {
   const warnings: ValidationIssue[] = [];
   const blocks: string[] = [];
 
@@ -349,6 +363,41 @@ export function compileSiteSheet(input: SiteSheetInput): SiteSheetArtifact {
   // compiling a set that omits it arrives here with the property undeclared —
   // and half of this rule is worse than none of it.
   blocks.push(emitContentWidth(declaredTokens, tokenPrefix));
+
+  return { blocks, warnings, tokenPrefix };
+}
+
+/**
+ * Compile the token declarations a stored artifact's `var()` references resolve against.
+ *
+ * For a consumer that compiles a page once, stores the CSS and hands it back: that artifact still
+ * carries every `var(--site-*)` it was compiled with, and a custom property nothing declares makes
+ * its declaration invalid at computed-value time, so the property falls to its INITIAL value
+ * rather than to the site's. The two initial values differ in kind — `background-color` is
+ * `transparent`, `border-color` is `currentColor` — so the omission does not merely mute a block,
+ * it repaints it in the text colour.
+ *
+ * The block-default and named-class tiers are deliberately absent: both are emitted under the
+ * at-rules the site's breakpoints imply, and a caller on this path has stated none.
+ */
+export function compileSiteTokenSheet(
+  input: Omit<SiteSheetInput, "breakpoints">
+): SiteSheetArtifact {
+  const { blocks, warnings } = compileBreakpointIndependentTiers(input);
+  const css = blocks.filter(block => block !== "").join("\n");
+  return { css, contentHash: hashId(css), warnings };
+}
+
+/**
+ * Compile the stylesheet every page of a site shares.
+ *
+ * Order is the cascade, so it is fixed: font faces, then tokens, then the block-type defaults,
+ * then the named classes. A page's own sheet is appended after this one, which is what lets a
+ * node's own value beat a class and a class beat a block default.
+ */
+export function compileSiteSheet(input: SiteSheetInput): SiteSheetArtifact {
+  const { blocks, warnings, tokenPrefix } =
+    compileBreakpointIndependentTiers(input);
 
   const blockBases = input.blockBases ?? {};
   const tiers = compilePageCss(documentUsingEveryType(blockBases), {

--- a/packages/blocks-react/src/blocks/card.test.tsx
+++ b/packages/blocks-react/src/blocks/card.test.tsx
@@ -10,9 +10,12 @@
  * declares them rather than repeating one here.
  */
 import type { BlockDocument } from "@nextlyhq/blocks-engine";
+import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
+import { PageRenderer } from "../page-renderer";
 import type { BlockResolver } from "../resolver";
+import { createBlockResolver } from "../resolver";
 import { resolvePageStyles } from "../styles";
 
 import { box } from "./box";
@@ -144,5 +147,81 @@ describe("the surface and border it carries", () => {
 
     expect(css).toContain("overflow: hidden");
     expect(css).toContain("border-radius: 12px");
+  });
+});
+
+/**
+ * The declarations a card's colours resolve against, on the path that has no
+ * write access to compile them.
+ *
+ * A consumer with no write path compiles a page once, stores the CSS and hands
+ * it back as `styles`. That artifact still carries every `var(--site-*)` it was
+ * compiled with, so the question is whether anything on the rendered page
+ * DECLARES them — and a custom property nothing declares makes its whole
+ * declaration invalid at computed-value time, dropping the property to its
+ * INITIAL value rather than to the site's.
+ *
+ * Which is why both colours are asserted rather than the background alone. The
+ * two initial values differ in kind: `background-color` is `transparent`, so a
+ * missing surface reads as no fill, while `border-color` is `currentColor`, so a
+ * missing border colour reads as a hairline in the TEXT colour. A card in that
+ * state is not an unstyled card, it is a hard box nobody asked for — and a test
+ * asserting only the surface passes on it.
+ */
+describe("the tokens a stored artifact resolves against", () => {
+  const DOC: BlockDocument = {
+    formatVersion: 1,
+    kind: "page",
+    nodes: [{ id: "c", type: CARD_BLOCK, version: 1, props: { as: "div" } }],
+  };
+
+  /** The page as a consumer stores it: compiled once, with no context kept. */
+  function renderFromStoredArtifact(): string {
+    const resolver = createBlockResolver([...coreBlocks]);
+    const stored = resolvePageStyles(
+      DOC,
+      undefined,
+      {
+        breakpoints: {
+          viewport: [{ id: "base", label: "Desktop" }],
+          container: [],
+        },
+      },
+      resolver
+    );
+    return renderToStaticMarkup(
+      <PageRenderer document={DOC} blocks={resolver} styles={stored} />
+    );
+  }
+
+  it("REFERENCES both colours, which is what makes the next case meaningful", () => {
+    // The precondition, asserted rather than assumed: if the card stopped
+    // emitting these references the declarations below would be pointless, and
+    // a test that only checked for the declarations would still pass.
+    const markup = renderFromStoredArtifact();
+
+    expect(markup).toContain("var(--site-color-surface)");
+    expect(markup).toContain("var(--site-color-border)");
+  });
+
+  it("DECLARES both colours, so neither falls back to its initial value", () => {
+    const markup = renderFromStoredArtifact();
+
+    expect(markup).toContain("--site-color-surface:");
+    expect(markup).toContain("--site-color-border:");
+  });
+
+  it("declares nothing on a page that emits no css of its own", () => {
+    // Must-differ. The token tier accompanies the CSS it exists to resolve, so a
+    // render with no stylesheet must stay silent rather than push `--site-*`
+    // onto a host that asked this renderer for markup alone. Without this the
+    // case above is satisfied by emitting the tier unconditionally, which is a
+    // different behaviour that passes the same assertion.
+    const markup = renderToStaticMarkup(
+      <PageRenderer document={DOC} blocks={createBlockResolver([])} />
+    );
+
+    expect(markup).not.toContain("--site-color-surface:");
+    expect(markup).not.toContain("<style");
   });
 });

--- a/packages/blocks-react/src/blocks/columns.test.tsx
+++ b/packages/blocks-react/src/blocks/columns.test.tsx
@@ -152,25 +152,22 @@ describe("the columns pair", () => {
 
     it("keeps the gutter on a STORED stylesheet handed back with no context", () => {
       /*
-       * The path a token reference does not survive, and the reason this gutter
-       * is a length.
+       * The gutter as a VALUE on the rendered page, on the path a consumer with
+       * no write path takes: compile once, store the artifact, hand it back as
+       * `styles`.
        *
-       * A consumer with no write path compiles once and stores the artifact,
-       * then hands it back as `styles`. `PageRenderer` withholds the site sheet
-       * when no breakpoints are stated, so nothing defines `--site-*` — while
-       * the stored page CSS still carries whatever it referenced. A `{ $token }`
-       * gutter therefore arrives as a `var()` with nothing behind it, which is
-       * invalid at computed-value time, and `gap` falls back to `normal`: zero
-       * for a grid, which is the exact defect this block was fixed for.
+       * This case was written when that path defined no `--site-*` at all, so a
+       * `{ $token }` gutter arrived as a `var()` with nothing behind it — invalid
+       * at computed-value time, `gap` falling back to `normal`, which is zero for
+       * a grid and the exact defect this block was fixed for. The renderer now
+       * emits the token tier alongside the page CSS, so that reason no longer
+       * holds and the gutter is a length only because nothing has migrated it.
        *
-       * Measured, not assumed: `core/card` is live in that state today, its
-       * `background-color: var(--site-color-surface)` reaching this path with
-       * the property undefined.
-       *
-       * So this asserts the gutter as a VALUE on the rendered page. It fails the
-       * moment the gutter becomes a token again, which is the point — the
-       * migration is waiting on the definition reaching every path a reference
-       * does, and this is what says so.
+       * Which changes what the assertion below DOES. It was a guard against a
+       * silent regression; it is now a pin, and it will fail on a migration that
+       * would render correctly. Read a failure here as the migration having
+       * happened and this case needing to assert the resolved gutter instead —
+       * not as the gutter having been lost.
        */
       const resolver = createBlockResolver([...coreBlocks]);
       const stored = resolvePageStyles(

--- a/packages/blocks-react/src/page-renderer.test.tsx
+++ b/packages/blocks-react/src/page-renderer.test.tsx
@@ -4762,17 +4762,31 @@ describe("PageRenderer", () => {
         />
       );
 
-      // The invariant is that the element closes exactly once, where this
+      // The invariant is that every element closes exactly once, where this
       // renderer put it. `<script>` remaining in the text is harmless while the
       // parser is still inside `<style>`, and asserting its absence would be
       // asserting the wrong thing; what must never happen is a second closing
       // tag letting the rest of the payload become markup.
-      expect(html.match(/<\/style>/g)).toHaveLength(1);
+      //
+      // Counted against the OPENS rather than against a fixed number: this page
+      // carries a token tier beside its own sheet, and a literal `1` here would
+      // be asserting how many tiers are emitted — so it would fail on a page
+      // that grew one and, worse, pass on a payload that smuggled a close into a
+      // page that lost one.
+      const opens = html.match(/<style[\s>]/g) ?? [];
+      const closes = html.match(/<\/style>/g) ?? [];
+      expect(opens.length).toBeGreaterThan(0);
+      expect(closes).toHaveLength(opens.length);
       expect(html).toContain("<\\/style");
-      // And the escape must not be reachable as a real close.
-      expect(
-        /<\/style[\s/>]/.test(html.slice(0, html.lastIndexOf("</style>")))
-      ).toBe(false);
+      // And no element's own body carries a close that is reachable as markup.
+      for (const element of html.match(/<style[^>]*>[\s\S]*?<\/style>/g) ??
+        []) {
+        const body = element.slice(
+          element.indexOf(">") + 1,
+          element.lastIndexOf("</style>")
+        );
+        expect(/<\/style[\s/>]/.test(body)).toBe(false);
+      }
     });
 
     it("takes the root scope from the artifact that carries it", async () => {

--- a/packages/blocks-react/src/page-renderer.tsx
+++ b/packages/blocks-react/src/page-renderer.tsx
@@ -1,5 +1,6 @@
 import {
   compileSiteSheet,
+  compileSiteTokenSheet,
   DOCUMENT_FORMAT_VERSION,
   PAGE_ROOT_CLASS,
   resolveSiteTokens,
@@ -763,59 +764,83 @@ export function PageRenderer({
   // tier is emitted under, invisibly, since each sheet is consistent on its own.
   const siteBreakpoints =
     siteStyles === false ? undefined : statedBreakpoints(shared.breakpoints);
+  // The input both compilers below are given, assembled ONCE. Breakpoints are
+  // the only member either of them disagrees about, so stating the rest twice
+  // is how the two paths would come to answer differently about a prefix or a
+  // fetch predicate while each stayed self-consistent.
+  const siteSheetInput = {
+    ...siteInput,
+    // The RESOLVED values, the same objects the page context above was
+    // given. Spreading `siteInput` alone would leave each consumer
+    // computing its own answer, which is the defect this closes.
+    ...(shared.blockBases == null ? {} : { blockBases: shared.blockBases }),
+    ...(shared.tokenPrefix == null ? {} : { tokenPrefix: shared.tokenPrefix }),
+    tokens: resolveSiteTokens(siteInput?.tokens),
+    // The SAME predicate the page sheet is compiled with, taken from the
+    // one place it is derived rather than derived again here. The class
+    // and block-default tiers are emitted verbatim into every page, so
+    // without this a stored class could name a host the node styles
+    // beside it are refused for — and this sheet is emitted first, where
+    // a later omission cannot retract it. A caller who put a predicate on
+    // `siteStyles` keeps it, matching how `effectiveCompile` treats one
+    // on the style context.
+    ...(mayFetchUrl === undefined || siteInput?.mayFetchUrl !== undefined
+      ? {}
+      : { mayFetchUrl }),
+    // The RESOLVED preview option, from the same reconciliation the page
+    // context above was given. A shared tier compiled for the published
+    // page beneath node styles compiled for a preview surface puts two
+    // answers to one breakpoint in one document.
+    // Carried into the SITE sheet as well as the page compile. A named
+    // class and a block-type default are emitted here, so an editor that
+    // asked only the page compile for forceable states gets a selected
+    // block whose hover appearance comes from a class showing nothing.
+    // ALWAYS written, rather than only when it is true. `siteInput` is
+    // spread above and can carry a preview flag of its own, so a
+    // conditional override is silently one-directional: a route turning
+    // the option OFF resolves correctly here and then loses to the value
+    // already in the spread, leaving the page sheet on published
+    // selectors while the class and block-default tiers use preview ones.
+    // Route-wins precedence has to be able to win downwards too.
+    previewStates: shared.previewStates === true,
+    ...(shared.previewContainer == null
+      ? {}
+      : { previewContainer: shared.previewContainer }),
+  };
+
   // A sheet by DEFAULT. Without one a block cannot reference a token at all —
   // a default reading `color.surface` would resolve on a route and resolve to
   // nothing here — which is why `core/card` shipped with no background.
-  // Withheld only when no breakpoints are known, because a sheet compiled
-  // against breakpoints nobody chose would put the block-default tier under
-  // at-rules the page sheet does not use.
+  //
+  // THREE outcomes, not two, because `siteBreakpoints` is undefined for two
+  // unrelated reasons and they want opposite answers. `siteStyles === false` is
+  // a caller declining the sheet, and a token tier emitted anyway would override
+  // the declining host's own custom properties. Breakpoints merely not stated is
+  // a caller who said nothing, and there the token tier is the half that must
+  // still arrive: a stored artifact carries `var(--site-*)` references whose
+  // declarations live nowhere else, and a custom property nothing declares makes
+  // its whole declaration invalid at computed-value time — so the property falls
+  // to its initial value, which for `border-color` is `currentColor` rather than
+  // nothing. Only the block-default and named-class tiers are withheld there,
+  // being the two the site's breakpoints decide the at-rules for.
+  //
+  // Paired with the page CSS rather than emitted beside every render: the token
+  // tier exists to resolve `var(--site-*)` in that CSS, so with no page sheet
+  // nothing references it, and declaring the custom properties anyway would push
+  // `--site-*` onto a host that asked this renderer for markup alone. It is also
+  // what stops a stylesheet withheld as untrustworthy from acquiring a companion
+  // sheet that the withholding was meant to suppress.
   const siteSheet =
-    siteBreakpoints === undefined
+    siteStyles === false
       ? undefined
-      : compileSiteSheet({
-          ...siteInput,
-          // The RESOLVED values, the same objects the page context above was
-          // given. Spreading `siteInput` alone would leave each consumer
-          // computing its own answer, which is the defect this closes.
-          breakpoints: siteBreakpoints,
-          ...(shared.blockBases == null
-            ? {}
-            : { blockBases: shared.blockBases }),
-          ...(shared.tokenPrefix == null
-            ? {}
-            : { tokenPrefix: shared.tokenPrefix }),
-          tokens: resolveSiteTokens(siteInput?.tokens),
-          // The SAME predicate the page sheet is compiled with, taken from the
-          // one place it is derived rather than derived again here. The class
-          // and block-default tiers are emitted verbatim into every page, so
-          // without this a stored class could name a host the node styles
-          // beside it are refused for — and this sheet is emitted first, where
-          // a later omission cannot retract it. A caller who put a predicate on
-          // `siteStyles` keeps it, matching how `effectiveCompile` treats one
-          // on the style context.
-          ...(mayFetchUrl === undefined || siteInput?.mayFetchUrl !== undefined
-            ? {}
-            : { mayFetchUrl }),
-          // The RESOLVED preview option, from the same reconciliation the page
-          // context above was given. A shared tier compiled for the published
-          // page beneath node styles compiled for a preview surface puts two
-          // answers to one breakpoint in one document.
-          // Carried into the SITE sheet as well as the page compile. A named
-          // class and a block-type default are emitted here, so an editor that
-          // asked only the page compile for forceable states gets a selected
-          // block whose hover appearance comes from a class showing nothing.
-          // ALWAYS written, rather than only when it is true. `siteInput` is
-          // spread above and can carry a preview flag of its own, so a
-          // conditional override is silently one-directional: a route turning
-          // the option OFF resolves correctly here and then loses to the value
-          // already in the spread, leaving the page sheet on published
-          // selectors while the class and block-default tiers use preview ones.
-          // Route-wins precedence has to be able to win downwards too.
-          previewStates: shared.previewStates === true,
-          ...(shared.previewContainer == null
-            ? {}
-            : { previewContainer: shared.previewContainer }),
-        });
+      : siteBreakpoints === undefined
+        ? css === ""
+          ? undefined
+          : compileSiteTokenSheet(siteSheetInput)
+        : compileSiteSheet({
+            ...siteSheetInput,
+            breakpoints: siteBreakpoints,
+          });
 
   return (
     <div className={rootClassName}>


### PR DESCRIPTION
A page rendered from a stored stylesheet drew its cards as **hard boxes in the text colour, with no fill**.

## The defect

A consumer with no write path compiles a page once, stores the CSS and hands it back as `styles`. That artifact still carries every `var(--site-*)` it was compiled with — but `PageRenderer` withheld the entire site sheet whenever the site's breakpoints were not stated, so nothing declared those properties.

An unresolved `var()` is invalid at computed-value time, which drops the property to its **initial** value rather than the site's. The two initial values differ in kind, which is why this is not simply an unstyled card:

| property | initial value | what the visitor sees |
| --- | --- | --- |
| `background-color` | `transparent` | no fill |
| `border-color` | `currentColor` | a hairline in the **text** colour |

Measured in Chrome on `main`, rendering `core/card` from a stored artifact: `backgroundColor: rgba(0, 0, 0, 0)` and `borderTopColor: rgb(17, 17, 17)` — exactly the page's text colour.

## Why the withholding was over-broad

Its stated reason is that a sheet compiled against breakpoints nobody chose would put the block-default tier under at-rules the page sheet does not use. That is true of the block-default and named-class tiers, and it does not reach the token tier: `compileSiteSheet` passes `breakpoints` to `compilePageCss` alone, and `emitTokenBlocks` takes no breakpoints at all — its only at-rule is `(prefers-color-scheme:dark)`, a colour-scheme query rather than a width one.

## The change

`compileSiteTokenSheet` compiles the breakpoint-independent tiers on their own, and the renderer now has **three** outcomes where it had two. `siteBreakpoints === undefined` was standing for two unrelated states that want opposite answers:

- `siteStyles === false` — a caller **declining** the sheet. Still receives nothing, so a host's own custom properties are not overridden.
- breakpoints merely **not stated** — a caller who said nothing. Now receives the token tier, paired with the page CSS it exists to resolve, so a render that emits no stylesheet still emits nothing rather than pushing `--site-*` onto its host.

## Verification

Measured in Chrome on the same markup, after the change: `--site-color-surface` resolves to `#f9fafb` and the computed background is `rgb(249, 250, 251)`; `--site-color-border` resolves to `#e5e7eb` and the computed border is `rgb(229, 231, 235)` — no longer the `rgb(17, 17, 17)` text colour it was collapsing to.

Three tests added in `card.test.tsx`, each break-verified by failing name:

- restoring the original defect kills **only** `DECLARES both colours`;
- widening the fix past its bound kills **only** the must-differ case `declares nothing on a page that emits no css of its own`;
- a precondition case asserts the card still **references** both colours, without which the declaration assertions would pass vacuously.

`page-renderer.test.tsx`'s style-injection case was rewritten: it asserted `</style>` appeared exactly once, which was a fact about there being one tier rather than the invariant it describes. It now counts closes against opens and checks each element's body, and was break-verified by removing the escaping in `styleTextForInjection` — 3 closes against 2 opens.

`blocks-react` 1097 tests pass; repo-wide `check-types` and `lint` 22/22; `fallow audit` passes over 5 changed files against `origin/main`.

## Follow-up, not included

This unblocks migrating the literal `1rem` gutters in `core/columns`, `core/gallery` and `core/accordion` back to `{ $token: "space.4" }`. Left out deliberately. The columns guard's rationale is corrected in a second commit, because that case is now a pin rather than a guard and will fail on a correct migration.
