### PR TITLE
fix(playground): feed the authored route's dynamic blocks

### DIFF
--- a/apps/playground/scripts/__tests__/site-data-provider.test.ts
+++ b/apps/playground/scripts/__tests__/site-data-provider.test.ts
@@ -8,15 +8,29 @@
  */
 import { describe, expect, it } from "vitest";
 
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { createSiteDataProvider } from "../../src/lib/site-content";
 
-/** The route whose dynamic blocks depend on a provider being wired in. */
-const BLOCKS_ROUTE = fileURLToPath(
-  new URL("../../src/app/blocks/[[...slug]]/page.tsx", import.meta.url)
-);
+/** The app directory every page route is found under. */
+const APP_DIR = fileURLToPath(new URL("../../src/app", import.meta.url));
+
+/** Every `page.tsx` beneath the app directory, path and source together. */
+function pageRoutes(): { path: string; source: string }[] {
+  const found: { path: string; source: string }[] = [];
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name === "page.tsx")
+        found.push({ path: full, source: readFileSync(full, "utf-8") });
+    }
+  };
+  walk(APP_DIR);
+  return found;
+}
 
 /** A reader that records what it was asked and answers with one row. */
 function stubReader() {
@@ -35,31 +49,54 @@ function stubReader() {
   };
 }
 
