### PR TITLE
build(root): typecheck a package against its dependencies' current build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -462,15 +462,23 @@ jobs:
         run: pnpm lint:workspace
 
       # Identified for the same reason `install` is, and the reason is in
-      # AGENTS.md rather than here: `turbo.jsonc` gives `lint` no dependency at
-      # all and `check-types` only `^check-types`, so neither rebuilds — they
-      # read whatever `dist` survived. On an unbuilt tree `check-types` fails
-      # workspace-wide on TS2307 through the siblings' export maps and `lint`
-      # fails on `import-x/no-unresolved`, and the dangerous half is that every
-      # TYPE-AWARE lint rule then reports on types the checker cannot see: the
+      # AGENTS.md rather than here: these steps read `dist`, and what they say
+      # without one is misleading rather than merely absent.
+      #
+      # `turbo.jsonc` gives `lint` no dependency at all, so it reads whatever
+      # `dist` survived. On an unbuilt tree it fails on
+      # `import-x/no-unresolved`, and the dangerous half is that every
+      # TYPE-AWARE rule then reports on types the checker cannot see: the
       # message names YOUR EXPRESSION and reads as a correctness defect whose
       # obvious remedy is a real regression. `publint` and `arethetypeswrong`
       # read `dist` directly and have nothing to say without one.
+      #
+      # `check-types` carries `^build`, so it rebuilds its own dependencies and
+      # no longer fails workspace-wide on TS2307 through the siblings' export
+      # maps. It stays on this gate anyway, for a different reason than the
+      # others: the build it would run is the one the Build step just ran and
+      # failed, so letting it proceed reports a single defect a second time
+      # under a name that points at the wrong package.
       #
       # So a failed Build legitimately skips those FOUR, exactly as a failed
       # install skips everything: reporting one defect four ways, all of them

--- a/scripts/turbo-inputs.test.mjs
+++ b/scripts/turbo-inputs.test.mjs
@@ -87,7 +87,16 @@ function dryRun() {
 }
 
 function resolvedTasks() {
-  return dryRun().tasks;
+  // The `check-types` tasks ONLY, rather than everything the run contains.
+  //
+  // `check-types` depends on `^build`, so the graph carries a `build` task for
+  // every dependency as well, and each assertion below is about how a package's
+  // TYPE-CHECK is hashed and what it depends on. Unfiltered, they read a
+  // `build` task's definition and report it under a check-types message — which
+  // is how a correct `build` (`dependsOn: ["^build"]`, and no command at all in
+  // a package that ships no build) arrives as a package that "has no runnable
+  // check-types command".
+  return dryRun().tasks.filter(entry => entry.task === "check-types");
 }
 
 /** The TypeScript modules git tracks inside a package. */

