### PR TITLE
test(playground): judge an ACTIVE provider option, not matching source text

### DIFF
--- a/apps/playground/scripts/__tests__/site-data-provider.test.ts
+++ b/apps/playground/scripts/__tests__/site-data-provider.test.ts
@@ -17,6 +17,25 @@ import { createSiteDataProvider } from "../../src/lib/site-content";
 /** The app directory every page route is found under. */
 const APP_DIR = fileURLToPath(new URL("../../src/app", import.meta.url));
 
+/**
+ * Source with its comments removed.
+ *
+ * The assertion below reads text, so without this it is satisfied by a property
+ * that is commented out — and by prose in a docblock that merely mentions the
+ * option. Both describe a route whose `createBlocksPage` receives no provider,
+ * which is exactly the state being guarded against.
+ *
+ * Stripping is deliberately blunt: a `//` inside a string literal would take
+ * the rest of that line with it. That direction is safe here — it can only
+ * remove the text the assertion looks for, failing the test — whereas leaving
+ * comments in place is what lets a broken route pass.
+ */
+function withoutComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/.*$/gm, "$1");
+}
+
 /** Every `page.tsx` beneath the app directory, path and source together. */
 function pageRoutes(): { path: string; source: string }[] {
   const found: { path: string; source: string }[] = [];
@@ -25,7 +44,10 @@ function pageRoutes(): { path: string; source: string }[] {
       const full = join(dir, entry.name);
       if (entry.isDirectory()) walk(full);
       else if (entry.name === "page.tsx")
-        found.push({ path: full, source: readFileSync(full, "utf-8") });
+        found.push({
+          path: full,
+          source: withoutComments(readFileSync(full, "utf-8")),
+        });
     }
   };
   walk(APP_DIR);


### PR DESCRIPTION
Recovers a commit stranded by #1508's merge. The Codex finding on that PR was fixed and pushed, but the merge had already been computed from the earlier head — so the fix is on the branch and **not on main**. Verified by content: `withoutComments` occurs **0 times** in `main`'s copy of the file.

The substantive half of #1508 did land — `data: siteDataProvider` is present on main — so the route is fixed and only the test hardening was lost.

## The finding

The guard reads source, so it was satisfied by a property **commented out while debugging**. Verified before changing anything, and it was broader than reported — the pattern matches inside all three of these:

| form | matches? |
| --- | --- |
| `data: siteDataProvider,` | yes — correct |
| `// data: siteDataProvider,` | **yes** — wrong |
| `/* data: siteDataProvider, */` | **yes** — wrong |
| docblock prose mentioning the option | **yes** — wrong |

Each of the last three describes a route whose `createBlocksPage` receives no provider, which is exactly the state being guarded.

## The fix

Comments are stripped before the assertion.

Bluntly, on purpose: a `//` inside a string literal would take the rest of that line with it. The two directions are not equally bad — over-stripping can only remove the text the assertion looks for and **fail** the test, while leaving comments in is what lets a broken route pass.

## Verification

Playground 81/81. Break-verified against the exact state named in review: commenting the provider out fails that route's case, where before it passed.

No changeset: test-only, and `apps/playground` is `private: true`.
