### PR TITLE
test(admin-css): compile the plugin fixture from itself, not from the monorepo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -507,11 +507,15 @@ jobs:
       #
       # ui / storage-s3 / storage-uploadthing have no test files yet; listed so
       # they gate automatically the moment they gain one.
+      # admin-css is listed because its suite compiles a fixture stylesheet, and
+      # what that compile emits depends on the repository around it rather than
+      # on this package alone - so it is a suite an unrelated change can turn
+      # red, which is exactly the kind nothing should have to remember to run.
       # NOT gated on Build, unlike the four steps around it: turbo.jsonc gives
       # `test` `dependsOn: ["^build"]`, so `turbo test` rebuilds the dependency
       # subgraph of whatever it is filtered to. A Build failure in a package
-      # none of these seventeen depends on - an app, which is a leaf - would
-      # otherwise silence all seventeen suites for no reason, and a failure in
+      # none of these depends on - an app, which is a leaf - would otherwise
+      # silence every suite listed here for no reason, and a failure in
       # one they DO depend on is reported as an attributed `#build` failure
       # here rather than as the type-aware noise the others would produce.
       - name: Test
@@ -526,6 +530,7 @@ jobs:
           --filter=@nextlyhq/plugin-seo
           --filter=@nextlyhq/plugin-sdk
           --filter=@nextlyhq/ui
+          --filter=@nextlyhq/admin-css
           --filter=@nextlyhq/adapter-drizzle
           --filter=@nextlyhq/adapter-postgres
           --filter=@nextlyhq/adapter-mysql
@@ -539,7 +544,7 @@ jobs:
           TURBO_CACHE_DIR: .turbo
 
       # The playground is an APP, so `turbo test`'s filter list above — which
-      # names the seventeen publishable packages — never reaches it, and its
+      # names publishable packages only — never reaches it, and its
       # suites ran nowhere. That was already true of its dev-tooling tests
       # (doctor, reset, the style-fixture manifest); it now also covers the
       # seeded block-page fixture, whose whole job is to fail when a block is

--- a/packages/admin-css/__fixtures__/poc-plugin/admin.css
+++ b/packages/admin-css/__fixtures__/poc-plugin/admin.css
@@ -7,7 +7,23 @@
  * `nextly-build-admin-css` compiles + scopes this into the plugin's shipped
  * `admin.styles`.
  */
-@import "tailwindcss";
+/*
+ * `source("./")` confines Tailwind's file scanning to this fixture.
+ *
+ * Without it the scan starts at this file and walks UP, so it reads the whole
+ * monorepo and generates a utility for every class any package happens to use.
+ * A published plugin has no such neighbours: it scans its own package and emits
+ * what its own markup asks for, and the point of this fixture is to compile the
+ * way that plugin does.
+ *
+ * It is also what makes the assertions below mean anything. Scanning upward,
+ * the emitted sheet reached 240KB and carried 38 colour declarations with
+ * literal values — `dark:hover:bg-[#ccc]` from a `create-nextly-app` template
+ * among them — so `checkAdminStyles` refused a fixture that never wrote a
+ * colour, and the refusal moved with whatever unrelated markup the repository
+ * gained. Confined, the same compile emits 13KB and no literal colour at all.
+ */
+@import "tailwindcss" source("./");
 /*
  * A published plugin writes `@import "@nextlyhq/ui/theme.css"`. This fixture
  * reaches the same file by path because `@nextlyhq/ui` cannot be a dependency

--- a/packages/admin-css/bin.integration.test.mjs
+++ b/packages/admin-css/bin.integration.test.mjs
@@ -20,24 +20,43 @@ import { findUnscopedRules } from "./src/index.mjs";
 // import.meta.dirname requires Node 20.11+, above the repo's Node >=20 floor.
 const ROOT = path.dirname(fileURLToPath(import.meta.url));
 
-describe("nextly-build-admin-css (POC)", () => {
-  it("compiles a plugin entry to scoped, token-driven CSS", () => {
-    const out = path.join(
-      fs.mkdtempSync(path.join(os.tmpdir(), "nx-poc-")),
-      "admin.css"
-    );
-    execSync(
-      `node "${ROOT}/bin/nextly-build-admin-css.mjs" "${ROOT}/__fixtures__/poc-plugin/admin.css" "${out}"`,
-      { cwd: ROOT }
-    );
-    const css = fs.readFileSync(out, "utf-8");
+/*
+ * This case spawns a Node process that runs the Tailwind CLI over a real
+ * stylesheet, so its cost is a process start plus a compile rather than the
+ * microseconds an in-process assertion takes. vitest's default 5s budget is
+ * sized for the latter: measured on a CI runner the compile alone reported
+ * 630ms while the case took 5547ms end to end and was killed at the limit,
+ * having done nothing wrong.
+ *
+ * Generous rather than tuned to that number. A timeout set just above what was
+ * observed once turns every slower runner into a red build, and the cost of a
+ * high limit is paid only when something genuinely hangs — where the difference
+ * between failing at 5s and at 60s is a wait, not a wrong answer.
+ */
+const COMPILE_TIMEOUT_MS = 60_000;
 
