### PR TITLE
fix(admin): stop an empty list counting a row it does not have

### DIFF
--- a/.changeset/an-empty-list-counts-honestly.md
+++ b/.changeset/an-empty-list-counts-honestly.md
@@ -1,0 +1,34 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+An empty paginated list no longer claims a row that is not there. The count
+line builds its range from the page and page size at one end and clamps it to
+the total at the other, so with no rows the two ends crossed and it read
+"Showing 1-0 of 0" — a range starting past its end. It now says how many there
+are, which for an empty list is none. Reachable today on a webhook endpoint's
+deliveries page, which renders the control with no rows.

--- a/packages/admin/src/components/shared/pagination/__tests__/pagination-count.test.tsx
+++ b/packages/admin/src/components/shared/pagination/__tests__/pagination-count.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+
+/**
+ * What the count line claims, which is the part of this component a reader
+ * takes at face value.
+ *
+ * The controls are exercised by the tables that mount them. What is only true
+ * HERE is the arithmetic: the range is built from `currentPage * pageSize + 1`
+ * and clamped at the other end by `totalItems`, so the two ends are computed
+ * from different things and can cross.
+ *
+ * @module components/shared/pagination/__tests__/pagination-count.test
+ */
+import { cleanup, render, screen } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { Pagination } from "../index";
+
+afterEach(cleanup);
+
+const props = {
+  currentPage: 0,
+  totalPages: 1,
+  pageSize: 20,
+  onPageChange: () => undefined,
+};
+
+describe("the count line", () => {
+  it("does not describe a first row that is not there", () => {
+    /*
+     * The range's start does not depend on the total, so on an empty list it
+     * is 1 while the clamped end is 0 — "Showing 1-0 of 0", a range whose
+     * start is past its end. Reachable today on a webhook's deliveries page,
+     * which renders this with no rows.
+     */
+    render(<Pagination {...props} totalItems={0} itemLabel="deliveries" />);
+
+    expect(screen.queryByText(/1-0/)).toBeNull();
+    expect(screen.getByText(/No deliveries/)).toBeTruthy();
+  });
+
+  it("still gives a real range when there ARE rows", () => {
+    // The control. Suppressing the range whenever it looked odd would also
+    // suppress it on every page that has one, which is the component's job.
+    render(<Pagination {...props} totalItems={42} itemLabel="entries" />);
+
+    expect(screen.getByText(/Showing/)).toBeTruthy();
+    expect(screen.getByText(/1-20/)).toBeTruthy();
+    expect(screen.getByText(/42/)).toBeTruthy();
+  });
+
+  it("clamps the range's end to the total on a partial last page", () => {
+    // The other end of the same arithmetic: page 3 of 42 items ends at 42,
+    // not at 80.
+    render(
+      <Pagination
+        {...props}
+        currentPage={2}
+        totalPages={3}
+        totalItems={42}
+        itemLabel="entries"
+      />
+    );
+
+    expect(screen.getByText(/41-42/)).toBeTruthy();
+  });
+
+  it("keeps the page-of-pages form when the total is UNKNOWN", () => {
+    /*
+     * `totalItems` is optional, and absent is not empty: a caller that cannot
+     * count says nothing about how many rows exist. Reading `!totalItems` here
+     * would collapse the two and report an unknown total as no rows.
+     */
+    const { container } = render(
+      <Pagination {...props} totalPages={7} currentPage={1} />
+    );
+
+    /*
+     * On the summary ELEMENT, not on the landmark. The landmark also contains
+     * the page-size selector, whose label reads "Rows per page" — measured,
+     * an assertion for "Page" against the landmark passes even when this line
+     * has been replaced by a broken count, which is what the first version of
+     * this test did.
+     */
+    const summary = container.querySelector('[data-slot="pagination-summary"]');
+    expect(summary?.textContent).toBe("Page 2 of 7");
+  });
+});

