### PR TITLE
test(plugin-seo): run the integration suites in their own task

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -248,10 +248,17 @@ jobs:
       # Builds all three adapters for the same reason the database job does:
       # nextly's database/factory.ts references them as optional peers, and
       # turbo's `^build` does not traverse peerDependencies.
+      # `plugin-seo` runs on THIS leg only, unlike the packages beside it. Its
+      # suites call `createTestNextly`, which boots on in-memory SQLite and
+      # names no dialect, so the postgres and mysql legs would run byte-identical
+      # work — three times the runtime for one answer. They are here rather than
+      # in the unit `Test` step because each case boots a real instance, and
+      # doing that while seventeen other suites run in parallel is what took one
+      # past a 30s budget on CI while it finishes in about 1.5s alone.
       - name: Run integration tests (sqlite)
         run: |
-          pnpm turbo build --filter=nextly --filter=@nextlyhq/adapter-postgres --filter=@nextlyhq/adapter-mysql --filter=@nextlyhq/adapter-sqlite --filter=@nextlyhq/plugin-page-builder
-          pnpm turbo test:integration --filter=@nextlyhq/adapter-sqlite --filter=nextly --filter=@nextlyhq/plugin-page-builder
+          pnpm turbo build --filter=nextly --filter=@nextlyhq/adapter-postgres --filter=@nextlyhq/adapter-mysql --filter=@nextlyhq/adapter-sqlite --filter=@nextlyhq/plugin-page-builder --filter=@nextlyhq/plugin-seo
+          pnpm turbo test:integration --filter=@nextlyhq/adapter-sqlite --filter=nextly --filter=@nextlyhq/plugin-page-builder --filter=@nextlyhq/plugin-seo
         env:
           TURBO_CACHE_DIR: .turbo
 

--- a/packages/eslint-config/base.js
+++ b/packages/eslint-config/base.js
@@ -161,6 +161,11 @@ export const config = [
       "**/tsup.*.config.{js,ts,mjs,cjs}",
       "**/next.config.{js,ts,mjs,cjs}",
       "**/vitest.config.{js,ts,mjs,cjs}",
+      // The same for a variant config, matching the `tsup.*.config` line above:
+      // a package that splits its unit and integration runs adds
+      // `vitest.integration.config.ts`, which sits outside every tsconfig
+      // project exactly as the config beside it does.
+      "**/vitest.*.config.{js,ts,mjs,cjs}",
       // A global-setup file is loaded by vitest the same way its config is, so
       // it lives outside every package's tsconfig project for the same reason.
       "**/vitest.global-setup.{js,ts,mjs,cjs}",

--- a/packages/plugin-seo/package.json
+++ b/packages/plugin-seo/package.json
@@ -25,6 +25,7 @@
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
     "test": "vitest run",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:watch": "vitest"
   },
   "peerDependencies": {

--- a/packages/plugin-seo/vitest.config.ts
+++ b/packages/plugin-seo/vitest.config.ts
@@ -1,14 +1,20 @@
 import { defineConfig } from "vitest/config";
 
-// The `*.integration.test.ts` suites boot a real Nextly instance per test via
-// `createTestNextly` (DI container + schema registry + in-memory SQLite). A
-// single boot is sub-second in isolation, but under the monorepo's parallel
-// `Test` step the runner saturates and a boot can exceed Vitest's 5s default.
-// Give the integration tests the headroom they legitimately need; fast unit
-// tests are unaffected.
+// Unit suites only. The `*.integration.test.ts` files boot a real Nextly
+// instance per test via `createTestNextly` (DI container + schema registry +
+// in-memory SQLite), which is not what the `test` task is sized for: turbo runs
+// it across every package at once, and a boot competing with seventeen other
+// suites took a case past 30s on CI while the same file finishes in about 1.5s
+// of test time in isolation. Raising the budget was the previous answer and it
+// has now been exceeded twice, so the suites move to their own task instead —
+// the split `nextly`, the three adapters and `plugin-page-builder` already use.
 export default defineConfig({
   test: {
-    testTimeout: 30000,
-    hookTimeout: 30000,
+    include: ["src/**/*.{test,spec}.ts"],
+    exclude: [
+      "**/node_modules/**",
+      "**/dist/**",
+      "src/**/*.integration.test.ts",
+    ],
   },
 });

--- a/packages/plugin-seo/vitest.integration.config.ts
+++ b/packages/plugin-seo/vitest.integration.config.ts
@@ -1,0 +1,24 @@
+// Integration config for the SEO plugin. Runs only `*.integration.test.ts`.
+//
+// Mirrors the split in `nextly` and `plugin-page-builder`: these boot a real
+// Nextly instance and exercise a route against it, so they need a budget a unit
+// default cannot give them and they must not compete with the parallel unit
+// step for the runner.
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    name: "plugin-seo-integration",
+    include: ["src/**/*.integration.test.ts"],
+    exclude: ["**/node_modules/**", "**/dist/**"],
+    // A real instance boot per test, so the unit default is far too tight.
+    // Kept at the value the unit config used to carry, which was sized for this
+    // work — what changes is that it is no longer paid while every other
+    // package's suite runs beside it.
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+    // Each test boots its own instance against a shared in-memory database, so
+    // the files cannot safely interleave.
+    fileParallelism: false,
+  },
+});


