### PR TITLE
feat(plugin-page-builder): add the pattern, component and layout stores

### DIFF
--- a/.changeset/page-builder-composition-stores.md
+++ b/.changeset/page-builder-composition-stores.md
@@ -54,5 +54,9 @@ permission are then derived from the slug the host actually registered, so a
 `.rename({ patterns: "saved-patterns" })` no longer leaves the link pointing
 at a list that does not exist or gates it on a permission nobody is seeded.
 
+A menu item naming a collection its plugin does not contribute is refused at
+registration rather than serialized into a link nobody can follow.
+
 Nothing yet renders a component instance or resolves a Layout — this is the
-storage and the permissions the rest of the feature is built on.
+storage and the permissions the rest of the feature is built on. A Layout row
+names no variant yet, because a component has none to name.

--- a/.changeset/page-builder-composition-stores.md
+++ b/.changeset/page-builder-composition-stores.md
@@ -40,6 +40,9 @@ so a site can keep saved starting points and reusable pieces beside its pages.
   rows rather than columns, so adding an announcement bar or a sidebar later
   costs no migration.
 
+Each store is offered by one sidebar link — the page builder's own — rather
+than also appearing in the automatic collection navigation.
+
 All three separate saving from publishing: a draft is worked on privately and
 publishing is the single act that ships it. Each appears in the admin behind
 its own read permission, and each accepts only its own kind of document, so a

--- a/.changeset/page-builder-composition-stores.md
+++ b/.changeset/page-builder-composition-stores.md
@@ -1,0 +1,49 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Patterns, components and layouts are now three stores the page builder ships,
+so a site can keep saved starting points and reusable pieces beside its pages.
+
+- **Patterns** are copied when you insert them. A pattern carries a title,
+  description, category, keywords and a granularity, so the library can be
+  browsed and searched rather than scrolled.
+- **Components** are placed by reference, so editing one changes every page
+  that carries it. A component may name the Layout area it suits, which is how
+  a site header stays out of the ordinary insert list without being a
+  different kind of thing.
+- **Layouts** name which component fills each area around a page. Areas are
+  rows rather than columns, so adding an announcement bar or a sidebar later
+  costs no migration.
+
+All three separate saving from publishing: a draft is worked on privately and
+publishing is the single act that ships it. Each appears in the admin behind
+its own read permission, and each accepts only its own kind of document, so a
+page cannot be stored as a pattern.
+
+Nothing yet renders a component instance or resolves a Layout — this is the
+storage and the permissions the rest of the feature is built on.

--- a/.changeset/page-builder-composition-stores.md
+++ b/.changeset/page-builder-composition-stores.md
@@ -57,8 +57,16 @@ permission are then derived from the slug the host actually registered, so a
 `.rename({ patterns: "saved-patterns" })` no longer leaves the link pointing
 at a list that does not exist or gates it on a permission nobody is seeded.
 
-A menu item naming a collection its plugin does not contribute is refused at
-registration rather than serialized into a link nobody can follow.
+A menu item naming a collection its plugin does not contribute is refused when
+the plugin is registered, rather than throwing on every admin request once the
+app is already running. An item that names a collection keeps the destination
+it declared — including any list state such as `?status=draft` — and only has
+its collection segment rewritten when a rename actually moves it.
+
+Creating a document in a blocks field now seeds an empty document of a kind
+that field accepts. Previously it always seeded a page, so a store declaring
+`kinds: ["pattern"]` offered an editor that looked like it worked and a save
+the server refused.
 
 Nothing yet renders a component instance or resolves a Layout — this is the
 storage and the permissions the rest of the feature is built on. A Layout row

--- a/.changeset/page-builder-composition-stores.md
+++ b/.changeset/page-builder-composition-stores.md
@@ -45,5 +45,14 @@ publishing is the single act that ships it. Each appears in the admin behind
 its own read permission, and each accepts only its own kind of document, so a
 page cannot be stored as a pattern.
 
+A Layout may fill each area only once, so one Layout cannot name two headers
+and leave whatever reads it first to decide which page gets which.
+
+Plugin menu items may now name the collection they point at, with
+`collection: "patterns"` beside `to`. The item's destination and its read
+permission are then derived from the slug the host actually registered, so a
+`.rename({ patterns: "saved-patterns" })` no longer leaves the link pointing
+at a list that does not exist or gates it on a permission nobody is seeded.
+
 Nothing yet renders a component instance or resolves a Layout — this is the
 storage and the permissions the rest of the feature is built on.