-    // Scoped: no rule escapes the wrapper.
-    expect(findUnscopedRules(css)).toEqual([]);
-    // No preflight reset re-emitted (that universal selector would restyle host).
-    expect(css).not.toMatch(/\*,\s*::before,\s*::after/);
-    // The fixture's utilities are present and token-driven.
-    expect(css).toContain(".nextly-admin");
-    expect(css).toMatch(/var\(--/);
-  });
+describe("nextly-build-admin-css (POC)", () => {
+  it(
+    "compiles a plugin entry to scoped, token-driven CSS",
+    () => {
+      const out = path.join(
+        fs.mkdtempSync(path.join(os.tmpdir(), "nx-poc-")),
+        "admin.css"
+      );
+      execSync(
+        `node "${ROOT}/bin/nextly-build-admin-css.mjs" "${ROOT}/__fixtures__/poc-plugin/admin.css" "${out}"`,
+        { cwd: ROOT }
+      );
+      const css = fs.readFileSync(out, "utf-8");
+
+      // Scoped: no rule escapes the wrapper.
+      expect(findUnscopedRules(css)).toEqual([]);
+      // No preflight reset re-emitted (that universal selector would restyle host).
+      expect(css).not.toMatch(/\*,\s*::before,\s*::after/);
+      // The fixture's utilities are present and token-driven.
+      expect(css).toContain(".nextly-admin");
+      expect(css).toMatch(/var\(--/);
+    },
+    COMPILE_TIMEOUT_MS
+  );
 });

--- a/packages/admin-css/turbo.json
+++ b/packages/admin-css/turbo.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "test": {
+      // The root inputs are `src/**`-centric, and almost nothing this package's
+      // suite exercises lives there. `bin.integration.test.mjs` sits at the
+      // package root, it runs `bin/nextly-build-admin-css.mjs`, and what that
+      // compiles is `__fixtures__/poc-plugin/admin.css` — so the task hash
+      // covered `src/**` while the CLI, the fixture and the test itself could
+      // all change without moving it. Turbo would then restore a previous pass
+      // for exactly the edits this suite exists to judge, and a cached green is
+      // indistinguishable from a real one.
+      //
+      // `$TURBO_EXTENDS$` appends to the root list rather than replacing it: a
+      // package task's `inputs` is a whole replacement otherwise, so restating
+      // the list here would silently drop whatever the root gains later.
+      //
+      // The theme is reached by RELATIVE PATH out of the package, which is
+      // unusual and is the only way this edge can exist. The fixture imports
+      // `../../../ui/src/styles/theme.css` because `@nextlyhq/ui` cannot be a
+      // dependency of this package — `ui` already depends on `admin-css` for
+      // the scoper, so the reverse edge is a cycle — and with no dependency
+      // there is no `^`-edge to carry the hash. Verified rather than assumed:
+      // editing that file moves this task's hash from `b1496e6d8c945e32` to a
+      // different value and restoring it returns the original, so the entry is
+      // doing work rather than merely being accepted.
+      "inputs": [
+        "$TURBO_EXTENDS$",
+        "bin/**",
+        "__fixtures__/**",
+        "*.test.mjs",
+        "../ui/src/styles/theme.css"
+      ]
+    }
+  }
+}

