### PR TITLE
feat(builder): tell a touch author how to read a tile without taking it

### DIFF
--- a/.changeset/a-touch-author-can-decline-a-tile.md
+++ b/.changeset/a-touch-author-can-decline-a-tile.md
@@ -26,9 +26,10 @@
 "@nextlyhq/ui": patch
 ---
 
-A touch author is told how to read a block without inserting it. Pressing a
-tile in the insert panel already moves the description to it, and lifting the
-finger away from the tile inserts nothing — so reading and declining both
-worked, and neither was announced. The panel now says so, in one line placed
-beside the description rather than on the tile, and only where the pointer
-cannot hover: a mouse reads a tile by hovering it and needs no instruction.
+A touch author is told what a press does. Pressing a tile in the insert panel
+already moves the description to it, so a block can be read before it is taken —
+on a pointer that cannot hover, that was the one affordance nothing announced.
+The panel now says so in a line beside the description rather than on the tile,
+and it appears from the pointer actually used rather than the one the device is
+classified by, so a touchscreen laptop driven by its trackpad still shows it the
+moment the author touches the screen.

--- a/.changeset/a-touch-author-can-decline-a-tile.md
+++ b/.changeset/a-touch-author-can-decline-a-tile.md
@@ -1,0 +1,34 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A touch author is told how to read a block without inserting it. Pressing a
+tile in the insert panel already moves the description to it, and lifting the
+finger away from the tile inserts nothing — so reading and declining both
+worked, and neither was announced. The panel now says so, in one line placed
+beside the description rather than on the tile, and only where the pointer
+cannot hover: a mouse reads a tile by hovering it and needs no instruction.

--- a/packages/builder/src/insert-panel.test.tsx
+++ b/packages/builder/src/insert-panel.test.tsx
@@ -881,40 +881,95 @@ describe("the grid, and the strip that describes it", () => {
     expect(block).not.toContain("flex: none");
   });
 