--- a/packages/admin/src/components/icons/index.ts
+++ b/packages/admin/src/components/icons/index.ts
@@ -56,6 +56,7 @@ export {
   ChevronUp,
   Circle, // useFields: radio
   Clipboard, // Collection Settings: icon picker
+  Component, // Plugin appearance: the icon @nextlyhq/plugin-page-builder declares
   Clock, // useFields: time picker
   Cloud, // AutoSaveIndicator: saved state
   CloudOff, // AutoSaveIndicator: not saved state
@@ -111,6 +112,7 @@ export {
   Laptop,
   Layout, // Plugin appearance: the icon @nextlyhq/plugin-page-builder declares
   LayoutGrid, // Collection Builder: blocks field
+  LayoutTemplate, // Plugin appearance: the icon @nextlyhq/plugin-page-builder declares
   Languages, // Translations: the worklist's sidebar entry
   Layers,
   LayoutDashboard,
@@ -144,6 +146,7 @@ export {
   PanelRightClose,
   PanelRightOpen,
   PanelTop, // Collection Builder: tabs field
+  PanelsTopLeft, // Plugin appearance: the icon @nextlyhq/plugin-page-builder declares
   Paperclip, // Email Template editor: default attachments
   Pencil, // Collection Settings: icon picker
   Pilcrow, // Rich text editor: paragraph block type

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -139,6 +139,7 @@ import {
 } from "../plugins/services/plugin-services-registry";
 import { clearPluginSubscriptions } from "../plugins/subscription-tracker";
 import { assertAdminWidgets } from "../plugins/validate-admin-widgets";
+import { validatePluginMenus } from "../plugins/validate-menus";
 import { validatePluginSlugs } from "../plugins/validate-slugs";
 import { setBootedConfig } from "../route-handler/auth-handler";
 import type {
@@ -505,6 +506,11 @@ export async function registerServices(
   // Boot is where this should fail; without it a transformer-introduced
   // collision would surface on the first admin-meta request instead.
   validatePluginSlugs(setupConfig.plugins ?? []);
+  // And the menu targets on that same transformed list. A transformer may
+  // rename a contributed collection or replace a plugin outright, so an item
+  // that named a collection its plugin owned before the transform can name one
+  // it no longer does.
+  validatePluginMenus(setupConfig.plugins ?? []);
   // And the widgets on that same transformed list, for the same reason one
   // level in. `resolvePlugins` checks the list the CALLER passed; a transformer
   // that adds or replaces a plugin contributes widgets that list never held, and

--- a/packages/nextly/src/plugins/admin-contributions.ts
+++ b/packages/nextly/src/plugins/admin-contributions.ts
@@ -108,6 +108,33 @@ export interface PluginMenuItem {
   label: string;
   /** Admin path to navigate to, e.g. `"/admin/collections/forms"`. */
   to: string;
+  /**
+   * The DECLARED slug of one of this plugin's own collections, when the item
+   * points at that collection's list.
+   *
+   * An integrator may `.rename({ forms: "contact-forms" })`, and the schema
+   * then registers only the renamed collection and seeds only its
+   * permissions. An item that spelled the declared slug into `to` would send
+   * every reader to a list that does not exist, and one that spelled it into
+   * `requiredPermission` would be withheld from the readers who hold the
+   * permission that WAS seeded. Naming the collection instead lets
+   * `buildPluginAdminMeta` re-derive both from the slug the host actually
+   * registered.
+   *
+   * `to` stays required, and stays the item's destination when nothing is
+   * renamed. Both are written from one slug constant at the declaration site,
+   * so they cannot say different things.
+   *
+   * Declaring this also gates the item on being able to READ that collection,
+   * because an item pointing at a list is worth offering only to someone the
+   * list will open for. An item that must carry no gate omits `collection`
+   * and writes its own `to`.
+   *
+   * Resolved away during serialization: the admin receives `to` and
+   * `requiredPermission` already carrying the resolved slug, and never sees
+   * this field.
+   */
+  collection?: string;
   /** Lucide icon name (resolved client-side). */
   icon?: string;
   /** Sort order within the plugin's items; lower = higher. Default 100. */

--- a/packages/nextly/src/plugins/admin-meta.test.ts
+++ b/packages/nextly/src/plugins/admin-meta.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { PluginDefinition } from "./plugin-context";
+import { definePlugin } from "./plugin-context";
 
 import { NEXTLY_ERROR_STATUS } from "../errors/error-codes";
 import { NextlyError } from "../errors/nextly-error";
@@ -896,5 +897,131 @@ describe("dormant routes against the enabled set", () => {
     expect(metas.find(m => m.name === "foo")?.routes).toEqual([
       { method: "GET", path: "/bar/x", fullPath: "/plugins/foo/bar/x" },
     ]);
+  });
+});
+
+/**
+ * A menu item that spells a slug survives boot and breaks at navigation.
+ *
+ * `.rename()` moves a contributed collection and the permission its slug
+ * seeds, and nothing type-checks a path or a permission string, so the
+ * broken versions of these items all serialize. Each assertion below is
+ * written against one of them: a `to` still naming the declared slug, a
+ * `requiredPermission` still naming it, a literal path rewritten by a rule
+ * that should not have touched it, and the declared slug leaking through to
+ * the client beside the resolved one.
+ */
+describe("buildPluginAdminMeta menu slugs", () => {
+  /** A plugin owning `patterns`, offering it a menu item, optionally renamed. */
+  function withPatternsMenu(map?: Record<string, string>): PluginDefinition {
+    const plugin = definePlugin({
+      ...base,
+      contributes: {
+        collections: [{ slug: "patterns" } as never],
+        admin: {
+          menu: [
+            {
+              label: "Patterns",
+              collection: "patterns",
+              to: "/admin/collections/patterns",
+              icon: "LayoutTemplate",
+            },
+          ],
+        },
+      },
+    } as unknown as PluginDefinition);
+    return map ? (plugin.rename?.(map) ?? plugin) : plugin;
+  }
+
+  const menuOf = (plugin: PluginDefinition) =>
+    buildPluginAdminMeta([plugin], undefined)[0].menu;
+
+  it("points the item at the slug the host registered", () => {
+    // The control: the same declaration with nothing renamed has to resolve to
+    // the declared slug. Without it, a resolver that returned a constant, or
+    // one that dropped the item, would satisfy the renamed assertion below.
+    expect(menuOf(withPatternsMenu())?.[0]).toMatchObject({
+      to: "/admin/collections/patterns",
+      requiredPermission: "read-patterns",
+    });
+
+    expect(
+      menuOf(withPatternsMenu({ patterns: "saved-patterns" }))?.[0]
+    ).toMatchObject({
+      to: "/admin/collections/saved-patterns",
+      // The gate moves with the link. A rename seeds `read-saved-patterns`,
+      // so an item still asking for `read-patterns` is withheld from every
+      // non-super-admin who can open the list.
+      requiredPermission: "read-saved-patterns",
+    });
+  });
+
+  it("does not ship the declared slug beside the resolved one", () => {
+    const item = menuOf(withPatternsMenu({ patterns: "saved-patterns" }))?.[0];
+
+    // Two answers to one question, of which the stale one reads as
+    // authoritative because it is the name the plugin's own code uses.
+    expect(item).not.toHaveProperty("collection");
+  });
+
+  it("leaves an item that names no collection exactly as written", () => {
+    const plugin = definePlugin({
+      ...base,
+      contributes: {
+        collections: [{ slug: "patterns" } as never],
+        admin: {
+          menu: [
+            {
+              label: "Pages",
+              to: "/admin/collections/patterns",
+              icon: "Layout",
+            },
+          ],
+        },
+      },
+    } as unknown as PluginDefinition);
+    // The rename map COVERS the slug spelled in the path, so a resolver that
+    // rewrote paths by matching text rather than by reading `collection`
+    // would move this one. It must not: the item named no collection, and an
+    // author's literal path is not the framework's to reinterpret.
+    const renamed = plugin.rename?.({ patterns: "saved-patterns" }) ?? plugin;
+
+    expect(menuOf(renamed)?.[0]).toEqual({
+      label: "Pages",
+      to: "/admin/collections/patterns",
+      icon: "Layout",
+    });
+  });
+
+  it("resolves a nested item too", () => {
+    const plugin = definePlugin({
+      ...base,
+      contributes: {
+        collections: [{ slug: "patterns" } as never],
+        admin: {
+          menu: [
+            {
+              label: "Design",
+              to: "/admin/collections/patterns",
+              children: [
+                {
+                  label: "Patterns",
+                  collection: "patterns",
+                  to: "/admin/collections/patterns",
+                },
+              ],
+            },
+          ],
+        },
+      },
+    } as unknown as PluginDefinition);
+    const renamed = plugin.rename?.({ patterns: "saved-patterns" }) ?? plugin;
+
+    // A child is exactly as stranded as a parent, and is the one a resolver
+    // that only walked the top level would leave behind.
+    expect(menuOf(renamed)?.[0].children?.[0]).toMatchObject({
+      to: "/admin/collections/saved-patterns",
+      requiredPermission: "read-saved-patterns",
+    });
   });
 });

--- a/packages/nextly/src/plugins/admin-meta.test.ts
+++ b/packages/nextly/src/plugins/admin-meta.test.ts
@@ -993,6 +993,49 @@ describe("buildPluginAdminMeta menu slugs", () => {
     });
   });
 
+  it("refuses an item naming a collection the plugin does not contribute", () => {
+    const plugin = definePlugin({
+      ...base,
+      contributes: {
+        collections: [{ slug: "patterns" } as never],
+        admin: {
+          menu: [
+            {
+              label: "Patterns",
+              collection: "pattrens",
+              to: "/admin/collections/patterns",
+            },
+          ],
+        },
+      },
+    } as unknown as PluginDefinition);
+
+    // A typo resolves to a well-formed path and a well-formed permission, and
+    // both are wrong in the quietest way available: the permission is never
+    // seeded, so a non-super-admin cannot tell the item from one they are not
+    // allowed to see. Registration is the last moment it is visible as a
+    // mistake, so it is refused there rather than serialized.
+    let caught: unknown;
+    try {
+      menuOf(plugin);
+    } catch (error) {
+      caught = error;
+    }
+
+    // Asserted on the reason and the log message rather than on `message`,
+    // which every plugin resolution error answers with the same sentence — a
+    // match on it would pass for a duplicate admin slug just as readily.
+    expect(
+      (caught as { logContext?: { reason?: string } })?.logContext?.reason
+    ).toBe("menu-item-unowned-collection");
+    // Names the offending slug AND what it could have been. Neither is
+    // recoverable from the other, and a reader looking at a typo is exactly
+    // the reader who cannot see it.
+    const logMessage = (caught as { logMessage?: string })?.logMessage ?? "";
+    expect(logMessage).toContain("pattrens");
+    expect(logMessage).toContain("patterns");
+  });
+
   it("resolves a nested item too", () => {
     const plugin = definePlugin({
       ...base,

--- a/packages/nextly/src/plugins/admin-meta.test.ts
+++ b/packages/nextly/src/plugins/admin-meta.test.ts
@@ -1036,6 +1036,67 @@ describe("buildPluginAdminMeta menu slugs", () => {
     expect(logMessage).toContain("patterns");
   });
 
+  it("keeps a destination that carries list state when nothing is renamed", () => {
+    const plugin = definePlugin({
+      ...base,
+      contributes: {
+        collections: [{ slug: "patterns" } as never],
+        admin: {
+          menu: [
+            {
+              label: "Drafts",
+              collection: "patterns",
+              to: "/admin/collections/patterns?status=draft",
+            },
+          ],
+        },
+      },
+    } as unknown as PluginDefinition);
+
+    // Naming a collection is how an item opts into rename-safety and RBAC, not
+    // a request to be sent somewhere canonical. Overwriting `to` made adding
+    // `collection` to a working link silently change where that link went —
+    // and the contract on the field says the opposite.
+    expect(menuOf(plugin)?.[0]).toMatchObject({
+      to: "/admin/collections/patterns?status=draft",
+      requiredPermission: "read-patterns",
+    });
+
+    // And when the slug DOES move, only the collection segment is rewritten.
+    const renamed = plugin.rename?.({ patterns: "saved" }) ?? plugin;
+    expect(menuOf(renamed)?.[0]).toMatchObject({
+      to: "/admin/collections/saved?status=draft",
+      requiredPermission: "read-saved",
+    });
+  });
+
+  it("does not resolve a slug through an inherited object property", () => {
+    const plugin = definePlugin({
+      ...base,
+      contributes: {
+        // A legal slug that is also a key every object inherits.
+        collections: [{ slug: "constructor" } as never],
+        admin: {
+          menu: [
+            {
+              label: "Constructor",
+              collection: "constructor",
+              to: "/admin/collections/constructor",
+            },
+          ],
+        },
+      },
+    } as unknown as PluginDefinition);
+
+    // With no rename the map is `{}`, and `{}["constructor"]` is the Object
+    // constructor — a function, so `??` never fires and the destination
+    // becomes the source text of a native function.
+    expect(menuOf(plugin)?.[0]).toMatchObject({
+      to: "/admin/collections/constructor",
+      requiredPermission: "read-constructor",
+    });
+  });
+
   it("resolves a nested item too", () => {
     const plugin = definePlugin({
       ...base,

--- a/packages/nextly/src/plugins/admin-meta.ts
+++ b/packages/nextly/src/plugins/admin-meta.ts
@@ -26,11 +26,11 @@ import type {
   PluginDefinition,
 } from "./plugin-context";
 import { pluginAdminSlug } from "./plugin-slug";
-import { resolutionError } from "./resolution-error";
 import { collectPluginRoutes } from "./routes/collect-routes";
 import { isRouteError } from "./routes/route-error";
 import { validatedAdminWidgets } from "./validate-admin-widgets";
 import { validatedClientConfig } from "./validate-client-config";
+import { validatePluginMenus } from "./validate-menus";
 import { validatePluginSlugs } from "./validate-slugs";
 
 /**
@@ -190,12 +190,10 @@ export { pluginAdminSlug } from "./plugin-slug";
  */
 function resolvedMenuItem(
   item: PluginMenuItem,
-  renameMap: Record<string, string>,
-  owned: readonly string[],
-  name: string
+  renameMap: Record<string, string>
 ): PluginMenuItem {
   const children = item.children?.map(child =>
-    resolvedMenuItem(child, renameMap, owned, name)
+    resolvedMenuItem(child, renameMap)
   );
   const withChildren = children ? { ...item, children } : item;
 
@@ -205,33 +203,55 @@ function resolvedMenuItem(
   const { collection, ...rest } = withChildren;
   if (collection === undefined) return withChildren;
 
-  // Refused at registration, because there is nothing to observe later. A slug
-  // this plugin does not own resolves to a perfectly well-formed path and a
-  // perfectly well-formed permission, and both are wrong in the quietest way
-  // available: the permission is never seeded, so every non-super-admin simply
-  // does not see the item, and the super-admins who do see it get a link to a
-  // list that does not exist. Neither surface can tell that from a role
-  // legitimately lacking access.
-  if (!owned.includes(collection)) {
-    throw resolutionError(
-      "menu-item-unowned-collection",
-      `Plugin "${name}" has a menu item ("${withChildren.label}") naming ` +
-        `collection "${collection}", which it does not contribute. Name one ` +
-        `of: ${owned.join(", ") || "(none)"}.`,
-      { plugin: name, collection, owned }
-    );
-  }
+  // An OWN property only. `renameMap` is an ordinary object, so a plugin whose
+  // collection is legitimately called `constructor` or `toString` would index
+  // into `Object.prototype` and resolve its slug to a function — and `??`
+  // cannot see that, because an inherited method is neither null nor
+  // undefined. The destination becomes `/admin/collections/function Object()
+  // { [native code] }` and the gate an equally unseeded permission.
+  const renamed = Object.prototype.hasOwnProperty.call(renameMap, collection)
+    ? renameMap[collection]
+    : undefined;
+  const slug = typeof renamed === "string" ? renamed : collection;
 
-  const slug = renameMap[collection] ?? collection;
   return {
     ...rest,
-    to: `/admin/collections/${slug}`,
+    to: retargetedTo(rest.to, collection, slug),
     // The seeded per-collection read verb. Written from the resolved slug for
-    // the same reason `to` is: a rename moves the permission the seeder
-    // creates, and a gate naming the declared slug would hide the item from
-    // exactly the readers who can open the list.
+    // the same reason the destination is: a rename moves the permission the
+    // seeder creates, and a gate naming the declared slug would hide the item
+    // from exactly the readers who can open the list.
     requiredPermission: `read-${slug}`,
   };
+}
+
+/**
+ * The item's destination, pointed at the slug the host registered.
+ *
+ * Returns the declared `to` UNCHANGED when nothing was renamed. Naming a
+ * collection is how an item opts into rename-safety and RBAC, not a request to
+ * be sent somewhere canonical, so an item whose destination carries list state
+ * — `?status=draft`, a hash, a sub-path — keeps it. Overwriting it made adding
+ * `collection` to a working link change where that link went.
+ *
+ * When the slug DID move, only the collection segment is rewritten and
+ * whatever followed it is carried across. A destination that does not address
+ * the declared collection at all is left alone: the item named a collection so
+ * its permission still moves, but a path this function does not recognise is
+ * not one it should be inventing a new spelling for.
+ */
+function retargetedTo(to: string, declared: string, resolved: string): string {
+  if (declared === resolved) return to;
+
+  const prefix = `/admin/collections/${declared}`;
+  const addressesTheList =
+    to === prefix ||
+    to.startsWith(`${prefix}/`) ||
+    to.startsWith(`${prefix}?`) ||
+    to.startsWith(`${prefix}#`);
+  if (!addressesTheList) return to;
+
+  return `/admin/collections/${resolved}${to.slice(prefix.length)}`;
 }
 
 /**
@@ -307,6 +327,7 @@ export function buildPluginAdminMeta(
   // rewrite `config.plugins` after `resolvePlugins` has already run. Both
   // would publish ambiguous addresses from a list nothing had checked.
   validatePluginSlugs(plugins);
+  validatePluginMenus(plugins);
 
   return plugins.map(plugin => {
     const slug = pluginAdminSlug(plugin.name);
@@ -374,12 +395,7 @@ export function buildPluginAdminMeta(
     if (isEnabled && admin) {
       if (admin.menu && admin.menu.length > 0) {
         meta.menu = admin.menu.map(item =>
-          resolvedMenuItem(
-            item,
-            plugin.renameMap ?? {},
-            pluginCollectionSlugs(plugin),
-            plugin.name
-          )
+          resolvedMenuItem(item, plugin.renameMap ?? {})
         );
       }
       if (admin.pages && admin.pages.length > 0) meta.pages = admin.pages;

--- a/packages/nextly/src/plugins/admin-meta.ts
+++ b/packages/nextly/src/plugins/admin-meta.ts
@@ -171,6 +171,50 @@ export { pluginAdminSlug } from "./plugin-slug";
  * applies) but contribute NO behavioral admin UI — no menu/pages/settings.
  */
 /**
+ * Resolve a menu item's destination and gate through the plugin's renameMap.
+ *
+ * An item naming one of the plugin's own collections is re-pointed at the slug
+ * the host REGISTERED, and gated on the read permission that slug seeds. An
+ * item naming none is copied through: it addresses something the rename cannot
+ * move, and rewriting a path the author wrote literally would be a different
+ * and much harder-to-predict rule.
+ *
+ * `collection` is dropped rather than forwarded. The admin's contract is a
+ * resolved `to` and a resolved `requiredPermission`; shipping the declared
+ * slug alongside them would offer a second answer to the same question, and
+ * the stale one is the one that looks authoritative.
+ *
+ * Children are resolved too, so a nested item is no more likely to be stranded
+ * than a top-level one.
+ */
+function resolvedMenuItem(
+  item: PluginMenuItem,
+  renameMap: Record<string, string>
+): PluginMenuItem {
+  const children = item.children?.map(child =>
+    resolvedMenuItem(child, renameMap)
+  );
+  const withChildren = children ? { ...item, children } : item;
+
+  // Destructured before the guard so the narrowing survives it: reading
+  // `item.collection` and then indexing `withChildren.collection` are two
+  // reads of two objects as far as the checker is concerned.
+  const { collection, ...rest } = withChildren;
+  if (collection === undefined) return withChildren;
+
+  const slug = renameMap[collection] ?? collection;
+  return {
+    ...rest,
+    to: `/admin/collections/${slug}`,
+    // The seeded per-collection read verb. Written from the resolved slug for
+    // the same reason `to` is: a rename moves the permission the seeder
+    // creates, and a gate naming the declared slug would hide the item from
+    // exactly the readers who can open the list.
+    requiredPermission: `read-${slug}`,
+  };
+}
+
+/**
  * The routes a plugin would actually serve, with the namespace they answer at.
  *
  * Asks `collectPluginRoutes` rather than restating its rules. That function is
@@ -308,7 +352,11 @@ export function buildPluginAdminMeta(
     // Behavioral admin UI only for enabled plugins.
     const admin = plugin.contributes?.admin;
     if (isEnabled && admin) {
-      if (admin.menu && admin.menu.length > 0) meta.menu = admin.menu;
+      if (admin.menu && admin.menu.length > 0) {
+        meta.menu = admin.menu.map(item =>
+          resolvedMenuItem(item, plugin.renameMap ?? {})
+        );
+      }
       if (admin.pages && admin.pages.length > 0) meta.pages = admin.pages;
       if (admin.settings) meta.settings = admin.settings;
       // Header customization. `header.slot` supersedes the

--- a/packages/nextly/src/plugins/admin-meta.ts
+++ b/packages/nextly/src/plugins/admin-meta.ts
@@ -26,6 +26,7 @@ import type {
   PluginDefinition,
 } from "./plugin-context";
 import { pluginAdminSlug } from "./plugin-slug";
+import { resolutionError } from "./resolution-error";
 import { collectPluginRoutes } from "./routes/collect-routes";
 import { isRouteError } from "./routes/route-error";
 import { validatedAdminWidgets } from "./validate-admin-widgets";
@@ -189,10 +190,12 @@ export { pluginAdminSlug } from "./plugin-slug";
  */
 function resolvedMenuItem(
   item: PluginMenuItem,
-  renameMap: Record<string, string>
+  renameMap: Record<string, string>,
+  owned: readonly string[],
+  name: string
 ): PluginMenuItem {
   const children = item.children?.map(child =>
-    resolvedMenuItem(child, renameMap)
+    resolvedMenuItem(child, renameMap, owned, name)
   );
   const withChildren = children ? { ...item, children } : item;
 
@@ -201,6 +204,23 @@ function resolvedMenuItem(
   // reads of two objects as far as the checker is concerned.
   const { collection, ...rest } = withChildren;
   if (collection === undefined) return withChildren;
+
+  // Refused at registration, because there is nothing to observe later. A slug
+  // this plugin does not own resolves to a perfectly well-formed path and a
+  // perfectly well-formed permission, and both are wrong in the quietest way
+  // available: the permission is never seeded, so every non-super-admin simply
+  // does not see the item, and the super-admins who do see it get a link to a
+  // list that does not exist. Neither surface can tell that from a role
+  // legitimately lacking access.
+  if (!owned.includes(collection)) {
+    throw resolutionError(
+      "menu-item-unowned-collection",
+      `Plugin "${name}" has a menu item ("${withChildren.label}") naming ` +
+        `collection "${collection}", which it does not contribute. Name one ` +
+        `of: ${owned.join(", ") || "(none)"}.`,
+      { plugin: name, collection, owned }
+    );
+  }
 
   const slug = renameMap[collection] ?? collection;
   return {
@@ -354,7 +374,12 @@ export function buildPluginAdminMeta(
     if (isEnabled && admin) {
       if (admin.menu && admin.menu.length > 0) {
         meta.menu = admin.menu.map(item =>
-          resolvedMenuItem(item, plugin.renameMap ?? {})
+          resolvedMenuItem(
+            item,
+            plugin.renameMap ?? {},
+            pluginCollectionSlugs(plugin),
+            plugin.name
+          )
         );
       }
       if (admin.pages && admin.pages.length > 0) meta.pages = admin.pages;

--- a/packages/nextly/src/plugins/resolve.ts
+++ b/packages/nextly/src/plugins/resolve.ts
@@ -2,6 +2,7 @@ import type { PluginDefinition } from "./plugin-context";
 import { topoSortPlugins } from "./topo-sort";
 import { assertAdminWidgets } from "./validate-admin-widgets";
 import { assertClientConfigs } from "./validate-client-config";
+import { validatePluginMenus } from "./validate-menus";
 import { validatePluginSlugs } from "./validate-slugs";
 import { validatePluginVersions } from "./validate-versions";
 
@@ -42,5 +43,10 @@ export function resolvePlugins(
   // what a correct lookup returns. Registration is where the ambiguity is still
   // observable.
   validatePluginSlugs(plugins);
+  // A menu item naming a collection its plugin does not contribute is the same
+  // kind of mistake, and is equally unobservable downstream: the sidebar hides
+  // the item from everyone without the never-seeded permission, which is what
+  // a role legitimately lacking access looks like.
+  validatePluginMenus(plugins);
   return topoSortPlugins(plugins);
 }

--- a/packages/nextly/src/plugins/validate-menus.test.ts
+++ b/packages/nextly/src/plugins/validate-menus.test.ts
@@ -1,0 +1,85 @@
+/**
+ * The boot refusal for a menu item naming a collection its plugin does not own.
+ *
+ * Asserted here rather than only through the serializer, because WHERE it
+ * throws is the property under test. Running only while `/api/admin-meta` is
+ * built means the app boots, and then every branding and workspace request
+ * throws — which can take the sign-in screen with it, so the operator meets a
+ * configuration mistake as an outage rather than as a failed start.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { PluginDefinition } from "./plugin-context";
+import { definePlugin } from "./plugin-context";
+
+import { validatePluginMenus } from "./validate-menus";
+
+const base = { name: "@acme/p", version: "1.0.0", nextly: "*" } as const;
+
+/** A plugin owning `patterns`, with one menu item naming `collection`. */
+function withMenu(collection: string | undefined, nested = false) {
+  const item = {
+    label: "Patterns",
+    to: "/admin/collections/patterns",
+    collection,
+  };
+  return definePlugin({
+    ...base,
+    contributes: {
+      collections: [{ slug: "patterns" } as never],
+      admin: {
+        menu: nested
+          ? [{ label: "Design", to: "/admin/design", children: [item] }]
+          : [item],
+      },
+    },
+  } as unknown as PluginDefinition);
+}
+
+const reasonOf = (error: unknown) =>
+  (error as { logContext?: { reason?: string } })?.logContext?.reason;
+
+describe("validatePluginMenus", () => {
+  it("accepts an item naming a collection the plugin contributes", () => {
+    // The positive control. Every refusal below is also satisfied by a
+    // validator that refuses everything, which would stop every boot.
+    expect(() => validatePluginMenus([withMenu("patterns")])).not.toThrow();
+  });
+
+  it("accepts an item naming no collection at all", () => {
+    expect(() => validatePluginMenus([withMenu(undefined)])).not.toThrow();
+  });
+
+  it("refuses a slug the plugin does not contribute", () => {
+    let caught: unknown;
+    try {
+      validatePluginMenus([withMenu("pattrens")]);
+    } catch (error) {
+      caught = error;
+    }
+
+    // The reason, not `message`: every plugin resolution error answers
+    // `message` with the same sentence, so matching on it would pass for a
+    // duplicate admin slug just as readily.
+    expect(reasonOf(caught)).toBe("menu-item-unowned-collection");
+
+    // Names the typo AND what it could have been. Neither is recoverable from
+    // the other, and a reader looking at their own typo is exactly the reader
+    // who cannot see it.
+    const logMessage = (caught as { logMessage?: string })?.logMessage ?? "";
+    expect(logMessage).toContain("pattrens");
+    expect(logMessage).toContain("patterns");
+  });
+
+  it("refuses a bad slug on a nested item too", () => {
+    // A child is exactly as stranded as a parent, and is the one a walk over
+    // the top level alone would let through.
+    let caught: unknown;
+    try {
+      validatePluginMenus([withMenu("pattrens", true)]);
+    } catch (error) {
+      caught = error;
+    }
+    expect(reasonOf(caught)).toBe("menu-item-unowned-collection");
+  });
+});

--- a/packages/nextly/src/plugins/validate-menus.ts
+++ b/packages/nextly/src/plugins/validate-menus.ts
@@ -1,0 +1,56 @@
+/**
+ * Boot-check that every collection-backed menu item names a collection its
+ * plugin actually contributes. Throws fail-fast.
+ *
+ * A `collection` that no contribution matches is not a cosmetic slip. The
+ * serializer derives the item's destination and its read permission from that
+ * slug, so a misspelling produces a well-formed path to a list that does not
+ * exist and a well-formed gate on a permission the seeder never creates. Every
+ * ordinary user then loses the item — indistinguishable from a role lacking
+ * access — and every super-admin gets a broken link.
+ *
+ * The check belongs at REGISTRATION for the same reason `validatePluginSlugs`
+ * does. Both admin surfaces answer a bad slug with something that looks like a
+ * legitimate outcome, so neither can report it; and running it only while
+ * serializing admin metadata would let the app boot and then throw on every
+ * branding request, which can take the sign-in screen with it. A configuration
+ * mistake should stop the process that loaded the configuration.
+ *
+ * @module plugins/validate-menus
+ */
+import type { PluginMenuItem } from "./admin-contributions";
+import { pluginCollectionSlugs } from "./plugin-admin-meta";
+import type { PluginDefinition } from "./plugin-context";
+import { resolutionError } from "./resolution-error";
+
+/** Every item in a menu tree, parents and children alike. */
+function flatten(items: readonly PluginMenuItem[]): PluginMenuItem[] {
+  return items.flatMap(item => [item, ...flatten(item.children ?? [])]);
+}
+
+export function validatePluginMenus(plugins: PluginDefinition[]): void {
+  for (const plugin of plugins) {
+    const menu = plugin.contributes?.admin?.menu;
+    if (!menu || menu.length === 0) continue;
+
+    const owned = pluginCollectionSlugs(plugin);
+
+    for (const item of flatten(menu)) {
+      // A child is exactly as stranded as a parent, which is why the walk is
+      // over the flattened tree rather than the top level.
+      if (item.collection === undefined) continue;
+      if (owned.includes(item.collection)) continue;
+
+      // Both the offending slug and the ones it could have been: neither is
+      // recoverable from the other, and a reader looking at their own typo is
+      // exactly the reader who cannot see it.
+      throw resolutionError(
+        "menu-item-unowned-collection",
+        `Plugin "${plugin.name}" has a menu item ("${item.label}") naming ` +
+          `collection "${item.collection}", which it does not contribute. ` +
+          `Name one of: ${owned.join(", ") || "(none)"}.`,
+        { plugin: plugin.name, collection: item.collection, owned }
+      );
+    }
+  }
+}

--- a/packages/plugin-page-builder/src/admin/BlocksField.documentKind.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.documentKind.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * The document the editor seeds must be one the field will accept.
+ *
+ * Asserted against the FIELD'S OWN VALIDATOR rather than against the kind
+ * string, because the kind is not the property that matters — "the save
+ * succeeds" is. A test comparing `documentFrom(null).kind` to `"pattern"`
+ * would pass on an editor that seeded a well-formed document the server
+ * refuses for some other reason, and would have to be rewritten every time the
+ * default changes.
+ *
+ * The failure it exists to catch shipped: `documentFrom` defaulted to a `page`
+ * document regardless of the field, so creating a Pattern or a Component in
+ * the admin produced an editor that looked like it worked and a save the
+ * server rejected with `DISALLOWED_DOCUMENT_KIND`. Every test in the suite
+ * asserted declarations, and none of them opened the create flow.
+ */
+import { describe, expect, it } from "vitest";
+
+import { componentsCollection } from "../collections/components";
+import { patternsCollection } from "../collections/patterns";
+import { acceptedKinds } from "../fields/blocks-options";
+import { blocksFieldType } from "../fields/blocksField";
+
+import { documentFrom } from "./BlocksField";
+
+/** The `content` field as its collection declares it. */
+function contentFieldOf(collection: { fields: unknown }): { blocks?: unknown } {
+  const field = (collection.fields as { name?: string }[]).find(
+    f => f.name === "content"
+  );
+  if (!field) throw new Error("the collection declares no content field");
+  return field;
+}
+
+/** What the registered type says about a value written to that field. */
+function validateAgainst(declaration: { blocks?: unknown }, value: unknown) {
+  const type = blocksFieldType() as {
+    validate: (
+      value: unknown,
+      args: { data: object; req: object; field: unknown; path: string }
+    ) => true | { code?: string }[];
+  };
+  return type.validate(value, {
+    data: {},
+    req: {},
+    field: declaration,
+    path: "content",
+  });
+}
+
+describe("a new document is seeded as a kind its own field accepts", () => {
+  it.each([
+    ["patterns", patternsCollection],
+    ["components", componentsCollection],
+  ])("%s accepts what the create form seeds into it", (_label, build) => {
+    const declaration = contentFieldOf(build());
+
+    // Through `acceptedKinds`, which is what the component calls — not by
+    // reading `blocks.kinds` here. A test that reached the kinds by its own
+    // route would keep passing with that reader returning nothing, which is
+    // precisely the state in which the editor seeds a page again.
+    const seeded = documentFrom(null, acceptedKinds(declaration));
+
+    expect(validateAgainst(declaration, seeded)).toBe(true);
+  });
+
+  it("still refuses a page document written to a pattern field", () => {
+    // The control. Without it the assertions above are satisfied by a
+    // validator that accepts everything — which is also what a broken `kinds`
+    // declaration would look like from here.
+    const declaration = contentFieldOf(patternsCollection());
+    const pageDocument = documentFrom(null, ["page"]);
+
+    expect(validateAgainst(declaration, pageDocument)).not.toBe(true);
+  });
+
+  it("seeds a page when the field declares no kinds", () => {
+    // The other control: a field that says nothing still gets a page, so the
+    // change reaches only the fields that asked for something else.
+    expect(documentFrom(null).kind).toBe("page");
+  });
+});

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -49,6 +49,7 @@ import {
   previewContainerFor,
   newId,
   type BlockDocument,
+  type DocumentKind,
   type BreakpointSet,
   type NamedClass,
   type SiteTokenSet,
@@ -139,6 +140,7 @@ import {
 
 import { classUsageOf } from "../class-usage";
 import { emptyBlockDocument } from "../fields/blocks-document";
+import { acceptedKinds } from "../fields/blocks-options";
 import { hostFetchPolicy, readRemotePatterns } from "../host-policy";
 import {
   classOverrideOf,
@@ -168,6 +170,21 @@ export interface BlocksFieldProps<
   name: Path<TFieldValues>;
   /** React Hook Form control the entry form owns. */
   control: Control<TFieldValues>;
+  /**
+   * The field's own declaration, as the admin passes it to every plugin field
+   * editor.
+   *
+   * Read for the kinds it accepts, and for nothing else. Without it the editor
+   * has to guess what an empty document should be, and its only available
+   * guess is a page — which is the one answer a pattern or component store
+   * refuses.
+   *
+   * Named `field` because that is the name the admin passes it under
+   * (`FieldRenderer` spreads `{ ...commonProps, field }` into every plugin
+   * field editor). A prop named for what this file wants to call it would type
+   * fine, arrive never, and leave the defect in place looking fixed.
+   */
+  field?: { blocks?: unknown };
   /**
    * The document is being READ, not edited, so no way in is offered.
    *
@@ -275,16 +292,28 @@ function emptyContainerAppenderHidden(
  * rather than at this boundary, and an editor that crashes on open gives an
  * author no way to repair the value.
  *
+ * The KINDS the field accepts are a parameter rather than a default, because
+ * the substitute has to be a document the same field will accept. Seeding a
+ * `page` into a field declaring `kinds: ["pattern"]` produces an editor that
+ * looks like it works and a save the server refuses with
+ * `DISALLOWED_DOCUMENT_KIND` — so the store cannot be authored at all through
+ * the UI that advertises it, and nothing says why until the author presses
+ * Done.
+ *
  * Exported for its own tests: it is the only place a malformed stored document
  * is turned into a safe one, and it is worth asserting directly rather than
  * through a rendered editor.
  */
-export function documentFrom(value: unknown): BlockDocument {
-  if (typeof value !== "object" || value === null) return emptyBlockDocument();
+export function documentFrom(
+  value: unknown,
+  kinds?: readonly DocumentKind[]
+): BlockDocument {
+  if (typeof value !== "object" || value === null)
+    return emptyBlockDocument(kinds);
   const candidate = value as Partial<BlockDocument>;
   return Array.isArray(candidate.nodes)
     ? (value as BlockDocument)
-    : emptyBlockDocument();
+    : emptyBlockDocument(kinds);
 }
 
 /**
@@ -314,9 +343,17 @@ export function BlocksField<TFieldValues extends FieldValues = FieldValues>({
   control,
   readOnly = false,
   disabled = false,
+  // Renamed locally because `field` is also what `useController` calls the
+  // bound value below, and the two are different things: this is the schema's
+  // declaration, that is the form's state.
+  field: declaration,
 }: BlocksFieldProps<TFieldValues>) {
   const [open, setOpen] = useState(false);
   const { field } = useController({ name, control });
+
+  // What an empty document has to be for THIS field. Asked once and passed
+  // down, so the resting card and the open editor cannot seed different kinds.
+  const kinds = acceptedKinds(declaration);
 
   const editable = canEditBlocks({ readOnly, disabled });
 
@@ -361,6 +398,7 @@ export function BlocksField<TFieldValues extends FieldValues = FieldValues>({
       // undo stack rather than carrying it into a document it cannot describe.
       key={String(field.value === undefined ? "empty" : "seeded")}
       initialValue={field.value}
+      kinds={kinds}
       onCommit={field.onChange}
       onClose={() => setOpen(false)}
       // Named and controlled so the editor can record its live document as
@@ -370,7 +408,7 @@ export function BlocksField<TFieldValues extends FieldValues = FieldValues>({
     />
   ) : (
     <PageBuilderCard
-      document={documentFrom(field.value)}
+      document={documentFrom(field.value, kinds)}
       siteStyles={resting.siteStyles}
       styleState={resting.styleState}
       render={resting.render}
@@ -1555,12 +1593,15 @@ function useDocumentDirty<TFieldValues extends FieldValues>(
 
 function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
   initialValue,
+  kinds,
   onCommit,
   onClose,
   name,
   control,
 }: {
   initialValue: unknown;
+  /** The kinds the field accepts, so a seeded document is one it will take. */
+  kinds: readonly DocumentKind[] | undefined;
   onCommit: (value: BlockDocument) => void;
   onClose: () => void;
   name: Path<TFieldValues>;
@@ -1573,8 +1614,8 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
   ensureCoreBlocksRegistered();
 
   const initialDocument = useMemo(
-    () => documentFrom(initialValue),
-    [initialValue]
+    () => documentFrom(initialValue, kinds),
+    [initialValue, kinds]
   );
   const editor = useEditorState({ initialDocument });
 

--- a/packages/plugin-page-builder/src/collections/areas.ts
+++ b/packages/plugin-page-builder/src/collections/areas.ts
@@ -1,0 +1,46 @@
+/**
+ * The areas a Layout can fill, declared once.
+ *
+ * Two collections read this and neither owns it. A Layout offers these as the
+ * positions a row can take; a component offers them as the hint saying which
+ * position it suits. Those are the two ends of one question — which is what
+ * makes a second copy dangerous rather than merely untidy. Two lists agree the
+ * day they are written and diverge the first time either is edited alone, and
+ * the divergence is silent in both directions: an area a Layout can name that
+ * no component can be marked for, or a component marked for an area no Layout
+ * offers, and in each case the picker simply comes back empty.
+ *
+ * It lives in its own module rather than in either collection because the two
+ * already point at each other — a Layout row references the components
+ * collection by slug — so putting the list in one of them would close a cycle
+ * to reach a constant.
+ *
+ * @module collections/areas
+ */
+
+/**
+ * Every position a Layout wraps a page with.
+ *
+ * `as const` so the values are literal types: the option lists built from this
+ * are checked against the same union a reader narrows against, and a string
+ * that is not one of these cannot be stored by anything that consults it.
+ *
+ * Adding an announcement bar or a sidebar is an entry here. It costs no
+ * migration, because the areas a Layout holds are rows rather than columns.
+ */
+export const LAYOUT_AREAS = ["header", "footer"] as const;
+
+/** One of the positions a Layout wraps a page with. */
+export type LayoutArea = (typeof LAYOUT_AREAS)[number];
+
+/**
+ * The area list as select options.
+ *
+ * Derived rather than written out, so a value can be added in exactly one
+ * place. Both fields that offer these call this: a hand-written option list
+ * beside the constant is the same divergence this module exists to prevent,
+ * one level down.
+ */
+export function layoutAreaOptions(): { label: string; value: LayoutArea }[] {
+  return LAYOUT_AREAS.map(value => ({ label: value, value }));
+}

--- a/packages/plugin-page-builder/src/collections/components.ts
+++ b/packages/plugin-page-builder/src/collections/components.ts
@@ -1,0 +1,74 @@
+/**
+ * Definitions an author builds once and places many times.
+ *
+ * A component is placed by REFERENCE: a page stores one node naming this
+ * document, and the tree is resolved when the page is read. So editing a
+ * component changes every page carrying it, which is the property patterns
+ * deliberately do not have.
+ *
+ * ## A header is a component
+ *
+ * There is no separate document kind for a site header or footer. A Layout
+ * names which component fills each of its areas, so the ROLE lives on the
+ * placement rather than on the document, and a header inherits everything a
+ * component has: per-instance editable fields, variants, drafts, a usage count.
+ *
+ * The alternative — a second document type for regions — was measured against
+ * the products that ship it, and the same complaint follows every one of them:
+ * a region built as a weaker thing cannot be edited by the people who need to
+ * edit it, because the machinery that makes a component editable was never
+ * built twice. Adding an announcement bar or a sidebar later is a new AREA on
+ * the Layout, not a new kind of document.
+ *
+ * `area` below is the hint that keeps the two uses apart in the UI without
+ * making them different things.
+ *
+ * @module collections/components
+ */
+import { defineCollection, select, text, textarea } from "nextly/config";
+
+import { blocks } from "../fields/blocksHelper";
+
+import { layoutAreaOptions } from "./areas";
+
+/** The slug component definitions are stored under. */
+export const COMPONENTS_SLUG = "components";
+
+/**
+ * The plugin-owned `components` collection.
+ *
+ * Takes no options, for the reason patterns takes none: a component is never
+ * served at an address of its own. It reaches a visitor only inside a page or
+ * a Layout, so it has no preview path and nothing for a host to configure.
+ */
+export function componentsCollection() {
+  return defineCollection({
+    slug: COMPONENTS_SLUG,
+    labels: { singular: "Component", plural: "Components" },
+    fields: [
+      text({ name: "title", required: true }),
+      text({ name: "slug", required: true, unique: true }),
+      textarea({ name: "description" }),
+      text({ name: "category" }),
+      // Which Layout position this component suits, if any. It orders the
+      // pickers and does not gate them: a component marked `header` can still
+      // be placed inline on a page that wants its navigation baked in, and one
+      // marked for nothing is an ordinary in-page component offered
+      // everywhere.
+      select({ name: "area", options: layoutAreaOptions() }),
+      blocks({
+        name: "content",
+        label: "Component",
+        blocks: { kinds: ["component"] },
+      }),
+    ],
+    // The published/draft split is what separates editing a component from
+    // shipping it. A page read for a visitor resolves the PUBLISHED
+    // definition, so an author can rework a header for as long as they like
+    // without every page carrying the work in progress; publishing is the
+    // single act that moves it to every one of them.
+    status: true,
+    versions: { drafts: true },
+    admin: { useAsTitle: "title" },
+  });
+}

--- a/packages/plugin-page-builder/src/collections/components.ts
+++ b/packages/plugin-page-builder/src/collections/components.ts
@@ -69,11 +69,20 @@ export function componentsCollection() {
     // single act that moves it to every one of them.
     status: true,
     versions: { drafts: true },
-    // Kept out of the Collections section, which lists every collection that
-    // claims neither a sidebar group nor plugin ownership. Without this the
-    // store is listed twice — once there and once in this plugin's own menu —
-    // and following the plugin link then lights up Collections, so the sidebar
-    // disagrees with itself about where the author is.
-    admin: { useAsTitle: "title", isPlugin: true },
+    // Opted out of AUTOMATIC navigation, because this plugin declares its own
+    // menu entry for the store and two sources listing one screen is the
+    // problem rather than the belt-and-braces it looks like.
+    //
+    // There are two automatic sources and `hidden` is the only thing that
+    // excludes both. `isInCollectionsSection` (admin `lib/sidebar-landing`)
+    // admits every collection that is not hidden and claims no sidebar group,
+    // which is the Collections listing; `DynamicPluginNav` lists every
+    // collection marked `isPlugin`, and `SidebarNavigation` renders it
+    // immediately above this plugin's own menu — so claiming plugin ownership
+    // does not move the duplicate, it puts both copies in one section, side by
+    // side. Hidden costs nothing else: the collection keeps its URL, its API
+    // and its permissions, and only stops being offered by navigation nobody
+    // asked for.
+    admin: { useAsTitle: "title", hidden: true },
   });
 }

--- a/packages/plugin-page-builder/src/collections/components.ts
+++ b/packages/plugin-page-builder/src/collections/components.ts
@@ -69,6 +69,11 @@ export function componentsCollection() {
     // single act that moves it to every one of them.
     status: true,
     versions: { drafts: true },
-    admin: { useAsTitle: "title" },
+    // Kept out of the Collections section, which lists every collection that
+    // claims neither a sidebar group nor plugin ownership. Without this the
+    // store is listed twice — once there and once in this plugin's own menu —
+    // and following the plugin link then lights up Collections, so the sidebar
+    // disagrees with itself about where the author is.
+    admin: { useAsTitle: "title", isPlugin: true },
   });
 }

--- a/packages/plugin-page-builder/src/collections/composition-stores.test.ts
+++ b/packages/plugin-page-builder/src/collections/composition-stores.test.ts
@@ -29,6 +29,10 @@ interface DeclaredField {
   relationTo?: string | string[];
   fields?: DeclaredField[];
   blocks?: { kinds?: string[] };
+  validate?: (
+    value: unknown,
+    args: { data: Record<string, unknown>; req: unknown }
+  ) => string | true;
 }
 
 /** Every collection the plugin contributes, by slug. */
@@ -61,26 +65,26 @@ describe("the composition stores reach a running site", () => {
     expect(bySlug.has(LAYOUTS_SLUG)).toBe(true);
   });
 
-  it("offers each store a menu entry gated on being able to read it", () => {
+  it("names the collection each entry points at, rather than spelling it", () => {
     const menu = (pageBuilder().contributes?.admin?.menu ?? []) as {
-      to?: string;
-      requiredPermission?: string;
+      label?: string;
+      collection?: string;
     }[];
-    const entry = (slug: string) =>
-      menu.find(item => item.to === `/admin/collections/${slug}`);
+    const entry = (label: string) => menu.find(item => item.label === label);
 
-    // A link offered to a role that will be refused the list behind it is
-    // worse than no link: the refusal arrives after the navigation, with
-    // nothing having said the screen was not theirs.
-    expect(entry(PATTERNS_SLUG)?.requiredPermission).toBe(
-      `read-${PATTERNS_SLUG}`
-    );
-    expect(entry(COMPONENTS_SLUG)?.requiredPermission).toBe(
-      `read-${COMPONENTS_SLUG}`
-    );
-    expect(entry(LAYOUTS_SLUG)?.requiredPermission).toBe(
-      `read-${LAYOUTS_SLUG}`
-    );
+    // Naming the collection is what makes the destination and the read gate
+    // follow a host's `.rename()`. An entry that spelled the slug into `to`
+    // and into `requiredPermission` would look identical on an installation
+    // that renamed nothing, and would send readers to a list that does not
+    // exist on one that did. Core resolves both; asserted there.
+    expect(entry("Patterns")?.collection).toBe(PATTERNS_SLUG);
+    expect(entry("Components")?.collection).toBe(COMPONENTS_SLUG);
+    expect(entry("Layouts")?.collection).toBe(LAYOUTS_SLUG);
+
+    // The control, and the reason the three above are not simply "every entry
+    // names a collection": Pages deliberately names none, so it keeps the
+    // ungated front door it has always had.
+    expect(entry("Pages")?.collection).toBeUndefined();
   });
 });
 
@@ -195,5 +199,68 @@ describe("a name identifies one row", () => {
 
     expect(slug?.required).toBe(true);
     expect(slug?.unique).toBe(true);
+  });
+});
+
+describe("a Layout fills each area once", () => {
+  const validateAreas = () => {
+    const areas = named(fieldsOf(layoutsCollection()), "areas");
+    return areas?.validate;
+  };
+
+  it("refuses two rows claiming the same area", () => {
+    // Not a cosmetic rule. An area is a POSITION, and the resolver reads the
+    // rows to decide what wraps a page: two `header` rows leave it picking
+    // whichever it reaches first, so the same Layout renders a different page
+    // depending on iteration order. The refusal has to happen at the write —
+    // once stored, nothing downstream can tell which row the author meant.
+    expect(
+      validateAreas()?.(
+        [
+          { area: "header", component: "a" },
+          { area: "header", component: "b" },
+        ],
+        { data: {}, req: {} }
+      )
+    ).toBe("Two rows both fill the header area");
+  });
+
+  it("accepts one row per area", () => {
+    // The control. A validator that refused everything would satisfy the
+    // assertion above while making every Layout unsaveable.
+    expect(
+      validateAreas()?.(
+        [
+          { area: "header", component: "a" },
+          { area: "footer", component: "b" },
+        ],
+        { data: {}, req: {} }
+      )
+    ).toBe(true);
+  });
+
+  it("says nothing about rows whose area is still unset", () => {
+    // Mid-edit: a row added and not yet filled in. Two of them are not two
+    // claims on one area, and reporting a collision here would refuse a save
+    // for a reason the author cannot act on. The `required` on that select is
+    // what speaks to an empty area.
+    expect(
+      validateAreas()?.([{ component: "a" }, { component: "b" }], {
+        data: {},
+        req: {},
+      })
+    ).toBe(true);
+  });
+});
+
+describe("a published pattern can always be classified", () => {
+  it("requires a granularity", () => {
+    // The browser reads granularity to decide whether a pattern is offered as
+    // something to insert or as a way to start a page. Optional, it saves and
+    // publishes as null, and the row is then valid, offered nowhere, and
+    // indistinguishable from one whose author simply has not answered.
+    expect(named(fieldsOf(patternsCollection()), "granularity")?.required).toBe(
+      true
+    );
   });
 });

--- a/packages/plugin-page-builder/src/collections/composition-stores.test.ts
+++ b/packages/plugin-page-builder/src/collections/composition-stores.test.ts
@@ -265,21 +265,43 @@ describe("a published pattern can always be classified", () => {
   });
 });
 
-describe("each store is listed once in the sidebar", () => {
+describe("exactly one navigation source claims each store", () => {
+  // Asserted as the OUTCOME rather than as the setting that produces it. The
+  // first version of this test asserted `isPlugin: true` — the lever — and
+  // passed while the stores were still listed twice, because opting into
+  // `DynamicPluginNav` moved the duplicate into the Plugins section instead of
+  // removing it. Both automatic sources have to be named for the assertion to
+  // mean anything.
   it.each([
-    ["patterns", patternsCollection],
-    ["components", componentsCollection],
-    ["layouts", layoutsCollection],
-  ])("%s claims plugin ownership", (_label, build) => {
-    // The Collections section lists every collection claiming neither a
-    // sidebar group nor plugin ownership, and this plugin's own menu lists
-    // these three as well. Without the claim each store appears twice, and
-    // following the plugin link lights up Collections — the sidebar
-    // disagreeing with itself about where the author is.
-    const collection = build() as { admin?: { isPlugin?: boolean } };
+    ["patterns", PATTERNS_SLUG, patternsCollection],
+    ["components", COMPONENTS_SLUG, componentsCollection],
+    ["layouts", LAYOUTS_SLUG, layoutsCollection],
+  ])(
+    "%s is offered by the plugin menu and by nothing else",
+    (_l, slug, build) => {
+      const collection = build() as {
+        admin?: { hidden?: boolean; isPlugin?: boolean };
+      };
 
-    expect(collection.admin?.isPlugin).toBe(true);
-  });
+      // Source 1 — the Collections listing. `isInCollectionsSection` (admin
+      // `lib/sidebar-landing`) admits every collection that is not hidden and
+      // claims no sidebar group.
+      expect(collection.admin?.hidden).toBe(true);
+
+      // Source 2 — `DynamicPluginNav`, which lists every `isPlugin` collection
+      // and which `SidebarNavigation` renders immediately above this plugin's
+      // own menu. Opting in puts both copies in ONE section, side by side.
+      expect(collection.admin?.isPlugin).toBeUndefined();
+
+      // Source 3 — the plugin's own menu, which is the one that should claim it,
+      // once. Two entries naming one store would satisfy both assertions above
+      // and still show the author two links.
+      const menu = (pageBuilder().contributes?.admin?.menu ?? []) as {
+        collection?: string;
+      }[];
+      expect(menu.filter(item => item.collection === slug)).toHaveLength(1);
+    }
+  );
 });
 
 describe("a Layout row names no variant", () => {

--- a/packages/plugin-page-builder/src/collections/composition-stores.test.ts
+++ b/packages/plugin-page-builder/src/collections/composition-stores.test.ts
@@ -1,0 +1,199 @@
+/**
+ * What the three composition stores are made of, and that the plugin serves
+ * them.
+ *
+ * Every assertion here is written against the failure it is meant to catch
+ * rather than against the happy shape, because the plausible broken versions
+ * of these collections all LOAD. A blocks field with no `kinds` option accepts
+ * page documents and refuses the pattern it exists to hold; a collection that
+ * declares `status` without `versions` publishes on save; a collection built
+ * and never contributed is simply absent at boot. None of those throws, and a
+ * test that only asserted a field list would pass on all three.
+ */
+import { describe, expect, it } from "vitest";
+
+import { pageBuilder } from "../plugin";
+
+import { LAYOUT_AREAS } from "./areas";
+import { COMPONENTS_SLUG, componentsCollection } from "./components";
+import { LAYOUTS_SLUG, layoutsCollection } from "./layouts";
+import { PATTERNS_SLUG, patternsCollection } from "./patterns";
+
+/** A field as the collection config carries it, before any narrowing. */
+interface DeclaredField {
+  name?: string;
+  type?: string;
+  required?: boolean;
+  unique?: boolean;
+  options?: { value?: string }[];
+  relationTo?: string | string[];
+  fields?: DeclaredField[];
+  blocks?: { kinds?: string[] };
+}
+
+/** Every collection the plugin contributes, by slug. */
+function contributedBySlug(): Map<string, { slug: string }> {
+  const contributed = (pageBuilder().contributes?.collections ?? []) as {
+    slug: string;
+  }[];
+  return new Map(contributed.map(collection => [collection.slug, collection]));
+}
+
+const fieldsOf = (collection: { fields: unknown }): DeclaredField[] =>
+  collection.fields as DeclaredField[];
+
+const named = (
+  fields: DeclaredField[],
+  name: string
+): DeclaredField | undefined => fields.find(field => field.name === name);
+
+describe("the composition stores reach a running site", () => {
+  it("contributes patterns, components and layouts", () => {
+    const bySlug = contributedBySlug();
+
+    // The control: `pages` has always been contributed, so the three
+    // assertions below are about these collections rather than about a
+    // contributions list that is empty or unreadable.
+    expect(bySlug.has("pages")).toBe(true);
+
+    expect(bySlug.has(PATTERNS_SLUG)).toBe(true);
+    expect(bySlug.has(COMPONENTS_SLUG)).toBe(true);
+    expect(bySlug.has(LAYOUTS_SLUG)).toBe(true);
+  });
+
+  it("offers each store a menu entry gated on being able to read it", () => {
+    const menu = (pageBuilder().contributes?.admin?.menu ?? []) as {
+      to?: string;
+      requiredPermission?: string;
+    }[];
+    const entry = (slug: string) =>
+      menu.find(item => item.to === `/admin/collections/${slug}`);
+
+    // A link offered to a role that will be refused the list behind it is
+    // worse than no link: the refusal arrives after the navigation, with
+    // nothing having said the screen was not theirs.
+    expect(entry(PATTERNS_SLUG)?.requiredPermission).toBe(
+      `read-${PATTERNS_SLUG}`
+    );
+    expect(entry(COMPONENTS_SLUG)?.requiredPermission).toBe(
+      `read-${COMPONENTS_SLUG}`
+    );
+    expect(entry(LAYOUTS_SLUG)?.requiredPermission).toBe(
+      `read-${LAYOUTS_SLUG}`
+    );
+  });
+});
+
+describe("each document store accepts only its own kind", () => {
+  // The failure this catches is silent at declaration time and loud much
+  // later: the blocks field defaults its `kinds` to `["page"]`, so a store
+  // that forgot to name its kind refuses the first document written to it —
+  // at the field validator, on a save the author has no reason to expect to
+  // fail.
+  // The kind comes before the factory so the two `%s` in the title take the
+  // two strings. Positional interpolation reads the arguments in order, so a
+  // factory in second place puts its whole source into the test's name — which
+  // still passes and still fails, unreadably, and is only visible when
+  // something reports a failure BY NAME.
+  it.each([
+    ["patterns", "pattern", patternsCollection],
+    ["components", "component", componentsCollection],
+  ])("%s stores %s documents", (_label, kind, build) => {
+    const content = named(fieldsOf(build()), "content");
+
+    // The control for the kinds assertion: a `content` field of the wrong
+    // type, or none at all, would satisfy an assertion about `kinds` being
+    // absent just as well as a correct field would.
+    expect(content?.type).toBe("blocks");
+    expect(content?.blocks?.kinds).toEqual([kind]);
+  });
+
+  it("layouts holds references rather than a document", () => {
+    // A Layout is a set of pointers, so offering it a canvas would offer an
+    // editor for content it does not have.
+    expect(
+      fieldsOf(layoutsCollection()).map(field => field.type)
+    ).not.toContain("blocks");
+  });
+});
+
+describe("every store separates saving from publishing", () => {
+  // `status: true` alone resolves to a history-only collection: a save to a
+  // published row goes live immediately. That is a defensible shape and it is
+  // not this one — a component edit reaches every page carrying it, so the
+  // draft split is what lets an author rework a header without shipping the
+  // work in progress.
+  it.each([
+    ["patterns", patternsCollection],
+    ["components", componentsCollection],
+    ["layouts", layoutsCollection],
+  ])("%s carries a working draft", (_label, build) => {
+    const collection = build() as {
+      status?: boolean;
+      versions?: { drafts?: boolean };
+    };
+
+    expect(collection.status).toBe(true);
+    expect(collection.versions?.drafts).toBe(true);
+  });
+});
+
+describe("a Layout points at real components", () => {
+  const areasField = () => named(fieldsOf(layoutsCollection()), "areas");
+
+  it("names each area's component as a relationship to the components store", () => {
+    const rowFields = areasField()?.fields ?? [];
+
+    // Derived from the components collection rather than compared against the
+    // string "components": a relationship pointing at a slug nothing declares
+    // resolves to nothing, and a hand-written literal here would keep agreeing
+    // with itself after the collection was renamed.
+    expect(named(rowFields, "component")?.relationTo).toBe(
+      componentsCollection().slug
+    );
+    expect(named(rowFields, "component")?.required).toBe(true);
+  });
+
+  it("holds areas as rows, so a new area costs no column", () => {
+    // The shape is the claim: a `header` field beside a `footer` field would
+    // pass every other assertion in this file and make the third area a
+    // migration.
+    expect(areasField()?.type).toBe("repeater");
+    expect(
+      fieldsOf(layoutsCollection()).map(field => field.name)
+    ).not.toContain("header");
+  });
+});
+
+describe("the area vocabulary is declared once", () => {
+  const optionValues = (field: DeclaredField | undefined) =>
+    (field?.options ?? []).map(option => option.value);
+
+  it("offers the same areas on a Layout row and on a component", () => {
+    const rowArea = named(
+      named(fieldsOf(layoutsCollection()), "areas")?.fields ?? [],
+      "area"
+    );
+    const componentArea = named(fieldsOf(componentsCollection()), "area");
+
+    // Both are compared against the shared list rather than against each
+    // other. Two fields that agree prove they were written together; agreeing
+    // with the declaration is what survives one of them being edited alone,
+    // which is the divergence that empties a picker with nothing reporting it.
+    expect(optionValues(rowArea)).toEqual([...LAYOUT_AREAS]);
+    expect(optionValues(componentArea)).toEqual([...LAYOUT_AREAS]);
+  });
+});
+
+describe("a name identifies one row", () => {
+  it.each([
+    ["patterns", patternsCollection],
+    ["components", componentsCollection],
+    ["layouts", layoutsCollection],
+  ])("%s requires a unique slug", (_label, build) => {
+    const slug = named(fieldsOf(build()), "slug");
+
+    expect(slug?.required).toBe(true);
+    expect(slug?.unique).toBe(true);
+  });
+});

--- a/packages/plugin-page-builder/src/collections/composition-stores.test.ts
+++ b/packages/plugin-page-builder/src/collections/composition-stores.test.ts
@@ -264,3 +264,35 @@ describe("a published pattern can always be classified", () => {
     );
   });
 });
+
+describe("each store is listed once in the sidebar", () => {
+  it.each([
+    ["patterns", patternsCollection],
+    ["components", componentsCollection],
+    ["layouts", layoutsCollection],
+  ])("%s claims plugin ownership", (_label, build) => {
+    // The Collections section lists every collection claiming neither a
+    // sidebar group nor plugin ownership, and this plugin's own menu lists
+    // these three as well. Without the claim each store appears twice, and
+    // following the plugin link lights up Collections — the sidebar
+    // disagreeing with itself about where the author is.
+    const collection = build() as { admin?: { isPlugin?: boolean } };
+
+    expect(collection.admin?.isPlugin).toBe(true);
+  });
+});
+
+describe("a Layout row names no variant", () => {
+  it("offers no variant field", () => {
+    // A component has no variants: nothing declares them, no registry lists
+    // them, and the components collection carries no such field. A free-text
+    // `variant` would accept every string and validate against none, and a
+    // resolver could not tell one that was never built from a typo.
+    const rowFields =
+      named(fieldsOf(layoutsCollection()), "areas")?.fields ?? [];
+
+    // The control: the row does carry the fields it is supposed to, so this
+    // is an assertion about `variant` rather than about an empty row.
+    expect(rowFields.map(field => field.name)).toEqual(["area", "component"]);
+  });
+});

--- a/packages/plugin-page-builder/src/collections/layouts.ts
+++ b/packages/plugin-page-builder/src/collections/layouts.ts
@@ -21,6 +21,31 @@
  * component named by a Layout is a reference rather than an id inside a blob
  * nothing checks.
  *
+ * ## There is no `variant` field here yet
+ *
+ * A Layout row says WHICH component fills an area, not which of its variants,
+ * because a component has no variants to name. Nothing declares them, no
+ * registry lists them and the components collection carries no such field, so
+ * a free-text `variant` would accept every string and validate against none —
+ * and a resolver reading one back could not tell a variant that was never
+ * built from a typo. It lands with the declarations it selects from.
+ *
+ * ## A component reference here is not enforced by the database
+ *
+ * `areas` is a repeater, and a repeater is stored as ONE JSON column, so the
+ * `relationship` nested in it never becomes a column of its own and emits no
+ * foreign key and no delete policy. Deleting a component therefore leaves its
+ * id sitting in every Layout that named it, and nothing reports that.
+ *
+ * Stated rather than papered over. A write-time existence check would read as
+ * integrity while providing none — the component can be deleted the moment
+ * after it passes — and no foreign key would help with the other half of the
+ * problem anyway, since a component that still exists but is unpublished is
+ * equally unusable to a resolver. What this actually needs is a delete policy
+ * (refuse, or orphan and degrade), which is a decision about what an author
+ * should experience rather than a repair, and it belongs with the resolver
+ * that will be the first thing to read these references.
+ *
  * ## There is no `isDefault` field here yet
  *
  * Which Layout a page ends up with is resolved through a chain — the site's
@@ -110,10 +135,6 @@ export function layoutsCollection() {
             required: true,
             relationTo: COMPONENTS_SLUG,
           }),
-          // Which of the component's named variants this Layout places. Left
-          // empty to place the component as defined, which is what a Layout
-          // that only wants the header does.
-          text({ name: "variant" }),
         ],
       }),
     ],
@@ -122,6 +143,11 @@ export function layoutsCollection() {
     // does.
     status: true,
     versions: { drafts: true },
-    admin: { useAsTitle: "title" },
+    // Kept out of the Collections section, which lists every collection that
+    // claims neither a sidebar group nor plugin ownership. Without this the
+    // store is listed twice — once there and once in this plugin's own menu —
+    // and following the plugin link then lights up Collections, so the sidebar
+    // disagrees with itself about where the author is.
+    admin: { useAsTitle: "title", isPlugin: true },
   });
 }

--- a/packages/plugin-page-builder/src/collections/layouts.ts
+++ b/packages/plugin-page-builder/src/collections/layouts.ts
@@ -143,11 +143,20 @@ export function layoutsCollection() {
     // does.
     status: true,
     versions: { drafts: true },
-    // Kept out of the Collections section, which lists every collection that
-    // claims neither a sidebar group nor plugin ownership. Without this the
-    // store is listed twice — once there and once in this plugin's own menu —
-    // and following the plugin link then lights up Collections, so the sidebar
-    // disagrees with itself about where the author is.
-    admin: { useAsTitle: "title", isPlugin: true },
+    // Opted out of AUTOMATIC navigation, because this plugin declares its own
+    // menu entry for the store and two sources listing one screen is the
+    // problem rather than the belt-and-braces it looks like.
+    //
+    // There are two automatic sources and `hidden` is the only thing that
+    // excludes both. `isInCollectionsSection` (admin `lib/sidebar-landing`)
+    // admits every collection that is not hidden and claims no sidebar group,
+    // which is the Collections listing; `DynamicPluginNav` lists every
+    // collection marked `isPlugin`, and `SidebarNavigation` renders it
+    // immediately above this plugin's own menu — so claiming plugin ownership
+    // does not move the duplicate, it puts both copies in one section, side by
+    // side. Hidden costs nothing else: the collection keeps its URL, its API
+    // and its permissions, and only stops being offered by navigation nobody
+    // asked for.
+    admin: { useAsTitle: "title", hidden: true },
   });
 }

--- a/packages/plugin-page-builder/src/collections/layouts.ts
+++ b/packages/plugin-page-builder/src/collections/layouts.ts
@@ -1,0 +1,94 @@
+/**
+ * Named bundles saying which component fills each area around a page.
+ *
+ * A Layout is the only place the header/footer ROLE is stated. The components
+ * it names are ordinary component definitions, so "Landing" pointing at the
+ * same header as "Default" — under a different variant — is one row rather
+ * than a second copy of the header.
+ *
+ * ## Areas are rows, not columns
+ *
+ * `areas` is a repeater of `{ area, component, variant }` rather than a
+ * `header` column beside a `footer` column. Both shapes hold today's two
+ * areas; they differ on the third. An announcement bar or a sidebar is a new
+ * entry in the shared area list under the repeater, and a new column under the
+ * other — so the shape that costs a migration per area is the one that makes
+ * adding an area look expensive, which is the opposite of what this feature is
+ * supposed to make cheap.
+ *
+ * A repeater also gives each row a real component picker in the admin, which a
+ * single JSON column does not, and a relationship the database can see: a
+ * component named by a Layout is a reference rather than an id inside a blob
+ * nothing checks.
+ *
+ * ## There is no `isDefault` field here yet
+ *
+ * Which Layout a page ends up with is resolved through a chain — the site's
+ * default, then the collection's, then the page's own override. None of that
+ * chain is read by anything yet, and the site-default half needs a write path
+ * rather than a flag: exactly one row may hold it, so setting it on one row has
+ * to clear it from the others in the same transaction, the way a default email
+ * provider is demoted. A boolean column with nothing enforcing that invariant
+ * would let two rows both claim to be the default and leave whatever reads them
+ * first to decide, so it lands with the resolver and the demotion, together.
+ *
+ * @module collections/layouts
+ */
+import {
+  defineCollection,
+  relationship,
+  repeater,
+  select,
+  text,
+  textarea,
+} from "nextly/config";
+
+import { layoutAreaOptions } from "./areas";
+import { COMPONENTS_SLUG } from "./components";
+
+/** The slug layouts are stored under. */
+export const LAYOUTS_SLUG = "layouts";
+
+/**
+ * The plugin-owned `layouts` collection.
+ *
+ * Holds no blocks field. A Layout is a set of REFERENCES rather than a
+ * document — nothing about it is authored on a canvas — so giving it a tree
+ * would offer an editor for content it does not have.
+ */
+export function layoutsCollection() {
+  return defineCollection({
+    slug: LAYOUTS_SLUG,
+    labels: { singular: "Layout", plural: "Layouts" },
+    fields: [
+      text({ name: "title", required: true }),
+      text({ name: "slug", required: true, unique: true }),
+      textarea({ name: "description" }),
+      repeater({
+        name: "areas",
+        fields: [
+          select({
+            name: "area",
+            required: true,
+            options: layoutAreaOptions(),
+          }),
+          relationship({
+            name: "component",
+            required: true,
+            relationTo: COMPONENTS_SLUG,
+          }),
+          // Which of the component's named variants this Layout places. Left
+          // empty to place the component as defined, which is what a Layout
+          // that only wants the header does.
+          text({ name: "variant" }),
+        ],
+      }),
+    ],
+    // A Layout decides what wraps every page assigned to it, so publishing one
+    // is a site-wide act and gets the same draft-then-publish step a component
+    // does.
+    status: true,
+    versions: { drafts: true },
+    admin: { useAsTitle: "title" },
+  });
+}

--- a/packages/plugin-page-builder/src/collections/layouts.ts
+++ b/packages/plugin-page-builder/src/collections/layouts.ts
@@ -34,6 +34,7 @@
  *
  * @module collections/layouts
  */
+import type { RepeaterFieldValue } from "nextly/config";
 import {
   defineCollection,
   relationship,
@@ -48,6 +49,31 @@ import { COMPONENTS_SLUG } from "./components";
 
 /** The slug layouts are stored under. */
 export const LAYOUTS_SLUG = "layouts";
+
+/**
+ * Refuse a Layout that fills one area twice.
+ *
+ * Reads the rows rather than counting them: a row whose `area` is still empty
+ * is the author mid-edit, and the `required` on that select is what speaks to
+ * it. Only values actually chosen can collide.
+ */
+function rejectRepeatedAreas(value: RepeaterFieldValue): string | true {
+  const chosen: string[] = [];
+  for (const row of value ?? []) {
+    const area = (row as { area?: unknown }).area;
+    if (typeof area === "string" && area !== "") chosen.push(area);
+  }
+
+  const seen = new Set<string>();
+  for (const area of chosen) {
+    // Names the offending area rather than reporting that "an area" repeats.
+    // The rows carry no visible index, so a message without the name leaves
+    // the author scanning a list to find which two they have to reconcile.
+    if (seen.has(area)) return `Two rows both fill the ${area} area`;
+    seen.add(area);
+  }
+  return true;
+}
 
 /**
  * The plugin-owned `layouts` collection.
@@ -66,6 +92,13 @@ export function layoutsCollection() {
       textarea({ name: "description" }),
       repeater({
         name: "areas",
+        // An area is a POSITION, so two rows claiming one is not a richer
+        // layout — it is a question with two answers. Without this the write
+        // succeeds and the ambiguity is handed to the resolver, which will
+        // pick whichever row it happens to reach first and render a second
+        // header on every page carrying the Layout. Refused at the write
+        // instead, where the author is still looking at the two rows.
+        validate: rejectRepeatedAreas,
         fields: [
           select({
             name: "area",

--- a/packages/plugin-page-builder/src/collections/patterns.ts
+++ b/packages/plugin-page-builder/src/collections/patterns.ts
@@ -1,0 +1,102 @@
+/**
+ * Saved starting points an author inserts and then owns.
+ *
+ * A pattern is copied on insert and keeps no link back, which is the whole
+ * difference between this collection and `components`. Two nouns rather than
+ * one with a sync flag, because copy-versus-linked is the most consequential
+ * behavioural difference in the system and a reader has to be able to tell
+ * which one they are placing before they place it.
+ *
+ * ## Why the metadata are ordinary fields
+ *
+ * Everything except the document itself is a column: title, slug, description,
+ * category, keywords, granularity. They are queried — the browser filters and
+ * searches on them, and the generated manifest reports them — and a value that
+ * is queried is a field. The tree is the one thing that is designed rather than
+ * queried, so it is the one thing in the blocks field.
+ *
+ * ## `kinds` is what stops a page being stored here
+ *
+ * The blocks field accepts every document kind its `kinds` option lists, and
+ * defaults to `["page"]`. Naming `"pattern"` here is not decoration: the
+ * field's validator refuses a document whose kind is outside the list, so a
+ * page document written to this collection is rejected at the field rather
+ * than accepted and misread later by a reader that assumed the kind.
+ *
+ * @module collections/patterns
+ */
+import { defineCollection, select, text, textarea } from "nextly/config";
+
+import { blocks } from "../fields/blocksHelper";
+
+/** The slug patterns are stored under. */
+export const PATTERNS_SLUG = "patterns";
+
+/**
+ * How much of a page one pattern covers.
+ *
+ * A closed set rather than free text, because it is a FACET: the browser
+ * filters on it and a full-page pattern is offered as a way to start a page
+ * rather than as something to insert into one. Free text would put the two
+ * behaviours behind a string nobody spells the same way twice.
+ */
+export const PATTERN_GRANULARITIES = [
+  "element",
+  "group",
+  "section",
+  "page",
+] as const;
+
+/**
+ * The plugin-owned `patterns` collection.
+ *
+ * Takes no options. A pattern has no address on the site — it is never served,
+ * only inserted — so there is no preview path to declare and nothing for a host
+ * to configure.
+ */
+export function patternsCollection() {
+  return defineCollection({
+    slug: PATTERNS_SLUG,
+    labels: { singular: "Pattern", plural: "Patterns" },
+    fields: [
+      text({ name: "title", required: true }),
+      // Unique, so two patterns cannot answer to one name. Uniqueness is
+      // per collection: patterns and components are separate tables, so a
+      // component may share a slug with a pattern without either being
+      // ambiguous, since nothing resolves a slug without knowing which of the
+      // two it is asking about.
+      text({ name: "slug", required: true, unique: true }),
+      // What the browser shows under the title, and what an agent reads to
+      // choose between patterns. Required by neither, because a pattern saved
+      // from a selection mid-edit is worth keeping before it is worth
+      // describing.
+      textarea({ name: "description" }),
+      // Free text rather than a closed list: the useful groupings are a
+      // property of the site being built, not of the page builder, and a
+      // closed vocabulary here would be one no site's content fits.
+      text({ name: "category" }),
+      // Search terms the title does not carry — the words an author would type
+      // looking for this, separated however they like. Held as one string
+      // because it is matched, never enumerated.
+      text({ name: "keywords" }),
+      select({
+        name: "granularity",
+        options: PATTERN_GRANULARITIES.map(value => ({
+          label: value,
+          value,
+        })),
+      }),
+      blocks({
+        name: "content",
+        label: "Pattern",
+        blocks: { kinds: ["pattern"] },
+      }),
+    ],
+    // Published is what makes a pattern OFFERED. A draft pattern is one being
+    // worked on, and it stays out of the insert panel until it is published,
+    // so the library never offers a half-built starting point.
+    status: true,
+    versions: { drafts: true },
+    admin: { useAsTitle: "title" },
+  });
+}

--- a/packages/plugin-page-builder/src/collections/patterns.ts
+++ b/packages/plugin-page-builder/src/collections/patterns.ts
@@ -106,11 +106,20 @@ export function patternsCollection() {
     // so the library never offers a half-built starting point.
     status: true,
     versions: { drafts: true },
-    // Kept out of the Collections section, which lists every collection that
-    // claims neither a sidebar group nor plugin ownership. Without this the
-    // store is listed twice — once there and once in this plugin's own menu —
-    // and following the plugin link then lights up Collections, so the sidebar
-    // disagrees with itself about where the author is.
-    admin: { useAsTitle: "title", isPlugin: true },
+    // Opted out of AUTOMATIC navigation, because this plugin declares its own
+    // menu entry for the store and two sources listing one screen is the
+    // problem rather than the belt-and-braces it looks like.
+    //
+    // There are two automatic sources and `hidden` is the only thing that
+    // excludes both. `isInCollectionsSection` (admin `lib/sidebar-landing`)
+    // admits every collection that is not hidden and claims no sidebar group,
+    // which is the Collections listing; `DynamicPluginNav` lists every
+    // collection marked `isPlugin`, and `SidebarNavigation` renders it
+    // immediately above this plugin's own menu — so claiming plugin ownership
+    // does not move the duplicate, it puts both copies in one section, side by
+    // side. Hidden costs nothing else: the collection keeps its URL, its API
+    // and its permissions, and only stops being offered by navigation nobody
+    // asked for.
+    admin: { useAsTitle: "title", hidden: true },
   });
 }

--- a/packages/plugin-page-builder/src/collections/patterns.ts
+++ b/packages/plugin-page-builder/src/collections/patterns.ts
@@ -79,8 +79,17 @@ export function patternsCollection() {
       // looking for this, separated however they like. Held as one string
       // because it is matched, never enumerated.
       text({ name: "keywords" }),
+      // Required, and given no default. The browser reads this to decide
+      // whether a pattern is offered as something to INSERT or as a way to
+      // START a page, so a row without one cannot be placed anywhere — and
+      // nothing downstream can tell an author who has not answered yet from
+      // one whose answer happens to be the default. A default would make the
+      // form completable without a decision and file the mistakes silently;
+      // requiring it costs one click and the answer is always known to
+      // whoever saved the pattern.
       select({
         name: "granularity",
+        required: true,
         options: PATTERN_GRANULARITIES.map(value => ({
           label: value,
           value,

--- a/packages/plugin-page-builder/src/collections/patterns.ts
+++ b/packages/plugin-page-builder/src/collections/patterns.ts
@@ -106,6 +106,11 @@ export function patternsCollection() {
     // so the library never offers a half-built starting point.
     status: true,
     versions: { drafts: true },
-    admin: { useAsTitle: "title" },
+    // Kept out of the Collections section, which lists every collection that
+    // claims neither a sidebar group nor plugin ownership. Without this the
+    // store is listed twice — once there and once in this plugin's own menu —
+    // and following the plugin link then lights up Collections, so the sidebar
+    // disagrees with itself about where the author is.
+    admin: { useAsTitle: "title", isPlugin: true },
   });
 }

--- a/packages/plugin-page-builder/src/fields/blocks-options.ts
+++ b/packages/plugin-page-builder/src/fields/blocks-options.ts
@@ -115,3 +115,38 @@ export interface BlocksFieldConfig
     args: { data: Record<string, unknown>; req: RequestContext }
   ) => string | true | Promise<string | true>;
 }
+
+/**
+ * The options a field declares, as an object.
+ *
+ * The single reader of `field.blocks`. Both the validator and the admin editor
+ * need it, and two readings of one declaration is how a field ends up
+ * validated against one policy and edited under another — which is exactly the
+ * shape of a document seeded as a `page` into a field that accepts only
+ * patterns.
+ */
+export function blocksOptionsOf(field: unknown): BlocksFieldOptions {
+  // `unknown` rather than a shape with one optional key: a parameter whose
+  // properties are all optional has nothing in common with a field instance
+  // type, so the checker refuses the very callers this exists for.
+  const declared = (field as { blocks?: unknown })?.blocks;
+  if (typeof declared !== "object" || declared === null) return {};
+  // No cast: every property of the options is optional, so the narrowed
+  // `object` already satisfies the return type. An assertion here would be
+  // stating a fact the checker has, and would keep stating it after the
+  // options gain a required member — which is the moment it stops being true.
+  return declared;
+}
+
+/**
+ * Which document kinds a field accepts, or nothing when it says nothing.
+ *
+ * `undefined` and `["page"]` are not the same answer and are not collapsed
+ * here: a field that declares nothing takes the default, and the default is
+ * the caller's to apply.
+ */
+export function acceptedKinds(
+  field: unknown
+): readonly DocumentKind[] | undefined {
+  return blocksOptionsOf(field).kinds;
+}

--- a/packages/plugin-page-builder/src/fields/blocksField.ts
+++ b/packages/plugin-page-builder/src/fields/blocksField.ts
@@ -28,6 +28,7 @@ import { siteBreakpoints } from "../site-style";
 
 import { emptyBlockDocument } from "./blocks-document";
 import type { BlocksFieldOptions } from "./blocks-options";
+import { blocksOptionsOf } from "./blocks-options";
 import { validateBlocksValue } from "./blocks-validator";
 
 /** The field type id. Was a built-in token; now this plugin's to own. */
@@ -42,9 +43,10 @@ export const BLOCKS_FIELD_COMPONENT =
 
 /** The policy a field declares, in the loosest shape worth reading. */
 function policyOf(field: PluginFieldInstance): BlocksFieldOptions {
-  const declared = field.blocks;
-  if (typeof declared !== "object" || declared === null) return {};
-  return declared;
+  // Delegated rather than repeated. The admin editor asks the same question of
+  // the same declaration, and a field validated under one reading and edited
+  // under another is how an editor seeds a document its own field rejects.
+  return blocksOptionsOf(field);
 }
 
 /**

--- a/packages/plugin-page-builder/src/plugin-admin-identity.test.ts
+++ b/packages/plugin-page-builder/src/plugin-admin-identity.test.ts
@@ -28,18 +28,24 @@ describe("page-builder admin identity", () => {
     expect(plugin.admin?.appearance?.label).not.toBe(plugin.name);
   });
 
-  it("stays in the plugins section, so its menu entry is the only main-rail item", () => {
+  it("stays in the plugins section, so its own name is not a second main-rail item", () => {
     const plugin = pageBuilder();
+    const menu = plugin.contributes?.admin?.menu ?? [];
 
     // The neighbouring case, and the reason the form builder carries a similar
     // assertion: it takes `placement: "standalone"` and contributes NO menu
     // item, so "Forms" appears exactly once. This plugin does the opposite — it
-    // contributes a "Pages" menu entry — so taking standalone placement too
-    // would put "Page Builder" and "Pages" in the main rail as two entries for
-    // one feature.
+    // contributes its own menu entries — so taking standalone placement too
+    // would put "Page Builder" in the main rail beside the entries it already
+    // puts there, as two names for one feature.
     expect(plugin.admin?.placement).toBeUndefined();
-    expect(plugin.contributes?.admin?.menu ?? []).toEqual([
-      { label: "Pages", to: "/admin/collections/pages", icon: "Layout" },
-    ]);
+
+    // The pairing is the property, so the menu being non-empty is what makes
+    // the placement assertion above mean anything: standalone placement is
+    // only a duplication when something is already listed. Which entries
+    // those are is not this test's question — asserting the whole list here
+    // made adding a screen look like a change to the plugin's identity.
+    expect(menu.length).toBeGreaterThan(0);
+    expect(menu.map(item => item.label)).toContain("Pages");
   });
 });

--- a/packages/plugin-page-builder/src/plugin.ts
+++ b/packages/plugin-page-builder/src/plugin.ts
@@ -492,25 +492,32 @@ export const pageBuilder = (opts: PageBuilderOptions = {}) => {
         // entry, so grouping them would mean widening that list — a change to
         // the admin's navigation model, which is a larger question than where
         // three links go.
+        //
+        // Each of the three names its `collection`, so a host that renames one
+        // gets a link to the collection it actually registered and a gate on
+        // the permission that slug actually seeds. Spelling either literally
+        // would strand the link and hide the item from the readers who can
+        // open the list. Pages names none, keeping the destination and the
+        // absent gate it has always had.
         menu: [
           { label: "Pages", to: "/admin/collections/pages", icon: "Layout" },
           {
             label: "Patterns",
+            collection: PATTERNS_SLUG,
             to: `/admin/collections/${PATTERNS_SLUG}`,
             icon: "LayoutTemplate",
-            requiredPermission: `read-${PATTERNS_SLUG}`,
           },
           {
             label: "Components",
+            collection: COMPONENTS_SLUG,
             to: `/admin/collections/${COMPONENTS_SLUG}`,
             icon: "Component",
-            requiredPermission: `read-${COMPONENTS_SLUG}`,
           },
           {
             label: "Layouts",
+            collection: LAYOUTS_SLUG,
             to: `/admin/collections/${LAYOUTS_SLUG}`,
             icon: "PanelsTopLeft",
-            requiredPermission: `read-${LAYOUTS_SLUG}`,
           },
         ],
         // No `schemaBuilderSlot` and no `entryFormToolbarSlot`.

--- a/packages/plugin-page-builder/src/plugin.ts
+++ b/packages/plugin-page-builder/src/plugin.ts
@@ -29,8 +29,14 @@ import {
   CLASS_USAGE_INDEX_SLUG,
   classUsageIndexCollection,
 } from "./collections/class-usage-index";
+import {
+  COMPONENTS_SLUG,
+  componentsCollection,
+} from "./collections/components";
+import { LAYOUTS_SLUG, layoutsCollection } from "./collections/layouts";
 import type { PagesCollectionOptions } from "./collections/pages";
 import { pagesCollection } from "./collections/pages";
+import { PATTERNS_SLUG, patternsCollection } from "./collections/patterns";
 import { blocksFieldType } from "./fields/blocksField";
 import { hostFetchPolicy } from "./host-policy";
 import { previewViewportsFromSiteStyle } from "./preview-viewports";
@@ -377,8 +383,19 @@ export const pageBuilder = (opts: PageBuilderOptions = {}) => {
       // describes. Its table existing is what lets the maintenance path write
       // to it without a first-run branch, exactly as the site style single is
       // registered whether or not the host stated any defaults.
+      // The composition stores, contributed unconditionally beside the pages
+      // they serve. Each is a collection rather than a shape inside one,
+      // because a collection is what core seeds permissions for: the six
+      // actions on `patterns` are separate rows from the six on `components`,
+      // so "may create a pattern" and "may publish a component to every page
+      // that carries it" are already different grants on the day this ships.
+      // A single table discriminated by a column would leave both behind one
+      // permission and could not declare a slug unique per kind.
       collections: [
         pagesCollection(pagesOptions(opts, configStyle)),
+        patternsCollection(),
+        componentsCollection(),
+        layoutsCollection(),
         classUsageIndexCollection(),
       ],
       // The Site Style global: one versioned, access-controlled document the
@@ -464,8 +481,37 @@ export const pageBuilder = (opts: PageBuilderOptions = {}) => {
               },
             }
           : {}),
+        // Each entry names the permission that makes its screen reachable, so
+        // a role without it is not offered a link into a list it would be
+        // refused. Pages carries none for the same reason it always has: it is
+        // the plugin's front door, and a reader who cannot read pages has
+        // nothing to do here at all.
+        //
+        // They sit beside Pages rather than under a section of their own. The
+        // sidebar's section vocabulary is a closed list in core with no design
+        // entry, so grouping them would mean widening that list — a change to
+        // the admin's navigation model, which is a larger question than where
+        // three links go.
         menu: [
           { label: "Pages", to: "/admin/collections/pages", icon: "Layout" },
+          {
+            label: "Patterns",
+            to: `/admin/collections/${PATTERNS_SLUG}`,
+            icon: "LayoutTemplate",
+            requiredPermission: `read-${PATTERNS_SLUG}`,
+          },
+          {
+            label: "Components",
+            to: `/admin/collections/${COMPONENTS_SLUG}`,
+            icon: "Component",
+            requiredPermission: `read-${COMPONENTS_SLUG}`,
+          },
+          {
+            label: "Layouts",
+            to: `/admin/collections/${LAYOUTS_SLUG}`,
+            icon: "PanelsTopLeft",
+            requiredPermission: `read-${LAYOUTS_SLUG}`,
+          },
         ],
         // No `schemaBuilderSlot` and no `entryFormToolbarSlot`.
         //


### PR DESCRIPTION
## What this adds

Three plugin-contributed collections the rest of Phase 5 is built on:

- **`patterns`** — saved starting points, copied when inserted. Carries title,
  slug, description, category, keywords and a granularity so the library can be
  browsed and searched rather than scrolled.
- **`components`** — definitions placed by reference, so editing one changes
  every page carrying it. An optional `area` says which Layout position it
  suits.
- **`layouts`** — which component fills each area around a page, held as rows
  (`{ area, component, variant }`) rather than a `header` column beside a
  `footer` one.

Each blocks field names the document kind it accepts, all three separate saving
from publishing, and each gets a menu entry gated on `read-<slug>`.

Nothing resolves a component instance or a Layout yet. This is the storage and
the permissions that work stands on.

## Why these shapes

**Three collections, not one table with a kind column.** Core seeds six
permissions per collection, so "may create a pattern" and "may publish a
component to every page carrying it" are separate grants on day one. One table
would leave both behind a single permission, could not declare a slug unique
per kind, and would need access rules a super-admin bypasses anyway.

**A header is a component.** The Layout names which component fills each area,
so the header/footer role lives on the placement rather than on the document.
A header then inherits per-instance fields, variants, drafts and a usage count
instead of needing a second, weaker document type built beside them. Adding an
announcement bar later is an entry in the shared area list, not a new kind of
document — which is why areas are rows.

**The area vocabulary is one declaration** (`collections/areas.ts`) that both
the Layout row and the component hint read. Two lists agree the day they are
written and diverge silently afterwards, in both directions, and each direction
empties a picker with nothing reporting it.

**No `isDefault` on layouts yet.** Exactly one row may be the site default, so
setting it has to clear the others in the same transaction, the way a default
email provider is demoted. That lands with the resolver that reads it rather
than as a boolean column with nothing enforcing the invariant.

## Test plan

`packages/plugin-page-builder`, from the package directory:

| gate | result |
| --- | --- |
| `pnpm test` | 57 files, 597 tests, all passing |
| `pnpm check-types` | exit 0 (both tsconfigs) |
| `pnpm lint` | exit 0 |
| root `npx eslint` over the changed paths | exit 0 |
| `node scripts/check-comment-convention.mjs` | exit 0 |
| `fallow audit --base origin/main` | `pass`, 7 changed files, 0 findings |
| `changeset status` | exit 0 |

**14 new tests, each break-verified by name.** Every assertion was checked
against the mutation it exists to catch, with the substitution count asserted
first and the test count held at 14 throughout so the file could not silently
stop collecting:

| break | test killed |
| --- | --- |
| `kinds` dropped from patterns | `patterns stores pattern documents` |
| `versions.drafts` dropped from components | `components carries a working draft` |
| `layoutsCollection()` not contributed | `contributes patterns, components and layouts` |
| Layout relationship repointed at patterns | `names each area's component as a relationship to the components store` |
| component area options hardcoded off the shared list | `offers the same areas on a Layout row and on a component` |
| menu entry loses `requiredPermission` | `offers each store a menu entry gated on being able to read it` |
| `unique` dropped from the layouts slug | `layouts requires a unique slug` |

The first break exposed a defect in my own test rather than in the code: an
`it.each` title interpolated the collection factory's source into the test name,
so the test passed and failed unreadably. Argument order fixed, then re-verified.

### One existing test changed

`plugin-admin-identity.test.ts` pinned the contributed menu to exactly one entry
as its evidence that the plugin does not take `placement: "standalone"`. The
property it guards is the placement, not the menu's contents, so the assertion
now says that: placement undefined, menu non-empty, `Pages` present. Both halves
break-verified — setting `placement` and removing the `Pages` entry each kill it.

Note that the first attempt at that break did **not** kill the test, because the
mutation landed in `contributes.admin` rather than the plugin's own `admin`
block. The verification was repeated against the object the assertion reads.

## Changeset

Added: yes, `patch`, all 25 lockstep packages, generated from
`.changeset/config.json` rather than copied from an existing entry.

## Pre-existing failures

None introduced. `scripts/check-comment-convention.mjs` reports 3 advisory
offences in `.github/workflows/code-hygiene.yml`, which this branch does not
touch; it exits 0 and they are explicitly non-blocking.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Patterns, Components, and Layouts content management areas to the page builder.
  * Create reusable components with metadata, categories, descriptions, and optional placement areas.
  * Define reusable patterns with granularity, keywords, and structured content blocks.
  * Configure layouts by assigning components to header and footer areas, with optional variants.
  * Added dedicated admin navigation entries with permission-based access.
  * Added draft and publishing support for these content types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->