### PR DESCRIPTION
`main` is red on two commits — `94dfbba63` (#1495) and `8527d8510` (#1496) — both failing the same way:

```
Failed: @nextlyhq/plugin-seo#test
  sitemap.integration.test.ts > serves published entries ...
  Error: Test timed out in 30000ms.
```

The cases after it report `Collection "pages" not found`, which is the first boot dying mid-setup rather than three separate defects.

## Not caused by the commit it starts at

The bisect signature points at #1495: every ancestor is green, everything from it onward is red. That is coincidental, and worth stating because it looks damning:

- `plugin-seo` declares only `@nextlyhq/plugin-sdk`, `nextly` and tooling. It does **not** depend on `blocks-react` or `blocks-engine`, and imports neither anywhere in `src/`. #1495 touched only those two packages.
- The suite passes locally with that change present: 7/7, 1.5s of test time.
- #1496, an unrelated admin fix, fails **identically**.

These are timeouts — load-sensitive, not content-sensitive.

## The actual cause

These suites call `createTestNextly`, which boots a real Nextly instance **per test** on in-memory SQLite. The `test` task is the wrong home: turbo runs it across every package simultaneously.

This package's own config already said so, raising the budget from vitest's 5s default to 30s because *"under the monorepo's parallel Test step the runner saturates and a boot can exceed Vitest's 5s default."* That budget has now been exceeded as well — so a third increase is not the answer.

`plugin-seo` was the outlier. `nextly`, the three adapters and `plugin-page-builder` all exclude `*.integration.test.ts` from the unit run and execute it under `test:integration`. This adopts that arrangement rather than inventing one.

## Both halves, because either alone is wrong

Excluding the suites without wiring them in would mean they run **nowhere** — a silent coverage loss dressed as a fix. So they are added to `integration.yml`.

**The SQLite leg only.** `createTestNextly` names no dialect and boots in memory, so the postgres and mysql legs would run byte-identical work for one answer.

## Verification

The partition is asserted by file, not by count — a count can match while a file goes missing:

| lane | collects |
| --- | --- |
| unit | `plugin.test.ts`, `sitemap.test.ts` — 65 tests |
| integration | `extend.integration.test.ts`, `sitemap.integration.test.ts` — 9 tests |

Union is all four tracked test files; none lost, none duplicated. Both lanes pass through turbo as CI invokes them, and `turbo run test:integration --filter=@nextlyhq/plugin-seo` resolves the new task.

`test:scripts` 673/673, lint 22/22, `lint:design` clean.

## One shared-config change

`packages/eslint-config/base.js` gains `**/vitest.*.config.{js,ts,mjs,cjs}`, matching the `tsup.*.config` line directly above it and for the same stated reason: a split package's second config sits outside every tsconfig project exactly as the config beside it does. Without it the new file fails type-aware lint with "not found by the project service".

It captures the five existing `vitest.integration.config.ts` files, which ESLint already reports as ignored — so it makes the treatment consistent rather than silencing anything that was being checked.

No changeset: test-and-CI-only, nothing shipped changes.