--- a/scripts/turbo-inputs.test.mjs
+++ b/scripts/turbo-inputs.test.mjs
@@ -286,6 +286,14 @@ describe("every tracked file a compiler reads is covered by some hash", () => {
   const dry = dryRun();
   const globalFiles = new Set(Object.keys(dry.globalCacheInputs.files));
   const byPackage = new Map(dry.tasks.map(task => [task.package, task]));
+  // Every runnable task in the run, `build` included — not just `check-types`.
+  //
+  // Unlike `resolvedTasks`, this block asks what a task's compiler READS and
+  // whether the hash covers it, which is as true of a build as of a typecheck:
+  // inputs that miss a source file leave the cache valid across an edit to it
+  // either way. `check-types` depends on `^build`, so the build tasks arrive
+  // here through that edge rather than by being asked for, and stating it is
+  // what stops them disappearing unremarked if the edge ever moves.
   const runnable = dry.tasks.filter(
     task => !String(task.command).includes("NONEXISTENT")
   );

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -209,9 +209,35 @@
       // `main`, a redundant run costs minutes — and turbo still runs
       // independent packages concurrently.
       //
-      // NOT `^build`: this needs the dependency's HASH, not its `dist`, and
-      // requiring artifacts would make every typecheck wait on a build.
-      "dependsOn": ["^check-types"],
+      // `^build` as well, because the sentence above was true of the packages
+      // that motivated it and of almost none of the others. `packages/admin`
+      // maps the bare `nextly` specifier at its own source, so its program does
+      // need the dependency's hash rather than its `dist` — but only five
+      // packages declare such a mapping (`admin`, the three `storage-*`
+      // adapters, and `playground`). Every other one resolves `@nextlyhq/*`
+      // through package exports, and those point at the artifact:
+      // `blocks-react` publishes `"types": "./dist/index.d.ts"`. For those, a
+      // typecheck reads a BUILD, and a stale one answers about code that is no
+      // longer there.
+      //
+      // Measured rather than argued, by renaming an exported symbol in
+      // `blocks-engine` that `builder` imports: with `dist` untouched
+      // `builder#check-types` exits 0, and after a rebuild the same tree
+      // reports `TS2724`. It fails in the PASSING direction, which is the one
+      // nobody re-checks.
+      //
+      // The cost this note previously weighed against is a build that turbo has
+      // usually already done: warm, `turbo run build` across every package
+      // completes in ~0.2s on a full cache hit, and does real work only when a
+      // dependency actually changed — which is exactly when the answer would
+      // otherwise be stale.
+      //
+      // `^check-types` STAYS beside it rather than being replaced. The two
+      // cover different programs: a package's build compiles the sources it
+      // ships, while its `check-types` also covers the test files its shipping
+      // tsconfig excludes, so a type error confined to a dependency's tests is
+      // invisible to `^build` alone.
+      "dependsOn": ["^check-types", "^build"],
       // Every extension TypeScript follows, not only `.ts`/`.tsx`. A task input
       // glob decides what turbo HASHES: a change confined to an extension
       // missing here leaves the hash unmoved, so CI replays a cached green


### PR DESCRIPTION
`check-types` depended on `^check-types` alone, with a note stating it needs the dependency's **hash**, not its `dist`.

That is true of the five packages declaring a tsconfig path mapping to a neighbour's source — `admin`, the three `storage-*` adapters, and `playground`. **Every other package** resolves `@nextlyhq/*` through package exports, and those point at the artifact (`blocks-react` publishes `"types": "./dist/index.d.ts"`). For those, a typecheck reads a build, and a stale one answers about code that is gone.

## Measured, not argued

Renamed an exported symbol in `blocks-engine` that dependents import, leaving `dist` untouched. Same tree, same break; the edge is the only difference:

| `dependsOn` | result |
| --- | --- |
| `["^check-types"]` | **exit 0**, 13 tasks successful — silent wrong answer |
| `["^check-types", "^build"]` | **exit 2**, `TS2724: has no exported member 'BLOCK_ICONS'` |

It fails in the **passing** direction, which is the one nobody re-checks. This cost five wrong diagnoses in a single day, and twice made a real Codex finding look like it already failed.

## Why `^check-types` stays beside it

They cover different programs. A package's build compiles what it ships; its `check-types` also covers the test files its shipping tsconfig excludes — so a type error confined to a dependency's tests is invisible to `^build` alone. The existing hash argument is preserved, not replaced.

## Cost

A fully warm `turbo run build` across all 20 packages is **222ms, FULL TURBO**. Repo-wide `check-types` warm is **348ms** for 36 tasks. It does real work only when a dependency actually changed — exactly when the current setup lies.

## `lint` is deliberately untouched

The task names it, but ESLint reads source directly. Measured on one tree with a stale `dist` and correct source: `check-types` reported `TS2305` while `lint` exited **0**. No evidence it is affected, so it is not changed on assumption.

## Test-infra changes this forces

`resolvedTasks` in `turbo-inputs.test.mjs` returned **every** task in the `check-types` dry run, which was correct only while that graph held nothing else. With `^build` it also carries a `build` task per dependency, so unfiltered the assertions read a `build` task's definition and report it under a check-types message — a correct `build` arrives as a package that "has no runnable check-types command". Now filtered to `check-types`.

The hash-coverage block filters `dryRun()` directly and legitimately gains those 14 build tasks, all passing — inputs that miss a source file leave the cache valid whether the task compiles types or output. Said explicitly in the file so a population that grew through this edge cannot shrink unremarked.

Verified by membership rather than count: **14 tests added, 0 removed.**

The `ci.yml` note beside the Build gate is rewritten, since `check-types` no longer fails workspace-wide on an unbuilt tree; the reason it stays on that gate is now that a Build failure it would rediscover has already been reported once under the right name.

## Verification

build 20/20, check-types 36/36, lint 22/22, `lint:design` and `lint:workspace` clean, `test:scripts` 687/687, `fallow` passes over 3 changed files with 0 introduced findings. Full `nextly` suite on this branch: 873 files / 11,093 tests, identical to `main`.

No changeset: root tooling, nothing shipped changes.