--- a/scripts/ci-steps-report-independently.test.mjs
+++ b/scripts/ci-steps-report-independently.test.mjs
@@ -99,7 +99,7 @@ const SETUP_STEPS = new Set([
  *
  * `Test` is NOT one of them, though it reads built output too: `turbo.jsonc`
  * gives `test` `dependsOn: ["^build"]`, so it rebuilds the dependency subgraph
- * of whatever it is filtered to. Gating it on Build would silence seventeen
+ * of whatever it is filtered to. Gating it on Build would silence every
  * suites for a failure in a package none of them depends on.
  *
  * `Playground tests` IS one, and the contrast with `Test` is the reason: it runs
@@ -332,7 +332,7 @@ describe("the ci job reports every gate, not only the first to fail", () => {
     ).toEqual([]);
   });
 
-  it("does NOT gate Test on Build, which would silence seventeen suites", async () => {
+  it("does NOT gate Test on Build, which would silence every filtered suite", async () => {
     const steps = ciJobSteps(await readFile(CI_WORKFLOW, "utf-8"));
     const test = steps.find(s => s.name === "Test");
 
@@ -340,8 +340,8 @@ describe("the ci job reports every gate, not only the first to fail", () => {
     // steps around it carry the build conjunct, so adding it here reads as
     // tidying up an inconsistency. It is not one — `turbo.jsonc` gives `test`
     // `dependsOn: ["^build"]`, so it rebuilds what it needs, and gating it
-    // means a Build failure in a package none of the seventeen filters depends
-    // on contributes nothing instead of seventeen suites' worth of verdict.
+    // means a Build failure in a package none of the filters depends on
+    // contributes nothing instead of every filtered suite's worth of verdict.
     expect(test).toBeDefined();
     expect(test.ifCondition).toContain(NOT_CANCELLED);
     expect(test.ifCondition).toContain(INSTALL_OK);


### PR DESCRIPTION
`packages/admin-css`'s integration test is failing on `main`, and nothing reports it.

## What was happening

The bin refused to emit, reporting **a hardcoded colour in a fixture that declares no colour at all**.

Tailwind's file scan starts at the CSS entry and walks *up*. From inside this repository the fixture therefore read every package around it and generated a utility for every class any of them uses. The emitted sheet reached **240KB with 38 colour declarations carrying literal values** — including `dark:hover:bg-[#ccc]`, authored here:

```
packages/create-nextly-app/templates/base/src/app/page.tsx:39
```

A colour written in a **Next.js starter template** was reaching a **plugin fixture's** compiled output.

So `checkAdminStyles` was correct and the input was contaminated. The refusal also moved with whatever unrelated markup the repository happened to gain, which makes it a test of the monorepo rather than of the fixture.

## The change

`@import "tailwindcss" source("./")` confines the scan to the fixture — which is how a published plugin compiles, having no neighbours to read. The same compile now emits 13KB and no literal colour.

| compile | output | colour declarations with literals |
| --- | --- | --- |
| as-is (scans upward) | 240,435 B | 38 |
| `source("./")` | 12,965 B | 0 |

**The gate is untouched.** Verified rather than assumed: writing `.probe { color: #ff0000 }` into the fixture still refuses the build with the same message. The contamination is gone; the check is exactly as strict.

## Why CI never caught it

The `Test` step enumerates its packages by `--filter`, and `@nextlyhq/admin-css` was not among them — so its 51 tests ran nowhere. This failure could stand on `main` indefinitely. It surfaced only through the pre-push hook, whose scope widens for a root-level diff, which means **it silently blocks any root-file change from any branch** while being invisible to a package-scoped one.

`@nextlyhq/admin-css` is added to that step.

The surrounding notes said "seventeen" in five places. Since the list they describe has now changed once, they say what they were counting instead of how many there were.

## Verification

`admin-css` 51/51; `pnpm test:scripts` 673/673, so the CI meta-test accepts the new filter. Pre-push passed, which is itself the evidence that the gate is unblocked.

No changeset: test-and-CI-only, and nothing shipped changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Limited style scanning in the admin CSS fixture to prevent oversized generated styles and unwanted color declarations.
  - Improved reliability for the admin CSS integration test by allowing additional time for compilation.

- **Tests**
  - Added the admin CSS test suite to continuous integration.
  - Improved change detection so relevant CLI, fixture, test, and theme updates trigger testing.
  - Updated CI documentation to reflect dynamically filtered test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->