--- a/packages/admin/src/components/shared/pagination/__tests__/pagination-count.test.tsx
+++ b/packages/admin/src/components/shared/pagination/__tests__/pagination-count.test.tsx
@@ -78,10 +78,10 @@ describe("the count line", () => {
 
     /*
      * On the summary ELEMENT, not on the landmark. The landmark also contains
-     * the page-size selector, whose label reads "Rows per page" — measured,
-     * an assertion for "Page" against the landmark passes even when this line
-     * has been replaced by a broken count, which is what the first version of
-     * this test did.
+     * the page-size selector, whose label reads "Rows per page", so an
+     * assertion for "Page" made against the landmark is satisfied by the
+     * selector alone — it holds even with this line replaced by a broken
+     * count, or removed. The exact text of the element is what separates them.
      */
     const summary = container.querySelector('[data-slot="pagination-summary"]');
     expect(summary?.textContent).toBe("Page 2 of 7");

--- a/packages/admin/src/components/shared/pagination/index.tsx
+++ b/packages/admin/src/components/shared/pagination/index.tsx
@@ -125,6 +125,78 @@ import type { PaginationProps } from "./types";
  * />
  * ```
  */
+/**
+ * What the control says about the rows, which is the part a reader takes at
+ * face value.
+ *
+ * Its own component because the question it answers has three outcomes and the
+ * control around it has none: an unknown total, an empty list, and a range.
+ * Inline, that is three nested conditionals inside a body that is already long.
+ *
+ * ADDRESSABLE, via `data-slot`. The landmark also contains the page-size
+ * selector, whose label carries the word "page" — so an assertion made against
+ * the whole landmark matches that text and passes whatever this line says,
+ * which is how a test written for this line came to pass on a render that had
+ * lost it entirely.
+ */
+function PaginationSummary({
+  currentPage,
+  itemLabel,
+  pageSize,
+  totalItems,
+  totalPages,
+}: {
+  currentPage: number;
+  itemLabel: string;
+  pageSize: number;
+  totalItems: number | undefined;
+  totalPages: number;
+}): React.JSX.Element {
+  /*
+   * An absent total is not an empty one: a caller that cannot count says
+   * nothing about how many rows exist, and gets the page-of-pages form.
+   */
+  if (totalItems === undefined) {
+    return (
+      <div
+        className="whitespace-nowrap order-2 @2xl/content:order-1"
+        data-slot="pagination-summary"
+      >
+        Page <span className="font-semibold">{currentPage + 1}</span> of{" "}
+        <span className="font-semibold">{totalPages}</span>
+      </div>
+    );
+  }
+
+  /*
+   * A RANGE only exists when there are rows to bound. Its start is
+   * `currentPage * pageSize + 1`, which is 1 on the first page whatever the
+   * total, while its end is clamped to the total — so an empty list read
+   * "Showing 1-0 of 0", a range whose start is past its end, describing a
+   * first row that is not there.
+   *
+   * Said as a count rather than a range, because that is what an empty list
+   * has. "Showing 0-0" would be arithmetically tidy and still answer a
+   * question nobody asked.
+   */
+  return (
+    <div
+      className="whitespace-nowrap order-2 @2xl/content:order-1"
+      data-slot="pagination-summary"
+    >
+      {totalItems === 0 ? (
+        <>No {itemLabel}</>
+      ) : (
+        <>
+          Showing {currentPage * pageSize + 1}-
+          {Math.min((currentPage + 1) * pageSize, totalItems)} of {totalItems}{" "}
+          {itemLabel}
+        </>
+      )}
+    </div>
+  );
+}
+
 export const Pagination = React.forwardRef<HTMLElement, PaginationProps>(
   (
     {
@@ -322,20 +394,13 @@ export const Pagination = React.forwardRef<HTMLElement, PaginationProps>(
         )}
       >
         {/* Left: Info */}
-        <div className="whitespace-nowrap order-2 @2xl/content:order-1">
-          {totalItems !== undefined ? (
-            <>
-              Showing {currentPage * pageSize + 1}-
-              {Math.min((currentPage + 1) * pageSize, totalItems)} of{" "}
-              {totalItems} {itemLabel}
-            </>
-          ) : (
-            <>
-              Page <span className="font-semibold">{currentPage + 1}</span> of{" "}
-              <span className="font-semibold">{totalPages}</span>
-            </>
-          )}
-        </div>
+        <PaginationSummary
+          currentPage={currentPage}
+          itemLabel={itemLabel}
+          pageSize={pageSize}
+          totalItems={totalItems}
+          totalPages={totalPages}
+        />
 
         {/* Right: Controls */}
         <div className="flex flex-wrap items-center justify-center gap-4 @md/content:gap-6 @4xl/content:gap-8 order-1 @2xl/content:order-2">

--- a/packages/admin/src/components/shared/pagination/index.tsx
+++ b/packages/admin/src/components/shared/pagination/index.tsx
@@ -14,6 +14,77 @@ import { cn } from "@admin/lib/utils";
 import type { PaginationProps } from "./types";
 
 /**
+ * What the control says about the rows, which is the part a reader takes at
+ * face value.
+ *
+ * Its own component because the question it answers has three outcomes and the
+ * control around it has none: an unknown total, an empty list, and a range.
+ * Inline, that is three nested conditionals inside a body that is already long.
+ *
+ * ADDRESSABLE, via `data-slot`. The landmark also contains the page-size
+ * selector, whose label carries the word "page", so a query made against the
+ * landmark as a whole cannot tell this line's text from the selector's — it
+ * has to be reachable on its own.
+ */
+function PaginationSummary({
+  currentPage,
+  itemLabel,
+  pageSize,
+  totalItems,
+  totalPages,
+}: {
+  currentPage: number;
+  itemLabel: string;
+  pageSize: number;
+  totalItems: number | undefined;
+  totalPages: number;
+}): React.JSX.Element {
+  /*
+   * An absent total is not an empty one: a caller that cannot count says
+   * nothing about how many rows exist, and gets the page-of-pages form.
+   */
+  if (totalItems === undefined) {
+    return (
+      <div
+        className="whitespace-nowrap order-2 @2xl/content:order-1"
+        data-slot="pagination-summary"
+      >
+        Page <span className="font-semibold">{currentPage + 1}</span> of{" "}
+        <span className="font-semibold">{totalPages}</span>
+      </div>
+    );
+  }
+
+  /*
+   * A RANGE only exists when there are rows to bound. Its start is
+   * `currentPage * pageSize + 1`, which is 1 on the first page whatever the
+   * total, while its end is clamped to the total — so an empty list read
+   * "Showing 1-0 of 0", a range whose start is past its end, describing a
+   * first row that is not there.
+   *
+   * Said as a count rather than a range, because that is what an empty list
+   * has. "Showing 0-0" would be arithmetically tidy and still answer a
+   * question nobody asked.
+   */
+  return (
+    <div
+      className="whitespace-nowrap order-2 @2xl/content:order-1"
+      data-slot="pagination-summary"
+    >
+      {totalItems === 0 ? (
+        <>No {itemLabel}</>
+      ) : (
+        <>
+          Showing {currentPage * pageSize + 1}-
+          {Math.min((currentPage + 1) * pageSize, totalItems)} of {totalItems}{" "}
+          {itemLabel}
+        </>
+      )}
+    </div>
+  );
+}
+
+/**
  * Pagination Component
  *
  * A reusable pagination component with page controls, page size selector, and smart page numbering.
@@ -125,78 +196,6 @@ import type { PaginationProps } from "./types";
  * />
  * ```
  */
-/**
- * What the control says about the rows, which is the part a reader takes at
- * face value.
- *
- * Its own component because the question it answers has three outcomes and the
- * control around it has none: an unknown total, an empty list, and a range.
- * Inline, that is three nested conditionals inside a body that is already long.
- *
- * ADDRESSABLE, via `data-slot`. The landmark also contains the page-size
- * selector, whose label carries the word "page" — so an assertion made against
- * the whole landmark matches that text and passes whatever this line says,
- * which is how a test written for this line came to pass on a render that had
- * lost it entirely.
- */
-function PaginationSummary({
-  currentPage,
-  itemLabel,
-  pageSize,
-  totalItems,
-  totalPages,
-}: {
-  currentPage: number;
-  itemLabel: string;
-  pageSize: number;
-  totalItems: number | undefined;
-  totalPages: number;
-}): React.JSX.Element {
-  /*
-   * An absent total is not an empty one: a caller that cannot count says
-   * nothing about how many rows exist, and gets the page-of-pages form.
-   */
-  if (totalItems === undefined) {
-    return (
-      <div
-        className="whitespace-nowrap order-2 @2xl/content:order-1"
-        data-slot="pagination-summary"
-      >
-        Page <span className="font-semibold">{currentPage + 1}</span> of{" "}
-        <span className="font-semibold">{totalPages}</span>
-      </div>
-    );
-  }
-
-  /*
-   * A RANGE only exists when there are rows to bound. Its start is
-   * `currentPage * pageSize + 1`, which is 1 on the first page whatever the
-   * total, while its end is clamped to the total — so an empty list read
-   * "Showing 1-0 of 0", a range whose start is past its end, describing a
-   * first row that is not there.
-   *
-   * Said as a count rather than a range, because that is what an empty list
-   * has. "Showing 0-0" would be arithmetically tidy and still answer a
-   * question nobody asked.
-   */
-  return (
-    <div
-      className="whitespace-nowrap order-2 @2xl/content:order-1"
-      data-slot="pagination-summary"
-    >
-      {totalItems === 0 ? (
-        <>No {itemLabel}</>
-      ) : (
-        <>
-          Showing {currentPage * pageSize + 1}-
-          {Math.min((currentPage + 1) * pageSize, totalItems)} of {totalItems}{" "}
-          {itemLabel}
-        </>
-      )}
-    </div>
-  );
-}
-
 export const Pagination = React.forwardRef<HTMLElement, PaginationProps>(
   (
     {


### PR DESCRIPTION
Found while measuring **R-16** (webhook page revamp) in a browser rather than from the source.

## The defect

The shared pagination control builds its count line from two different things — the range starts at `currentPage * pageSize + 1`, which is `1` on the first page whatever the total, and ends clamped to the total. With no rows the ends cross:

```
Showing 1-0 of 0 deliveries
```

A range whose start is past its end, describing a first row that is not there. Measured on a webhook endpoint's deliveries page, which renders the control with zero rows; other empty lists hide pagination, so this is where it surfaces today.

An empty list now reports a count — `No deliveries` — because a count is what it has. `Showing 0-0` would be arithmetically tidy and still answer a question nobody asked.

## Why it is extracted rather than nested

The question has three outcomes — an unknown total, an empty list, a range — and the control around it has none. Inline that is three conditionals inside a body already long enough that `fallow` refuses it on cognitive complexity, attributed to this change. Extracting `PaginationSummary` clears that honestly rather than by suppression, and the gate now passes with `complexity_introduced: 0`.

## The `data-slot` is load-bearing

The landmark also contains the page-size selector, whose label reads **"Rows per page"**. An assertion made against the whole landmark therefore matches the word "page" regardless of what the count line says.

That is not hypothetical. My first version of the unknown-total test asserted against the landmark, and it **passed with the guard it exists to protect removed** — and passed again with the count line replaced by a broken one. Two break-verifications in a row came back green, which is what exposed it. The summary is now addressable, and the test asserts its exact text.

## Evidence

The component had **no tests at all** before this. Four cases, each break-verified individually against the previous implementation:

| break | fails |
| --- | --- |
| remove the empty branch | the empty case only |
| suppress the range always | both range cases |
| let an absent total fall through to the count form | the unknown-total case |

Re-run after the extraction, since refactoring the implementation changes the experiment.

Verified in a running admin, not only in jsdom: the deliveries page now renders `No deliveries`.

Gates from the worktree root — `build`, `lint`, `check-types` clean; `@nextlyhq/admin` **392 files / 3825 tests**; `fallow audit --base origin/main` passes with nothing introduced; `changeset status` exits 0.