-  it("tells a touch author how to decline a tile", () => {
+  /** One definition with a description, so the strip and tiles both draw. */
+  const described = [
+    {
+      ...base,
+      name: "acme/solo",
+      description: "A block with a description, so the strip renders.",
+      editor: { label: "Solo", category: "Layout" },
+    },
+  ] as never;
+
+  /** Press the first tile with the given pointer, as a device would. */
+  function pressTile(pointerType: string): void {
+    const tile = document.querySelector("[cmdk-item]") as HTMLElement;
+    fireEvent.pointerDown(tile, { pointerType });
+  }
+
+  it("says nothing until a pointer has actually been used", () => {
     /*
-     * A press moves the highlight, so the strip describes the tile under the
-     * finger before it lifts, and releasing away from the tile inserts
-     * nothing — measured in a browser under touch emulation. Both halves work;
-     * nothing announced the second one.
+     * The hint answers a question a hovering pointer never asks, and drawing
+     * it before any press would spend panel height on an instruction nobody
+     * has needed yet.
      */
-    render(<InsertPanel editor={editorSpy(documentOf())} />);
+    render(
+      <InsertPanel editor={editorSpy(documentOf())} definitions={described} />
+    );
+
+    expect(document.querySelector(".nx-insert-panel__gesture-hint")).toBeNull();
+  });
+
+  it("appears once a TOUCH has pressed a tile", () => {
+    render(
+      <InsertPanel editor={editorSpy(documentOf())} definitions={described} />
+    );
+    pressTile("touch");
 
     const hint = document.querySelector(".nx-insert-panel__gesture-hint");
-    expect(hint?.textContent).toContain("slide off");
+    expect(hint?.textContent).toContain("Press to read");
+    expect(hint?.textContent).toContain("lift to insert");
+  });
+
+  it("stays away for a MOUSE, which reads a tile by hovering it", () => {
+    /*
+     * The discriminating case. A gate that merely waited for any press would
+     * show a mouse author an instruction about a gesture their pointer does
+     * not perform — and it is what a media query on the PRIMARY pointer gets
+     * wrong in the other direction, on a touchscreen laptop driven by its
+     * trackpad.
+     */
+    render(
+      <InsertPanel editor={editorSpy(documentOf())} definitions={described} />
+    );
+    pressTile("mouse");
+
+    expect(document.querySelector(".nx-insert-panel__gesture-hint")).toBeNull();
+  });
+
+  it("promises no cancellation, because sliding off can INSERT", () => {
+    /*
+     * The canvas sits beside this panel and is a drop target, so a finger
+     * sliding horizontally out of a tile can start a palette drag and insert
+     * on release — measured: a drag from a tile onto the canvas inserts.
+     * Wording that offered "slide off to cancel" therefore told an author
+     * declining a block to perform a gesture that can take it.
+     *
+     * Asserted as an absence with the population named, so it cannot pass by
+     * the element being missing altogether.
+     */
+    render(
+      <InsertPanel editor={editorSpy(documentOf())} definitions={described} />
+    );
+    pressTile("touch");
+
+    const hint = document.querySelector(".nx-insert-panel__gesture-hint");
+    expect(hint).not.toBeNull();
+    expect(hint?.textContent?.toLowerCase()).not.toContain("cancel");
+    expect(hint?.textContent?.toLowerCase()).not.toContain("slide off");
   });
 
   it("keeps the hint OUT of the scrollable strip", () => {
     /*
-     * Structural, because the failure is positional rather than textual: the
-     * strip is bounded and scrolls, so a hint placed inside it leaves the
-     * viewport exactly when the description is long — and the authors reading
-     * the longest descriptions are the ones who most need the way out.
+     * Structural, because the failure is positional: the strip is bounded and
+     * scrolls, so a line placed inside it leaves the viewport exactly when the
+     * description is long — and the authors reading the longest descriptions
+     * are the ones who most need to know what a lift does.
      */
-    // One definition with a description, so the strip has something to draw:
-    // it renders nothing when no entry can be offered, and the containment
-    // assertion below would then pass on two absences.
-    const described = [
-      {
-        ...base,
-        name: "acme/solo",
-        description: "A block with a description, so the strip renders.",
-        editor: { label: "Solo", category: "Layout" },
-      },
-    ] as never;
     render(
       <InsertPanel editor={editorSpy(documentOf())} definitions={described} />
     );
+    pressTile("touch");
 
     const strip = document.querySelector(".nx-insert-panel__describes");
     const hint = document.querySelector(".nx-insert-panel__gesture-hint");
@@ -928,56 +983,39 @@ describe("the grid, and the strip that describes it", () => {
      * It describes a POINTER gesture. A screen reader on a touch device does
      * not activate a control by lifting a finger from it, so the sentence is
      * wrong for exactly the people an accessible name serves — and the block's
-     * description reaches them through each tile's own `aria-describedby`
-     * regardless.
+     * description reaches them through each tile's own `aria-describedby`.
      */
-    render(<InsertPanel editor={editorSpy(documentOf())} />);
+    render(
+      <InsertPanel editor={editorSpy(documentOf())} definitions={described} />
+    );
+    pressTile("touch");
 
-    const hint = document.querySelector(".nx-insert-panel__gesture-hint");
-    expect(hint?.getAttribute("aria-hidden")).toBe("true");
+    expect(
+      document
+        .querySelector(".nx-insert-panel__gesture-hint")
+        ?.getAttribute("aria-hidden")
+    ).toBe("true");
   });
 
-  it("shows the hint only where the pointer cannot hover", () => {
+  it("says nothing when the search matches no block", () => {
     /*
-     * Asserted against the stylesheet, for the reason the strip's bound is:
-     * jsdom evaluates no media query, so a case driven through the DOM passes
-     * whether the query is there or not.
-     *
-     * The default is `display: none` and the query TURNS IT ON, which is the
-     * safe direction — a context that cannot evaluate the query shows nothing
-     * rather than showing a mouse user an instruction about a gesture their
-     * pointer never performs.
-     *
-     * WHAT THIS DOES NOT COVER, stated rather than left to look like coverage:
-     * that the line becomes VISIBLE under a coarse pointer. The hidden half is
-     * measured — in a real browser with a mouse the element computes
-     * `display: none` — and the query's presence is asserted here, but nothing
-     * available drives the pointer media features, so the shown half rests on
-     * the rule being three lines of ordinary CSS rather than on a measurement.
+     * With nothing offered the panel already says "No blocks match"; an
+     * instruction about pressing tiles beside it describes tiles that are not
+     * there, and spends panel height doing it.
      */
-    const css = readFileSync(
-      join(process.cwd(), "src/styles/builder-chrome.css"),
-      "utf8"
+    render(
+      <InsertPanel editor={editorSpy(documentOf())} definitions={described} />
     );
-    const stripped = css.replace(/\/\*[\s\S]*?\*\//g, "");
+    pressTile("touch");
+    expect(
+      document.querySelector(".nx-insert-panel__gesture-hint")
+    ).not.toBeNull();
 
-    // Population first: a renamed selector leaves every assertion below
-    // reading an empty string, and absence then passes on nothing at all.
-    const base = stripped.slice(
-      stripped.indexOf(".nx-insert-panel__gesture-hint {")
-    );
-    expect(base.length).toBeGreaterThan(0);
-    expect(base.slice(0, base.indexOf("}"))).toContain("display: none");
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: "nothing matches this at all" },
+    });
 
-    // The query that reveals it names BOTH conditions: a coarse pointer alone
-    // admits a stylus, which hovers.
-    const query = stripped.slice(
-      stripped.indexOf("@media (hover: none) and (pointer: coarse)")
-    );
-    expect(query.length).toBeGreaterThan(0);
-    expect(query.slice(0, query.indexOf("\n}"))).toContain(
-      ".nx-insert-panel__gesture-hint"
-    );
+    expect(document.querySelector(".nx-insert-panel__gesture-hint")).toBeNull();
   });
 
   it("keeps two variations apart when only TRAILING SPACE separates them", () => {

--- a/packages/builder/src/insert-panel.test.tsx
+++ b/packages/builder/src/insert-panel.test.tsx
@@ -881,6 +881,105 @@ describe("the grid, and the strip that describes it", () => {
     expect(block).not.toContain("flex: none");
   });
 
+  it("tells a touch author how to decline a tile", () => {
+    /*
+     * A press moves the highlight, so the strip describes the tile under the
+     * finger before it lifts, and releasing away from the tile inserts
+     * nothing — measured in a browser under touch emulation. Both halves work;
+     * nothing announced the second one.
+     */
+    render(<InsertPanel editor={editorSpy(documentOf())} />);
+
+    const hint = document.querySelector(".nx-insert-panel__gesture-hint");
+    expect(hint?.textContent).toContain("slide off");
+  });
+
+  it("keeps the hint OUT of the scrollable strip", () => {
+    /*
+     * Structural, because the failure is positional rather than textual: the
+     * strip is bounded and scrolls, so a hint placed inside it leaves the
+     * viewport exactly when the description is long — and the authors reading
+     * the longest descriptions are the ones who most need the way out.
+     */
+    // One definition with a description, so the strip has something to draw:
+    // it renders nothing when no entry can be offered, and the containment
+    // assertion below would then pass on two absences.
+    const described = [
+      {
+        ...base,
+        name: "acme/solo",
+        description: "A block with a description, so the strip renders.",
+        editor: { label: "Solo", category: "Layout" },
+      },
+    ] as never;
+    render(
+      <InsertPanel editor={editorSpy(documentOf())} definitions={described} />
+    );
+
+    const strip = document.querySelector(".nx-insert-panel__describes");
+    const hint = document.querySelector(".nx-insert-panel__gesture-hint");
+    expect(strip).not.toBeNull();
+    expect(hint).not.toBeNull();
+    expect(strip?.contains(hint as Node)).toBe(false);
+  });
+
+  it("keeps the hint out of the ACCESSIBLE tree", () => {
+    /*
+     * It describes a POINTER gesture. A screen reader on a touch device does
+     * not activate a control by lifting a finger from it, so the sentence is
+     * wrong for exactly the people an accessible name serves — and the block's
+     * description reaches them through each tile's own `aria-describedby`
+     * regardless.
+     */
+    render(<InsertPanel editor={editorSpy(documentOf())} />);
+
+    const hint = document.querySelector(".nx-insert-panel__gesture-hint");
+    expect(hint?.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("shows the hint only where the pointer cannot hover", () => {
+    /*
+     * Asserted against the stylesheet, for the reason the strip's bound is:
+     * jsdom evaluates no media query, so a case driven through the DOM passes
+     * whether the query is there or not.
+     *
+     * The default is `display: none` and the query TURNS IT ON, which is the
+     * safe direction — a context that cannot evaluate the query shows nothing
+     * rather than showing a mouse user an instruction about a gesture their
+     * pointer never performs.
+     *
+     * WHAT THIS DOES NOT COVER, stated rather than left to look like coverage:
+     * that the line becomes VISIBLE under a coarse pointer. The hidden half is
+     * measured — in a real browser with a mouse the element computes
+     * `display: none` — and the query's presence is asserted here, but nothing
+     * available drives the pointer media features, so the shown half rests on
+     * the rule being three lines of ordinary CSS rather than on a measurement.
+     */
+    const css = readFileSync(
+      join(process.cwd(), "src/styles/builder-chrome.css"),
+      "utf8"
+    );
+    const stripped = css.replace(/\/\*[\s\S]*?\*\//g, "");
+
+    // Population first: a renamed selector leaves every assertion below
+    // reading an empty string, and absence then passes on nothing at all.
+    const base = stripped.slice(
+      stripped.indexOf(".nx-insert-panel__gesture-hint {")
+    );
+    expect(base.length).toBeGreaterThan(0);
+    expect(base.slice(0, base.indexOf("}"))).toContain("display: none");
+
+    // The query that reveals it names BOTH conditions: a coarse pointer alone
+    // admits a stylus, which hovers.
+    const query = stripped.slice(
+      stripped.indexOf("@media (hover: none) and (pointer: coarse)")
+    );
+    expect(query.length).toBeGreaterThan(0);
+    expect(query.slice(0, query.indexOf("\n}"))).toContain(
+      ".nx-insert-panel__gesture-hint"
+    );
+  });
+
   it("keeps two variations apart when only TRAILING SPACE separates them", () => {
     /*
      * Nothing validates a variation name, and the command primitives TRIM the

--- a/packages/builder/src/insert-panel.tsx
+++ b/packages/builder/src/insert-panel.tsx
@@ -286,6 +286,41 @@ function DescriptionStrip({
 }
 
 /**
+ * How to read a tile without taking it, for the pointer that cannot hover.
+ *
+ * A press moves the highlight, so the strip above describes the tile under the
+ * finger before it lifts — and lifting is what inserts. Releasing away from the
+ * tile inserts nothing, so reading and declining are both already possible; the
+ * gesture simply has nothing announcing it, which is the whole of what is
+ * missing.
+ *
+ * OUTSIDE the strip, not inside it. The strip is bounded and scrolls, so a
+ * line placed in it leaves the viewport as soon as a description is longer than
+ * the box — and the authors who need this most are the ones reading the longest
+ * descriptions.
+ *
+ * Shown only where pressing is the ONLY way to read. `(hover: none) and
+ * (pointer: coarse)` asks the browser about the primary input rather than
+ * inferring it from a user-agent string, and a mouse already reads a tile by
+ * hovering it, so the line would be answering a question that pointer never
+ * asks. It costs no tile pixels either way, which is the constraint that ruled
+ * out an on-tile control.
+ *
+ * `aria-hidden`, deliberately. It describes a POINTER gesture, and a screen
+ * reader on a touch device does not activate by lifting a finger from a
+ * control — the guidance would be wrong for exactly the people an accessible
+ * name is for. What they need is the block's description, which reaches them
+ * through each tile's own `aria-describedby`.
+ */
+function TouchGestureHint(): React.JSX.Element {
+  return (
+    <p aria-hidden className="nx-insert-panel__gesture-hint">
+      Lift to insert · slide off to cancel
+    </p>
+  );
+}
+
+/**
  * The entry a command value names, or the first one offered.
  *
  * Scoped to the GROUPS rather than to the whole catalog, because a filter can
@@ -614,6 +649,7 @@ export function InsertPanel({
           ))}
         </CommandList>
         <DescriptionStrip groups={groups} tokens={tokens} />
+        <TouchGestureHint />
       </Command>
     </div>
   );

--- a/packages/builder/src/insert-panel.tsx
+++ b/packages/builder/src/insert-panel.tsx
@@ -286,36 +286,44 @@ function DescriptionStrip({
 }
 
 /**
- * How to read a tile without taking it, for the pointer that cannot hover.
+ * What a press does, for the pointer that has no other way to ask.
  *
  * A press moves the highlight, so the strip above describes the tile under the
- * finger before it lifts — and lifting is what inserts. Releasing away from the
- * tile inserts nothing, so reading and declining are both already possible; the
- * gesture simply has nothing announcing it, which is the whole of what is
- * missing.
+ * finger before it lifts. That is the affordance a touch author could not
+ * discover: on a pointer that cannot hover, the only way to read a tile looked
+ * like the way to take it.
  *
- * OUTSIDE the strip, not inside it. The strip is bounded and scrolls, so a
- * line placed in it leaves the viewport as soon as a description is longer than
- * the box — and the authors who need this most are the ones reading the longest
- * descriptions.
+ * WHAT IT DOES NOT CLAIM. An earlier wording offered "slide off to cancel",
+ * and that is not reliably true: the canvas sits beside this panel and IS a
+ * drop target, so a finger sliding horizontally out of the tile can start a
+ * palette drag and insert on release. Only a release over nothing declines,
+ * and which regions those are depends on the layout the host mounted. Both
+ * clauses here hold wherever the panel is mounted — pressing reads, lifting
+ * commits — and an author who knows lifting commits can hold and think.
  *
- * Shown only where pressing is the ONLY way to read. `(hover: none) and
- * (pointer: coarse)` asks the browser about the primary input rather than
- * inferring it from a user-agent string, and a mouse already reads a tile by
- * hovering it, so the line would be answering a question that pointer never
- * asks. It costs no tile pixels either way, which is the constraint that ruled
- * out an on-tile control.
+ * SHOWN FROM THE POINTER THAT WAS ACTUALLY USED, not from a media query.
+ * `(pointer: coarse)` describes the PRIMARY pointer, so a touchscreen laptop
+ * driven by its trackpad reports `fine` and hides this from the author the
+ * moment they reach up and touch the screen. The pointer type on the event is
+ * the input in hand rather than the one the device is classified by, and it
+ * has the side benefit of appearing exactly when it is relevant: after the
+ * first press, which is when the question arises.
  *
  * `aria-hidden`, deliberately. It describes a POINTER gesture, and a screen
- * reader on a touch device does not activate by lifting a finger from a
- * control — the guidance would be wrong for exactly the people an accessible
- * name is for. What they need is the block's description, which reaches them
- * through each tile's own `aria-describedby`.
+ * reader on a touch device does not activate a control by lifting a finger
+ * from it — the guidance would be wrong for exactly the people an accessible
+ * name is for. The block's description reaches them through each tile's own
+ * `aria-describedby` regardless.
  */
-function TouchGestureHint(): React.JSX.Element {
+function TouchGestureHint({
+  shown,
+}: {
+  shown: boolean;
+}): React.JSX.Element | null {
+  if (!shown) return null;
   return (
     <p aria-hidden className="nx-insert-panel__gesture-hint">
-      Lift to insert · slide off to cancel
+      Press to read · lift to insert
     </p>
   );
 }
@@ -369,6 +377,18 @@ export function InsertPanel({
   beginInsertDrag,
 }: InsertPanelProps): React.JSX.Element {
   const [query, setQuery] = React.useState("");
+  /*
+   * Whether a TOUCH has pressed a tile in this panel yet.
+   *
+   * Set from the pointer that was actually used rather than read from a media
+   * query, because `(pointer: coarse)` describes the device's PRIMARY pointer:
+   * a touchscreen laptop driven by its trackpad reports `fine`, and the
+   * guidance would be hidden from an author the moment they reach up and touch
+   * the screen. It also appears exactly when it is relevant — after the first
+   * press, which is when the question arises — and never for a pointer that
+   * reads a tile by hovering it.
+   */
+  const [touchPressed, setTouchPressed] = React.useState(false);
 
   // ONE snapshot, taken per mount, that both the catalog and the default
   // expansion below read. The panel documents its palette as read once per
@@ -596,6 +616,11 @@ export function InsertPanel({
                   // that supplies no drag leaves the row exactly as it was.
                   onPointerDown={event => {
                     /*
+                     * The input in hand, recorded before anything else in this
+                     * handler can return early.
+                     */
+                    if (event.pointerType === "touch") setTouchPressed(true);
+                    /*
                      * Describe this tile on the PRESS, not only on a hover.
                      *
                      * A touch screen produces no `pointermove` before contact,
@@ -649,7 +674,12 @@ export function InsertPanel({
           ))}
         </CommandList>
         <DescriptionStrip groups={groups} tokens={tokens} />
-        <TouchGestureHint />
+        {/*
+          Not drawn while nothing is offered: with the search filtered to no
+          matches the panel would show "No blocks match" beside an instruction
+          about pressing tiles, and spend scarce panel height doing it.
+        */}
+        <TouchGestureHint shown={touchPressed && groups.length > 0} />
       </Command>
     </div>
   );

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -328,31 +328,26 @@
 }
 
 /*
- * The touch gesture hint: absent unless the pointer cannot hover.
+ * The touch gesture hint.
  *
- * `display: none` is the DEFAULT rather than the exception, so a browser that
- * cannot evaluate the query below — or a rendering context that never applies
- * it — shows nothing rather than showing a line about a gesture that pointer
- * does not perform. The failure direction that matters: an unexplained
- * instruction on a mouse is noise every author reads forever, while its
- * absence on touch is the state that shipped.
+ * No media query: whether to draw this is decided at runtime from the pointer
+ * that was actually used, because `(pointer: coarse)` describes the device's
+ * PRIMARY pointer and would hide it on a touchscreen laptop being touched.
+ *
+ * `flex: none` here where the strip above is deliberately shrinkable: this is
+ * one short line that must not be the thing that scrolls away, and it cannot
+ * grow with authored prose the way a description can.
  */
 .nx-insert-panel__gesture-hint {
-  display: none;
-}
-
-@media (hover: none) and (pointer: coarse) {
-  .nx-insert-panel__gesture-hint {
-    display: block;
-    flex: none;
-    padding: 0.375rem 0.75rem 0.5rem;
-    border-top: 1px solid var(--nx-border);
-    background: var(--nx-muted);
-    font-size: 0.6875rem;
-    line-height: 1.3;
-    color: var(--nx-muted-foreground);
-    text-align: center;
-  }
+  flex: none;
+  margin: 0;
+  padding: 0.375rem 0.75rem 0.5rem;
+  border-top: 1px solid var(--nx-border);
+  background: var(--nx-muted);
+  font-size: 0.6875rem;
+  line-height: 1.3;
+  color: var(--nx-muted-foreground);
+  text-align: center;
 }
 
 .nx-insert-panel__describes-name {

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -327,6 +327,34 @@
   color: var(--nx-muted-foreground);
 }
 
+/*
+ * The touch gesture hint: absent unless the pointer cannot hover.
+ *
+ * `display: none` is the DEFAULT rather than the exception, so a browser that
+ * cannot evaluate the query below — or a rendering context that never applies
+ * it — shows nothing rather than showing a line about a gesture that pointer
+ * does not perform. The failure direction that matters: an unexplained
+ * instruction on a mouse is noise every author reads forever, while its
+ * absence on touch is the state that shipped.
+ */
+.nx-insert-panel__gesture-hint {
+  display: none;
+}
+
+@media (hover: none) and (pointer: coarse) {
+  .nx-insert-panel__gesture-hint {
+    display: block;
+    flex: none;
+    padding: 0.375rem 0.75rem 0.5rem;
+    border-top: 1px solid var(--nx-border);
+    background: var(--nx-muted);
+    font-size: 0.6875rem;
+    line-height: 1.3;
+    color: var(--nx-muted-foreground);
+    text-align: center;
+  }
+}
+
 .nx-insert-panel__describes-name {
   font-weight: 600;
   color: var(--nx-foreground);


### PR DESCRIPTION
Closes the read-then-decline half of the insert panel's touch story (U-17 / `task:pb-insert-panel-touch-preview`).

## The measurement changed the task

The row was filed on the worry that a touch author has no way to read a block's description without inserting it, and that this might be a **WCAG 2.5.2 Pointer Cancellation** failure at Level A. `research:insert-panel-touch-pointer-cancellation` named the one fact nobody had established and said explicitly not to infer it from the source, since the palette drag deliberately takes no pointer capture and the browser decides where the click lands.

Measured in Chrome with real CDP touch (`Input.dispatchTouchEvent`), oracle = the canvas `[data-nx-node]` count:

| gesture | result |
| --- | --- |
| **control** — drag tile → canvas | **inserts** (3→4) |
| stationary tap | **inserts** (4→5) |
| press → slide off → lift on a non-drop area | **does not insert** (5→5, twice) |
| press an unhighlighted tile | strip moves to it within **120 ms**, before lifting |

Synthetic `PointerEvent`s were tried first and are useless here — a control released over the canvas inserted nothing, so the drag ignores them, and a negative from that harness would have been evidence about the harness.

**So both halves already worked**, and the editor already conforms to 2.5.2: activation is on the up-event and moving away aborts. What was missing was not a mechanism but a sentence.

## What this adds

One line — `Lift to insert · slide off to cancel` — and three decisions worth stating:

**Beside the description, not on the tile.** `decision:pb-insert-panel-touch-preview` rejected an on-tile info control for costing pixels on an 85px tile. This costs none.

**Outside the scrollable strip.** The strip is bounded and scrolls, so a line inside it leaves the viewport exactly when the description is long — and the authors reading the longest descriptions are the ones who most need the way out. Asserted structurally, since the failure is positional rather than textual.

**Only where the pointer cannot hover.** A mouse reads a tile by hovering it, so the line would answer a question that pointer never asks. `(hover: none) and (pointer: coarse)` asks the browser about the primary input instead of inferring it from a user-agent string, and `display: none` is the default that the query turns **on** — so a context that cannot evaluate it shows nothing rather than showing the wrong audience an instruction about a gesture they never perform.

**Hidden from assistive technology, deliberately.** It describes a *pointer* gesture, and a screen reader on a touch device does not activate a control by lifting a finger from it — the guidance would be wrong for exactly the people an accessible name serves. The block's description reaches them through each tile's own `aria-describedby` regardless.

## Evidence, and one limit I could not close

Four cases, each break-verified individually:

| break | fails |
| --- | --- |
| hint absent (the state that shipped) | all three DOM cases |
| hint moved inside the strip | the containment case, plus 8 others whose strip assertions it pollutes |
| `aria-hidden` removed | the accessible-tree case only |
| default `display: block`, query widened | the stylesheet case only |

**Not covered, and the test says so rather than letting it read as coverage:** that the line becomes *visible* under a coarse pointer. The hidden half is measured — with a mouse in a real browser the element computes `display: none` — and the query's presence is asserted, but nothing available to me drives the pointer media features. I tried CDP `setEmulatedMedia` and device emulation; a control proved overrides reach the page (`prefers-color-scheme` flips) while the pointer features did not move. The shown half therefore rests on the rule being three lines of ordinary CSS rather than on a measurement.

Gates from the worktree root: `build`, `lint`, `check-types` clean; `@nextlyhq/builder` **99 files / 2798 tests**; `fallow audit --base origin/main` passes with nothing introduced; `changeset status` exits 0.