### PR TITLE
fix(blocks-react): let three gutters follow the site's spacing token

### DIFF
--- a/.changeset/block-gutters-follow-the-site-token.md
+++ b/.changeset/block-gutters-follow-the-site-token.md
@@ -1,0 +1,42 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The gutters in `core/columns`, `core/gallery` and `core/accordion` follow the
+site's spacing token again instead of a hard-coded length.
+
+All three shipped with `{ $token: "space.4" }`, rendered their children
+touching, and were changed to a literal `1rem` for it. The cause was not the
+token: the renderer withheld the token tier from a consumer handing back a
+stored stylesheet, so the reference arrived as a `var()` with nothing behind it
+— invalid at computed-value time, and `gap` falls back to `normal`, which is
+zero for a grid.
+
+That path now carries the declaration, so the reference resolves and a site that
+redefines `space.4` moves all three. The rendered value is unchanged for a site
+that does not: measured in a browser on the path that used to fail, the computed
+`column-gap` is `16px` and the space between two columns is 16 pixels.

--- a/packages/blocks-react/src/blocks/accordion.test.tsx
+++ b/packages/blocks-react/src/blocks/accordion.test.tsx
@@ -115,19 +115,21 @@ describe("the accordion pair", () => {
   });
 
   it("separates sections with spacing, never a hardcoded divider colour", () => {
-    // The divider reasoning below is unchanged and was right. What changed is
-    // the SPACING: this required `space.4`, and a token resolves to nothing.
+    // The divider reasoning below is unchanged and was right. The SPACING moved
+    // twice: it required `space.4`, became a length when a token resolved to
+    // nothing on the stored-artifact path — `var(--site-space-4)` with the
+    // property undeclared is invalid at computed-value time, so `gap` fell back
+    // to `normal`, zero for a grid, and the sections touched — and is a token
+    // again now that the declaration reaches that path.
     //
-    // `defaultSiteTokens()` guarantees nothing today — `compileSiteSheet` has
-    // zero consumers outside `blocks-engine` and `--site-` appears in no source
-    // file outside it, so `gap: { $token: "space.4" }` compiled to
-    // `var(--site-space-4)`, nothing defined it, and the gap fell back to
-    // `normal`: zero for a grid. The sections touched, which is precisely the
-    // separation this test exists to guarantee.
+    // That the reference RESOLVES is proved against a rendered page in
+    // `columns.test.tsx`. This asserts what this block declares.
     const declared = JSON.stringify(ACCORDION_BASE_STYLES);
 
-    expect(declared).toContain("1rem");
-    expect(declared).not.toContain("$token");
+    expect(declared).toContain('"$token":"space.4"');
+    // Must-differ: a raw length would pass the check above if the object
+    // carried both, and would stop following the site's own spacing.
+    expect(declared).not.toContain("1rem");
     // The older block drew its dividers with `var(--nx-color-border)` — the
     // ADMIN namespace, which this renderer never emits, so that rule resolves
     // to nothing on a published page while looking right in an admin preview.

--- a/packages/blocks-react/src/blocks/accordion.tsx
+++ b/packages/blocks-react/src/blocks/accordion.tsx
@@ -36,20 +36,17 @@
  * makes it design pressure rather than three mistakes: when the correct
  * mechanism is unreachable, the thing that LOOKS like it works gets reached for.
  *
- * This docblock used to continue "…this renderer emits `--site-*`", and to say
- * `defaultSiteTokens()` "guarantees" a named set. **Both were false and the
- * second is the load-bearing one: this renderer emits NOTHING.**
- * `compileSiteSheet` — the only thing that turns a token set into CSS — has zero
- * consumers outside `blocks-engine`, and `--site-` appears in no source file
- * outside the engine (positive control: `--nx-` appears in over a hundred). So
- * the default token set is a default nobody applies, and a `{ $token }` here
- * would dangle for the same reason `--nx-*` does — not a different namespace,
- * the same emptiness.
+ * The gap is `space.4`, and the route it took is worth keeping. This block
+ * shipped with `{ $token: "space.4" }` and its sections rendered touching,
+ * because nothing turned the token set into CSS: an unresolved `var()` makes
+ * the declaration invalid at computed-value time and `gap` falls back to
+ * `normal` — zero for a grid. It became a plain length for that reason, and is
+ * a token again now that `PageRenderer` emits the token tier on every path a
+ * reference reaches, including a stored artifact handed back with no context.
  *
- * That is not hypothetical here: this block shipped with `{ $token: "space.4" }`
- * and its sections rendered touching, because an unresolved `var()` makes the
- * declaration invalid at computed-value time and `gap` falls back to `normal` —
- * zero for a grid.
+ * The `--nx-` half of that history stands: that namespace belongs to the admin
+ * and this renderer never emits it, so a rule using it resolves to nothing on a
+ * published page while looking right in an editor preview.
  *
  * Separation between sections is therefore a LENGTH, which needs no stylesheet
  * to resolve, and the divider is left to the author until the site stylesheet
@@ -86,11 +83,13 @@ export const ACCORDION_BASE_STYLES = {
   base: {
     base: {
       display: "grid",
-      // A LENGTH, not a token: nothing emits token CSS yet, so a `{ $token }`
-      // reference compiles to a `var()` with nothing behind it and the gap
-      // silently falls back to `normal`, which for a grid is zero. `1rem` is
-      // what `space.4` itself declares, so the value survives the change back.
-      gap: "1rem",
+      // The site's spacing token. This was a length while nothing declared
+      // `--site-*` on every path a reference reaches: the value compiled to a
+      // `var()` with nothing behind it and `gap` fell back to `normal`, zero for
+      // a grid. Measured on the path that used to fail — a stored artifact
+      // handed back with no context — the property is now declared and resolves
+      // to `1rem`, the value the literal stood in for.
+      gap: { $token: "space.4" },
     },
   },
 } as const;

--- a/packages/blocks-react/src/blocks/columns.test.tsx
+++ b/packages/blocks-react/src/blocks/columns.test.tsx
@@ -144,30 +144,29 @@ describe("the columns pair", () => {
        */
       const css = compiledCss();
 
-      expect(css).toContain("gap: 1rem");
+      // The REFERENCE reaching the compiled sheet. That it resolves to a real
+      // length is the next case, which reads a rendered page — a compiled `var()`
+      // proves the property survived the catalog, not that anything defines it.
+      expect(css).toContain("gap: var(--site-space-4)");
       // Must-differ: the row is still a grid, so this is about the gutter and
       // not about the layout having been replaced by something simpler.
       expect(css).toContain("display: grid");
     });
 
-    it("keeps the gutter on a STORED stylesheet handed back with no context", () => {
+    it("RESOLVES the gutter on a STORED stylesheet handed back with no context", () => {
       /*
-       * The gutter as a VALUE on the rendered page, on the path a consumer with
-       * no write path takes: compile once, store the artifact, hand it back as
-       * `styles`.
+       * The path a consumer with no write path takes: compile once, store the
+       * artifact, hand it back as `styles`. It is the path a token gutter did
+       * not survive — nothing declared `--site-*` there, so the reference was a
+       * `var()` with nothing behind it, invalid at computed-value time, and
+       * `gap` fell back to `normal`: zero for a grid, and the exact defect this
+       * block was fixed for.
        *
-       * This case was written when that path defined no `--site-*` at all, so a
-       * `{ $token }` gutter arrived as a `var()` with nothing behind it — invalid
-       * at computed-value time, `gap` falling back to `normal`, which is zero for
-       * a grid and the exact defect this block was fixed for. The renderer now
-       * emits the token tier alongside the page CSS, so that reason no longer
-       * holds and the gutter is a length only because nothing has migrated it.
-       *
-       * Which changes what the assertion below DOES. It was a guard against a
-       * silent regression; it is now a pin, and it will fail on a migration that
-       * would render correctly. Read a failure here as the migration having
-       * happened and this case needing to assert the resolved gutter instead —
-       * not as the gutter having been lost.
+       * Both halves are asserted on ONE rendered page, because either alone is
+       * satisfied by the broken state. The reference without the declaration is
+       * precisely the defect; the declaration without the reference says only
+       * that a sheet was emitted, which is true of a page whose gutter went
+       * missing entirely.
        */
       const resolver = createBlockResolver([...coreBlocks]);
       const stored = resolvePageStyles(
@@ -185,10 +184,15 @@ describe("the columns pair", () => {
         <PageRenderer document={DOC} blocks={resolver} styles={stored} />
       );
 
-      expect(markup).toContain("gap: 1rem");
-      // Must-differ: no unresolved custom property is carrying the gutter, which
-      // is the failure this case exists to refuse rather than merely to describe.
-      expect(markup).not.toMatch(/gap:\s*var\(/);
+      // The reference the page CSS carries.
+      expect(markup).toContain("gap: var(--site-space-4)");
+      // And the declaration it resolves against, on the same page. Without this
+      // the assertion above passes on exactly the broken state.
+      expect(markup).toContain("--site-space-4:");
+      // The VALUE, so the migration is behaviour-preserving rather than merely
+      // resolvable: matched up to `;` or `}`, since the token block runs
+      // straight into the theme block after it.
+      expect(markup).toMatch(/--site-space-4:\s*1rem\s*[;}]/);
     });
 
     it("emits the column's min-width so a long child cannot force overflow", () => {

--- a/packages/blocks-react/src/blocks/columns.tsx
+++ b/packages/blocks-react/src/blocks/columns.tsx
@@ -95,19 +95,19 @@ export const COLUMNS_BASE_STYLES = {
        * nothing turned a token set into CSS; that is fixed, and `PageRenderer`
        * now compiles a site sheet by default.
        *
-       * It is still not safe HERE. A consumer holding a stored `styles`
-       * artifact and passing it back with no `styleContext` gets no site sheet
-       * at all — `PageRenderer` withholds one when no breakpoints are stated —
-       * while the stored page CSS still carries the reference. Measured on that
-       * path: `gap: var(--site-space-4)` present, `--site-space-4` undefined, so
-       * the declaration is invalid at computed-value time and the gutter is zero
-       * again. `core/card` is live in exactly that state today, which is what
-       * the token migration is waiting on rather than this block.
+       * It was not safe HERE until the renderer stopped withholding the token
+       * tier from a consumer holding a stored `styles` artifact. On that path
+       * the stored page CSS carried `gap: var(--site-space-4)` with the property
+       * undeclared, which is invalid at computed-value time, and `gap` fell back
+       * to `normal` — zero for a grid, and the exact defect this block was fixed
+       * for. Measured on that same path now: `--site-space-4` is declared and
+       * resolves to `1rem`, which is the value the literal was standing in for.
        *
-       * `1rem` is what `space.4` declares, so the value survives the change back
-       * once the definition reaches every path a reference does.
+       * So the gutter follows the site again. A site that redefines `space.4`
+       * moves this row with it, which is what a token set is for and what a
+       * length hard-coded here could never do.
        */
-      gap: "1rem",
+      gap: { $token: "space.4" },
     },
   },
 } as const;

--- a/packages/blocks-react/src/blocks/gallery.test.tsx
+++ b/packages/blocks-react/src/blocks/gallery.test.tsx
@@ -79,24 +79,25 @@ describe("core/gallery", () => {
   });
 
   it("spaces its tiles with a value that actually resolves", () => {
-    // This test used to require `space.4` and was named "uses only guaranteed
-    // tokens, so it resolves under every theme". The `--nx-` half was right and
-    // is kept; the token half asserted a premise that does not hold.
+    // This asserted a LENGTH for as long as nothing declared `--site-*` on
+    // every path a reference reaches: a `{ $token }` compiled to
+    // `var(--site-space-4)`, nothing defined it, the declaration was invalid at
+    // computed-value time, and `gap` fell back to `normal` — zero for a grid,
+    // and the tiles touched.
     //
-    // `defaultSiteTokens()` guarantees NOTHING today: `compileSiteSheet` — the
-    // only thing that turns a token set into CSS — has zero consumers outside
-    // `blocks-engine`, and `--site-` appears in no source file outside the
-    // engine (positive control: `--nx-` appears in four). So a `{ $token }`
-    // compiled to `var(--site-space-4)`, nothing defined it, the declaration
-    // was invalid at computed-value time, and `gap` fell back to `normal` —
-    // zero for a grid. The tiles touched.
+    // The declaration now arrives on that path, so the gutter is a token again
+    // and follows a site that redefines `space.4`. That the reference RESOLVES
+    // is proved against a rendered page in `columns.test.tsx`, on the stored
+    // artifact that used to fail; this asserts what this block declares.
     //
     // The ratchet that catches this class for every block lives in
-    // `base-styles.test.tsx`; this asserts the value this block settled on.
+    // `base-styles.test.tsx`.
     const declared = JSON.stringify(GALLERY_BASE_STYLES);
 
-    expect(declared).toContain("1rem");
-    expect(declared).not.toContain("$token");
+    expect(declared).toContain('"$token":"space.4"');
+    // Must-differ: a raw length here would pass the check above if the object
+    // carried both, and would stop following the site's own spacing.
+    expect(declared).not.toContain("1rem");
     // The ADMIN namespace, which this renderer never emits — so a rule using it
     // resolves to nothing on a published page while looking right in an admin
     // preview. Three separate blocks reached for it independently.

--- a/packages/blocks-react/src/blocks/gallery.tsx
+++ b/packages/blocks-react/src/blocks/gallery.tsx
@@ -40,15 +40,14 @@
  * `minmax(180px, 1fr)` makes a single track wider than its parent and the
  * pictures overflow. `min(180px, 100%)` lets the last one fit.
  *
- * **The gap is a plain length, and no aspect ratio.** `defaultSiteTokens()`
- * NAMES `space.4` but guarantees nothing: `compileSiteSheet` — the only thing
- * that turns a token set into CSS — has zero consumers outside `blocks-engine`,
- * and `--site-` appears in no source file outside the engine (positive control:
- * `--nx-` appears in 103). This block shipped with `{ $token: "space.4" }` and
- * its tiles rendered touching, because an unresolved `var()` makes the
- * declaration invalid at computed-value time and `gap` falls back to `normal`,
- * which is zero for a grid. `1rem` is what `space.4` itself declares, so the
- * value survives the change back once tokens are emitted. A default `aspect-ratio` was considered and refused: it
+ * **The gap is the site's spacing token, and there is no aspect ratio.** This
+ * block shipped with `{ $token: "space.4" }`, rendered its tiles touching, and
+ * spent a while as a plain length because of it: the renderer withheld the
+ * token tier from a consumer handing back a stored artifact, so the reference
+ * arrived as a `var()` with nothing behind it — invalid at computed-value time,
+ * and `gap` falls back to `normal`, zero for a grid. The declaration now reaches
+ * that path and resolves to `1rem`, which is the value the literal stood in for,
+ * so the gutter follows a site that redefines `space.4`. A default `aspect-ratio` was considered and refused: it
  * would crop every picture in the library to one shape, and the crop is
  * invisible in the editor's own preview because the same rule applies there.
  * Uniform tiles are a real want, so `aspectRatio` stays available on the image
@@ -85,11 +84,13 @@ export const GALLERY_BASE_STYLES = {
     base: {
       display: "grid",
       gridTemplateColumns: "repeat(auto-fit, minmax(min(180px, 100%), 1fr))",
-      // A LENGTH, not a token: nothing emits token CSS yet, so a `{ $token }`
-      // reference compiles to a `var()` with nothing behind it and the gap
-      // silently falls back to `normal`, which for a grid is zero. `1rem` is
-      // what `space.4` itself declares, so the value survives the change back.
-      gap: "1rem",
+      // The site's spacing token. This was a length while nothing declared
+      // `--site-*` on every path a reference reaches: the value compiled to a
+      // `var()` with nothing behind it and `gap` fell back to `normal`, zero for
+      // a grid. Measured on the path that used to fail — a stored artifact
+      // handed back with no context — the property is now declared and resolves
+      // to `1rem`, the value the literal stood in for.
+      gap: { $token: "space.4" },
     },
   },
 } as const;


### PR DESCRIPTION
`core/columns`, `core/gallery` and `core/accordion` all shipped with `{ $token: "space.4" }`, rendered their children **touching**, and were changed to a literal `1rem` for it.

The token was never the cause. `PageRenderer` withheld the token tier from a consumer handing back a stored stylesheet, so the reference arrived as a `var()` with nothing behind it — invalid at computed-value time, and `gap` falls back to `normal`, which is zero for a grid. #1495 fixed that; this collects the debt.

## Measured before changing any block

On the stored-artifact path that used to fail:

```
--site-space-4 is DECLARED:  true
--site-space-4 resolves to:  1rem
gutter currently emitted:    gap: 1rem
values match:                true
```

So the migration is **behaviour-preserving** for a site that does not redefine `space.4`, and finally works for one that does.

Confirmed in a browser on that same path — computed `column-gap` **16px**, and **16 pixels** measured between two columns.

## The tests now assert resolution, not a value

Three cases pinned the literal and legitimately fail on a correct migration; my own note in `columns.test.tsx` predicted this and said what to do. They now assert the token.

The stored-artifact case asserts the **reference and the declaration on one rendered page**, because either alone is satisfied by the broken state:

- reference without declaration **is** the defect;
- declaration without reference says only that a sheet was emitted, which is true of a page whose gutter went missing entirely.

Plus the declared value, so behaviour-preservation is asserted rather than assumed.

**Break-verified in both directions:**

| break | fails |
| --- | --- |
| a gutter reverted to a literal | that block's cases |
| token tier withheld again (pre-#1495) | **only** the resolution case |

The second is the one that matters — its diff shows `gap: var(--site-space-4)` present and `--site-space-4:` absent, which is the original bug exactly.

## Two docblocks corrected

Both stated `compileSiteSheet` has no consumers outside `blocks-engine` and that `--site-` appears in no source file outside it. `page-renderer.tsx` imports it, as do three modules in `packages/builder`. One added that "this renderer emits NOTHING", which the render path contradicts. They were false independently of this change and argued *for* the literals being replaced here.

## Verification

`blocks-react` 1097/1097 across 44 files, lint clean. Changeset included — this changes what three published blocks render by default.

One instrument note: my first reading of the token value used `[^;]+` and over-captured past the closing brace into the dark-theme block, reporting the value as `1rem}[data-nx-theme="dark"]{...` and the match as **false**. Stopping at `;` or `}` gives `1rem`. The measurements above are from the corrected form.
