### PR TITLE
test(admin-css): exercise the timeout's process-group kill, and bound its stderr

### DIFF
--- a/packages/admin-css/__fixtures__/hang/nested-child.mjs
+++ b/packages/admin-css/__fixtures__/hang/nested-child.mjs
@@ -1,0 +1,14 @@
+/**
+ * The nested process a group kill must reach.
+ *
+ * Stands in for the Tailwind CLI, which `nextly-build-admin-css` runs as its own
+ * child — so killing only the wrapper leaves this alive and reparented to init.
+ * It reports both ends of its life through the filesystem rather than through a
+ * pid, because a pid lookup needs a process table this suite cannot assume.
+ */
+import { writeFileSync } from "node:fs";
+
+const [startedPath, finishedPath, sleepMs] = process.argv.slice(2);
+
+writeFileSync(startedPath, "started");
+setTimeout(() => writeFileSync(finishedPath, "finished"), Number(sleepMs));

--- a/packages/admin-css/__fixtures__/hang/wrapper.mjs
+++ b/packages/admin-css/__fixtures__/hang/wrapper.mjs
@@ -1,0 +1,18 @@
+/**
+ * A wrapper that runs its child SYNCHRONOUSLY, mirroring the CLI's own shape.
+ *
+ * The synchronous call is the point: it is what makes the wrapper unable to
+ * pass a signal on, so a kill aimed at this process alone leaves the child
+ * below it running.
+ */
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+execFileSync(
+  process.execPath,
+  [path.join(here, "nested-child.mjs"), ...process.argv.slice(2)],
+  { stdio: "inherit" }
+);

--- a/packages/admin-css/bin.integration.test.mjs
+++ b/packages/admin-css/bin.integration.test.mjs
@@ -50,18 +50,26 @@ const ROOT = path.dirname(fileURLToPath(import.meta.url));
  * free for the case budget below to act as a second bound.
  */
 const CHILD_TIMEOUT_MS = 60_000;
+/** Enough of a failing compile's output to diagnose it, bounded so a noisy hang cannot grow it without limit. */
+const STDERR_TAIL_BYTES = 16_384;
 const COMPILE_TIMEOUT_MS = CHILD_TIMEOUT_MS + 30_000;
 
 /** Run the CLI, killing the whole process tree if it outlives its budget. */
-function compile(args, cwd) {
+function compile(args, cwd, timeoutMs = CHILD_TIMEOUT_MS) {
   return new Promise((resolve, reject) => {
     const child = spawn(process.execPath, args, {
       cwd,
       detached: true,
       stdio: ["ignore", "pipe", "pipe"],
     });
+    // Drained continuously so the pipe never fills and stalls the child, but
+    // only the TAIL is retained: a compiler failing noisily can emit for as long
+    // as the bound allows, and keeping every byte to build one error message
+    // lets the worker exhaust its heap before the bound it was waiting for.
     let stderr = "";
-    child.stderr.on("data", chunk => (stderr += chunk));
+    child.stderr.on("data", chunk => {
+      stderr = (stderr + chunk).slice(-STDERR_TAIL_BYTES);
+    });
     const timer = setTimeout(() => {
       // The negative pid addresses the GROUP. Wrapped because the group is gone
       // already when the child exits between the timer firing and this call.
@@ -70,8 +78,8 @@ function compile(args, cwd) {
       } catch {
         /* already gone */
       }
-      reject(new Error(`compile exceeded ${String(CHILD_TIMEOUT_MS)}ms`));
-    }, CHILD_TIMEOUT_MS);
+      reject(new Error(`compile exceeded ${String(timeoutMs)}ms`));
+    }, timeoutMs);
     child.on("error", error => {
       clearTimeout(timer);
       reject(error);
@@ -112,4 +120,58 @@ describe("nextly-build-admin-css (POC)", () => {
     },
     COMPILE_TIMEOUT_MS
   );
+});
+
+/*
+ * The timeout branch, which the compile case above never reaches.
+ *
+ * Without this the helper's kill could regress to signalling the wrapper alone
+ * and every other case here would still pass — the failure it exists to prevent
+ * is invisible to a suite whose only invocation succeeds.
+ *
+ * Asserted through the FILESYSTEM rather than a process table: the nested child
+ * writes one file when it starts and another when it finishes, so "was it
+ * killed" becomes "did the second file never appear". That needs no `pgrep`,
+ * no pid arithmetic, and behaves the same wherever the suite runs.
+ */
+describe("the compile timeout", () => {
+  const HANG = path.join(ROOT, "__fixtures__", "hang");
+  // The child outlives its bound by enough that a surviving process would
+  // certainly have finished before the assertion, and no longer.
+  const CHILD_SLEEP_MS = 3_000;
+  const BOUND_MS = 500;
+
+  it("kills the NESTED process, not only the wrapper it signalled", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nx-hang-"));
+    const started = path.join(dir, "started");
+    const finished = path.join(dir, "finished");
+
+    await expect(
+      compile(
+        [
+          path.join(HANG, "wrapper.mjs"),
+          started,
+          finished,
+          String(CHILD_SLEEP_MS),
+        ],
+        ROOT,
+        BOUND_MS
+      )
+    ).rejects.toThrow(/exceeded/);
+
+    // Must-be-found: the nested child really ran, so its absence below is a
+    // kill rather than a fixture that never started.
+    expect(
+      fs.existsSync(started),
+      "the nested child never started, so this case proves nothing about killing it"
+    ).toBe(true);
+
+    // Past the point it would have finished had it survived.
+    await new Promise(resolve => setTimeout(resolve, CHILD_SLEEP_MS));
+
+    expect(
+      fs.existsSync(finished),
+      "the nested child outlived the kill aimed at its parent's process group"
+    ).toBe(false);
+  }, 30_000);
 });


### PR DESCRIPTION
Follow-up to #1504, which merged carrying two Codex findings. Both are correct.

## The kill was never exercised (P2)

The suite's only invocation completes normally, so the timeout branch never ran. `process.kill(-child.pid)` could regress to signalling the wrapper alone — the exact failure that helper exists to prevent — and all 51 cases would still pass. I had verified the behaviour with a throwaway probe and deleted it, which left nothing enforcing it.

A fixture now reproduces the shape that makes the kill necessary: a wrapper running a nested child **synchronously**, which is what leaves that child alive when a signal reaches only its parent.

**Asserted through the filesystem, not a process table.** The nested child writes one file when it starts and another when it finishes, so "was it killed" becomes "did the second file never appear". No `pgrep`, no pid arithmetic, same behaviour wherever the suite runs. The *started* file is asserted too, so its absence is a kill rather than a fixture that never ran.

Break-verified — with the kill changed to `child.pid`:

```
× kills the NESTED process, not only the wrapper it signalled
AssertionError: the nested child outlived the kill aimed at its
parent's process group: expected true to be false
```

## Unbounded stderr (P2)

Also right. `stderr += chunk` retained every byte until the bound fired, so a compiler failing noisily could exhaust the worker's heap **before** the timeout it was waiting for — turning a bounded failure into an unbounded one.

Now capped to a trailing window. Still drained continuously, so the pipe cannot fill and stall the child; only what is retained for the eventual message is bounded.

## Verification

52/52, lint clean. Both new fixtures are covered by the task hash (`__fixtures__/hang/nested-child.mjs`, `__fixtures__/hang/wrapper.mjs`), so editing them re-runs the suite rather than restoring a cached pass — which is what #1499's own review round was about.

No changeset: test-only.
