### PR TITLE
fix(nextly): make a Builder collection's migration carry its registry row

### DIFF
--- a/.changeset/builder-migrations-carry-the-metadata-row.md
+++ b/.changeset/builder-migrations-carry-the-metadata-row.md
@@ -36,6 +36,5 @@ rather than merely showing a stale status.
 
 The migration now carries the row too, built by the same builder `migrate:create`
 uses rather than a second statement that would have to agree with it. The two
-authoring paths are disjoint by construction -- the Builder writes no `meta/`
-snapshot, so `migrate:create` never sees its tables -- which is why each has to
-be self-sufficient.
+committed migration is the only thing replayed against the target database, so
+it has to be self-sufficient: nothing else recreates the registry row there.

--- a/.changeset/builder-migrations-carry-the-metadata-row.md
+++ b/.changeset/builder-migrations-carry-the-metadata-row.md
@@ -1,0 +1,41 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+A collection built in the Schema Builder now survives the deploy.
+
+The migration that path writes created the table and nothing else. That file is
+committed and replayed against a database that has never seen the Builder, where
+the `dynamic_collections` row it writes locally does not exist -- so production
+got the table and no row at all, and the collection was absent from the admin
+rather than merely showing a stale status.
+
+The migration now carries the row too, built by the same builder `migrate:create`
+uses rather than a second statement that would have to agree with it. The two
+authoring paths are disjoint by construction -- the Builder writes no `meta/`
+snapshot, so `migrate:create` never sees its tables -- which is why each has to
+be self-sufficient.

--- a/packages/admin/src/lib/builder/__tests__/to-manifest-entity-single.test.ts
+++ b/packages/admin/src/lib/builder/__tests__/to-manifest-entity-single.test.ts
@@ -55,3 +55,30 @@ describe("fieldGroupToManifestEntity", () => {
     expect(e.fields).toEqual([{ name: "title", type: "text" }]);
   });
 });
+
+describe("a description survives a field-group save", () => {
+  it("reaches the manifest entity", () => {
+    // 🔴 The migration's upsert writes this column unconditionally so that
+    // clearing a description propagates, so a manifest omitting it does not
+    // leave the deployed value alone — it replaces it with NULL. The field-group
+    // projections pass their settings inline, so the mapper carrying it is only
+    // half the fix; the call sites have to send it.
+    const entity = fieldGroupToManifestEntity({
+      slug: "seo",
+      settings: { singularName: "SEO", description: "Search metadata" },
+      fields: [],
+    });
+    expect(entity.description).toBe("Search metadata");
+  });
+
+  it("leaves the key absent when there is none", () => {
+    // The control against a mapper that always sets it, which would serialise a
+    // present-but-empty key into the manifest.
+    const entity = fieldGroupToManifestEntity({
+      slug: "seo",
+      settings: { singularName: "SEO" },
+      fields: [],
+    });
+    expect("description" in entity).toBe(false);
+  });
+});

