### PR TITLE
fix(admin-css): bound the compile on the child process, not on the case

### DIFF
--- a/packages/admin-css/__fixtures__/poc-plugin/admin.css
+++ b/packages/admin-css/__fixtures__/poc-plugin/admin.css
@@ -13,15 +13,15 @@
  * Without it the scan starts at this file and walks UP, so it reads the whole
  * monorepo and generates a utility for every class any package happens to use.
  * A published plugin has no such neighbours: it scans its own package and emits
- * what its own markup asks for, and the point of this fixture is to compile the
- * way that plugin does.
+ * what its own markup asks for, and compiling the way that plugin does is the
+ * point of this fixture.
  *
- * It is also what makes the assertions below mean anything. Scanning upward,
- * the emitted sheet reached 240KB and carried 38 colour declarations with
- * literal values — `dark:hover:bg-[#ccc]` from a `create-nextly-app` template
- * among them — so `checkAdminStyles` refused a fixture that never wrote a
- * colour, and the refusal moved with whatever unrelated markup the repository
- * gained. Confined, the same compile emits 13KB and no literal colour at all.
+ * It is also what makes the assertions below mean anything. Scanning upward
+ * pulls in utilities carrying literal colours that this fixture never wrote —
+ * an arbitrary-value class in any unrelated package is enough — so
+ * `checkAdminStyles` refuses the build, and what it refuses moves with whatever
+ * markup the repository happens to gain. That makes the result a statement
+ * about the monorepo rather than about this stylesheet.
  */
 @import "tailwindcss" source("./");
 /*

--- a/packages/admin-css/bin.integration.test.mjs
+++ b/packages/admin-css/bin.integration.test.mjs
@@ -28,12 +28,20 @@ const ROOT = path.dirname(fileURLToPath(import.meta.url));
  * 630ms while the case took 5547ms end to end and was killed at the limit,
  * having done nothing wrong.
  *
- * Generous rather than tuned to that number. A timeout set just above what was
- * observed once turns every slower runner into a red build, and the cost of a
- * high limit is paid only when something genuinely hangs — where the difference
- * between failing at 5s and at 60s is a wait, not a wrong answer.
+ * TWO limits, because a vitest timeout cannot bound this work on its own.
+ * `execSync` blocks the worker's event loop for as long as the child runs, and
+ * a timer that cannot be serviced cannot fire — so against a child that HANGS
+ * rather than merely running slowly, the case-level budget below expires
+ * unnoticed and the suite sits until the workflow's own limit kills it.
+ *
+ * `CHILD_TIMEOUT_MS` is therefore the real bound: node enforces it on the child
+ * and kills it, which unblocks the loop and surfaces a normal assertion
+ * failure. The case-level budget is deliberately LARGER, so a hung child is
+ * reported as the child failing rather than as vitest giving up on a test whose
+ * subprocess is still alive.
  */
