### PR TITLE
fix(root): order a package's own build before its typecheck

### DIFF
--- a/scripts/turbo-inputs.test.mjs
+++ b/scripts/turbo-inputs.test.mjs
@@ -374,6 +374,43 @@ describe("a package's hash covers the program it actually compiles", () => {
       ).toContain("^check-types");
     }
   });
+
+  // Each edge gets its own case, because they answer different questions and a
+  // single assertion over the array would report the wrong one as missing.
+  it("reads each dependency's BUILD, not only its hash", () => {
+    // Five packages map a neighbour at its source; every other one resolves
+    // `@nextlyhq/*` through package exports, which point at `dist`. Without
+    // this edge such a package typechecks against whatever artifact survived,
+    // and a stale one answers about code that is gone — silently, in the
+    // passing direction.
+    const withCommand = resolvedTasks().filter(
+      task => !String(task.command).includes("NONEXISTENT")
+    );
+    expect(withCommand.length).toBeGreaterThan(15);
+    for (const task of withCommand) {
+      expect(
+        task.resolvedTaskDefinition.dependsOn,
+        `${task.package} typechecks without building its dependencies, so a stale dist answers for them`
+      ).toContain("^build");
+    }
+  });
+
+  it("orders its OWN build before it, so one build-info file has one writer", () => {
+    // `${configDir}/.tsbuildinfo` is one file per package and both tasks write
+    // it. The `^build` edge above puts both in a single run, so without this
+    // they are unordered siblings free to write and restore it at once.
+    // Asserted as the un-prefixed `build`: `^build` is a different edge and
+    // satisfies neither this nor the case above.
+    const withCommand = resolvedTasks().filter(
+      task => !String(task.command).includes("NONEXISTENT")
+    );
+    for (const task of withCommand) {
+      expect(
+        task.resolvedTaskDefinition.dependsOn,
+        `${task.package} may typecheck while its own build writes the same .tsbuildinfo`
+      ).toContain("build");
+    }
+  });
 });
 
 describe("the shared TypeScript config is hashed", () => {

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -181,17 +181,25 @@
 
     // check-types - Run TypeScript compiler for type validation
     //
-    // Fast Parallel Execution:
-    //   - NO "^build" dependency (optimized in TASK-MONO-007)
-    //   - Can run in parallel with builds for faster CI/CD
-    //   - Validates source code directly (doesn't need built artifacts)
+    // What it depends on, and why each edge is there:
+    //   - "^check-types" = a dependency's HASH, so editing a file that this
+    //     package's program reaches through a tsconfig path mapping moves this
+    //     task's hash
+    //   - "^build" = a dependency's ARTIFACT, because only five packages map a
+    //     neighbour at its source and the rest resolve through package exports,
+    //     which point at `dist`
+    //   - "build" = this package's OWN artifact, for ordering rather than
+    //     coverage: both tasks write one `.tsbuildinfo` per package
     //
-    // Why This Matters:
-    //   - Catches type errors early in development
-    //   - Runs faster than full build (type-check only, no emit)
-    //   - Can lint and type-check while builds run in parallel
+    // This section previously said the opposite — no `^build`, runs in parallel
+    // with builds, validates source without artifacts. That was true of the
+    // packages that motivated it and of almost none of the others, and a
+    // typecheck reading a stale `dist` answers about code that is gone. It is
+    // recorded rather than deleted because the claim is an attractive one to
+    // re-derive from the task name.
     //
-    // Note: Uses incremental compilation (.tsbuildinfo) for speed
+    // Note: Uses incremental compilation (.tsbuildinfo) for speed. That file is
+    // shared with `build`, which is what the third edge orders.
     "check-types": {
       // A package's TypeScript PROGRAM crosses workspace boundaries, so its
       // hash has to as well. `packages/admin` maps the bare `nextly` specifier
@@ -237,7 +245,25 @@
       // ships, while its `check-types` also covers the test files its shipping
       // tsconfig excludes, so a type error confined to a dependency's tests is
       // invisible to `^build` alone.
-      "dependsOn": ["^check-types", "^build"],
+      //
+      // `build` WITHOUT the caret is this package's own, and it is here for a
+      // different reason than the two beside it: ordering, not coverage.
+      // `${configDir}/.tsbuildinfo` is one file per package, `incremental` is on
+      // in the shared config, and BOTH tasks write it — `tsup`'s declaration
+      // pass and this `tsc --noEmit` alike, which is why both declare it under
+      // `outputs`. Before `^build` existed the two never shared a run, so
+      // nothing ordered them and nothing had to. Pulling every dependency's
+      // build into this graph put 19 packages' `build` and `check-types` in one
+      // run as unordered siblings, free to write and restore that file at the
+      // same moment — and the note in `packages/tsconfig/base.json` records what
+      // a shared build-info file does when two writers reach it.
+      //
+      // Ordering is what removes that, rather than a second output path: the
+      // file is named by the shared tsconfig, so splitting it means every
+      // package's script carrying its own `--tsBuildInfoFile`, which is a
+      // second place for the two halves to disagree. The build this waits on is
+      // one turbo has almost always already done.
+      "dependsOn": ["^check-types", "^build", "build"],
       // Every extension TypeScript follows, not only `.ts`/`.tsx`. A task input
       // glob decides what turbo HASHES: a change confined to an extension
       // missing here leaves the hash unmoved, so CI replays a cached green


### PR DESCRIPTION
Follow-up to #1503, which merged carrying three Codex findings. All three are addressed here; the first is a defect that change introduced.

## The race (P2)

`^build` put every dependency's build into the `check-types` graph — and a package's own `build` and `check-types` landed there as **unordered siblings**. Measured on the merged tree:

| | |
| --- | --- |
| packages with both tasks in the graph | **19** |
| ordered | **0** |
| unordered — free to run concurrently | **19** |

Both write `${configDir}/.tsbuildinfo`. The shared config gives that one path per package and keeps `incremental` on, and `tsc --noEmit` genuinely rewrites it — verified by deleting the file, running `check-types`, and watching it reappear. `tsup`'s declaration pass writes it too, which is why **both tasks declare it under `outputs`**.

Before `^build` existed the two never shared a run, so nothing ordered them and nothing had to. `packages/tsconfig/base.json` already records what a shared build-info file does when two writers reach it.

**Ordering rather than a second output path:** the filename comes from the shared tsconfig, so splitting it means every package's script carrying its own `--tsBuildInfoFile` — a second place for the two halves to disagree, which is the defect this repo keeps finding. After the edge: **27 packages, 27 ordered, 0 unordered.**

Warm cost 392ms for 42 tasks, against 348ms for 36 before.

## The stale summary (P3)

The section header above the task said the opposite of what the task does — no `^build`, runs in parallel with builds, validates source without artifacts. I rewrote the note in `ci.yml` when the edge landed and missed this one, which is the same half-edit the change was about.

Rewritten, with the old claim recorded rather than deleted: it is an attractive thing to re-derive from the task's name.

## Nothing asserted either edge (P2)

Correct, and it applied to both. Removing `^build` failed no test; so did removing the edge added here. Each now has a case, break-verified one at a time:

| removed | test that fails |
| --- | --- |
| `^build` | *reads each dependency's BUILD, not only its hash* |
| `build` | *orders its OWN build, so one build-info file has one writer* |

Only the named test fails in each case.

## Verification

`test:scripts` 695/695, `check-types` 42/42, lint 22/22.

Note on the push: the pre-push hook failed twice on `nextly#test` with a **varying** set of files (6, then 7, six shared). The same suite in isolation gives 873/873 and 11,093 tests on this branch, on `main`, and on #1503's branch, and both pushes succeeded on a plain retry with no code change. Filed as `finding:pre-push-suite-flakes-under-its-own-load` rather than folded in here.

No changeset: root tooling, nothing shipped changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated type-checking task order so dependency packages are built before type checks run.
  * Prevented concurrent writes to shared build metadata during builds and type checks.
  * Added validation to ensure package hashing and task dependencies reflect the actual compilation order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->