--- a/packages/admin/src/lib/builder/__tests__/to-manifest-entity-single.test.ts
+++ b/packages/admin/src/lib/builder/__tests__/to-manifest-entity-single.test.ts
@@ -58,11 +58,10 @@ describe("fieldGroupToManifestEntity", () => {
 
 describe("a description survives a field-group save", () => {
   it("reaches the manifest entity", () => {
-    // 🔴 The migration's upsert writes this column unconditionally so that
-    // clearing a description propagates, so a manifest omitting it does not
-    // leave the deployed value alone — it replaces it with NULL. The field-group
-    // projections pass their settings inline, so the mapper carrying it is only
-    // half the fix; the call sites have to send it.
+    // 🔴 The migration replays where the Builder's local row does not exist,
+    // so a manifest omitting the description deploys a field group without one.
+    // The field-group projections pass their settings inline, so the mapper
+    // carrying it is only half the fix; the call sites have to send it.
     const entity = fieldGroupToManifestEntity({
       slug: "seo",
       settings: { singularName: "SEO", description: "Search metadata" },

--- a/packages/admin/src/lib/builder/settings-to-manifest.test.ts
+++ b/packages/admin/src/lib/builder/settings-to-manifest.test.ts
@@ -161,3 +161,40 @@ describe("cache revalidation in the manifest mirror", () => {
     });
   }
 });
+
+describe("the description a later save must not erase", () => {
+  it("carries it into the manifest entity for a collection and a single", () => {
+    // 🔴 The migration's upsert writes this column UNCONDITIONALLY so that
+    // clearing a description propagates. A manifest omitting it therefore does
+    // not leave the stored value alone — it replaces it with NULL, erasing on
+    // the next Builder save a description the create migration had deployed.
+    const settings = {
+      slug: "articles",
+      singularName: "Article",
+      pluralName: "Articles",
+      description: "Long-form editorial pieces",
+      icon: "FileText",
+    } as never;
+    expect(
+      collectionEntityFromSettings("articles", settings, []).description
+    ).toBe("Long-form editorial pieces");
+    expect(singleEntityFromSettings("about", settings, []).description).toBe(
+      "Long-form editorial pieces"
+    );
+  });
+
+  it("omits the key entirely when there is no description", () => {
+    // The control: writing an explicit undefined would serialise into the
+    // manifest as a present-but-empty key, and a mapper that always set it
+    // would satisfy the assertion above.
+    const settings = {
+      slug: "articles",
+      singularName: "Article",
+      pluralName: "Articles",
+      icon: "FileText",
+    } as never;
+    expect(
+      "description" in collectionEntityFromSettings("articles", settings, [])
+    ).toBe(false);
+  });
+});

--- a/packages/admin/src/lib/builder/settings-to-manifest.test.ts
+++ b/packages/admin/src/lib/builder/settings-to-manifest.test.ts
@@ -164,10 +164,10 @@ describe("cache revalidation in the manifest mirror", () => {
 
 describe("the description a later save must not erase", () => {
   it("carries it into the manifest entity for a collection and a single", () => {
-    // 🔴 The migration's upsert writes this column UNCONDITIONALLY so that
-    // clearing a description propagates. A manifest omitting it therefore does
-    // not leave the stored value alone — it replaces it with NULL, erasing on
-    // the next Builder save a description the create migration had deployed.
+    // 🔴 The migration replays where the Builder's local row does not exist,
+    // so a manifest omitting the description deploys a collection without one —
+    // the help text is simply absent on the deployed copy, visible only to
+    // whoever opens it there.
     const settings = {
       slug: "articles",
       singularName: "Article",

--- a/packages/admin/src/lib/builder/settings-to-manifest.ts
+++ b/packages/admin/src/lib/builder/settings-to-manifest.ts
@@ -26,6 +26,7 @@ export function collectionEntityFromSettings(
     slug,
     settings: {
       singularName: settings.singularName,
+      description: settings.description,
       pluralName: settings.pluralName,
       status: settings.status === true,
       // i18n: the collection-level Internationalization toggle.
@@ -53,6 +54,7 @@ export function singleEntityFromSettings(
     slug,
     settings: {
       singularName: settings.singularName,
+      description: settings.description,
       status: settings.status === true,
       // i18n: the single-level Internationalization toggle (mirrors collectionEntityFromSettings).
       localized: settings.i18n === true,

--- a/packages/admin/src/lib/builder/to-manifest-entity.ts
+++ b/packages/admin/src/lib/builder/to-manifest-entity.ts
@@ -86,6 +86,8 @@ export interface BuilderFieldInput {
 export interface BuilderSettingsInput {
   singularName?: string;
   pluralName?: string;
+  /** The entity's own help text, distinct from a field's description. */
+  description?: string;
   status?: boolean;
   /** i18n: collection has translatable fields (companion `_locales` table). */
   localized?: boolean;
@@ -151,6 +153,15 @@ export interface ManifestField {
 export interface ManifestEntity {
   slug: string;
   labels?: { singular: string; plural: string };
+  /**
+   * The entity's own help text.
+   *
+   * Carried because the migration's upsert writes this column
+   * unconditionally — so that clearing a description propagates — which means a
+   * manifest omitting it REPLACES the stored value with NULL rather than
+   * leaving it alone.
+   */
+  description?: string;
   admin?: { useAsTitle?: string; defaultColumns?: string[]; group?: string };
   status?: boolean;
   /** i18n: collection has translatable fields. */
@@ -234,6 +245,7 @@ export function applyCommonSettings(
   settings: BuilderSettingsInput
 ): void {
   const {
+    description,
     useAsTitle,
     defaultColumns,
     group,
@@ -251,6 +263,12 @@ export function applyCommonSettings(
   }
   if (group) admin.group = group;
   if (Object.keys(admin).length > 0) entity.admin = admin;
+  // 🔴 Carried, because the migration's upsert writes this column
+  // UNCONDITIONALLY so that clearing a description propagates. A manifest that
+  // omitted it therefore did not leave the stored value alone — it replaced it
+  // with NULL, erasing on the next save a description an earlier migration had
+  // correctly deployed.
+  if (description !== undefined) entity.description = description;
   if (status !== undefined) entity.status = status;
   if (localized !== undefined) entity.localized = localized;
   if (versions !== undefined) entity.versions = versions;

--- a/packages/admin/src/lib/builder/to-manifest-entity.ts
+++ b/packages/admin/src/lib/builder/to-manifest-entity.ts
@@ -156,10 +156,11 @@ export interface ManifestEntity {
   /**
    * The entity's own help text.
    *
-   * Carried because the migration's upsert writes this column
-   * unconditionally — so that clearing a description propagates — which means a
-   * manifest omitting it REPLACES the stored value with NULL rather than
-   * leaving it alone.
+   * Carried so the description reaches a database the manifest is replayed
+   * against, where the Builder's local row does not exist. The upsert omits
+   * the column when a manifest carries none, so this SUPPLIES the value rather
+   * than protecting it — the standing limitation being that a cleared
+   * description cannot propagate through a migration.
    */
   description?: string;
   admin?: { useAsTitle?: string; defaultColumns?: string[]; group?: string };
@@ -263,11 +264,10 @@ export function applyCommonSettings(
   }
   if (group) admin.group = group;
   if (Object.keys(admin).length > 0) entity.admin = admin;
-  // 🔴 Carried, because the migration's upsert writes this column
-  // UNCONDITIONALLY so that clearing a description propagates. A manifest that
-  // omitted it therefore did not leave the stored value alone — it replaced it
-  // with NULL, erasing on the next save a description an earlier migration had
-  // correctly deployed.
+  // 🔴 Carried so the description reaches a database the manifest is replayed
+  // against. The upsert omits the column when a manifest carries none, so a
+  // partial projection leaves the stored value alone rather than erasing it;
+  // this supplies the value, it does not protect it.
   if (description !== undefined) entity.description = description;
   if (status !== undefined) entity.status = status;
   if (localized !== undefined) entity.localized = localized;

--- a/packages/admin/src/pages/dashboard/field-group/builder/[slug].tsx
+++ b/packages/admin/src/pages/dashboard/field-group/builder/[slug].tsx
@@ -185,6 +185,12 @@ export default function FieldGroupBuilderEditPage({
               slug,
               settings: {
                 singularName: settings?.singularName,
+                // 🔴 The description travels too. The migration's upsert writes
+                // that column unconditionally so that clearing one propagates,
+                // so a manifest omitting it does not leave the stored value
+                // alone — it replaces it with NULL, erasing on this save a
+                // description an earlier migration had deployed.
+                description: settings?.description,
                 // Mirror the Internationalization flag into ui-schema.json.
                 localized: settings?.i18n === true,
               },

--- a/packages/admin/src/pages/dashboard/field-group/builder/[slug].tsx
+++ b/packages/admin/src/pages/dashboard/field-group/builder/[slug].tsx
@@ -185,11 +185,10 @@ export default function FieldGroupBuilderEditPage({
               slug,
               settings: {
                 singularName: settings?.singularName,
-                // 🔴 The description travels too. The migration's upsert writes
-                // that column unconditionally so that clearing one propagates,
-                // so a manifest omitting it does not leave the stored value
-                // alone — it replaces it with NULL, erasing on this save a
-                // description an earlier migration had deployed.
+                // 🔴 The description travels too, so it reaches a database
+                // the manifest is replayed against. The upsert omits the column
+                // when a manifest carries none, so this supplies the value
+                // rather than protecting it from being nulled.
                 description: settings?.description,
                 // Mirror the Internationalization flag into ui-schema.json.
                 localized: settings?.i18n === true,

--- a/packages/admin/src/pages/dashboard/field-group/builder/index.tsx
+++ b/packages/admin/src/pages/dashboard/field-group/builder/index.tsx
@@ -42,12 +42,17 @@ export default function FieldGroupBuilderPage(): React.ReactElement | null {
   const handleSubmit = (values: BuilderSettingsValues) => {
     const singular = values.singularName.trim();
     const slug = values.slug?.trim() || toSnakeName(singular);
+    // Normalised once. The request and the manifest projection describe the
+    // same field group, so deriving them from one value is what keeps a
+    // whitespace-only description from being stored as text in the manifest
+    // while the row it mirrors holds NULL.
+    const description = values.description?.trim() || undefined;
 
     createFieldGroup(
       {
         slug,
         label: singular,
-        description: values.description?.trim() || undefined,
+        description,
         admin: {
           category: values.category?.trim() || undefined,
           icon: values.icon,
@@ -71,11 +76,11 @@ export default function FieldGroupBuilderPage(): React.ReactElement | null {
                   slug,
                   settings: {
                     singularName: singular,
-                    // Carried for the same reason the edit path carries it: the
-                    // upsert writes this column unconditionally, so a manifest
-                    // omitting it clears a deployed description rather than
-                    // leaving it alone.
-                    description: values.description,
+                    // Carried so the description reaches a database the
+                    // manifest is replayed against; the builder omits the
+                    // column when it is absent, so this is what supplies it
+                    // rather than what protects it.
+                    description,
                     // i18n: mirror the Internationalization flag into ui-schema.json.
                     localized: values.i18n === true,
                   },

--- a/packages/admin/src/pages/dashboard/field-group/builder/index.tsx
+++ b/packages/admin/src/pages/dashboard/field-group/builder/index.tsx
@@ -71,6 +71,11 @@ export default function FieldGroupBuilderPage(): React.ReactElement | null {
                   slug,
                   settings: {
                     singularName: singular,
+                    // Carried for the same reason the edit path carries it: the
+                    // upsert writes this column unconditionally, so a manifest
+                    // omitting it clears a deployed description rather than
+                    // leaving it alone.
+                    description: values.description,
                     // i18n: mirror the Internationalization flag into ui-schema.json.
                     localized: values.i18n === true,
                   },

--- a/packages/nextly/src/cli/commands/migrate.test.ts
+++ b/packages/nextly/src/cli/commands/migrate.test.ts
@@ -147,3 +147,26 @@ describe("splitSqlStatements", () => {
     expect(splitSqlStatements(sql, "postgresql")).toHaveLength(2);
   });
 });
+
+describe("splitting a statement whose value ends in a backslash", () => {
+  it("closes the quote when the backslash run is EVEN", () => {
+    // 🔴 A doubled backslash is ONE literal backslash — how MySQL escaping
+    // writes a value ending in one — so it sits immediately before the closing
+    // quote. Reading only that last character calls the quote escaped, leaves
+    // the splitter inside a string it has left, swallows the semicolon and
+    // concatenates the next statement. A driver with multi-statements disabled
+    // then rejects the pair, after earlier statements in the file have run.
+    const sql = [
+      `INSERT INTO t (d) VALUES ('ends with a backslash \\\\');`,
+      `INSERT INTO u (d) VALUES ('second');`,
+    ].join("\n");
+    expect(splitSqlStatements(sql, "mysql")).toHaveLength(2);
+  });
+
+  it("still treats an ODD run as escaping the quote", () => {
+    // The control: a rule that stopped honouring backslash escapes entirely
+    // would satisfy the case above and split this one in the wrong place.
+    const sql = `INSERT INTO t (d) VALUES ('not \\' the end; still inside');`;
+    expect(splitSqlStatements(sql, "mysql")).toHaveLength(1);
+  });
+});

--- a/packages/nextly/src/cli/commands/migrate.test.ts
+++ b/packages/nextly/src/cli/commands/migrate.test.ts
@@ -163,6 +163,22 @@ describe("splitting a statement whose value ends in a backslash", () => {
     expect(splitSqlStatements(sql, "mysql")).toHaveLength(2);
   });
 
+  it("does NOT treat a backslash as an escape on PostgreSQL or SQLite", () => {
+    // 🔴 Only MySQL reads a backslash as an escape inside a string literal;
+    // SQLite has no C-style escapes at all. `quoteSqlLiteral` therefore leaves
+    // a trailing backslash SINGLE on those dialects, so a parity rule applied
+    // unconditionally calls the closing quote escaped and swallows the
+    // semicolon — the very defect the parity check was added to remove, moved
+    // to the other two dialects.
+    const sql = [
+      `INSERT INTO t (d) VALUES ('ends with a backslash \\');`,
+      `INSERT INTO u (d) VALUES ('second');`,
+    ].join("\n");
+    for (const dialect of ["postgresql", "sqlite"] as const) {
+      expect(splitSqlStatements(sql, dialect)).toHaveLength(2);
+    }
+  });
+
   it("still treats an ODD run as escaping the quote", () => {
     // The control: a rule that stopped honouring backslash escapes entirely
     // would satisfy the case above and split this one in the wrong place.

--- a/packages/nextly/src/cli/commands/migrate.test.ts
+++ b/packages/nextly/src/cli/commands/migrate.test.ts
@@ -297,3 +297,41 @@ describe("a line inside a string literal is data, not SQL", () => {
     expect(out).toHaveLength(2);
   });
 });
+
+describe("a doubled delimiter escapes the delimiter, it does not end the literal", () => {
+  it("keeps a Postgres escape string whole across a doubled quote", () => {
+    // 🔴 Closing on the first quote of `''` and reopening on the second looks
+    // harmless — the state toggles twice and comes back correct — but the
+    // reopened literal is a DIFFERENT one. `escapesWithBackslash` is read from
+    // the prefix at the opening quote, and the second quote of a pair is no
+    // longer adjacent to the `E`. The mode is lost, the later `\'` reads as the
+    // closing quote, and the statement is cut at the semicolon INSIDE the
+    // value.
+    //
+    // Asserted on CONTENT, not on the number of statements: the splitter drops
+    // fragments carrying no SQL keyword, so the tail of a mis-split statement
+    // disappears and a count assertion passes on the broken implementation.
+    const sql = `SELECT E'it''s left \\'; right' AS v;`;
+    expect(splitSqlStatements(sql, "postgresql").join(" | ")).toBe(
+      `SELECT E'it''s left \\'; right' AS v`
+    );
+  });
+
+  it("keeps an ordinary literal whole across a doubled quote", () => {
+    // The control. This case is correct even when the pair is treated as a
+    // close followed by an open, because both literals carry the same escape
+    // mode — so it passes on the broken implementation and shows that the fix
+    // is about the MODE rather than about doubled quotes in general.
+    const sql = `INSERT INTO "t" ("d") VALUES ('it''s fine; really');`;
+    expect(splitSqlStatements(sql, "postgresql").join(" | ")).toBe(
+      `INSERT INTO "t" ("d") VALUES ('it''s fine; really')`
+    );
+  });
+
+  it("still CLOSES on a single delimiter, so a doubled one is not assumed", () => {
+    // 🔴 The other direction: an implementation that never closed on a quote
+    // adjacent to another would swallow the boundary between two statements.
+    const sql = `INSERT INTO "t" ("d") VALUES ('a');INSERT INTO "t" ("d") VALUES ('b');`;
+    expect(splitSqlStatements(sql, "postgresql")).toHaveLength(2);
+  });
+});

--- a/packages/nextly/src/cli/commands/migrate.test.ts
+++ b/packages/nextly/src/cli/commands/migrate.test.ts
@@ -238,3 +238,42 @@ describe("MySQL escapes inside BOTH literal quotes", () => {
     expect(splitSqlStatements(sql, "mysql")).toHaveLength(2);
   });
 });
+
+describe("a line inside a string literal is data, not SQL", () => {
+  it("KEEPS a continuation line that begins with a comment marker", () => {
+    // 🔴 A multiline description whose second line starts with `--` puts
+    // comment-looking text at the start of a line. Read as a standalone SQL
+    // comment it is dropped, the migration still succeeds, and the replayed
+    // database stores a SILENTLY TRUNCATED description — no error anywhere.
+    const sql = `INSERT INTO "t" ("d") VALUES ('Summary\n-- internal note');`;
+    const out = splitSqlStatements(sql, "sqlite").join(";");
+    expect(out).toContain("internal note");
+  });
+
+  it("KEEPS a literal that contains the breakpoint marker text", () => {
+    // The same rule for the rewrite half of the cleanup: stripping the marker
+    // out of prose corrupts the stored value exactly as dropping the line does.
+    const sql = `INSERT INTO "t" ("d") VALUES ('note\n--> statement-breakpoint here');`;
+    const out = splitSqlStatements(sql, "sqlite").join(";");
+    expect(out).toContain("--> statement-breakpoint here");
+  });
+
+  it("still DROPS a standalone comment line outside any literal", () => {
+    // 🔴 The control. Both cases above pass on an implementation that simply
+    // stopped cleaning up, which would put marker text and comments back into
+    // the SQL the driver receives — so the cleanup must be shown to still run.
+    const sql = `-- a leading note\nCREATE TABLE "t" ("a" text);`;
+    const out = splitSqlStatements(sql, "sqlite").join(";");
+    expect(out).not.toContain("a leading note");
+    expect(out).toContain("CREATE TABLE");
+  });
+
+  it("still STRIPS an inline breakpoint marker outside any literal", () => {
+    // The rewrite half of the same control: unstripped, the marker text
+    // pollutes the next accumulated statement and MySQL rejects it.
+    const sql = `CREATE TABLE "t" ("a" text);--> statement-breakpoint\nCREATE INDEX "i" ON "t" ("a");`;
+    const out = splitSqlStatements(sql, "sqlite");
+    expect(out.join(";")).not.toContain("statement-breakpoint");
+    expect(out).toHaveLength(2);
+  });
+});

--- a/packages/nextly/src/cli/commands/migrate.test.ts
+++ b/packages/nextly/src/cli/commands/migrate.test.ts
@@ -216,8 +216,7 @@ describe("PostgreSQL escape strings honour backslashes; ordinary literals do not
 
 describe("MySQL escapes inside BOTH literal quotes", () => {
   it("keeps a double-quoted MySQL value whole when a backslash escapes its quote", () => {
-    // 🔴 A regression this branch introduced and this test now pins. Under
-    // MySQL's default SQL mode a double quote also delimits a string, and the
+    // 🔴 Under MySQL's default SQL mode a double quote also delimits a string, and the
     // scanner this replaced applied its backslash check to whichever quote had
     // opened the region. Gating on the single quote alone split this valid
     // statement at the semicolon INSIDE the value.
@@ -273,6 +272,27 @@ describe("a line inside a string literal is data, not SQL", () => {
     // pollutes the next accumulated statement and MySQL rejects it.
     const sql = `CREATE TABLE "t" ("a" text);--> statement-breakpoint\nCREATE INDEX "i" ON "t" ("a");`;
     const out = splitSqlStatements(sql, "sqlite");
+    expect(out.join(";")).not.toContain("statement-breakpoint");
+    expect(out).toHaveLength(2);
+  });
+
+  it("KEEPS marker text in a literal that opens LATER on the line", () => {
+    // 🔴 A per-line answer is not enough. This line begins as ordinary SQL, so
+    // any rule keyed on where the LINE starts treats the whole line as SQL and
+    // rewrites the value inside it — storing a truncated description while the
+    // migration reports success.
+    const sql = `INSERT INTO "t" ("d") VALUES ('note --> statement-breakpoint here');`;
+    const out = splitSqlStatements(sql, "sqlite").join(";");
+    expect(out).toContain("--> statement-breakpoint here");
+  });
+
+  it("does not let an apostrophe inside a BLOCK comment open a literal", () => {
+    // 🔴 `it's` here is prose, not an opening quote. Counted as one, everything
+    // after it reads as being inside a literal, so the real breakpoint line
+    // below is treated as data and survives — and on MySQL, where `-->` is not
+    // a comment, that text reaches the driver as invalid SQL.
+    const sql = `/* it's a note\n   spanning lines */\nCREATE TABLE "t" ("a" text);\n--> statement-breakpoint\nCREATE INDEX "i" ON "t" ("a");`;
+    const out = splitSqlStatements(sql, "mysql");
     expect(out.join(";")).not.toContain("statement-breakpoint");
     expect(out).toHaveLength(2);
   });

--- a/packages/nextly/src/cli/commands/migrate.test.ts
+++ b/packages/nextly/src/cli/commands/migrate.test.ts
@@ -186,3 +186,30 @@ describe("splitting a statement whose value ends in a backslash", () => {
     expect(splitSqlStatements(sql, "mysql")).toHaveLength(1);
   });
 });
+
+describe("PostgreSQL escape strings honour backslashes; ordinary literals do not", () => {
+  it("keeps an E'...' literal WHOLE when a backslash escapes its quote", () => {
+    // 🔴 PostgreSQL DOES read a backslash as an escape inside an `E'…'` string.
+    // Disabling backslash handling for the whole dialect split this valid
+    // statement at the semicolon INSIDE the literal.
+    //
+    // Asserted on CONTENT, not on the count: `splitSqlStatements` discards a
+    // fragment carrying no SQL keyword, so the tail `right';` vanishes either
+    // way and a length check passes on the broken implementation too.
+    const sql = `SELECT E'left \\'; right' AS v;`;
+    const out = splitSqlStatements(sql, "postgresql");
+    expect(out).toHaveLength(1);
+    expect(out[0]).toContain("right");
+  });
+
+  it("still splits an ORDINARY PostgreSQL literal ending in a backslash", () => {
+    // The control, and why this is a property of the LITERAL rather than the
+    // dialect: outside `E'…'` PostgreSQL stores a backslash verbatim, so the
+    // quote after it closes the string and the semicolon separates.
+    const sql = [
+      `INSERT INTO t (d) VALUES ('ends with a backslash \\\\');`,
+      `INSERT INTO u (d) VALUES ('second');`,
+    ].join("\n");
+    expect(splitSqlStatements(sql, "postgresql")).toHaveLength(2);
+  });
+});

--- a/packages/nextly/src/cli/commands/migrate.test.ts
+++ b/packages/nextly/src/cli/commands/migrate.test.ts
@@ -213,3 +213,28 @@ describe("PostgreSQL escape strings honour backslashes; ordinary literals do not
     expect(splitSqlStatements(sql, "postgresql")).toHaveLength(2);
   });
 });
+
+describe("MySQL escapes inside BOTH literal quotes", () => {
+  it("keeps a double-quoted MySQL value whole when a backslash escapes its quote", () => {
+    // 🔴 A regression this branch introduced and this test now pins. Under
+    // MySQL's default SQL mode a double quote also delimits a string, and the
+    // scanner this replaced applied its backslash check to whichever quote had
+    // opened the region. Gating on the single quote alone split this valid
+    // statement at the semicolon INSIDE the value.
+    //
+    // Asserted on CONTENT: a fragment carrying no SQL keyword is discarded, so
+    // a length check passes on the broken implementation too.
+    const sql = `SELECT "left \\"; right" AS v;`;
+    const out = splitSqlStatements(sql, "mysql");
+    expect(out).toHaveLength(1);
+    expect(out[0]).toContain("right");
+  });
+
+  it("does NOT treat a backtick-quoted identifier as escaping", () => {
+    // The control: a backtick delimits a NAME, not a literal, so a backslash
+    // inside one escapes nothing and the following semicolon still separates.
+    const sql =
+      "INSERT INTO `t` (d) VALUES (1); INSERT INTO `u` (d) VALUES (2);";
+    expect(splitSqlStatements(sql, "mysql")).toHaveLength(2);
+  });
+});

--- a/packages/nextly/src/cli/commands/migrate.test.ts
+++ b/packages/nextly/src/cli/commands/migrate.test.ts
@@ -25,9 +25,10 @@ describe("registerMigrateCommand", () => {
 
 describe("splitSqlStatements", () => {
   // A comment mentioning a DDL keyword survives the line filter, so its prose
-  // reaches the scanner. An apostrophe there used to open a string that never
-  // closed, which stopped every later semicolon from separating statements and
-  // handed the driver one merged statement it rejects.
+  // reaches the scanner. An apostrophe there is prose, not an opening quote:
+  // counted as one it opens a string that never closes, which stops every later
+  // semicolon from separating statements and hands the driver one merged
+  // statement it rejects.
   it("does not let an apostrophe in a comment merge the statements after it", () => {
     const sql = [
       `CREATE TABLE "a" ("id" TEXT);`,
@@ -216,10 +217,10 @@ describe("PostgreSQL escape strings honour backslashes; ordinary literals do not
 
 describe("MySQL escapes inside BOTH literal quotes", () => {
   it("keeps a double-quoted MySQL value whole when a backslash escapes its quote", () => {
-    // 🔴 Under MySQL's default SQL mode a double quote also delimits a string, and the
-    // scanner this replaced applied its backslash check to whichever quote had
-    // opened the region. Gating on the single quote alone split this valid
-    // statement at the semicolon INSIDE the value.
+    // 🔴 Under MySQL's default SQL mode a double quote also delimits a string,
+    // so the backslash check has to apply to whichever quote opened the region.
+    // Gating on the single quote alone splits this valid statement at the
+    // semicolon INSIDE the value.
     //
     // Asserted on CONTENT: a fragment carrying no SQL keyword is discarded, so
     // a length check passes on the broken implementation too.

--- a/packages/nextly/src/cli/commands/migrate.ts
+++ b/packages/nextly/src/cli/commands/migrate.ts
@@ -964,21 +964,6 @@ function quoteOpenerAt(
 }
 
 /**
- * Whether the character at `index` is escaped by the backslash run before it.
- *
- * 🔴 PARITY, not the single preceding character. A doubled backslash is one
- * LITERAL backslash — which is how MySQL string escaping writes it — so a value
- * ending in a backslash puts `\\` immediately before its closing quote.
- * Reading only that last character calls the quote escaped, leaves the splitter
- * inside a string it has actually left, swallows the statement's semicolon, and
- * concatenates the next statement onto it. A driver with multi-statements
- * disabled then rejects the pair, after earlier statements in the same file
- * have already run.
- *
- * An EVEN run means the backslashes escape each other and the character stands
- * on its own; an odd run means the last one escapes it.
- */
-/**
  * Whether a string literal opening at `index` honours backslash escapes.
  *
  * 🔴 A PROPERTY OF THE LITERAL, not of the dialect alone. MySQL escapes with
@@ -1015,13 +1000,6 @@ function opensBackslashEscapedString(
 }
 
 /**
- * Whether the character at `index` is escaped by the backslash run before it.
- *
- * An EVEN run means the backslashes escape each other and the character stands
- * on its own; an odd run means the last one escapes it. Consulted only for a
- * literal that honours backslash escapes at all.
- */
-/**
  * Whether a quote at `index` CLOSES the literal it appears in.
  *
  * The two questions — does this literal escape at all, and is this particular
@@ -1036,6 +1014,21 @@ function closesLiteral(
   return !(escapesWithBackslash && precededByOddBackslashes(text, index));
 }
 
+/**
+ * Whether the character at `index` is escaped by the backslash run before it.
+ *
+ * 🔴 PARITY, not the single preceding character. A doubled backslash is one
+ * LITERAL backslash — which is how MySQL string escaping writes it — so a value
+ * ending in a backslash puts `\\` immediately before its closing quote.
+ * Reading only that last character calls the quote escaped, leaves the splitter
+ * inside a string it has actually left, swallows the statement's semicolon, and
+ * concatenates the next statement onto it. A driver with multi-statements
+ * disabled then rejects the pair, after earlier statements in the same file
+ * have already run.
+ *
+ * An EVEN run means the backslashes escape each other and the character stands
+ * on its own; an odd run means the last one escapes it.
+ */
 function precededByOddBackslashes(text: string, index: number): boolean {
   let run = 0;
   for (let k = index - 1; k >= 0 && text[k] === "\\"; k -= 1) run += 1;

--- a/packages/nextly/src/cli/commands/migrate.ts
+++ b/packages/nextly/src/cli/commands/migrate.ts
@@ -983,10 +983,10 @@ function opensBackslashEscapedString(
   // not a literal — so only the two literal quotes are candidates.
   if (opener !== "'" && opener !== '"') return false;
   // 🔴 MySQL escapes in BOTH literal quotes. Under its default SQL mode a
-  // double quote also delimits a string, and the scanner this replaced applied
-  // its backslash check to whatever quote had opened the region — so gating on
-  // the single quote alone silently regressed `SELECT "left \"; right"`, which
-  // then splits at the semicolon inside the value.
+  // double quote also delimits a string, so backslash handling has to apply to
+  // whichever of the two opened the region. Gating on the single quote alone
+  // leaves `SELECT "left \"; right"` splitting at the semicolon INSIDE the
+  // value.
   if (dialect === "mysql") return true;
   if (dialect !== "postgresql") return false;
   // PostgreSQL's escape strings are single-quoted only: `E"…"` is not one.

--- a/packages/nextly/src/cli/commands/migrate.ts
+++ b/packages/nextly/src/cli/commands/migrate.ts
@@ -963,6 +963,27 @@ function quoteOpenerAt(
   return undefined;
 }
 
+/**
+ * Whether the character at `index` is escaped by the backslash run before it.
+ *
+ * 🔴 PARITY, not the single preceding character. A doubled backslash is one
+ * LITERAL backslash — which is how MySQL string escaping writes it — so a value
+ * ending in a backslash puts `\\` immediately before its closing quote.
+ * Reading only that last character calls the quote escaped, leaves the splitter
+ * inside a string it has actually left, swallows the statement's semicolon, and
+ * concatenates the next statement onto it. A driver with multi-statements
+ * disabled then rejects the pair, after earlier statements in the same file
+ * have already run.
+ *
+ * An EVEN run means the backslashes escape each other and the character stands
+ * on its own; an odd run means the last one escapes it.
+ */
+function precededByOddBackslashes(text: string, index: number): boolean {
+  let run = 0;
+  for (let i = index - 1; i >= 0 && text[i] === "\\"; i -= 1) run += 1;
+  return run % 2 === 1;
+}
+
 export function splitSqlStatements(
   sql: string,
   dialect?: SupportedDialect
@@ -1003,7 +1024,6 @@ export function splitSqlStatements(
 
   for (let i = 0; i < cleanedSql.length; i++) {
     const char = cleanedSql[i];
-    const prevChar = cleanedSql[i - 1];
 
     // Comments are copied through verbatim without being scanned, because the
     // characters inside one are prose rather than SQL. An apostrophe in a
@@ -1037,7 +1057,11 @@ export function splitSqlStatements(
     if (!inString && opener) {
       inString = true;
       stringChar = opener;
-    } else if (inString && char === stringChar && prevChar !== "\\") {
+    } else if (
+      inString &&
+      char === stringChar &&
+      !precededByOddBackslashes(cleanedSql, i)
+    ) {
       inString = false;
     }
 

--- a/packages/nextly/src/cli/commands/migrate.ts
+++ b/packages/nextly/src/cli/commands/migrate.ts
@@ -1087,24 +1087,41 @@ function advanceLiteralState(
 }
 
 /**
- * For each line of `sql`, whether that line BEGINS inside a string literal.
+ * End index (exclusive) of the comment beginning at `index`, or -1 if none.
  *
- * 🔴 The line-based cleanup below removes comment lines and breakpoint markers,
- * and a physical newline inside a literal makes its continuation look like an
- * ordinary line. A description entered as `Summary\n-- internal note` puts
- * `-- internal note` at the start of a line, where the cleanup reads it as a
- * standalone SQL comment and drops it -- the migration then succeeds and stores
- * a SILENTLY TRUNCATED description, which is the failure that does not announce
- * itself.
- *
- * Scanned with the same rules the splitter itself uses, so the two agree about
- * where a literal starts and ends rather than being two answers to one question.
+ * Both comment forms in one place because a scan that knows about `--` and not
+ * about a block comment disagrees with one that knows about both -- and an
+ * apostrophe inside `/* it's a note *\/` then reads as an opening quote,
+ * putting the rest of the file "inside a literal" for that scan alone.
  */
-function lineStartsInsideLiteral(
-  sql: string,
+function commentEndAt(
+  text: string,
+  index: number,
   dialect?: SupportedDialect
-): boolean[] {
-  const flags: boolean[] = [false];
+): number {
+  if (isLineCommentAt(text, index, dialect)) {
+    const lineEnd = text.indexOf("\n", index);
+    return lineEnd === -1 ? text.length : lineEnd;
+  }
+  if (text[index] === "/" && text[index + 1] === "*") {
+    const close = text.indexOf("*/", index + 2);
+    return close === -1 ? text.length : close + 2;
+  }
+  return -1;
+}
+
+/**
+ * For every character of `sql`, whether it sits inside a string literal.
+ *
+ * 🔴 The cleanup below both DROPS lines and REWRITES them, and each is an edit
+ * to whatever it touches. A description carrying a comment marker or a
+ * breakpoint marker is data, and editing it stores a silently truncated value
+ * in the replayed database -- the migration still succeeds, so nothing reports
+ * it. A per-LINE answer is not enough: a literal can open midway through a line
+ * that began as ordinary SQL.
+ */
+function literalMask(sql: string, dialect?: SupportedDialect): boolean[] {
+  const mask: boolean[] = new Array(sql.length).fill(false);
   const state: LiteralState = {
     inString: false,
     stringChar: "",
@@ -1112,23 +1129,36 @@ function lineStartsInsideLiteral(
   };
 
   for (let i = 0; i < sql.length; i++) {
-    // Outside a literal, a comment runs to end of line and holds prose rather
-    // than SQL, so nothing inside one can open a literal.
-    if (!state.inString && isLineCommentAt(sql, i, dialect)) {
-      const lineEnd = sql.indexOf("\n", i);
-      if (lineEnd === -1) break;
-      i = lineEnd;
-      flags.push(false);
-      continue;
-    }
-    if (sql[i] === "\n") {
-      flags.push(state.inString);
-      continue;
+    if (!state.inString) {
+      const commentEnd = commentEndAt(sql, i, dialect);
+      if (commentEnd !== -1) {
+        i = commentEnd - 1;
+        continue;
+      }
     }
     advanceLiteralState(sql, i, dialect, state);
+    mask[i] = state.inString;
   }
 
-  return flags;
+  return mask;
+}
+
+/** Remove breakpoint markers that lie OUTSIDE a literal, leaving data intact. */
+function stripMarkersOutsideLiterals(
+  line: string,
+  lineStart: number,
+  mask: boolean[]
+): string {
+  const MARKER = "--> statement-breakpoint";
+  let out = "";
+  for (let i = 0; i < line.length; i++) {
+    if (!mask[lineStart + i] && line.startsWith(MARKER, i)) {
+      i += MARKER.length - 1;
+      continue;
+    }
+    out += line[i];
+  }
+  return out;
 }
 
 export function splitSqlStatements(
@@ -1141,16 +1171,19 @@ export function splitSqlStatements(
   //   2. Inline: `SQL_STATEMENT;--> statement-breakpoint` on the same line (after CREATE INDEX/ALTER)
   // Both must be cleaned out before executing, otherwise the marker text
   // ends up as invalid SQL in the next statement.
-  // A line that BEGINS inside a string literal is data, not SQL, so none of the
-  // cleanup below may touch it.
-  // A line that BEGINS inside a string literal is data, not SQL, so no cleanup
-  // below may touch it -- neither dropping it nor rewriting its contents.
-  const insideLiteral = lineStartsInsideLiteral(sql, dialect);
+  // Where every literal sits, so neither half of the cleanup edits data.
+  const mask = literalMask(sql, dialect);
+  let lineStart = 0;
   const cleanedSql = sql
     .split("\n")
-    .map((line, index) => ({ line, index }))
-    .filter(({ line, index }) => {
-      if (insideLiteral[index]) return true;
+    .map(line => {
+      const entry = { line, start: lineStart };
+      lineStart += line.length + 1;
+      return entry;
+    })
+    .filter(({ line, start }) => {
+      // A line that BEGINS inside a literal is a continuation of a value.
+      if (mask[start]) return true;
       const trimmed = line.trim();
       if (trimmed.startsWith("--> statement-breakpoint")) return false;
       // Remove pure SQL comment lines (but keep lines that have SQL after comments)
@@ -1167,13 +1200,10 @@ export function splitSqlStatements(
     // Strip inline markers (pattern 2) that appear after semicolons on the
     // same line, e.g. `CREATE INDEX ...;--> statement-breakpoint`. Without
     // this, the text after the semicolon pollutes the next accumulated
-    // statement and causes a MySQL syntax error. Keyed on the ORIGINAL index,
-    // which a map chained after a filter no longer has.
-    .map(({ line, index }) =>
-      insideLiteral[index]
-        ? line
-        : line.replace(/--> statement-breakpoint/g, "")
-    )
+    // statement and causes a MySQL syntax error. Per OCCURRENCE rather than
+    // per line: a literal can open midway through a line of ordinary SQL, and
+    // rewriting the whole line edits the value inside it.
+    .map(({ line, start }) => stripMarkersOutsideLiterals(line, start, mask))
     .join("\n");
 
   const statements: string[] = [];

--- a/packages/nextly/src/cli/commands/migrate.ts
+++ b/packages/nextly/src/cli/commands/migrate.ts
@@ -994,11 +994,18 @@ function opensBackslashEscapedString(
   opener: string,
   dialect: SupportedDialect | undefined
 ): boolean {
-  // Only a single-quoted STRING can escape; a quoted identifier never does, and
-  // asking that here keeps the caller's loop to one question.
-  if (opener !== "'") return false;
+  // A quoted IDENTIFIER never escapes — a backtick or a bracket delimits a name,
+  // not a literal — so only the two literal quotes are candidates.
+  if (opener !== "'" && opener !== '"') return false;
+  // 🔴 MySQL escapes in BOTH literal quotes. Under its default SQL mode a
+  // double quote also delimits a string, and the scanner this replaced applied
+  // its backslash check to whatever quote had opened the region — so gating on
+  // the single quote alone silently regressed `SELECT "left \"; right"`, which
+  // then splits at the semicolon inside the value.
   if (dialect === "mysql") return true;
   if (dialect !== "postgresql") return false;
+  // PostgreSQL's escape strings are single-quoted only: `E"…"` is not one.
+  if (opener !== "'") return false;
   const prev = text[index - 1];
   if (prev !== "E" && prev !== "e") return false;
   // Not part of a longer word: `VALUES (E'x')` opens an escape string, while an

--- a/packages/nextly/src/cli/commands/migrate.ts
+++ b/packages/nextly/src/cli/commands/migrate.ts
@@ -1054,29 +1054,42 @@ function advanceLiteralState(
   index: number,
   dialect: SupportedDialect | undefined,
   state: LiteralState
-): void {
+): number {
   const char = text[index];
-  const opener = quoteOpenerAt(char, dialect);
-  if (!state.inString && opener) {
-    state.inString = true;
-    state.stringChar = opener;
-    // Recorded when the literal OPENS: the `E` prefix is only visible here,
-    // and by the closing quote it is long past.
-    state.escapesWithBackslash = opensBackslashEscapedString(
-      text,
-      index,
-      opener,
-      dialect
-    );
-    return;
+  if (!state.inString) {
+    const opener = quoteOpenerAt(char, dialect);
+    if (opener) {
+      state.inString = true;
+      state.stringChar = opener;
+      // Recorded when the literal OPENS: the `E` prefix is only visible here,
+      // and by the closing quote it is long past.
+      state.escapesWithBackslash = opensBackslashEscapedString(
+        text,
+        index,
+        opener,
+        dialect
+      );
+    }
+    return 1;
   }
-  if (
-    state.inString &&
-    char === state.stringChar &&
-    closesLiteral(text, index, state.escapesWithBackslash)
-  ) {
-    state.inString = false;
-  }
+
+  if (char !== state.stringChar) return 1;
+
+  // Backslash-escaped: an ordinary character that happens to be the delimiter.
+  if (!closesLiteral(text, index, state.escapesWithBackslash)) return 1;
+
+  // 🔴 A DOUBLED delimiter escapes the delimiter and does NOT leave the
+  // literal. Closing on the first and reopening on the second looks harmless
+  // -- the state toggles twice and comes back correct -- but the REOPENED
+  // literal is a different one: `escapesWithBackslash` is recorded from the
+  // prefix at the opening quote, and the second quote of a pair is no longer
+  // adjacent to the `E` of a Postgres escape string. The mode is silently
+  // lost, so a later `\'` reads as the closing quote and the statement is cut
+  // at the next semicolon INSIDE the value.
+  if (text[index + 1] === state.stringChar) return 2;
+
+  state.inString = false;
+  return 1;
 }
 
 /**
@@ -1129,8 +1142,12 @@ function literalMask(sql: string, dialect?: SupportedDialect): boolean[] {
         continue;
       }
     }
-    advanceLiteralState(sql, i, dialect, state);
+    const consumed = advanceLiteralState(sql, i, dialect, state);
     mask[i] = state.inString;
+    if (consumed === 2) {
+      mask[i + 1] = state.inString;
+      i += 1;
+    }
   }
 
   return mask;
@@ -1238,7 +1255,12 @@ export function splitSqlStatements(
     // The bracket and backtick forms are applied per dialect rather than
     // everywhere: `[` is not a quote in Postgres, where it subscripts an array,
     // so treating it as one there would swallow ordinary SQL.
-    advanceLiteralState(cleanedSql, i, dialect, state);
+    const consumed = advanceLiteralState(cleanedSql, i, dialect, state);
+    if (consumed === 2) {
+      current += cleanedSql[i] + cleanedSql[i + 1];
+      i += 1;
+      continue;
+    }
 
     if (char === ";" && !state.inString) {
       const statement = current.trim();

--- a/packages/nextly/src/cli/commands/migrate.ts
+++ b/packages/nextly/src/cli/commands/migrate.ts
@@ -991,8 +991,12 @@ function quoteOpenerAt(
 function opensBackslashEscapedString(
   text: string,
   index: number,
+  opener: string,
   dialect: SupportedDialect | undefined
 ): boolean {
+  // Only a single-quoted STRING can escape; a quoted identifier never does, and
+  // asking that here keeps the caller's loop to one question.
+  if (opener !== "'") return false;
   if (dialect === "mysql") return true;
   if (dialect !== "postgresql") return false;
   const prev = text[index - 1];
@@ -1010,6 +1014,21 @@ function opensBackslashEscapedString(
  * on its own; an odd run means the last one escapes it. Consulted only for a
  * literal that honours backslash escapes at all.
  */
+/**
+ * Whether a quote at `index` CLOSES the literal it appears in.
+ *
+ * The two questions — does this literal escape at all, and is this particular
+ * quote escaped — are answered here rather than in the scanning loop, which is
+ * long enough that one more condition inside it is one more thing to read past.
+ */
+function closesLiteral(
+  text: string,
+  index: number,
+  escapesWithBackslash: boolean
+): boolean {
+  return !(escapesWithBackslash && precededByOddBackslashes(text, index));
+}
+
 function precededByOddBackslashes(text: string, index: number): boolean {
   let run = 0;
   for (let k = index - 1; k >= 0 && text[k] === "\\"; k -= 1) run += 1;
@@ -1092,12 +1111,16 @@ export function splitSqlStatements(
       stringChar = opener;
       // Recorded when the literal OPENS: the `E` prefix is only visible here,
       // and by the closing quote it is long past.
-      stringEscapesWithBackslash =
-        opener === "'" && opensBackslashEscapedString(cleanedSql, i, dialect);
+      stringEscapesWithBackslash = opensBackslashEscapedString(
+        cleanedSql,
+        i,
+        opener,
+        dialect
+      );
     } else if (
       inString &&
       char === stringChar &&
-      !(stringEscapesWithBackslash && precededByOddBackslashes(cleanedSql, i))
+      closesLiteral(cleanedSql, i, stringEscapesWithBackslash)
     ) {
       inString = false;
     }

--- a/packages/nextly/src/cli/commands/migrate.ts
+++ b/packages/nextly/src/cli/commands/migrate.ts
@@ -978,23 +978,41 @@ function quoteOpenerAt(
  * An EVEN run means the backslashes escape each other and the character stands
  * on its own; an odd run means the last one escapes it.
  */
-function precededByOddBackslashes(
+/**
+ * Whether a string literal opening at `index` honours backslash escapes.
+ *
+ * 🔴 A PROPERTY OF THE LITERAL, not of the dialect alone. MySQL escapes with
+ * backslashes in every string; SQLite never does; PostgreSQL does so only in an
+ * `E'...'` escape string and treats a backslash in an ordinary literal as an
+ * ordinary character. Deciding by dialect alone is wrong in both directions --
+ * it mis-splits a valid PostgreSQL escape string, and applying parity to every
+ * dialect mis-splits an ordinary value ending in a backslash.
+ */
+function opensBackslashEscapedString(
   text: string,
   index: number,
   dialect: SupportedDialect | undefined
 ): boolean {
-  // 🔴 MySQL ONLY. PostgreSQL and SQLite do not read a backslash as an escape
-  // inside a standard string literal — SQLite has no C-style escapes at all —
-  // so a value ending in one leaves a SINGLE backslash before the closing
-  // quote there. Counting parity unconditionally then calls that quote escaped
-  // and swallows the statement's semicolon: the same defect this function was
-  // written to remove, moved to the other two dialects.
-  // An unknown dialect takes the conservative reading: no dialect but MySQL
-  // escapes with backslashes, so treating the quote as unescaped is what the
-  // other two need and what a caller that named none most likely has.
-  if (dialect !== "mysql") return false;
+  if (dialect === "mysql") return true;
+  if (dialect !== "postgresql") return false;
+  const prev = text[index - 1];
+  if (prev !== "E" && prev !== "e") return false;
+  // Not part of a longer word: `VALUES (E'x')` opens an escape string, while an
+  // identifier merely ending in `e` before a literal does not.
+  const before = text[index - 2];
+  return before === undefined || !/[A-Za-z0-9_$]/.test(before);
+}
+
+/**
+ * Whether the character at `index` is escaped by the backslash run before it.
+ *
+ * An EVEN run means the backslashes escape each other and the character stands
+ * on its own; an odd run means the last one escapes it. Consulted only for a
+ * literal that honours backslash escapes at all.
+ */
+function precededByOddBackslashes(text: string, index: number): boolean {
   let run = 0;
-  for (let i = index - 1; i >= 0 && text[i] === "\\"; i -= 1) run += 1;
+  for (let k = index - 1; k >= 0 && text[k] === "\\"; k -= 1) run += 1;
   return run % 2 === 1;
 }
 
@@ -1035,6 +1053,7 @@ export function splitSqlStatements(
   let current = "";
   let inString = false;
   let stringChar = "";
+  let stringEscapesWithBackslash = false;
 
   for (let i = 0; i < cleanedSql.length; i++) {
     const char = cleanedSql[i];
@@ -1071,10 +1090,14 @@ export function splitSqlStatements(
     if (!inString && opener) {
       inString = true;
       stringChar = opener;
+      // Recorded when the literal OPENS: the `E` prefix is only visible here,
+      // and by the closing quote it is long past.
+      stringEscapesWithBackslash =
+        opener === "'" && opensBackslashEscapedString(cleanedSql, i, dialect);
     } else if (
       inString &&
       char === stringChar &&
-      !precededByOddBackslashes(cleanedSql, i, dialect)
+      !(stringEscapesWithBackslash && precededByOddBackslashes(cleanedSql, i))
     ) {
       inString = false;
     }

--- a/packages/nextly/src/cli/commands/migrate.ts
+++ b/packages/nextly/src/cli/commands/migrate.ts
@@ -978,7 +978,21 @@ function quoteOpenerAt(
  * An EVEN run means the backslashes escape each other and the character stands
  * on its own; an odd run means the last one escapes it.
  */
-function precededByOddBackslashes(text: string, index: number): boolean {
+function precededByOddBackslashes(
+  text: string,
+  index: number,
+  dialect: SupportedDialect | undefined
+): boolean {
+  // 🔴 MySQL ONLY. PostgreSQL and SQLite do not read a backslash as an escape
+  // inside a standard string literal — SQLite has no C-style escapes at all —
+  // so a value ending in one leaves a SINGLE backslash before the closing
+  // quote there. Counting parity unconditionally then calls that quote escaped
+  // and swallows the statement's semicolon: the same defect this function was
+  // written to remove, moved to the other two dialects.
+  // An unknown dialect takes the conservative reading: no dialect but MySQL
+  // escapes with backslashes, so treating the quote as unescaped is what the
+  // other two need and what a caller that named none most likely has.
+  if (dialect !== "mysql") return false;
   let run = 0;
   for (let i = index - 1; i >= 0 && text[i] === "\\"; i -= 1) run += 1;
   return run % 2 === 1;
@@ -1060,7 +1074,7 @@ export function splitSqlStatements(
     } else if (
       inString &&
       char === stringChar &&
-      !precededByOddBackslashes(cleanedSql, i)
+      !precededByOddBackslashes(cleanedSql, i, dialect)
     ) {
       inString = false;
     }

--- a/packages/nextly/src/cli/commands/migrate.ts
+++ b/packages/nextly/src/cli/commands/migrate.ts
@@ -1042,6 +1042,95 @@ function precededByOddBackslashes(text: string, index: number): boolean {
   return run % 2 === 1;
 }
 
+/** Where a scan currently stands with respect to an open string literal. */
+type LiteralState = {
+  inString: boolean;
+  stringChar: string;
+  escapesWithBackslash: boolean;
+};
+
+/**
+ * Advance `state` across the character at `index`.
+ *
+ * The splitter and the line pre-scan both have to agree about where a literal
+ * begins and ends; two copies of this decision would drift, and the drift would
+ * be silent because each looks correct beside its own caller.
+ */
+function advanceLiteralState(
+  text: string,
+  index: number,
+  dialect: SupportedDialect | undefined,
+  state: LiteralState
+): void {
+  const char = text[index];
+  const opener = quoteOpenerAt(char, dialect);
+  if (!state.inString && opener) {
+    state.inString = true;
+    state.stringChar = opener;
+    // Recorded when the literal OPENS: the `E` prefix is only visible here,
+    // and by the closing quote it is long past.
+    state.escapesWithBackslash = opensBackslashEscapedString(
+      text,
+      index,
+      opener,
+      dialect
+    );
+    return;
+  }
+  if (
+    state.inString &&
+    char === state.stringChar &&
+    closesLiteral(text, index, state.escapesWithBackslash)
+  ) {
+    state.inString = false;
+  }
+}
+
+/**
+ * For each line of `sql`, whether that line BEGINS inside a string literal.
+ *
+ * 🔴 The line-based cleanup below removes comment lines and breakpoint markers,
+ * and a physical newline inside a literal makes its continuation look like an
+ * ordinary line. A description entered as `Summary\n-- internal note` puts
+ * `-- internal note` at the start of a line, where the cleanup reads it as a
+ * standalone SQL comment and drops it -- the migration then succeeds and stores
+ * a SILENTLY TRUNCATED description, which is the failure that does not announce
+ * itself.
+ *
+ * Scanned with the same rules the splitter itself uses, so the two agree about
+ * where a literal starts and ends rather than being two answers to one question.
+ */
+function lineStartsInsideLiteral(
+  sql: string,
+  dialect?: SupportedDialect
+): boolean[] {
+  const flags: boolean[] = [false];
+  const state: LiteralState = {
+    inString: false,
+    stringChar: "",
+    escapesWithBackslash: false,
+  };
+
+  for (let i = 0; i < sql.length; i++) {
+    // Outside a literal, a comment runs to end of line and holds prose rather
+    // than SQL, so nothing inside one can open a literal.
+    if (!state.inString && isLineCommentAt(sql, i, dialect)) {
+      const lineEnd = sql.indexOf("\n", i);
+      if (lineEnd === -1) break;
+      i = lineEnd;
+      flags.push(false);
+      continue;
+    }
+    if (sql[i] === "\n") {
+      flags.push(state.inString);
+      continue;
+    }
+    advanceLiteralState(sql, i, dialect, state);
+  }
+
+  return flags;
+}
+
 export function splitSqlStatements(
   sql: string,
   dialect?: SupportedDialect
@@ -1052,9 +1141,16 @@ export function splitSqlStatements(
   //   2. Inline: `SQL_STATEMENT;--> statement-breakpoint` on the same line (after CREATE INDEX/ALTER)
   // Both must be cleaned out before executing, otherwise the marker text
   // ends up as invalid SQL in the next statement.
+  // A line that BEGINS inside a string literal is data, not SQL, so none of the
+  // cleanup below may touch it.
+  // A line that BEGINS inside a string literal is data, not SQL, so no cleanup
+  // below may touch it -- neither dropping it nor rewriting its contents.
+  const insideLiteral = lineStartsInsideLiteral(sql, dialect);
   const cleanedSql = sql
     .split("\n")
-    .filter(line => {
+    .map((line, index) => ({ line, index }))
+    .filter(({ line, index }) => {
+      if (insideLiteral[index]) return true;
       const trimmed = line.trim();
       if (trimmed.startsWith("--> statement-breakpoint")) return false;
       // Remove pure SQL comment lines (but keep lines that have SQL after comments)
@@ -1071,15 +1167,22 @@ export function splitSqlStatements(
     // Strip inline markers (pattern 2) that appear after semicolons on the
     // same line, e.g. `CREATE INDEX ...;--> statement-breakpoint`. Without
     // this, the text after the semicolon pollutes the next accumulated
-    // statement and causes a MySQL syntax error.
-    .map(line => line.replace(/--> statement-breakpoint/g, ""))
+    // statement and causes a MySQL syntax error. Keyed on the ORIGINAL index,
+    // which a map chained after a filter no longer has.
+    .map(({ line, index }) =>
+      insideLiteral[index]
+        ? line
+        : line.replace(/--> statement-breakpoint/g, "")
+    )
     .join("\n");
 
   const statements: string[] = [];
   let current = "";
-  let inString = false;
-  let stringChar = "";
-  let stringEscapesWithBackslash = false;
+  const state: LiteralState = {
+    inString: false,
+    stringChar: "",
+    escapesWithBackslash: false,
+  };
 
   for (let i = 0; i < cleanedSql.length; i++) {
     const char = cleanedSql[i];
@@ -1089,14 +1192,14 @@ export function splitSqlStatements(
     // retained comment ("SQLite doesn't support ...") would otherwise open a
     // string that never closes, and every semicolon after it stops separating
     // statements — the whole file then reaches the driver as one statement.
-    if (!inString && isLineCommentAt(cleanedSql, i, dialect)) {
+    if (!state.inString && isLineCommentAt(cleanedSql, i, dialect)) {
       const lineEnd = cleanedSql.indexOf("\n", i);
       const end = lineEnd === -1 ? cleanedSql.length : lineEnd;
       current += cleanedSql.slice(i, end);
       i = end - 1;
       continue;
     }
-    if (!inString && char === "/" && cleanedSql[i + 1] === "*") {
+    if (!state.inString && char === "/" && cleanedSql[i + 1] === "*") {
       const close = cleanedSql.indexOf("*/", i + 2);
       const end = close === -1 ? cleanedSql.length : close + 2;
       current += cleanedSql.slice(i, end);
@@ -1112,27 +1215,9 @@ export function splitSqlStatements(
     // The bracket and backtick forms are applied per dialect rather than
     // everywhere: `[` is not a quote in Postgres, where it subscripts an array,
     // so treating it as one there would swallow ordinary SQL.
-    const opener = quoteOpenerAt(char, dialect);
-    if (!inString && opener) {
-      inString = true;
-      stringChar = opener;
-      // Recorded when the literal OPENS: the `E` prefix is only visible here,
-      // and by the closing quote it is long past.
-      stringEscapesWithBackslash = opensBackslashEscapedString(
-        cleanedSql,
-        i,
-        opener,
-        dialect
-      );
-    } else if (
-      inString &&
-      char === stringChar &&
-      closesLiteral(cleanedSql, i, stringEscapesWithBackslash)
-    ) {
-      inString = false;
-    }
+    advanceLiteralState(cleanedSql, i, dialect, state);
 
-    if (char === ";" && !inString) {
+    if (char === ";" && !state.inString) {
       const statement = current.trim();
       const hasSQL =
         /\b(CREATE|ALTER|DROP|INSERT|UPDATE|DELETE|SELECT|TRUNCATE|GRANT|REVOKE)\b/i.test(

--- a/packages/nextly/src/domains/collections/services/collection-metadata-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-metadata-service.ts
@@ -11,6 +11,7 @@ import { toDbError } from "../../../database/errors";
 import type { PermissionSeedService } from "../../../domains/auth/services/permission-seed-service";
 import { NextlyError, isProgrammerError } from "../../../errors";
 import { errorEnvelopeFields } from "../../../errors/from-service-envelope";
+import type { StoredHookConfig } from "../../../schemas/dynamic-collections/types";
 import type { CollectionFileManager } from "../../../services/collection-file-manager";
 import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
@@ -376,7 +377,7 @@ export class CollectionMetadataService extends BaseService {
      */
     webhooks?: boolean;
     fields: FieldDefinition[];
-    hooks?: Record<string, unknown>[];
+    hooks?: StoredHookConfig[];
     createdBy?: string;
   }): Promise<MetadataServiceResult> {
     try {
@@ -728,7 +729,7 @@ export class CollectionMetadataService extends BaseService {
       /** Toggle webhook recording. Honoured when defined; undefined leaves it unchanged. */
       webhooks?: boolean;
       fields?: FieldDefinition[];
-      hooks?: Record<string, unknown>[];
+      hooks?: StoredHookConfig[];
     }
   ): Promise<MetadataServiceResult> {
     try {

--- a/packages/nextly/src/domains/collections/services/collection-metadata-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-metadata-service.ts
@@ -392,7 +392,13 @@ export class CollectionMetadataService extends BaseService {
 
       if (this.isDevelopment()) {
         try {
-          await this.fileManager.runMigration(artifacts.migrationSQL);
+          // The artefact carries the registry-row upsert so the committed file
+          // recreates it where the Builder has never run. This database gets
+          // that row from `registerCollection` below, and it refuses a slug
+          // that already exists -- so what runs HERE is the DDL alone.
+          await this.fileManager.runMigration(
+            artifacts.localMigrationSQL ?? artifacts.migrationSQL
+          );
           // Verify table was actually created before marking as applied
           const tableExists = await this.adapter.tableExists(
             artifacts.tableName

--- a/packages/nextly/src/domains/collections/services/collection-metadata-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-metadata-service.ts
@@ -377,6 +377,11 @@ export class CollectionMetadataService extends BaseService {
      */
     webhooks?: boolean;
     fields: FieldDefinition[];
+    /**
+     * The canonical stored-hook shape, not a looser record: the registry row
+     * these feed is typed with it, and the executor reads `config` and `order`
+     * off every entry.
+     */
     hooks?: StoredHookConfig[];
     createdBy?: string;
   }): Promise<MetadataServiceResult> {
@@ -729,6 +734,11 @@ export class CollectionMetadataService extends BaseService {
       /** Toggle webhook recording. Honoured when defined; undefined leaves it unchanged. */
       webhooks?: boolean;
       fields?: FieldDefinition[];
+      /**
+       * The canonical stored-hook shape, not a looser record: the registry row
+       * these feed is typed with it, and the executor reads `config` and `order`
+       * off every entry.
+       */
       hooks?: StoredHookConfig[];
     }
   ): Promise<MetadataServiceResult> {

--- a/packages/nextly/src/domains/dynamic-collections/services/__tests__/generate-collection-metadata-row.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/__tests__/generate-collection-metadata-row.test.ts
@@ -59,6 +59,7 @@ async function generate(overrides: Record<string, unknown> = {}) {
     ...overrides,
   } as never)) as unknown as {
     migrationSQL: string;
+    localMigrationSQL?: string;
     metadata: {
       slug: string;
       labels: { singular: string; plural: string };
@@ -110,6 +111,45 @@ describe("the migration a Builder create writes", () => {
     // the replacement reads as correct everywhere the slug happens to match.
     const sql = await sqlFor({ label: "Story" });
     expect(sql).toContain("Story");
+  });
+
+  it("carries EVERY admin key the local row gets, not just the queryable two", async () => {
+    // 🔴 These decide what a reader SEES — whether the collection appears at
+    // all, where in the sidebar, under which icon. A narrower mapping rebuilt a
+    // visibly different collection wherever the file was replayed while looking
+    // correct in the one place it was authored, which is the failure that does
+    // not announce itself.
+    const sql = await sqlFor({
+      icon: "Sparkles",
+      hidden: true,
+      order: 7,
+      sidebarGroup: "Editorial",
+      useAsTitle: "title",
+      group: "Content",
+    });
+    for (const fragment of [
+      "Sparkles",
+      "sidebarGroup",
+      "Editorial",
+      "hidden",
+    ]) {
+      expect(sql).toContain(fragment);
+    }
+  });
+
+  it("does not run the registry row against THIS database", async () => {
+    // 🔴 The artefact and the local execution are not the same statement. Here
+    // the row is written by `registerCollection`, which refuses a slug that
+    // already exists — so running the upsert locally would take the slug, make
+    // that refusal fire, and leave a created table beside a half-written
+    // registry with every retry failing on the slug it just took.
+    const { migrationSQL, localMigrationSQL } = await generate();
+    expect(migrationSQL).toContain("dynamic_collections");
+    expect(localMigrationSQL).toBeDefined();
+    expect(localMigrationSQL).not.toContain("dynamic_collections");
+    // The control: the local SQL is still the DDL, not empty — a variant that
+    // returned nothing would satisfy the refusal above and create no table.
+    expect(localMigrationSQL).toContain("dc_articles");
   });
 
   it("emits EXACTLY what migrate:create emits for the same entity", async () => {

--- a/packages/nextly/src/domains/dynamic-collections/services/__tests__/generate-collection-metadata-row.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/__tests__/generate-collection-metadata-row.test.ts
@@ -158,6 +158,24 @@ describe("the migration a Builder create writes", () => {
     expect(localMigrationSQL).toContain("dc_articles");
   });
 
+  it("carries the collection's own description", async () => {
+    // 🔴 The Builder's create modal collects it and the local row stores it, so
+    // an entity that omitted it wrote NULL wherever the file was replayed and
+    // the help text vanished on the deployed copy — visible only to whoever
+    // opened the collection there.
+    const sql = await sqlFor({ description: "Long-form editorial pieces" });
+    expect(sql).toContain("Long-form editorial pieces");
+  });
+
+  it("writes NULL, not the text 'undefined', when there is no description", async () => {
+    // The control the case above needs: a mapping that stringified an absent
+    // value would satisfy it and store the four characters "null" — or worse,
+    // "undefined" — as the help text of every collection created without one.
+    const sql = await sqlFor();
+    expect(sql).not.toContain("'undefined'");
+    expect(sql).toContain("NULL");
+  });
+
   it("emits EXACTLY what migrate:create emits for the same entity", async () => {
     // 🔴 The control the other four exist for. Each of them passes against a
     // second, separately written statement that merely looks right — which is

--- a/packages/nextly/src/domains/dynamic-collections/services/__tests__/generate-collection-metadata-row.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/__tests__/generate-collection-metadata-row.test.ts
@@ -183,7 +183,15 @@ describe("the migration a Builder create writes", () => {
     // where it was deployed. Not reachable from the Builder's own modal, which
     // sends no hooks, but the service accepts them and stores them.
     const sql = await sqlFor({
-      hooks: [{ type: "beforeChange", handler: "slugify" }],
+      hooks: [
+        {
+          hookId: "slugify",
+          hookType: "beforeChange",
+          enabled: true,
+          config: {},
+          order: 0,
+        },
+      ],
     });
     expect(sql).toContain("slugify");
   });

--- a/packages/nextly/src/domains/dynamic-collections/services/__tests__/generate-collection-metadata-row.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/__tests__/generate-collection-metadata-row.test.ts
@@ -127,14 +127,20 @@ describe("the migration a Builder create writes", () => {
       useAsTitle: "title",
       group: "Content",
     });
-    for (const fragment of [
-      "Sparkles",
-      "sidebarGroup",
-      "Editorial",
-      "hidden",
-    ]) {
-      expect(sql).toContain(fragment);
-    }
+    // Asserted as the whole serialized block rather than as a handful of
+    // fragments: a fragment list is a SAMPLE, and the key it happens to omit is
+    // the one that goes missing. `order` is the interesting member — it is the
+    // only number, so a mapping that survived every string would still drop it.
+    expect(sql).toContain(
+      JSON.stringify({
+        useAsTitle: "title",
+        group: "content",
+        icon: "Sparkles",
+        hidden: true,
+        order: 7,
+        sidebarGroup: "Editorial",
+      })
+    );
   });
 
   it("does not run the registry row against THIS database", async () => {

--- a/packages/nextly/src/domains/dynamic-collections/services/__tests__/generate-collection-metadata-row.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/__tests__/generate-collection-metadata-row.test.ts
@@ -176,6 +176,31 @@ describe("the migration a Builder create writes", () => {
     expect(sql).toContain("NULL");
   });
 
+  it("carries stored hooks, which the hook service runs off the row", async () => {
+    // 🔴 The hook service reads `collection.hooks` from the registry row and
+    // executes them, so a replayed row without them runs none — the collection
+    // validates and transforms where it was authored and silently does neither
+    // where it was deployed. Not reachable from the Builder's own modal, which
+    // sends no hooks, but the service accepts them and stores them.
+    const sql = await sqlFor({
+      hooks: [{ type: "beforeChange", handler: "slugify" }],
+    });
+    expect(sql).toContain("slugify");
+  });
+
+  it("hashes the local row the SAME way the migration does", async () => {
+    // 🔴 One question, one answer. The row this service writes and the row the
+    // migration recreates must agree about the schema hash, because
+    // `syncCodeFirstCollections` decides whether a definition changed by
+    // comparing it — so two values mean the two databases reach opposite
+    // answers, one reopening `migration_status` for a collection the other
+    // considers settled.
+    const { migrationSQL, metadata } = await generate();
+    expect(migrationSQL).toContain(
+      (metadata as unknown as { schemaHash: string }).schemaHash
+    );
+  });
+
   it("emits EXACTLY what migrate:create emits for the same entity", async () => {
     // 🔴 The control the other four exist for. Each of them passes against a
     // second, separately written statement that merely looks right — which is

--- a/packages/nextly/src/domains/dynamic-collections/services/__tests__/generate-collection-metadata-row.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/__tests__/generate-collection-metadata-row.test.ts
@@ -1,0 +1,139 @@
+/**
+ * The migration a Schema Builder create writes has to carry the REGISTRY ROW,
+ * not only the table.
+ *
+ * The file is committed and replayed against a database that has never seen the
+ * Builder. That database has the `dynamic_collections` row this service writes
+ * locally only if the migration recreates it — so without the upsert a deploy
+ * gets the table and no row, and the collection is absent from the admin rather
+ * than showing a stale status.
+ *
+ * The control that matters is the LAST test: the statement this path appends
+ * must be the one `migrate:create` writes for the same entity. Two authoring
+ * paths that both emit "the metadata row" and can disagree about its contents
+ * are the defect, not the fix.
+ *
+ * @module domains/dynamic-collections/services/__tests__/generate-collection-metadata-row
+ */
+
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { buildCollectionMetadataUpsert } from "../../../schema/ui-schema/metadata-sql";
+import { DynamicCollectionService } from "../dynamic-collection-service";
+
+beforeAll(() => {
+  process.env.DB_DIALECT ??= "sqlite";
+  process.env.DATABASE_URL ??= "file::memory:";
+});
+
+function service(): DynamicCollectionService {
+  const logger = {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  };
+  // The registry's existence check runs before any SQL is generated, so the
+  // stub answers that one query and nothing else: a select chain resolving to
+  // no rows, which is "this slug is free".
+  const emptySelect = {
+    select: () => emptySelect,
+    from: () => emptySelect,
+    where: () => emptySelect,
+    limit: async () => [] as unknown[],
+  };
+  const adapter = {
+    getCapabilities: () => ({ dialect: "sqlite" as const }),
+    getDrizzle: () => emptySelect,
+    dialect: "sqlite" as const,
+  } as unknown as ConstructorParameters<typeof DynamicCollectionService>[0];
+  return new DynamicCollectionService(adapter, logger);
+}
+
+const FIELDS = [{ name: "title", type: "text" }];
+
+async function generate(overrides: Record<string, unknown> = {}) {
+  return (await service().generateCollection({
+    name: "articles",
+    fields: FIELDS,
+    ...overrides,
+  } as never)) as unknown as {
+    migrationSQL: string;
+    metadata: {
+      slug: string;
+      labels: { singular: string; plural: string };
+      fields: unknown;
+      status: boolean;
+      localized: boolean;
+    };
+  };
+}
+
+async function sqlFor(
+  overrides: Record<string, unknown> = {}
+): Promise<string> {
+  return (await generate(overrides)).migrationSQL;
+}
+
+describe("the migration a Builder create writes", () => {
+  it("carries the dynamic_collections row, not only the table", async () => {
+    const sql = await sqlFor();
+    // The control first: the table itself is still created, so a filter that
+    // dropped the DDL would not pass this by only adding the row.
+    expect(sql).toContain("dc_articles");
+    expect(sql).toContain("INSERT INTO");
+    expect(sql).toContain("dynamic_collections");
+  });
+
+  it("records the row as applied, because replaying the file IS the apply", async () => {
+    // On the database this file is replayed against, running it is exactly the
+    // moment the table arrives — so the row it inserts describes a table that
+    // is present, and anything reading the status to decide queryability may
+    // believe it.
+    expect(await sqlFor()).toContain("'applied'");
+  });
+
+  it("separates the upsert with the breakpoint marker", async () => {
+    // 🔴 Not cosmetic. The runner splits the file on this marker and a driver
+    // with multi-statements disabled — MySQL — rejects a chunk holding both the
+    // CREATE and the INSERT. Without it the whole migration fails on one
+    // dialect and passes on the other two.
+    const sql = await sqlFor();
+    const afterLastMarker = sql.slice(
+      sql.lastIndexOf("--> statement-breakpoint")
+    );
+    expect(afterLastMarker).toContain("dynamic_collections");
+  });
+
+  it("carries the author's own labels rather than the slug-derived default", async () => {
+    // A custom label is the thing a slug-derived default silently replaces, and
+    // the replacement reads as correct everywhere the slug happens to match.
+    const sql = await sqlFor({ label: "Story" });
+    expect(sql).toContain("Story");
+  });
+
+  it("emits EXACTLY what migrate:create emits for the same entity", async () => {
+    // 🔴 The control the other four exist for. Each of them passes against a
+    // second, separately written statement that merely looks right — which is
+    // the divergence this change removes rather than adds to. The two authoring
+    // paths are disjoint by construction: this one writes no `meta/` snapshot,
+    // so `migrate:create` never sees its tables and cannot correct it.
+    const { migrationSQL, metadata } = await generate();
+    // Built from the row this service says it WROTE, not from the raw input:
+    // the fields it stores are normalised, so an expectation assembled from the
+    // request would differ in both the fields JSON and the schema hash derived
+    // from it — and would be asserting a row nobody has.
+    const expected = buildCollectionMetadataUpsert(
+      {
+        slug: metadata.slug,
+        labels: metadata.labels,
+        admin: {},
+        status: metadata.status,
+        localized: metadata.localized,
+        fields: metadata.fields,
+      } as never,
+      "sqlite"
+    );
+    expect(migrationSQL).toContain(expected);
+  });
+});

--- a/packages/nextly/src/domains/dynamic-collections/services/__tests__/generate-collection-metadata-row.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/__tests__/generate-collection-metadata-row.test.ts
@@ -220,11 +220,11 @@ describe("the migration a Builder create writes", () => {
 
   it("emits EXACTLY what migrate:create emits for the same entity", async () => {
     // 🔴 The control the other four exist for. Each of them passes against a
-    // second, separately written statement that merely looks right — which is
-    // the divergence this change removes rather than adds to. The statement
-    // this path appends must be the one `migrate:create` writes for the same
-    // entity, because the committed file is the only thing replayed against the
-    // target database.
+    // second, separately written statement that merely LOOKS right, so none of
+    // them can tell the two authoring paths apart. The statement this path
+    // appends must be byte-for-byte the one `migrate:create` writes for the
+    // same entity, because the committed file is the only thing replayed
+    // against the target database.
     const { migrationSQL, metadata } = await generate();
     // Built from the row this service says it WROTE, not from the raw input:
     // the fields it stores are normalised, so an expectation assembled from the

--- a/packages/nextly/src/domains/dynamic-collections/services/__tests__/generate-collection-metadata-row.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/__tests__/generate-collection-metadata-row.test.ts
@@ -167,13 +167,22 @@ describe("the migration a Builder create writes", () => {
     expect(sql).toContain("Long-form editorial pieces");
   });
 
-  it("writes NULL, not the text 'undefined', when there is no description", async () => {
-    // The control the case above needs: a mapping that stringified an absent
-    // value would satisfy it and store the four characters "null" — or worse,
-    // "undefined" — as the help text of every collection created without one.
+  it("OMITS the description column entirely when there is none", async () => {
+    // 🔴 Searching the statement for NULL cannot separate the two
+    // implementations: the default `versions`, `revalidate` and `webhooks`
+    // columns already emit NULL, so that assertion passes on an unconditional
+    // description column as readily as on an omitted one. Whether the column is
+    // NAMED at all is the property that differs — omitted, it is absent from
+    // the INSERT and from the DO UPDATE SET, so replaying a manifest that
+    // carries no description leaves a deployed one alone.
     const sql = await sqlFor();
+    expect(sql).not.toContain('"description"');
+    // A mapping that stringified an absent value would store the characters
+    // "undefined" as the help text of every collection created without one.
     expect(sql).not.toContain("'undefined'");
-    expect(sql).toContain("NULL");
+    // The control: a run that generated no statement would satisfy both
+    // refusals above without the column having been omitted by anything.
+    expect(sql).toContain("dynamic_collections");
   });
 
   it("carries stored hooks, which the hook service runs off the row", async () => {
@@ -212,9 +221,10 @@ describe("the migration a Builder create writes", () => {
   it("emits EXACTLY what migrate:create emits for the same entity", async () => {
     // 🔴 The control the other four exist for. Each of them passes against a
     // second, separately written statement that merely looks right — which is
-    // the divergence this change removes rather than adds to. The two authoring
-    // paths are disjoint by construction: this one writes no `meta/` snapshot,
-    // so `migrate:create` never sees its tables and cannot correct it.
+    // the divergence this change removes rather than adds to. The statement
+    // this path appends must be the one `migrate:create` writes for the same
+    // entity, because the committed file is the only thing replayed against the
+    // target database.
     const { migrationSQL, metadata } = await generate();
     // Built from the row this service says it WROTE, not from the raw input:
     // the fields it stores are normalised, so an expectation assembled from the

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-registry-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-registry-service.ts
@@ -83,6 +83,11 @@ export interface CollectionMetadata {
     publish?: { type: string; allowedRoles?: string[] };
     unpublish?: { type: string; allowedRoles?: string[] };
   };
+  /**
+   * The canonical stored-hook shape, not a looser record: the registry row
+   * these feed is typed with it, and the executor reads `config` and `order`
+   * off every entry.
+   */
   hooks?: StoredHookConfig[];
   createdBy?: string;
 }

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-registry-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-registry-service.ts
@@ -6,6 +6,7 @@ import type { RevalidateConfig } from "../../../revalidation/types";
 import { isReservedResourceSlug } from "../../../schemas/_zod/rbac";
 import type { FieldDefinition } from "../../../schemas/dynamic-collections";
 import type {
+  StoredHookConfig,
   MigrationStatus,
   StoredWebhookRecording,
 } from "../../../schemas/dynamic-collections/types";
@@ -82,7 +83,7 @@ export interface CollectionMetadata {
     publish?: { type: string; allowedRoles?: string[] };
     unpublish?: { type: string; allowedRoles?: string[] };
   };
-  hooks?: Record<string, unknown>[];
+  hooks?: StoredHookConfig[];
   createdBy?: string;
 }
 

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
@@ -400,9 +400,9 @@ export class DynamicCollectionService extends BaseService {
     // rather than merely stale.
     //
     // Built by the SAME builder `migrate:create` uses, not a second statement
-    // that would have to agree with it. The two authoring paths are otherwise
-    // disjoint -- this one writes no `meta/` snapshot, so `migrate:create` never
-    // sees its tables -- which is exactly why each has to be self-sufficient.
+    // that would have to agree with it. What makes this file have to be
+    // self-sufficient is simply that it is the only thing replayed against the
+    // target database: nothing else recreates the registry row there.
     // 🔴 The ARTEFACT and what runs HERE are not the same statement, and this
     // path had no reason to distinguish them until the artefact gained the
     // registry row. The committed file must recreate that row, because the
@@ -478,25 +478,6 @@ export class DynamicCollectionService extends BaseService {
   }
 
   /**
-   * i18n: append the create-only companion `<table>_locales` CREATE statement to a
-   * fresh localized collection's migration. Returns the original SQL unchanged when
-   * the collection has no translatable fields (nothing to store per-locale).
-   */
-  /**
-   * Append the `dynamic_collections` upsert that recreates this collection's
-   * registry row when the migration is replayed elsewhere.
-   *
-   * Separated with the breakpoint marker for the same reason the companion
-   * CREATE is: the runner splits on it, and a driver with multi-statements
-   * disabled rejects a combined chunk.
-   *
-   * The upsert conflicts on `slug` and leaves `id`, `table_name`, `source` and
-   * `migration_status` to the INSERT, so replaying it against a database that
-   * already holds the row -- this one, in development -- refreshes the fields
-   * and labels without renaming the row or overwriting a status the runtime
-   * owns.
-   */
-  /**
    * This collection as the manifest describes it, which is what the metadata
    * upsert is built from.
    *
@@ -549,6 +530,20 @@ export class DynamicCollectionService extends BaseService {
     };
   }
 
+  /**
+   * Append the `dynamic_collections` upsert that recreates this collection's
+   * registry row when the migration is replayed elsewhere.
+   *
+   * Separated with the breakpoint marker for the same reason the companion
+   * CREATE is: the runner splits on it, and a driver with multi-statements
+   * disabled rejects a combined chunk.
+   *
+   * The upsert conflicts on `slug` and leaves `id`, `table_name`, `source` and
+   * `migration_status` to the INSERT, so replaying it against a database that
+   * already holds the row -- this one, in development -- refreshes the fields
+   * and labels without renaming the row or overwriting a status the runtime
+   * owns.
+   */
   private appendMetadataUpsertSQL(
     migrationSQL: string,
     entity: UiSchemaEntity
@@ -557,6 +552,11 @@ export class DynamicCollectionService extends BaseService {
     return `${migrationSQL}\n--> statement-breakpoint\n${upsert}`;
   }
 
+  /**
+   * i18n: append the create-only companion `<table>_locales` CREATE statement to a
+   * fresh localized collection's migration. Returns the original SQL unchanged when
+   * the collection has no translatable fields (nothing to store per-locale).
+   */
   private appendCompanionCreateSQL(
     migrationSQL: string,
     slug: string,

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
@@ -506,6 +506,7 @@ export class DynamicCollectionService extends BaseService {
   ): UiSchemaEntity {
     return {
       slug,
+      description: data.description,
       labels: data.labels ?? {
         singular: data.label || slug,
         plural: (data.label || slug) + "s",

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
@@ -43,7 +43,21 @@ import { DynamicCollectionSchemaService } from "./dynamic-collection-schema-serv
 import { DynamicCollectionValidationService } from "./dynamic-collection-validation-service";
 
 export interface CollectionArtifacts {
+  /**
+   * The migration to COMMIT. Carries the `dynamic_collections` upsert, because
+   * the database this file is replayed against has no row for the collection.
+   */
   migrationSQL: string;
+  /**
+   * What to run against THIS database, which differs from the artefact.
+   *
+   * The registry row here is written by `registerCollection`, and it refuses a
+   * slug that already exists — so the upsert the artefact carries must not run
+   * locally. Optional so a caller that has no reason to distinguish the two can
+   * fall back to `migrationSQL`, which is how the update path already reads its
+   * own local variant.
+   */
+  localMigrationSQL?: string;
   migrationFileName: string;
   tableName: string;
   metadata: {
@@ -375,6 +389,17 @@ export class DynamicCollectionService extends BaseService {
     // that would have to agree with it. The two authoring paths are otherwise
     // disjoint -- this one writes no `meta/` snapshot, so `migrate:create` never
     // sees its tables -- which is exactly why each has to be self-sufficient.
+    // 🔴 The ARTEFACT and what runs HERE are not the same statement, and this
+    // path had no reason to distinguish them until the artefact gained the
+    // registry row. The committed file must recreate that row, because the
+    // database it is replayed against has none. THIS database is about to get
+    // one from `registerCollection`, which refuses a slug that already exists --
+    // so running the upsert locally would insert the row, make that refusal
+    // fire, and leave a created table beside a half-written registry with every
+    // retry failing on the slug it just took.
+    //
+    // The update path already draws this distinction and names it the same way;
+    // the create path simply never needed it before.
     const fullMigrationSQL = this.appendMetadataUpsertSQL(
       withCompanion,
       this.manifestEntityFor(normalizedName, data, userDefinedFields)
@@ -429,6 +454,9 @@ export class DynamicCollectionService extends BaseService {
 
     return {
       migrationSQL: fullMigrationSQL,
+      // What to run against THIS database: the DDL without the registry row,
+      // which `registerCollection` writes a moment later.
+      localMigrationSQL: withCompanion,
       migrationFileName: `${Date.now()}_create_${normalizedName}.sql`,
       tableName,
       metadata,
@@ -482,7 +510,19 @@ export class DynamicCollectionService extends BaseService {
         singular: data.label || slug,
         plural: (data.label || slug) + "s",
       },
-      admin: { useAsTitle: data.useAsTitle, group: data.group?.toLowerCase() },
+      // 🔴 EVERY admin key the local row gets, not the two the manifest used to
+      // declare. These are what a reader sees -- whether the collection appears
+      // at all, where in the sidebar, under which icon -- so a narrower mapping
+      // here rebuilt a visibly different collection wherever the file was
+      // replayed, and looked correct in the one place it was authored.
+      admin: {
+        useAsTitle: data.useAsTitle,
+        group: data.group?.toLowerCase(),
+        icon: data.icon,
+        hidden: data.hidden,
+        order: data.order,
+        sidebarGroup: data.sidebarGroup,
+      },
       status: data.status === true,
       localized: data.localized === true,
       versions: data.versions,

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
@@ -3,7 +3,7 @@
  * registry services for dynamic collections.
  */
 
-import { createHash, randomBytes } from "crypto";
+import { randomBytes } from "crypto";
 
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 
@@ -29,6 +29,7 @@ import {
   readIndexNames,
   tableHasRows,
 } from "../../schema/pipeline/live-table-facts";
+import { calculateSchemaHash } from "../../schema/services/schema-hash";
 import { buildCollectionMetadataUpsert } from "../../schema/ui-schema/metadata-sql";
 import { resolveBuilderVersions } from "../../versions/builder-versions";
 import { resolveBuilderWebhooks } from "../../webhooks/builder-webhooks";
@@ -507,6 +508,7 @@ export class DynamicCollectionService extends BaseService {
     return {
       slug,
       description: data.description,
+      hooks: data.hooks,
       labels: data.labels ?? {
         singular: data.label || slug,
         plural: (data.label || slug) + "s",
@@ -567,9 +569,25 @@ export class DynamicCollectionService extends BaseService {
     return `${migrationSQL}\n--> statement-breakpoint\n${buildCompanionCreateOnlySql(spec)}`;
   }
 
+  /**
+   * The schema hash for this collection's stored row.
+   *
+   * 🔴 DELEGATES to the canonical function, and the delegation is the point.
+   * This hashed the raw field JSON; `calculateSchemaHash` normalises the fields
+   * and folds in `SYSTEM_SCHEMA_VERSION`, so the two produce different values
+   * for the same collection. The migration this service writes carries the
+   * canonical one -- the shared upsert computes it -- so the local row and the
+   * replayed row disagreed about a collection neither had changed.
+   *
+   * What that costs is not cosmetic: `syncCodeFirstCollections` decides whether
+   * a definition changed by comparing this hash, so the two databases reach
+   * opposite answers -- one reopening `migration_status` and bumping
+   * `schema_version` for a collection the other considers settled.
+   */
   private generateSchemaHash(fields: FieldDefinition[]): string {
-    const fieldsJson = JSON.stringify(fields);
-    return createHash("sha256").update(fieldsJson).digest("hex");
+    return calculateSchemaHash(
+      fields as unknown as Parameters<typeof calculateSchemaHash>[0]
+    );
   }
 
   /**

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
@@ -9,6 +9,7 @@ import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 
 import { NextlyError } from "../../../errors";
 import { resolveBuilderRevalidate } from "../../../revalidation/builder-revalidate";
+import type { UiSchemaEntity } from "../../../schemas/_zod/ui-schema";
 import type { FieldDefinition } from "../../../schemas/dynamic-collections";
 import type { MigrationStatus } from "../../../schemas/dynamic-collections/types";
 import { getI18nArchiveDdl } from "../../../schemas/nextly-i18n-archive";
@@ -28,6 +29,7 @@ import {
   readIndexNames,
   tableHasRows,
 } from "../../schema/pipeline/live-table-facts";
+import { buildCollectionMetadataUpsert } from "../../schema/ui-schema/metadata-sql";
 import { resolveBuilderVersions } from "../../versions/builder-versions";
 import { resolveBuilderWebhooks } from "../../webhooks/builder-webhooks";
 
@@ -355,12 +357,28 @@ export class DynamicCollectionService extends BaseService {
     // fresh collection, no data to seed, no main-table columns to drop). Without
     // this, a UI-created localized collection has nowhere to store per-language
     // values and every language shares the main columns.
-    const fullMigrationSQL = data.localized
+    const withCompanion = data.localized
       ? this.appendCompanionCreateSQL(migrationSQL, normalizedName, tableName, {
           fields: userDefinedFields,
           status: data.status === true,
         })
       : migrationSQL;
+
+    // 🔴 The committed migration has to carry the REGISTRY ROW as well as the
+    // table. This file is replayed against a database that has never seen the
+    // Schema Builder -- production -- where the `dynamic_collections` row this
+    // service writes locally does not exist. Without the upsert the deploy gets
+    // the table and no row at all, and the collection is absent from the admin
+    // rather than merely stale.
+    //
+    // Built by the SAME builder `migrate:create` uses, not a second statement
+    // that would have to agree with it. The two authoring paths are otherwise
+    // disjoint -- this one writes no `meta/` snapshot, so `migrate:create` never
+    // sees its tables -- which is exactly why each has to be self-sufficient.
+    const fullMigrationSQL = this.appendMetadataUpsertSQL(
+      withCompanion,
+      this.manifestEntityFor(normalizedName, data, userDefinedFields)
+    );
 
     const schemaHash = this.generateSchemaHash(userDefinedFields);
 
@@ -422,6 +440,67 @@ export class DynamicCollectionService extends BaseService {
    * fresh localized collection's migration. Returns the original SQL unchanged when
    * the collection has no translatable fields (nothing to store per-locale).
    */
+  /**
+   * Append the `dynamic_collections` upsert that recreates this collection's
+   * registry row when the migration is replayed elsewhere.
+   *
+   * Separated with the breakpoint marker for the same reason the companion
+   * CREATE is: the runner splits on it, and a driver with multi-statements
+   * disabled rejects a combined chunk.
+   *
+   * The upsert conflicts on `slug` and leaves `id`, `table_name`, `source` and
+   * `migration_status` to the INSERT, so replaying it against a database that
+   * already holds the row -- this one, in development -- refreshes the fields
+   * and labels without renaming the row or overwriting a status the runtime
+   * owns.
+   */
+  /**
+   * This collection as the manifest describes it, which is what the metadata
+   * upsert is built from.
+   *
+   * 🔴 Every optional value is passed STRAIGHT THROUGH, `undefined` included,
+   * rather than being conditionally spread in. The upsert builder hands each to
+   * its own literal helper -- `versionsLiteral`, `revalidateLiteral`,
+   * `webhooksLiteral` -- which decide what an absent flag means, and
+   * `JSON.stringify` drops an undefined member, so an omitted key and a
+   * present-but-undefined one produce the same row. Spreading conditionally
+   * bought nothing and put six branches on this mapping.
+   *
+   * The BOOLEAN forms, not the resolved objects this service stores: the
+   * builder runs the same `resolveBuilder*` helpers itself, so handing it the
+   * resolved form would resolve twice and could write a row `migrate:create`
+   * would not.
+   */
+  private manifestEntityFor(
+    slug: string,
+    data: CreateCollectionInput,
+    fields: FieldDefinition[]
+  ): UiSchemaEntity {
+    return {
+      slug,
+      labels: data.labels ?? {
+        singular: data.label || slug,
+        plural: (data.label || slug) + "s",
+      },
+      admin: { useAsTitle: data.useAsTitle, group: data.group?.toLowerCase() },
+      status: data.status === true,
+      localized: data.localized === true,
+      versions: data.versions,
+      versionsMaxPerDoc: data.versionsMaxPerDoc,
+      revalidate: data.revalidate,
+      webhooks: data.webhooks,
+      fields: fields as unknown as UiSchemaEntity["fields"],
+    };
+  }
+
+  private appendMetadataUpsertSQL(
+    migrationSQL: string,
+    entity: UiSchemaEntity
+  ): string {
+    const upsert = buildCollectionMetadataUpsert(entity, this.adapter.dialect);
+    return `${migrationSQL}\n--> statement-breakpoint\n${upsert}`;
+  }
+
   private appendCompanionCreateSQL(
     migrationSQL: string,
     slug: string,

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
@@ -122,6 +122,11 @@ export interface CreateCollectionInput {
    */
   webhooks?: boolean;
   fields: FieldDefinition[];
+  /**
+   * The canonical stored-hook shape, not a looser record: the registry row
+   * these feed is typed with it, and the executor reads `config` and `order`
+   * off every entry.
+   */
   hooks?: StoredHookConfig[];
   createdBy?: string;
 }
@@ -150,6 +155,11 @@ export interface UpdateCollectionInput {
   /** Toggle webhook recording. Honoured when defined; undefined leaves it unchanged. */
   webhooks?: boolean;
   fields?: FieldDefinition[];
+  /**
+   * The canonical stored-hook shape, not a looser record: the registry row
+   * these feed is typed with it, and the executor reads `config` and `order`
+   * off every entry.
+   */
   hooks?: StoredHookConfig[];
 }
 

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
@@ -11,7 +11,10 @@ import { NextlyError } from "../../../errors";
 import { resolveBuilderRevalidate } from "../../../revalidation/builder-revalidate";
 import type { UiSchemaEntity } from "../../../schemas/_zod/ui-schema";
 import type { FieldDefinition } from "../../../schemas/dynamic-collections";
-import type { MigrationStatus } from "../../../schemas/dynamic-collections/types";
+import type {
+  MigrationStatus,
+  StoredHookConfig,
+} from "../../../schemas/dynamic-collections/types";
 import { getI18nArchiveDdl } from "../../../schemas/nextly-i18n-archive";
 import { BaseService } from "../../../shared/base-service";
 import type { Logger } from "../../../shared/types";
@@ -119,7 +122,7 @@ export interface CreateCollectionInput {
    */
   webhooks?: boolean;
   fields: FieldDefinition[];
-  hooks?: Record<string, unknown>[];
+  hooks?: StoredHookConfig[];
   createdBy?: string;
 }
 
@@ -147,7 +150,7 @@ export interface UpdateCollectionInput {
   /** Toggle webhook recording. Honoured when defined; undefined leaves it unchanged. */
   webhooks?: boolean;
   fields?: FieldDefinition[];
-  hooks?: Record<string, unknown>[];
+  hooks?: StoredHookConfig[];
 }
 
 export class DynamicCollectionService extends BaseService {

--- a/packages/nextly/src/domains/schema/ui-schema/metadata-sql.test.ts
+++ b/packages/nextly/src/domains/schema/ui-schema/metadata-sql.test.ts
@@ -416,3 +416,55 @@ describe("webhooks column", () => {
     expect(parsed.success).toBe(false);
   });
 });
+
+describe("escaping the values a Builder-authored entity can carry", () => {
+  // A validation pattern is the ordinary way a backslash reaches this SQL.
+  const PATTERN = "^\\d+$";
+  const withPattern = {
+    slug: "posts",
+    fields: [{ name: "code", type: "text", options: { pattern: PATTERN } }],
+  } as never;
+  // What the fields column holds before any SQL quoting: JSON encodes the
+  // backslash, so this already carries two characters where the pattern had one.
+  const asJson = JSON.stringify([
+    { name: "code", type: "text", options: { pattern: PATTERN } },
+  ]);
+
+  it("DOUBLES a backslash for MySQL, which reads one as an escape", () => {
+    // 🔴 Under the default SQL mode MySQL consumes a level of backslash
+    // escaping, so the JSON it stores is not the JSON that was written — or the
+    // statement stops parsing. Either way it fails AFTER the table DDL in the
+    // same file has already run, leaving the migration half applied.
+    //
+    // The expectation is COMPUTED rather than written out: an escape sequence
+    // typed by hand is exactly the thing this test is about getting wrong.
+    const sql = buildCollectionMetadataUpsert(withPattern, "mysql");
+    expect(sql).toContain(asJson.replace(/\\/g, "\\\\"));
+  });
+
+  it("leaves it alone for PostgreSQL and SQLite, which store it verbatim", () => {
+    // The control: a rule that doubled everywhere would corrupt these two, and
+    // would still satisfy the assertion above.
+    for (const dialect of ["postgresql", "sqlite"] as const) {
+      const sql = buildCollectionMetadataUpsert(withPattern, dialect);
+      expect(sql).toContain(asJson);
+      expect(sql).not.toContain(asJson.replace(/\\/g, "\\\\"));
+    }
+  });
+
+  it("still doubles an apostrophe on every dialect", () => {
+    // The other control: delegating must not have dropped the escaping that
+    // was already right.
+    for (const dialect of ["postgresql", "sqlite", "mysql"] as const) {
+      const sql = buildCollectionMetadataUpsert(
+        {
+          slug: "posts",
+          labels: { singular: "O'Reilly", plural: "x" },
+          fields: [],
+        } as never,
+        dialect
+      );
+      expect(sql).toContain("O''Reilly");
+    }
+  });
+});

--- a/packages/nextly/src/domains/schema/ui-schema/metadata-sql.test.ts
+++ b/packages/nextly/src/domains/schema/ui-schema/metadata-sql.test.ts
@@ -526,7 +526,21 @@ describe("hooks are a collection-only manifest key", () => {
     collections: [],
     singles: [],
     components: [],
-    [kind]: [{ slug: "x", hooks: [{ type: "beforeChange" }], fields: [] }],
+    [kind]: [
+      {
+        slug: "x",
+        hooks: [
+          {
+            hookId: "auto-slug",
+            hookType: "beforeChange",
+            enabled: true,
+            config: {},
+            order: 0,
+          },
+        ],
+        fields: [],
+      },
+    ],
   });
 
   it("REFUSES hooks on a single and on a component", () => {
@@ -544,7 +558,19 @@ describe("hooks are a collection-only manifest key", () => {
     // refusal above and silently drop the one kind that can store them.
     const parsed = uiSchemaManifest.safeParse({
       collections: [
-        { slug: "posts", hooks: [{ type: "beforeChange" }], fields: [] },
+        {
+          slug: "posts",
+          hooks: [
+            {
+              hookId: "auto-slug",
+              hookType: "beforeChange",
+              enabled: true,
+              config: {},
+              order: 0,
+            },
+          ],
+          fields: [],
+        },
       ],
       singles: [],
       components: [],

--- a/packages/nextly/src/domains/schema/ui-schema/metadata-sql.test.ts
+++ b/packages/nextly/src/domains/schema/ui-schema/metadata-sql.test.ts
@@ -471,8 +471,7 @@ describe("escaping the values a Builder-authored entity can carry", () => {
 
 describe("a column that is absent from the manifest must not clear the row", () => {
   it("omits the description column entirely when the manifest carries none", () => {
-    // 🔴 The correction this branch made after four rounds of the same finding.
-    // Written unconditionally — NULL when absent — the column does not merely
+    // 🔴 Written unconditionally — NULL when absent — the column does not merely
     // fail to set a description, it CLEARS one: every manifest projection that
     // does not carry the value erases what an earlier migration deployed, and
     // there are six such projections.

--- a/packages/nextly/src/domains/schema/ui-schema/metadata-sql.test.ts
+++ b/packages/nextly/src/domains/schema/ui-schema/metadata-sql.test.ts
@@ -515,3 +515,38 @@ describe("hooks are a collection-only manifest key", () => {
     expect(parsed.success).toBe(true);
   });
 });
+
+describe("presentation metadata reaches every kind that can store it", () => {
+  const withAdmin = {
+    slug: "x",
+    admin: { hidden: true, icon: "Sparkles", order: 3 },
+    fields: [],
+  } as never;
+
+  it("emits the admin column for singles and components, not only collections", () => {
+    // 🔴 The shared manifest schema accepts `icon`, `hidden`, `order` and
+    // `sidebarGroup` for all three kinds, and all three registry tables HAVE an
+    // admin column — checked per table. A builder that omitted it let those
+    // settings validate, deploy, and be ignored, leaving an entity visible that
+    // the manifest said was hidden.
+    for (const build of [
+      buildSingleMetadataUpsert,
+      buildComponentMetadataUpsert,
+    ]) {
+      const sql = build(withAdmin, "sqlite");
+      expect(sql).toContain("Sparkles");
+      expect(sql).toContain('"admin"');
+    }
+  });
+
+  it("omits the column when the manifest says nothing about presentation", () => {
+    // The control: unlike `description`, admin is CONDITIONAL — an absent block
+    // must leave the stored value alone rather than clearing it, so a builder
+    // that always emitted it would erase presentation on every save.
+    const sql = buildSingleMetadataUpsert(
+      { slug: "x", fields: [] } as never,
+      "sqlite"
+    );
+    expect(sql).not.toContain('"admin"');
+  });
+});

--- a/packages/nextly/src/domains/schema/ui-schema/metadata-sql.test.ts
+++ b/packages/nextly/src/domains/schema/ui-schema/metadata-sql.test.ts
@@ -489,9 +489,9 @@ describe("a column that is absent from the manifest must not clear the row", () 
 
   it("treats an explicit null the same as absent, rather than throwing", () => {
     // `generateCollection` forwards the create body unvalidated, and `null` is
-    // what "clear it" looks like over JSON. It previously reached the quoting
-    // helper and threw on `.replace` of a non-string, AFTER the table DDL in
-    // the same file had run.
+    // what "clear it" looks like over JSON. Handed to the quoting helper it
+    // throws on `.replace` of a non-string — AFTER the table DDL in the same
+    // file has run — so the column is decided before the value is quoted.
     const sql = buildCollectionMetadataUpsert(
       { slug: "posts", description: null, fields: [] } as never,
       "sqlite"

--- a/packages/nextly/src/domains/schema/ui-schema/metadata-sql.test.ts
+++ b/packages/nextly/src/domains/schema/ui-schema/metadata-sql.test.ts
@@ -468,3 +468,50 @@ describe("escaping the values a Builder-authored entity can carry", () => {
     }
   });
 });
+
+describe("values the create body can carry that the schema does not validate", () => {
+  it("writes NULL for an explicit null description rather than throwing", () => {
+    // 🔴 `generateCollection` forwards the create body unvalidated, and `null`
+    // is what "clear it" looks like over JSON. Reaching the quoting helper with
+    // a non-string threw on `.replace`, turning an ordinary create into a 500
+    // AFTER the table DDL in the same file had run.
+    const sql = buildCollectionMetadataUpsert(
+      { slug: "posts", description: null, fields: [] } as never,
+      "sqlite"
+    );
+    expect(sql).toContain("NULL");
+    expect(sql).not.toContain("'null'");
+  });
+});
+
+describe("hooks are a collection-only manifest key", () => {
+  const withHooks = (kind: "singles" | "components") => ({
+    collections: [],
+    singles: [],
+    components: [],
+    [kind]: [{ slug: "x", hooks: [{ type: "beforeChange" }], fields: [] }],
+  });
+
+  it("REFUSES hooks on a single and on a component", () => {
+    // 🔴 Only `dynamic_collections` has a hooks column, so those builders emit
+    // none. Accepting the key would let a manifest validate, deploy, and run no
+    // hooks at all, with nothing saying why — a setting the deployment cannot
+    // honour should not parse.
+    for (const kind of ["singles", "components"] as const) {
+      expect(uiSchemaManifest.safeParse(withHooks(kind)).success).toBe(false);
+    }
+  });
+
+  it("ACCEPTS hooks on a collection", () => {
+    // The control: a rule that refused the key everywhere would satisfy the
+    // refusal above and silently drop the one kind that can store them.
+    const parsed = uiSchemaManifest.safeParse({
+      collections: [
+        { slug: "posts", hooks: [{ type: "beforeChange" }], fields: [] },
+      ],
+      singles: [],
+      components: [],
+    });
+    expect(parsed.success).toBe(true);
+  });
+});

--- a/packages/nextly/src/domains/schema/ui-schema/metadata-sql.test.ts
+++ b/packages/nextly/src/domains/schema/ui-schema/metadata-sql.test.ts
@@ -603,9 +603,10 @@ describe("presentation metadata reaches every kind that can store it", () => {
   });
 
   it("omits the column when the manifest says nothing about presentation", () => {
-    // The control: unlike `description`, admin is CONDITIONAL — an absent block
-    // must leave the stored value alone rather than clearing it, so a builder
-    // that always emitted it would erase presentation on every save.
+    // The control: admin is CONDITIONAL, on the same rule `description`
+    // follows — an absent block must leave the stored value alone rather than
+    // clearing it, so a builder that always emitted it would erase
+    // presentation on every save.
     const sql = buildSingleMetadataUpsert(
       { slug: "x", fields: [] } as never,
       "sqlite"

--- a/packages/nextly/src/domains/schema/ui-schema/metadata-sql.test.ts
+++ b/packages/nextly/src/domains/schema/ui-schema/metadata-sql.test.ts
@@ -471,10 +471,11 @@ describe("escaping the values a Builder-authored entity can carry", () => {
 
 describe("a column that is absent from the manifest must not clear the row", () => {
   it("omits the description column entirely when the manifest carries none", () => {
-    // 🔴 Written unconditionally — NULL when absent — the column does not merely
-    // fail to set a description, it CLEARS one: every manifest projection that
-    // does not carry the value erases what an earlier migration deployed, and
-    // there are six such projections.
+    // 🔴 The column is OMITTED here, and this asserts that. Were it written
+    // unconditionally — NULL when absent — it would not merely fail to set a
+    // description, it would CLEAR one: every manifest projection that does not
+    // carry the value would erase what an earlier migration deployed, and there
+    // are six such projections.
     //
     // Omitted, it is absent from the INSERT and from the DO UPDATE SET, so the
     // stored value survives. `admin` has behaved this way throughout and

--- a/packages/nextly/src/domains/schema/ui-schema/metadata-sql.test.ts
+++ b/packages/nextly/src/domains/schema/ui-schema/metadata-sql.test.ts
@@ -469,18 +469,55 @@ describe("escaping the values a Builder-authored entity can carry", () => {
   });
 });
 
-describe("values the create body can carry that the schema does not validate", () => {
-  it("writes NULL for an explicit null description rather than throwing", () => {
-    // 🔴 `generateCollection` forwards the create body unvalidated, and `null`
-    // is what "clear it" looks like over JSON. Reaching the quoting helper with
-    // a non-string threw on `.replace`, turning an ordinary create into a 500
-    // AFTER the table DDL in the same file had run.
+describe("a column that is absent from the manifest must not clear the row", () => {
+  it("omits the description column entirely when the manifest carries none", () => {
+    // 🔴 The correction this branch made after four rounds of the same finding.
+    // Written unconditionally — NULL when absent — the column does not merely
+    // fail to set a description, it CLEARS one: every manifest projection that
+    // does not carry the value erases what an earlier migration deployed, and
+    // there are six such projections.
+    //
+    // Omitted, it is absent from the INSERT and from the DO UPDATE SET, so the
+    // stored value survives. `admin` has behaved this way throughout and
+    // produced none of that.
+    const sql = buildCollectionMetadataUpsert(
+      { slug: "posts", fields: [] } as never,
+      "sqlite"
+    );
+    expect(sql).not.toContain('"description"');
+  });
+
+  it("treats an explicit null the same as absent, rather than throwing", () => {
+    // `generateCollection` forwards the create body unvalidated, and `null` is
+    // what "clear it" looks like over JSON. It previously reached the quoting
+    // helper and threw on `.replace` of a non-string, AFTER the table DDL in
+    // the same file had run.
     const sql = buildCollectionMetadataUpsert(
       { slug: "posts", description: null, fields: [] } as never,
       "sqlite"
     );
-    expect(sql).toContain("NULL");
-    expect(sql).not.toContain("'null'");
+    expect(sql).not.toContain('"description"');
+  });
+
+  it("DOES write the column when the manifest carries a description", () => {
+    // The control: a helper that returned nothing unconditionally would satisfy
+    // both assertions above and never deploy a description at all.
+    const sql = buildCollectionMetadataUpsert(
+      { slug: "posts", description: "Editorial", fields: [] } as never,
+      "sqlite"
+    );
+    expect(sql).toContain("Editorial");
+    expect(sql).toContain('"description"');
+  });
+
+  it("omits the hooks column when the manifest carries none", () => {
+    // No manifest projection carries hooks, so an unconditional NULL would
+    // disable the validation and transformation a deployed collection runs.
+    const sql = buildCollectionMetadataUpsert(
+      { slug: "posts", fields: [] } as never,
+      "sqlite"
+    );
+    expect(sql).not.toContain('"hooks"');
   });
 });
 

--- a/packages/nextly/src/domains/schema/ui-schema/metadata-sql.ts
+++ b/packages/nextly/src/domains/schema/ui-schema/metadata-sql.ts
@@ -180,17 +180,45 @@ interface Column {
  * description impossible to propagate -- the same reasoning `versions`,
  * `revalidate` and `webhooks` state beside their own columns.
  */
-function descriptionLiteral(
-  description: string | undefined | null,
+/**
+ * The `description` column, when the manifest actually carries one.
+ *
+ * 🔴 CONDITIONAL, and that is a correction rather than a preference. Written
+ * unconditionally — NULL when absent — it does not merely fail to set a
+ * description, it CLEARS one: every manifest projection that does not carry the
+ * value erases whatever an earlier migration deployed. There are six such
+ * projections and each was found one review round at a time.
+ *
+ * `admin` has been conditional throughout and produced none of that, which is
+ * the precedent this now follows. The cost is that clearing a description
+ * cannot propagate through a migration, and that is the smaller defect by far:
+ * not being able to remove a value is recoverable, silently removing one is not.
+ */
+function descriptionColumns(
+  entity: UiSchemaEntity,
   dialect: Dialect
-): string {
-  // 🔴 `null` as well as `undefined`. The create body reaches this unvalidated,
-  // so a caller sending `description: null` — which is what "clear it" looks
-  // like over JSON — otherwise reached `quoteSqlLiteral` and threw on `.replace`
-  // of a non-string, turning a routine create into a 500.
-  return description === undefined || description === null
-    ? "NULL"
-    : sqlStr(description, dialect);
+): Column[] {
+  const description = entity.description;
+  if (description === undefined || description === null) return [];
+  return [
+    { name: "description", value: sqlStr(description, dialect), update: true },
+  ];
+}
+
+/**
+ * The `hooks` column, when the manifest carries any. COLLECTIONS ONLY —
+ * `dynamic_singles` and the component registry have no such column, so naming
+ * it there would fail every migration for those kinds.
+ *
+ * Conditional for the same reason as {@link descriptionColumns}: no manifest
+ * projection carries hooks today, so writing NULL when absent would disable the
+ * validation and transformation a deployed collection was running.
+ */
+function hooksColumns(entity: UiSchemaEntity, dialect: Dialect): Column[] {
+  if (entity.hooks === undefined) return [];
+  return [
+    { name: "hooks", value: jsonLiteral(entity.hooks, dialect), update: true },
+  ];
 }
 
 /**
@@ -270,26 +298,6 @@ export function buildCollectionMetadataUpsert(
     { name: "slug", value: sqlStr(entity.slug, dialect) },
     { name: "labels", value: jsonLiteral(labels, dialect), update: true },
     {
-      name: "description",
-      value: descriptionLiteral(entity.description, dialect),
-      update: true,
-    },
-    {
-      // 🔴 COLLECTIONS ONLY. Stored hook configs travel with the row for the
-      // same reason its fields do: the hook service reads them from here, so a
-      // row without them runs none. `dynamic_singles` and the component
-      // registry have NO such column, so emitting it there would name a column
-      // that does not exist and fail every migration for those kinds.
-      // NULL when absent, and always emitted, so removing every hook
-      // propagates rather than leaving the previous set standing.
-      name: "hooks",
-      value:
-        entity.hooks === undefined
-          ? "NULL"
-          : jsonLiteral(entity.hooks, dialect),
-      update: true,
-    },
-    {
       name: "table_name",
       value: sqlStr(tableNameFor(entity.slug, "dc_"), dialect),
     },
@@ -358,7 +366,9 @@ export function buildCollectionMetadataUpsert(
   // alone rather than clearing it, which is what lets a manifest that says
   // nothing about presentation not erase it.
   columns.push(...adminColumns(entity, dialect));
+  columns.push(...hooksColumns(entity, dialect));
   columns.push(...timestampColumns(dialect));
+  columns.push(...descriptionColumns(entity, dialect));
   return buildUpsert("dynamic_collections", columns, dialect);
 }
 
@@ -370,11 +380,6 @@ export function buildSingleMetadataUpsert(
     { name: "id", value: sqlStr(deterministicId(entity.slug), dialect) },
     { name: "slug", value: sqlStr(entity.slug, dialect) },
     { name: "label", value: sqlStr(singular(entity), dialect), update: true },
-    {
-      name: "description",
-      value: descriptionLiteral(entity.description, dialect),
-      update: true,
-    },
     {
       name: "table_name",
       value: sqlStr(tableNameFor(entity.slug, "single_"), dialect),
@@ -432,6 +437,7 @@ export function buildSingleMetadataUpsert(
   ];
   columns.push(...timestampColumns(dialect));
   columns.push(...adminColumns(entity, dialect));
+  columns.push(...descriptionColumns(entity, dialect));
   return buildUpsert("dynamic_singles", columns, dialect);
 }
 
@@ -443,11 +449,6 @@ export function buildComponentMetadataUpsert(
     { name: "id", value: sqlStr(deterministicId(entity.slug), dialect) },
     { name: "slug", value: sqlStr(entity.slug, dialect) },
     { name: "label", value: sqlStr(singular(entity), dialect), update: true },
-    {
-      name: "description",
-      value: descriptionLiteral(entity.description, dialect),
-      update: true,
-    },
     {
       name: "table_name",
       value: sqlStr(
@@ -478,5 +479,6 @@ export function buildComponentMetadataUpsert(
   ];
   columns.push(...timestampColumns(dialect));
   columns.push(...adminColumns(entity, dialect));
+  columns.push(...descriptionColumns(entity, dialect));
   return buildUpsert(STORAGE_FORMAT.registryTable, columns, dialect);
 }

--- a/packages/nextly/src/domains/schema/ui-schema/metadata-sql.ts
+++ b/packages/nextly/src/domains/schema/ui-schema/metadata-sql.ts
@@ -329,6 +329,16 @@ export function buildCollectionMetadataUpsert(
     },
     { name: "migration_status", value: sqlStr("applied", dialect) },
   ];
+  // 🔴 Emitted for every kind, because every registry table HAS this column —
+  // checked per table rather than assumed. The shared manifest schema accepts
+  // `icon`, `hidden`, `order` and `sidebarGroup` for singles and components as
+  // well, so a builder that omitted the column let those settings validate,
+  // deploy, and be ignored, leaving an entity visible that the manifest said
+  // was hidden.
+  //
+  // CONDITIONAL, unlike `description`: an absent block leaves the stored value
+  // alone rather than clearing it, which is what lets a manifest that says
+  // nothing about presentation not erase it.
   if (entity.admin !== undefined) {
     columns.push({
       name: "admin",
@@ -409,6 +419,13 @@ export function buildSingleMetadataUpsert(
     { name: "migration_status", value: sqlStr("applied", dialect) },
   ];
   columns.push(...timestampColumns(dialect));
+  if (entity.admin !== undefined) {
+    columns.push({
+      name: "admin",
+      value: jsonLiteral(entity.admin, dialect),
+      update: true,
+    });
+  }
   return buildUpsert("dynamic_singles", columns, dialect);
 }
 
@@ -454,5 +471,12 @@ export function buildComponentMetadataUpsert(
     { name: "migration_status", value: sqlStr("applied", dialect) },
   ];
   columns.push(...timestampColumns(dialect));
+  if (entity.admin !== undefined) {
+    columns.push({
+      name: "admin",
+      value: jsonLiteral(entity.admin, dialect),
+      update: true,
+    });
+  }
   return buildUpsert(STORAGE_FORMAT.registryTable, columns, dialect);
 }

--- a/packages/nextly/src/domains/schema/ui-schema/metadata-sql.ts
+++ b/packages/nextly/src/domains/schema/ui-schema/metadata-sql.ts
@@ -251,6 +251,21 @@ export function buildCollectionMetadataUpsert(
       update: true,
     },
     {
+      // 🔴 COLLECTIONS ONLY. Stored hook configs travel with the row for the
+      // same reason its fields do: the hook service reads them from here, so a
+      // row without them runs none. `dynamic_singles` and the component
+      // registry have NO such column, so emitting it there would name a column
+      // that does not exist and fail every migration for those kinds.
+      // NULL when absent, and always emitted, so removing every hook
+      // propagates rather than leaving the previous set standing.
+      name: "hooks",
+      value:
+        entity.hooks === undefined
+          ? "NULL"
+          : jsonLiteral(entity.hooks, dialect),
+      update: true,
+    },
+    {
       name: "table_name",
       value: sqlStr(tableNameFor(entity.slug, "dc_"), dialect),
     },

--- a/packages/nextly/src/domains/schema/ui-schema/metadata-sql.ts
+++ b/packages/nextly/src/domains/schema/ui-schema/metadata-sql.ts
@@ -183,16 +183,17 @@ interface Column {
 /**
  * The `description` column, when the manifest actually carries one.
  *
- * 🔴 CONDITIONAL, and that is a correction rather than a preference. Written
- * unconditionally — NULL when absent — it does not merely fail to set a
- * description, it CLEARS one: every manifest projection that does not carry the
- * value erases whatever an earlier migration deployed. There are six such
- * projections and each was found one review round at a time.
+ * 🔴 CONDITIONAL, because a column written unconditionally does not merely fail
+ * to set a value — it CLEARS one. Absent-means-NULL would let any manifest
+ * projection that does not carry the description erase whatever an earlier
+ * migration deployed, and the projections are hand-written per entity kind and
+ * per page, so several of them carry only part of the settings.
  *
- * `admin` has been conditional throughout and produced none of that, which is
- * the precedent this now follows. The cost is that clearing a description
- * cannot propagate through a migration, and that is the smaller defect by far:
- * not being able to remove a value is recoverable, silently removing one is not.
+ * Omitted, the column is absent from the INSERT and from the DO UPDATE SET, so
+ * a partial projection leaves the stored value alone. `admin` behaves the same
+ * way for the same reason. The cost is that clearing a description cannot
+ * propagate through a migration, which is much the smaller defect: being unable
+ * to remove a value is recoverable, silently removing one is not.
  */
 function descriptionColumns(
   entity: UiSchemaEntity,

--- a/packages/nextly/src/domains/schema/ui-schema/metadata-sql.ts
+++ b/packages/nextly/src/domains/schema/ui-schema/metadata-sql.ts
@@ -172,6 +172,21 @@ interface Column {
 }
 
 /** Assemble an INSERT … upsert for the given dialect. */
+/**
+ * The `description` column value: the text, or NULL when the entity has none.
+ *
+ * 🔴 ALWAYS emitted, including when absent. A column left out of the upsert is
+ * untouched by its `DO UPDATE SET`, so omitting it would make clearing a
+ * description impossible to propagate -- the same reasoning `versions`,
+ * `revalidate` and `webhooks` state beside their own columns.
+ */
+function descriptionLiteral(
+  description: string | undefined,
+  dialect: Dialect
+): string {
+  return description === undefined ? "NULL" : sqlStr(description, dialect);
+}
+
 function buildUpsert(
   table: string,
   columns: Column[],
@@ -230,6 +245,11 @@ export function buildCollectionMetadataUpsert(
     { name: "id", value: sqlStr(deterministicId(entity.slug), dialect) },
     { name: "slug", value: sqlStr(entity.slug, dialect) },
     { name: "labels", value: jsonLiteral(labels, dialect), update: true },
+    {
+      name: "description",
+      value: descriptionLiteral(entity.description, dialect),
+      update: true,
+    },
     {
       name: "table_name",
       value: sqlStr(tableNameFor(entity.slug, "dc_"), dialect),
@@ -308,6 +328,11 @@ export function buildSingleMetadataUpsert(
     { name: "slug", value: sqlStr(entity.slug, dialect) },
     { name: "label", value: sqlStr(singular(entity), dialect), update: true },
     {
+      name: "description",
+      value: descriptionLiteral(entity.description, dialect),
+      update: true,
+    },
+    {
       name: "table_name",
       value: sqlStr(tableNameFor(entity.slug, "single_"), dialect),
     },
@@ -374,6 +399,11 @@ export function buildComponentMetadataUpsert(
     { name: "id", value: sqlStr(deterministicId(entity.slug), dialect) },
     { name: "slug", value: sqlStr(entity.slug, dialect) },
     { name: "label", value: sqlStr(singular(entity), dialect), update: true },
+    {
+      name: "description",
+      value: descriptionLiteral(entity.description, dialect),
+      update: true,
+    },
     {
       name: "table_name",
       value: sqlStr(

--- a/packages/nextly/src/domains/schema/ui-schema/metadata-sql.ts
+++ b/packages/nextly/src/domains/schema/ui-schema/metadata-sql.ts
@@ -216,10 +216,11 @@ function hooksColumns(entity: UiSchemaEntity, dialect: Dialect): Column[] {
 /**
  * The `admin` column, when the manifest says anything about presentation.
  *
- * 🔴 CONDITIONAL, unlike `description`. An absent block must leave the stored
- * value alone rather than clear it, so this returns nothing rather than NULL --
- * a manifest that says nothing about presentation is not an instruction to
- * forget it.
+ * 🔴 CONDITIONAL, on the same rule `description` follows. An absent block must
+ * leave the stored value alone rather than clear it, so this returns nothing
+ * rather than NULL -- a manifest that says nothing about presentation is not an
+ * instruction to forget it. The two differ only in payload: this one carries a
+ * JSON block of presentation keys, that one a single string.
  *
  * One helper rather than the same block in each builder: all three kinds have
  * this column and all three must agree about when it is written.
@@ -355,9 +356,9 @@ export function buildCollectionMetadataUpsert(
   // deploy, and be ignored, leaving an entity visible that the manifest said
   // was hidden.
   //
-  // CONDITIONAL, unlike `description`: an absent block leaves the stored value
-  // alone rather than clearing it, which is what lets a manifest that says
-  // nothing about presentation not erase it.
+  // CONDITIONAL, on the same rule `description` follows: an absent block leaves
+  // the stored value alone rather than clearing it, which is what lets a
+  // manifest that says nothing about presentation not erase it.
   columns.push(...adminColumns(entity, dialect));
   columns.push(...hooksColumns(entity, dialect));
   columns.push(...timestampColumns(dialect));

--- a/packages/nextly/src/domains/schema/ui-schema/metadata-sql.ts
+++ b/packages/nextly/src/domains/schema/ui-schema/metadata-sql.ts
@@ -193,6 +193,24 @@ function descriptionLiteral(
     : sqlStr(description, dialect);
 }
 
+/**
+ * The `admin` column, when the manifest says anything about presentation.
+ *
+ * 🔴 CONDITIONAL, unlike `description`. An absent block must leave the stored
+ * value alone rather than clear it, so this returns nothing rather than NULL --
+ * a manifest that says nothing about presentation is not an instruction to
+ * forget it.
+ *
+ * One helper rather than the same block in each builder: all three kinds have
+ * this column and all three must agree about when it is written.
+ */
+function adminColumns(entity: UiSchemaEntity, dialect: Dialect): Column[] {
+  if (entity.admin === undefined) return [];
+  return [
+    { name: "admin", value: jsonLiteral(entity.admin, dialect), update: true },
+  ];
+}
+
 function buildUpsert(
   table: string,
   columns: Column[],
@@ -339,13 +357,7 @@ export function buildCollectionMetadataUpsert(
   // CONDITIONAL, unlike `description`: an absent block leaves the stored value
   // alone rather than clearing it, which is what lets a manifest that says
   // nothing about presentation not erase it.
-  if (entity.admin !== undefined) {
-    columns.push({
-      name: "admin",
-      value: jsonLiteral(entity.admin, dialect),
-      update: true,
-    });
-  }
+  columns.push(...adminColumns(entity, dialect));
   columns.push(...timestampColumns(dialect));
   return buildUpsert("dynamic_collections", columns, dialect);
 }
@@ -419,13 +431,7 @@ export function buildSingleMetadataUpsert(
     { name: "migration_status", value: sqlStr("applied", dialect) },
   ];
   columns.push(...timestampColumns(dialect));
-  if (entity.admin !== undefined) {
-    columns.push({
-      name: "admin",
-      value: jsonLiteral(entity.admin, dialect),
-      update: true,
-    });
-  }
+  columns.push(...adminColumns(entity, dialect));
   return buildUpsert("dynamic_singles", columns, dialect);
 }
 
@@ -471,12 +477,6 @@ export function buildComponentMetadataUpsert(
     { name: "migration_status", value: sqlStr("applied", dialect) },
   ];
   columns.push(...timestampColumns(dialect));
-  if (entity.admin !== undefined) {
-    columns.push({
-      name: "admin",
-      value: jsonLiteral(entity.admin, dialect),
-      update: true,
-    });
-  }
+  columns.push(...adminColumns(entity, dialect));
   return buildUpsert(STORAGE_FORMAT.registryTable, columns, dialect);
 }

--- a/packages/nextly/src/domains/schema/ui-schema/metadata-sql.ts
+++ b/packages/nextly/src/domains/schema/ui-schema/metadata-sql.ts
@@ -171,15 +171,6 @@ interface Column {
   update?: boolean;
 }
 
-/** Assemble an INSERT … upsert for the given dialect. */
-/**
- * The `description` column value: the text, or NULL when the entity has none.
- *
- * 🔴 ALWAYS emitted, including when absent. A column left out of the upsert is
- * untouched by its `DO UPDATE SET`, so omitting it would make clearing a
- * description impossible to propagate -- the same reasoning `versions`,
- * `revalidate` and `webhooks` state beside their own columns.
- */
 /**
  * The `description` column, when the manifest actually carries one.
  *
@@ -240,6 +231,7 @@ function adminColumns(entity: UiSchemaEntity, dialect: Dialect): Column[] {
   ];
 }
 
+/** Assemble an INSERT … upsert for the given dialect. */
 function buildUpsert(
   table: string,
   columns: Column[],

--- a/packages/nextly/src/domains/schema/ui-schema/metadata-sql.ts
+++ b/packages/nextly/src/domains/schema/ui-schema/metadata-sql.ts
@@ -48,6 +48,7 @@ import { resolveBuilderVersions } from "../../versions/builder-versions";
 import { resolveBuilderWebhooks } from "../../webhooks/builder-webhooks";
 import { quoteIdent } from "../pipeline/sql-templates/identifier-quoting";
 import { calculateSchemaHash } from "../services/schema-hash";
+import { quoteSqlLiteral } from "../utils/sql-literal";
 
 type Dialect = SupportedDialect;
 
@@ -64,13 +65,27 @@ function deterministicId(slug: string): string {
 }
 
 /** SQL single-quoted string literal (standard single-quote doubling). */
-function sqlStr(value: string): string {
-  return `'${value.replace(/'/g, "''")}'`;
+/**
+ * A quoted SQL string literal for the target dialect.
+ *
+ * 🔴 DELEGATES rather than escaping here. This doubled apostrophes and left
+ * backslashes alone, which is correct for PostgreSQL and SQLite and wrong for
+ * MySQL, where a backslash introduces an escape. JSON is where that bites:
+ * every `\d` in a field's validation pattern, and every encoded newline, is a
+ * backslash pair that MySQL would consume -- changing the stored JSON or making
+ * the statement invalid, after the table DDL in the same file has already run.
+ *
+ * `quoteSqlLiteral` is the answer this repository already has, and its own
+ * docblock describes this exact failure. A second escaping rule beside it is
+ * how the two came to disagree.
+ */
+function sqlStr(value: string, dialect: Dialect): string {
+  return quoteSqlLiteral(value, dialect);
 }
 
 /** JSON value literal. PG casts to jsonb; MySQL/SQLite store the JSON text. */
 function jsonLiteral(value: unknown, dialect: Dialect): string {
-  const lit = sqlStr(JSON.stringify(value));
+  const lit = sqlStr(JSON.stringify(value), dialect);
   return dialect === "postgresql" ? `${lit}::jsonb` : lit;
 }
 
@@ -212,17 +227,24 @@ export function buildCollectionMetadataUpsert(
     plural: entity.labels?.plural ?? toPluralLabel(entity.slug),
   };
   const columns: Column[] = [
-    { name: "id", value: sqlStr(deterministicId(entity.slug)) },
-    { name: "slug", value: sqlStr(entity.slug) },
+    { name: "id", value: sqlStr(deterministicId(entity.slug), dialect) },
+    { name: "slug", value: sqlStr(entity.slug, dialect) },
     { name: "labels", value: jsonLiteral(labels, dialect), update: true },
-    { name: "table_name", value: sqlStr(tableNameFor(entity.slug, "dc_")) },
+    {
+      name: "table_name",
+      value: sqlStr(tableNameFor(entity.slug, "dc_"), dialect),
+    },
     {
       name: "fields",
       value: jsonLiteral(entity.fields, dialect),
       update: true,
     },
-    { name: "source", value: sqlStr("ui") },
-    { name: "schema_hash", value: sqlStr(hashOf(entity)), update: true },
+    { name: "source", value: sqlStr("ui", dialect) },
+    {
+      name: "schema_hash",
+      value: sqlStr(hashOf(entity), dialect),
+      update: true,
+    },
     {
       name: "status",
       value: boolLiteral(entity.status === true, dialect),
@@ -264,7 +286,7 @@ export function buildCollectionMetadataUpsert(
       value: webhooksLiteral(entity.webhooks, dialect),
       update: true,
     },
-    { name: "migration_status", value: sqlStr("applied") },
+    { name: "migration_status", value: sqlStr("applied", dialect) },
   ];
   if (entity.admin !== undefined) {
     columns.push({
@@ -282,20 +304,24 @@ export function buildSingleMetadataUpsert(
   dialect: Dialect
 ): string {
   const columns: Column[] = [
-    { name: "id", value: sqlStr(deterministicId(entity.slug)) },
-    { name: "slug", value: sqlStr(entity.slug) },
-    { name: "label", value: sqlStr(singular(entity)), update: true },
+    { name: "id", value: sqlStr(deterministicId(entity.slug), dialect) },
+    { name: "slug", value: sqlStr(entity.slug, dialect) },
+    { name: "label", value: sqlStr(singular(entity), dialect), update: true },
     {
       name: "table_name",
-      value: sqlStr(tableNameFor(entity.slug, "single_")),
+      value: sqlStr(tableNameFor(entity.slug, "single_"), dialect),
     },
     {
       name: "fields",
       value: jsonLiteral(entity.fields, dialect),
       update: true,
     },
-    { name: "source", value: sqlStr("ui") },
-    { name: "schema_hash", value: sqlStr(hashOf(entity)), update: true },
+    { name: "source", value: sqlStr("ui", dialect) },
+    {
+      name: "schema_hash",
+      value: sqlStr(hashOf(entity), dialect),
+      update: true,
+    },
     {
       name: "status",
       value: boolLiteral(entity.status === true, dialect),
@@ -334,7 +360,7 @@ export function buildSingleMetadataUpsert(
       value: webhooksLiteral(entity.webhooks, dialect),
       update: true,
     },
-    { name: "migration_status", value: sqlStr("applied") },
+    { name: "migration_status", value: sqlStr("applied", dialect) },
   ];
   columns.push(...timestampColumns(dialect));
   return buildUpsert("dynamic_singles", columns, dialect);
@@ -345,19 +371,22 @@ export function buildComponentMetadataUpsert(
   dialect: Dialect
 ): string {
   const columns: Column[] = [
-    { name: "id", value: sqlStr(deterministicId(entity.slug)) },
-    { name: "slug", value: sqlStr(entity.slug) },
-    { name: "label", value: sqlStr(singular(entity)), update: true },
+    { name: "id", value: sqlStr(deterministicId(entity.slug), dialect) },
+    { name: "slug", value: sqlStr(entity.slug, dialect) },
+    { name: "label", value: sqlStr(singular(entity), dialect), update: true },
     {
       name: "table_name",
-      value: sqlStr(tableNameFor(entity.slug, STORAGE_FORMAT.tablePrefix)),
+      value: sqlStr(
+        tableNameFor(entity.slug, STORAGE_FORMAT.tablePrefix),
+        dialect
+      ),
     },
     {
       name: "fields",
       value: jsonLiteral(entity.fields, dialect),
       update: true,
     },
-    { name: "source", value: sqlStr("ui") },
+    { name: "source", value: sqlStr("ui", dialect) },
     {
       // Persist the Builder localized flag so boot reads the component as localized and
       // resolves/writes its companion `comp_<slug>_locales` fields; without it the registry
@@ -366,8 +395,12 @@ export function buildComponentMetadataUpsert(
       value: boolLiteral(entity.localized === true, dialect),
       update: true,
     },
-    { name: "schema_hash", value: sqlStr(hashOf(entity)), update: true },
-    { name: "migration_status", value: sqlStr("applied") },
+    {
+      name: "schema_hash",
+      value: sqlStr(hashOf(entity), dialect),
+      update: true,
+    },
+    { name: "migration_status", value: sqlStr("applied", dialect) },
   ];
   columns.push(...timestampColumns(dialect));
   return buildUpsert(STORAGE_FORMAT.registryTable, columns, dialect);

--- a/packages/nextly/src/domains/schema/ui-schema/metadata-sql.ts
+++ b/packages/nextly/src/domains/schema/ui-schema/metadata-sql.ts
@@ -181,10 +181,16 @@ interface Column {
  * `revalidate` and `webhooks` state beside their own columns.
  */
 function descriptionLiteral(
-  description: string | undefined,
+  description: string | undefined | null,
   dialect: Dialect
 ): string {
-  return description === undefined ? "NULL" : sqlStr(description, dialect);
+  // 🔴 `null` as well as `undefined`. The create body reaches this unvalidated,
+  // so a caller sending `description: null` — which is what "clear it" looks
+  // like over JSON — otherwise reached `quoteSqlLiteral` and threw on `.replace`
+  // of a non-string, turning a routine create into a 500.
+  return description === undefined || description === null
+    ? "NULL"
+    : sqlStr(description, dialect);
 }
 
 function buildUpsert(

--- a/packages/nextly/src/schemas/_zod/ui-schema.test.ts
+++ b/packages/nextly/src/schemas/_zod/ui-schema.test.ts
@@ -193,3 +193,61 @@ describe("parseUiSchema", () => {
     expect(js).toHaveProperty("properties");
   });
 });
+
+describe("a manifest hook is validated as the executor requires it", () => {
+  // A hook the executor can actually run: `StoredHookExecutor` reads `config`
+  // and `order` off every entry, so those are as load-bearing as `hookId`.
+  const RUNNABLE = {
+    hookId: "auto-slug",
+    hookType: "beforeChange",
+    enabled: true,
+    config: { sourceField: "title", targetField: "slug" },
+    order: 0,
+  };
+
+  function manifestWithHooks(hooks: unknown) {
+    return {
+      version: 1,
+      collections: [
+        {
+          slug: "articles",
+          labels: { singular: "Article", plural: "Articles" },
+          fields: [{ name: "title", type: "text" }],
+          hooks,
+        },
+      ],
+    };
+  }
+
+  it("KEEPS a runnable hook rather than merely accepting it", () => {
+    // 🔴 The control the rejection below needs, and it asserts the value
+    // SURVIVES rather than that the parse succeeded. Zod strips what a schema
+    // does not declare, so a manifest whose hooks are silently dropped parses
+    // exactly as cleanly as one whose hooks are carried — and the deployed
+    // collection then runs no hooks, which is the failure this key exists to
+    // prevent.
+    const result = parseUiSchema(manifestWithHooks([RUNNABLE]));
+    expect(result.success).toBe(true);
+    expect(result.data?.collections[0]?.hooks).toEqual([RUNNABLE]);
+  });
+
+  it("REFUSES a hook missing the fields the executor destructures", () => {
+    // 🔴 The shape a hand-written manifest most plausibly carries: the three
+    // keys a reader would guess, and neither of the two the executor reads.
+    // Accepted, it deploys and then throws on the next content write — an
+    // accepted manifest turning into failed writes, which is strictly worse
+    // than a refused one because the refusal names the file.
+    const { config: _config, order: _order, ...missingBoth } = RUNNABLE;
+    expect(parseUiSchema(manifestWithHooks([missingBoth])).success).toBe(false);
+  });
+
+  it("REFUSES a hookType the runtime cannot dispatch", () => {
+    // A plausible typo, and the one a loose record could never catch: the
+    // value is a string of the right type and simply names no lifecycle point.
+    expect(
+      parseUiSchema(
+        manifestWithHooks([{ ...RUNNABLE, hookType: "beforeSave" }])
+      ).success
+    ).toBe(false);
+  });
+});

--- a/packages/nextly/src/schemas/_zod/ui-schema.ts
+++ b/packages/nextly/src/schemas/_zod/ui-schema.ts
@@ -476,11 +476,29 @@ const storedHookConfig = z.object({
   order: z.number(),
 });
 
-/** Compile-time proof that the schema above still describes the stored shape. */
-type StoredHookSchemaMatchesInterface =
+/**
+ * Compile-time proof that the schema and the stored shape describe each other.
+ *
+ * 🔴 BOTH directions, because each catches a different drift and neither
+ * catches the other's. Schema-to-interface fails when the schema goes wider
+ * than the runtime accepts. Interface-to-schema fails when the schema goes
+ * NARROWER — a lifecycle point added to `StoredHookType` leaves this enum short,
+ * and a one-way proof still passes while every manifest naming the new hook is
+ * silently refused. The narrow direction is the quiet one, so it is the one
+ * worth stating.
+ *
+ * `StoredHookType` is a union in a module with no runtime exports, so the enum
+ * is spelled here rather than derived from a shared array; keeping that module
+ * type-only is worth more than removing this pair of assertions.
+ */
+type SchemaAcceptsOnlyStoredHooks =
   z.infer<typeof storedHookConfig> extends StoredHookConfig ? true : never;
-const _storedHookShapeHolds: StoredHookSchemaMatchesInterface = true;
-void _storedHookShapeHolds;
+type SchemaAcceptsEveryStoredHook =
+  StoredHookConfig extends z.infer<typeof storedHookConfig> ? true : never;
+const _schemaAcceptsOnlyStoredHooks: SchemaAcceptsOnlyStoredHooks = true;
+const _schemaAcceptsEveryStoredHook: SchemaAcceptsEveryStoredHook = true;
+void _schemaAcceptsOnlyStoredHooks;
+void _schemaAcceptsEveryStoredHook;
 
 const admin = z.object({
   useAsTitle: z.string().optional(),

--- a/packages/nextly/src/schemas/_zod/ui-schema.ts
+++ b/packages/nextly/src/schemas/_zod/ui-schema.ts
@@ -590,6 +590,18 @@ function entity(kind?: "collection" | "single" | "component") {
           path: ["webhooks"],
         });
       }
+      // 🔴 Only `dynamic_collections` has a `hooks` column. Singles and
+      // components have none, so their upsert builders cannot emit one — and a
+      // manifest that ACCEPTED hooks there would validate, deploy, and run
+      // none of them, with nothing saying why. Refusing the key is the honest
+      // answer: a setting the deployment cannot honour should not parse.
+      if (kind !== "collection" && e.hooks !== undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `'hooks' is only supported on collections`,
+          path: ["hooks"],
+        });
+      }
       // `status` reserved as a field name only when the lifecycle column is on.
       if (e.status === true && e.fields.some(f => f.name === "status")) {
         ctx.addIssue({

--- a/packages/nextly/src/schemas/_zod/ui-schema.ts
+++ b/packages/nextly/src/schemas/_zod/ui-schema.ts
@@ -429,10 +429,27 @@ export const uiSchemaFieldSchema: z.ZodType<FieldNode> = z.lazy(() =>
     })
 );
 
+/**
+ * The admin presentation a UI-built entity carries.
+ *
+ * 🔴 WIDER than the three keys this began with, because the Schema Builder
+ * stores more than it could express here. A zod object strips what it does not
+ * declare, so a collection created hidden, with an icon, an explicit order or a
+ * sidebar group lost all four on the way into a manifest -- and a migration
+ * generated from that manifest rebuilt a visibly different collection
+ * elsewhere: shown when it was hidden, unordered, no icon.
+ *
+ * These are presentation only. Nothing here changes a table, which is why they
+ * can be added without a migration concern of their own.
+ */
 const admin = z.object({
   useAsTitle: z.string().optional(),
   defaultColumns: z.array(z.string()).optional(),
   group: z.string().optional(),
+  icon: z.string().optional(),
+  hidden: z.boolean().optional(),
+  order: z.number().optional(),
+  sidebarGroup: z.string().optional(),
 });
 
 function entity(kind?: "collection" | "single" | "component") {

--- a/packages/nextly/src/schemas/_zod/ui-schema.ts
+++ b/packages/nextly/src/schemas/_zod/ui-schema.ts
@@ -22,6 +22,7 @@ import {
 } from "../../plugins/plugin-options";
 import { STORAGE_FORMAT } from "../../schemas/storage-format";
 import { pluginStorageFieldType } from "../../shared/lib/plugin-storage";
+import type { StoredHookConfig } from "../dynamic-collections/types";
 
 /**
  * Canonical field-type tokens supported in ui-schema.json. Mirrors the set
@@ -442,6 +443,45 @@ export const uiSchemaFieldSchema: z.ZodType<FieldNode> = z.lazy(() =>
  * These are presentation only. Nothing here changes a table, which is why they
  * can be added without a migration concern of their own.
  */
+/**
+ * A stored hook config, validated as the executor actually requires it.
+ *
+ * 🔴 NOT a loose record. `StoredHookExecutor` reads `config` and `order` off
+ * each entry, so a manifest carrying `{ hookId, hookType, enabled }` and
+ * nothing else parses, deploys, and then throws on the next content write —
+ * an accepted manifest turning into failed writes, which is worse than a
+ * refused one.
+ *
+ * The assertion below is what keeps this in step with `StoredHookConfig`
+ * rather than drifting from it: if that interface gains a required field, this
+ * stops being assignable and the build says so.
+ */
+const storedHookConfig = z.object({
+  hookId: z.string().min(1),
+  hookType: z.enum([
+    "beforeOperation",
+    "beforeCreate",
+    "afterCreate",
+    "beforeUpdate",
+    "afterUpdate",
+    "beforeDelete",
+    "afterDelete",
+    "beforeRead",
+    "afterRead",
+    "beforeChange",
+    "afterChange",
+  ]),
+  enabled: z.boolean(),
+  config: z.record(z.string(), z.unknown()),
+  order: z.number(),
+});
+
+/** Compile-time proof that the schema above still describes the stored shape. */
+type StoredHookSchemaMatchesInterface =
+  z.infer<typeof storedHookConfig> extends StoredHookConfig ? true : never;
+const _storedHookShapeHolds: StoredHookSchemaMatchesInterface = true;
+void _storedHookShapeHolds;
+
 const admin = z.object({
   useAsTitle: z.string().optional(),
   defaultColumns: z.array(z.string()).optional(),
@@ -471,7 +511,7 @@ function entity(kind?: "collection" | "single" | "component") {
        * ran them where it was authored and silently ran none where the file was
        * replayed.
        */
-      hooks: z.array(z.record(z.string(), z.unknown())).optional(),
+      hooks: z.array(storedHookConfig).optional(),
       admin: admin.optional(),
       status: z.boolean().optional(),
       localized: z.boolean().optional(),

--- a/packages/nextly/src/schemas/_zod/ui-schema.ts
+++ b/packages/nextly/src/schemas/_zod/ui-schema.ts
@@ -431,19 +431,6 @@ export const uiSchemaFieldSchema: z.ZodType<FieldNode> = z.lazy(() =>
 );
 
 /**
- * The admin presentation a UI-built entity carries.
- *
- * 🔴 WIDER than the three keys this began with, because the Schema Builder
- * stores more than it could express here. A zod object strips what it does not
- * declare, so a collection created hidden, with an icon, an explicit order or a
- * sidebar group lost all four on the way into a manifest -- and a migration
- * generated from that manifest rebuilt a visibly different collection
- * elsewhere: shown when it was hidden, unordered, no icon.
- *
- * These are presentation only. Nothing here changes a table, which is why they
- * can be added without a migration concern of their own.
- */
-/**
  * A stored hook config, validated as the executor actually requires it.
  *
  * 🔴 NOT a loose record. `StoredHookExecutor` reads `config` and `order` off
@@ -500,6 +487,19 @@ const _schemaAcceptsEveryStoredHook: SchemaAcceptsEveryStoredHook = true;
 void _schemaAcceptsOnlyStoredHooks;
 void _schemaAcceptsEveryStoredHook;
 
+/**
+ * The admin presentation a UI-built entity carries.
+ *
+ * 🔴 WIDER than the three keys this began with, because the Schema Builder
+ * stores more than it could express here. A zod object strips what it does not
+ * declare, so a collection created hidden, with an icon, an explicit order or a
+ * sidebar group lost all four on the way into a manifest -- and a migration
+ * generated from that manifest rebuilt a visibly different collection
+ * elsewhere: shown when it was hidden, unordered, no icon.
+ *
+ * These are presentation only. Nothing here changes a table, which is why they
+ * can be added without a migration concern of their own.
+ */
 const admin = z.object({
   useAsTitle: z.string().optional(),
   defaultColumns: z.array(z.string()).optional(),

--- a/packages/nextly/src/schemas/_zod/ui-schema.ts
+++ b/packages/nextly/src/schemas/_zod/ui-schema.ts
@@ -457,6 +457,13 @@ function entity(kind?: "collection" | "single" | "component") {
     .object({
       slug,
       labels: z.object({ singular: z.string(), plural: z.string() }).optional(),
+      /**
+       * The entity's own help text, distinct from a FIELD's `admin.description`
+       * declared above. The Builder collects one and stores it on the registry
+       * row; without it here the manifest could not carry it, so a migration
+       * generated from either path rebuilt the entity with no description.
+       */
+      description: z.string().optional(),
       admin: admin.optional(),
       status: z.boolean().optional(),
       localized: z.boolean().optional(),

--- a/packages/nextly/src/schemas/_zod/ui-schema.ts
+++ b/packages/nextly/src/schemas/_zod/ui-schema.ts
@@ -464,6 +464,14 @@ function entity(kind?: "collection" | "single" | "component") {
        * generated from either path rebuilt the entity with no description.
        */
       description: z.string().optional(),
+      /**
+       * Stored hook CONFIGS, which are data rather than functions — the hook
+       * service reads them off the registry row and runs them. Declared here so
+       * a migration can carry them: without it a collection created with hooks
+       * ran them where it was authored and silently ran none where the file was
+       * replayed.
+       */
+      hooks: z.array(z.record(z.string(), z.unknown())).optional(),
       admin: admin.optional(),
       status: z.boolean().optional(),
       localized: z.boolean().optional(),


### PR DESCRIPTION
A collection built in the Schema Builder did not survive the deploy.

## What was wrong

The migration that path writes creates the table and nothing else. That file is committed and replayed against a database that has never seen the Builder — where the `dynamic_collections` row this service writes locally does not exist. So production got the table and **no row at all**, and the collection was absent from the admin rather than showing a stale `migration_status`.

`migrate:create` already solves this for the entities it authors: it appends a per-entity metadata upsert, and its module says why — *"so that after `nextly migrate` runs in production the collection/single/component appears in the admin UI"*. The Builder path appended nothing.

## Why this seam, and not the obvious one

The tempting fix is to record Builder entities in `ui-schema.json` — `schemaFileApi` already exposes `writeCollection`/`writeSingle`/`writeFieldGroup`, and they have **zero callers**; only the three deletes are wired. **That fix would break production deploys**, and three measurements say so:

1. The Builder writes **no** paired `meta/` snapshot — zero hits for `snapshot` in `collection-file-manager.ts` or `collection-metadata-service.ts`. `migrate-create/generate.ts` step 1 loads the latest snapshot from `migrations/meta/`; step 8 writes `.sql` **and** `.snapshot.json`.
2. `migrate:create` has **no** already-exists guard — zero hits for `tableExists`/`skipExisting`/`alreadyExists` across the domain.
3. The only consumers of `saveMigration` are the Builder's own create, update and drop.

So the entity would land on `migrate:create`'s *desired* side while its baseline snapshot still lacks the table, emitting a second `CREATE TABLE` for a table the committed file already creates. The two authors are disjoint *because* the manifest is never written on create — which means each has to be self-sufficient, and the Builder's file must carry its own row.

## The change

`buildCollectionMetadataUpsert` — the same builder `migrate:create` uses, not a second statement that would have to agree with it — appended beside the existing `appendCompanionCreateSQL`, separated by `--> statement-breakpoint` because the runner splits on it and MySQL rejects a combined chunk.

The upsert conflicts on `slug` and leaves `id`, `table_name`, `source` and `migration_status` to the INSERT, so replaying it where the row already exists — this database, in development — refreshes fields and labels without renaming the row or overwriting a status the runtime owns.

## Verification

Five tests, and the **last is the one the others exist for**: the appended statement must equal what `migrate:create` emits for the same entity. Its expectation is built from the row the service says it *wrote* (`result.metadata`), not from the request — the stored fields are normalised, so an expectation assembled from the input would differ in both the fields JSON and the schema hash, and would be asserting a row nobody has.

Break-verified against two wrong implementations, not mutations:

| Wrong implementation | Result |
| --- | --- |
| No upsert appended (the shape before this change) | all five fail |
| A hand-written upsert that *looks* right — `INSERT INTO`, `dynamic_collections`, `'applied'`, breakpoint | **passes three of five**; only the exact-match control and the labels test catch it |

That second row is the point: a plausible-looking second implementation survives most assertions. It is the divergence this change removes rather than adds to.

Gates, each status read on its own line rather than through a pipe: check-types 0, lint 0, **873 files / 11049 tests**, comment convention 0, `fallow audit --base origin/main` **pass** with every `*_introduced` at 0.

fallow initially reported `complexity_introduced: 1` and it was genuinely mine — six conditionally-spread optional keys took `generateCollection` to CC 23. Fixed by passing the optional values straight through, `undefined` included: the builder hands each to a literal helper that decides what an absent flag means, and `JSON.stringify` drops an undefined member, so the emitted row is identical and the branches are gone.

## Deliberately not here

Recorded as `task:builder-update-and-singles-carry-the-metadata-row`:

- **The Builder's UPDATE path.** Its `metadataUpdates` is a patch, so building the manifest entity needs merging onto the fetched collection, and `migrationSQL` is assembled across archive/companion/main branches with a separate `localMigrationSQL`. That is where a mistake in a production migration generator would hide.
- **Singles and field groups.** `buildSingleMetadataUpsert` and `buildComponentMetadataUpsert` each have one caller, `migrate-create.ts` — the same gap.

The create path closes *"the collection is absent from production"*; those close *"its stored shape is stale"*, which is real but lesser.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Dynamic collection migrations now register collection metadata, including descriptions, hooks, presentation settings, and administrative configuration.
  - Builder settings retain descriptions for collections and single entities.
  - Generated migrations separate schema changes from metadata updates for more reliable application.

- **Bug Fixes**
  - Improved SQL escaping for backslashes and apostrophes across supported database dialects.
  - Fixed migration statement splitting when escaped values, comments, or breakpoint markers appear within strings.
  - Development collection creation avoids applying registry metadata more than once.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->