### PR TITLE
feat(admin): arrange the dashboard in columns the reader chooses

### DIFF
--- a/.changeset/a-dashboard-in-columns-the-reader-chooses.md
+++ b/.changeset/a-dashboard-in-columns-the-reader-chooses.md
@@ -1,0 +1,57 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+A dashboard is arranged in COLUMNS the reader chooses, rather than in one
+wrapped twelve-column grid.
+
+Cards took uneven fractions of twelve, so a card's width depended on its
+neighbours. dnd-kit's sorting strategies predict positions from measured
+rectangles and need a predictable layout; with mixed spans they mispredict and
+the cards visibly resize mid-drag -- the behaviour its own tracker records as
+variable sized sortables being stretched when dragged. Each column is now an
+independent vertical list of equal-width items, which is the case those
+strategies are built for and one that supports items of varying HEIGHT, the
+dimension a dashboard card genuinely varies in.
+
+A reader picks 2, 3 or 4 columns while editing. Placements gain a `column`
+beside their existing `order`, the stored layout gains a `columnCount`, and the
+schema moves to v2 -- migrating a v1 row on READ rather than refusing it, since
+the reader would otherwise meet their own saved dashboard as an internal error.
+
+Crossing columns is reachable by CLICK as well as by dragging. WCAG 2.2 SC
+2.5.7 requires a single-pointer route to anything a drag achieves and states
+that a keyboard equivalent does not satisfy it on its own, so the sideways
+controls are what make the new drag permissible rather than a convenience
+beside it.
+
+Two fixes fall out of the same work. A card that changed only its column
+compared as unchanged, so Save stayed disabled and a sideways move could not be
+persisted at all. And a card whose column falls outside the current count is
+folded into the last column for drawing while KEEPING its stored column, so
+narrowing the dashboard and widening it again returns every card to where the
+reader put it.