-const COMPILE_TIMEOUT_MS = 60_000;
+const CHILD_TIMEOUT_MS = 60_000;
+const COMPILE_TIMEOUT_MS = CHILD_TIMEOUT_MS + 30_000;
 
 describe("nextly-build-admin-css (POC)", () => {
   it(
@@ -45,7 +53,7 @@ describe("nextly-build-admin-css (POC)", () => {
       );
       execSync(
         `node "${ROOT}/bin/nextly-build-admin-css.mjs" "${ROOT}/__fixtures__/poc-plugin/admin.css" "${out}"`,
-        { cwd: ROOT }
+        { cwd: ROOT, timeout: CHILD_TIMEOUT_MS }
       );
       const css = fs.readFileSync(out, "utf-8");
 

--- a/packages/admin-css/bin.integration.test.mjs
+++ b/packages/admin-css/bin.integration.test.mjs
@@ -7,7 +7,11 @@
  * a re-emitted preflight reset (which would restyle the host page) — the
  * properties the loading + isolation model depends on.
  */
-import { execSync } from "node:child_process";
+import { spawn } from "node:child_process";
+// Imported rather than taken from the global scope: this file lints under a
+// config that supplies `setTimeout` and not `clearTimeout`, and a timer that is
+// set but never cleared keeps the worker alive after the case has passed.
+import { clearTimeout, setTimeout } from "node:timers";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -28,32 +32,73 @@ const ROOT = path.dirname(fileURLToPath(import.meta.url));
  * 630ms while the case took 5547ms end to end and was killed at the limit,
  * having done nothing wrong.
  *
- * TWO limits, because a vitest timeout cannot bound this work on its own.
- * `execSync` blocks the worker's event loop for as long as the child runs, and
- * a timer that cannot be serviced cannot fire — so against a child that HANGS
- * rather than merely running slowly, the case-level budget below expires
- * unnoticed and the suite sits until the workflow's own limit kills it.
+ * Run ASYNCHRONOUSLY, and killed as a process GROUP, for two reasons that a
+ * synchronous call cannot satisfy at once:
  *
- * `CHILD_TIMEOUT_MS` is therefore the real bound: node enforces it on the child
- * and kills it, which unblocks the loop and surfaces a normal assertion
- * failure. The case-level budget is deliberately LARGER, so a hung child is
- * reported as the child failing rather than as vitest giving up on a test whose
- * subprocess is still alive.
+ *   - `execSync` blocks the worker's event loop for as long as the child runs,
+ *     and a timer that cannot be serviced cannot fire. Against a child that
+ *     HANGS the case budget is inert: measured, a child sleeping 20s under a 5s
+ *     budget ran the full 20032ms before the case failed.
+ *   - node's own `timeout` option signals the DIRECT child only. The CLI runs
+ *     Tailwind as a nested process, so that kill leaves the compiler alive and
+ *     reparented to init, still consuming the runner through later steps —
+ *     measured: the outer call returns `ETIMEDOUT` while the nested process
+ *     survives.
+ *
+ * `detached` makes the child a group leader, so `process.kill(-pid)` reaches
+ * the compiler beneath it, and awaiting rather than blocking leaves the loop
+ * free for the case budget below to act as a second bound.
  */
 const CHILD_TIMEOUT_MS = 60_000;
 const COMPILE_TIMEOUT_MS = CHILD_TIMEOUT_MS + 30_000;
 
+/** Run the CLI, killing the whole process tree if it outlives its budget. */
+function compile(args, cwd) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, args, {
+      cwd,
+      detached: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stderr = "";
+    child.stderr.on("data", chunk => (stderr += chunk));
+    const timer = setTimeout(() => {
+      // The negative pid addresses the GROUP. Wrapped because the group is gone
+      // already when the child exits between the timer firing and this call.
+      try {
+        process.kill(-child.pid, "SIGKILL");
+      } catch {
+        /* already gone */
+      }
+      reject(new Error(`compile exceeded ${String(CHILD_TIMEOUT_MS)}ms`));
+    }, CHILD_TIMEOUT_MS);
+    child.on("error", error => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.on("exit", code => {
+      clearTimeout(timer);
+      if (code === 0) resolve();
+      else reject(new Error(`exited ${String(code)}: ${stderr}`));
+    });
+  });
+}
+
 describe("nextly-build-admin-css (POC)", () => {
   it(
     "compiles a plugin entry to scoped, token-driven CSS",
-    () => {
+    async () => {
       const out = path.join(
         fs.mkdtempSync(path.join(os.tmpdir(), "nx-poc-")),
         "admin.css"
       );
-      execSync(
-        `node "${ROOT}/bin/nextly-build-admin-css.mjs" "${ROOT}/__fixtures__/poc-plugin/admin.css" "${out}"`,
-        { cwd: ROOT, timeout: CHILD_TIMEOUT_MS }
+      await compile(
+        [
+          `${ROOT}/bin/nextly-build-admin-css.mjs`,
+          `${ROOT}/__fixtures__/poc-plugin/admin.css`,
+          out,
+        ],
+        ROOT
       );
       const css = fs.readFileSync(out, "utf-8");
 


### PR DESCRIPTION
Follow-up to #1499, which merged before these two review findings were worked.

## Codex (P2): the timeout could not stop a hang

`execSync` blocks the worker's event loop for as long as the child runs, and a timer that cannot be serviced cannot fire. So the 60s case budget #1499 added was **inert against a child that hangs** rather than merely running slowly — the suite would sit until the workflow's own limit killed it. The comment I wrote claiming otherwise was wrong.

Verified in both directions rather than taken on the report:

| child bound | child behaviour | case budget | outcome |
| --- | --- | --- | --- |
| none | sleeps 20s | 5s | ran the **full 20032ms** — budget inert |
| 2s | sleeps forever | 32s | **failed at 2012ms**, `spawnSync /bin/sh ETIMEDOUT` |

The first row is the finding, reproduced. Node now enforces the limit on the child and kills it, which unblocks the loop and surfaces an ordinary failure. The case budget is deliberately **larger** than the child's, so a hung child is reported as the child failing rather than as vitest giving up on a test whose subprocess is still alive.

## CodeRabbit (Minor): historical measurements in the fixture comment

Partly taken. This repository's convention does favour measured evidence in comments — `turbo.jsonc` cites an exact task hash for the same reason — so "no measurements" is not the house rule.

But the durability point is right about the *specific figures*: byte counts and a named utility class move with whatever markup the repository gains, which is precisely the property the comment exists to warn about. A comment that rots in step with the hazard it documents is worse than a shorter one.

So the mechanism stays — the scan walks up, pulls in literal colours this fixture never wrote, and the gate refuses a build that is a statement about the monorepo rather than about this stylesheet — and the counts and the class name go.

## Verification

`admin-css` 51/51.