-describe("the blocks route", () => {
-  it("hands its dynamic blocks a provider", () => {
-    /*
-     * Everything else in this file tests the provider in isolation, so all of it
-     * stays green when the route stops passing one — and a route with no `data`
-     * gets `emptyDataProvider`, which answers every `core/collection-loop` with
-     * nothing. The page then renders a section that lists posts and shows an
-     * empty box.
-     *
-     * Read from the route's SOURCE, which is the honest limit of a unit test
-     * here: a Next page module exports what the framework expects and nothing
-     * this file could import to inspect. The repository already checks a
-     * configuration file this way, in `ci-steps-report-independently.test.mjs`.
-     */
-    const source = readFileSync(BLOCKS_ROUTE, "utf-8");
+describe("every route that renders stored blocks", () => {
+  /*
+   * DERIVED from the app directory rather than named, so a route added later
+   * inherits this without anyone remembering to extend the list. The previous
+   * version checked one path by hand and stayed green while the authored route
+   * — the one real authors publish to — shipped without a provider.
+   *
+   * Read from SOURCE, which is the honest limit here: a Next page module
+   * exports what the framework expects and nothing this file could import to
+   * inspect. The repository already checks a configuration file this way, in
+   * `ci-steps-report-independently.test.mjs`.
+   */
+  const routes = pageRoutes().filter(route =>
+    route.source.includes("createBlocksPage(")
+  );
 
-    // Must-be-found: the file was read and is the route, so an absent `data`
-    // below means it is missing rather than that the path is wrong.
-    expect(source).toContain("createBlocksPage(");
-    expect(
-      source,
-      "the blocks route passes no `data` provider, so every core/collection-loop " +
-        "on a stored page renders an empty container"
-    ).toMatch(/\bdata:\s*siteDataProvider\b/);
+  it("finds the routes it is meant to judge", () => {
+    // Must-be-found, and by IDENTITY rather than count: a walk that reached the
+    // wrong directory, or a filter that matched nothing, would leave the case
+    // below asserting over an empty list and passing for that reason alone.
+    const paths = routes.map(route => route.path);
+    expect(paths.length).toBeGreaterThan(0);
+    expect(paths.some(p => p.includes("blocks"))).toBe(true);
+    expect(paths.some(p => p.includes("(frontend)"))).toBe(true);
   });
+
+  it.each(routes.map(route => [route.path, route] as const))(
+    "%s hands its dynamic blocks a provider",
+    (_path, route) => {
+      /*
+       * Everything else in this file tests the provider in isolation, so all of
+       * it stays green when a route stops passing one — and a route with no
+       * `data` gets `emptyDataProvider`, which answers every
+       * `core/collection-loop` with nothing. The page then renders a section
+       * that lists posts and shows an empty box.
+       *
+       * `\bdata:` rather than `data:`, because the latter is a substring of
+       * `metadata:`, which every one of these routes declares — an assertion
+       * satisfied by the wrong option would pass on exactly the defect this
+       * exists to catch.
+       */
+      expect(
+        route.source,
+        "this route passes no `data` provider, so every core/collection-loop " +
+          "on a stored page renders an empty container"
+      ).toMatch(/\bdata:\s*siteDataProvider\b/);
+    }
+  );
 });
 
 describe("the site's data provider", () => {

--- a/apps/playground/src/app/(frontend)/[...slug]/page.tsx
+++ b/apps/playground/src/app/(frontend)/[...slug]/page.tsx
@@ -42,6 +42,7 @@ import { createBlocksPage } from "@nextlyhq/blocks-react/next";
 import { previewDraftGate } from "nextly/runtime";
 
 import {
+  siteDataProvider,
   siteReader,
   SITE_STYLE_CONTEXT,
   SITE_STYLES,
@@ -94,6 +95,16 @@ const { ContentPage, generateMetadata } = createBlocksPage({
   // — so a public route depending on it renders the unknown-block placeholder
   // whenever this request arrived before the admin did.
   blocks: createBlockResolver(coreBlocks),
+  // What a `core/collection-loop` reads. Without it `createStandaloneContext`
+  // installs `emptyDataProvider`, which answers every query with nothing — so a
+  // block an author inserted from the palette renders as an empty container on
+  // a page that is otherwise entirely correct, and nothing reports it.
+  //
+  // The SAME provider the `/blocks` route uses, rather than a second one built
+  // here: it reads as the visitor with `overrideAccess: false` and
+  // `status: "published"`, and a route that assembled its own would be one
+  // rewrite away from a trusted read serving drafts to anyone with a URL.
+  data: siteDataProvider,
   styleContext: SITE_STYLE_CONTEXT,
   // The one provider, shared with the two single-page routes so all three
   // resolve their tokens the same way. See `SITE_STYLES`.


### PR DESCRIPTION
An author who inserts a `core/collection-loop` from the palette gets an **empty container** on the live site.

The route passed no `data`, so `createStandaloneContext` installed `emptyDataProvider`, which answers every query with nothing. `finding:blocks-routes-feed-no-dynamic-block-data` — the `/blocks` half was fixed in #1478; this is the route real authors publish to.

## Measured on the running route

One line as the only variable, toggled both ways:

| provider | loop template renders | page |
| --- | --- | --- |
| absent | **0 times** | HTTP 200, heading and loop container both present |
| present | **3 times** (declared limit 3) | HTTP 200 |
| removed again | **0 times** | HTTP 200 |

The page answers 200 and renders correctly in every case. That is why nothing reports this: it is an empty box on a page that is otherwise entirely right.

## The security half, verified rather than inferred

This reuses the **same** provider the `/blocks` route uses rather than building a second one — it reads as the visitor with `overrideAccess: false` and `status: "published"`. A route assembling its own would be one rewrite away from a trusted read serving drafts to anyone with a URL.

`Nextly.find` defaults to a **trusted** read: no access rules, no lifecycle filter. So the flags were checked against the rendered page, not read off the source. With **4 published and 1 draft** post and a loop at `limit: 10`:

**4 entries render.** The draft does not reach the page.

A limit of 3 would have masked this — a trusted read returns 3 as well. The limit had to exceed the published count for the measurement to discriminate at all.

## The guard now derives its routes

It named one path by hand, which is why it stayed green while this route shipped without a provider. It now walks the app directory for `createBlocksPage` and asserts every route it finds.

**The discovered set is asserted by identity first.** A walk that reached the wrong directory would otherwise leave the per-route cases iterating an empty list and passing for that reason — pointed at a real directory holding no routes, that control fails and the per-route cases silently drop from two to none.

`\bdata:` rather than `data:`, because the latter is a substring of `metadata:`, which every one of these routes declares. My own shell check made exactly that mistake and reported the broken route as fixed.

## Verification

Playground 81/81 (was 79; the derived guard adds the control plus one case per route), lint and check-types clean. Break-verified: removing the provider fails that route's case by name and nothing else.

No changeset: `apps/playground` is `private: true` and ships nothing.