--- a/packages/admin/src/components/features/widgets/WidgetGrid.tsx
+++ b/packages/admin/src/components/features/widgets/WidgetGrid.tsx
@@ -142,10 +142,17 @@ export function WidgetGrid() {
   // wrapper's identity never changes, so nothing downstream re-renders on it,
   // and by the time a reader can move a card the announcer is long since
   // assigned.
-  const announcer = useRef<(t: string, p: number, c: number) => void>(() => {});
-  const announceMove = useCallback(
-    (title: string, position: number, count: number) =>
-      announcer.current(title, position, count),
+  const announcer = useRef<
+    (t: string, col: number, cols: number, p: number, c: number) => void
+  >(() => {});
+  const announceColumn = useCallback(
+    (
+      title: string,
+      column: number,
+      columnCount: number,
+      position: number,
+      count: number
+    ) => announcer.current(title, column, columnCount, position, count),
     []
   );
 
@@ -160,7 +167,7 @@ export function WidgetGrid() {
     hasArrangement,
     sensors,
     handleDragEnd,
-  } = useDashboardArrangement(declared, layout, announceMove);
+  } = useDashboardArrangement(declared, layout, announceColumn);
 
   const byId = useMemo(
     () => new Map(declared.map(widget => [widget.id, widget])),
@@ -172,12 +179,9 @@ export function WidgetGrid() {
   const { slots, isFetching, updatedAt, requested, counted, failed, settling } =
     useWidgetBatch(widgets);
 
-  const { announcement, announceMove: announceSettledMove } = useGridAnnouncer(
-    settling,
-    counted,
-    failed
-  );
-  announcer.current = announceSettledMove;
+  const { announcement, announceColumn: announceSettledColumn } =
+    useGridAnnouncer(settling, counted, failed);
+  announcer.current = announceSettledColumn;
 
   // Nothing DECLARED. Returned after the hooks above so the hook order is the
   // same on every render, whatever the branding says.

--- a/packages/admin/src/components/features/widgets/WidgetGrid.tsx
+++ b/packages/admin/src/components/features/widgets/WidgetGrid.tsx
@@ -156,6 +156,7 @@ export function WidgetGrid() {
     columnCount,
     editor,
     moveBy,
+    moveColumn,
     hasArrangement,
     sensors,
     handleDragEnd,
@@ -240,6 +241,7 @@ export function WidgetGrid() {
           isFetching={isFetching}
           announcement={announcement}
           onMove={moveBy}
+          onMoveColumn={moveColumn}
           onToggleHidden={editor.toggleHidden}
           onRemove={editor.remove}
         />

--- a/packages/admin/src/components/features/widgets/WidgetGrid.tsx
+++ b/packages/admin/src/components/features/widgets/WidgetGrid.tsx
@@ -155,7 +155,7 @@ export function WidgetGrid() {
     columns,
     columnCount,
     editor,
-    moveBy,
+    moveWithinColumn,
     moveColumn,
     hasArrangement,
     sensors,
@@ -242,7 +242,7 @@ export function WidgetGrid() {
           updatedAt={updatedAt}
           isFetching={isFetching}
           announcement={announcement}
-          onMove={moveBy}
+          onMove={moveWithinColumn}
           onMoveColumn={moveColumn}
           onToggleHidden={editor.toggleHidden}
           onRemove={editor.remove}

--- a/packages/admin/src/components/features/widgets/WidgetGrid.tsx
+++ b/packages/admin/src/components/features/widgets/WidgetGrid.tsx
@@ -216,6 +216,8 @@ export function WidgetGrid() {
         // reader had no way out and every read went on logging the same decode
         // failure. The version is what says a row is there.
         canReset={(layout.layout?.version ?? 0) > 0}
+        columnCount={columnCount}
+        onColumnCount={editor.setColumnCount}
       />
 
       <DndContext

--- a/packages/admin/src/components/features/widgets/WidgetGrid.tsx
+++ b/packages/admin/src/components/features/widgets/WidgetGrid.tsx
@@ -20,8 +20,7 @@
  * @module components/features/widgets/WidgetGrid
  */
 
-import { DndContext, closestCenter } from "@dnd-kit/core";
-import { SortableContext, rectSortingStrategy } from "@dnd-kit/sortable";
+import { DndContext, closestCorners } from "@dnd-kit/core";
 import { useCallback, useMemo, useRef } from "react";
 
 import {
@@ -33,7 +32,7 @@ import { useCurrentUserPermissions } from "@admin/hooks/useCurrentUserPermission
 
 import { registerCoreWidgetComponents } from "./core-components";
 import { AddWidgetPicker } from "./edit/AddWidgetPicker";
-import { ArrangedCell } from "./edit/ArrangedCell";
+import { ArrangedColumns } from "./edit/ArrangedColumns";
 import { DashboardEditChrome } from "./edit/DashboardEditChrome";
 import { useDashboardArrangement } from "./edit/useDashboardArrangement";
 import { resolveDashboardWidgets } from "./resolve-widgets";
@@ -117,25 +116,6 @@ function NothingToDraw({
  * body carries neither branch. Rendered inside the widgets section, so the
  * landmark and the live region stay where a reader left them.
  */
-function EmptyArrangement({
-  count,
-  isEditing,
-}: {
-  count: number;
-  isEditing: boolean;
-}) {
-  if (count > 0) return null;
-  return (
-    <p
-      data-testid="widget-grid-empty"
-      className="col-span-12 rounded-lg border border-dashed border-border px-4 py-10 text-center text-sm text-muted-foreground"
-    >
-      {isEditing
-        ? "Every card is put away. Add one back below, or reset to the default arrangement."
-        : "Your dashboard has no cards on it. Edit it to bring one back, or reset to the default arrangement."}
-    </p>
-  );
-}
 
 export function WidgetGrid() {
   const branding = useBranding();
@@ -172,10 +152,11 @@ export function WidgetGrid() {
   const layout = useDashboardLayout();
   const {
     visible,
+    columns,
+    columnCount,
     editor,
     moveBy,
     hasArrangement,
-    sortableItems,
     sensors,
     handleDragEnd,
   } = useDashboardArrangement(declared, layout, announceMove);
@@ -241,55 +222,27 @@ export function WidgetGrid() {
         // `closestCenter` rather than pointer-within: the cells are different
         // widths, so a small card dragged over a full-width one never contains
         // the pointer and the drop target reads as nothing.
-        collisionDetection={closestCenter}
+        // `closestCorners` rather than `closestCenter`: with several droppable
+        // containers the nearest CENTRE is often a tall card's centre rather
+        // than the column the pointer is actually over, so a drop near the top
+        // of one column resolves to its neighbour.
+        collisionDetection={closestCorners}
         onDragEnd={handleDragEnd}
       >
-        <SortableContext
-          items={sortableItems}
-          // The grid wraps, so cards move in two dimensions. The list strategy
-          // assumes a single column and animates neighbours the wrong way.
-          strategy={rectSortingStrategy}
-        >
-          <section
-            aria-label="Dashboard widgets"
-            className="grid grid-cols-12 gap-6"
-          >
-            <span
-              role="status"
-              aria-live="polite"
-              className="sr-only"
-              data-testid="widget-grid-live"
-            >
-              {announcement}
-            </span>
-            <EmptyArrangement
-              count={visible.length}
-              isEditing={editor.isEditing}
-            />
-            {visible.map((row, index) => (
-              <ArrangedCell
-                key={row.placementId}
-                row={row}
-                index={index}
-                count={visible.length}
-                isEditing={editor.isEditing}
-                slot={slots[row.widget.id]}
-                // Only a widget that actually ASKED can be waiting on an answer. A
-                // card drawn entirely by a plugin component took no part in the
-                // batch, and neither did one whose archetype nothing can draw, so a
-                // refetch says nothing about either.
-                updatedAt={requested.has(row.widget.id) ? updatedAt : null}
-                isFetching={requested.has(row.widget.id) ? isFetching : false}
-                // The arrangement hook announces, because it is the one that
-                // resolves the destination -- announcing here would name a
-                // position computed a second time, and the two would drift.
-                onMove={moveBy}
-                onToggleHidden={editor.toggleHidden}
-                onRemove={editor.remove}
-              />
-            ))}
-          </section>
-        </SortableContext>
+        <ArrangedColumns
+          columns={columns}
+          columnCount={columnCount}
+          visible={visible}
+          isEditing={editor.isEditing}
+          slots={slots}
+          requested={requested}
+          updatedAt={updatedAt}
+          isFetching={isFetching}
+          announcement={announcement}
+          onMove={moveBy}
+          onToggleHidden={editor.toggleHidden}
+          onRemove={editor.remove}
+        />
       </DndContext>
 
       {editor.isEditing ? (

--- a/packages/admin/src/components/features/widgets/__tests__/layout-editor.test.ts
+++ b/packages/admin/src/components/features/widgets/__tests__/layout-editor.test.ts
@@ -8,8 +8,7 @@ import type { WidgetPlacement } from "@admin/types/dashboard/widgets";
 import {
   addPlacement,
   columnAffordance,
-  columnDropId,
-  columnFromDropId,
+  columnFromDropData,
   resolveDrop,
   moveToColumn,
   placementsByColumn,
@@ -342,12 +341,12 @@ describe("resolving where a drag landed", () => {
     // 🔴 The case a card-to-card resolution cannot express. An empty column
     // holds no card to drop onto, so unless the column itself is a target it
     // is reachable only until its last card leaves and never again.
-    const next = resolveDrop(start, "a", columnDropId(2), 3);
+    const next = resolveDrop(start, "a", { kind: "column", column: 2 }, 3);
     expect(next.find(p => p.id === "a")?.column).toBe(2);
   });
 
   it("takes the column of the card it was dropped onto", () => {
-    const next = resolveDrop(start, "a", "c", 3);
+    const next = resolveDrop(start, "a", { kind: "card", placementId: "c" }, 3);
     expect(next.find(p => p.id === "a")?.column).toBe(1);
   });
 
@@ -355,7 +354,7 @@ describe("resolving where a drag landed", () => {
     // 🔴 The control for the case above. Setting the column and stopping there
     // passes "took the column" while every card lands in arrival order, so a
     // reader can never place one BELOW another in the same column.
-    const next = resolveDrop(start, "b", "a", 3);
+    const next = resolveDrop(start, "b", { kind: "card", placementId: "a" }, 3);
     const column0 = next.filter(p => (p.column ?? 0) === 0).map(p => p.id);
     expect(column0).toEqual(["b", "a"]);
   });
@@ -366,7 +365,9 @@ describe("resolving where a drag landed", () => {
   });
 
   it("leaves the arrangement alone when a card is dropped on itself", () => {
-    expect(resolveDrop(start, "a", "a", 3)).toEqual(start);
+    expect(
+      resolveDrop(start, "a", { kind: "card", placementId: "a" }, 3)
+    ).toEqual(start);
   });
 });
 
@@ -395,30 +396,21 @@ describe("a column move counts as an unsaved change", () => {
 });
 
 describe("a card is never mistaken for a column", () => {
-  const at = (id: string, column: number, order: number): WidgetPlacement => ({
-    id,
-    widgetId: `w-${id}`,
-    column,
-    order,
-    hidden: false,
+  it("reads the KIND from droppable data, not from an id", () => {
+    // 🔴 Columns and cards share one id space in dnd-kit, and a placement may
+    // legitimately be named `widget-column:1` — ids are opaque, the layout API
+    // accepts any non-empty string, and a widget id becomes a default
+    // placement id under no prefix rule. Only a column carries this data, so
+    // there is nothing for a collision to be mistaken for.
+    expect(columnFromDropData({ widgetColumn: 2 })).toBe(2);
+    expect(columnFromDropData(undefined)).toBeUndefined();
+    expect(columnFromDropData({})).toBeUndefined();
+    // A card's own data never names a column, whatever the card is called.
+    expect(columnFromDropData({ sortable: { index: 1 } })).toBeUndefined();
   });
 
-  it("treats a placement NAMED like a column as the card it is", () => {
-    // 🔴 Placement ids are opaque and the layout API accepts any non-empty
-    // string; a widget id also becomes a default placement id, and no prefix
-    // rule governs those. A card called `widget-column:1` must stay a card, or
-    // dropping onto it silently re-columns instead of reordering.
-    const colliding = columnDropId(1);
-    const start = [at("a", 0, 0), { ...at("x", 2, 10), id: colliding }];
-    const next = resolveDrop(start, "a", colliding, 3);
-    // It took the CARD's column (2), not the column the name spells (1).
-    expect(next.find(p => p.id === "a")?.column).toBe(2);
-  });
-
-  it("refuses a column id whose remainder is not all digits", () => {
-    // 🔴 `parseInt` reads a numeric prefix and stops, so `widget-column:1-card`
-    // parsed as column 1 — a card id classified as a column.
-    expect(columnFromDropId(`${columnDropId(1)}-card`)).toBeUndefined();
-    expect(columnFromDropId(columnDropId(1))).toBe(1);
+  it("refuses a non-integer or negative column in data", () => {
+    expect(columnFromDropData({ widgetColumn: -1 })).toBeUndefined();
+    expect(columnFromDropData({ widgetColumn: 1.5 })).toBeUndefined();
   });
 });

--- a/packages/admin/src/components/features/widgets/__tests__/layout-editor.test.ts
+++ b/packages/admin/src/components/features/widgets/__tests__/layout-editor.test.ts
@@ -414,3 +414,44 @@ describe("a card is never mistaken for a column", () => {
     expect(columnFromDropData({ widgetColumn: 1.5 })).toBeUndefined();
   });
 });
+
+describe("a card can reach the MIDDLE of another column", () => {
+  const at = (id: string, column: number, order: number): WidgetPlacement => ({
+    id,
+    widgetId: `w-${id}`,
+    column,
+    order,
+    hidden: false,
+  });
+  // Interleaved on purpose: A and D share column 0 but are not adjacent in the
+  // flat sequence, which is what makes the middle position hard to reach.
+  const start = [at("A", 0, 0), at("B", 1, 10), at("C", 2, 20), at("D", 0, 30)];
+
+  const columnZero = (placements: WidgetPlacement[]) =>
+    placements
+      .filter(p => (p.column ?? 0) === 0)
+      .sort((a, b) => a.order - b.order)
+      .map(p => p.id);
+
+  it("lands BETWEEN two cards of the destination column", () => {
+    // 🔴 Reordering the interleaved whole cannot express this: moving B toward
+    // A puts it before A, moving it toward D puts it after D, and [A, B, D] is
+    // reachable from no card target at all. Resolved inside column 0's bucket,
+    // B takes D's index — the position the pointer was actually over.
+    const next = resolveDrop(start, "B", { kind: "card", placementId: "D" }, 3);
+    expect(columnZero(next)).toEqual(["A", "B", "D"]);
+  });
+
+  it("still lands at the TOP when aimed at the first card", () => {
+    // The control: a resolution that always inserted at the end would satisfy
+    // nothing above, and one that always inserted at the start would satisfy
+    // the first case by accident.
+    const next = resolveDrop(start, "B", { kind: "card", placementId: "A" }, 3);
+    expect(columnZero(next)).toEqual(["B", "A", "D"]);
+  });
+
+  it("APPENDS when the target is the column itself", () => {
+    const next = resolveDrop(start, "B", { kind: "column", column: 0 }, 3);
+    expect(columnZero(next)).toEqual(["A", "D", "B"]);
+  });
+});

--- a/packages/admin/src/components/features/widgets/__tests__/layout-editor.test.ts
+++ b/packages/admin/src/components/features/widgets/__tests__/layout-editor.test.ts
@@ -9,8 +9,8 @@ import {
   addPlacement,
   columnAffordance,
   columnFromDropData,
+  dropSide,
   resolveDrop,
-  moveToColumn,
   placementsByColumn,
   hasChanges,
   moveAffordance,
@@ -283,26 +283,6 @@ describe("arranging across columns", () => {
     });
   });
 
-  describe("moving between columns", () => {
-    it("moves a card into the column asked for", () => {
-      const moved = moveToColumn([at("a", 0, 0), at("b", 1, 10)], "a", 1);
-      expect(moved.find(p => p.id === "a")?.column).toBe(1);
-    });
-
-    it("leaves the other placements' columns alone", () => {
-      // The control: a rebuild that renumbered every column would satisfy the
-      // assertion above while quietly rearranging the whole dashboard.
-      const moved = moveToColumn([at("a", 0, 0), at("b", 1, 10)], "a", 1);
-      expect(moved.find(p => p.id === "b")?.column).toBe(1);
-      expect(moved).toHaveLength(2);
-    });
-
-    it("ignores an id it does not hold, rather than throwing", () => {
-      const before = [at("a", 0, 0)];
-      expect(moveToColumn(before, "nope", 1)).toEqual(before);
-    });
-  });
-
   describe("what the single-pointer controls may offer", () => {
     it("refuses left at the first column and right at the last", () => {
       // 🔴 WCAG 2.2 SC 2.5.7: crossing columns must be reachable by CLICK, not
@@ -346,7 +326,12 @@ describe("resolving where a drag landed", () => {
   });
 
   it("takes the column of the card it was dropped onto", () => {
-    const next = resolveDrop(start, "a", { kind: "card", placementId: "c" }, 3);
+    const next = resolveDrop(
+      start,
+      "a",
+      { kind: "card", placementId: "c", side: "before" },
+      3
+    );
     expect(next.find(p => p.id === "a")?.column).toBe(1);
   });
 
@@ -354,7 +339,12 @@ describe("resolving where a drag landed", () => {
     // 🔴 The control for the case above. Setting the column and stopping there
     // passes "took the column" while every card lands in arrival order, so a
     // reader can never place one BELOW another in the same column.
-    const next = resolveDrop(start, "b", { kind: "card", placementId: "a" }, 3);
+    const next = resolveDrop(
+      start,
+      "b",
+      { kind: "card", placementId: "a", side: "before" },
+      3
+    );
     const column0 = next.filter(p => (p.column ?? 0) === 0).map(p => p.id);
     expect(column0).toEqual(["b", "a"]);
   });
@@ -366,7 +356,12 @@ describe("resolving where a drag landed", () => {
 
   it("leaves the arrangement alone when a card is dropped on itself", () => {
     expect(
-      resolveDrop(start, "a", { kind: "card", placementId: "a" }, 3)
+      resolveDrop(
+        start,
+        "a",
+        { kind: "card", placementId: "a", side: "before" },
+        3
+      )
     ).toEqual(start);
   });
 });
@@ -438,7 +433,12 @@ describe("a card can reach the MIDDLE of another column", () => {
     // A puts it before A, moving it toward D puts it after D, and [A, B, D] is
     // reachable from no card target at all. Resolved inside column 0's bucket,
     // B takes D's index — the position the pointer was actually over.
-    const next = resolveDrop(start, "B", { kind: "card", placementId: "D" }, 3);
+    const next = resolveDrop(
+      start,
+      "B",
+      { kind: "card", placementId: "D", side: "before" },
+      3
+    );
     expect(columnZero(next)).toEqual(["A", "B", "D"]);
   });
 
@@ -446,12 +446,136 @@ describe("a card can reach the MIDDLE of another column", () => {
     // The control: a resolution that always inserted at the end would satisfy
     // nothing above, and one that always inserted at the start would satisfy
     // the first case by accident.
-    const next = resolveDrop(start, "B", { kind: "card", placementId: "A" }, 3);
+    const next = resolveDrop(
+      start,
+      "B",
+      { kind: "card", placementId: "A", side: "before" },
+      3
+    );
     expect(columnZero(next)).toEqual(["B", "A", "D"]);
   });
 
   it("APPENDS when the target is the column itself", () => {
     const next = resolveDrop(start, "B", { kind: "column", column: 0 }, 3);
     expect(columnZero(next)).toEqual(["A", "D", "B"]);
+  });
+
+  it("lands BELOW the last card when the drop is on its lower half", () => {
+    // 🔴 The bottom of a populated column is otherwise unreachable by drag. A
+    // column disables its own droppable once it holds anything, so releasing
+    // in the space under D resolves to D -- and inserting at D's own index put
+    // the card in front of it, so no gesture at all produced [A, D, B].
+    const next = resolveDrop(
+      start,
+      "B",
+      { kind: "card", placementId: "D", side: "after" },
+      3
+    );
+    expect(columnZero(next)).toEqual(["A", "D", "B"]);
+  });
+
+  it("still lands ABOVE that same card on its upper half", () => {
+    // The control for the case above, on the SAME target. A resolution that
+    // ignored the side and always appended would satisfy it while making the
+    // position above the last card unreachable instead -- the same defect
+    // pointing the other way.
+    const next = resolveDrop(
+      start,
+      "B",
+      { kind: "card", placementId: "D", side: "before" },
+      3
+    );
+    expect(columnZero(next)).toEqual(["A", "B", "D"]);
+  });
+
+  it("moves a card DOWN past its own neighbour", () => {
+    // Within one column the active card is removed from the bucket it is being
+    // re-inserted into, so the index read before the removal is one too many
+    // afterwards. Uncorrected, A lands back above D and the gesture does
+    // nothing -- which reads as the drag having been dropped.
+    const next = resolveDrop(
+      start,
+      "A",
+      { kind: "card", placementId: "D", side: "after" },
+      3
+    );
+    expect(columnZero(next)).toEqual(["D", "A"]);
+  });
+});
+
+describe("the stored sequence reads ACROSS the rows", () => {
+  const at = (id: string, column: number, order: number): WidgetPlacement => ({
+    id,
+    widgetId: `w-${id}`,
+    column,
+    order,
+    hidden: false,
+  });
+  const start = [at("A", 0, 0), at("B", 1, 10), at("C", 2, 20), at("D", 0, 30)];
+
+  it("orders the placements row-major, not column by column", () => {
+    // 🔴 `byPosition` sorts on `order` and reads the dashboard across the top
+    // before going down, so the stored numbers have to agree with that reading.
+    // Numbering column by column stored [D, A, B, C] for a grid drawn as
+    // [D, B, C] then [A], and every client consuming the canonical sequence
+    // reordered cards nobody had touched.
+    const next = resolveDrop(
+      start,
+      "D",
+      { kind: "card", placementId: "A", side: "before" },
+      3
+    );
+    const sequence = [...next]
+      .sort((a, b) => a.order - b.order || (a.column ?? 0) - (b.column ?? 0))
+      .map(p => p.id);
+    expect(sequence).toEqual(["D", "B", "C", "A"]);
+  });
+
+  it("still orders each column top to bottom", () => {
+    // The control: a sequence that interleaved wrongly could satisfy the row
+    // reading while scrambling the column the reader is actually looking at.
+    // Both are read off the same numbers, so both have to hold at once.
+    const next = resolveDrop(
+      start,
+      "D",
+      { kind: "card", placementId: "A", side: "before" },
+      3
+    );
+    const column0 = next
+      .filter(p => (p.column ?? 0) === 0)
+      .sort((a, b) => a.order - b.order)
+      .map(p => p.id);
+    expect(column0).toEqual(["D", "A"]);
+  });
+});
+
+describe("which side of a card a drop landed on", () => {
+  it("is AFTER once the dragged card's middle passes the target's", () => {
+    expect(dropSide({ top: 120, height: 40 }, { top: 100, height: 40 })).toBe(
+      "after"
+    );
+  });
+
+  it("is BEFORE while it is still above", () => {
+    expect(dropSide({ top: 80, height: 40 }, { top: 100, height: 40 })).toBe(
+      "before"
+    );
+  });
+
+  it("compares CENTRES, not edges", () => {
+    // 🔴 The separating case. A tall card overlapping the target's top edge has
+    // a lower top and a higher centre, so an edge comparison answers "before"
+    // for a gesture whose weight is plainly below -- and the two agree on every
+    // pair of equal-height cards, which is most of them.
+    expect(dropSide({ top: 90, height: 100 }, { top: 100, height: 40 })).toBe(
+      "after"
+    );
+  });
+
+  it("falls back to BEFORE when a rectangle is missing", () => {
+    // The position a drop resolved to before sides existed, so a measurement
+    // that cannot be taken costs the old behaviour rather than an arbitrary one.
+    expect(dropSide(null, { top: 100, height: 40 })).toBe("before");
+    expect(dropSide({ top: 100, height: 40 }, undefined)).toBe("before");
   });
 });

--- a/packages/admin/src/components/features/widgets/__tests__/layout-editor.test.ts
+++ b/packages/admin/src/components/features/widgets/__tests__/layout-editor.test.ts
@@ -9,6 +9,7 @@ import {
   addPlacement,
   columnAffordance,
   columnDropId,
+  columnFromDropId,
   resolveDrop,
   moveToColumn,
   placementsByColumn,
@@ -390,5 +391,34 @@ describe("a column move counts as an unsaved change", () => {
     // The control: a comparison that answered true for everything would pass
     // the assertion above while leaving Save permanently enabled.
     expect(hasChanges([at("a", 0, 0)], [at("a", 0, 0)])).toBe(false);
+  });
+});
+
+describe("a card is never mistaken for a column", () => {
+  const at = (id: string, column: number, order: number): WidgetPlacement => ({
+    id,
+    widgetId: `w-${id}`,
+    column,
+    order,
+    hidden: false,
+  });
+
+  it("treats a placement NAMED like a column as the card it is", () => {
+    // 🔴 Placement ids are opaque and the layout API accepts any non-empty
+    // string; a widget id also becomes a default placement id, and no prefix
+    // rule governs those. A card called `widget-column:1` must stay a card, or
+    // dropping onto it silently re-columns instead of reordering.
+    const colliding = columnDropId(1);
+    const start = [at("a", 0, 0), { ...at("x", 2, 10), id: colliding }];
+    const next = resolveDrop(start, "a", colliding, 3);
+    // It took the CARD's column (2), not the column the name spells (1).
+    expect(next.find(p => p.id === "a")?.column).toBe(2);
+  });
+
+  it("refuses a column id whose remainder is not all digits", () => {
+    // 🔴 `parseInt` reads a numeric prefix and stops, so `widget-column:1-card`
+    // parsed as column 1 — a card id classified as a column.
+    expect(columnFromDropId(`${columnDropId(1)}-card`)).toBeUndefined();
+    expect(columnFromDropId(columnDropId(1))).toBe(1);
   });
 });

--- a/packages/admin/src/components/features/widgets/__tests__/layout-editor.test.ts
+++ b/packages/admin/src/components/features/widgets/__tests__/layout-editor.test.ts
@@ -368,3 +368,27 @@ describe("resolving where a drag landed", () => {
     expect(resolveDrop(start, "a", "a", 3)).toEqual(start);
   });
 });
+
+describe("a column move counts as an unsaved change", () => {
+  const at = (id: string, column: number, order: number): WidgetPlacement => ({
+    id,
+    widgetId: `w-${id}`,
+    column,
+    order,
+    hidden: false,
+  });
+
+  it("SEES a card that only changed column", () => {
+    // 🔴 Moving a card sideways changes `column` and nothing else. Compared on
+    // the other fields alone the arrangement reads as untouched, so Save stays
+    // disabled and the reader cannot keep the move they just made — the work
+    // is on screen and unsaveable, which is worse than an error.
+    expect(hasChanges([at("a", 0, 0)], [at("a", 1, 0)])).toBe(true);
+  });
+
+  it("still reports NO change when nothing moved", () => {
+    // The control: a comparison that answered true for everything would pass
+    // the assertion above while leaving Save permanently enabled.
+    expect(hasChanges([at("a", 0, 0)], [at("a", 0, 0)])).toBe(false);
+  });
+});

--- a/packages/admin/src/components/features/widgets/__tests__/layout-editor.test.ts
+++ b/packages/admin/src/components/features/widgets/__tests__/layout-editor.test.ts
@@ -503,6 +503,103 @@ describe("a card can reach the MIDDLE of another column", () => {
   });
 });
 
+describe("a keyboard drag, whose rectangles cannot say which way it went", () => {
+  const at = (id: string, column: number, order: number): WidgetPlacement => ({
+    id,
+    widgetId: `w-${id}`,
+    column,
+    order,
+    hidden: false,
+  });
+  const column = (placements: WidgetPlacement[], index: number) =>
+    placements
+      .filter(p => (p.column ?? 0) === index)
+      .sort((a, b) => a.order - b.order)
+      .map(p => p.id);
+
+  // 🔴 What `sortableKeyboardCoordinates` produces. It translates the active
+  // card exactly ONTO its target, so for two cards of equal height the two
+  // centres coincide and `dropSide` answers "before" — for a move the reader
+  // made by pressing ArrowDown.
+  const asKeyboardWouldMeasure = dropSide(
+    { top: 100, height: 80 },
+    { top: 100, height: 80 }
+  );
+
+  it("measures equal rectangles as `before`, which is the whole difficulty", () => {
+    expect(asKeyboardWouldMeasure).toBe("before");
+  });
+
+  it("still moves a card DOWN within its column", () => {
+    // 🔴 Resolved from the measured side, this cancels against the adjustment
+    // for removing the active card and lands it back where it started, so
+    // Space, ArrowDown, Space does nothing at all. The two indices say which
+    // way the card is going without needing a rectangle to agree.
+    const start = [at("a", 0, 0), at("b", 0, 10)];
+    const next = resolveDrop(
+      start,
+      "a",
+      { kind: "card", placementId: "b", side: asKeyboardWouldMeasure },
+      3
+    );
+    expect(column(next, 0)).toEqual(["b", "a"]);
+  });
+
+  it("still moves a card UP within its column", () => {
+    // The control: a resolution that ignored the side by always appending
+    // would satisfy the case above and make an upward move impossible.
+    const start = [at("a", 0, 0), at("b", 0, 10)];
+    const next = resolveDrop(
+      start,
+      "b",
+      { kind: "card", placementId: "a", side: asKeyboardWouldMeasure },
+      3
+    );
+    expect(column(next, 0)).toEqual(["b", "a"]);
+  });
+
+  it("gives the SAME answer whichever side a same-column drop reports", () => {
+    // The invariant that makes the two paths agree: within a column the side is
+    // not consulted, so a pointer gesture and a keyboard one that reach the
+    // same two cards resolve identically however their rectangles measured.
+    const start = [at("a", 0, 0), at("b", 0, 10), at("c", 0, 20)];
+    const before = resolveDrop(
+      start,
+      "a",
+      { kind: "card", placementId: "c", side: "before" },
+      3
+    );
+    const after = resolveDrop(
+      start,
+      "a",
+      { kind: "card", placementId: "c", side: "after" },
+      3
+    );
+    expect(column(before, 0)).toEqual(["b", "c", "a"]);
+    expect(column(after, 0)).toEqual(column(before, 0));
+  });
+
+  it("still reads the side ACROSS columns, where no index can", () => {
+    // The other control. Ignoring the side everywhere would satisfy every case
+    // above while making the bottom of another column unreachable again.
+    const start = [at("A", 0, 0), at("D", 0, 10), at("B", 1, 20)];
+    const appended = resolveDrop(
+      start,
+      "B",
+      { kind: "card", placementId: "D", side: "after" },
+      3
+    );
+    expect(column(appended, 0)).toEqual(["A", "D", "B"]);
+    const inserted = resolveDrop(
+      start,
+      "B",
+      { kind: "card", placementId: "D", side: "before" },
+      3
+    );
+    expect(column(inserted, 0)).toEqual(["A", "B", "D"]);
+  });
+});
+
 describe("the stored sequence reads ACROSS the rows", () => {
   const at = (id: string, column: number, order: number): WidgetPlacement => ({
     id,

--- a/packages/admin/src/components/features/widgets/__tests__/layout-editor.test.ts
+++ b/packages/admin/src/components/features/widgets/__tests__/layout-editor.test.ts
@@ -8,6 +8,8 @@ import type { WidgetPlacement } from "@admin/types/dashboard/widgets";
 import {
   addPlacement,
   columnAffordance,
+  columnDropId,
+  resolveDrop,
   moveToColumn,
   placementsByColumn,
   hasChanges,
@@ -322,5 +324,47 @@ describe("arranging across columns", () => {
         canMoveRight: true,
       });
     });
+  });
+});
+
+describe("resolving where a drag landed", () => {
+  const at = (id: string, column: number, order: number): WidgetPlacement => ({
+    id,
+    widgetId: `w-${id}`,
+    column,
+    order,
+    hidden: false,
+  });
+  const start = [at("a", 0, 0), at("b", 0, 10), at("c", 1, 20)];
+
+  it("drops onto an EMPTY column when the target is the column itself", () => {
+    // 🔴 The case a card-to-card resolution cannot express. An empty column
+    // holds no card to drop onto, so unless the column itself is a target it
+    // is reachable only until its last card leaves and never again.
+    const next = resolveDrop(start, "a", columnDropId(2), 3);
+    expect(next.find(p => p.id === "a")?.column).toBe(2);
+  });
+
+  it("takes the column of the card it was dropped onto", () => {
+    const next = resolveDrop(start, "a", "c", 3);
+    expect(next.find(p => p.id === "a")?.column).toBe(1);
+  });
+
+  it("REORDERS within a column rather than only re-columning", () => {
+    // 🔴 The control for the case above. Setting the column and stopping there
+    // passes "took the column" while every card lands in arrival order, so a
+    // reader can never place one BELOW another in the same column.
+    const next = resolveDrop(start, "b", "a", 3);
+    const column0 = next.filter(p => (p.column ?? 0) === 0).map(p => p.id);
+    expect(column0).toEqual(["b", "a"]);
+  });
+
+  it("leaves the arrangement alone when the drop resolves to nothing", () => {
+    // A drag released over empty space is an ordinary outcome, not an error.
+    expect(resolveDrop(start, "a", null, 3)).toEqual(start);
+  });
+
+  it("leaves the arrangement alone when a card is dropped on itself", () => {
+    expect(resolveDrop(start, "a", "a", 3)).toEqual(start);
   });
 });

--- a/packages/admin/src/components/features/widgets/__tests__/layout-editor.test.ts
+++ b/packages/admin/src/components/features/widgets/__tests__/layout-editor.test.ts
@@ -7,6 +7,9 @@ import type { WidgetPlacement } from "@admin/types/dashboard/widgets";
 
 import {
   addPlacement,
+  columnAffordance,
+  moveToColumn,
+  placementsByColumn,
   hasChanges,
   moveAffordance,
   movePlacement,
@@ -233,5 +236,91 @@ describe("addPlacement at the write contract's ceiling", () => {
 
     expect(after).toHaveLength(MAX_PLACEMENTS);
     expect(after.map(p => p.widgetId)).toContain("core/surplus");
+  });
+});
+
+describe("arranging across columns", () => {
+  const at = (id: string, column: number, order: number): WidgetPlacement => ({
+    id,
+    widgetId: `w-${id}`,
+    column,
+    order,
+    hidden: false,
+  });
+
+  describe("grouping for the grid", () => {
+    it("puts each placement under its own column, in order", () => {
+      const grouped = placementsByColumn(
+        [at("a", 0, 0), at("b", 1, 10), at("c", 0, 20)],
+        2
+      );
+      expect(grouped.map(col => col.map(p => p.id))).toEqual([
+        ["a", "c"],
+        ["b"],
+      ]);
+    });
+
+    it("KEEPS a card whose column no longer exists", () => {
+      // 🔴 The property that decides whether narrowing the dashboard destroys
+      // work. A reader who moves 4 columns down to 2 still owns the cards that
+      // were in columns 2 and 3; dropping them would silently delete an
+      // arrangement, which is worse than showing them somewhere unexpected.
+      const grouped = placementsByColumn([at("a", 0, 0), at("far", 3, 10)], 2);
+      expect(grouped.flat().map(p => p.id)).toContain("far");
+      expect(grouped).toHaveLength(2);
+    });
+
+    it("returns one bucket PER COLUMN even when a column is empty", () => {
+      // 🔴 The control an empty column needs: a drop target only exists if the
+      // grid renders that column, so collapsing empty buckets would make a
+      // column unreachable the moment its last card left it.
+      const grouped = placementsByColumn([at("a", 0, 0)], 3);
+      expect(grouped).toHaveLength(3);
+      expect(grouped[1]).toEqual([]);
+      expect(grouped[2]).toEqual([]);
+    });
+  });
+
+  describe("moving between columns", () => {
+    it("moves a card into the column asked for", () => {
+      const moved = moveToColumn([at("a", 0, 0), at("b", 1, 10)], "a", 1);
+      expect(moved.find(p => p.id === "a")?.column).toBe(1);
+    });
+
+    it("leaves the other placements' columns alone", () => {
+      // The control: a rebuild that renumbered every column would satisfy the
+      // assertion above while quietly rearranging the whole dashboard.
+      const moved = moveToColumn([at("a", 0, 0), at("b", 1, 10)], "a", 1);
+      expect(moved.find(p => p.id === "b")?.column).toBe(1);
+      expect(moved).toHaveLength(2);
+    });
+
+    it("ignores an id it does not hold, rather than throwing", () => {
+      const before = [at("a", 0, 0)];
+      expect(moveToColumn(before, "nope", 1)).toEqual(before);
+    });
+  });
+
+  describe("what the single-pointer controls may offer", () => {
+    it("refuses left at the first column and right at the last", () => {
+      // 🔴 WCAG 2.2 SC 2.5.7: crossing columns must be reachable by CLICK, not
+      // only by dragging — so these buttons are the conformance, and their
+      // enabled state has to be right or they are a control that lies.
+      expect(columnAffordance(0, 3)).toEqual({
+        canMoveLeft: false,
+        canMoveRight: true,
+      });
+      expect(columnAffordance(2, 3)).toEqual({
+        canMoveLeft: true,
+        canMoveRight: false,
+      });
+    });
+
+    it("offers both in the middle", () => {
+      expect(columnAffordance(1, 3)).toEqual({
+        canMoveLeft: true,
+        canMoveRight: true,
+      });
+    });
   });
 });

--- a/packages/admin/src/components/features/widgets/edit/ArrangedCell.tsx
+++ b/packages/admin/src/components/features/widgets/edit/ArrangedCell.tsx
@@ -15,7 +15,7 @@
 import { cn } from "@admin/lib/utils";
 import type { WidgetSlot } from "@admin/types/dashboard/widgets";
 
-import { moveAffordance } from "../layout-editor";
+import { moveAffordance, columnAffordance } from "../layout-editor";
 import { widgetSpanClass } from "../sizes";
 import { WidgetRenderer } from "../WidgetRenderer";
 
@@ -33,6 +33,9 @@ export interface ArrangedCellProps {
   updatedAt: Date | null;
   isFetching: boolean;
   onMove: (index: number, delta: number) => void;
+  /** How many columns the dashboard is drawn in, for the sideways controls. */
+  columnCount: number;
+  onMoveColumn: (placementId: string, delta: number) => void;
   onToggleHidden: (placementId: string) => void;
   onRemove: (placementId: string) => void;
 }
@@ -46,11 +49,17 @@ export function ArrangedCell({
   updatedAt,
   isFetching,
   onMove,
+  columnCount,
+  onMoveColumn,
   onToggleHidden,
   onRemove,
 }: ArrangedCellProps) {
   const widget = row.widget;
   const { canMoveUp, canMoveDown } = moveAffordance(index, count);
+  const { canMoveLeft, canMoveRight } = columnAffordance(
+    row.column ?? 0,
+    columnCount
+  );
 
   return (
     <SortableWidgetCell
@@ -104,8 +113,14 @@ export function ArrangedCell({
           hidden={row.hidden}
           canMoveUp={canMoveUp}
           canMoveDown={canMoveDown}
+          column={(row.column ?? 0) + 1}
+          columnCount={columnCount}
+          canMoveLeft={canMoveLeft}
+          canMoveRight={canMoveRight}
           onMoveUp={() => onMove(index, -1)}
           onMoveDown={() => onMove(index, 1)}
+          onMoveLeft={() => onMoveColumn(row.placementId, -1)}
+          onMoveRight={() => onMoveColumn(row.placementId, 1)}
           onToggleHidden={() => onToggleHidden(row.placementId)}
           onRemove={() => onRemove(row.placementId)}
         />

--- a/packages/admin/src/components/features/widgets/edit/ArrangedCell.tsx
+++ b/packages/admin/src/components/features/widgets/edit/ArrangedCell.tsx
@@ -32,10 +32,21 @@ export interface ArrangedCellProps {
   /** `null` when this card took no part in the batch. */
   updatedAt: Date | null;
   isFetching: boolean;
-  onMove: (index: number, delta: number) => void;
+  /**
+   * Move this card one step within ITS OWN column.
+   *
+   * 🔴 Bound by the caller rather than resolved from an index here. `index` is
+   * a position within the rendered column, and the cell has no way to turn one
+   * into the neighbour it should swap with -- the arrangement is interleaved
+   * across columns, so the card before this one in the whole sequence usually
+   * sits in a different column entirely.
+   */
+  onMove: (delta: number) => void;
   /** How many columns the dashboard is drawn in, for the sideways controls. */
   columnCount: number;
-  onMoveColumn: (placementId: string, delta: number) => void;
+  /** The column this card is DRAWN in, which a stored value may differ from. */
+  column: number;
+  onMoveColumn: (placementId: string, targetColumn: number) => void;
   onToggleHidden: (placementId: string) => void;
   onRemove: (placementId: string) => void;
 }
@@ -50,16 +61,18 @@ export function ArrangedCell({
   isFetching,
   onMove,
   columnCount,
+  column,
   onMoveColumn,
   onToggleHidden,
   onRemove,
 }: ArrangedCellProps) {
   const widget = row.widget;
   const { canMoveUp, canMoveDown } = moveAffordance(index, count);
-  const { canMoveLeft, canMoveRight } = columnAffordance(
-    row.column ?? 0,
-    columnCount
-  );
+  // Derived from the column this card is DRAWN in. A card stored past the
+  // current count is folded into the last column, so computing from the stored
+  // value offers a Left that lands outside the dashboard and a label naming a
+  // column the reader cannot see.
+  const { canMoveLeft, canMoveRight } = columnAffordance(column, columnCount);
 
   return (
     <SortableWidgetCell
@@ -113,14 +126,14 @@ export function ArrangedCell({
           hidden={row.hidden}
           canMoveUp={canMoveUp}
           canMoveDown={canMoveDown}
-          column={(row.column ?? 0) + 1}
+          column={column + 1}
           columnCount={columnCount}
           canMoveLeft={canMoveLeft}
           canMoveRight={canMoveRight}
-          onMoveUp={() => onMove(index, -1)}
-          onMoveDown={() => onMove(index, 1)}
-          onMoveLeft={() => onMoveColumn(row.placementId, -1)}
-          onMoveRight={() => onMoveColumn(row.placementId, 1)}
+          onMoveUp={() => onMove(-1)}
+          onMoveDown={() => onMove(1)}
+          onMoveLeft={() => onMoveColumn(row.placementId, column - 1)}
+          onMoveRight={() => onMoveColumn(row.placementId, column + 1)}
           onToggleHidden={() => onToggleHidden(row.placementId)}
           onRemove={() => onRemove(row.placementId)}
         />

--- a/packages/admin/src/components/features/widgets/edit/ArrangedColumns.tsx
+++ b/packages/admin/src/components/features/widgets/edit/ArrangedColumns.tsx
@@ -103,8 +103,8 @@ export function ArrangedColumns({
               key={row.placementId}
               row={row}
               // 🔴 The SAME list the click resolves against. Derived from the
-              // global sequence, the first card of column 2 had an enabled Up
-              // whose neighbour does not exist in its column -- an enabled
+              // global sequence instead, the first card of column 2 gets an
+              // enabled Up whose neighbour is not in its column -- an enabled
               // control that does nothing, which is the failure SC 2.5.7 is
               // about rather than a cosmetic one.
               index={indexInColumn}
@@ -122,8 +122,8 @@ export function ArrangedColumns({
               // position computed a second time, and the two would drift.
               // 🔴 Resolved against THIS column, not the whole arrangement.
               // The sequence is interleaved across columns, so the row before
-              // this one globally is usually in a different column -- moving
-              // toward it swapped two cards a reader could not see move.
+              // this one globally is usually in a different column, and moving
+              // toward it swaps two cards a reader cannot see move.
               onMove={(delta: number) => {
                 const neighbour = rowsInColumn[indexInColumn + delta];
                 // The delta already says which way the reader asked to go, so

--- a/packages/admin/src/components/features/widgets/edit/ArrangedColumns.tsx
+++ b/packages/admin/src/components/features/widgets/edit/ArrangedColumns.tsx
@@ -29,8 +29,9 @@ export interface ArrangedColumnsProps {
   updatedAt: Date | null;
   isFetching: boolean;
   announcement: string;
-  onMove: (index: number, delta: number) => void;
-  onMoveColumn: (placementId: string, delta: number) => void;
+  /** Move one card one step within the column it is drawn in. */
+  onMove: (placementId: string, neighbourId: string) => void;
+  onMoveColumn: (placementId: string, targetColumn: number) => void;
   onToggleHidden: (placementId: string) => void;
   onRemove: (placementId: string) => void;
 }
@@ -95,7 +96,7 @@ export function ArrangedColumns({
           items={rowsInColumn.map(row => row.placementId)}
           isEditing={isEditing}
         >
-          {rowsInColumn.map(row => (
+          {rowsInColumn.map((row, indexInColumn) => (
             <ArrangedCell
               key={row.placementId}
               row={row}
@@ -112,8 +113,16 @@ export function ArrangedColumns({
               // The arrangement hook announces, because it is the one that
               // resolves the destination -- announcing here would name a
               // position computed a second time, and the two would drift.
-              onMove={onMove}
+              // 🔴 Resolved against THIS column, not the whole arrangement.
+              // The sequence is interleaved across columns, so the row before
+              // this one globally is usually in a different column -- moving
+              // toward it swapped two cards a reader could not see move.
+              onMove={(delta: number) => {
+                const neighbour = rowsInColumn[indexInColumn + delta];
+                if (neighbour) onMove(row.placementId, neighbour.placementId);
+              }}
               columnCount={columnCount}
+              column={columnIndex}
               onMoveColumn={onMoveColumn}
               onToggleHidden={onToggleHidden}
               onRemove={onRemove}

--- a/packages/admin/src/components/features/widgets/edit/ArrangedColumns.tsx
+++ b/packages/admin/src/components/features/widgets/edit/ArrangedColumns.tsx
@@ -1,0 +1,122 @@
+"use client";
+/**
+ * The dashboard's columns, and everything drawn inside them.
+ *
+ * Lifted out of `WidgetGrid` so that the grid reads as what it orchestrates --
+ * permissions, the arrangement, the batch, the drag context -- rather than as
+ * those plus a nested render. The tracks, the live region and the per-card
+ * wiring are one concern and they live together here.
+ *
+ * @module components/features/widgets/edit/ArrangedColumns
+ */
+import { cn } from "@admin/lib/utils";
+import type { WidgetSlot } from "@admin/types/dashboard/widgets";
+
+import { COLUMN_TRACK_CLASSES } from "../sizes";
+
+import { ArrangedCell } from "./ArrangedCell";
+import type { ArrangedWidget } from "./useDashboardArrangement";
+import { WidgetColumn } from "./WidgetColumn";
+
+export interface ArrangedColumnsProps {
+  columns: ArrangedWidget[][];
+  columnCount: number;
+  /** The same cards as one sequence, which the per-card controls count from. */
+  visible: ArrangedWidget[];
+  isEditing: boolean;
+  slots: Record<string, WidgetSlot>;
+  requested: ReadonlySet<string>;
+  updatedAt: Date | null;
+  isFetching: boolean;
+  announcement: string;
+  onMove: (index: number, delta: number) => void;
+  onToggleHidden: (placementId: string) => void;
+  onRemove: (placementId: string) => void;
+}
+
+function EmptyArrangement({
+  count,
+  isEditing,
+}: {
+  count: number;
+  isEditing: boolean;
+}) {
+  if (count > 0) return null;
+  return (
+    <p
+      data-testid="widget-grid-empty"
+      className="col-span-12 rounded-lg border border-dashed border-border px-4 py-10 text-center text-sm text-muted-foreground"
+    >
+      {isEditing
+        ? "Every card is put away. Add one back below, or reset to the default arrangement."
+        : "Your dashboard has no cards on it. Edit it to bring one back, or reset to the default arrangement."}
+    </p>
+  );
+}
+
+export function ArrangedColumns({
+  columns,
+  columnCount,
+  visible,
+  isEditing,
+  slots,
+  requested,
+  updatedAt,
+  isFetching,
+  announcement,
+  onMove,
+  onToggleHidden,
+  onRemove,
+}: ArrangedColumnsProps) {
+  return (
+    <section
+      aria-label="Dashboard widgets"
+      // One track per column, each an independent vertical list. Nothing
+      // spans tracks, so a card's width never depends on its neighbours --
+      // which is the property the previous twelve-column grid lacked and
+      // the reason dragging one resized it.
+      className={cn("grid gap-6", COLUMN_TRACK_CLASSES[columnCount] ?? "")}
+    >
+      <span
+        role="status"
+        aria-live="polite"
+        className="sr-only"
+        data-testid="widget-grid-live"
+      >
+        {announcement}
+      </span>
+      <EmptyArrangement count={visible.length} isEditing={isEditing} />
+      {columns.map((rowsInColumn, columnIndex) => (
+        <WidgetColumn
+          key={columnIndex}
+          column={columnIndex}
+          items={rowsInColumn.map(row => row.placementId)}
+          isEditing={isEditing}
+        >
+          {rowsInColumn.map(row => (
+            <ArrangedCell
+              key={row.placementId}
+              row={row}
+              index={visible.indexOf(row)}
+              count={visible.length}
+              isEditing={isEditing}
+              slot={slots[row.widget.id]}
+              // Only a widget that actually ASKED can be waiting on an answer. A
+              // card drawn entirely by a plugin component took no part in the
+              // batch, and neither did one whose archetype nothing can draw, so a
+              // refetch says nothing about either.
+              updatedAt={requested.has(row.widget.id) ? updatedAt : null}
+              isFetching={requested.has(row.widget.id) ? isFetching : false}
+              // The arrangement hook announces, because it is the one that
+              // resolves the destination -- announcing here would name a
+              // position computed a second time, and the two would drift.
+              onMove={onMove}
+              onToggleHidden={onToggleHidden}
+              onRemove={onRemove}
+            />
+          ))}
+        </WidgetColumn>
+      ))}
+    </section>
+  );
+}

--- a/packages/admin/src/components/features/widgets/edit/ArrangedColumns.tsx
+++ b/packages/admin/src/components/features/widgets/edit/ArrangedColumns.tsx
@@ -94,6 +94,7 @@ export function ArrangedColumns({
         <WidgetColumn
           key={columnIndex}
           column={columnIndex}
+          columnCount={columnCount}
           items={rowsInColumn.map(row => row.placementId)}
           isEditing={isEditing}
         >

--- a/packages/admin/src/components/features/widgets/edit/ArrangedColumns.tsx
+++ b/packages/admin/src/components/features/widgets/edit/ArrangedColumns.tsx
@@ -47,7 +47,7 @@ function EmptyArrangement({
   return (
     <p
       data-testid="widget-grid-empty"
-      className="col-span-12 rounded-lg border border-dashed border-border px-4 py-10 text-center text-sm text-muted-foreground"
+      className="col-span-full rounded-lg border border-dashed border-border px-4 py-10 text-center text-sm text-muted-foreground"
     >
       {isEditing
         ? "Every card is put away. Add one back below, or reset to the default arrangement."
@@ -100,8 +100,13 @@ export function ArrangedColumns({
             <ArrangedCell
               key={row.placementId}
               row={row}
-              index={visible.indexOf(row)}
-              count={visible.length}
+              // 🔴 The SAME list the click resolves against. Derived from the
+              // global sequence, the first card of column 2 had an enabled Up
+              // whose neighbour does not exist in its column -- an enabled
+              // control that does nothing, which is the failure SC 2.5.7 is
+              // about rather than a cosmetic one.
+              index={indexInColumn}
+              count={rowsInColumn.length}
               isEditing={isEditing}
               slot={slots[row.widget.id]}
               // Only a widget that actually ASKED can be waiting on an answer. A

--- a/packages/admin/src/components/features/widgets/edit/ArrangedColumns.tsx
+++ b/packages/admin/src/components/features/widgets/edit/ArrangedColumns.tsx
@@ -12,6 +12,7 @@
 import { cn } from "@admin/lib/utils";
 import type { WidgetSlot } from "@admin/types/dashboard/widgets";
 
+import type { DropSide } from "../layout-editor";
 import { COLUMN_TRACK_CLASSES } from "../sizes";
 
 import { ArrangedCell } from "./ArrangedCell";
@@ -30,7 +31,7 @@ export interface ArrangedColumnsProps {
   isFetching: boolean;
   announcement: string;
   /** Move one card one step within the column it is drawn in. */
-  onMove: (placementId: string, neighbourId: string) => void;
+  onMove: (placementId: string, neighbourId: string, side: DropSide) => void;
   onMoveColumn: (placementId: string, targetColumn: number) => void;
   onToggleHidden: (placementId: string) => void;
   onRemove: (placementId: string) => void;
@@ -124,7 +125,17 @@ export function ArrangedColumns({
               // toward it swapped two cards a reader could not see move.
               onMove={(delta: number) => {
                 const neighbour = rowsInColumn[indexInColumn + delta];
-                if (neighbour) onMove(row.placementId, neighbour.placementId);
+                // The delta already says which way the reader asked to go, so
+                // it says which side of that neighbour the card lands on. Up
+                // is above it, down is below -- and below is the side that
+                // makes the bottom of a column reachable at all.
+                if (neighbour) {
+                  onMove(
+                    row.placementId,
+                    neighbour.placementId,
+                    delta < 0 ? "before" : "after"
+                  );
+                }
               }}
               columnCount={columnCount}
               column={columnIndex}

--- a/packages/admin/src/components/features/widgets/edit/ArrangedColumns.tsx
+++ b/packages/admin/src/components/features/widgets/edit/ArrangedColumns.tsx
@@ -30,6 +30,7 @@ export interface ArrangedColumnsProps {
   isFetching: boolean;
   announcement: string;
   onMove: (index: number, delta: number) => void;
+  onMoveColumn: (placementId: string, delta: number) => void;
   onToggleHidden: (placementId: string) => void;
   onRemove: (placementId: string) => void;
 }
@@ -65,6 +66,7 @@ export function ArrangedColumns({
   isFetching,
   announcement,
   onMove,
+  onMoveColumn,
   onToggleHidden,
   onRemove,
 }: ArrangedColumnsProps) {
@@ -111,6 +113,8 @@ export function ArrangedColumns({
               // resolves the destination -- announcing here would name a
               // position computed a second time, and the two would drift.
               onMove={onMove}
+              columnCount={columnCount}
+              onMoveColumn={onMoveColumn}
               onToggleHidden={onToggleHidden}
               onRemove={onRemove}
             />

--- a/packages/admin/src/components/features/widgets/edit/DashboardEditBar.tsx
+++ b/packages/admin/src/components/features/widgets/edit/DashboardEditBar.tsx
@@ -20,6 +20,11 @@ export interface DashboardEditBarProps {
   isSaving: boolean;
   /** Whether the reader has an arrangement of their own to reset. */
   canReset: boolean;
+  /** How many columns the dashboard is currently drawn in. */
+  columnCount: number;
+  /** The counts a reader may choose between. */
+  columnChoices: readonly number[];
+  onColumnCount: (columnCount: number) => void;
   onBegin: () => void;
   onSave: () => void;
   onCancel: () => void;
@@ -31,6 +36,9 @@ export function DashboardEditBar({
   hasUnsavedChanges,
   isSaving,
   canReset,
+  columnCount,
+  columnChoices,
+  onColumnCount,
   onBegin,
   onSave,
   onCancel,
@@ -59,6 +67,48 @@ export function DashboardEditBar({
           because it discards an arrangement rather than an edit. Offered only
           when there IS one: a reader already on the default has nothing to
           reset, and a button that does nothing is worse than no button. */}
+      {/* 🔴 A RADIO GROUP, not a select. Three or four short, mutually
+          exclusive choices are what radios are for: every option is visible
+          without opening anything, the arrow keys move between them, and the
+          current one is announced. A select hides the alternatives behind a
+          click and reads its own value rather than the set.
+
+          Labelled by a real element rather than an `aria-label` on the group,
+          so the name is visible to everyone rather than only to a screen
+          reader deciding what this cluster of numbers is for. */}
+      <div
+        role="radiogroup"
+        aria-labelledby="dashboard-columns-label"
+        className="mr-auto flex items-center gap-1"
+        data-testid="dashboard-column-picker"
+      >
+        <span
+          id="dashboard-columns-label"
+          className="mr-1 text-xs text-muted-foreground"
+        >
+          Columns
+        </span>
+        {columnChoices.map(choice => (
+          <Button
+            key={choice}
+            type="button"
+            role="radio"
+            aria-checked={choice === columnCount}
+            variant={choice === columnCount ? "secondary" : "ghost"}
+            size="sm"
+            disabled={isSaving}
+            onClick={() => onColumnCount(choice)}
+            // The count is in the label because the digit alone does not say
+            // what it counts, and a reader arriving on it by keyboard has no
+            // surrounding context to read.
+            aria-label={`${choice} columns`}
+            data-testid={`dashboard-column-choice-${choice}`}
+          >
+            {choice}
+          </Button>
+        ))}
+      </div>
+
       {canReset ? (
         <Button
           type="button"
@@ -66,7 +116,7 @@ export function DashboardEditBar({
           size="sm"
           onClick={onReset}
           disabled={isSaving}
-          className="mr-auto text-muted-foreground"
+          className="text-muted-foreground"
           data-testid="dashboard-edit-reset"
         >
           Reset to default

--- a/packages/admin/src/components/features/widgets/edit/DashboardEditBar.tsx
+++ b/packages/admin/src/components/features/widgets/edit/DashboardEditBar.tsx
@@ -10,9 +10,10 @@
  * @module components/features/widgets/edit/DashboardEditBar
  */
 
-import { Button } from "@nextlyhq/ui";
+import { Button, RadioGroup, RadioGroupItem } from "@nextlyhq/ui";
 
 import * as Icons from "@admin/components/icons";
+import { cn } from "@admin/lib/utils";
 
 export interface DashboardEditBarProps {
   isEditing: boolean;
@@ -67,46 +68,55 @@ export function DashboardEditBar({
           because it discards an arrangement rather than an edit. Offered only
           when there IS one: a reader already on the default has nothing to
           reset, and a button that does nothing is worse than no button. */}
-      {/* 🔴 A RADIO GROUP, not a select. Three or four short, mutually
-          exclusive choices are what radios are for: every option is visible
-          without opening anything, the arrow keys move between them, and the
-          current one is announced. A select hides the alternatives behind a
-          click and reads its own value rather than the set.
+      {/* 🔴 The REAL radio group, not buttons wearing `role="radio"`.
+          ARIA roles announce a widget; they do not implement one. Custom
+          buttons with those roles leave every choice a separate Tab stop and
+          the arrow keys inert, so a keyboard reader meets something that
+          claims to be a radio group and does not behave like one -- which is
+          worse than a plain set of buttons, because the announcement sets an
+          expectation the control then breaks.
 
-          Labelled by a real element rather than an `aria-label` on the group,
-          so the name is visible to everyone rather than only to a screen
-          reader deciding what this cluster of numbers is for. */}
-      <div
-        role="radiogroup"
-        aria-labelledby="dashboard-columns-label"
-        className="mr-auto flex items-center gap-1"
-        data-testid="dashboard-column-picker"
-      >
+          Radix supplies roving focus, arrow-key selection and the checked
+          state; this only has to style it and say what it is for. The label is
+          a visible element rather than an `aria-label`, so the name of the
+          control is available to everyone rather than only to a screen reader
+          deciding what a cluster of digits means. */}
+      <div className="mr-auto flex items-center gap-2">
         <span
           id="dashboard-columns-label"
-          className="mr-1 text-xs text-muted-foreground"
+          className="text-xs text-muted-foreground"
         >
           Columns
         </span>
-        {columnChoices.map(choice => (
-          <Button
-            key={choice}
-            type="button"
-            role="radio"
-            aria-checked={choice === columnCount}
-            variant={choice === columnCount ? "secondary" : "ghost"}
-            size="sm"
-            disabled={isSaving}
-            onClick={() => onColumnCount(choice)}
-            // The count is in the label because the digit alone does not say
-            // what it counts, and a reader arriving on it by keyboard has no
-            // surrounding context to read.
-            aria-label={`${choice} columns`}
-            data-testid={`dashboard-column-choice-${choice}`}
-          >
-            {choice}
-          </Button>
-        ))}
+        <RadioGroup
+          aria-labelledby="dashboard-columns-label"
+          value={String(columnCount)}
+          onValueChange={value => onColumnCount(Number(value))}
+          disabled={isSaving}
+          className="flex items-center gap-1"
+          data-testid="dashboard-column-picker"
+        >
+          {columnChoices.map(choice => (
+            <label
+              key={choice}
+              // The whole chip is the target, so the hit area matches what a
+              // reader sees rather than a small circle beside it.
+              className={cn(
+                "flex cursor-pointer items-center gap-1.5 rounded-md border px-2 py-1 text-xs",
+                choice === columnCount
+                  ? "border-primary bg-primary/10 text-foreground"
+                  : "border-border text-muted-foreground hover:bg-muted"
+              )}
+              data-testid={`dashboard-column-choice-${choice}`}
+            >
+              <RadioGroupItem
+                value={String(choice)}
+                aria-label={`${choice} columns`}
+              />
+              {choice}
+            </label>
+          ))}
+        </RadioGroup>
       </div>
 
       {canReset ? (

--- a/packages/admin/src/components/features/widgets/edit/DashboardEditChrome.tsx
+++ b/packages/admin/src/components/features/widgets/edit/DashboardEditChrome.tsx
@@ -12,6 +12,8 @@
  * @module components/features/widgets/edit/DashboardEditChrome
  */
 
+import { COLUMN_COUNTS } from "nextly/config";
+
 import { DashboardEditBar } from "./DashboardEditBar";
 import type { LayoutEditor } from "./useLayoutEditor";
 
@@ -26,6 +28,8 @@ export interface DashboardEditChromeProps {
   hasArrangement: boolean;
   /** Whether this reader has an arrangement of their own to reset. */
   canReset: boolean;
+  columnCount: number;
+  onColumnCount: (columnCount: number) => void;
 }
 
 export function DashboardEditChrome({
@@ -33,6 +37,8 @@ export function DashboardEditChrome({
   writeError,
   hasArrangement,
   canReset,
+  columnCount,
+  onColumnCount,
 }: DashboardEditChromeProps) {
   return (
     <>
@@ -42,6 +48,9 @@ export function DashboardEditChrome({
           hasUnsavedChanges={editor.hasUnsavedChanges}
           isSaving={editor.isSaving}
           canReset={canReset}
+          columnCount={columnCount}
+          columnChoices={COLUMN_COUNTS}
+          onColumnCount={onColumnCount}
           onBegin={editor.begin}
           onSave={editor.save}
           onCancel={editor.cancel}

--- a/packages/admin/src/components/features/widgets/edit/WidgetColumn.tsx
+++ b/packages/admin/src/components/features/widgets/edit/WidgetColumn.tsx
@@ -57,9 +57,11 @@ export function WidgetColumn({
   // anything, every drop in a populated column resolves against a card and the
   // vertical position matches the gesture.
   //
-  // The `data` is what makes the kind unambiguous. Columns and cards share one
-  // id space in dnd-kit, and a placement may legitimately be named like a
-  // column, so any decision that reads the id string has to guess.
+  // The id is NUMERIC, which is what keeps it disjoint: dnd-kit keys its
+  // registry by id alone, so a string shared with a placement would make one
+  // registration replace the other before any metadata could be read. The
+  // `data` then says which column this is, without anything having to
+  // interpret the id.
   const { setNodeRef, isOver } = useDroppable({
     id: columnDropId(column),
     disabled: items.length > 0,
@@ -78,7 +80,17 @@ export function WidgetColumn({
           // then just absent space rather than a target.
           isEditing && "min-h-24 rounded-lg border border-dashed p-2",
           isEditing && isOver && "border-primary bg-primary/5",
-          isEditing && !isOver && "border-border/60"
+          // 🔴 The border token at FULL strength, never an alpha-faded one.
+          // This outline says where a card may be dropped, so it carries
+          // information rather than decorating, and non-text contrast has to
+          // reach 3:1 — a sixty-percent alpha measures 1.13:1 on the page
+          // surface and the contrast suite refuses it.
+          //
+          // The faded variant is described here rather than written out: that
+          // suite and Tailwind's scanner both read this file as TEXT, so
+          // spelling the class in prose registers it as a usage and fails the
+          // check the comment exists to explain.
+          isEditing && !isOver && "border-border"
         )}
         data-testid={`widget-column-${column}`}
       >

--- a/packages/admin/src/components/features/widgets/edit/WidgetColumn.tsx
+++ b/packages/admin/src/components/features/widgets/edit/WidgetColumn.tsx
@@ -1,0 +1,73 @@
+"use client";
+/**
+ * One column of the dashboard, and the drop target it has to be.
+ *
+ * ## Why a column is its own sortable context
+ *
+ * 🔴 A card's width no longer depends on its neighbours. On the wrapped grid
+ * this replaced, cards took uneven fractions of twelve, so dragging one past a
+ * wider one reflowed the row and the sorting strategy — which predicts
+ * positions from measured rectangles — mispredicted, and the cards visibly
+ * resized mid-gesture. dnd-kit's own tracker describes that as variable sized
+ * sortables being stretched when dragged.
+ *
+ * A column is a single list of equal-width items, which is the case
+ * `verticalListSortingStrategy` is built for, and it supports items of varying
+ * HEIGHT — the one dimension a dashboard card genuinely varies in.
+ *
+ * ## Why the column is droppable as well as its cards
+ *
+ * An empty column holds no card to aim at. Without a drop target of its own it
+ * is reachable only until its last card leaves, and never again — a reader
+ * could empty column three and have no way to put anything back.
+ *
+ * @module components/features/widgets/edit/WidgetColumn
+ */
+import { useDroppable } from "@dnd-kit/core";
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import type { ReactNode } from "react";
+
+import { cn } from "@admin/lib/utils";
+
+import { columnDropId } from "../layout-editor";
+
+export interface WidgetColumnProps {
+  column: number;
+  /** The placement ids in this column, in the order they are drawn. */
+  items: string[];
+  isEditing: boolean;
+  children: ReactNode;
+}
+
+export function WidgetColumn({
+  column,
+  items,
+  isEditing,
+  children,
+}: WidgetColumnProps) {
+  const { setNodeRef, isOver } = useDroppable({ id: columnDropId(column) });
+
+  return (
+    <SortableContext items={items} strategy={verticalListSortingStrategy}>
+      <div
+        ref={setNodeRef}
+        className={cn(
+          "flex min-w-0 flex-col gap-6",
+          // A column with nothing in it still has to be AIMED AT, so while
+          // editing it keeps a minimum height and shows where a card would
+          // land. Outside editing it collapses, because an empty column is
+          // then just absent space rather than a target.
+          isEditing && "min-h-24 rounded-lg border border-dashed p-2",
+          isEditing && isOver && "border-primary bg-primary/5",
+          isEditing && !isOver && "border-border/60"
+        )}
+        data-testid={`widget-column-${column}`}
+      >
+        {children}
+      </div>
+    </SortableContext>
+  );
+}

--- a/packages/admin/src/components/features/widgets/edit/WidgetColumn.tsx
+++ b/packages/admin/src/components/features/widgets/edit/WidgetColumn.tsx
@@ -15,11 +15,23 @@
  * `verticalListSortingStrategy` is built for, and it supports items of varying
  * HEIGHT — the one dimension a dashboard card genuinely varies in.
  *
- * ## Why the column is droppable as well as its cards
+ * ## Why the droppable sits BELOW the cards rather than around them
  *
- * An empty column holds no card to aim at. Without a drop target of its own it
- * is reachable only until its last card leaves, and never again — a reader
- * could empty column three and have no way to put anything back.
+ * A column's own empty space belongs to no card, and collision detection
+ * resolves a release there to whichever card is geometrically nearest — which,
+ * when the neighbouring column is longer, is a card in a DIFFERENT column. So a
+ * release under a short column's last card moved the card sideways instead of
+ * appending to the column it was released over.
+ *
+ * Wrapping the whole column in a droppable fixes that and creates the opposite
+ * fault: the container's rectangle covers the cards too, so a release aimed at
+ * a position between two of them can resolve to the container instead, and the
+ * position the reader aimed at is lost.
+ *
+ * A zone occupying only the space the cards do not is both. It cannot compete
+ * with a card, because it never overlaps one; and it covers exactly the region
+ * whose nearest card is in the wrong column. It grows to fill whatever is left,
+ * so a short column's target is as large as its empty space.
  *
  * @module components/features/widgets/edit/WidgetColumn
  */
@@ -36,6 +48,8 @@ import { columnDropId, type ColumnDropData } from "../layout-editor";
 
 export interface WidgetColumnProps {
   column: number;
+  /** How many columns the dashboard has, so this one can say which it is. */
+  columnCount: number;
   /** The placement ids in this column, in the order they are drawn. */
   items: string[];
   isEditing: boolean;
@@ -44,57 +58,64 @@ export interface WidgetColumnProps {
 
 export function WidgetColumn({
   column,
+  columnCount,
   items,
   isEditing,
   children,
 }: WidgetColumnProps) {
-  // 🔴 A target only while EMPTY, and the kind travels in `data`.
-  //
-  // Empty is the case a column droppable exists for: a column with cards has
-  // cards to aim at, and leaving the container active there meant a release in
-  // its padding resolved to the column rather than to a position, so a card
-  // dropped at the bottom could appear at the top. Disabled once it holds
-  // anything, every drop in a populated column resolves against a card and the
-  // vertical position matches the gesture.
-  //
-  // The id is NUMERIC, which is what keeps it disjoint: dnd-kit keys its
+  // 🔴 The id is NUMERIC, which is what keeps it disjoint: dnd-kit keys its
   // registry by id alone, so a string shared with a placement would make one
   // registration replace the other before any metadata could be read. The
   // `data` then says which column this is, without anything having to
   // interpret the id.
+  //
+  // Registered only while editing. Outside it there is no zone to attach the
+  // ref to, and a droppable with no element has no rectangle to collide with.
   const { setNodeRef, isOver } = useDroppable({
     id: columnDropId(column),
-    disabled: items.length > 0,
+    disabled: !isEditing,
     data: { widgetColumn: column } satisfies ColumnDropData,
   });
 
   return (
     <SortableContext items={items} strategy={verticalListSortingStrategy}>
       <div
-        ref={setNodeRef}
-        className={cn(
-          "flex min-w-0 flex-col gap-6",
-          // A column with nothing in it still has to be AIMED AT, so while
-          // editing it keeps a minimum height and shows where a card would
-          // land. Outside editing it collapses, because an empty column is
-          // then just absent space rather than a target.
-          isEditing && "min-h-24 rounded-lg border border-dashed p-2",
-          isEditing && isOver && "border-primary bg-primary/5",
-          // 🔴 The border token at FULL strength, never an alpha-faded one.
-          // This outline says where a card may be dropped, so it carries
-          // information rather than decorating, and non-text contrast has to
-          // reach 3:1 — a sixty-percent alpha measures 1.13:1 on the page
-          // surface and the contrast suite refuses it.
-          //
-          // The faded variant is described here rather than written out: that
-          // suite and Tailwind's scanner both read this file as TEXT, so
-          // spelling the class in prose registers it as a usage and fails the
-          // check the comment exists to explain.
-          isEditing && !isOver && "border-border"
-        )}
+        // Named as a group so a reader moving through the dashboard is told
+        // when they cross a column boundary. The cards say which column they
+        // are in visually; without this the same fact is available to a screen
+        // reader only from the move announcement, which a reader browsing
+        // rather than rearranging never hears.
+        role="group"
+        aria-label={`Column ${column + 1} of ${columnCount}`}
+        className="flex min-w-0 flex-col gap-6"
         data-testid={`widget-column-${column}`}
       >
         {children}
+        {isEditing && (
+          <div
+            ref={setNodeRef}
+            data-testid={`widget-column-drop-${column}`}
+            className={cn(
+              // Grows into whatever the cards leave, so the target is the whole
+              // of this column's empty space rather than a strip inside it. The
+              // grid stretches every column to the tallest, so a short column
+              // has space to fill and the tallest keeps its stated minimum.
+              "flex-1 rounded-lg border border-dashed",
+              items.length === 0 ? "min-h-24" : "min-h-12",
+              // 🔴 The border token at FULL strength, never an alpha-faded one.
+              // This outline says where a card may be dropped, so it carries
+              // information rather than decorating, and non-text contrast has
+              // to reach 3:1 — a sixty-percent alpha measures 1.13:1 on the
+              // page surface and the contrast suite refuses it.
+              //
+              // The faded variant is described here rather than written out:
+              // that suite and Tailwind's scanner both read this file as TEXT,
+              // so spelling the class in prose registers it as a usage and
+              // fails the check the comment exists to explain.
+              isOver ? "border-primary bg-primary/5" : "border-border"
+            )}
+          />
+        )}
       </div>
     </SortableContext>
   );

--- a/packages/admin/src/components/features/widgets/edit/WidgetColumn.tsx
+++ b/packages/admin/src/components/features/widgets/edit/WidgetColumn.tsx
@@ -32,7 +32,7 @@ import type { ReactNode } from "react";
 
 import { cn } from "@admin/lib/utils";
 
-import { columnDropId } from "../layout-editor";
+import { columnDropId, type ColumnDropData } from "../layout-editor";
 
 export interface WidgetColumnProps {
   column: number;
@@ -48,7 +48,23 @@ export function WidgetColumn({
   isEditing,
   children,
 }: WidgetColumnProps) {
-  const { setNodeRef, isOver } = useDroppable({ id: columnDropId(column) });
+  // 🔴 A target only while EMPTY, and the kind travels in `data`.
+  //
+  // Empty is the case a column droppable exists for: a column with cards has
+  // cards to aim at, and leaving the container active there meant a release in
+  // its padding resolved to the column rather than to a position, so a card
+  // dropped at the bottom could appear at the top. Disabled once it holds
+  // anything, every drop in a populated column resolves against a card and the
+  // vertical position matches the gesture.
+  //
+  // The `data` is what makes the kind unambiguous. Columns and cards share one
+  // id space in dnd-kit, and a placement may legitimately be named like a
+  // column, so any decision that reads the id string has to guess.
+  const { setNodeRef, isOver } = useDroppable({
+    id: columnDropId(column),
+    disabled: items.length > 0,
+    data: { widgetColumn: column } satisfies ColumnDropData,
+  });
 
   return (
     <SortableContext items={items} strategy={verticalListSortingStrategy}>

--- a/packages/admin/src/components/features/widgets/edit/WidgetEditControls.tsx
+++ b/packages/admin/src/components/features/widgets/edit/WidgetEditControls.tsx
@@ -41,8 +41,15 @@ export interface WidgetEditControlsProps {
   hidden: boolean;
   canMoveUp: boolean;
   canMoveDown: boolean;
+  /** Which column this card is in, 1-based, for what the labels announce. */
+  column: number;
+  columnCount: number;
+  canMoveLeft: boolean;
+  canMoveRight: boolean;
   onMoveUp: () => void;
   onMoveDown: () => void;
+  onMoveLeft: () => void;
+  onMoveRight: () => void;
   onToggleHidden: () => void;
   onRemove: () => void;
 }
@@ -54,8 +61,14 @@ export function WidgetEditControls({
   hidden,
   canMoveUp,
   canMoveDown,
+  column,
+  columnCount,
+  canMoveLeft,
+  canMoveRight,
   onMoveUp,
   onMoveDown,
+  onMoveLeft,
+  onMoveRight,
   onToggleHidden,
   onRemove,
 }: WidgetEditControlsProps) {
@@ -102,6 +115,47 @@ export function WidgetEditControls({
       >
         <Icons.ChevronDown aria-hidden className="size-4" />
       </Button>
+
+      {/* 🔴 Crossing columns is reachable by CLICK, not only by dragging.
+          Dragging a card into another column is new functionality, and SC
+          2.5.7 asks for a single-pointer route to anything a drag achieves --
+          so these are the conformance rather than a convenience, exactly as
+          Move up / Move down are for ordering.
+
+          Rendered only where there is more than one column, because a control
+          that can never be enabled is noise in a toolbar a reader tabs
+          through. */}
+      {columnCount > 1 ? (
+        <>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-7"
+            onClick={onMoveLeft}
+            disabled={!canMoveLeft}
+            // The column travels in the label for the same reason the position
+            // does: the grid does not say which column a card landed in, and a
+            // reader who just moved one needs to know.
+            aria-label={`Move ${title} to the previous column, currently column ${column} of ${columnCount}`}
+            data-testid="widget-move-left"
+          >
+            <Icons.ChevronLeft aria-hidden className="size-4" />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-7"
+            onClick={onMoveRight}
+            disabled={!canMoveRight}
+            aria-label={`Move ${title} to the next column, currently column ${column} of ${columnCount}`}
+            data-testid="widget-move-right"
+          >
+            <Icons.ChevronRight aria-hidden className="size-4" />
+          </Button>
+        </>
+      ) : null}
 
       <Button
         type="button"

--- a/packages/admin/src/components/features/widgets/edit/__tests__/WidgetGrid.edit.test.tsx
+++ b/packages/admin/src/components/features/widgets/edit/__tests__/WidgetGrid.edit.test.tsx
@@ -1052,6 +1052,78 @@ describe("the per-card controls act on the column a reader sees", () => {
     );
   });
 
+  it("gives a POPULATED column a drop zone of its own", async () => {
+    // 🔴 A column's empty space belongs to no card, so a release there resolves
+    // to whichever card is geometrically nearest — and when the neighbouring
+    // column is longer that is a card in a DIFFERENT column, so releasing under
+    // a short column's last card moved it sideways. A zone of this column's own
+    // is what makes that space reachable.
+    layoutResponse = layout([
+      { id: "p1", widgetId: "core/a", order: 0, column: 0 },
+      { id: "p2", widgetId: "core/b", order: 10, column: 0 },
+      { id: "p3", widgetId: "core/c", order: 20, column: 1 },
+    ]);
+    renderGrid();
+    await beginEditing();
+
+    // Column 1 holds a card, so it is the case that had no target at all.
+    expect(
+      screen
+        .getByTestId("widget-column-1")
+        .querySelectorAll("[data-testid^='widget-cell-']")
+    ).toHaveLength(1);
+    expect(screen.getByTestId("widget-column-drop-1")).toBeInTheDocument();
+  });
+
+  it("puts that zone BELOW the cards rather than around them", async () => {
+    // 🔴 The property that stops it competing with a position. Wrapping the
+    // column would cover the cards too, so a release aimed between two of them
+    // could resolve to the container and lose the position the reader aimed at.
+    // Occupying only what the cards leave, it cannot be nearer than a card the
+    // pointer is actually over.
+    renderGrid();
+    await beginEditing();
+
+    const column = screen.getByTestId("widget-column-0");
+    const zone = screen.getByTestId("widget-column-drop-0");
+    expect(column.lastElementChild).toBe(zone);
+    // The control: the zone holds no card, which is what "below rather than
+    // around" means and what a wrapping droppable would fail.
+    expect(zone.querySelector("[data-testid^='widget-cell-']")).toBeNull();
+    expect(
+      column.querySelectorAll("[data-testid^='widget-cell-']").length
+    ).toBeGreaterThan(0);
+  });
+
+  it("shows no drop zone outside editing", async () => {
+    // Outside editing an empty column is absent space rather than a target, and
+    // a dashed rectangle under every column would be chrome for a gesture that
+    // is not on offer.
+    renderGrid();
+    await waitFor(() =>
+      expect(screen.getAllByTestId("widget-card-body").length).toBeGreaterThan(
+        0
+      )
+    );
+    expect(screen.queryByTestId("widget-column-drop-0")).toBeNull();
+  });
+
+  it("names each column, so crossing one is audible", async () => {
+    // The move announcement says which column a card landed in, but a reader
+    // BROWSING rather than rearranging never triggers it. The group name is
+    // where that same fact is available to them.
+    renderGrid();
+    await waitFor(() =>
+      expect(screen.getAllByTestId("widget-card-body").length).toBeGreaterThan(
+        0
+      )
+    );
+    expect(screen.getByTestId("widget-column-1")).toHaveAttribute(
+      "aria-label",
+      "Column 2 of 3"
+    );
+  });
+
   it("offers Left from the column a card is DRAWN in, not its stored one", async () => {
     // 🔴 A card stored past the count is folded into the last column for
     // drawing. Computing from the stored value offered a Left that resolved

--- a/packages/admin/src/components/features/widgets/edit/__tests__/WidgetGrid.edit.test.tsx
+++ b/packages/admin/src/components/features/widgets/edit/__tests__/WidgetGrid.edit.test.tsx
@@ -868,3 +868,63 @@ describe("the dashboard draws columns", () => {
     ).not.toBeNull();
   });
 });
+
+describe("crossing columns without dragging", () => {
+  it("offers a CLICKABLE control for every column move a drag can make", async () => {
+    // 🔴 WCAG 2.2 SC 2.5.7: anything a drag achieves needs a single-pointer
+    // route, and the Understanding document states that a keyboard equivalent
+    // does not satisfy it on its own. Dragging a card into another column is
+    // new functionality, so these buttons are the conformance — without them
+    // the column layout regresses what this toolbar already established.
+    layoutResponse = layout(
+      [{ id: "p1", widgetId: "core/a", column: 0, order: 0 }],
+      { columnCount: 3 }
+    );
+    renderGrid();
+    await waitFor(() => expect(screen.queryByText("Widget core/b")).toBeNull());
+    await beginEditing();
+    expect(screen.getByTestId("widget-move-right")).toBeEnabled();
+    // Left is refused in the first column: a control that looks available and
+    // does nothing is worse than one that says it cannot act.
+    expect(screen.getByTestId("widget-move-left")).toBeDisabled();
+  });
+
+  it("actually moves the card, rather than only enabling a button", async () => {
+    // 🔴 The control the assertion above needs. Rendering an enabled button
+    // satisfies "a single-pointer route exists" while clicking it does
+    // nothing — which is the shape of a conformance claim that is not true.
+    layoutResponse = layout(
+      [{ id: "p1", widgetId: "core/a", column: 0, order: 0 }],
+      { columnCount: 3 }
+    );
+    renderGrid();
+    await waitFor(() => expect(screen.queryByText("Widget core/b")).toBeNull());
+    const user = await beginEditing();
+    expect(
+      screen
+        .getByTestId("widget-column-0")
+        .querySelector("[data-testid^='widget-cell-']")
+    ).not.toBeNull();
+    await user.click(screen.getByTestId("widget-move-right"));
+    await waitFor(() =>
+      expect(
+        screen
+          .getByTestId("widget-column-1")
+          .querySelector("[data-testid^='widget-cell-']")
+      ).not.toBeNull()
+    );
+  });
+
+  it("hides the sideways controls when there is only ONE column", async () => {
+    // A control that can never be enabled is noise in a toolbar a reader tabs
+    // through card by card.
+    layoutResponse = layout(
+      [{ id: "p1", widgetId: "core/a", column: 0, order: 0 }],
+      { columnCount: 1 }
+    );
+    renderGrid();
+    await waitFor(() => expect(screen.queryByText("Widget core/b")).toBeNull());
+    await beginEditing();
+    expect(screen.queryByTestId("widget-move-right")).toBeNull();
+  });
+});

--- a/packages/admin/src/components/features/widgets/edit/__tests__/WidgetGrid.edit.test.tsx
+++ b/packages/admin/src/components/features/widgets/edit/__tests__/WidgetGrid.edit.test.tsx
@@ -232,6 +232,35 @@ describe("moving a card without a drag", () => {
     );
   });
 
+  it("counts only the cards the grid DRAWS", async () => {
+    // 🔴 A placement whose declaration this admin cannot resolve is skipped
+    // from the render and still sits in the arrangement, so a position read
+    // from the stored list describes a grid nobody is looking at. Here the
+    // reader sees two cards and the unrendered one sits between them: counted
+    // from storage, moving the first card down announces "position 3 of 3"
+    // while the screen plainly shows it second of two.
+    mockBranding = branding(["core/a", "core/b"]);
+    layoutResponse = layout([
+      { id: "p1", widgetId: "core/a", order: 0, column: 0 },
+      { id: "pX", widgetId: "plugin/absent", order: 10, column: 0 },
+      { id: "p2", widgetId: "core/b", order: 20, column: 0 },
+    ]);
+
+    renderGrid();
+    const user = await beginEditing();
+
+    // The control for the fixture itself: the unresolvable placement really is
+    // absent from the grid, so the case being tested is the case being set up.
+    expect(screen.queryByTestId("widget-cell-plugin/absent")).toBeNull();
+    expect(screen.getAllByTestId("widget-move-down")).toHaveLength(2);
+
+    await user.click(screen.getAllByTestId("widget-move-down")[0]);
+
+    expect(screen.getByTestId("widget-grid-live").textContent).toMatch(
+      /Widget core\/a moved to column 1 of 3, position 2 of 2/
+    );
+  });
+
   it("names the position in each button, so a reader knows where they are", async () => {
     renderGrid();
     await beginEditing();

--- a/packages/admin/src/components/features/widgets/edit/__tests__/WidgetGrid.edit.test.tsx
+++ b/packages/admin/src/components/features/widgets/edit/__tests__/WidgetGrid.edit.test.tsx
@@ -928,3 +928,58 @@ describe("crossing columns without dragging", () => {
     expect(screen.queryByTestId("widget-move-right")).toBeNull();
   });
 });
+
+describe("choosing how many columns", () => {
+  it("REDRAWS the dashboard at the count the reader picked", async () => {
+    // 🔴 The whole point of the control. A picker that stores a preference the
+    // grid does not read is a setting that appears to work and changes
+    // nothing — so this asserts the new column exists, not that a button
+    // became selected.
+    layoutResponse = layout(
+      [{ id: "p1", widgetId: "core/a", column: 0, order: 0 }],
+      { columnCount: 2 }
+    );
+    renderGrid();
+    await waitFor(() => expect(screen.queryByText("Widget core/b")).toBeNull());
+    const user = await beginEditing();
+    expect(screen.queryByTestId("widget-column-3")).toBeNull();
+    await user.click(screen.getByTestId("dashboard-column-choice-4"));
+    await waitFor(() =>
+      expect(screen.getByTestId("widget-column-3")).toBeInTheDocument()
+    );
+  });
+
+  it("lets the new count be SAVED", async () => {
+    // 🔴 Changing only the count touches no placement, so an unsaved-changes
+    // check that compares placements alone leaves Save disabled and the
+    // reader cannot keep the layout they are looking at.
+    layoutResponse = layout(
+      [{ id: "p1", widgetId: "core/a", column: 0, order: 0 }],
+      { columnCount: 2 }
+    );
+    renderGrid();
+    await waitFor(() => expect(screen.queryByText("Widget core/b")).toBeNull());
+    const user = await beginEditing();
+    expect(screen.getByTestId("dashboard-edit-save")).toBeDisabled();
+    await user.click(screen.getByTestId("dashboard-column-choice-3"));
+    await waitFor(() =>
+      expect(screen.getByTestId("dashboard-edit-save")).toBeEnabled()
+    );
+  });
+
+  it("SENDS the count with the arrangement", async () => {
+    // A placement's `column` only means anything against a count, so saving
+    // one without the other leaves a row whose cards name columns it lacks.
+    layoutResponse = layout(
+      [{ id: "p1", widgetId: "core/a", column: 0, order: 0 }],
+      { columnCount: 2 }
+    );
+    renderGrid();
+    await waitFor(() => expect(screen.queryByText("Widget core/b")).toBeNull());
+    const user = await beginEditing();
+    await user.click(screen.getByTestId("dashboard-column-choice-4"));
+    await user.click(screen.getByTestId("dashboard-edit-save"));
+    await waitFor(() => expect(api.put).toHaveBeenCalled());
+    expect(api.put.mock.calls[0][1]).toMatchObject({ columnCount: 4 });
+  });
+});

--- a/packages/admin/src/components/features/widgets/edit/__tests__/WidgetGrid.edit.test.tsx
+++ b/packages/admin/src/components/features/widgets/edit/__tests__/WidgetGrid.edit.test.tsx
@@ -1040,3 +1040,33 @@ describe("the per-card controls act on the column a reader sees", () => {
     );
   });
 });
+
+describe("a control is offered only where it can act", () => {
+  it("DISABLES Up on the first card of every column, not just the first", async () => {
+    // 🔴 Derived from the global sequence, the first card of columns 2 and 3
+    // had an enabled Up whose neighbour does not exist in its own column — the
+    // click resolved against `rowsInColumn` and found nothing, so the control
+    // was enabled and inert. That is the SC 2.5.7 failure again, not a
+    // cosmetic one.
+    layoutResponse = layout(
+      [
+        { id: "p1", widgetId: "core/a", column: 0, order: 0 },
+        { id: "p2", widgetId: "core/b", column: 1, order: 10 },
+        { id: "p3", widgetId: "core/c", column: 2, order: 20 },
+      ],
+      { columnCount: 3 }
+    );
+    renderGrid();
+    await waitFor(() =>
+      expect(screen.getAllByTestId("widget-card-body").length).toBe(3)
+    );
+    await beginEditing();
+    // Every card is alone in its column, so no card may move up or down.
+    for (const up of screen.getAllByTestId("widget-move-up")) {
+      expect(up).toBeDisabled();
+    }
+    for (const down of screen.getAllByTestId("widget-move-down")) {
+      expect(down).toBeDisabled();
+    }
+  });
+});

--- a/packages/admin/src/components/features/widgets/edit/__tests__/WidgetGrid.edit.test.tsx
+++ b/packages/admin/src/components/features/widgets/edit/__tests__/WidgetGrid.edit.test.tsx
@@ -66,6 +66,7 @@ function layout(
     order: number;
     hidden?: boolean;
     size?: string;
+    column?: number;
   }>,
   patch: Partial<DashboardLayoutResponse> = {}
 ): DashboardLayoutResponse {
@@ -801,5 +802,69 @@ describe("reset", () => {
 
     await waitFor(() => expect(api.delete).toHaveBeenCalledTimes(1));
     expect(api.put).not.toHaveBeenCalled();
+  });
+});
+
+describe("the dashboard draws columns", () => {
+  it("renders one column per the count the SERVER reported", async () => {
+    // 🔴 The count comes from the arrangement, not from a client default. A
+    // grid that picked its own would draw a dashboard the reader never made
+    // and then save that back on their next edit.
+    layoutResponse = layout(
+      [{ id: "p1", widgetId: "core/a", column: 0, order: 0 }],
+      { columnCount: 4 }
+    );
+    renderGrid();
+    await waitFor(() =>
+      expect(screen.getByTestId("widget-column-3")).toBeInTheDocument()
+    );
+  });
+
+  it("draws an EMPTY column, so a card can be moved back into it", async () => {
+    // 🔴 A column is a drop target only while it is rendered. Collapsing the
+    // empty ones would let a reader move the last card out of a column and
+    // never move one back.
+    layoutResponse = layout(
+      [{ id: "p1", widgetId: "core/a", column: 0, order: 0 }],
+      { columnCount: 3 }
+    );
+    renderGrid();
+    // 🔴 Waited on the ARRANGEMENT, not on a column. Every column exists from
+    // the first paint, so waiting for one is satisfied before the stored
+    // layout has arrived — and the default arrangement drawn in the meantime
+    // has a card in every column, which is what a weaker wait asserts against.
+    await waitFor(() => expect(screen.queryByText("Widget core/b")).toBeNull());
+    // "Holds no card" rather than an empty DOM node: the column legitimately
+    // carries its own drop-target chrome while editing, and a node-level
+    // emptiness check would fail on that rather than on a card.
+    expect(
+      screen
+        .getByTestId("widget-column-2")
+        .querySelector("[data-testid^='widget-cell-']")
+    ).toBeNull();
+  });
+
+  it("KEEPS a card whose column is past the count", async () => {
+    // 🔴 The property that decides whether narrowing the dashboard destroys
+    // work: a card stored in column 3 must still be drawn when the reader has
+    // asked for two columns.
+    layoutResponse = layout(
+      [{ id: "p1", widgetId: "core/a", column: 3, order: 0 }],
+      { columnCount: 2 }
+    );
+    renderGrid();
+    // 🔴 Wait for the ARRANGEMENT first. Until the stored layout arrives the
+    // grid draws the declared defaults, which include core/a in a column that
+    // exists — so asserting core/a directly passes whether or not the
+    // out-of-range card was kept, and the test certifies nothing. core/b is
+    // absent only once the single-placement arrangement is the one on screen.
+    await waitFor(() => expect(screen.queryByText("Widget core/b")).toBeNull());
+    expect(screen.getByText("Widget core/a")).toBeInTheDocument();
+    // And it is drawn in the LAST column that exists, not left nowhere.
+    expect(
+      screen
+        .getByTestId("widget-column-1")
+        .querySelector("[data-testid^='widget-cell-']")
+    ).not.toBeNull();
   });
 });

--- a/packages/admin/src/components/features/widgets/edit/__tests__/WidgetGrid.edit.test.tsx
+++ b/packages/admin/src/components/features/widgets/edit/__tests__/WidgetGrid.edit.test.tsx
@@ -221,8 +221,14 @@ describe("moving a card without a drag", () => {
     await user.click(screen.getAllByTestId("widget-move-down")[0]);
 
     // Through the grid's ONE region -- a move is not worth a second announcer.
+    //
+    // 🔴 The COLUMN is named as well as the position, and the position counts
+    // that column rather than the whole dashboard. A card dropped into an
+    // otherwise empty column was announced as "position 3 of 3" -- a place it
+    // does not hold, in a list whose length is not its column's -- because a
+    // column coordinate was being passed to a position formatter.
     expect(screen.getByTestId("widget-grid-live").textContent).toMatch(
-      /Widget core\/a moved to position 2 of 3/
+      /Widget core\/a moved to column 1 of 3, position 2 of 3/
     );
   });
 
@@ -1068,5 +1074,34 @@ describe("a control is offered only where it can act", () => {
     for (const down of screen.getAllByTestId("widget-move-down")) {
       expect(down).toBeDisabled();
     }
+  });
+});
+
+describe("what a move announces", () => {
+  it("counts the DESTINATION column, not the whole dashboard", async () => {
+    // 🔴 Read from the global sequence, a card dropped into an otherwise empty
+    // column announced a position and a total that describe nothing the reader
+    // can see — cards in other columns precede it, so the numbers came from a
+    // list it is not in.
+    layoutResponse = layout(
+      [
+        { id: "p1", widgetId: "core/a", column: 0, order: 0 },
+        { id: "p2", widgetId: "core/b", column: 0, order: 10 },
+        { id: "p3", widgetId: "core/c", column: 0, order: 20 },
+      ],
+      { columnCount: 3 }
+    );
+    renderGrid();
+    await waitFor(() =>
+      expect(screen.getAllByTestId("widget-card-body").length).toBe(3)
+    );
+    const user = await beginEditing();
+    // Move the first card into column 2, which holds nothing.
+    await user.click(screen.getAllByTestId("widget-move-right")[0]);
+    await waitFor(() =>
+      expect(screen.getByTestId("widget-grid-live").textContent).toMatch(
+        /column 2 of 3, position 1 of 1/
+      )
+    );
   });
 });

--- a/packages/admin/src/components/features/widgets/edit/__tests__/WidgetGrid.edit.test.tsx
+++ b/packages/admin/src/components/features/widgets/edit/__tests__/WidgetGrid.edit.test.tsx
@@ -983,3 +983,60 @@ describe("choosing how many columns", () => {
     expect(api.put.mock.calls[0][1]).toMatchObject({ columnCount: 4 });
   });
 });
+
+describe("the per-card controls act on the column a reader sees", () => {
+  it("moves a card DOWN past its own column's neighbour, not the global one", async () => {
+    // 🔴 The arrangement is interleaved across columns, so the card after this
+    // one in the whole sequence usually sits in a different column. Resolved
+    // globally, Move down swapped two entries and the reader saw nothing move
+    // — an enabled control that is not the pointer equivalent of dragging.
+    layoutResponse = layout(
+      [
+        { id: "p1", widgetId: "core/a", column: 0, order: 0 },
+        { id: "p2", widgetId: "core/b", column: 1, order: 10 },
+        { id: "p3", widgetId: "core/c", column: 0, order: 20 },
+      ],
+      { columnCount: 2 }
+    );
+    renderGrid();
+    await waitFor(() =>
+      expect(screen.getAllByTestId("widget-card-body").length).toBe(3)
+    );
+    const user = await beginEditing();
+    const columnZero = () =>
+      Array.from(
+        screen
+          .getByTestId("widget-column-0")
+          .querySelectorAll("[data-testid^='widget-cell-']")
+      ).map(node => node.getAttribute("data-testid"));
+    expect(columnZero()).toEqual(["widget-cell-core/a", "widget-cell-core/c"]);
+    const [firstDown] = screen.getAllByTestId("widget-move-down");
+    await user.click(firstDown);
+    await waitFor(() =>
+      expect(columnZero()).toEqual(["widget-cell-core/c", "widget-cell-core/a"])
+    );
+  });
+
+  it("offers Left from the column a card is DRAWN in, not its stored one", async () => {
+    // 🔴 A card stored past the count is folded into the last column for
+    // drawing. Computing from the stored value offered a Left that resolved
+    // outside the dashboard and a label naming a column the reader cannot see.
+    layoutResponse = layout(
+      [{ id: "p1", widgetId: "core/a", column: 3, order: 0 }],
+      { columnCount: 2 }
+    );
+    renderGrid();
+    await waitFor(() => expect(screen.queryByText("Widget core/b")).toBeNull());
+    const user = await beginEditing();
+    const left = screen.getByTestId("widget-move-left");
+    expect(left).toBeEnabled();
+    await user.click(left);
+    await waitFor(() =>
+      expect(
+        screen
+          .getByTestId("widget-column-0")
+          .querySelector("[data-testid^='widget-cell-']")
+      ).not.toBeNull()
+    );
+  });
+});

--- a/packages/admin/src/components/features/widgets/edit/useDashboardArrangement.ts
+++ b/packages/admin/src/components/features/widgets/edit/useDashboardArrangement.ts
@@ -22,8 +22,10 @@ import type { DashboardWidget } from "@admin/types/dashboard/widgets";
 import { useSortableFieldArray } from "../../entries/fields/structured/field-array-helpers";
 import {
   columnFromDropData,
+  dropSide,
   placementsByColumn,
   resolveDrop,
+  type DropSide,
   type DropTarget,
 } from "../layout-editor";
 
@@ -68,8 +70,19 @@ export interface DashboardArrangement {
   /** How many columns this reader arranged their dashboard into. */
   columnCount: number;
   editor: LayoutEditor;
-  /** Swap one card with a named neighbour in the same column. */
-  moveWithinColumn: (placementId: string, neighbourId: string) => void;
+  /**
+   * Swap one card with a named neighbour in the same column.
+   *
+   * `side` says whether that neighbour sits above or below, which is the same
+   * answer a drag reads off the pointer. The caller renders the column and
+   * already knows; resolving it here would be a second reading of the
+   * arrangement, free to disagree with the one the reader is looking at.
+   */
+  moveWithinColumn: (
+    placementId: string,
+    neighbourId: string,
+    side: DropSide
+  ) => void;
   /**
    * Move one card into `targetColumn`, named absolutely.
    *
@@ -198,6 +211,12 @@ export function useDashboardArrangement(
     [visible]
   );
 
+  /** The placements the grid actually draws, which is what a position counts. */
+  const renderedIds = useMemo(
+    () => new Set(visible.map(row => row.placementId)),
+    [visible]
+  );
+
   // The drag path and the button path move a card through the SAME function.
   // Two implementations of "where does this land" agree until one is edited,
   // and a grid whose drag and whose buttons disagreed would be impossible to
@@ -229,7 +248,16 @@ export function useDashboardArrangement(
         target,
         columnCount
       );
-      const buckets = placementsByColumn(settled, columnCount);
+      // 🔴 Counted over the cards the grid DRAWS, not over every stored
+      // placement. A placement whose declaration this admin cannot resolve is
+      // skipped from the render and still sits in `editor.placements`, so a
+      // column holding one announced "position 3 of 3" for a card the reader
+      // sees second of two — a position and a total describing a grid nobody
+      // is looking at.
+      const buckets = placementsByColumn(
+        settled.filter(p => renderedIds.has(p.id)),
+        columnCount
+      );
       const column = buckets.findIndex(bucket =>
         bucket.some(p => p.id === placementId)
       );
@@ -243,7 +271,7 @@ export function useDashboardArrangement(
         buckets[column].length
       );
     },
-    [editor.placements, columnCount, announceColumn]
+    [editor.placements, columnCount, announceColumn, renderedIds]
   );
 
   const handleDragEnd = useCallback(
@@ -259,7 +287,18 @@ export function useDashboardArrangement(
       const target: DropTarget | null =
         droppedColumn !== undefined
           ? { kind: "column", column: droppedColumn }
-          : { kind: "card", placementId: String(event.over.id) };
+          : {
+              kind: "card",
+              placementId: String(event.over.id),
+              // Which SIDE of that card the gesture ended on. A populated
+              // column disables its own droppable, so releasing below its last
+              // card resolves to that card and the side is the only thing
+              // saying the reader meant underneath it rather than above.
+              side: dropSide(
+                event.active.rect.current.translated,
+                event.over.rect
+              ),
+            };
       if (target.kind === "card" && target.placementId === activeId) return;
       editor.dropOn(activeId, target);
       // 🔴 A drop onto a COLUMN has no neighbouring card to count from, and
@@ -302,10 +341,18 @@ export function useDashboardArrangement(
    * translation that moved the wrong card.
    */
   const moveWithinColumn = useCallback(
-    (placementId: string, neighbourId: string) => {
+    (placementId: string, neighbourId: string, side: DropSide) => {
       const moved = visible.find(row => row.placementId === placementId);
       if (!moved) return;
-      const target: DropTarget = { kind: "card", placementId: neighbourId };
+      // The caller renders the column, so it knows whether the neighbour it
+      // named sits above or below — which is exactly the side the card lands
+      // on. Deriving it here would answer from the stored arrangement a second
+      // time, and the two readings are what already moved the wrong card.
+      const target: DropTarget = {
+        kind: "card",
+        placementId: neighbourId,
+        side,
+      };
       editor.dropOn(placementId, target);
       announceLanding(moved.widget.title, placementId, target);
     },

--- a/packages/admin/src/components/features/widgets/edit/useDashboardArrangement.ts
+++ b/packages/admin/src/components/features/widgets/edit/useDashboardArrangement.ts
@@ -21,9 +21,9 @@ import type { DashboardWidget } from "@admin/types/dashboard/widgets";
 
 import { useSortableFieldArray } from "../../entries/fields/structured/field-array-helpers";
 import {
-  columnDropId,
-  columnFromDropId,
+  columnFromDropData,
   placementsByColumn,
+  type DropTarget,
 } from "../layout-editor";
 
 import { useLayoutEditor, type LayoutEditor } from "./useLayoutEditor";
@@ -209,25 +209,34 @@ export function useDashboardArrangement(
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
       const activeId = String(event.active.id);
-      const overId = event.over ? String(event.over.id) : null;
-      if (overId === null || overId === activeId) return;
+      if (!event.over) return;
       const moved = visible.find(row => row.placementId === activeId);
       if (!moved) return;
-      editor.dropOn(activeId, overId);
+      // 🔴 Read from the droppable's DATA, not from the shape of its id. Only a
+      // column carries `widgetColumn`, so a card named like a column cannot be
+      // mistaken for one.
+      const droppedColumn = columnFromDropData(event.over.data.current);
+      const target: DropTarget | null =
+        droppedColumn !== undefined
+          ? { kind: "column", column: droppedColumn }
+          : { kind: "card", placementId: String(event.over.id) };
+      if (target.kind === "card" && target.placementId === activeId) return;
+      editor.dropOn(activeId, target);
       // 🔴 A drop onto a COLUMN has no neighbouring card to count from, and
       // `findIndex` answers -1 for it. Announced from that, every empty-column
       // drop claimed the card had gone to the last position in the whole
       // dashboard, whichever column actually received it. The column target is
       // parsed instead, and the announcement names the column.
-      const droppedColumn = columnFromDropId(overId);
-      if (droppedColumn !== undefined) {
-        announceMove(moved.widget.title, droppedColumn + 1, columnCount);
+      if (target.kind === "column") {
+        announceMove(moved.widget.title, target.column + 1, columnCount);
         return;
       }
-      const target = visible.findIndex(row => row.placementId === overId);
+      const landed = visible.findIndex(
+        row => row.placementId === target.placementId
+      );
       announceMove(
         moved.widget.title,
-        target === -1 ? visible.length : target + 1,
+        landed === -1 ? visible.length : landed + 1,
         visible.length
       );
     },
@@ -248,7 +257,7 @@ export function useDashboardArrangement(
       const moved = visible.find(row => row.placementId === placementId);
       if (!moved) return;
       if (targetColumn < 0 || targetColumn >= columnCount) return;
-      editor.dropOn(placementId, columnDropId(targetColumn));
+      editor.dropOn(placementId, { kind: "column", column: targetColumn });
       announceMove(moved.widget.title, targetColumn + 1, columnCount);
     },
     [visible, editor, columnCount, announceMove]
@@ -266,7 +275,7 @@ export function useDashboardArrangement(
     (placementId: string, neighbourId: string) => {
       const moved = visible.find(row => row.placementId === placementId);
       if (!moved) return;
-      editor.dropOn(placementId, neighbourId);
+      editor.dropOn(placementId, { kind: "card", placementId: neighbourId });
       const column = placementsByColumn(visible, columnCount)[
         Math.min(Math.max(0, moved.column ?? 0), columnCount - 1)
       ];

--- a/packages/admin/src/components/features/widgets/edit/useDashboardArrangement.ts
+++ b/packages/admin/src/components/features/widgets/edit/useDashboardArrangement.ts
@@ -23,6 +23,7 @@ import { useSortableFieldArray } from "../../entries/fields/structured/field-arr
 import {
   columnFromDropData,
   placementsByColumn,
+  resolveDrop,
   type DropTarget,
 } from "../layout-editor";
 
@@ -95,7 +96,13 @@ export interface DashboardArrangement {
 export function useDashboardArrangement(
   declared: DashboardWidget[],
   layout: UseDashboardLayoutResult,
-  announceMove: (title: string, position: number, count: number) => void
+  announceColumn: (
+    title: string,
+    column: number,
+    columnCount: number,
+    position: number,
+    count: number
+  ) => void
 ): DashboardArrangement {
   // The DECLARATIONS, by id. The arrangement says which cards and in what
   // order; this says what each one actually is. Two questions, two sources:
@@ -206,6 +213,39 @@ export function useDashboardArrangement(
   // and a keyboard sensor, configured identically wherever this admin drags.
   const { sensors } = useSortableFieldArray(sortableItems, () => {});
 
+  /**
+   * Say where a card ended up, in the terms the reader can verify.
+   *
+   * 🔴 Resolved AFTER the move, against the destination column's bucket. Read
+   * from the global sequence, a card dropped onto the second card of a short
+   * column announced "position 4 of 4" because cards in other columns precede
+   * it — a position and a total that describe nothing the reader can see.
+   */
+  const announceLanding = useCallback(
+    (title: string, placementId: string, target: DropTarget) => {
+      const settled = resolveDrop(
+        editor.placements,
+        placementId,
+        target,
+        columnCount
+      );
+      const buckets = placementsByColumn(settled, columnCount);
+      const column = buckets.findIndex(bucket =>
+        bucket.some(p => p.id === placementId)
+      );
+      if (column === -1) return;
+      const position = buckets[column].findIndex(p => p.id === placementId) + 1;
+      announceColumn(
+        title,
+        column + 1,
+        columnCount,
+        position,
+        buckets[column].length
+      );
+    },
+    [editor.placements, columnCount, announceColumn]
+  );
+
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
       const activeId = String(event.active.id);
@@ -227,20 +267,9 @@ export function useDashboardArrangement(
       // drop claimed the card had gone to the last position in the whole
       // dashboard, whichever column actually received it. The column target is
       // parsed instead, and the announcement names the column.
-      if (target.kind === "column") {
-        announceMove(moved.widget.title, target.column + 1, columnCount);
-        return;
-      }
-      const landed = visible.findIndex(
-        row => row.placementId === target.placementId
-      );
-      announceMove(
-        moved.widget.title,
-        landed === -1 ? visible.length : landed + 1,
-        visible.length
-      );
+      announceLanding(moved.widget.title, activeId, target);
     },
-    [visible, editor, announceMove, columnCount]
+    [visible, editor, announceLanding]
   );
 
   /**
@@ -257,10 +286,11 @@ export function useDashboardArrangement(
       const moved = visible.find(row => row.placementId === placementId);
       if (!moved) return;
       if (targetColumn < 0 || targetColumn >= columnCount) return;
-      editor.dropOn(placementId, { kind: "column", column: targetColumn });
-      announceMove(moved.widget.title, targetColumn + 1, columnCount);
+      const target: DropTarget = { kind: "column", column: targetColumn };
+      editor.dropOn(placementId, target);
+      announceLanding(moved.widget.title, placementId, target);
     },
-    [visible, editor, columnCount, announceMove]
+    [visible, editor, announceLanding, columnCount]
   );
 
   /**
@@ -275,18 +305,11 @@ export function useDashboardArrangement(
     (placementId: string, neighbourId: string) => {
       const moved = visible.find(row => row.placementId === placementId);
       if (!moved) return;
-      editor.dropOn(placementId, { kind: "card", placementId: neighbourId });
-      const column = placementsByColumn(visible, columnCount)[
-        Math.min(Math.max(0, moved.column ?? 0), columnCount - 1)
-      ];
-      const landed = column.findIndex(row => row.placementId === neighbourId);
-      announceMove(
-        moved.widget.title,
-        landed === -1 ? column.length : landed + 1,
-        column.length
-      );
+      const target: DropTarget = { kind: "card", placementId: neighbourId };
+      editor.dropOn(placementId, target);
+      announceLanding(moved.widget.title, placementId, target);
     },
-    [visible, editor, columnCount, announceMove]
+    [visible, editor, announceLanding]
   );
 
   return {

--- a/packages/admin/src/components/features/widgets/edit/useDashboardArrangement.ts
+++ b/packages/admin/src/components/features/widgets/edit/useDashboardArrangement.ts
@@ -158,11 +158,10 @@ export function useDashboardArrangement(
     return rows;
   }, [hasArrangement, declared, editor.placements, editor.isEditing, byId]);
 
-  // The reader's own count, or the default while the arrangement is unread.
-  // Read from the SERVER's answer rather than assumed: the count decides which
-  // column a placement's coordinate names, so a client picking its own would
-  // draw an arrangement the reader never made.
-  const columnCount = layout.layout?.columnCount ?? DEFAULT_COLUMN_COUNT;
+  // The EDITOR's count, which is the draft's while editing and the saved one
+  // otherwise. Deriving a second answer here would draw the saved count while
+  // the reader is looking at the one they just chose.
+  const columnCount = editor.columnCount;
 
   const columns = useMemo(() => {
     const buckets: ArrangedWidget[][] = Array.from(

--- a/packages/admin/src/components/features/widgets/edit/useDashboardArrangement.ts
+++ b/packages/admin/src/components/features/widgets/edit/useDashboardArrangement.ts
@@ -12,6 +12,8 @@
  * @module components/features/widgets/edit/useDashboardArrangement
  */
 
+import type { DragEndEvent } from "@dnd-kit/core";
+import { DEFAULT_COLUMN_COUNT } from "nextly/config";
 import { useCallback, useMemo } from "react";
 
 import type { UseDashboardLayoutResult } from "@admin/hooks/queries/useDashboardLayout";
@@ -34,11 +36,24 @@ export interface ArrangedWidget {
    * span helper already falls back on a value it does not recognise.
    */
   size?: string;
+  /** Which column this card is drawn in. Absent on a pre-column arrangement. */
+  column?: number;
 }
 
 export interface DashboardArrangement {
   /** The cards to draw, in the arrangement's order. */
   visible: ArrangedWidget[];
+  /**
+   * The same cards, grouped into the columns the grid renders.
+   *
+   * Derived from `visible` rather than resolved a second time: two answers to
+   * "which cards are drawn" drift, and the one nobody looks at is the one that
+   * goes wrong. Always `columnCount` buckets, empty ones included, because a
+   * column is a drop target only while the grid draws it.
+   */
+  columns: ArrangedWidget[][];
+  /** How many columns this reader arranged their dashboard into. */
+  columnCount: number;
   editor: LayoutEditor;
   /** Move the card at a VIEW index one step, resolving ids for the editor. */
   moveBy: (index: number, delta: number) => void;
@@ -101,10 +116,14 @@ export function useDashboardArrangement(
     // No arrangement yet: draw the declarations in their declared order, which
     // is exactly what this dashboard did before it could be arranged at all.
     if (!hasArrangement) {
-      return declared.map(widget => ({
+      // Dealt across the columns exactly as the server's defaults are, so the
+      // dashboard a reader sees before they arrange anything matches the one
+      // they get the moment they save.
+      return declared.map((widget, index) => ({
         placementId: widget.id,
         widget,
         hidden: false,
+        column: index % DEFAULT_COLUMN_COUNT,
       }));
     }
     const rows: ArrangedWidget[] = [];
@@ -123,10 +142,30 @@ export function useDashboardArrangement(
         widget,
         hidden: placement.hidden,
         ...(placement.size === undefined ? {} : { size: placement.size }),
+        ...(placement.column === undefined ? {} : { column: placement.column }),
       });
     }
     return rows;
   }, [hasArrangement, declared, editor.placements, editor.isEditing, byId]);
+
+  // The reader's own count, or the default while the arrangement is unread.
+  // Read from the SERVER's answer rather than assumed: the count decides which
+  // column a placement's coordinate names, so a client picking its own would
+  // draw an arrangement the reader never made.
+  const columnCount = layout.layout?.columnCount ?? DEFAULT_COLUMN_COUNT;
+
+  const columns = useMemo(() => {
+    const buckets: ArrangedWidget[][] = Array.from(
+      { length: Math.max(1, columnCount) },
+      () => []
+    );
+    for (const row of visible) {
+      const declaredColumn = row.column ?? 0;
+      const index = Math.min(Math.max(0, declaredColumn), buckets.length - 1);
+      buckets[index].push(row);
+    }
+    return buckets;
+  }, [visible, columnCount]);
 
   const sortableItems = useMemo(
     () => visible.map(row => ({ id: row.placementId })),
@@ -141,15 +180,33 @@ export function useDashboardArrangement(
   // that list is the filtered view. They are turned into placement ids here,
   // once, so the editor never sees a position that means something different to
   // it than it did to the grid.
-  const { sensors, handleDragEnd } = useSortableFieldArray(
-    sortableItems,
-    (from, to) => {
-      const moved = visible[from];
-      const target = visible[to];
-      if (!moved || !target) return;
-      editor.move(moved.placementId, target.placementId);
-      announceMove(moved.widget.title, to + 1, visible.length);
-    }
+  // Only the SENSORS are borrowed. `useSortableFieldArray` resolves a drop to a
+  // pair of indices into one list, which cannot express a column: an index says
+  // where in a sequence a card landed and says nothing about which column it
+  // landed in. The sensors are the half that is genuinely shared -- a pointer
+  // and a keyboard sensor, configured identically wherever this admin drags.
+  const { sensors } = useSortableFieldArray(sortableItems, () => {});
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const activeId = String(event.active.id);
+      const overId = event.over ? String(event.over.id) : null;
+      if (overId === null || overId === activeId) return;
+      const moved = visible.find(row => row.placementId === activeId);
+      if (!moved) return;
+      editor.dropOn(activeId, overId);
+      // Announced from the position the card is moving TO, resolved against
+      // the view it was dropped in. A card dropped onto a column has no
+      // neighbour to count from, so it is announced as the column's arrival
+      // rather than with a position that would be invented.
+      const target = visible.findIndex(row => row.placementId === overId);
+      announceMove(
+        moved.widget.title,
+        target === -1 ? visible.length : target + 1,
+        visible.length
+      );
+    },
+    [visible, editor, announceMove]
   );
 
   /**
@@ -172,6 +229,8 @@ export function useDashboardArrangement(
   return {
     visible,
     editor,
+    columns,
+    columnCount,
     moveBy,
     hasArrangement,
     sortableItems,

--- a/packages/admin/src/components/features/widgets/edit/useDashboardArrangement.ts
+++ b/packages/admin/src/components/features/widgets/edit/useDashboardArrangement.ts
@@ -20,7 +20,11 @@ import type { UseDashboardLayoutResult } from "@admin/hooks/queries/useDashboard
 import type { DashboardWidget } from "@admin/types/dashboard/widgets";
 
 import { useSortableFieldArray } from "../../entries/fields/structured/field-array-helpers";
-import { columnDropId } from "../layout-editor";
+import {
+  columnDropId,
+  columnFromDropId,
+  placementsByColumn,
+} from "../layout-editor";
 
 import { useLayoutEditor, type LayoutEditor } from "./useLayoutEditor";
 
@@ -39,6 +43,13 @@ export interface ArrangedWidget {
   size?: string;
   /** Which column this card is drawn in. Absent on a pre-column arrangement. */
   column?: number;
+  /**
+   * Its position within that column.
+   *
+   * Carried so the ONE grouping helper can order these rows, rather than the
+   * grid relying on the sequence they happen to arrive in.
+   */
+  order: number;
 }
 
 export interface DashboardArrangement {
@@ -56,17 +67,17 @@ export interface DashboardArrangement {
   /** How many columns this reader arranged their dashboard into. */
   columnCount: number;
   editor: LayoutEditor;
-  /** Move the card at a VIEW index one step, resolving ids for the editor. */
-  moveBy: (index: number, delta: number) => void;
+  /** Swap one card with a named neighbour in the same column. */
+  moveWithinColumn: (placementId: string, neighbourId: string) => void;
   /**
-   * Move one card sideways by `delta` columns.
+   * Move one card into `targetColumn`, named absolutely.
    *
    * The CLICKABLE route across columns. Dragging one there is the same
    * capability, and WCAG 2.2 SC 2.5.7 asks for a single-pointer alternative to
    * anything a drag achieves -- so this is not a convenience beside the drag,
    * it is what makes the drag permissible.
    */
-  moveColumn: (placementId: string, delta: number) => void;
+  moveColumn: (placementId: string, targetColumn: number) => void;
   /**
    * Whether an arrangement has been READ — not whether it holds anything.
    *
@@ -134,6 +145,7 @@ export function useDashboardArrangement(
         widget,
         hidden: false,
         column: index % DEFAULT_COLUMN_COUNT,
+        order: index,
       }));
     }
     const rows: ArrangedWidget[] = [];
@@ -153,6 +165,7 @@ export function useDashboardArrangement(
         hidden: placement.hidden,
         ...(placement.size === undefined ? {} : { size: placement.size }),
         ...(placement.column === undefined ? {} : { column: placement.column }),
+        order: placement.order,
       });
     }
     return rows;
@@ -163,18 +176,15 @@ export function useDashboardArrangement(
   // the reader is looking at the one they just chose.
   const columnCount = editor.columnCount;
 
-  const columns = useMemo(() => {
-    const buckets: ArrangedWidget[][] = Array.from(
-      { length: Math.max(1, columnCount) },
-      () => []
-    );
-    for (const row of visible) {
-      const declaredColumn = row.column ?? 0;
-      const index = Math.min(Math.max(0, declaredColumn), buckets.length - 1);
-      buckets[index].push(row);
-    }
-    return buckets;
-  }, [visible, columnCount]);
+  // 🔴 The SHARED helper, not a second grouping. An inline copy here is the
+  // path production takes while the unit tests exercise the helper, so the
+  // tests stay green while the shipped grid regresses -- and the two already
+  // disagreed, since the helper orders each bucket by `order` and a local copy
+  // took whatever sequence the rows arrived in.
+  const columns = useMemo(
+    () => placementsByColumn(visible, columnCount),
+    [visible, columnCount]
+  );
 
   const sortableItems = useMemo(
     () => visible.map(row => ({ id: row.placementId })),
@@ -204,10 +214,16 @@ export function useDashboardArrangement(
       const moved = visible.find(row => row.placementId === activeId);
       if (!moved) return;
       editor.dropOn(activeId, overId);
-      // Announced from the position the card is moving TO, resolved against
-      // the view it was dropped in. A card dropped onto a column has no
-      // neighbour to count from, so it is announced as the column's arrival
-      // rather than with a position that would be invented.
+      // 🔴 A drop onto a COLUMN has no neighbouring card to count from, and
+      // `findIndex` answers -1 for it. Announced from that, every empty-column
+      // drop claimed the card had gone to the last position in the whole
+      // dashboard, whichever column actually received it. The column target is
+      // parsed instead, and the announcement names the column.
+      const droppedColumn = columnFromDropId(overId);
+      if (droppedColumn !== undefined) {
+        announceMove(moved.widget.title, droppedColumn + 1, columnCount);
+        return;
+      }
       const target = visible.findIndex(row => row.placementId === overId);
       announceMove(
         moved.widget.title,
@@ -215,39 +231,53 @@ export function useDashboardArrangement(
         visible.length
       );
     },
-    [visible, editor, announceMove]
+    [visible, editor, announceMove, columnCount]
   );
 
   /**
-   * The button path: move the card at `index` one step in the VIEW.
+   * Move one card into `targetColumn`.
    *
-   * Resolved to the neighbour's id here rather than to `index + delta`, because
-   * the neighbour in the view may not be the neighbour in the stored array.
+   * 🔴 An ABSOLUTE target, computed by the caller from the column the card is
+   * DRAWN in. A delta applied to the stored column is wrong for any card whose
+   * column is past the current count: folded into the last column for drawing,
+   * it would offer a Left that lands outside the dashboard and a label naming a
+   * column the reader cannot see.
    */
   const moveColumn = useCallback(
-    (placementId: string, delta: number) => {
+    (placementId: string, targetColumn: number) => {
       const moved = visible.find(row => row.placementId === placementId);
       if (!moved) return;
-      const target = (moved.column ?? 0) + delta;
-      // Refused rather than clamped. Clamping would let a button that LOOKS
-      // disabled still act -- the affordance and the handler would disagree,
-      // and the one a reader trusts is whichever moved the card.
-      if (target < 0 || target >= columnCount) return;
-      editor.dropOn(placementId, columnDropId(target));
-      announceMove(moved.widget.title, target + 1, columnCount);
+      if (targetColumn < 0 || targetColumn >= columnCount) return;
+      editor.dropOn(placementId, columnDropId(targetColumn));
+      announceMove(moved.widget.title, targetColumn + 1, columnCount);
     },
     [visible, editor, columnCount, announceMove]
   );
 
-  const moveBy = useCallback(
-    (index: number, delta: number) => {
-      const moved = visible[index];
-      const target = visible[index + delta];
-      if (!moved || !target) return;
-      editor.move(moved.placementId, target.placementId);
-      announceMove(moved.widget.title, index + delta + 1, visible.length);
+  /**
+   * The button path: swap one card with a NAMED neighbour.
+   *
+   * Takes both ids rather than an index and a delta. The caller renders one
+   * column and knows which card sits next to which; an index handed back here
+   * would have to be re-resolved against the interleaved whole, which is the
+   * translation that moved the wrong card.
+   */
+  const moveWithinColumn = useCallback(
+    (placementId: string, neighbourId: string) => {
+      const moved = visible.find(row => row.placementId === placementId);
+      if (!moved) return;
+      editor.dropOn(placementId, neighbourId);
+      const column = placementsByColumn(visible, columnCount)[
+        Math.min(Math.max(0, moved.column ?? 0), columnCount - 1)
+      ];
+      const landed = column.findIndex(row => row.placementId === neighbourId);
+      announceMove(
+        moved.widget.title,
+        landed === -1 ? column.length : landed + 1,
+        column.length
+      );
     },
-    [visible, editor, announceMove]
+    [visible, editor, columnCount, announceMove]
   );
 
   return {
@@ -255,7 +285,7 @@ export function useDashboardArrangement(
     editor,
     columns,
     columnCount,
-    moveBy,
+    moveWithinColumn,
     moveColumn,
     hasArrangement,
     sortableItems,

--- a/packages/admin/src/components/features/widgets/edit/useDashboardArrangement.ts
+++ b/packages/admin/src/components/features/widgets/edit/useDashboardArrangement.ts
@@ -20,6 +20,7 @@ import type { UseDashboardLayoutResult } from "@admin/hooks/queries/useDashboard
 import type { DashboardWidget } from "@admin/types/dashboard/widgets";
 
 import { useSortableFieldArray } from "../../entries/fields/structured/field-array-helpers";
+import { columnDropId } from "../layout-editor";
 
 import { useLayoutEditor, type LayoutEditor } from "./useLayoutEditor";
 
@@ -57,6 +58,15 @@ export interface DashboardArrangement {
   editor: LayoutEditor;
   /** Move the card at a VIEW index one step, resolving ids for the editor. */
   moveBy: (index: number, delta: number) => void;
+  /**
+   * Move one card sideways by `delta` columns.
+   *
+   * The CLICKABLE route across columns. Dragging one there is the same
+   * capability, and WCAG 2.2 SC 2.5.7 asks for a single-pointer alternative to
+   * anything a drag achieves -- so this is not a convenience beside the drag,
+   * it is what makes the drag permissible.
+   */
+  moveColumn: (placementId: string, delta: number) => void;
   /**
    * Whether an arrangement has been READ — not whether it holds anything.
    *
@@ -215,6 +225,21 @@ export function useDashboardArrangement(
    * Resolved to the neighbour's id here rather than to `index + delta`, because
    * the neighbour in the view may not be the neighbour in the stored array.
    */
+  const moveColumn = useCallback(
+    (placementId: string, delta: number) => {
+      const moved = visible.find(row => row.placementId === placementId);
+      if (!moved) return;
+      const target = (moved.column ?? 0) + delta;
+      // Refused rather than clamped. Clamping would let a button that LOOKS
+      // disabled still act -- the affordance and the handler would disagree,
+      // and the one a reader trusts is whichever moved the card.
+      if (target < 0 || target >= columnCount) return;
+      editor.dropOn(placementId, columnDropId(target));
+      announceMove(moved.widget.title, target + 1, columnCount);
+    },
+    [visible, editor, columnCount, announceMove]
+  );
+
   const moveBy = useCallback(
     (index: number, delta: number) => {
       const moved = visible[index];
@@ -232,6 +257,7 @@ export function useDashboardArrangement(
     columns,
     columnCount,
     moveBy,
+    moveColumn,
     hasArrangement,
     sortableItems,
     sensors,

--- a/packages/admin/src/components/features/widgets/edit/useLayoutEditor.ts
+++ b/packages/admin/src/components/features/widgets/edit/useLayoutEditor.ts
@@ -20,20 +20,15 @@
  * @module components/features/widgets/edit/useLayoutEditor
  */
 
-import { MAX_PLACEMENTS } from "nextly/config";
+import { DEFAULT_COLUMN_COUNT, MAX_PLACEMENTS } from "nextly/config";
 import { useCallback, useMemo, useState } from "react";
 
 import type { UseDashboardLayoutResult } from "@admin/hooks/queries/useDashboardLayout";
 import type { WidgetPlacement } from "@admin/types/dashboard/widgets";
 
-import {
-  addPlacement,
-  hasChanges,
-  movePlacementTo,
-  removePlacement,
-  renumber,
-  togglePlacementHidden,
-} from "../layout-editor";
+import { addPlacement, hasChanges, renumber } from "../layout-editor";
+
+import { usePlacementMutations } from "./usePlacementMutations";
 
 /** Where a card's declared geometry comes from when it is added. */
 export interface WidgetGeometrySource {
@@ -85,6 +80,15 @@ export interface LayoutEditor {
   reload: () => void;
   /** Move by IDENTITY: the placement `fromId` takes the position of `toId`. */
   move: (fromId: string, toId: string) => void;
+  /**
+   * Apply a drag that may have crossed columns.
+   *
+   * A named operation rather than a placements setter, for the same reason
+   * every other mutation here is one: a setter lets a caller write an arbitrary
+   * draft, and the invariants this module keeps -- ids unique, order dense,
+   * columns in range -- would then be enforced nowhere.
+   */
+  dropOn: (activeId: string, overId: string | null) => void;
   toggleHidden: (placementId: string) => void;
   remove: (placementId: string) => void;
   add: (widgetId: string) => void;
@@ -96,7 +100,7 @@ export interface LayoutEditor {
  * One object, so a placement list can never be sent against a version and a
  * scope it was not derived from.
  */
-interface LayoutDraft {
+export interface LayoutDraft {
   placements: WidgetPlacement[];
   version: number;
   scope: string;
@@ -192,46 +196,14 @@ export function useLayoutEditor(
   // the stored array — which is exactly the translation that was wrong: with an
   // unresolvable placement between two visible ones, a view index moved the
   // wrong card and persisted it.
-  const move = useCallback(
-    (fromId: string, toId: string) =>
-      setDraft(current =>
-        current
-          ? {
-              ...current,
-              placements: movePlacementTo(current.placements, fromId, toId),
-            }
-          : current
-      ),
-    []
-  );
+  // The reader's own count, from the SERVER's answer. `resolveDrop` clamps a
+  // target against it, so a count guessed here would let a drop land in a
+  // column the dashboard does not draw.
+  const columnCount = layout.layout?.columnCount ?? DEFAULT_COLUMN_COUNT;
 
-  const toggleHidden = useCallback(
-    (placementId: string) =>
-      setDraft(current =>
-        current
-          ? {
-              ...current,
-              placements: togglePlacementHidden(
-                current.placements,
-                placementId
-              ),
-            }
-          : current
-      ),
-    []
-  );
-
-  const remove = useCallback(
-    (placementId: string) =>
-      setDraft(current =>
-        current
-          ? {
-              ...current,
-              placements: removePlacement(current.placements, placementId),
-            }
-          : current
-      ),
-    []
+  const { move, dropOn, toggleHidden, remove } = usePlacementMutations(
+    setDraft,
+    columnCount
   );
 
   const add = useCallback(
@@ -285,6 +257,7 @@ export function useLayoutEditor(
     reset,
     reload,
     move,
+    dropOn,
     toggleHidden,
     remove,
     add,

--- a/packages/admin/src/components/features/widgets/edit/useLayoutEditor.ts
+++ b/packages/admin/src/components/features/widgets/edit/useLayoutEditor.ts
@@ -26,8 +26,9 @@ import { useCallback, useMemo, useState } from "react";
 import type { UseDashboardLayoutResult } from "@admin/hooks/queries/useDashboardLayout";
 import type { WidgetPlacement } from "@admin/types/dashboard/widgets";
 
-import { addPlacement, hasChanges, renumber } from "../layout-editor";
+import { addPlacement, draftDiffers } from "../layout-editor";
 
+import { useLayoutLifecycle } from "./useLayoutLifecycle";
 import { usePlacementMutations } from "./usePlacementMutations";
 
 /** Where a card's declared geometry comes from when it is added. */
@@ -89,6 +90,24 @@ export interface LayoutEditor {
    * columns in range -- would then be enforced nowhere.
    */
   dropOn: (activeId: string, overId: string | null) => void;
+  /**
+   * Choose how many columns the dashboard is drawn in.
+   *
+   * Placements are NOT rewritten here. A card whose column falls outside the
+   * new count is folded into the last one for drawing, and its stored column
+   * is left alone -- so widening the dashboard again puts it back where the
+   * reader had it, rather than where a narrower view happened to show it.
+   */
+  setColumnCount: (columnCount: number) => void;
+  /**
+   * The count the dashboard is being drawn in RIGHT NOW.
+   *
+   * The draft's while editing, the saved one otherwise. Published rather than
+   * re-derived by each consumer: a second derivation would answer the saved
+   * count while the reader is looking at a different one, and the card that
+   * landed in a column they cannot see would be nobody's fault in particular.
+   */
+  columnCount: number;
   toggleHidden: (placementId: string) => void;
   remove: (placementId: string) => void;
   add: (widgetId: string) => void;
@@ -104,6 +123,8 @@ export interface LayoutDraft {
   placements: WidgetPlacement[];
   version: number;
   scope: string;
+  /** The count being edited, which may differ from the one last saved. */
+  columnCount: number;
 }
 
 export function useLayoutEditor(
@@ -129,53 +150,11 @@ export function useLayoutEditor(
     [layout.layout]
   );
 
-  const begin = useCallback(() => {
-    const current = layout.layout;
-    // Nothing to edit against. Editing is offered only once a read has landed,
-    // so this is a guard rather than a state the UI can reach.
-    if (!current) return;
-    setDraft({
-      placements: [...current.placements],
-      version: current.version,
-      scope: current.scope,
-    });
-  }, [layout.layout]);
-  // 🔴 The failed-write state goes with the draft, because the message it
-  // renders describes the draft. After a non-conflict failure the chrome says
-  // "your changes are still here -- try again"; Cancel discarded them and left
-  // that sentence on screen, pointing at nothing, and it was still there when
-  // the reader next entered edit mode. A mutation error outlives the thing it
-  // is about unless something clears it.
-  const cancel = useCallback(() => {
-    setDraft(null);
-    layout.save.reset();
-    layout.reset.reset();
-  }, [layout]);
-
-  const save = useCallback(() => {
-    if (!draft) return;
-    layout.save.mutate(
-      // Renumbered on the way out: the editor reorders an ARRAY, so a moved
-      // card still carries the `order` it had before. Sent as-is, the server
-      // sorts by a number that no longer matches what the reader sees.
-      //
-      // The guards come from the DRAFT, so they are the ones this arrangement
-      // was derived from rather than whatever the last refetch produced.
-      {
-        placements: renumber(draft.placements),
-        version: draft.version,
-        scope: draft.scope,
-      },
-      // Only on success. A conflict must LEAVE the draft in place, because
-      // dropping it here would discard the reader's work at the exact moment
-      // they are being told to try again.
-      { onSuccess: () => setDraft(null) }
-    );
-  }, [draft, layout]);
-
-  const reset = useCallback(() => {
-    layout.reset.mutate(undefined, { onSuccess: () => setDraft(null) });
-  }, [layout]);
+  const { begin, cancel, save, reset } = useLayoutLifecycle(
+    layout,
+    draft,
+    setDraft
+  );
 
   const reload = useCallback(() => {
     // The draft goes first: it is the thing the reader was warned they would
@@ -199,7 +178,19 @@ export function useLayoutEditor(
   // The reader's own count, from the SERVER's answer. `resolveDrop` clamps a
   // target against it, so a count guessed here would let a drop land in a
   // column the dashboard does not draw.
-  const columnCount = layout.layout?.columnCount ?? DEFAULT_COLUMN_COUNT;
+  // The DRAFT's count while editing, the saved one otherwise. A drop resolved
+  // against the saved count while the reader is looking at a different one
+  // would land a card in a column they cannot see.
+  const columnCount =
+    draft?.columnCount ?? layout.layout?.columnCount ?? DEFAULT_COLUMN_COUNT;
+
+  const setColumnCount = useCallback(
+    (next: number) =>
+      setDraft(current =>
+        current ? { ...current, columnCount: next } : current
+      ),
+    []
+  );
 
   const { move, dropOn, toggleHidden, remove } = usePlacementMutations(
     setDraft,
@@ -248,7 +239,14 @@ export function useLayoutEditor(
     placements,
     available,
     atCapacity: placements.length >= MAX_PLACEMENTS,
-    hasUnsavedChanges: draft !== null && hasChanges(server, draft.placements),
+    hasUnsavedChanges:
+      draft !== null &&
+      draftDiffers(
+        server,
+        layout.layout?.columnCount ?? DEFAULT_COLUMN_COUNT,
+        draft.placements,
+        draft.columnCount
+      ),
     isSaving: layout.save.isPending || layout.reset.isPending,
     isConflict: layout.isConflict,
     begin,
@@ -258,6 +256,8 @@ export function useLayoutEditor(
     reload,
     move,
     dropOn,
+    setColumnCount,
+    columnCount,
     toggleHidden,
     remove,
     add,

--- a/packages/admin/src/components/features/widgets/edit/useLayoutEditor.ts
+++ b/packages/admin/src/components/features/widgets/edit/useLayoutEditor.ts
@@ -26,7 +26,7 @@ import { useCallback, useMemo, useState } from "react";
 import type { UseDashboardLayoutResult } from "@admin/hooks/queries/useDashboardLayout";
 import type { WidgetPlacement } from "@admin/types/dashboard/widgets";
 
-import { addPlacement, draftDiffers } from "../layout-editor";
+import { addPlacement, draftDiffers, type DropTarget } from "../layout-editor";
 
 import { useLayoutLifecycle } from "./useLayoutLifecycle";
 import { usePlacementMutations } from "./usePlacementMutations";
@@ -89,7 +89,7 @@ export interface LayoutEditor {
    * draft, and the invariants this module keeps -- ids unique, order dense,
    * columns in range -- would then be enforced nowhere.
    */
-  dropOn: (activeId: string, overId: string | null) => void;
+  dropOn: (activeId: string, target: DropTarget | null) => void;
   /**
    * Choose how many columns the dashboard is drawn in.
    *

--- a/packages/admin/src/components/features/widgets/edit/useLayoutLifecycle.ts
+++ b/packages/admin/src/components/features/widgets/edit/useLayoutLifecycle.ts
@@ -1,0 +1,86 @@
+"use client";
+/**
+ * Beginning, abandoning, saving and resetting a dashboard edit.
+ *
+ * The LIFECYCLE of a draft, as opposed to the mutations that change one. Lifted
+ * out of `useLayoutEditor` for the same reason those were: each is small, and a
+ * hook holding all of them is a body nobody reads end to end -- which matters
+ * most here, because these are the four that decide whether a reader's work
+ * survives.
+ *
+ * @module components/features/widgets/edit/useLayoutLifecycle
+ */
+import { DEFAULT_COLUMN_COUNT } from "nextly/config";
+import { useCallback, type Dispatch, type SetStateAction } from "react";
+
+import type { UseDashboardLayoutResult } from "@admin/hooks/queries/useDashboardLayout";
+
+import { renumber } from "../layout-editor";
+
+import type { LayoutDraft } from "./useLayoutEditor";
+
+export interface LayoutLifecycle {
+  begin: () => void;
+  cancel: () => void;
+  save: () => void;
+  reset: () => void;
+}
+
+export function useLayoutLifecycle(
+  layout: UseDashboardLayoutResult,
+  draft: LayoutDraft | null,
+  setDraft: Dispatch<SetStateAction<LayoutDraft | null>>
+): LayoutLifecycle {
+  const begin = useCallback(() => {
+    const current = layout.layout;
+    // Nothing to edit against. Editing is offered only once a read has landed,
+    // so this is a guard rather than a state the UI can reach.
+    if (!current) return;
+    setDraft({
+      placements: [...current.placements],
+      version: current.version,
+      scope: current.scope,
+      // Seeded from what was READ, so an edit that never touches the picker
+      // saves the count back unchanged rather than resetting it to a default.
+      columnCount: current.columnCount ?? DEFAULT_COLUMN_COUNT,
+    });
+  }, [layout.layout, setDraft]);
+  // 🔴 The failed-write state goes with the draft, because the message it
+  // renders describes the draft. After a non-conflict failure the chrome says
+  // "your changes are still here -- try again"; Cancel discarded them and left
+  // that sentence on screen, pointing at nothing, and it was still there when
+  // the reader next entered edit mode. A mutation error outlives the thing it
+  // is about unless something clears it.
+  const cancel = useCallback(() => {
+    setDraft(null);
+    layout.save.reset();
+    layout.reset.reset();
+  }, [layout, setDraft]);
+
+  const save = useCallback(() => {
+    if (!draft) return;
+    layout.save.mutate(
+      // Renumbered on the way out: the editor reorders an ARRAY, so a moved
+      // card still carries the `order` it had before. Sent as-is, the server
+      // sorts by a number that no longer matches what the reader sees.
+      //
+      // The guards come from the DRAFT, so they are the ones this arrangement
+      // was derived from rather than whatever the last refetch produced.
+      {
+        placements: renumber(draft.placements),
+        version: draft.version,
+        scope: draft.scope,
+        columnCount: draft.columnCount,
+      },
+      // Only on success. A conflict must LEAVE the draft in place, because
+      // dropping it here would discard the reader's work at the exact moment
+      // they are being told to try again.
+      { onSuccess: () => setDraft(null) }
+    );
+  }, [draft, layout, setDraft]);
+
+  const reset = useCallback(() => {
+    layout.reset.mutate(undefined, { onSuccess: () => setDraft(null) });
+  }, [layout, setDraft]);
+  return { begin, cancel, save, reset };
+}

--- a/packages/admin/src/components/features/widgets/edit/usePlacementMutations.ts
+++ b/packages/admin/src/components/features/widgets/edit/usePlacementMutations.ts
@@ -1,0 +1,89 @@
+"use client";
+/**
+ * The draft mutations a reader performs while editing their dashboard.
+ *
+ * Lifted out of `useLayoutEditor` rather than left inline. Each is a small
+ * closure, but a hook accumulating a dozen of them becomes a body nobody reads
+ * end to end — and the mutations are the part where a mistake silently edits
+ * the wrong card, so they are worth reading as a set.
+ *
+ * Every one goes through `mutatePlacements`, which owns the single decision
+ * they all share: with no draft, do nothing. Spelled out per mutation it was
+ * five copies of one null check, and the next one written slightly differently
+ * would no-op when the draft is PRESENT rather than when it is absent.
+ *
+ * @module components/features/widgets/edit/usePlacementMutations
+ */
+import { useCallback, type Dispatch, type SetStateAction } from "react";
+
+import type { WidgetPlacement } from "@admin/types/dashboard/widgets";
+
+import {
+  movePlacementTo,
+  removePlacement,
+  resolveDrop,
+  togglePlacementHidden,
+} from "../layout-editor";
+
+import type { LayoutDraft } from "./useLayoutEditor";
+
+export interface PlacementMutations {
+  move: (fromId: string, toId: string) => void;
+  dropOn: (activeId: string, overId: string | null) => void;
+  toggleHidden: (placementId: string) => void;
+  remove: (placementId: string) => void;
+}
+
+export function usePlacementMutations(
+  setDraft: Dispatch<SetStateAction<LayoutDraft | null>>,
+  columnCount: number
+): PlacementMutations {
+  /**
+   * Apply a change to the draft's placements, or do nothing without a draft.
+   *
+   * Every mutation below was spelling this out: the same null check, the same
+   * spread, the same field. Five copies of one decision is five places for the
+   * next one to be written slightly differently, and the difference would be a
+   * mutation that silently no-ops when the draft is absent instead of when it
+   * is present.
+   */
+  const mutatePlacements = useCallback(
+    (change: (placements: WidgetPlacement[]) => WidgetPlacement[]) =>
+      setDraft(current =>
+        current
+          ? { ...current, placements: change(current.placements) }
+          : current
+      ),
+    [setDraft]
+  );
+
+  const move = useCallback(
+    (fromId: string, toId: string) =>
+      mutatePlacements(placements => movePlacementTo(placements, fromId, toId)),
+    [mutatePlacements]
+  );
+
+  const dropOn = useCallback(
+    (activeId: string, overId: string | null) =>
+      mutatePlacements(placements =>
+        resolveDrop(placements, activeId, overId, columnCount)
+      ),
+    [mutatePlacements, columnCount]
+  );
+
+  const toggleHidden = useCallback(
+    (placementId: string) =>
+      mutatePlacements(placements =>
+        togglePlacementHidden(placements, placementId)
+      ),
+    [mutatePlacements]
+  );
+
+  const remove = useCallback(
+    (placementId: string) =>
+      mutatePlacements(placements => removePlacement(placements, placementId)),
+    [mutatePlacements]
+  );
+
+  return { move, dropOn, toggleHidden, remove };
+}

--- a/packages/admin/src/components/features/widgets/edit/usePlacementMutations.ts
+++ b/packages/admin/src/components/features/widgets/edit/usePlacementMutations.ts
@@ -22,6 +22,7 @@ import {
   movePlacementTo,
   removePlacement,
   resolveDrop,
+  type DropTarget,
   togglePlacementHidden,
 } from "../layout-editor";
 
@@ -29,7 +30,7 @@ import type { LayoutDraft } from "./useLayoutEditor";
 
 export interface PlacementMutations {
   move: (fromId: string, toId: string) => void;
-  dropOn: (activeId: string, overId: string | null) => void;
+  dropOn: (activeId: string, target: DropTarget | null) => void;
   toggleHidden: (placementId: string) => void;
   remove: (placementId: string) => void;
 }
@@ -64,9 +65,9 @@ export function usePlacementMutations(
   );
 
   const dropOn = useCallback(
-    (activeId: string, overId: string | null) =>
+    (activeId: string, target: DropTarget | null) =>
       mutatePlacements(placements =>
-        resolveDrop(placements, activeId, overId, columnCount)
+        resolveDrop(placements, activeId, target, columnCount)
       ),
     [mutatePlacements, columnCount]
   );

--- a/packages/admin/src/components/features/widgets/layout-editor.ts
+++ b/packages/admin/src/components/features/widgets/layout-editor.ts
@@ -318,11 +318,13 @@ export type DropTarget =
 /**
  * Which side of the card under the pointer a drop lands on.
  *
- * 🔴 The side is what makes the BOTTOM of a populated column reachable. A
- * column disables its own droppable the moment it holds anything, so the space
- * below its last card resolves to that card — and landing every drop at the
- * target's own index put the card in front of it, leaving the last position
- * unreachable by drag however the pointer was placed.
+ * 🔴 Consulted only where a drop CROSSES columns, which is the case with no
+ * index in the destination to compare against. It is what makes the bottom of
+ * another column reachable: that column's own droppable covers only the space
+ * its cards leave, so a release below its last card resolves to the card, and
+ * a drop landing at the target's own index arrives in front of it. Within one
+ * column the two indices decide instead, because the rectangles a keyboard
+ * drag produces are identical and cannot say — see `resolveDrop`.
  *
  * Compared on vertical centres, because a column is a vertical list: past the
  * middle of the card underneath, the reader is aiming below it. The dragged
@@ -385,6 +387,55 @@ export function columnFromDropData(data: unknown): number | undefined {
  * correctly and leave the stored sequence column-major — the exact disagreement
  * with `byPosition` that `rowMajor` below exists to prevent.
  */
+/**
+ * Where a drop lands: which bucket, and the index in it.
+ *
+ * 🔴 The index names a position in the bucket as it stands BEFORE the active
+ * card is taken out, and the single adjustment for that removal is made by the
+ * caller. Each branch compensating for it itself is how one of them came to
+ * compensate twice.
+ *
+ * `undefined` when the target names a card no bucket holds, which is an
+ * ordinary end to a drag rather than an error.
+ */
+function landingSlot(
+  buckets: readonly WidgetPlacement[][],
+  target: DropTarget,
+  from: number,
+  fromIndex: number
+): { column: number; insertAt: number } | undefined {
+  if (target.kind === "column") {
+    // A column target is the empty-column case, so the card appends.
+    const column = Math.min(Math.max(0, target.column), buckets.length - 1);
+    return { column, insertAt: buckets[column].length };
+  }
+
+  const column = buckets.findIndex(bucket =>
+    bucket.some(p => p.id === target.placementId)
+  );
+  if (column === -1) return undefined;
+  const targetIndex = buckets[column].findIndex(
+    p => p.id === target.placementId
+  );
+
+  // 🔴 Within ONE column the two indices already say which way the card is
+  // going, and the side is not consulted. The keyboard sensor lands the active
+  // card exactly ON its target, so the rectangles a side is measured from are
+  // identical and answer "before" for a move that is plainly downward — which
+  // cancels against the caller's removal adjustment and makes Space,
+  // ArrowDown, Space do nothing for two cards of equal height.
+  //
+  // ACROSS columns there is no index in the destination to compare against, so
+  // the measured side is the only thing separating "above this card" from
+  // "below it" — and without it the position after a populated column's last
+  // card cannot be reached at all.
+  const offset =
+    from === column
+      ? Number(fromIndex < targetIndex)
+      : Number(target.side === "after");
+  return { column, insertAt: targetIndex + offset };
+}
+
 export function resolveDrop(
   placements: readonly WidgetPlacement[],
   activeId: string,
@@ -405,36 +456,15 @@ export function resolveDrop(
   // unreachable however the pointer is placed. Column 0 is `[A, D]` and B goes
   // at D's index, which is the position the reader aimed at.
   const buckets = placementsByColumn(placements, columnCount);
-  const last = Math.max(0, buckets.length - 1);
 
   const from = buckets.findIndex(bucket => bucket.some(p => p.id === activeId));
   if (from === -1) return [...placements];
   const fromIndex = buckets[from].findIndex(p => p.id === activeId);
 
-  // 🔴 Every branch below names a position in the bucket as it stands BEFORE
-  // the active card is taken out, and the one adjustment for that removal is
-  // made in a single place afterwards. Two branches each compensating for it
-  // themselves is how one of them came to compensate twice.
-  let column: number;
-  let insertAt: number;
-  if (target.kind === "column") {
-    column = Math.min(Math.max(0, target.column), last);
-    // A column target is the empty-column case, so the card appends.
-    insertAt = buckets[column].length;
-  } else {
-    const found = buckets.findIndex(bucket =>
-      bucket.some(p => p.id === target.placementId)
-    );
-    if (found === -1) return [...placements];
-    column = found;
-    // The side is what separates "above this card" from "below it". Without
-    // it every drop landed at the target's own index, so the position after
-    // the last card of a populated column could not be reached at all.
-    const targetIndex = buckets[found].findIndex(
-      p => p.id === target.placementId
-    );
-    insertAt = targetIndex + (target.side === "after" ? 1 : 0);
-  }
+  const slot = landingSlot(buckets, target, from, fromIndex);
+  if (slot === undefined) return [...placements];
+  const { column } = slot;
+  let { insertAt } = slot;
 
   buckets[from].splice(fromIndex, 1);
   // 🔴 The removal shifts every later index down by one, so a card moving DOWN

--- a/packages/admin/src/components/features/widgets/layout-editor.ts
+++ b/packages/admin/src/components/features/widgets/layout-editor.ts
@@ -297,3 +297,63 @@ export function columnAffordance(
     canMoveRight: column < columnCount - 1,
   };
 }
+
+/** The prefix that marks a droppable id as a COLUMN rather than a card. */
+const COLUMN_DROP_PREFIX = "widget-column:";
+
+/**
+ * The droppable id for a column.
+ *
+ * 🔴 Built and read in one place. A column and a card share one id space in
+ * dnd-kit, so the only thing separating them is this spelling — and two copies
+ * of it drift the moment one is edited, which reads as "dropping onto a column
+ * silently does nothing".
+ */
+export function columnDropId(column: number): string {
+  return `${COLUMN_DROP_PREFIX}${column}`;
+}
+
+/** The column a droppable id names, or `undefined` when it names a card. */
+function columnFromDropId(id: string): number | undefined {
+  if (!id.startsWith(COLUMN_DROP_PREFIX)) return undefined;
+  const parsed = Number.parseInt(id.slice(COLUMN_DROP_PREFIX.length), 10);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+/**
+ * The arrangement after a card was dropped somewhere.
+ *
+ * Two kinds of target, because a column needs both. Dropping onto a CARD takes
+ * that card's column and lands beside it, which is how a reader orders one
+ * widget above another. Dropping onto the COLUMN itself is the only way to
+ * reach an empty one -- it holds no card to aim at, so without this a column
+ * becomes unreachable the moment its last card leaves.
+ *
+ * A drop that resolves to nothing returns the arrangement unchanged. Released
+ * over empty space, or onto itself, is an ordinary end to a drag rather than an
+ * error worth reporting.
+ */
+export function resolveDrop(
+  placements: readonly WidgetPlacement[],
+  activeId: string,
+  overId: string | null,
+  columnCount: number
+): WidgetPlacement[] {
+  if (overId === null || overId === activeId) return [...placements];
+
+  const targetColumn = columnFromDropId(overId);
+  if (targetColumn !== undefined) {
+    const bounded = Math.min(targetColumn, Math.max(0, columnCount - 1));
+    return renumber(moveToColumn(placements, activeId, bounded));
+  }
+
+  const over = placements.find(placement => placement.id === overId);
+  if (over === undefined) return [...placements];
+
+  // The column FIRST, then the position, and both are needed. Taking the
+  // column alone lands every card in arrival order, so a reader could never
+  // put one below another; moving the position alone would reorder a card
+  // inside the column it came from while the drop was aimed at another.
+  const recolumned = moveToColumn(placements, activeId, over.column ?? 0);
+  return renumber(movePlacementTo(recolumned, activeId, overId));
+}

--- a/packages/admin/src/components/features/widgets/layout-editor.ts
+++ b/packages/admin/src/components/features/widgets/layout-editor.ts
@@ -269,26 +269,6 @@ export function placementsByColumn<
 }
 
 /**
- * The same placements, with one card moved into `column`.
- *
- * Identified by id rather than by position, for the reason `movePlacementTo`
- * gives: a view index means something different from a stored index the moment
- * one placement is unresolvable, and translating between them moved the wrong
- * card. An id nobody holds is an ordinary outcome, not an error.
- */
-export function moveToColumn(
-  placements: readonly WidgetPlacement[],
-  placementId: string,
-  column: number
-): WidgetPlacement[] {
-  return placements.map(placement =>
-    placement.id === placementId
-      ? { ...placement, column: Math.max(0, column) }
-      : placement
-  );
-}
-
-/**
  * Which sideways moves a card may offer.
  *
  * 🔴 These back the CLICKABLE controls, not the drag. WCAG 2.2 SC 2.5.7 says
@@ -327,10 +307,41 @@ export function columnDropId(column: number): number {
 /** Where column droppable ids start. */
 const COLUMN_DROP_ID_BASE = 1_000_000;
 
+/** Which side of a card a drop lands on. */
+export type DropSide = "before" | "after";
+
 /** What a drag was released over. */
 export type DropTarget =
   | { kind: "column"; column: number }
-  | { kind: "card"; placementId: string };
+  | { kind: "card"; placementId: string; side: DropSide };
+
+/**
+ * Which side of the card under the pointer a drop lands on.
+ *
+ * 🔴 The side is what makes the BOTTOM of a populated column reachable. A
+ * column disables its own droppable the moment it holds anything, so the space
+ * below its last card resolves to that card — and landing every drop at the
+ * target's own index put the card in front of it, leaving the last position
+ * unreachable by drag however the pointer was placed.
+ *
+ * Compared on vertical centres, because a column is a vertical list: past the
+ * middle of the card underneath, the reader is aiming below it. The dragged
+ * rectangle is the TRANSLATED one, which is where the card currently is rather
+ * than where the gesture started.
+ *
+ * Defaults to `before` when either rectangle is missing. That is the position a
+ * drop resolved to before sides existed, so a measurement this cannot take
+ * costs the old behaviour rather than an arbitrary one.
+ */
+export function dropSide(
+  active: { top: number; height: number } | null | undefined,
+  over: { top: number; height: number } | null | undefined
+): DropSide {
+  if (!active || !over) return "before";
+  return active.top + active.height / 2 > over.top + over.height / 2
+    ? "after"
+    : "before";
+}
 
 /**
  * The droppable data a column registers.
@@ -367,6 +378,12 @@ export function columnFromDropData(data: unknown): number | undefined {
  * A drop that resolves to nothing returns the arrangement unchanged. Released
  * over empty space, or onto itself, is an ordinary end to a drag rather than an
  * error worth reporting.
+ *
+ * 🔴 This is the ONLY way a card changes column, and the single-pointer
+ * controls go through it too rather than through a helper of their own. A
+ * second one that set `column` and left `order` alone would move the card
+ * correctly and leave the stored sequence column-major — the exact disagreement
+ * with `byPosition` that `rowMajor` below exists to prevent.
  */
 export function resolveDrop(
   placements: readonly WidgetPlacement[],
@@ -394,33 +411,71 @@ export function resolveDrop(
   if (from === -1) return [...placements];
   const fromIndex = buckets[from].findIndex(p => p.id === activeId);
 
+  // 🔴 Every branch below names a position in the bucket as it stands BEFORE
+  // the active card is taken out, and the one adjustment for that removal is
+  // made in a single place afterwards. Two branches each compensating for it
+  // themselves is how one of them came to compensate twice.
   let column: number;
   let insertAt: number;
   if (target.kind === "column") {
     column = Math.min(Math.max(0, target.column), last);
     // A column target is the empty-column case, so the card appends.
-    insertAt =
-      column === from ? buckets[column].length - 1 : buckets[column].length;
+    insertAt = buckets[column].length;
   } else {
     const found = buckets.findIndex(bucket =>
       bucket.some(p => p.id === target.placementId)
     );
     if (found === -1) return [...placements];
     column = found;
-    // 🔴 The target's index BEFORE the active card is taken out. Removing it
-    // first shifts every later index down by one, so a card moving DOWN past
-    // its neighbour is re-inserted in front of it and nothing moves.
-    insertAt = buckets[found].findIndex(p => p.id === target.placementId);
+    // The side is what separates "above this card" from "below it". Without
+    // it every drop landed at the target's own index, so the position after
+    // the last card of a populated column could not be reached at all.
+    const targetIndex = buckets[found].findIndex(
+      p => p.id === target.placementId
+    );
+    insertAt = targetIndex + (target.side === "after" ? 1 : 0);
   }
 
   buckets[from].splice(fromIndex, 1);
+  // 🔴 The removal shifts every later index down by one, so a card moving DOWN
+  // past a neighbour in its OWN column would be re-inserted in front of it and
+  // nothing would move. Across columns nothing shifted, so nothing is adjusted.
+  if (from === column && fromIndex < insertAt) insertAt -= 1;
   buckets[column].splice(insertAt, 0, { ...active, column });
 
-  // Flattened column by column, so a card's neighbours within its column are
-  // adjacent in the stored sequence and `order` stays globally unique.
-  return buckets
-    .flat()
-    .map((placement, index) => ({ ...placement, order: index * ORDER_STEP }));
+  return rowMajor(buckets);
+}
+
+/**
+ * The buckets as ONE sequence, read ACROSS the rows.
+ *
+ * 🔴 Row-major, not column by column. `byPosition` is the single order in which
+ * the API presents a placement list as a line, and it reads the dashboard the
+ * way a person does: across the top, then the next row down. Numbering column
+ * by column made the stored `order` disagree with that — an arrangement drawn
+ * as `[A, D] [B] [C]` was stored as `A, D, B, C` while the reader sees
+ * `A, B, C, D` — so every client consuming the canonical sequence reordered
+ * cards nobody had moved.
+ *
+ * Sparse steps rather than 0..n, for the reason `renumber` gives: an insertion
+ * between two cards then needs no renumbering at all.
+ */
+function rowMajor(buckets: readonly WidgetPlacement[][]): WidgetPlacement[] {
+  const depth = buckets.reduce(
+    (deepest, bucket) => Math.max(deepest, bucket.length),
+    0
+  );
+  const sequence: WidgetPlacement[] = [];
+  for (let row = 0; row < depth; row += 1) {
+    for (const bucket of buckets) {
+      const placement = bucket[row];
+      if (placement !== undefined) sequence.push(placement);
+    }
+  }
+  return sequence.map((placement, index) => ({
+    ...placement,
+    order: index * ORDER_STEP,
+  }));
 }
 
 /**

--- a/packages/admin/src/components/features/widgets/layout-editor.ts
+++ b/packages/admin/src/components/features/widgets/layout-editor.ts
@@ -223,3 +223,77 @@ export function hasChanges(
     );
   });
 }
+
+/** Whether a card at `column` may move left or right, given the count. */
+export interface ColumnAffordance {
+  canMoveLeft: boolean;
+  canMoveRight: boolean;
+}
+
+/**
+ * The placements of each column, in reading order, one bucket per column.
+ *
+ * 🔴 Always `columnCount` buckets, including empty ones. A column exists as a
+ * drop target only because the grid renders it, so collapsing an empty bucket
+ * would make a column unreachable the moment its last card left — the reader
+ * could move a card out of column 3 and never move one back.
+ *
+ * A card whose column is out of range is KEPT, folded into the last column
+ * rather than dropped. Narrowing the dashboard is a presentation change and the
+ * cards in the columns that went away are still the reader's; showing one
+ * somewhere unexpected is recoverable, deleting it is not.
+ */
+export function placementsByColumn(
+  placements: readonly WidgetPlacement[],
+  columnCount: number
+): WidgetPlacement[][] {
+  const columns: WidgetPlacement[][] = Array.from(
+    { length: Math.max(1, columnCount) },
+    () => []
+  );
+  for (const placement of placements) {
+    const declared = placement.column ?? 0;
+    const index = Math.min(Math.max(0, declared), columns.length - 1);
+    columns[index].push(placement);
+  }
+  return columns.map(column => [...column].sort((a, b) => a.order - b.order));
+}
+
+/**
+ * The same placements, with one card moved into `column`.
+ *
+ * Identified by id rather than by position, for the reason `movePlacementTo`
+ * gives: a view index means something different from a stored index the moment
+ * one placement is unresolvable, and translating between them moved the wrong
+ * card. An id nobody holds is an ordinary outcome, not an error.
+ */
+export function moveToColumn(
+  placements: readonly WidgetPlacement[],
+  placementId: string,
+  column: number
+): WidgetPlacement[] {
+  return placements.map(placement =>
+    placement.id === placementId
+      ? { ...placement, column: Math.max(0, column) }
+      : placement
+  );
+}
+
+/**
+ * Which sideways moves a card may offer.
+ *
+ * 🔴 These back the CLICKABLE controls, not the drag. WCAG 2.2 SC 2.5.7 says
+ * functionality reachable by dragging must also be reachable with a single
+ * pointer, and states that a keyboard equivalent does not satisfy it on its
+ * own. Crossing columns is new functionality, so it arrives with its buttons or
+ * it regresses the conformance `WidgetEditControls` already argues for.
+ */
+export function columnAffordance(
+  column: number,
+  columnCount: number
+): ColumnAffordance {
+  return {
+    canMoveLeft: column > 0,
+    canMoveRight: column < columnCount - 1,
+  };
+}

--- a/packages/admin/src/components/features/widgets/layout-editor.ts
+++ b/packages/admin/src/components/features/widgets/layout-editor.ts
@@ -174,6 +174,11 @@ export function addPlacement(
       id: newPlacementId(),
       widgetId,
       order: last ? last.order + ORDER_STEP : 0,
+      // 🔴 The LAST placement's column, not the missing-column fallback of 0.
+      // `addPlacement` appends, and the picker sits below the grid — landing a
+      // new card at the top of column 0 puts it above everything the reader
+      // was looking at, which reads as the button having done nothing.
+      column: last?.column ?? 0,
       hidden: false,
       ...(geometry?.size === undefined ? {} : { size: geometry.size }),
       ...(geometry?.height === undefined ? {} : { height: geometry.height }),
@@ -302,30 +307,37 @@ export function columnAffordance(
   };
 }
 
-/** The prefix that marks a droppable id as a COLUMN rather than a card. */
-const COLUMN_DROP_PREFIX = "widget-column:";
-
-/**
- * The droppable id for a column.
- *
- * 🔴 Built and read in one place. A column and a card share one id space in
- * dnd-kit, so the only thing separating them is this spelling — and two copies
- * of it drift the moment one is edited, which reads as "dropping onto a column
- * silently does nothing".
- */
+/** The droppable id for a column. Unique within the grid, never interpreted. */
 export function columnDropId(column: number): string {
-  return `${COLUMN_DROP_PREFIX}${column}`;
+  return `widget-column:${column}`;
 }
 
-/** The column a droppable id names, or `undefined` when it names a card. */
-export function columnFromDropId(id: string): number | undefined {
-  if (!id.startsWith(COLUMN_DROP_PREFIX)) return undefined;
-  const rest = id.slice(COLUMN_DROP_PREFIX.length);
-  // 🔴 The WHOLE remainder must be digits. `parseInt` reads a numeric prefix
-  // and stops, so `widget-column:1-card` would parse as column 1 -- a card id
-  // silently classified as a column.
-  if (!/^\d+$/.test(rest)) return undefined;
-  return Number.parseInt(rest, 10);
+/** What a drag was released over. */
+export type DropTarget =
+  | { kind: "column"; column: number }
+  | { kind: "card"; placementId: string };
+
+/**
+ * The droppable data a column registers.
+ *
+ * 🔴 The KIND travels in dnd-kit's `data`, not in the shape of the id. Columns
+ * and cards share one id space, so a placement is free to be called
+ * `widget-column:1` -- ids are opaque, the layout API accepts any non-empty
+ * string, and a widget id becomes a default placement id under no prefix rule
+ * at all. Any rule that reads the string has to guess which of the two a
+ * collision meant; data cannot collide, because only a column carries it.
+ */
+export interface ColumnDropData {
+  widgetColumn: number;
+}
+
+/** The column a droppable's data names, or `undefined` when it names a card. */
+export function columnFromDropData(data: unknown): number | undefined {
+  if (typeof data !== "object" || data === null) return undefined;
+  const column = (data as { widgetColumn?: unknown }).widgetColumn;
+  return typeof column === "number" && Number.isInteger(column) && column >= 0
+    ? column
+    : undefined;
 }
 
 /**
@@ -344,30 +356,38 @@ export function columnFromDropId(id: string): number | undefined {
 export function resolveDrop(
   placements: readonly WidgetPlacement[],
   activeId: string,
-  overId: string | null,
+  target: DropTarget | null,
   columnCount: number
 ): WidgetPlacement[] {
-  if (overId === null || overId === activeId) return [...placements];
+  if (target === null) return [...placements];
 
-  // 🔴 A PLACEMENT wins over the column namespace. Placement ids are opaque and
-  // the layout API accepts any non-empty string, so a card can legitimately be
-  // named `widget-column:1` -- and a widget id becomes a default placement id,
-  // which no prefix rule governs. Asking the placements first means a real card
-  // is never mistaken for a column, whatever it is called.
-  const over = placements.find(placement => placement.id === overId);
-  if (over === undefined) {
-    const targetColumn = columnFromDropId(overId);
-    if (targetColumn === undefined) return [...placements];
-    const bounded = Math.min(targetColumn, Math.max(0, columnCount - 1));
+  if (target.kind === "column") {
+    const bounded = Math.min(
+      Math.max(0, target.column),
+      Math.max(0, columnCount - 1)
+    );
     return renumber(moveToColumn(placements, activeId, bounded));
   }
+
+  if (target.placementId === activeId) return [...placements];
+  const over = placements.find(p => p.id === target.placementId);
+  if (over === undefined) return [...placements];
 
   // The column FIRST, then the position, and both are needed. Taking the
   // column alone lands every card in arrival order, so a reader could never
   // put one below another; moving the position alone would reorder a card
   // inside the column it came from while the drop was aimed at another.
-  const recolumned = moveToColumn(placements, activeId, over.column ?? 0);
-  return renumber(movePlacementTo(recolumned, activeId, overId));
+  //
+  // 🔴 The target's RENDERED column, bounded the way the grid bounds it. A
+  // target stored past the current count is drawn in the last column, so
+  // copying its stored value looks right while narrowed and throws the card
+  // back out to column 3 the moment the dashboard is widened again.
+  const targetColumn = Math.min(
+    Math.max(0, over.column ?? 0),
+    Math.max(0, columnCount - 1)
+  );
+  const recolumned = moveToColumn(placements, activeId, targetColumn);
+  return renumber(movePlacementTo(recolumned, activeId, target.placementId));
 }
 
 /**

--- a/packages/admin/src/components/features/widgets/layout-editor.ts
+++ b/packages/admin/src/components/features/widgets/layout-editor.ts
@@ -248,11 +248,10 @@ export interface ColumnAffordance {
  * cards in the columns that went away are still the reader's; showing one
  * somewhere unexpected is recoverable, deleting it is not.
  */
-export function placementsByColumn(
-  placements: readonly WidgetPlacement[],
-  columnCount: number
-): WidgetPlacement[][] {
-  const columns: WidgetPlacement[][] = Array.from(
+export function placementsByColumn<
+  T extends { column?: number; order: number },
+>(placements: readonly T[], columnCount: number): T[][] {
+  const columns: T[][] = Array.from(
     { length: Math.max(1, columnCount) },
     () => []
   );
@@ -319,10 +318,14 @@ export function columnDropId(column: number): string {
 }
 
 /** The column a droppable id names, or `undefined` when it names a card. */
-function columnFromDropId(id: string): number | undefined {
+export function columnFromDropId(id: string): number | undefined {
   if (!id.startsWith(COLUMN_DROP_PREFIX)) return undefined;
-  const parsed = Number.parseInt(id.slice(COLUMN_DROP_PREFIX.length), 10);
-  return Number.isInteger(parsed) && parsed >= 0 ? parsed : undefined;
+  const rest = id.slice(COLUMN_DROP_PREFIX.length);
+  // 🔴 The WHOLE remainder must be digits. `parseInt` reads a numeric prefix
+  // and stops, so `widget-column:1-card` would parse as column 1 -- a card id
+  // silently classified as a column.
+  if (!/^\d+$/.test(rest)) return undefined;
+  return Number.parseInt(rest, 10);
 }
 
 /**
@@ -346,14 +349,18 @@ export function resolveDrop(
 ): WidgetPlacement[] {
   if (overId === null || overId === activeId) return [...placements];
 
-  const targetColumn = columnFromDropId(overId);
-  if (targetColumn !== undefined) {
+  // 🔴 A PLACEMENT wins over the column namespace. Placement ids are opaque and
+  // the layout API accepts any non-empty string, so a card can legitimately be
+  // named `widget-column:1` -- and a widget id becomes a default placement id,
+  // which no prefix rule governs. Asking the placements first means a real card
+  // is never mistaken for a column, whatever it is called.
+  const over = placements.find(placement => placement.id === overId);
+  if (over === undefined) {
+    const targetColumn = columnFromDropId(overId);
+    if (targetColumn === undefined) return [...placements];
     const bounded = Math.min(targetColumn, Math.max(0, columnCount - 1));
     return renumber(moveToColumn(placements, activeId, bounded));
   }
-
-  const over = placements.find(placement => placement.id === overId);
-  if (over === undefined) return [...placements];
 
   // The column FIRST, then the position, and both are needed. Taking the
   // column alone lands every card in arrival order, so a reader could never

--- a/packages/admin/src/components/features/widgets/layout-editor.ts
+++ b/packages/admin/src/components/features/widgets/layout-editor.ts
@@ -391,9 +391,8 @@ export function columnFromDropData(data: unknown): number | undefined {
  * Where a drop lands: which bucket, and the index in it.
  *
  * 🔴 The index names a position in the bucket as it stands BEFORE the active
- * card is taken out, and the single adjustment for that removal is made by the
- * caller. Each branch compensating for it itself is how one of them came to
- * compensate twice.
+ * card is taken out, and the single adjustment for that removal belongs to the
+ * caller. A branch that compensated for it here would compensate twice.
  *
  * `undefined` when the target names a card no bucket holds, which is an
  * ordinary end to a drag rather than an error.

--- a/packages/admin/src/components/features/widgets/layout-editor.ts
+++ b/packages/admin/src/components/features/widgets/layout-editor.ts
@@ -217,6 +217,11 @@ export function hasChanges(
       placement.id !== other.id ||
       placement.widgetId !== other.widgetId ||
       placement.order !== other.order ||
+      // 🔴 `column` is the only field a sideways move touches. Left out, an
+      // arrangement whose cards changed columns compares as untouched, Save
+      // stays disabled, and the reader watches work they can see refuse to
+      // persist.
+      (placement.column ?? 0) !== (other.column ?? 0) ||
       placement.hidden !== other.hidden ||
       placement.size !== other.size ||
       placement.height !== other.height
@@ -356,4 +361,22 @@ export function resolveDrop(
   // inside the column it came from while the drop was aimed at another.
   const recolumned = moveToColumn(placements, activeId, over.column ?? 0);
   return renumber(movePlacementTo(recolumned, activeId, overId));
+}
+
+/**
+ * Whether a draft differs from what was last saved.
+ *
+ * 🔴 Both halves, because a reader can change either alone. Moving a card
+ * sideways touches only its `column`; switching 3 columns to 2 touches no
+ * placement at all. A check that asked about placements only would leave Save
+ * disabled on an arrangement the reader is looking at and has plainly changed,
+ * which reads as the dashboard refusing to keep their work.
+ */
+export function draftDiffers(
+  saved: readonly WidgetPlacement[],
+  savedColumnCount: number,
+  draft: readonly WidgetPlacement[],
+  draftColumnCount: number
+): boolean {
+  return hasChanges(saved, draft) || savedColumnCount !== draftColumnCount;
 }

--- a/packages/admin/src/components/features/widgets/layout-editor.ts
+++ b/packages/admin/src/components/features/widgets/layout-editor.ts
@@ -307,10 +307,25 @@ export function columnAffordance(
   };
 }
 
-/** The droppable id for a column. Unique within the grid, never interpreted. */
-export function columnDropId(column: number): string {
-  return `widget-column:${column}`;
+/**
+ * The droppable id for a column.
+ *
+ * 🔴 A NUMBER, and that is the whole of the guarantee. dnd-kit keys its
+ * droppable registry by id alone, so a string id shared with a placement makes
+ * one registration replace the other before any metadata can be read — the
+ * card becomes undroppable or the column misclassifies, depending on which
+ * registered last. Placement ids are always strings, so a numeric id cannot
+ * collide with one at all.
+ *
+ * The offset keeps a column id away from any numeric id another surface might
+ * register in the same context.
+ */
+export function columnDropId(column: number): number {
+  return COLUMN_DROP_ID_BASE + column;
 }
+
+/** Where column droppable ids start. */
+const COLUMN_DROP_ID_BASE = 1_000_000;
 
 /** What a drag was released over. */
 export type DropTarget =
@@ -360,34 +375,52 @@ export function resolveDrop(
   columnCount: number
 ): WidgetPlacement[] {
   if (target === null) return [...placements];
+  if (target.kind === "card" && target.placementId === activeId) {
+    return [...placements];
+  }
+  const active = placements.find(p => p.id === activeId);
+  if (active === undefined) return [...placements];
 
+  // 🔴 Resolved inside the DESTINATION COLUMN's bucket, not against the
+  // interleaved whole. Reordering the flat sequence cannot express a middle
+  // position: with `[A(0), B(1), C(2), D(0)]`, moving B toward A lands it
+  // before A and moving it toward D lands it after D, so `[A, B, D]` is
+  // unreachable however the pointer is placed. Column 0 is `[A, D]` and B goes
+  // at D's index, which is the position the reader aimed at.
+  const buckets = placementsByColumn(placements, columnCount);
+  const last = Math.max(0, buckets.length - 1);
+
+  const from = buckets.findIndex(bucket => bucket.some(p => p.id === activeId));
+  if (from === -1) return [...placements];
+  const fromIndex = buckets[from].findIndex(p => p.id === activeId);
+
+  let column: number;
+  let insertAt: number;
   if (target.kind === "column") {
-    const bounded = Math.min(
-      Math.max(0, target.column),
-      Math.max(0, columnCount - 1)
+    column = Math.min(Math.max(0, target.column), last);
+    // A column target is the empty-column case, so the card appends.
+    insertAt =
+      column === from ? buckets[column].length - 1 : buckets[column].length;
+  } else {
+    const found = buckets.findIndex(bucket =>
+      bucket.some(p => p.id === target.placementId)
     );
-    return renumber(moveToColumn(placements, activeId, bounded));
+    if (found === -1) return [...placements];
+    column = found;
+    // 🔴 The target's index BEFORE the active card is taken out. Removing it
+    // first shifts every later index down by one, so a card moving DOWN past
+    // its neighbour is re-inserted in front of it and nothing moves.
+    insertAt = buckets[found].findIndex(p => p.id === target.placementId);
   }
 
-  if (target.placementId === activeId) return [...placements];
-  const over = placements.find(p => p.id === target.placementId);
-  if (over === undefined) return [...placements];
+  buckets[from].splice(fromIndex, 1);
+  buckets[column].splice(insertAt, 0, { ...active, column });
 
-  // The column FIRST, then the position, and both are needed. Taking the
-  // column alone lands every card in arrival order, so a reader could never
-  // put one below another; moving the position alone would reorder a card
-  // inside the column it came from while the drop was aimed at another.
-  //
-  // 🔴 The target's RENDERED column, bounded the way the grid bounds it. A
-  // target stored past the current count is drawn in the last column, so
-  // copying its stored value looks right while narrowed and throws the card
-  // back out to column 3 the moment the dashboard is widened again.
-  const targetColumn = Math.min(
-    Math.max(0, over.column ?? 0),
-    Math.max(0, columnCount - 1)
-  );
-  const recolumned = moveToColumn(placements, activeId, targetColumn);
-  return renumber(movePlacementTo(recolumned, activeId, target.placementId));
+  // Flattened column by column, so a card's neighbours within its column are
+  // adjacent in the stored sequence and `order` stays globally unique.
+  return buckets
+    .flat()
+    .map((placement, index) => ({ ...placement, order: index * ORDER_STEP }));
 }
 
 /**

--- a/packages/admin/src/components/features/widgets/sizes.ts
+++ b/packages/admin/src/components/features/widgets/sizes.ts
@@ -91,3 +91,23 @@ export function widgetSpanClass(size: string | undefined): string {
  * where the dashboard's size questions are answered from.
  */
 export { legacySizeToWidgetSize } from "nextly/config";
+
+/**
+ * The grid tracks for each supported column count.
+ *
+ * 🔴 Spelled out rather than built from a template string. Tailwind scans this
+ * file as TEXT, so `grid-cols-${n}` produces a class the build never emits and
+ * the dashboard renders as one column whatever the reader chose.
+ *
+ * Every count folds to ONE column on small screens and, above two, to two at
+ * the middle breakpoint. Folding rather than reflowing is what keeps a card's
+ * position derivable at every width: a column's contents stay together and in
+ * order, so a reader who arranged on a wide screen recognises the same
+ * dashboard on a narrow one.
+ */
+export const COLUMN_TRACK_CLASSES: Readonly<Record<number, string>> =
+  Object.freeze({
+    2: "grid-cols-1 md:grid-cols-2",
+    3: "grid-cols-1 md:grid-cols-2 lg:grid-cols-3",
+    4: "grid-cols-1 md:grid-cols-2 lg:grid-cols-4",
+  });

--- a/packages/admin/src/components/features/widgets/useGridAnnouncer.ts
+++ b/packages/admin/src/components/features/widgets/useGridAnnouncer.ts
@@ -25,6 +25,22 @@ export interface GridAnnouncer {
   announcement: string;
   /** Say where a card landed. */
   announceMove: (title: string, position: number, count: number) => void;
+  /**
+   * Say that a card changed COLUMN.
+   *
+   * 🔴 Its own sentence rather than the position formatter. Passing a column
+   * through `announceMove` produced "moved to position 3 of 3" for a card that
+   * is the only one in column 3 — a position it does not hold, in a list of a
+   * length that is not its column's. Two different facts need two different
+   * wordings.
+   */
+  announceColumn: (
+    title: string,
+    column: number,
+    columnCount: number,
+    position: number,
+    count: number
+  ) => void;
 }
 
 /**
@@ -83,5 +99,23 @@ export function useGridAnnouncer(
     []
   );
 
-  return { announcement, announceMove };
+  const announceColumn = useCallback(
+    (
+      title: string,
+      column: number,
+      columnCount: number,
+      position: number,
+      count: number
+    ) => {
+      setAnnouncement(
+        current =>
+          `${title} moved to column ${column} of ${columnCount}, position ${position} of ${count}.${
+            current.endsWith("\u200b") ? "" : "\u200b"
+          }`
+      );
+    },
+    []
+  );
+
+  return { announcement, announceMove, announceColumn };
 }

--- a/packages/admin/src/components/features/widgets/useGridAnnouncer.ts
+++ b/packages/admin/src/components/features/widgets/useGridAnnouncer.ts
@@ -28,11 +28,11 @@ export interface GridAnnouncer {
   /**
    * Say that a card changed COLUMN.
    *
-   * 🔴 Its own sentence rather than the position formatter. Passing a column
-   * through `announceMove` produced "moved to position 3 of 3" for a card that
-   * is the only one in column 3 — a position it does not hold, in a list of a
-   * length that is not its column's. Two different facts need two different
-   * wordings.
+   * 🔴 Its own sentence rather than the position formatter. A column and a
+   * position within one are different facts, so passing a column through
+   * `announceMove` says "moved to position 3 of 3" about a card that is the
+   * only one in column 3 — a position it does not hold, in a list whose length
+   * is not its column's. Two facts, two wordings.
    */
   announceColumn: (
     title: string,

--- a/packages/admin/src/hooks/queries/useDashboardLayout.ts
+++ b/packages/admin/src/hooks/queries/useDashboardLayout.ts
@@ -53,6 +53,14 @@ export interface SaveLayoutInput {
   placements: WidgetPlacement[];
   version: number;
   scope: string;
+  /**
+   * The column count this arrangement was made in.
+   *
+   * Sent WITH the placements rather than saved separately: a placement's
+   * `column` only means anything against a count, so two writes could leave a
+   * row whose cards name columns the count does not have.
+   */
+  columnCount: number;
 }
 
 export interface UseDashboardLayoutResult {

--- a/packages/admin/src/types/dashboard/widgets.ts
+++ b/packages/admin/src/types/dashboard/widgets.ts
@@ -140,6 +140,15 @@ export interface WidgetPlacement {
   /** Opaque, and unique within a layout. Not a widget id, except by default. */
   id: string;
   widgetId: string;
+  /**
+   * Which column this card sits in, 0-based.
+   *
+   * Optional on the wire because a row written before columns existed carries
+   * none, and the server migrates those on read rather than refusing them — so
+   * a client that treats absent as column 0 agrees with the server instead of
+   * inventing a second answer.
+   */
+  column?: number;
   order: number;
   hidden: boolean;
   size?: string;
@@ -150,6 +159,15 @@ export interface WidgetPlacement {
 /** What `GET /api/dashboard/layout` answers. */
 export interface DashboardLayoutResponse {
   placements: WidgetPlacement[];
+  /**
+   * How many columns this reader's arrangement is drawn in.
+   *
+   * The SERVER's answer, not a client default: the count decides which column
+   * a placement's coordinate names, so drawing a stored arrangement in a count
+   * the client picked would render something the reader never arranged — and
+   * then save it back on their next edit.
+   */
+  columnCount?: number;
   /**
    * Widget ids this reader may see and has not placed.
    *

--- a/packages/nextly/src/api/widget-layout.test.ts
+++ b/packages/nextly/src/api/widget-layout.test.ts
@@ -1290,6 +1290,99 @@ describe("a stored row describes itself", () => {
     expect(saved?.placements.find(p => p.id === "p2")?.column).toBe(3);
   });
 
+  it("inherits from the DEFAULT arrangement when there is no stored row", async () => {
+    // 🔴 A caller who has never saved was still handed an arrangement — the
+    // server's round-robin default, which spreads the first widgets across the
+    // columns. A pre-column client round-trips that set without the field it
+    // does not know about, and inheritance that reads only the stored row finds
+    // nothing to inherit, so the very first save flattens the default into one
+    // column. The baseline has to be what the caller was SHOWN, and with no row
+    // that is the defaults.
+    registerWidget(widget({ id: "core/a", defaultOrder: 0 }));
+    registerWidget(widget({ id: "core/b", defaultOrder: 1 }));
+    registerWidget(widget({ id: "core/c", defaultOrder: 2 }));
+
+    // Exactly what a GET hands out, so the fixture is the arrangement the
+    // client is round-tripping rather than one invented here.
+    const offered = (await bodyOf(await getWidgetLayout(getReq()))).placements;
+    expect(offered?.map(p => p.column)).toEqual([0, 1, 2]);
+
+    const res = await putWidgetLayout(
+      putReq({
+        // The same placements with `column` dropped, which is all a pre-column
+        // client can send.
+        placements: offered?.map(({ id, widgetId, order, hidden }) => ({
+          id,
+          widgetId,
+          order,
+          hidden,
+        })),
+        version: 0,
+        scope: scopeFor(["core/a", "core/b", "core/c"]),
+      })
+    );
+
+    expect(res.status).toBe(200);
+    const saved2 = (await itemOf(res)).placements;
+    expect(saved2?.map(p => p.column)).toEqual([0, 1, 2]);
+  });
+
+  it("never inherits from a placement this caller cannot SEE", async () => {
+    // 🔴 An existence oracle. Default placement ids ARE widget ids, so a caller
+    // can submit a placement whose id names a widget they may not know about
+    // and whose `widgetId` is one they may. Inheriting across the whole stored
+    // row echoed the hidden placement's column straight back, and a nonzero one
+    // distinguishes a hit — which is the disclosure `mergePreservingHidden`
+    // re-keys collisions to prevent. The baseline is the caller's own visible
+    // half, so there is nothing of the hidden row in it to leak.
+    registerWidget(widget({ id: "core/a", defaultOrder: 0 }));
+    registerWidget(
+      widget({ id: "core/gated", requiredPermission: "read-secrets" })
+    );
+    callerHoldsPermission.mockResolvedValue(false);
+    stored = {
+      version: 2,
+      layout: serializeLayout(
+        [
+          { id: "p1", widgetId: "core/a", column: 0, order: 0, hidden: false },
+          {
+            id: "probe",
+            widgetId: "core/gated",
+            column: 3,
+            order: 10,
+            hidden: false,
+          },
+        ],
+        4
+      ),
+    };
+
+    const res = await putWidgetLayout(
+      putReq({
+        placements: [
+          // The probe: an id that collides with the hidden placement, carrying
+          // a widget this caller legitimately holds, and stating no column.
+          { id: "probe", widgetId: "core/a", order: 0, hidden: false },
+        ],
+        version: 2,
+        scope: scopeFor(["core/a"]),
+      })
+    );
+
+    expect(res.status).toBe(200);
+    const echoed = (await itemOf(res)).placements ?? [];
+    expect(echoed).toHaveLength(1);
+    // Column 0 is the reader's own fallback, which says nothing. Column 3 would
+    // be the hidden placement's, and is the whole finding.
+    expect(echoed[0]?.column).toBe(0);
+    // The control: the hidden placement is still CARRIED into the row, so this
+    // is inheritance being scoped rather than the placement having vanished —
+    // which would satisfy the assertion above for the wrong reason.
+    expect(
+      saved?.placements.find(p => p.widgetId === "core/gated")?.column
+    ).toBe(3);
+  });
+
   it("still MOVES a card whose placement states a column", async () => {
     // The control. Inheriting whenever a stored placement exists would satisfy
     // the case above while making every sideways move unsaveable — the same

--- a/packages/nextly/src/api/widget-layout.test.ts
+++ b/packages/nextly/src/api/widget-layout.test.ts
@@ -41,6 +41,7 @@ vi.mock("../auth/entity-read-access", async importOriginal => {
 import { requireAuthentication } from "../auth/middleware";
 import type { WidgetDefinition } from "../domains/widgets/definition";
 import {
+  DEFAULT_COLUMN_COUNT,
   MAX_PLACEMENTS,
   layoutSizeProblem,
   serializeLayout,
@@ -65,7 +66,9 @@ const reqAuth = vi.mocked(requireAuthentication);
 
 /** A stand-in for the row, so a test can state what is stored and read it back. */
 let stored: { layout: string; version: number } | undefined;
-let saved: { placements: WidgetPlacement[]; expected: number } | undefined;
+let saved:
+  | { placements: WidgetPlacement[]; expected: number; columnCount?: number }
+  | undefined;
 let saveThrows: Error | undefined;
 let deleted: { kind: string; scope: string } | undefined;
 const logged: object[] = [];
@@ -95,10 +98,14 @@ const fakeService = {
     _kind: string,
     _scope: string,
     placements: WidgetPlacement[],
-    expected: number
+    expected: number,
+    columnCount?: number
   ) => {
     if (saveThrows) throw saveThrows;
-    saved = { placements, expected };
+    // The count is recorded because the response ECHOES one: a writer that
+    // answered with the right number while storing another would satisfy every
+    // assertion made on the body alone.
+    saved = { placements, expected, columnCount };
     return expected + 1;
   },
 };
@@ -1170,5 +1177,93 @@ describe("a stored row describes itself", () => {
     for (const placement of saved.placements ?? []) {
       expect(placement.column).toBeLessThan(saved.columnCount ?? 3);
     }
+  });
+
+  it("KEEPS the stored count when a PUT omits one", async () => {
+    // 🔴 Every client written before columns sends no `columnCount`, and this
+    // endpoint accepts the omission. Defaulting on their behalf rewrote a
+    // four-column row as a three-column one, after which the bounding step
+    // folds every card in the fourth column into the third — permanently, and
+    // during an edit that touched neither the count nor that card.
+    registerWidget(widget({ id: "core/a", defaultOrder: 0 }));
+    stored = {
+      version: 2,
+      layout: serializeLayout(
+        [{ id: "p1", widgetId: "core/a", column: 3, order: 0, hidden: false }],
+        4
+      ),
+    };
+
+    const res = await putWidgetLayout(
+      putReq({
+        placements: [
+          { id: "p1", widgetId: "core/a", column: 3, order: 0, hidden: false },
+        ],
+        version: 2,
+        scope: scopeFor(["core/a"]),
+      })
+    );
+
+    expect(res.status).toBe(200);
+    const item = await itemOf(res);
+    expect(item.columnCount).toBe(4);
+    // The consequence, not only the number: the card in the fourth column is
+    // still in the fourth column. A row that kept the count while the bounding
+    // step had already moved the card would satisfy the assertion above.
+    expect(item.placements?.[0]?.column).toBe(3);
+    expect(saved?.columnCount).toBe(4);
+    expect(saved?.placements[0]?.column).toBe(3);
+  });
+
+  it("still takes a count the client actually SENT", async () => {
+    // The control. Inheriting whenever the stored row has a count would
+    // satisfy the case above while making the picker unable to narrow a
+    // dashboard at all — the same defect pointing the other way.
+    registerWidget(widget({ id: "core/a", defaultOrder: 0 }));
+    stored = {
+      version: 2,
+      layout: serializeLayout(
+        [{ id: "p1", widgetId: "core/a", column: 3, order: 0, hidden: false }],
+        4
+      ),
+    };
+
+    const res = await putWidgetLayout(
+      putReq({
+        placements: [
+          { id: "p1", widgetId: "core/a", column: 3, order: 0, hidden: false },
+        ],
+        version: 2,
+        scope: scopeFor(["core/a"]),
+        columnCount: 2,
+      })
+    );
+
+    expect(res.status).toBe(200);
+    const item = await itemOf(res);
+    expect(item.columnCount).toBe(2);
+    // Narrowing folds the card into the last column that now exists, which is
+    // the documented behaviour for a column that went away.
+    expect(item.placements?.[0]?.column).toBe(1);
+  });
+
+  it("DEFAULTS the count when there is no stored row to inherit from", async () => {
+    // The other control. Inheriting is only right where something exists to
+    // inherit; a first save has to land on a count this core supports rather
+    // than on whatever an absent row reads as.
+    registerWidget(widget({ id: "core/a", defaultOrder: 0 }));
+
+    const res = await putWidgetLayout(
+      putReq({
+        placements: [
+          { id: "p1", widgetId: "core/a", column: 0, order: 0, hidden: false },
+        ],
+        version: 0,
+        scope: scopeFor(["core/a"]),
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect((await itemOf(res)).columnCount).toBe(DEFAULT_COLUMN_COUNT);
   });
 });

--- a/packages/nextly/src/api/widget-layout.test.ts
+++ b/packages/nextly/src/api/widget-layout.test.ts
@@ -240,8 +240,8 @@ describe("GET /api/dashboard/layout", () => {
     stored = {
       version: 4,
       layout: serializeLayout([
-        { id: "p2", widgetId: "core/b", order: 0, hidden: false },
-        { id: "p1", widgetId: "core/a", order: 10, hidden: true },
+        { id: "p2", widgetId: "core/b", column: 0, order: 0, hidden: false },
+        { id: "p1", widgetId: "core/a", column: 0, order: 10, hidden: true },
       ]),
     };
 
@@ -259,8 +259,14 @@ describe("GET /api/dashboard/layout", () => {
     stored = {
       version: 1,
       layout: serializeLayout([
-        { id: "p1", widgetId: "core/a", order: 0, hidden: false },
-        { id: "p2", widgetId: "plugin/uninstalled", order: 10, hidden: false },
+        { id: "p1", widgetId: "core/a", column: 0, order: 0, hidden: false },
+        {
+          id: "p2",
+          widgetId: "plugin/uninstalled",
+          column: 0,
+          order: 10,
+          hidden: false,
+        },
       ]),
     };
 
@@ -311,7 +317,13 @@ describe("a widget that only CONTRIBUTED", () => {
     const res = await putWidgetLayout(
       putReq({
         placements: [
-          { id: "p1", widgetId: "forms/latest", order: 0, hidden: false },
+          {
+            id: "p1",
+            widgetId: "forms/latest",
+            column: 0,
+            order: 0,
+            hidden: false,
+          },
         ],
         version: 0,
         scope: scopeFor(["forms/latest"]),
@@ -328,7 +340,7 @@ describe("a widget that only CONTRIBUTED", () => {
     stored = {
       version: 2,
       layout: serializeLayout([
-        { id: "p1", widgetId: "core/a", order: 0, hidden: false },
+        { id: "p1", widgetId: "core/a", column: 0, order: 0, hidden: false },
       ]),
     };
 
@@ -372,7 +384,7 @@ describe("a widget registered after the reader last saved", () => {
     stored = {
       version: 3,
       layout: serializeLayout([
-        { id: "p1", widgetId: "core/a", order: 0, hidden: false },
+        { id: "p1", widgetId: "core/a", column: 0, order: 0, hidden: false },
       ]),
     };
 
@@ -391,7 +403,7 @@ describe("a widget registered after the reader last saved", () => {
     stored = {
       version: 3,
       layout: serializeLayout([
-        { id: "p1", widgetId: "core/a", order: 0, hidden: false },
+        { id: "p1", widgetId: "core/a", column: 0, order: 0, hidden: false },
       ]),
     };
 
@@ -411,7 +423,7 @@ describe("a widget registered after the reader last saved", () => {
     stored = {
       version: 1,
       layout: serializeLayout([
-        { id: "p1", widgetId: "core/a", order: 0, hidden: false },
+        { id: "p1", widgetId: "core/a", column: 0, order: 0, hidden: false },
       ]),
     };
 
@@ -445,7 +457,13 @@ describe("opaque config survives the response pipeline", () => {
         putWidgetLayout(
           putReq({
             placements: [
-              { id: "p1", widgetId: "core/a", order: 0, hidden: false },
+              {
+                id: "p1",
+                widgetId: "core/a",
+                column: 0,
+                order: 0,
+                hidden: false,
+              },
             ],
             version: 0,
             scope: visibilityToken(["core/a"]),
@@ -469,7 +487,7 @@ describe("opaque config survives the response pipeline", () => {
 
 describe("PUT /api/dashboard/layout", () => {
   const onePlacement: WidgetPlacement[] = [
-    { id: "p1", widgetId: "core/a", order: 0, hidden: false },
+    { id: "p1", widgetId: "core/a", column: 0, order: 0, hidden: false },
   ];
 
   it("stores what the caller submitted", async () => {
@@ -497,8 +515,14 @@ describe("PUT /api/dashboard/layout", () => {
     stored = {
       version: 2,
       layout: serializeLayout([
-        { id: "p1", widgetId: "core/a", order: 0, hidden: false },
-        { id: "p9", widgetId: "core/gated", order: 10, hidden: false },
+        { id: "p1", widgetId: "core/a", column: 0, order: 0, hidden: false },
+        {
+          id: "p9",
+          widgetId: "core/gated",
+          column: 0,
+          order: 10,
+          hidden: false,
+        },
       ]),
     };
 
@@ -525,7 +549,13 @@ describe("PUT /api/dashboard/layout", () => {
     stored = {
       version: 2,
       layout: serializeLayout([
-        { id: "p9", widgetId: "core/gated", order: 10, hidden: false },
+        {
+          id: "p9",
+          widgetId: "core/gated",
+          column: 0,
+          order: 10,
+          hidden: false,
+        },
       ]),
     };
 
@@ -555,7 +585,13 @@ describe("PUT /api/dashboard/layout", () => {
     const res = await putWidgetLayout(
       putReq({
         placements: [
-          { id: "p1", widgetId: "core/gated", order: 0, hidden: false },
+          {
+            id: "p1",
+            widgetId: "core/gated",
+            column: 0,
+            order: 0,
+            hidden: false,
+          },
         ],
         version: 0,
         // The visible set is EMPTY here, and that is the scope the client
@@ -575,8 +611,8 @@ describe("PUT /api/dashboard/layout", () => {
     const res = await putWidgetLayout(
       putReq({
         placements: [
-          { id: "dup", widgetId: "core/a", order: 0, hidden: false },
-          { id: "dup", widgetId: "core/a", order: 1, hidden: false },
+          { id: "dup", widgetId: "core/a", column: 0, order: 0, hidden: false },
+          { id: "dup", widgetId: "core/a", column: 0, order: 1, hidden: false },
         ],
         version: 0,
         scope: scopeFor(),
@@ -621,8 +657,14 @@ describe("PUT /api/dashboard/layout", () => {
     stored = {
       version: 2,
       layout: serializeLayout([
-        { id: "p1", widgetId: "core/a", order: 0, hidden: false },
-        { id: "p9", widgetId: "core/gated", order: 10, hidden: false },
+        { id: "p1", widgetId: "core/a", column: 0, order: 0, hidden: false },
+        {
+          id: "p9",
+          widgetId: "core/gated",
+          column: 0,
+          order: 10,
+          hidden: false,
+        },
       ]),
     };
     // The grant has landed by the time the PUT arrives.
@@ -654,7 +696,13 @@ describe("PUT /api/dashboard/layout", () => {
     const res = await putWidgetLayout(
       putReq({
         placements: [
-          { id: "p1", widgetId: "core/gated", order: 0, hidden: false },
+          {
+            id: "p1",
+            widgetId: "core/gated",
+            column: 0,
+            order: 0,
+            hidden: false,
+          },
         ],
         version: 0,
         scope: scopeFor(["core/a", "core/gated"]),
@@ -708,6 +756,7 @@ describe("PUT /api/dashboard/layout", () => {
           {
             id: "p1",
             widgetId: "core/a",
+            column: 0,
             order: 0,
             hidden: false,
             config: { blob: "x".repeat(40_000) },
@@ -820,6 +869,7 @@ describe("PUT /api/dashboard/layout", () => {
         {
           id: "p9",
           widgetId: "core/gated",
+          column: 0,
           order: 0,
           hidden: false,
           config: { blob: "y".repeat(60_000) },
@@ -833,7 +883,13 @@ describe("PUT /api/dashboard/layout", () => {
     stored = {
       version: 1,
       layout: serializeLayout([
-        { id: "p9", widgetId: "core/gated", order: 0, hidden: false },
+        {
+          id: "p9",
+          widgetId: "core/gated",
+          column: 0,
+          order: 0,
+          hidden: false,
+        },
       ]),
     };
     const withoutHidden = await putWidgetLayout(putReq(submission));
@@ -892,6 +948,7 @@ describe("PUT /api/dashboard/layout", () => {
         {
           id: "p1",
           widgetId: "core/a",
+          column: 0,
           order: 0,
           hidden: false,
           config: { blob: "z".repeat(200_000) },
@@ -923,6 +980,7 @@ describe("PUT /api/dashboard/layout", () => {
     const many = Array.from({ length: 400 }, (_, i) => ({
       id: `p${i}`,
       widgetId: "core/a",
+      column: 0,
       order: i,
       hidden: false,
     }));
@@ -955,7 +1013,7 @@ describe("DELETE /api/dashboard/layout", () => {
     stored = {
       version: 4,
       layout: serializeLayout([
-        { id: "p1", widgetId: "core/a", order: 0, hidden: true },
+        { id: "p1", widgetId: "core/a", column: 0, order: 0, hidden: true },
       ]),
     };
 
@@ -977,7 +1035,7 @@ describe("DELETE /api/dashboard/layout", () => {
     stored = {
       version: 4,
       layout: serializeLayout([
-        { id: "p1", widgetId: "core/a", order: 0, hidden: true },
+        { id: "p1", widgetId: "core/a", column: 0, order: 0, hidden: true },
       ]),
     };
 

--- a/packages/nextly/src/api/widget-layout.test.ts
+++ b/packages/nextly/src/api/widget-layout.test.ts
@@ -1247,6 +1247,77 @@ describe("a stored row describes itself", () => {
     expect(item.placements?.[0]?.column).toBe(1);
   });
 
+  it("KEEPS each card's column when the placements state none", async () => {
+    // 🔴 Preserving the count alone was half an answer. A client written before
+    // columns omits the coordinate on every placement as well, and the reader
+    // has to turn an omission into a number — so the row kept its four columns
+    // while every card in it had been moved into the first. The arrangement was
+    // destroyed by an edit that named neither the count nor any column.
+    registerWidget(widget({ id: "core/a", defaultOrder: 0 }));
+    registerWidget(widget({ id: "core/b", defaultOrder: 1 }));
+    stored = {
+      version: 2,
+      layout: serializeLayout(
+        [
+          { id: "p1", widgetId: "core/a", column: 0, order: 0, hidden: false },
+          { id: "p2", widgetId: "core/b", column: 3, order: 10, hidden: false },
+        ],
+        4
+      ),
+    };
+
+    const res = await putWidgetLayout(
+      putReq({
+        // Exactly what a pre-column client sends: no `columnCount`, and no
+        // `column` on any placement.
+        placements: [
+          { id: "p1", widgetId: "core/a", order: 0, hidden: false },
+          { id: "p2", widgetId: "core/b", order: 10, hidden: false },
+        ],
+        version: 2,
+        scope: scopeFor(["core/a", "core/b"]),
+      })
+    );
+
+    expect(res.status).toBe(200);
+    const byId = new Map(
+      (await itemOf(res)).placements?.map(p => [p.id, p.column]) ?? []
+    );
+    expect(byId.get("p2")).toBe(3);
+    // The control: `p1` was already in column 0, so it alone cannot tell
+    // "kept its column" from "collapsed everything into the first".
+    expect(byId.get("p1")).toBe(0);
+    expect(saved?.placements.find(p => p.id === "p2")?.column).toBe(3);
+  });
+
+  it("still MOVES a card whose placement states a column", async () => {
+    // The control. Inheriting whenever a stored placement exists would satisfy
+    // the case above while making every sideways move unsaveable — the same
+    // defect pointing the other way, and the one a reader would notice first.
+    registerWidget(widget({ id: "core/a", defaultOrder: 0 }));
+    stored = {
+      version: 2,
+      layout: serializeLayout(
+        [{ id: "p1", widgetId: "core/a", column: 3, order: 0, hidden: false }],
+        4
+      ),
+    };
+
+    const res = await putWidgetLayout(
+      putReq({
+        placements: [
+          { id: "p1", widgetId: "core/a", column: 0, order: 0, hidden: false },
+        ],
+        version: 2,
+        scope: scopeFor(["core/a"]),
+        columnCount: 4,
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect((await itemOf(res)).placements?.[0]?.column).toBe(0);
+  });
+
   it("DEFAULTS the count when there is no stored row to inherit from", async () => {
     // The other control. Inheriting is only right where something exists to
     // inherit; a first save has to land on a count this core supports rather

--- a/packages/nextly/src/api/widget-layout.test.ts
+++ b/packages/nextly/src/api/widget-layout.test.ts
@@ -143,6 +143,7 @@ interface LayoutPayload {
   version?: number;
   source?: string;
   scope?: string;
+  columnCount?: number;
 }
 
 /** A GET answers with the object itself. */
@@ -1117,5 +1118,21 @@ describe("the submission cap, when an install declares more than one write may c
     expect(layoutSizeProblem(body.placements ?? [])).toBeUndefined();
     // The surplus is reachable rather than lost.
     expect(body.available).toContain(`core/w${MAX_PLACEMENTS}`);
+  });
+});
+
+describe("the column count travels with the arrangement", () => {
+  it("ANSWERS a column count on a dashboard nobody has arranged", async () => {
+    // 🔴 The count decides which column a placement's coordinate names, so a
+    // client left to assume it draws a DIFFERENT arrangement from the stored
+    // one — and then saves that back. Sending it is what stops a dashboard
+    // being silently re-columned by whatever the client guessed.
+    registerWidget(widget({ id: "core/a", defaultOrder: 0 }));
+    const body = await bodyOf(await getWidgetLayout(getReq()));
+    expect(typeof body.columnCount).toBe("number");
+    // The control: not merely present, but a count this core would honour on
+    // the way back in. A response carrying a value the reader refuses is worse
+    // than one carrying none.
+    expect([2, 3, 4]).toContain(body.columnCount);
   });
 });

--- a/packages/nextly/src/api/widget-layout.test.ts
+++ b/packages/nextly/src/api/widget-layout.test.ts
@@ -1136,3 +1136,39 @@ describe("the column count travels with the arrangement", () => {
     expect([2, 3, 4]).toContain(body.columnCount);
   });
 });
+
+describe("a stored row describes itself", () => {
+  it("BOUNDS a submitted column against the count that was accepted", async () => {
+    // 🔴 The two tolerances disagreed. An unsupported `columnCount` is coerced
+    // to the default, while a placement's `column` was only bounded downward —
+    // so `{ columnCount: 5, column: 4 }` persisted as a 3-column row holding a
+    // card in column 4. Nothing rejects that row; every reader silently
+    // reinterprets it, and the arrangement a reader gets back is not the one
+    // they sent.
+    registerWidget(widget({ id: "core/a", defaultOrder: 0 }));
+    const res = await putWidgetLayout(
+      putReq({
+        placements: [
+          {
+            id: "p1",
+            widgetId: "core/a",
+            column: 4,
+            order: 0,
+            hidden: false,
+          },
+        ],
+        version: 0,
+        scope: scopeFor(["core/a"]),
+        columnCount: 5,
+      })
+    );
+    expect(res.status).toBe(200);
+    const saved = await itemOf(res);
+    // Coerced ONCE, at the boundary, so the row is self-describing rather than
+    // reinterpreted differently by whoever reads it next.
+    expect(saved.columnCount).toBeLessThanOrEqual(4);
+    for (const placement of saved.placements ?? []) {
+      expect(placement.column).toBeLessThan(saved.columnCount ?? 3);
+    }
+  });
+});

--- a/packages/nextly/src/api/widget-layout.ts
+++ b/packages/nextly/src/api/widget-layout.ts
@@ -56,6 +56,9 @@ import {
   visibilityToken,
   type WidgetPlacement,
   byPosition,
+  COLUMN_COUNTS,
+  DEFAULT_COLUMN_COUNT,
+  type ColumnCount,
 } from "../domains/widgets/layout";
 import {
   holdsWidgetPermission,
@@ -317,6 +320,12 @@ export const getWidgetLayout = withErrorHandler(async (req: Request) => {
       available,
       version: stored.version,
       source,
+      // The reader's own column count, or the default when they have never
+      // arranged anything. Sent rather than left for the client to assume: the
+      // count decides which column each placement's coordinate refers to, so a
+      // client guessing it would draw a DIFFERENT arrangement from the stored
+      // one and then save that back.
+      columnCount: stored.layout?.columnCount ?? DEFAULT_COLUMN_COUNT,
       scope: visibilityToken(widgets.map(w => w.id)),
     },
     { headers: OPAQUE_CONFIG_HEADERS }
@@ -331,6 +340,21 @@ export const getWidgetLayout = withErrorHandler(async (req: Request) => {
  * an empty string, would be read as asserting the row does not exist and would
  * overwrite a real arrangement through the insert path.
  */
+/**
+ * The submitted column count, or the default.
+ *
+ * TOLERANT rather than strict, and for the same reason a placement's `size` is
+ * typed `string` here: the count is presentation, an unknown value has an
+ * obviously safe reading, and refusing an entire save over it would discard a
+ * reader's arrangement to protect a field nothing depends on. A count from a
+ * NEWER admin is exactly the case this has to survive.
+ */
+function readColumnCount(value: unknown): ColumnCount {
+  return COLUMN_COUNTS.includes(value as ColumnCount)
+    ? (value as ColumnCount)
+    : DEFAULT_COLUMN_COUNT;
+}
+
 function readVersion(body: Record<string, unknown>): number {
   const { version } = body;
   if (!Number.isInteger(version) || (version as number) < 0) {
@@ -436,6 +460,9 @@ export const putWidgetLayout = withErrorHandler(async (req: Request) => {
   const submitted = readPlacements(
     (body as Record<string, unknown>).placements
   );
+  const submittedColumnCount = readColumnCount(
+    (body as Record<string, unknown>).columnCount
+  );
   const expectedVersion = readVersion(body as Record<string, unknown>);
   const submittedScope = readScope(body as Record<string, unknown>);
 
@@ -518,7 +545,8 @@ export const putWidgetLayout = withErrorHandler(async (req: Request) => {
     SCOPE_KIND,
     caller.userId,
     toStore,
-    expectedVersion
+    expectedVersion,
+    submittedColumnCount
   );
 
   // `respondMutation`, not `respondData`: this is a write, and every write in

--- a/packages/nextly/src/api/widget-layout.ts
+++ b/packages/nextly/src/api/widget-layout.ts
@@ -55,6 +55,7 @@ import {
   readPlacements,
   statesColumn,
   visibilityToken,
+  type StoredLayout,
   type WidgetPlacement,
   byPosition,
   DEFAULT_COLUMN_COUNT,
@@ -159,6 +160,31 @@ function carriedPlacements(
     return partitionPlacements(storedPlacements, visibleIds).invisible;
   }
   return defaultRow(visibleIds).invisible;
+}
+
+/**
+ * The arrangement this caller was HANDED: their stored row, or the default.
+ *
+ * 🔴 One implementation, because the writer has to inherit from exactly what
+ * the reader was shown. Two separate answers went wrong in both directions at
+ * once: reading only the stored row left a caller who had never saved
+ * inheriting nothing, so a client that round-trips the default set without its
+ * columns collapsed the server's round-robin into a single column on the first
+ * save; and reading the row UNFILTERED let a submitted placement inherit the
+ * column of one this caller may not know exists, which is an existence oracle
+ * over any id — and default placement ids are widget ids, so they are
+ * guessable. The visible half of the stored row is what was sent, and the
+ * visible defaults are what was sent when there was no row.
+ */
+function visibleArrangement(
+  stored: StoredLayout | undefined,
+  widgets: readonly CanonicalWidget[]
+): WidgetPlacement[] {
+  if (!stored) return visibleDefaults(widgets);
+  return partitionPlacements(
+    stored.placements,
+    new Set(widgets.map(widget => widget.id))
+  ).visible;
 }
 
 /**
@@ -288,12 +314,7 @@ export const getWidgetLayout = withErrorHandler(async (req: Request) => {
   ]);
 
   const source: LayoutSource = stored.layout ? "own" : "default";
-  const placements = stored.layout
-    ? partitionPlacements(
-        stored.layout.placements,
-        new Set(widgets.map(widget => widget.id))
-      ).visible
-    : visibleDefaults(widgets);
+  const placements = visibleArrangement(stored.layout, widgets);
 
   // Widgets this caller may see and has not placed. A stored arrangement is a
   // full snapshot, so a widget registered AFTER the reader last saved has no
@@ -569,14 +590,17 @@ export const putWidgetLayout = withErrorHandler(async (req: Request) => {
       ? readColumnCount(stored.layout?.columnCount)
       : readColumnCount(sentColumnCount);
 
-  // 🔴 A placement that stated no column KEEPS the one it had. Preserving the
-  // count alone was half an answer: a client written before columns omits the
-  // coordinate on every placement as well, so the row held its four columns
-  // while every card in it had been moved into the first — the arrangement
-  // destroyed by an edit that named neither. A placement nothing has seen
-  // before has nothing to inherit and keeps the reader's fallback.
+  // 🔴 A placement that stated no column KEEPS the one it was handed.
+  // Preserving the count alone was half an answer: a client written before
+  // columns omits the coordinate on every placement as well, so the row held
+  // its four columns while every card in it had been moved into the first —
+  // the arrangement destroyed by an edit that named neither.
+  //
+  // The baseline is what this caller was SHOWN, which is the stored row's
+  // visible half or the visible defaults. A placement nothing handed them has
+  // nothing to inherit and keeps the reader's fallback.
   const storedColumns = new Map(
-    (stored.layout?.placements ?? []).map(placement => [
+    visibleArrangement(stored.layout, widgets).map(placement => [
       placement.id,
       placement.column,
     ])

--- a/packages/nextly/src/api/widget-layout.ts
+++ b/packages/nextly/src/api/widget-layout.ts
@@ -165,16 +165,19 @@ function carriedPlacements(
 /**
  * The arrangement this caller was HANDED: their stored row, or the default.
  *
- * 🔴 One implementation, because the writer has to inherit from exactly what
- * the reader was shown. Two separate answers went wrong in both directions at
- * once: reading only the stored row left a caller who had never saved
- * inheriting nothing, so a client that round-trips the default set without its
- * columns collapsed the server's round-robin into a single column on the first
- * save; and reading the row UNFILTERED let a submitted placement inherit the
- * column of one this caller may not know exists, which is an existence oracle
- * over any id — and default placement ids are widget ids, so they are
- * guessable. The visible half of the stored row is what was sent, and the
- * visible defaults are what was sent when there was no row.
+ * 🔴 One implementation, because the writer inherits from exactly what the
+ * reader was shown, and each half of that is load-bearing in a different
+ * direction.
+ *
+ * The DEFAULT half matters because a caller who has never saved was still
+ * handed an arrangement. A baseline reading only the stored row gives them
+ * nothing to inherit, so a client that round-trips the default set without its
+ * columns collapses the round-robin into a single column on its first save.
+ *
+ * The VISIBILITY half is a trust boundary. A baseline reading the row
+ * unfiltered lets a submitted placement inherit the column of one this caller
+ * may not know exists, which is an existence oracle over any id — and default
+ * placement ids are widget ids, so the probe space is guessable.
  */
 function visibleArrangement(
   stored: StoredLayout | undefined,
@@ -590,11 +593,11 @@ export const putWidgetLayout = withErrorHandler(async (req: Request) => {
       ? readColumnCount(stored.layout?.columnCount)
       : readColumnCount(sentColumnCount);
 
-  // 🔴 A placement that stated no column KEEPS the one it was handed.
-  // Preserving the count alone was half an answer: a client written before
-  // columns omits the coordinate on every placement as well, so the row held
-  // its four columns while every card in it had been moved into the first —
-  // the arrangement destroyed by an edit that named neither.
+  // 🔴 A placement that stated no column KEEPS the one it was handed. A client
+  // written before columns omits the coordinate on every placement as well as
+  // the count, so a row whose count is preserved while its coordinates are not
+  // holds four columns with every card moved into the first — an arrangement
+  // destroyed by an edit that names neither.
   //
   // The baseline is what this caller was SHOWN, which is the stored row's
   // visible half or the visible defaults. A placement nothing handed them has

--- a/packages/nextly/src/api/widget-layout.ts
+++ b/packages/nextly/src/api/widget-layout.ts
@@ -53,6 +53,7 @@ import {
   mergePreservingHidden,
   partitionPlacements,
   readPlacements,
+  statesColumn,
   visibilityToken,
   type WidgetPlacement,
   byPosition,
@@ -463,8 +464,16 @@ export const putWidgetLayout = withErrorHandler(async (req: Request) => {
       ],
     });
   }
-  const submitted = readPlacements(
-    (body as Record<string, unknown>).placements
+  const rawPlacements = (body as Record<string, unknown>).placements;
+  const submitted = readPlacements(rawPlacements);
+  // Which placements NAMED a column, asked through the reader's own predicate
+  // so the two cannot disagree about what counts as naming one. An id missing
+  // from this set stated nothing, which is not the same as stating zero.
+  const statedColumns = new Set(
+    (Array.isArray(rawPlacements) ? rawPlacements : [])
+      .filter(statesColumn)
+      .map(placement => (placement as { id?: unknown }).id)
+      .filter((id): id is string => typeof id === "string")
   );
   // Read RAW, and resolved against the stored row further down. `undefined` is
   // an omission rather than a value, and the two need different answers.
@@ -560,8 +569,29 @@ export const putWidgetLayout = withErrorHandler(async (req: Request) => {
       ? readColumnCount(stored.layout?.columnCount)
       : readColumnCount(sentColumnCount);
 
+  // 🔴 A placement that stated no column KEEPS the one it had. Preserving the
+  // count alone was half an answer: a client written before columns omits the
+  // coordinate on every placement as well, so the row held its four columns
+  // while every card in it had been moved into the first — the arrangement
+  // destroyed by an edit that named neither. A placement nothing has seen
+  // before has nothing to inherit and keeps the reader's fallback.
+  const storedColumns = new Map(
+    (stored.layout?.placements ?? []).map(placement => [
+      placement.id,
+      placement.column,
+    ])
+  );
+  const positioned = submitted.map(placement =>
+    statedColumns.has(placement.id)
+      ? placement
+      : {
+          ...placement,
+          column: storedColumns.get(placement.id) ?? placement.column,
+        }
+  );
+
   const toStore = boundColumns(
-    mergePreservingHidden(submitted, carried),
+    mergePreservingHidden(positioned, carried),
     submittedColumnCount
   );
   const version = await service.saveLayout(
@@ -581,7 +611,9 @@ export const putWidgetLayout = withErrorHandler(async (req: Request) => {
   // Echoing the raw array made this response a SECOND representation of the
   // same arrangement: a client trusting it to chain another edit without
   // re-reading would render `[10, 0]` where a reload gives `[0, 10]`.
-  const echoed = boundColumns(submitted, submittedColumnCount).sort(byPosition);
+  const echoed = boundColumns(positioned, submittedColumnCount).sort(
+    byPosition
+  );
 
   return respondMutation(
     "Dashboard layout saved.",

--- a/packages/nextly/src/api/widget-layout.ts
+++ b/packages/nextly/src/api/widget-layout.ts
@@ -349,6 +349,17 @@ export const getWidgetLayout = withErrorHandler(async (req: Request) => {
  * reader's arrangement to protect a field nothing depends on. A count from a
  * NEWER admin is exactly the case this has to survive.
  */
+/** Placements whose columns all fall inside `columnCount`. */
+function boundColumns(
+  placements: readonly WidgetPlacement[],
+  columnCount: ColumnCount
+): WidgetPlacement[] {
+  const last = columnCount - 1;
+  return placements.map(placement =>
+    placement.column > last ? { ...placement, column: last } : placement
+  );
+}
+
 function readColumnCount(value: unknown): ColumnCount {
   return COLUMN_COUNTS.includes(value as ColumnCount)
     ? (value as ColumnCount)
@@ -463,6 +474,14 @@ export const putWidgetLayout = withErrorHandler(async (req: Request) => {
   const submittedColumnCount = readColumnCount(
     (body as Record<string, unknown>).columnCount
   );
+  // 🔴 BOUNDED against the count that was accepted, not the one that was sent.
+  // The two tolerances would otherwise disagree: an unsupported count is
+  // coerced to the default while a column was only bounded downward, so
+  // `{ columnCount: 5, column: 4 }` stored a three-column row holding a card in
+  // column 4. Nothing rejects such a row -- every reader reinterprets it, and
+  // the arrangement handed back is not the one that was sent. Coerced ONCE,
+  // here, so the stored row describes itself.
+  const bounded = boundColumns(submitted, submittedColumnCount);
   const expectedVersion = readVersion(body as Record<string, unknown>);
   const submittedScope = readScope(body as Record<string, unknown>);
 
@@ -540,7 +559,7 @@ export const putWidgetLayout = withErrorHandler(async (req: Request) => {
   const stored = await service.getLayout(SCOPE_KIND, caller.userId);
   const carried = carriedPlacements(stored.layout?.placements, visibleIds);
 
-  const toStore = mergePreservingHidden(submitted, carried);
+  const toStore = mergePreservingHidden(bounded, carried);
   const version = await service.saveLayout(
     SCOPE_KIND,
     caller.userId,
@@ -558,12 +577,17 @@ export const putWidgetLayout = withErrorHandler(async (req: Request) => {
   // Echoing the raw array made this response a SECOND representation of the
   // same arrangement: a client trusting it to chain another edit without
   // re-reading would render `[10, 0]` where a reload gives `[0, 10]`.
-  const echoed = [...submitted].sort(byPosition);
+  const echoed = [...bounded].sort(byPosition);
 
   return respondMutation(
     "Dashboard layout saved.",
     {
       placements: echoed,
+      // Echoed for the same reason the placements are: a client making a
+      // second edit without a round trip needs the count its coordinates mean
+      // something against, and this is the accepted one rather than the sent
+      // one.
+      columnCount: submittedColumnCount,
       version,
       source: "own" satisfies LayoutSource,
       // Echoed so a client can make a second edit without a round trip. It is

--- a/packages/nextly/src/api/widget-layout.ts
+++ b/packages/nextly/src/api/widget-layout.ts
@@ -56,8 +56,8 @@ import {
   visibilityToken,
   type WidgetPlacement,
   byPosition,
-  COLUMN_COUNTS,
   DEFAULT_COLUMN_COUNT,
+  readColumnCount,
   type ColumnCount,
 } from "../domains/widgets/layout";
 import {
@@ -340,16 +340,17 @@ export const getWidgetLayout = withErrorHandler(async (req: Request) => {
  * an empty string, would be read as asserting the row does not exist and would
  * overwrite a real arrangement through the insert path.
  */
+
 /**
- * The submitted column count, or the default.
+ * Placements whose columns all fall inside `columnCount`.
  *
- * TOLERANT rather than strict, and for the same reason a placement's `size` is
- * typed `string` here: the count is presentation, an unknown value has an
- * obviously safe reading, and refusing an entire save over it would discard a
- * reader's arrangement to protect a field nothing depends on. A count from a
- * NEWER admin is exactly the case this has to survive.
+ * 🔴 Applied to the MERGED row, not to what the caller sent. A carried
+ * placement -- one this reader can no longer see, kept so it is not lost --
+ * holds the column it had when it was last visible, so bounding only the
+ * submission lets a hidden card smuggle a column past the count the row
+ * declares. The invariant is about the stored ROW, so it is enforced where the
+ * row is assembled.
  */
-/** Placements whose columns all fall inside `columnCount`. */
 function boundColumns(
   placements: readonly WidgetPlacement[],
   columnCount: ColumnCount
@@ -358,12 +359,6 @@ function boundColumns(
   return placements.map(placement =>
     placement.column > last ? { ...placement, column: last } : placement
   );
-}
-
-function readColumnCount(value: unknown): ColumnCount {
-  return COLUMN_COUNTS.includes(value as ColumnCount)
-    ? (value as ColumnCount)
-    : DEFAULT_COLUMN_COUNT;
 }
 
 function readVersion(body: Record<string, unknown>): number {
@@ -481,7 +476,6 @@ export const putWidgetLayout = withErrorHandler(async (req: Request) => {
   // column 4. Nothing rejects such a row -- every reader reinterprets it, and
   // the arrangement handed back is not the one that was sent. Coerced ONCE,
   // here, so the stored row describes itself.
-  const bounded = boundColumns(submitted, submittedColumnCount);
   const expectedVersion = readVersion(body as Record<string, unknown>);
   const submittedScope = readScope(body as Record<string, unknown>);
 
@@ -559,7 +553,10 @@ export const putWidgetLayout = withErrorHandler(async (req: Request) => {
   const stored = await service.getLayout(SCOPE_KIND, caller.userId);
   const carried = carriedPlacements(stored.layout?.placements, visibleIds);
 
-  const toStore = mergePreservingHidden(bounded, carried);
+  const toStore = boundColumns(
+    mergePreservingHidden(submitted, carried),
+    submittedColumnCount
+  );
   const version = await service.saveLayout(
     SCOPE_KIND,
     caller.userId,
@@ -577,7 +574,7 @@ export const putWidgetLayout = withErrorHandler(async (req: Request) => {
   // Echoing the raw array made this response a SECOND representation of the
   // same arrangement: a client trusting it to chain another edit without
   // re-reading would render `[10, 0]` where a reload gives `[0, 10]`.
-  const echoed = [...bounded].sort(byPosition);
+  const echoed = boundColumns(submitted, submittedColumnCount).sort(byPosition);
 
   return respondMutation(
     "Dashboard layout saved.",

--- a/packages/nextly/src/api/widget-layout.ts
+++ b/packages/nextly/src/api/widget-layout.ts
@@ -55,6 +55,7 @@ import {
   readPlacements,
   visibilityToken,
   type WidgetPlacement,
+  byPosition,
 } from "../domains/widgets/layout";
 import {
   holdsWidgetPermission,
@@ -529,7 +530,7 @@ export const putWidgetLayout = withErrorHandler(async (req: Request) => {
   // Echoing the raw array made this response a SECOND representation of the
   // same arrangement: a client trusting it to chain another edit without
   // re-reading would render `[10, 0]` where a reload gives `[0, 10]`.
-  const echoed = [...submitted].sort((a, b) => a.order - b.order);
+  const echoed = [...submitted].sort(byPosition);
 
   return respondMutation(
     "Dashboard layout saved.",

--- a/packages/nextly/src/api/widget-layout.ts
+++ b/packages/nextly/src/api/widget-layout.ts
@@ -466,16 +466,9 @@ export const putWidgetLayout = withErrorHandler(async (req: Request) => {
   const submitted = readPlacements(
     (body as Record<string, unknown>).placements
   );
-  const submittedColumnCount = readColumnCount(
-    (body as Record<string, unknown>).columnCount
-  );
-  // 🔴 BOUNDED against the count that was accepted, not the one that was sent.
-  // The two tolerances would otherwise disagree: an unsupported count is
-  // coerced to the default while a column was only bounded downward, so
-  // `{ columnCount: 5, column: 4 }` stored a three-column row holding a card in
-  // column 4. Nothing rejects such a row -- every reader reinterprets it, and
-  // the arrangement handed back is not the one that was sent. Coerced ONCE,
-  // here, so the stored row describes itself.
+  // Read RAW, and resolved against the stored row further down. `undefined` is
+  // an omission rather than a value, and the two need different answers.
+  const sentColumnCount = (body as Record<string, unknown>).columnCount;
   const expectedVersion = readVersion(body as Record<string, unknown>);
   const submittedScope = readScope(body as Record<string, unknown>);
 
@@ -552,6 +545,20 @@ export const putWidgetLayout = withErrorHandler(async (req: Request) => {
 
   const stored = await service.getLayout(SCOPE_KIND, caller.userId);
   const carried = carriedPlacements(stored.layout?.placements, visibleIds);
+
+  // 🔴 An OMITTED count inherits the stored one; only a row that does not exist
+  // yet falls back to the default. Every client written before columns sends no
+  // `columnCount`, and defaulting on their behalf saved a four-column row as a
+  // three-column one -- after which `boundColumns` folds every card in the
+  // fourth column into the third, permanently, during an edit that touched
+  // neither. A value that was actually SENT is still coerced, because the two
+  // tolerances have to agree: an unsupported count becoming the default while a
+  // column was only bounded downward stored `{ columnCount: 5, column: 4 }`, a
+  // three-column row holding a card in column 4 that every reader reinterprets.
+  const submittedColumnCount =
+    sentColumnCount === undefined
+      ? readColumnCount(stored.layout?.columnCount)
+      : readColumnCount(sentColumnCount);
 
   const toStore = boundColumns(
     mergePreservingHidden(submitted, carried),

--- a/packages/nextly/src/config.ts
+++ b/packages/nextly/src/config.ts
@@ -248,7 +248,12 @@ export { MAX_QUERIES_PER_REQUEST } from "./domains/widgets/batch-limit";
 // submission carrying more placements than this, so the editor has to know the
 // number to stop a reader building an arrangement that can never be saved --
 // and a second copy of it on the client is a second answer that drifts.
-export { MAX_PLACEMENTS } from "./domains/widgets/layout";
+export {
+  COLUMN_COUNTS,
+  DEFAULT_COLUMN_COUNT,
+  MAX_PLACEMENTS,
+  type ColumnCount,
+} from "./domains/widgets/layout";
 export type {
   WidgetOp,
   WidgetSourceField,

--- a/packages/nextly/src/domains/widgets/__tests__/layout.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/layout.test.ts
@@ -225,6 +225,48 @@ describe("the default arrangement", () => {
     for (const p of placements) expect(Number.isFinite(p.order)).toBe(true);
   });
 
+  it("orders widgets that state NO order the same way every time", () => {
+    // 🔴 The position a widget takes here becomes a COLUMN, so two instances
+    // holding the same widgets have to deal them identically. Comparing the
+    // two sentinels by SUBTRACTION gives `NaN`, which leaves the comparator
+    // inconsistent — what a sort does with one is unspecified — and the answer
+    // then falls out of registration order and the engine. A caller who has
+    // never saved would be handed a different arrangement depending on which
+    // instance answered, and their first save would keep it.
+    const registered = defaultPlacements([
+      widget({ id: "core/c" }),
+      widget({ id: "core/a" }),
+      widget({ id: "core/b" }),
+    ]);
+    const reregistered = defaultPlacements([
+      widget({ id: "core/b" }),
+      widget({ id: "core/c" }),
+      widget({ id: "core/a" }),
+    ]);
+    expect(registered.map(p => p.widgetId)).toEqual([
+      "core/a",
+      "core/b",
+      "core/c",
+    ]);
+    expect(reregistered).toEqual(registered);
+    // The control: the columns are the thing that has to agree, and asserting
+    // the sequence alone would pass on a deal that spread them differently.
+    expect(registered.map(p => p.column)).toEqual(
+      reregistered.map(p => p.column)
+    );
+  });
+
+  it("still lets a STATED order win over the tie-break", () => {
+    // The control for the case above. Ordering by id outright would satisfy it
+    // while ignoring every `defaultOrder` a plugin declares — the position
+    // authors actually control.
+    const placements = defaultPlacements([
+      widget({ id: "core/a", defaultOrder: 30 }),
+      widget({ id: "core/z", defaultOrder: 10 }),
+    ]);
+    expect(placements.map(p => p.widgetId)).toEqual(["core/z", "core/a"]);
+  });
+
   it("names each default placement after its widget, so reads are idempotent", () => {
     const once = defaultPlacements([widget({ id: "core/team" })]);
     const twice = defaultPlacements([widget({ id: "core/team" })]);

--- a/packages/nextly/src/domains/widgets/__tests__/layout.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/layout.test.ts
@@ -225,41 +225,43 @@ describe("the default arrangement", () => {
     for (const p of placements) expect(Number.isFinite(p.order)).toBe(true);
   });
 
-  it("orders widgets that state NO order the same way every time", () => {
-    // 🔴 The position a widget takes here becomes a COLUMN, so two instances
-    // holding the same widgets have to deal them identically. Comparing the
-    // two sentinels by SUBTRACTION gives `NaN`, which leaves the comparator
-    // inconsistent — what a sort does with one is unspecified — and the answer
-    // then falls out of registration order and the engine. A caller who has
-    // never saved would be handed a different arrangement depending on which
-    // instance answered, and their first save would keep it.
-    const registered = defaultPlacements([
+  it("keeps widgets that state NO order in DECLARATION order", () => {
+    // 🔴 The guarantee `defaultOrder` documents: omit it and your card keeps
+    // the position it was declared in. `Array.prototype.sort` is stable, so
+    // equal elements hold their input order, and the admin's comparator rests
+    // on the same property — every widget shipping today states no order, so
+    // they all compare equal. Any tie-break, on the id or on anything else,
+    // rearranges every default dashboard holding plugin widgets and makes core
+    // answer the ordering question differently from the admin.
+    const declared = defaultPlacements([
       widget({ id: "core/c" }),
       widget({ id: "core/a" }),
       widget({ id: "core/b" }),
     ]);
-    const reregistered = defaultPlacements([
-      widget({ id: "core/b" }),
-      widget({ id: "core/c" }),
-      widget({ id: "core/a" }),
-    ]);
-    expect(registered.map(p => p.widgetId)).toEqual([
+    expect(declared.map(p => p.widgetId)).toEqual([
+      "core/c",
       "core/a",
       "core/b",
-      "core/c",
     ]);
-    expect(reregistered).toEqual(registered);
-    // The control: the columns are the thing that has to agree, and asserting
-    // the sequence alone would pass on a deal that spread them differently.
-    expect(registered.map(p => p.column)).toEqual(
-      reregistered.map(p => p.column)
-    );
+    // The control: declaring them in another order gives that order back, so
+    // this is the input being preserved rather than a sequence that happens to
+    // match. A comparator sorting by id answers "core/a, core/b, core/c" to
+    // both, and the first assertion alone cannot tell the two apart.
+    const reordered = defaultPlacements([
+      widget({ id: "core/b" }),
+      widget({ id: "core/c" }),
+      widget({ id: "core/a" }),
+    ]);
+    expect(reordered.map(p => p.widgetId)).toEqual([
+      "core/b",
+      "core/c",
+      "core/a",
+    ]);
   });
 
-  it("still lets a STATED order win over the tie-break", () => {
-    // The control for the case above. Ordering by id outright would satisfy it
-    // while ignoring every `defaultOrder` a plugin declares — the position
-    // authors actually control.
+  it("still lets a STATED order override the declaration order", () => {
+    // The control in the other direction: a comparator returning 0 for every
+    // pair would preserve declaration order perfectly and ignore the field.
     const placements = defaultPlacements([
       widget({ id: "core/a", defaultOrder: 30 }),
       widget({ id: "core/z", defaultOrder: 10 }),

--- a/packages/nextly/src/domains/widgets/__tests__/layout.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/layout.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 
 import type { WidgetDefinition } from "../definition";
 import {
+  DEFAULT_COLUMN_COUNT,
   LAYOUT_SCHEMA_VERSION,
   MAX_CONFIG_DEPTH,
   MAX_PLACEMENTS,
@@ -28,6 +29,7 @@ function placement(
   return {
     id: "p1",
     widgetId: "core/team",
+    column: 0,
     order: 0,
     hidden: false,
     ...patch,
@@ -128,6 +130,7 @@ describe("reading placements", () => {
     expect(read).toEqual({
       id: "p1",
       widgetId: "core/team",
+      column: 0,
       order: 0,
       hidden: false,
       config: { a: 1 },
@@ -149,7 +152,14 @@ describe("reading placements", () => {
 describe("reading a stored row", () => {
   it("round-trips what it serialized", () => {
     const placements: WidgetPlacement[] = [
-      { id: "a", widgetId: "core/team", order: 0, hidden: true, size: "md" },
+      {
+        id: "a",
+        widgetId: "core/team",
+        column: 1,
+        order: 0,
+        hidden: true,
+        size: "md",
+      },
     ];
     expect(readStoredLayout(serializeLayout(placements)).placements).toEqual(
       placements
@@ -222,20 +232,56 @@ describe("the default arrangement", () => {
     expect(once[0].id).toBe("core/team");
   });
 
-  it("leaves room to insert between two neighbours", () => {
-    const placements = defaultPlacements([
-      widget({ id: "core/a", defaultOrder: 0 }),
-      widget({ id: "core/b", defaultOrder: 1 }),
-    ]);
-    expect(placements[1].order - placements[0].order).toBeGreaterThan(1);
+  it("leaves room to insert between two neighbours in a column", () => {
+    // `order` sequences a COLUMN, not the dashboard, so the two placements to
+    // compare are the ones dealt into the same column — which, with the
+    // round-robin deal, are DEFAULT_COLUMN_COUNT apart in declared order.
+    const placements = defaultPlacements(
+      Array.from({ length: DEFAULT_COLUMN_COUNT + 1 }, (_unused, i) =>
+        widget({ id: `core/${i}`, defaultOrder: i })
+      )
+    );
+    const first = placements[0];
+    const below = placements[DEFAULT_COLUMN_COUNT];
+    expect(below.column).toBe(first.column);
+    expect(below.order - first.order).toBeGreaterThan(1);
+  });
+
+  it("deals the first widgets ACROSS the columns, not down one", () => {
+    // 🔴 The property that decides whether a reader sees the widgets that were
+    // declared first. Filling column 0 before starting column 1 puts the
+    // second-most-important card below the fold on a wide screen while two
+    // columns sit empty beside it.
+    const placements = defaultPlacements(
+      Array.from({ length: DEFAULT_COLUMN_COUNT }, (_unused, i) =>
+        widget({ id: `core/${i}`, defaultOrder: i })
+      )
+    );
+    expect(new Set(placements.map(p => p.column)).size).toBe(
+      DEFAULT_COLUMN_COUNT
+    );
+    // 🔴 And `order` stays a GLOBAL sequence rather than restarting per column.
+    // Numbering within a column collides across them, and these positions are
+    // materialized twice — over the whole registry and over the set a caller
+    // may see — so a collision reorders a reader's dashboard the moment they
+    // gain a permission.
+    expect(new Set(placements.map(p => p.order)).size).toBe(
+      DEFAULT_COLUMN_COUNT
+    );
   });
 });
 
 describe("partitioning by what a reader may see", () => {
   const stored: WidgetPlacement[] = [
-    { id: "p2", widgetId: "core/visible", order: 20, hidden: false },
-    { id: "p1", widgetId: "core/secret", order: 10, hidden: false },
-    { id: "p0", widgetId: "core/visible-2", order: 0, hidden: false },
+    { id: "p2", widgetId: "core/visible", column: 0, order: 20, hidden: false },
+    { id: "p1", widgetId: "core/secret", column: 0, order: 10, hidden: false },
+    {
+      id: "p0",
+      widgetId: "core/visible-2",
+      column: 0,
+      order: 0,
+      hidden: false,
+    },
   ];
 
   it("returns the visible half sorted by order", () => {
@@ -261,7 +307,7 @@ describe("partitioning by what a reader may see", () => {
     // `hidden` is the reader's own choice to put a card away, so it must come
     // back to them -- otherwise nothing could ever put it back.
     const { visible } = partitionPlacements(
-      [{ id: "p", widgetId: "core/x", order: 0, hidden: true }],
+      [{ id: "p", widgetId: "core/x", column: 0, order: 0, hidden: true }],
       new Set(["core/x"])
     );
     expect(visible).toHaveLength(1);
@@ -270,12 +316,18 @@ describe("partitioning by what a reader may see", () => {
 
 describe("merging a write with what the writer could not see", () => {
   const invisible: WidgetPlacement[] = [
-    { id: "hidden-1", widgetId: "core/secret", order: 5, hidden: false },
+    {
+      id: "hidden-1",
+      widgetId: "core/secret",
+      column: 0,
+      order: 5,
+      hidden: false,
+    },
   ];
 
   it("carries the invisible placements through", () => {
     const merged = mergePreservingHidden(
-      [{ id: "p1", widgetId: "core/team", order: 0, hidden: false }],
+      [{ id: "p1", widgetId: "core/team", column: 0, order: 0, hidden: false }],
       invisible
     );
     expect(merged.map(p => p.widgetId)).toEqual(["core/team", "core/secret"]);
@@ -286,7 +338,15 @@ describe("merging a write with what the writer could not see", () => {
     // placement happens to hold that id -- an oracle for the existence of a
     // card this caller must not know about.
     const merged = mergePreservingHidden(
-      [{ id: "hidden-1", widgetId: "core/team", order: 0, hidden: false }],
+      [
+        {
+          id: "hidden-1",
+          widgetId: "core/team",
+          column: 0,
+          order: 0,
+          hidden: false,
+        },
+      ],
       invisible
     );
     expect(merged).toHaveLength(2);
@@ -307,6 +367,7 @@ describe("the size ceiling", () => {
     const many = Array.from({ length: MAX_PLACEMENTS + 1 }, (_, i) => ({
       id: `p${i}`,
       widgetId: "core/team",
+      column: 0,
       order: i,
       hidden: false,
     }));
@@ -321,6 +382,7 @@ describe("the size ceiling", () => {
       {
         id: "p",
         widgetId: "core/team",
+        column: 0,
         order: 0,
         hidden: false,
         config: { note: "\u{1F600}".repeat(9000) },
@@ -421,5 +483,42 @@ describe("config nesting", () => {
     expect(placementProblem(placement({ config: { a: node } }))).toMatch(
       /nest at most/
     );
+  });
+});
+
+describe("a v1 arrangement survives the move to columns", () => {
+  // 🔴 The stored row is a USER'S arrangement, and the reader throws on a
+  // version it does not know rather than resetting — so shipping v2 without a
+  // migrator turns every saved dashboard into an internal error. Reading a v1
+  // row must produce a v2 layout, not a refusal.
+  const V1 = JSON.stringify({
+    schemaVersion: 1,
+    placements: [
+      { id: "a", widgetId: "w-a", column: 0, order: 0, hidden: false },
+      { id: "b", widgetId: "w-b", column: 0, order: 10, hidden: false },
+      { id: "c", widgetId: "w-c", column: 0, order: 20, hidden: true },
+    ],
+  });
+
+  it("reads a v1 row rather than throwing on its version", () => {
+    const layout = readStoredLayout(V1);
+    expect(layout.schemaVersion).toBe(LAYOUT_SCHEMA_VERSION);
+    expect(layout.placements).toHaveLength(3);
+  });
+
+  it("gives every placement a column, and keeps the order the reader saw", () => {
+    // The arrangement is the one thing a user actually authored here, so the
+    // migration may add a coordinate but must not reorder anything.
+    const { placements } = readStoredLayout(V1);
+    expect(placements.map(p => p.widgetId)).toEqual(["w-a", "w-b", "w-c"]);
+    for (const p of placements) expect(typeof p.column).toBe("number");
+  });
+
+  it("keeps a hidden placement hidden across the migration", () => {
+    // 🔴 The control. A migration that rebuilt placements from defaults would
+    // satisfy both assertions above while silently un-hiding a card the user
+    // had put away — the one field whose loss is invisible until it reappears.
+    const { placements } = readStoredLayout(V1);
+    expect(placements.find(p => p.widgetId === "w-c")?.hidden).toBe(true);
   });
 });

--- a/packages/nextly/src/domains/widgets/layout.ts
+++ b/packages/nextly/src/domains/widgets/layout.ts
@@ -59,7 +59,22 @@ import { NextlyError } from "../../errors/nextly-error";
  * refused rather than guessed at, because guessing would silently discard the
  * fields this core cannot see.
  */
-export const LAYOUT_SCHEMA_VERSION = 1;
+export const LAYOUT_SCHEMA_VERSION = 2;
+
+/**
+ * How many columns a dashboard has when nobody has chosen.
+ *
+ * Three rather than two or four: it is the widest count that still leaves a
+ * card readable at the admin's content width, and folding 3 -> 2 -> 1 by
+ * breakpoint keeps a placement's column derivable at every width.
+ */
+export const DEFAULT_COLUMN_COUNT = 3;
+
+/** The column counts a dashboard may have. */
+export const COLUMN_COUNTS = [2, 3, 4] as const;
+
+/** One of the column counts a dashboard may have. */
+export type ColumnCount = (typeof COLUMN_COUNTS)[number];
 
 /**
  * One card, at one position, for one reader.
@@ -72,7 +87,16 @@ export interface WidgetPlacement {
   id: string;
   /** Which registry entry this draws. Resolved live on every read. */
   widgetId: string;
-  /** Ascending. Finite, so it survives a JSON round trip. */
+  /**
+   * Which column this card sits in, 0-based.
+   *
+   * CLAMPED on read rather than refused: the stored count and the count being
+   * rendered can differ -- a reader who narrows a 4-column dashboard to 2 still
+   * owns every card that was in columns 2 and 3, and losing them would be a
+   * worse answer than moving them.
+   */
+  column: number;
+  /** Ascending WITHIN a column. Finite, so it survives a JSON round trip. */
   order: number;
   /** Hidden placements are RETURNED, so the reader can put them back. */
   hidden: boolean;
@@ -85,6 +109,8 @@ export interface WidgetPlacement {
 /** The decoded contents of one `nextly_widget_layout.layout` column. */
 export interface StoredLayout {
   schemaVersion: number;
+  /** How many columns the reader arranged these placements into. */
+  columnCount: ColumnCount;
   placements: WidgetPlacement[];
 }
 
@@ -216,6 +242,13 @@ function toPlacement(value: Record<string, unknown>): WidgetPlacement {
   return {
     id: value.id as string,
     widgetId: value.widgetId as string,
+    // Absent means column 0 rather than a refusal. A caller PUTting a
+    // placement without one is describing a single-column intent, and the
+    // migrator below is what spreads a pre-column arrangement out.
+    column:
+      typeof value.column === "number" && Number.isFinite(value.column)
+        ? Math.max(0, Math.trunc(value.column))
+        : 0,
     order: value.order as number,
     hidden: value.hidden as boolean,
     ...(value.size === undefined ? {} : { size: value.size as string }),
@@ -285,6 +318,8 @@ export function readStoredLayout(raw: string): StoredLayout {
   // from a NEWER core and holds fields we would silently drop on the next
   // write; a version below ours means a migrator is missing. Neither is a
   // shape to guess at. When v2 arrives this is where `migrateLayout` runs.
+  if (decoded.schemaVersion === 1) return migrateV1(decoded);
+
   if (decoded.schemaVersion !== LAYOUT_SCHEMA_VERSION) {
     throw NextlyError.internal({
       logContext: {
@@ -297,16 +332,72 @@ export function readStoredLayout(raw: string): StoredLayout {
 
   return {
     schemaVersion: LAYOUT_SCHEMA_VERSION,
+    columnCount: readColumnCount(decoded.columnCount),
     placements: readPlacements(decoded.placements),
   };
 }
 
+/** The stored column count, or the default when it names none this core has. */
+function readColumnCount(value: unknown): ColumnCount {
+  return COLUMN_COUNTS.includes(value as ColumnCount)
+    ? (value as ColumnCount)
+    : DEFAULT_COLUMN_COUNT;
+}
+
+/**
+ * A v1 arrangement, read as a v2 one.
+ *
+ * 🔴 Migrated on READ and not written back. The row is the reader's own
+ * arrangement and this core refuses a version it cannot name, so shipping v2
+ * without this turns every saved dashboard into an internal error -- the
+ * failure the reader would meet as "your dashboard is gone".
+ *
+ * v1 had one flat `order` and no column, over a grid that flowed left to right
+ * and wrapped. Dealing the placements round-robin across the columns is what
+ * that flow becomes when the same sequence is read down columns instead of
+ * across rows, so a reader's arrangement stays recognisable rather than being
+ * rebuilt from defaults.
+ */
+function migrateV1(decoded: Record<string, unknown>): StoredLayout {
+  const flat = readPlacements(decoded.placements);
+  const ordered = [...flat].sort((a, b) => a.order - b.order);
+  return {
+    schemaVersion: LAYOUT_SCHEMA_VERSION,
+    columnCount: DEFAULT_COLUMN_COUNT,
+    // The reader's own `order` values are KEPT: they are the arrangement, and
+    // v1 already spread them. Only the column is new.
+    placements: ordered.map((placement, index) => ({
+      ...placement,
+      column: index % DEFAULT_COLUMN_COUNT,
+    })),
+  };
+}
+
+/**
+ * The one order in which placements are read as a SEQUENCE.
+ *
+ * 🔴 `order` alone stopped being a total order when columns arrived: the deal
+ * puts the first N widgets at `order: 0` in N different columns, so a sort on
+ * `order` falls back to whatever order the array happened to be in. Comparing
+ * the column second reproduces the row-major reading of the dashboard -- across
+ * the top, then the next row down -- which is what "position" means everywhere
+ * a placement list is presented as a line rather than as columns.
+ *
+ * Drawing the grid does NOT use this: that groups by column and sorts each
+ * column by `order`. Two different questions, and this is only the first.
+ */
+export function byPosition(a: WidgetPlacement, b: WidgetPlacement): number {
+  return a.order - b.order || a.column - b.column;
+}
+
 /** The payload written into the `layout` column. */
 export function serializeLayout(
-  placements: readonly WidgetPlacement[]
+  placements: readonly WidgetPlacement[],
+  columnCount: ColumnCount = DEFAULT_COLUMN_COUNT
 ): string {
   return JSON.stringify({
     schemaVersion: LAYOUT_SCHEMA_VERSION,
+    columnCount,
     placements,
   });
 }
@@ -354,6 +445,17 @@ export function defaultPlacements(
   return [...widgets].sort(byDeclaredOrder).map((widget, index) => ({
     id: widget.id,
     widgetId: widget.id,
+    // Dealt across the columns in declared order, so the first widgets a
+    // reader is meant to see sit along the TOP of the dashboard rather than
+    // filling column 0 and pushing the rest below the fold.
+    column: index % DEFAULT_COLUMN_COUNT,
+    // 🔴 The GLOBAL sequence, not a per-column one. Numbering within a column
+    // would restart at each column and collide across them, and positions here
+    // are materialized twice -- once over the whole registry and once over the
+    // set a caller may see -- so two placements landing on one number is how a
+    // reader's arrangement reorders itself the moment a permission is granted.
+    // A globally unique `order` keeps that impossible; the column is a second
+    // coordinate beside it, never a replacement for it.
     order: index * DEFAULT_ORDER_STEP,
     hidden: false,
     // The declared geometry travels WITH the placement, rather than being left
@@ -396,7 +498,7 @@ export function partitionPlacements(
     if (visibleWidgetIds.has(placement.widgetId)) visible.push(placement);
     else invisible.push(placement);
   }
-  visible.sort((a, b) => a.order - b.order);
+  visible.sort(byPosition);
   return { visible, invisible };
 }
 
@@ -434,9 +536,7 @@ export function mergePreservingHidden(
   const room = Math.max(0, MAX_STORED_PLACEMENTS - submitted.length);
   // Oldest-positioned first, so the cap keeps a stable, order-derived subset
   // rather than whichever ones happened to arrive last.
-  const bounded = [...invisible]
-    .sort((a, b) => a.order - b.order)
-    .slice(0, room);
+  const bounded = [...invisible].sort(byPosition).slice(0, room);
   const carried = bounded.map(placement => {
     if (!taken.has(placement.id)) {
       taken.add(placement.id);

--- a/packages/nextly/src/domains/widgets/layout.ts
+++ b/packages/nextly/src/domains/widgets/layout.ts
@@ -425,14 +425,23 @@ export function serializeLayout(
  * `POSITIVE_INFINITY` rather than a large finite sentinel, because there is no
  * largest finite number a declaration could not legally name -- `Number.MAX_VALUE`
  * as the sentinel sorted a widget declaring it BELOW the unstated ones.
- * Two unstated widgets compare as `NaN`, which `Array.prototype.sort` treats as
- * "leave them alone", so they keep registration order.
+ *
+ * 🔴 TOTAL, and compared by value rather than by difference. Subtracting two
+ * infinities gives `NaN`, which leaves the comparator inconsistent -- what a
+ * sort does with one is unspecified -- so the position of two widgets that
+ * state no order was decided by registration order and by the engine. That
+ * position is a COLUMN once these are materialized, so two instances holding
+ * the same widgets could hand out different default arrangements, and a first
+ * save would keep whichever one it happened to be served. The id is the
+ * tie-break because it is the one thing about a widget that cannot change
+ * between two reads.
  */
 function byDeclaredOrder(a: PlaceableWidget, b: PlaceableWidget): number {
-  return (
-    (a.defaultOrder ?? Number.POSITIVE_INFINITY) -
-    (b.defaultOrder ?? Number.POSITIVE_INFINITY)
-  );
+  const aOrder = a.defaultOrder ?? Number.POSITIVE_INFINITY;
+  const bOrder = b.defaultOrder ?? Number.POSITIVE_INFINITY;
+  if (aOrder !== bOrder) return aOrder < bOrder ? -1 : 1;
+  if (a.id === b.id) return 0;
+  return a.id < b.id ? -1 : 1;
 }
 
 /**

--- a/packages/nextly/src/domains/widgets/layout.ts
+++ b/packages/nextly/src/domains/widgets/layout.ts
@@ -426,22 +426,26 @@ export function serializeLayout(
  * largest finite number a declaration could not legally name -- `Number.MAX_VALUE`
  * as the sentinel sorted a widget declaring it BELOW the unstated ones.
  *
- * 🔴 TOTAL, and compared by value rather than by difference. Subtracting two
- * infinities gives `NaN`, which leaves the comparator inconsistent -- what a
- * sort does with one is unspecified -- so the position of two widgets that
- * state no order was decided by registration order and by the engine. That
- * position is a COLUMN once these are materialized, so two instances holding
- * the same widgets could hand out different default arrangements, and a first
- * save would keep whichever one it happened to be served. The id is the
- * tie-break because it is the one thing about a widget that cannot change
- * between two reads.
+ * 🔴 Equal orders compare EQUAL, and the declaration order then stands, which
+ * is the guarantee this field documents: a widget that omits `defaultOrder`
+ * keeps the position it was declared in. `Array.prototype.sort` has been
+ * stable since ES2019, so equal elements keep their input order, and the
+ * admin's own comparator relies on exactly that -- every widget shipping today
+ * states no order, so they all compare equal and keep the arrangement they
+ * have. Any tie-break here, on the id or on anything else, rearranges every
+ * default dashboard holding plugin widgets and puts core's answer at odds with
+ * the admin's.
+ *
+ * Written as a value comparison rather than a subtraction only so that no
+ * branch produces `NaN`. Two infinities subtract to `NaN`, which the spec then
+ * converts to +0 -- the same answer, reached by a route that reads like an
+ * accident.
  */
 function byDeclaredOrder(a: PlaceableWidget, b: PlaceableWidget): number {
   const aOrder = a.defaultOrder ?? Number.POSITIVE_INFINITY;
   const bOrder = b.defaultOrder ?? Number.POSITIVE_INFINITY;
-  if (aOrder !== bOrder) return aOrder < bOrder ? -1 : 1;
-  if (a.id === b.id) return 0;
-  return a.id < b.id ? -1 : 1;
+  if (aOrder === bOrder) return 0;
+  return aOrder < bOrder ? -1 : 1;
 }
 
 /**

--- a/packages/nextly/src/domains/widgets/layout.ts
+++ b/packages/nextly/src/domains/widgets/layout.ts
@@ -338,7 +338,7 @@ export function readStoredLayout(raw: string): StoredLayout {
 }
 
 /** The stored column count, or the default when it names none this core has. */
-function readColumnCount(value: unknown): ColumnCount {
+export function readColumnCount(value: unknown): ColumnCount {
   return COLUMN_COUNTS.includes(value as ColumnCount)
     ? (value as ColumnCount)
     : DEFAULT_COLUMN_COUNT;

--- a/packages/nextly/src/domains/widgets/layout.ts
+++ b/packages/nextly/src/domains/widgets/layout.ts
@@ -237,18 +237,34 @@ export function placementProblem(value: unknown): string | undefined {
   return undefined;
 }
 
+/**
+ * Whether a caller's placement NAMED a column, as opposed to omitting one.
+ *
+ * 🔴 The two are different answers and the stored type cannot hold the
+ * difference: `column` is a required number, so an omission has already become
+ * a 0 by the time anything downstream looks. A writer that needs to tell them
+ * apart — to leave a card where it was rather than to move it to the first
+ * column — has to ask before the rebuild, and this is the one predicate that
+ * decides it, so the rebuild below and the writer cannot disagree.
+ */
+export function statesColumn(value: unknown): boolean {
+  if (typeof value !== "object" || value === null) return false;
+  const column = (value as { column?: unknown }).column;
+  return typeof column === "number" && Number.isFinite(column);
+}
+
 /** A placement, with only the fields this core stores, in a stable order. */
 function toPlacement(value: Record<string, unknown>): WidgetPlacement {
   return {
     id: value.id as string,
     widgetId: value.widgetId as string,
-    // Absent means column 0 rather than a refusal. A caller PUTting a
-    // placement without one is describing a single-column intent, and the
-    // migrator below is what spreads a pre-column arrangement out.
-    column:
-      typeof value.column === "number" && Number.isFinite(value.column)
-        ? Math.max(0, Math.trunc(value.column))
-        : 0,
+    // Absent becomes 0 here because the stored shape has no way to say
+    // "unstated". A writer that can do better asks `statesColumn` first: the
+    // layout endpoint keeps the column a card already had rather than reading
+    // an omission as a move to the first column.
+    column: statesColumn(value)
+      ? Math.max(0, Math.trunc(value.column as number))
+      : 0,
     order: value.order as number,
     hidden: value.hidden as boolean,
     ...(value.size === undefined ? {} : { size: value.size as string }),

--- a/packages/nextly/src/services/widgets/__tests__/widget-layout.integration.test.ts
+++ b/packages/nextly/src/services/widgets/__tests__/widget-layout.integration.test.ts
@@ -41,6 +41,7 @@ function placement(patch: Partial<WidgetPlacement> = {}): WidgetPlacement {
   return {
     id: "p1",
     widgetId: "core/team",
+    column: 0,
     order: 0,
     hidden: false,
     ...patch,
@@ -69,7 +70,13 @@ function layoutSuite(
       const scope = `u-roundtrip-${label}`;
       const placements = [
         placement({ id: "a", order: 0, size: "md" }),
-        placement({ id: "b", widgetId: "core/other", order: 10, hidden: true }),
+        placement({
+          id: "b",
+          widgetId: "core/other",
+          column: 0,
+          order: 10,
+          hidden: true,
+        }),
       ];
 
       const version = await service.saveLayout("user", scope, placements, 0);

--- a/packages/nextly/src/services/widgets/widget-layout-service.test.ts
+++ b/packages/nextly/src/services/widgets/widget-layout-service.test.ts
@@ -63,7 +63,9 @@ class StubbedService extends WidgetLayoutService {
   }
 }
 
-const placements = [{ id: "p1", widgetId: "core/a", order: 0, hidden: false }];
+const placements = [
+  { id: "p1", widgetId: "core/a", column: 0, order: 0, hidden: false },
+];
 
 describe("a failed insert", () => {
   it("is a conflict when a row is there afterwards", async () => {

--- a/packages/nextly/src/services/widgets/widget-layout-service.ts
+++ b/packages/nextly/src/services/widgets/widget-layout-service.ts
@@ -14,6 +14,8 @@ import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 import { and, eq } from "drizzle-orm";
 
 import {
+  DEFAULT_COLUMN_COUNT,
+  type ColumnCount,
   readStoredLayout,
   serializeLayout,
   type StoredLayout,
@@ -175,10 +177,11 @@ export class WidgetLayoutService extends BaseService {
     kind: LayoutScopeKind,
     scopeId: string,
     placements: readonly WidgetPlacement[],
-    expectedVersion: number
+    expectedVersion: number,
+    columnCount: ColumnCount = DEFAULT_COLUMN_COUNT
   ): Promise<number> {
     const id = layoutRowId(kind, scopeId);
-    const layout = serializeLayout(placements);
+    const layout = serializeLayout(placements, columnCount);
     const now = new Date();
 
     if (expectedVersion === NO_STORED_LAYOUT_VERSION) {


### PR DESCRIPTION
A dashboard is arranged in **columns the reader chooses**, rather than in one wrapped twelve-column grid.

## Why the drag felt wrong, and why this is the fix

Card widths were uneven fractions of twelve — `sm` 3/12, `md` 4/12, `lg` 6/12, `xl` 8/12 — so a card's width depended on its neighbours, and the grid was sorted with `rectSortingStrategy`.

dnd-kit's sorting strategies predict positions from measured rectangles and need a **predictable** layout. With mixed spans they mispredict: dragging a 3-wide card past a 6-wide one reflows the row and the cards visibly resize mid-gesture. That is a catalogued behaviour of the library rather than a defect here — [#117 "Variable sized sortables stretched when dragged"](https://github.com/clauderic/dnd-kit/issues/117), [#44](https://github.com/clauderic/dnd-kit/issues/44), [#720](https://github.com/clauderic/dnd-kit/issues/720). The maintainer guidance in those threads is that the strategies work for uniform grids **or** for vertical/horizontal lists, and lists explicitly DO support items of varying size.

So the library was never the problem and stays. Each column is now an independent vertical list of equal-width items — the supported case, and one that handles varying **height**, the dimension a dashboard card genuinely varies in. Nothing spans tracks, so no card's width depends on another's.

`closestCorners` replaces `closestCenter`: with several droppable containers the nearest *centre* is often a tall card's centre rather than the column the pointer is over.

## Prior art

WordPress has run draggable metaboxes in a user-chosen column count for fifteen years, across a plugin ecosystem far larger than ours; Jira dashboards use the same model. It survives third-party widgets of unknown height, which is exactly the plugin requirement here. Free drag-and-resize was considered and rejected — the design doc already declined it, and it needs collision/compaction, layouts that survive an uninstall, a touch resize story, and a mobile fallback that ends up being a column model anyway.

## Accessibility is load-bearing, not a footnote

`WidgetEditControls` already established **WCAG 2.2 SC 2.5.7** conformance for ordering. Verified against W3C rather than taken from the docblock: *"Achieving keyboard equivalence for a dragging operation does not automatically meet this success criterion, unless that equivalent keyboard operation also provides controls that can be clicked or tapped with a pointer."*

Dragging a card into another column is **new functionality**, so without a clickable route this would have regressed that conformance. The sideways controls are what make the new drag permissible. They refuse rather than clamp at the ends — a button that looks disabled but still acts means the affordance and the handler disagree, and a reader believes whichever moved the card.

The count picker is a **radio group, not a select**: three short mutually exclusive choices, every option visible without opening anything, arrow keys between them, and a visible label rather than an `aria-label` on a cluster of digits.

## Two defects found on the way

- **A sideways move could not be saved.** `hasChanges` compared id, widgetId, order, hidden, size and height — not `column`. Moving a card sideways changes only that field, so the arrangement compared as untouched and Save stayed disabled. Changing only the *count* had the same problem one level up, and no placement records it at all.
- **Two answers to one question.** The grid derived `columnCount` from the server while the editor held the draft's, so the dashboard drew the saved count while the reader looked at the one they had just chosen — and a drop resolved against a column they could not see.

## Data safety

- **v1 rows migrate on READ, never written back.** The reader throws on a version it cannot name, so shipping v2 without a migrator would turn every saved dashboard into an internal error. It is not rewritten during a GET, because that would change data the reader never asked to change.
- **`order` stays the globally unique sequence; `column` is a second coordinate beside it.** My first shape numbered each column from zero, which collides across columns — and these positions are materialized twice, once over the whole registry and once over the set a caller may see, so a collision reorders a reader's dashboard the moment they gain a permission. An existing test caught it.
- **A card outside the current count is folded into the last column for DRAWING and keeps its stored column.** Narrowing 4 → 2 and widening back returns every card to where the reader put it.
- **A column is droppable as well as its cards.** An empty column holds nothing to aim at; without its own target it stays reachable only until its last card leaves.

## Plugin/DX surface

A plugin declares intent, never coordinates — it keeps `defaultSize`/`defaultOrder` and never names a column, because one that could pin itself to column 0 would fight every other plugin for that slot. `size` remains an accepted input, the unknown-archetype tolerance is preserved, and out-of-range values clamp rather than throw.

The shared `useSortableFieldArray` is untouched — `RepeaterInput` and `ComponentInput` are single lists that will never cross containers, so only its **sensors** are borrowed. An index cannot express which column a card landed in.

## Verification

Every behaviour change is break-verified against a wrong implementation, and each break moved only its own test:

- drop the column comparison in `hasChanges` → fails only `SEES a card that only changed column`
- point the grid at the saved count → fails only `REDRAWS the dashboard at the count the reader picked`
- render the sideways buttons but make the handler inert → fails only `actually moves the card, rather than only enabling a button`
- remove the sideways buttons → fails both conformance tests
- collapse empty columns → fails the empty-column and column-count tests
- drop out-of-range cards → fails only `KEEPS a card whose column is past the count`
- remove the v1 migrator → fails all three migration tests
- remove column-target support → fails only the empty-column drop test

Two of my own tests initially passed against a break that deleted the code they covered — they were asserting against the *default* rendering before the stored arrangement arrived. Both now wait on the arrangement itself and discriminate.

Gates, each status read on its own line: `nextly` check-types 0, lint 0, **873 files / 11098 tests**; `admin` check-types 0, lint 0, **392 files / 3853 tests**; comment convention 0; `changeset status` 0; fallow **`pass`** with every `*_introduced` at 0 over 26 changed files.

fallow refused this branch twice on cognitive complexity and both were fixed by extraction rather than by suppression — `usePlacementMutations`, `useLayoutLifecycle` and `ArrangedColumns` all came out of that.

## Not here

The 2/3/4 picker is the whole of the layout phase. The catalogue's widget work — the `system:` source kind, Content Health, the table and quick-create widgets — follows in its own PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-column dashboard layouts with support for 2–4 columns.
  * Added drag-and-drop movement of widgets between columns, including empty columns.
  * Added controls for moving widgets left or right between columns.
  * Added column selection to the dashboard layout editor.
  * Preserved and migrated existing dashboard layouts to the new column-aware format.

* **Bug Fixes**
  * Layout changes now correctly detect column movements and column-count updates as unsaved changes.
  * Improved drop positioning and announcements for column and within-column moves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->