### PR TITLE
feat(nextly): offer a collection a table card, and refuse a malformed column

### DIFF
--- a/.changeset/a-column-is-refused-or-omitted-never-guessed.md
+++ b/.changeset/a-column-is-refused-or-omitted-never-guessed.md
@@ -44,3 +44,16 @@ so the cards sharing a column are not the ones they were. The save renumbered
 the array it was handed, which stored a reading of a grid that was no longer
 on screen -- the canonical sequence disagreed with the arrangement until the
 next drag. It is now numbered from the buckets at the count in force.
+
+A collection also offers a TABLE card beside its count and its list: the same
+recent entries drawn across named columns, which is the first consumer of the
+`table` archetype the admin has always been able to draw and nothing has ever
+generated.
+
+Its columns are asked of the SOURCE rather than assumed. `status` exists only
+for a collection declaring it and the timestamps only for one that has not
+turned them off, so the card selects the ones that are there -- three columns
+for a collection with a status and two without, rather than a fixed shape
+padded with blanks or a select the read path refuses. A collection whose rows
+nothing names, or that has no `updatedAt` to mean "recent", gets no table at
+all, which are the two refusals the list card already makes.

--- a/.changeset/a-column-is-refused-or-omitted-never-guessed.md
+++ b/.changeset/a-column-is-refused-or-omitted-never-guessed.md
@@ -57,3 +57,14 @@ for a collection with a status and two without, rather than a fixed shape
 padded with blanks or a select the read path refuses. A collection whose rows
 nothing names, or that has no `updatedAt` to mean "recent", gets no table at
 all, which are the two refusals the list card already makes.
+
+The dashboard also offers a QUICK CREATE card: one click from the dashboard to
+an empty entry form, for the collections this reader may create in.
+
+Its shortcuts depend on the reader, which a declaration cannot express -- the
+collection set changes while the process runs, and which of them a caller may
+create in is a second question on top of that. So it is drawn from the
+collection list the server already filtered, narrowed again by the create
+grant. Neither half is a security boundary and the card does not pretend to be
+one: the create endpoint enforces regardless, so a shortcut shown in error
+costs a click rather than an entry nobody was allowed to make.

--- a/.changeset/a-column-is-refused-or-omitted-never-guessed.md
+++ b/.changeset/a-column-is-refused-or-omitted-never-guessed.md
@@ -1,0 +1,46 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+A placement's `column` is refused when it is present and malformed, and a
+dashboard narrowed to fewer columns stores the arrangement the reader is
+looking at.
+
+`column` was the one placement field with no shape rule, so `column: "2"`
+passed validation, failed the predicate that asks whether a placement stated a
+column, became a 0, and was then read as an OMISSION -- which the layout
+endpoint answers by keeping the column the card already had. A broken client
+was told nothing and had its card silently kept or moved. Present and
+malformed is now refused; omitted stays valid, because a client written
+before columns sends none and that payload is supported.
+
+Changing the column count moves no card and changes every answer about where
+the cards are: narrowing four columns to two folds two of them into the last,
+so the cards sharing a column are not the ones they were. The save renumbered
+the array it was handed, which stored a reading of a grid that was no longer
+on screen -- the canonical sequence disagreed with the arrangement until the
+next drag. It is now numbered from the buckets at the count in force.

--- a/.changeset/a-column-is-refused-or-omitted-never-guessed.md
+++ b/.changeset/a-column-is-refused-or-omitted-never-guessed.md
@@ -68,3 +68,17 @@ collection list the server already filtered, narrowed again by the create
 grant. Neither half is a security boundary and the card does not pretend to be
 one: the create endpoint enforces regardless, so a shortcut shown in error
 costs a click rather than an entry nobody was allowed to make.
+
+The singular label of a collection now has ONE resolver, which the create
+shortcut and the entry form both ask, so a button and the page it opens name
+the entity identically. The two recent-entry cards likewise share ONE
+eligibility decision, so a collection cannot be given a table without its list.
+
+The shortcut card also waits for both of its requests before speaking. Its two
+queries resolve independently, so a collection list arriving before the
+permission set filtered every row out and the card told the reader they could
+create nothing -- for the whole of that interval, and permanently when either
+request failed. It now says nothing until both have answered, and says nothing
+about an empty set when the page it read was truncated, because "you may create
+nothing" is false rather than incomplete on an install with more collections
+than one page holds.

--- a/packages/admin/src/components/features/dashboard/QuickCreate.test.tsx
+++ b/packages/admin/src/components/features/dashboard/QuickCreate.test.tsx
@@ -43,15 +43,25 @@ function collection(
   return { id: patch.name, label: patch.name, ...patch };
 }
 
-function listing(items: TestCollection[], isLoading = false) {
-  return { data: { items }, isLoading } as unknown as ReturnType<
-    typeof useCollections
-  >;
+function listing(
+  items: TestCollection[],
+  extra: { isLoading?: boolean; error?: Error; hasNext?: boolean } = {}
+) {
+  return {
+    data: { items, meta: { hasNext: extra.hasNext ?? false } },
+    isLoading: extra.isLoading ?? false,
+    error: extra.error ?? null,
+  } as unknown as ReturnType<typeof useCollections>;
 }
 
-function granting(slugs: string[]) {
+function granting(
+  slugs: string[],
+  extra: { isLoading?: boolean; error?: Error } = {}
+) {
   return {
     hasPermission: (slug: string) => slugs.includes(slug),
+    isLoading: extra.isLoading ?? false,
+    error: extra.error ?? null,
   } as unknown as ReturnType<typeof useCurrentUserPermissions>;
 }
 
@@ -122,7 +132,7 @@ describe("the quick-create card", () => {
     // the reader they may create nothing, which is a claim rather than a
     // delay — and it is wrong for most readers for the whole of every page
     // load. Absence is the honest answer until the list has arrived.
-    mockCollections.mockReturnValue(listing([], true));
+    mockCollections.mockReturnValue(listing([], { isLoading: true }));
     mockPermissions.mockReturnValue(granting([]));
 
     render(<QuickCreate />);
@@ -136,6 +146,64 @@ describe("the quick-create card", () => {
     // empty would satisfy the loading test and leave a reader who genuinely
     // has no create grant looking at a titled card with no body.
     mockCollections.mockReturnValue(listing([collection({ name: "posts" })]));
+    mockPermissions.mockReturnValue(granting([]));
+
+    render(<QuickCreate />);
+
+    expect(screen.getByTestId("quick-create-empty")).toBeInTheDocument();
+  });
+
+  it("says nothing while the PERMISSIONS are still in flight", () => {
+    // 🔴 The two requests resolve independently. `hasPermission` answers from
+    // an empty set until `/me/permissions` lands, so a collection list that
+    // arrives first filters every row out — and the card tells the reader they
+    // may create nothing, for the whole of that interval, on every page load.
+    mockCollections.mockReturnValue(listing([collection({ name: "posts" })]));
+    mockPermissions.mockReturnValue(granting([], { isLoading: true }));
+
+    render(<QuickCreate />);
+
+    expect(screen.queryByTestId("quick-create-empty")).toBeNull();
+    expect(screen.queryByTestId("quick-create")).toBeNull();
+  });
+
+  it("says nothing when either request FAILED", () => {
+    // A failure is not an answer. Drawing the empty state from one turns a
+    // transport error into a claim about this reader's permissions, and it
+    // never clears.
+    mockCollections.mockReturnValue(
+      listing([collection({ name: "posts" })], { error: new Error("boom") })
+    );
+    mockPermissions.mockReturnValue(granting(["create-posts"]));
+
+    render(<QuickCreate />);
+
+    expect(screen.queryByTestId("quick-create-empty")).toBeNull();
+    expect(screen.queryByTestId("quick-create")).toBeNull();
+  });
+
+  it("does not claim an empty set when the page was TRUNCATED", () => {
+    // 🔴 The card reads one page. On an install with more collections than
+    // that, every creatable one can sit beyond the boundary — so "nothing to
+    // create" is false rather than merely incomplete. Saying nothing is
+    // recoverable; saying the wrong thing is not.
+    mockCollections.mockReturnValue(
+      listing([collection({ name: "posts" })], { hasNext: true })
+    );
+    mockPermissions.mockReturnValue(granting([]));
+
+    render(<QuickCreate />);
+
+    expect(screen.queryByTestId("quick-create-empty")).toBeNull();
+  });
+
+  it("STILL says so on a complete page with nothing creatable", () => {
+    // The control for the case above. Withholding the empty state whenever it
+    // is empty would satisfy it and leave every reader without a create grant
+    // looking at a titled card with no body.
+    mockCollections.mockReturnValue(
+      listing([collection({ name: "posts" })], { hasNext: false })
+    );
     mockPermissions.mockReturnValue(granting([]));
 
     render(<QuickCreate />);
@@ -157,6 +225,6 @@ describe("the quick-create card", () => {
     render(<QuickCreate />);
 
     expect(screen.getAllByRole("link")).toHaveLength(6);
-    expect(screen.getByText("3 more in the sidebar.")).toBeInTheDocument();
+    expect(screen.getByText("3 more.")).toBeInTheDocument();
   });
 });

--- a/packages/admin/src/components/features/dashboard/QuickCreate.test.tsx
+++ b/packages/admin/src/components/features/dashboard/QuickCreate.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * What the quick-create card offers, and what it deliberately does not.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { render, screen } from "@admin/__tests__/utils";
+import { useCollections } from "@admin/hooks/queries/useCollections";
+import { useCurrentUserPermissions } from "@admin/hooks/useCurrentUserPermissions";
+
+import { QuickCreate } from "./QuickCreate";
+
+// Mocked through the same specifiers the component imports: a mock registered
+// against a module nobody loads leaves the real hook in place, which is a green
+// that tested nothing.
+vi.mock("@admin/hooks/queries/useCollections", () => ({
+  useCollections: vi.fn(),
+}));
+vi.mock("@admin/hooks/useCurrentUserPermissions", () => ({
+  useCurrentUserPermissions: vi.fn(),
+}));
+
+const mockCollections = vi.mocked(useCollections);
+const mockPermissions = vi.mocked(useCurrentUserPermissions);
+
+/**
+ * Only the fields this card reads; the API row is far wider.
+ *
+ * The return type is STATED rather than inferred. Inferred, it comes from the
+ * literal before the spread, so `name` is absent from it and a caller reading
+ * one back does not compile -- which `vitest` cannot see, because it does not
+ * typecheck.
+ */
+interface TestCollection {
+  id?: unknown;
+  name: string;
+  label?: string;
+  labels?: { singular: string; plural: string };
+}
+
+function collection(
+  patch: Partial<TestCollection> & { name: string }
+): TestCollection {
+  return { id: patch.name, label: patch.name, ...patch };
+}
+
+function listing(items: TestCollection[], isLoading = false) {
+  return { data: { items }, isLoading } as unknown as ReturnType<
+    typeof useCollections
+  >;
+}
+
+function granting(slugs: string[]) {
+  return {
+    hasPermission: (slug: string) => slugs.includes(slug),
+  } as unknown as ReturnType<typeof useCurrentUserPermissions>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("the quick-create card", () => {
+  it("offers a shortcut only where the reader may CREATE", () => {
+    // 🔴 Two gates compose here and each removes a different set. The server's
+    // list has already dropped collections this reader cannot see at all; this
+    // one drops the ones they may read but not create in. Drawing every
+    // collection the list returns would advertise a capability that answers
+    // with a refusal screen.
+    mockCollections.mockReturnValue(
+      listing([collection({ name: "posts" }), collection({ name: "pages" })])
+    );
+    mockPermissions.mockReturnValue(granting(["create-posts"]));
+
+    render(<QuickCreate />);
+
+    expect(screen.getByTestId("quick-create-posts")).toBeInTheDocument();
+    // The control: `pages` IS in the list the server returned, so its absence
+    // is this filter acting rather than the fixture never offering it.
+    expect(screen.queryByTestId("quick-create-pages")).toBeNull();
+  });
+
+  it("names the entity the way its form does", () => {
+    // The author's declared singular wins over the display label, which is the
+    // order `useEntryForm` resolves — so the button and the page it opens call
+    // the entity the same thing. A label-only reading says "New Blog Posts".
+    mockCollections.mockReturnValue(
+      listing([
+        collection({
+          name: "posts",
+          label: "Blog Posts",
+          labels: { singular: "Article", plural: "Articles" },
+        }),
+      ])
+    );
+    mockPermissions.mockReturnValue(granting(["create-posts"]));
+
+    render(<QuickCreate />);
+
+    expect(screen.getByText("New Article")).toBeInTheDocument();
+  });
+
+  it("falls back to the display label, then to the slug", () => {
+    // The control for the case above: a resolution that only read `labels`
+    // would render nothing at all for the collections that declare none, which
+    // is most of them.
+    mockCollections.mockReturnValue(
+      listing([
+        collection({ name: "pages", label: "Page" }),
+        collection({ name: "notes", label: undefined }),
+      ])
+    );
+    mockPermissions.mockReturnValue(granting(["create-pages", "create-notes"]));
+
+    render(<QuickCreate />);
+
+    expect(screen.getByText("New Page")).toBeInTheDocument();
+    expect(screen.getByText("New notes")).toBeInTheDocument();
+  });
+
+  it("says nothing at all while the list is still loading", () => {
+    // 🔴 A card that drew its empty state first and filled in afterwards tells
+    // the reader they may create nothing, which is a claim rather than a
+    // delay — and it is wrong for most readers for the whole of every page
+    // load. Absence is the honest answer until the list has arrived.
+    mockCollections.mockReturnValue(listing([], true));
+    mockPermissions.mockReturnValue(granting([]));
+
+    render(<QuickCreate />);
+
+    expect(screen.queryByTestId("quick-create-empty")).toBeNull();
+    expect(screen.queryByTestId("quick-create")).toBeNull();
+  });
+
+  it("says so when the reader may create nothing", () => {
+    // The control for the case above. Returning nothing whenever the list is
+    // empty would satisfy the loading test and leave a reader who genuinely
+    // has no create grant looking at a titled card with no body.
+    mockCollections.mockReturnValue(listing([collection({ name: "posts" })]));
+    mockPermissions.mockReturnValue(granting([]));
+
+    render(<QuickCreate />);
+
+    expect(screen.getByTestId("quick-create-empty")).toBeInTheDocument();
+  });
+
+  it("counts the surplus rather than drawing it", () => {
+    // Past a handful this stops being a shortcut and becomes a second
+    // navigation menu, which the sidebar already is.
+    const many = Array.from({ length: 9 }, (_unused, i) =>
+      collection({ name: `c${i}` })
+    );
+    mockCollections.mockReturnValue(listing(many));
+    mockPermissions.mockReturnValue(
+      granting(many.map(c => `create-${c.name}`))
+    );
+
+    render(<QuickCreate />);
+
+    expect(screen.getAllByRole("link")).toHaveLength(6);
+    expect(screen.getByText("3 more in the sidebar.")).toBeInTheDocument();
+  });
+});

--- a/packages/admin/src/components/features/dashboard/QuickCreate.tsx
+++ b/packages/admin/src/components/features/dashboard/QuickCreate.tsx
@@ -40,6 +40,7 @@ import { Link } from "@admin/components/ui/link";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
 import { useCollections } from "@admin/hooks/queries/useCollections";
 import { useCurrentUserPermissions } from "@admin/hooks/useCurrentUserPermissions";
+import { collectionSingularLabel } from "@admin/lib/collection-label";
 
 /**
  * How many shortcuts are drawn before the rest are counted.
@@ -50,15 +51,34 @@ import { useCurrentUserPermissions } from "@admin/hooks/useCurrentUserPermission
  */
 const MAX_SHORTCUTS = 6;
 
+/**
+ * How many collections are asked for.
+ *
+ * The card needs the first few CREATABLE ones, and the server cannot filter on
+ * that, so it reads a page and narrows it here. A page rather than every
+ * collection because this is a shortcut card on a dashboard, not a directory —
+ * and the empty state refuses to speak when the page was truncated, so the
+ * bound costs a missing shortcut rather than a false claim.
+ */
+const COLLECTION_PAGE_SIZE = 100;
+
 export function QuickCreate() {
   // 🔴 The SERVER's list, not the whole registry. This is the same query the
   // sidebar reads, and it is already filtered to what this reader may see — so
   // a collection they are not allowed to know exists is absent before any
   // permission check here runs, rather than being drawn and then hidden.
-  const { data, isLoading } = useCollections({
-    pagination: { page: 0, pageSize: 100 },
+  const {
+    data,
+    isLoading: collectionsLoading,
+    error: collectionsError,
+  } = useCollections({
+    pagination: { page: 0, pageSize: COLLECTION_PAGE_SIZE },
   });
-  const { hasPermission } = useCurrentUserPermissions();
+  const {
+    hasPermission,
+    isLoading: permissionsLoading,
+    error: permissionsError,
+  } = useCurrentUserPermissions();
 
   const creatable = useMemo(() => {
     const items = data?.items ?? [];
@@ -67,10 +87,24 @@ export function QuickCreate() {
     );
   }, [data?.items, hasPermission]);
 
-  // Nothing at all while the list is in flight. A card that drew its empty
-  // state first and then filled in would tell the reader they may create
-  // nothing, which is a claim rather than a delay.
-  if (isLoading) return null;
+  // 🔴 BOTH requests, and a failure of either. `hasPermission` answers from an
+  // empty set until `/me/permissions` lands, so a collection list that resolves
+  // first filters every row out and the card says the reader may create
+  // nothing — for the whole of that interval, and permanently if either request
+  // fails. Absence is the honest answer until both have arrived, because a
+  // claim about what someone may do cannot be made from an answer that has not
+  // come back.
+  if (collectionsLoading || permissionsLoading) return null;
+  if (collectionsError || permissionsError) return null;
+
+  // 🔴 A truncated list cannot support the empty claim either. The page holds
+  // the first `COLLECTION_PAGE_SIZE` collections, so an install with more than
+  // that may have every creatable one beyond the boundary — and "you may create
+  // nothing" would then be false rather than merely incomplete. Saying nothing
+  // is wrong in a way the reader can recover from; saying the wrong thing is
+  // not.
+  const truncated = data?.meta?.hasNext === true;
+  if (creatable.length === 0 && truncated) return null;
 
   if (creatable.length === 0) {
     return (
@@ -99,27 +133,17 @@ export function QuickCreate() {
             className="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-sm transition-colors hover:border-primary hover:bg-accent"
           >
             <Plus className="size-4 text-muted-foreground" aria-hidden="true" />
-            {/* 🔴 The author's declared singular, then the display label, then
-                the slug -- the same order `useEntryForm` resolves, so the
-                button and the form it opens name the entity identically.
-                Written out rather than shared because the admin currently
-                answers this question in four places that disagree: the sidebar
-                honours `labels.plural`, the entry list ignores `labels`
-                entirely. Matching the most correct of them adds no fifth
-                variant; converging them is its own change. */}
-            <span>
-              New{" "}
-              {collection.labels?.singular ||
-                collection.label ||
-                collection.name}
-            </span>
+            {/* The SHARED resolver, which the entry form asks too, so the
+                button and the page it opens name the entity identically. */}
+            <span>New {collectionSingularLabel(collection)}</span>
           </Link>
         ))}
       </div>
       {hidden > 0 && (
-        <p className="text-xs text-muted-foreground">
-          {hidden} more in the sidebar.
-        </p>
+        // Counted, not located. The surplus is reachable from the sidebar only
+        // while it reads the same page this does, so naming it as the way there
+        // is a promise this card cannot keep on a large install.
+        <p className="text-xs text-muted-foreground">{hidden} more.</p>
       )}
     </div>
   );

--- a/packages/admin/src/components/features/dashboard/QuickCreate.tsx
+++ b/packages/admin/src/components/features/dashboard/QuickCreate.tsx
@@ -1,0 +1,126 @@
+"use client";
+/**
+ * "New Post", "New Page": one click from the dashboard to an empty entry form.
+ *
+ * ## Why a component rather than a declared `actions` widget
+ *
+ * The shortcuts depend on the READER, and a declaration cannot. Which
+ * collections exist changes while the process runs — the Schema Builder makes
+ * one without a restart — and which of them a given reader may create in is a
+ * second, per-caller question on top of that. A widget declared at boot
+ * describes neither.
+ *
+ * The `actions` archetype gates each item on `requiredPermission`, which
+ * `resolve-widgets` filters against the flat permission list. That list is the
+ * wrong instrument for this question: a collection's create rule can live in
+ * its code-defined `access.create`, which no flat slug expresses. So the
+ * shortcuts here are built from the collection list the SERVER already
+ * filtered, and narrowed again by the create grant the client can see.
+ *
+ * ## What that gate does and does not promise
+ *
+ * 🔴 Neither half is a security boundary and this card must never be read as
+ * one. The create endpoint runs `checkCollectionAccess(slug, "create", ...)`
+ * whatever is drawn here, so a shortcut this card shows in error costs a click
+ * and a refusal screen rather than an entry nobody was allowed to make.
+ *
+ * What the two gates buy is that the common cases are right: the server's list
+ * removes collections the reader cannot see at all, and `create-<slug>` removes
+ * the ones plain RBAC denies. What neither sees is a create rule expressed only
+ * in code — a reader that rule refuses is still offered the shortcut. Closing
+ * that needs a card whose BODY is filtered server-side, which nothing in the
+ * widget model does yet, and it is not worth building for one card.
+ *
+ * @module components/features/dashboard/QuickCreate
+ */
+import { Plus } from "lucide-react";
+import { useMemo } from "react";
+
+import { Link } from "@admin/components/ui/link";
+import { ROUTES, buildRoute } from "@admin/constants/routes";
+import { useCollections } from "@admin/hooks/queries/useCollections";
+import { useCurrentUserPermissions } from "@admin/hooks/useCurrentUserPermissions";
+
+/**
+ * How many shortcuts are drawn before the rest are counted.
+ *
+ * The same budget the `actions` archetype uses, for the same reason: past a
+ * handful this stops being a shortcut and becomes a second navigation menu,
+ * which the sidebar already is. The surplus is reachable there.
+ */
+const MAX_SHORTCUTS = 6;
+
+export function QuickCreate() {
+  // 🔴 The SERVER's list, not the whole registry. This is the same query the
+  // sidebar reads, and it is already filtered to what this reader may see — so
+  // a collection they are not allowed to know exists is absent before any
+  // permission check here runs, rather than being drawn and then hidden.
+  const { data, isLoading } = useCollections({
+    pagination: { page: 0, pageSize: 100 },
+  });
+  const { hasPermission } = useCurrentUserPermissions();
+
+  const creatable = useMemo(() => {
+    const items = data?.items ?? [];
+    return items.filter(collection =>
+      hasPermission(`create-${collection.name}`)
+    );
+  }, [data?.items, hasPermission]);
+
+  // Nothing at all while the list is in flight. A card that drew its empty
+  // state first and then filled in would tell the reader they may create
+  // nothing, which is a claim rather than a delay.
+  if (isLoading) return null;
+
+  if (creatable.length === 0) {
+    return (
+      <p
+        data-testid="quick-create-empty"
+        className="text-sm text-muted-foreground"
+      >
+        Nothing here for you to create.
+      </p>
+    );
+  }
+
+  const shown = creatable.slice(0, MAX_SHORTCUTS);
+  const hidden = creatable.length - shown.length;
+
+  return (
+    <div className="flex flex-col gap-2" data-testid="quick-create">
+      <div className="flex flex-wrap gap-2">
+        {shown.map(collection => (
+          <Link
+            key={collection.name}
+            href={buildRoute(ROUTES.COLLECTION_ENTRY_CREATE, {
+              slug: collection.name,
+            })}
+            data-testid={`quick-create-${collection.name}`}
+            className="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-sm transition-colors hover:border-primary hover:bg-accent"
+          >
+            <Plus className="size-4 text-muted-foreground" aria-hidden="true" />
+            {/* 🔴 The author's declared singular, then the display label, then
+                the slug -- the same order `useEntryForm` resolves, so the
+                button and the form it opens name the entity identically.
+                Written out rather than shared because the admin currently
+                answers this question in four places that disagree: the sidebar
+                honours `labels.plural`, the entry list ignores `labels`
+                entirely. Matching the most correct of them adds no fifth
+                variant; converging them is its own change. */}
+            <span>
+              New{" "}
+              {collection.labels?.singular ||
+                collection.label ||
+                collection.name}
+            </span>
+          </Link>
+        ))}
+      </div>
+      {hidden > 0 && (
+        <p className="text-xs text-muted-foreground">
+          {hidden} more in the sidebar.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/packages/admin/src/components/features/entries/EntryForm/useEntryForm.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/useEntryForm.ts
@@ -21,6 +21,7 @@ import { useCreateEntry } from "@admin/hooks/queries/useCreateEntry";
 import { useDeleteEntry } from "@admin/hooks/queries/useDeleteEntry";
 import { useDiscardWorkingDraft } from "@admin/hooks/queries/useDiscardWorkingDraft";
 import { useUpdateEntry } from "@admin/hooks/queries/useUpdateEntry";
+import { collectionSingularLabel } from "@admin/lib/collection-label";
 import { generateClientSchema } from "@admin/lib/field-validation";
 import { getDefaultValues } from "@admin/lib/form/default-values";
 import type { EntryValue } from "@admin/types/collection";
@@ -338,10 +339,14 @@ export interface UseEntryFormReturn {
  */
 
 /**
- * Gets the singular label for a collection
+ * Gets the singular label for a collection.
+ *
+ * Delegates to the shared resolver rather than restating the fallback, so the
+ * heading of this form and the shortcut that opens it name the entity
+ * identically -- and keep doing so if the order ever changes.
  */
 function getSingularLabel(collection: EntryFormCollection): string {
-  return collection.labels?.singular || collection.label || collection.name;
+  return collectionSingularLabel(collection);
 }
 
 // ============================================================================

--- a/packages/admin/src/components/features/widgets/__tests__/layout-editor.test.ts
+++ b/packages/admin/src/components/features/widgets/__tests__/layout-editor.test.ts
@@ -10,6 +10,7 @@ import {
   columnAffordance,
   columnFromDropData,
   dropSide,
+  renumberForColumns,
   resolveDrop,
   placementsByColumn,
   hasChanges,
@@ -643,6 +644,67 @@ describe("the stored sequence reads ACROSS the rows", () => {
       .sort((a, b) => a.order - b.order)
       .map(p => p.id);
     expect(column0).toEqual(["D", "A"]);
+  });
+});
+
+describe("narrowing the dashboard renumbers what is on screen", () => {
+  const at = (id: string, column: number, order: number): WidgetPlacement => ({
+    id,
+    widgetId: `w-${id}`,
+    column,
+    order,
+    hidden: false,
+  });
+
+  it("numbers the arrangement for the count in FORCE, not the one it was built at", () => {
+    // 🔴 Changing the count moves no card and changes every answer about where
+    // the cards are. At four columns these sit one per column with E under A;
+    // at two, the grid folds columns 2 and 3 into the last, so the reader sees
+    // [A, E] and [B, C, D] — read across the rows, A, B, E, C, D. Renumbering
+    // the array instead stores A, B, C, D, E, a reading of a grid that is no
+    // longer on screen, and the canonical order stays wrong until a drag.
+    const draft = [
+      at("A", 0, 0),
+      at("B", 1, 10),
+      at("C", 2, 20),
+      at("D", 3, 30),
+      at("E", 0, 40),
+    ];
+    const stored = renumberForColumns(draft, 2);
+    const sequence = [...stored]
+      .sort((a, b) => a.order - b.order || (a.column ?? 0) - (b.column ?? 0))
+      .map(p => p.id);
+    expect(sequence).toEqual(["A", "B", "E", "C", "D"]);
+  });
+
+  it("still orders each column of the NARROWED grid top to bottom", () => {
+    // The control: a sequence that interleaved wrongly could satisfy the row
+    // reading while scrambling the column the reader is looking at. Both are
+    // read off the same numbers, so both have to hold at once.
+    const draft = [
+      at("A", 0, 0),
+      at("B", 1, 10),
+      at("C", 2, 20),
+      at("D", 3, 30),
+      at("E", 0, 40),
+    ];
+    const stored = renumberForColumns(draft, 2);
+    expect(placementsByColumn(stored, 2).map(b => b.map(p => p.id))).toEqual([
+      ["A", "E"],
+      ["B", "C", "D"],
+    ]);
+  });
+
+  it("leaves an arrangement alone when the count did not change", () => {
+    // The other control. A renumber that always reshuffled would satisfy both
+    // cases above while rewriting every save that touched nothing.
+    const draft = [at("A", 0, 0), at("B", 1, 10), at("C", 0, 20)];
+    const stored = renumberForColumns(draft, 2);
+    expect(stored.map(p => p.id)).toEqual(["A", "B", "C"]);
+    expect(placementsByColumn(stored, 2).map(b => b.map(p => p.id))).toEqual([
+      ["A", "C"],
+      ["B"],
+    ]);
   });
 });
 

--- a/packages/admin/src/components/features/widgets/__tests__/layout-editor.test.ts
+++ b/packages/admin/src/components/features/widgets/__tests__/layout-editor.test.ts
@@ -647,6 +647,26 @@ describe("the stored sequence reads ACROSS the rows", () => {
   });
 });
 
+describe("a column that is not a whole number", () => {
+  it("places the card instead of throwing", () => {
+    // 🔴 The value indexes an array. Clamping alone leaves a fraction intact,
+    // `columns[0.5]` is undefined, and the push throws — which does not lose one
+    // card, it takes the whole grid down. Nothing produces a fractional column
+    // today, because the reader truncates before storing one; this is exported
+    // and called on placements from the editor as well as from the wire, so the
+    // guard costs one operation on a value already in hand.
+    const grouped = placementsByColumn([{ id: "a", column: 0.5, order: 0 }], 2);
+    expect(grouped.map(bucket => bucket.map(p => p.id))).toEqual([["a"], []]);
+  });
+
+  it("still sends a whole number to the column it names", () => {
+    // The control: truncating toward zero would satisfy the case above while
+    // moving every card in column 1 into column 0.
+    const grouped = placementsByColumn([{ id: "a", column: 1, order: 0 }], 2);
+    expect(grouped.map(bucket => bucket.map(p => p.id))).toEqual([[], ["a"]]);
+  });
+});
+
 describe("narrowing the dashboard renumbers what is on screen", () => {
   const at = (id: string, column: number, order: number): WidgetPlacement => ({
     id,

--- a/packages/admin/src/components/features/widgets/core-components.ts
+++ b/packages/admin/src/components/features/widgets/core-components.ts
@@ -18,6 +18,7 @@
  */
 
 import { CollectionQuickLinks } from "@admin/components/features/dashboard/CollectionQuickLinks";
+import { QuickCreate } from "@admin/components/features/dashboard/QuickCreate";
 import { SeedDemoContentCard } from "@admin/components/features/dashboard/SeedDemoContentCard";
 import { SinglesQuickLinks } from "@admin/components/features/dashboard/SinglesQuickLinks";
 import { TeamSummary } from "@admin/components/features/dashboard/TeamSummary";
@@ -35,5 +36,6 @@ export function registerCoreWidgetComponents(): void {
   registerCoreComponent("core#SeedDemoContentCard", SeedDemoContentCard);
   registerCoreComponent("core#CollectionQuickLinks", CollectionQuickLinks);
   registerCoreComponent("core#SinglesQuickLinks", SinglesQuickLinks);
+  registerCoreComponent("core#QuickCreate", QuickCreate);
   registerCoreComponent("core#TeamSummary", TeamSummary);
 }

--- a/packages/admin/src/components/features/widgets/edit/useLayoutLifecycle.ts
+++ b/packages/admin/src/components/features/widgets/edit/useLayoutLifecycle.ts
@@ -15,7 +15,7 @@ import { useCallback, type Dispatch, type SetStateAction } from "react";
 
 import type { UseDashboardLayoutResult } from "@admin/hooks/queries/useDashboardLayout";
 
-import { renumber } from "../layout-editor";
+import { renumberForColumns } from "../layout-editor";
 
 import type { LayoutDraft } from "./useLayoutEditor";
 
@@ -60,14 +60,16 @@ export function useLayoutLifecycle(
   const save = useCallback(() => {
     if (!draft) return;
     layout.save.mutate(
-      // Renumbered on the way out: the editor reorders an ARRAY, so a moved
-      // card still carries the `order` it had before. Sent as-is, the server
-      // sorts by a number that no longer matches what the reader sees.
+      // Renumbered on the way out, AT THE DRAFT'S COLUMN COUNT: the editor
+      // reorders an array, so a moved card still carries the `order` it had
+      // before, and the count decides which cards share a column and therefore
+      // what reading across the rows means. Narrowing the dashboard moves no
+      // card and changes every one of those answers.
       //
       // The guards come from the DRAFT, so they are the ones this arrangement
       // was derived from rather than whatever the last refetch produced.
       {
-        placements: renumber(draft.placements),
+        placements: renumberForColumns(draft.placements, draft.columnCount),
         version: draft.version,
         scope: draft.scope,
         columnCount: draft.columnCount,

--- a/packages/admin/src/components/features/widgets/layout-editor.ts
+++ b/packages/admin/src/components/features/widgets/layout-editor.ts
@@ -261,7 +261,15 @@ export function placementsByColumn<
     () => []
   );
   for (const placement of placements) {
-    const declared = placement.column ?? 0;
+    // 🔴 TRUNCATED, because this value indexes an array. A fractional column
+    // survives the clamp and `columns[0.5]` is undefined, so the push throws
+    // and takes the whole grid with it. The reader that builds a stored
+    // placement truncates already, so nothing reaches here fractional today —
+    // which is what makes the guard cheap rather than what makes it
+    // unnecessary: this is exported, it is called on placements from the
+    // editor as well as from the wire, and reachability is a property of the
+    // call graph rather than of the code.
+    const declared = Math.trunc(placement.column ?? 0);
     const index = Math.min(Math.max(0, declared), columns.length - 1);
     columns[index].push(placement);
   }

--- a/packages/admin/src/components/features/widgets/layout-editor.ts
+++ b/packages/admin/src/components/features/widgets/layout-editor.ts
@@ -489,6 +489,23 @@ export function resolveDrop(
  * Sparse steps rather than 0..n, for the reason `renumber` gives: an insertion
  * between two cards then needs no renumbering at all.
  */
+/**
+ * The arrangement as it will be STORED, for the column count in force.
+ *
+ * 🔴 Bucketed at that count BEFORE the orders are assigned, because the count
+ * decides which cards share a column and therefore what the row-major reading
+ * is. Renumbering the array instead numbers the sequence the cards happened to
+ * be in: narrowing four columns to two folds two of them into the last, so the
+ * stored sequence keeps a reading of a grid that is no longer on screen, and
+ * the canonical order disagrees with the arrangement until the next drag.
+ */
+export function renumberForColumns(
+  placements: readonly WidgetPlacement[],
+  columnCount: number
+): WidgetPlacement[] {
+  return rowMajor(placementsByColumn(placements, columnCount));
+}
+
 function rowMajor(buckets: readonly WidgetPlacement[][]): WidgetPlacement[] {
   const depth = buckets.reduce(
     (deepest, bucket) => Math.max(deepest, bucket.length),

--- a/packages/admin/src/lib/collection-label.ts
+++ b/packages/admin/src/lib/collection-label.ts
@@ -1,0 +1,32 @@
+/**
+ * What a human calls ONE entry of a collection.
+ *
+ * 🔴 One implementation, because the answer is read in two places that must
+ * agree: the button that opens a create form, and the form itself. Two
+ * resolutions agree on the day they are written and drift afterwards, and the
+ * drift is silent -- a shortcut reading "New Blog Posts" opening a page headed
+ * "New Article" looks like two features rather than one bug.
+ *
+ * The order is the author's declared singular first, then the display label,
+ * then the slug. `labels.singular` is the only one of the three that is
+ * ACTUALLY singular: `label` is whatever the collection is called in the
+ * sidebar, which is usually plural, and the slug is a storage identifier.
+ *
+ * Structurally typed rather than taking a named collection interface, because
+ * the callers hold different shapes of the same row -- the API's `ApiCollection`
+ * and the entry form's narrower `EntryFormCollection` -- and neither should
+ * have to convert to ask a question about three of its own fields.
+ *
+ * @module lib/collection-label
+ */
+
+export interface CollectionNaming {
+  name: string;
+  label?: string;
+  labels?: { singular?: string; plural?: string };
+}
+
+/** The singular label, falling back to the display label and then the slug. */
+export function collectionSingularLabel(collection: CollectionNaming): string {
+  return collection.labels?.singular || collection.label || collection.name;
+}

--- a/packages/nextly/src/domains/widgets/__tests__/collection-widgets.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/collection-widgets.test.ts
@@ -29,11 +29,12 @@ function source(patch: Partial<WidgetSource>): WidgetSource {
 }
 
 describe("what a collection gets", () => {
-  it("derives a metric and a list from one source", () => {
+  it("derives a metric, a list and a table from one source", () => {
     const widgets = collectionWidgets([source({})]);
     expect(widgets.map(w => [w.id, w.archetype])).toEqual([
       ["collection/posts-count", "metric"],
       ["collection/posts-recent", "list"],
+      ["collection/posts-table", "table"],
     ]);
   });
 
@@ -48,7 +49,7 @@ describe("what a collection gets", () => {
     const widgets = collectionWidgets([
       source({ requiredPermission: "read-articles" }),
     ]);
-    expect(widgets).toHaveLength(2);
+    expect(widgets).toHaveLength(3);
     for (const widget of widgets) {
       expect(widget).not.toHaveProperty("requiredPermission");
     }
@@ -64,6 +65,7 @@ describe("what a collection gets", () => {
     expect(widgets.map(w => w.id)).toEqual([
       "collection/customer-notes-count",
       "collection/customer-notes-recent",
+      "collection/customer-notes-table",
     ]);
   });
 
@@ -90,6 +92,7 @@ describe("what a collection gets", () => {
     expect(widgets.map(w => w.id)).toEqual([
       "collection/posts-count",
       "collection/posts-recent",
+      "collection/posts-table",
     ]);
   });
 
@@ -162,7 +165,78 @@ describe("what a collection does NOT get", () => {
 
   it("no metric when the source does not answer count", () => {
     const widgets = collectionWidgets([source({ supports: ["list"] })]);
-    expect(widgets.map(w => w.archetype)).toEqual(["list"]);
+    expect(widgets.map(w => w.archetype)).toEqual(["list", "table"]);
+  });
+
+  it("selects the status column when the collection HAS one", () => {
+    // 🔴 Asked of the source, because `status` is a per-collection fact: the
+    // schema pipeline injects the column only for a collection declaring
+    // `status: true`, and the source lists it only then. Selecting it
+    // unconditionally is refused by the read path — a refusal about a field
+    // nothing declared, on a card the reader did not misconfigure.
+    const [table] = collectionWidgets([
+      source({
+        fields: [
+          { name: "id", type: "string" },
+          { name: "title", type: "string" },
+          { name: "status", type: "string" },
+          { name: "updatedAt", type: "date" },
+        ],
+      }),
+    ]).filter(w => w.archetype === "table");
+    expect(table?.query?.select).toEqual(["title", "status", "updatedAt"]);
+  });
+
+  it("OMITS it when the collection has none", () => {
+    // The control. Selecting `status` unconditionally satisfies the case above
+    // and breaks every collection that turned it off, which is the direction
+    // that fails on the reader's dashboard rather than in a test.
+    const [table] = collectionWidgets([source({})]).filter(
+      w => w.archetype === "table"
+    );
+    expect(table?.query?.select).toEqual(["title", "updatedAt"]);
+  });
+
+  it("gives NO table to a collection nothing names its rows by", () => {
+    // 🔴 The same refusal the list makes, for the same reason: with no field
+    // naming a row, every line of the table reads as an identifier. A table is
+    // worse than a list here, not better — a column of ids under a heading
+    // looks like data rather than like a card that declined to guess.
+    const widgets = collectionWidgets([
+      source({
+        titleField: undefined,
+        fields: [
+          { name: "id", type: "string" },
+          { name: "updatedAt", type: "date" },
+        ],
+      }),
+    ]);
+    expect(widgets.map(w => w.archetype)).toEqual(["metric"]);
+  });
+
+  it("gives NO table when nothing can order it", () => {
+    // "Recent" is a claim, and `updatedAt` is what supports it. Sorting by id
+    // would produce a card whose title its rows do not bear out.
+    const widgets = collectionWidgets([
+      source({
+        fields: [
+          { name: "id", type: "string" },
+          { name: "title", type: "string" },
+        ],
+      }),
+    ]);
+    expect(widgets.map(w => w.archetype)).toEqual(["metric"]);
+  });
+
+  it("asks for every entry, so a draft is visible in the table", () => {
+    // The counterpart of the metric counting drafts. A table that silently
+    // excluded them would disagree with the collection's own list view, and a
+    // reader has no way to tell which of the two answers a narrower question.
+    const [table] = collectionWidgets([source({})]).filter(
+      w => w.archetype === "table"
+    );
+    expect(table?.query?.status).toBe("all");
+    expect(table?.query?.sort).toBe("-updatedAt");
   });
 
   it("nothing at all for a source that is not a collection", () => {

--- a/packages/nextly/src/domains/widgets/__tests__/collection-widgets.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/collection-widgets.test.ts
@@ -239,6 +239,53 @@ describe("what a collection does NOT get", () => {
     expect(table?.query?.sort).toBe("-updatedAt");
   });
 
+  it("gives a collection BOTH recent cards or NEITHER", () => {
+    // 🔴 The list and the table put the same question to a source — can it be
+    // listed, does a field name its rows, is there an `updatedAt` — so a
+    // collection that gets one must get the other. Asked twice, the two answers
+    // drift: a change to one card's conditions leaves a collection with a table
+    // and no list, from an edit that pointed at neither.
+    const sources = [
+      // Eligible.
+      source({ id: "collection:posts", label: "posts" }),
+      // No field names its rows.
+      source({
+        id: "collection:events",
+        label: "events",
+        titleField: undefined,
+        fields: [
+          { name: "id", type: "string" },
+          { name: "updatedAt", type: "date" },
+        ],
+      }),
+      // Nothing to order "recent" by.
+      source({
+        id: "collection:tags",
+        label: "tags",
+        fields: [
+          { name: "id", type: "string" },
+          { name: "title", type: "string" },
+        ],
+      }),
+      // Cannot be listed at all.
+      source({ id: "collection:audit", label: "audit", supports: ["count"] }),
+    ];
+
+    for (const one of sources) {
+      const kinds = new Set(
+        collectionWidgets([one]).map(widget => widget.archetype)
+      );
+      expect(kinds.has("list")).toBe(kinds.has("table"));
+    }
+
+    // The control: at least one of those sources DOES produce the pair, so the
+    // agreement above is not satisfied by a generator that makes neither for
+    // anything.
+    const eligible = collectionWidgets([sources[0]]).map(w => w.archetype);
+    expect(eligible).toContain("list");
+    expect(eligible).toContain("table");
+  });
+
   it("nothing at all for a source that is not a collection", () => {
     // Singles hold one entry, so a count of them is a constant and a list of
     // them is that one entry. Neither is a card worth offering.

--- a/packages/nextly/src/domains/widgets/__tests__/layout.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/layout.test.ts
@@ -189,6 +189,43 @@ describe("reading a stored row", () => {
   });
 });
 
+describe("a placement's column, when it states one", () => {
+  const base = { id: "p1", widgetId: "core/a", order: 0, hidden: false };
+
+  it("REFUSES a column that is present and not a number", () => {
+    // 🔴 Absent and malformed are different answers, and without a rule they
+    // collapse into one. A client sending `column: "2"` fails the "did this
+    // state a column" predicate, becomes a 0, and is then read as an OMISSION
+    // — so a broken client is silently told nothing and has its card kept
+    // where it was, or moved to the first column.
+    expect(placementProblem({ ...base, column: "2" })).toMatch(/column/);
+  });
+
+  it("REFUSES a column JSON cannot carry", () => {
+    // The reason `order` uses `Number.isFinite` rather than a typeof check:
+    // NaN and the infinities are numbers that serialize to `null` and come
+    // back failing this same rule, so accepting one writes a row that can
+    // never be read.
+    expect(placementProblem({ ...base, column: Number.NaN })).toMatch(/column/);
+    expect(
+      placementProblem({ ...base, column: Number.POSITIVE_INFINITY })
+    ).toMatch(/column/);
+  });
+
+  it("ACCEPTS a placement that states no column at all", () => {
+    // 🔴 The control, and the reason this is not simply a required field. A
+    // client written before columns sends none, and that payload is supported
+    // — the layout endpoint keeps the column such a card already had.
+    expect(placementProblem(base)).toBeUndefined();
+  });
+
+  it("ACCEPTS a column that is a finite number", () => {
+    // The other control: a rule refusing everything would satisfy both
+    // refusals above and reject every well-formed request.
+    expect(placementProblem({ ...base, column: 2 })).toBeUndefined();
+  });
+});
+
 describe("the default arrangement", () => {
   it("follows the declared order and materializes it as finite numbers", () => {
     const placements = defaultPlacements([

--- a/packages/nextly/src/domains/widgets/collection-widgets.ts
+++ b/packages/nextly/src/domains/widgets/collection-widgets.ts
@@ -107,6 +107,49 @@ function countWidget(source: WidgetSource): WidgetDefinition | undefined {
 }
 
 /**
+ * Whether a source can answer a RECENT-ENTRIES query, and what it needs to.
+ *
+ * 🔴 One decision, asked by both cards that draw one. The list and the table
+ * put the same question to a source -- can it be listed, does a field name its
+ * rows, is there an `updatedAt` for "recent" to mean anything -- and asking it
+ * twice lets the two disagree about which collections support the same query.
+ * A collection would then get a table and no list, or the reverse, from a
+ * change to one function that nothing points at the other.
+ *
+ * `undefined` for a source this cannot draw HONESTLY, and each condition is a
+ * refusal rather than a fallback:
+ *
+ * - no field names the entries, so every row would read as an identifier. The
+ *   renderers already refuse a widget that selects nothing rather than guessing
+ *   a key out of a document they know nothing about; generating one that
+ *   selects the wrong key defeats that by answering the question badly instead
+ *   of declining it.
+ * - no `updatedAt`, so "recently" has nothing to sort by. Sorting by id would
+ *   produce a card whose title is a claim its rows do not support.
+ */
+interface RecentEntries {
+  /** The field that names a row, from the source's own resolution. */
+  label: string;
+  /** Every field name the source carries, for asking what else it has. */
+  names: ReadonlySet<string>;
+}
+
+function recentEntries(source: WidgetSource): RecentEntries | undefined {
+  if (!source.supports.includes("list")) return undefined;
+  // The source's own answer, which already went through the shared rule with
+  // the author's `admin.useAsTitle` AND the full field list. Resolving it again
+  // from `fields` alone would ignore the nomination and pick a conventional
+  // name instead, so a collection whose author chose `headline` would be
+  // labelled by something else -- two answers to one question, and the
+  // dashboard holding the worse one.
+  const label = source.titleField;
+  if (label === undefined) return undefined;
+  const names = new Set(source.fields.map(field => field.name));
+  if (!names.has("updatedAt")) return undefined;
+  return { label, names };
+}
+
+/**
  * The list card for a source: the entries touched most recently.
  *
  * Returns `undefined` for a collection this cannot draw HONESTLY, and both
@@ -121,17 +164,9 @@ function countWidget(source: WidgetSource): WidgetDefinition | undefined {
  *   produce a card whose title is a claim its rows do not support.
  */
 function recentWidget(source: WidgetSource): WidgetDefinition | undefined {
-  if (!source.supports.includes("list")) return undefined;
-  const names = source.fields.map(field => field.name);
-  // The source's own answer, which already went through the shared rule with
-  // the author's `admin.useAsTitle` AND the full field list. Resolving it again
-  // here from `fields` alone would ignore the nomination and pick a
-  // conventional name instead, so a collection whose author chose `headline`
-  // would be labelled by something else -- two answers to one question, and the
-  // dashboard holding the worse one.
-  const label = source.titleField;
-  if (label === undefined) return undefined;
-  if (!names.includes("updatedAt")) return undefined;
+  const recent = recentEntries(source);
+  if (recent === undefined) return undefined;
+  const { label } = recent;
   const id = widgetId(source, "recent");
   if (id === undefined) return undefined;
 
@@ -166,6 +201,9 @@ function recentWidget(source: WidgetSource): WidgetDefinition | undefined {
  * dashboard of collections scannable rather than a wall of separate boxes.
  * Neither is placed; a reader picks the one their dashboard wants.
  *
+ * Its eligibility is `recentEntries`, the same decision the list card asks, so
+ * a collection cannot end up with one of the two and not the other.
+ *
  * ## Why the columns are ASKED of the source
  *
  * `status` and `updatedAt` are per-collection facts, not constants. The schema
@@ -181,14 +219,9 @@ function recentWidget(source: WidgetSource): WidgetDefinition | undefined {
  * scrolls inside a card, and a table that scrolls is one nobody reads.
  */
 function tableWidget(source: WidgetSource): WidgetDefinition | undefined {
-  if (!source.supports.includes("list")) return undefined;
-  // The same two refusals `recentWidget` makes, and for the same reasons: with
-  // no field naming a row every line reads as an identifier, and with no
-  // `updatedAt` the card's own title is a claim its rows cannot support.
-  const label = source.titleField;
-  if (label === undefined) return undefined;
-  const names = new Set(source.fields.map(field => field.name));
-  if (!names.has("updatedAt")) return undefined;
+  const recent = recentEntries(source);
+  if (recent === undefined) return undefined;
+  const { label, names } = recent;
   const id = widgetId(source, "table");
   if (id === undefined) return undefined;
 

--- a/packages/nextly/src/domains/widgets/collection-widgets.ts
+++ b/packages/nextly/src/domains/widgets/collection-widgets.ts
@@ -45,6 +45,15 @@ import { listSources, type WidgetSource } from "./sources";
 const LIST_ROWS = 5;
 
 /**
+ * How many rows a generated table asks for.
+ *
+ * The same as a list's, and asked separately rather than shared, because the
+ * two renderers cap independently -- a table's rows are wider, so its own limit
+ * is lower than a list's and may move without dragging the list with it.
+ */
+const TABLE_ROWS = 5;
+
+/**
  * The id of a generated widget, from the source it draws.
  *
  * Namespaced under `collection/` so it cannot collide with core's own `core/`
@@ -54,7 +63,7 @@ const LIST_ROWS = 5;
  */
 function widgetId(
   source: WidgetSource,
-  kind: "count" | "recent"
+  kind: "count" | "recent" | "table"
 ): string | undefined {
   // 🔴 An underscore is legal in a collection slug (`SLUG_PATTERN` permits it)
   // and illegal in a widget id, so `customer_notes` produced an id the registry
@@ -146,6 +155,64 @@ function recentWidget(source: WidgetSource): WidgetDefinition | undefined {
 }
 
 /**
+ * The table card for a source: the same recent entries, across named columns.
+ *
+ * ## Why this is offered BESIDE the list rather than replacing it
+ *
+ * They answer different questions. A list is a column of titles with one muted
+ * line under each, which suits a narrow card in a three-column dashboard. A
+ * table aligns its values, so a reader compares them down a column -- which
+ * status is draft, what changed most recently -- and that is what makes a
+ * dashboard of collections scannable rather than a wall of separate boxes.
+ * Neither is placed; a reader picks the one their dashboard wants.
+ *
+ * ## Why the columns are ASKED of the source
+ *
+ * `status` and `updatedAt` are per-collection facts, not constants. The schema
+ * pipeline injects a `status` column only for a collection declaring
+ * `status: true`, and the timestamps only when it has not turned them off, so
+ * the source lists exactly the ones that exist. Selecting a column the rows do
+ * not carry is refused by the read path -- a refusal about a field nothing
+ * declared, on a card the reader did not misconfigure.
+ *
+ * The result is three columns for a collection with a status and two without,
+ * rather than a fixed shape padded with blanks. `defaultSize` is `lg` for the
+ * same reason the renderer caps its rows: a table narrower than its content
+ * scrolls inside a card, and a table that scrolls is one nobody reads.
+ */
+function tableWidget(source: WidgetSource): WidgetDefinition | undefined {
+  if (!source.supports.includes("list")) return undefined;
+  // The same two refusals `recentWidget` makes, and for the same reasons: with
+  // no field naming a row every line reads as an identifier, and with no
+  // `updatedAt` the card's own title is a claim its rows cannot support.
+  const label = source.titleField;
+  if (label === undefined) return undefined;
+  const names = new Set(source.fields.map(field => field.name));
+  if (!names.has("updatedAt")) return undefined;
+  const id = widgetId(source, "table");
+  if (id === undefined) return undefined;
+
+  return {
+    id,
+    title: `${source.label} table`,
+    description: `Recent ${source.label} entries across their columns`,
+    archetype: "table",
+    defaultSize: "lg",
+    query: {
+      source: source.id,
+      op: "list",
+      status: "all",
+      // Read left to right by the renderer, so the row's own name leads and the
+      // timestamp the sort is on closes. `status` sits between them when the
+      // collection has one.
+      select: [label, ...(names.has("status") ? ["status"] : []), "updatedAt"],
+      sort: "-updatedAt",
+      limit: TABLE_ROWS,
+    },
+  };
+}
+
+/**
  * Every generated card the given sources support, in source order.
  *
  * Pure, so the derivation can be asserted without a container: the refresh
@@ -165,7 +232,11 @@ export function collectionWidgets(
   const candidates: WidgetDefinition[] = [];
   for (const source of sources) {
     if (source.kind !== "collection") continue;
-    for (const widget of [countWidget(source), recentWidget(source)]) {
+    for (const widget of [
+      countWidget(source),
+      recentWidget(source),
+      tableWidget(source),
+    ]) {
       if (!widget) continue;
       claimed.set(widget.id, (claimed.get(widget.id) ?? 0) + 1);
       candidates.push(widget);

--- a/packages/nextly/src/domains/widgets/core-widgets.ts
+++ b/packages/nextly/src/domains/widgets/core-widgets.ts
@@ -82,6 +82,16 @@ export const CORE_WIDGETS: readonly WidgetDefinition[] = [
     component: "core#SinglesQuickLinks",
   },
   {
+    id: "core/quick-create",
+    title: "Create",
+    description:
+      "One click to an empty entry form, for the collections this reader may create in.",
+    archetype: "custom",
+    defaultSize: "full",
+    defaultOrder: 15,
+    component: "core#QuickCreate",
+  },
+  {
     id: "core/team",
     title: "Team",
     description: "How many users and roles the project has.",

--- a/packages/nextly/src/domains/widgets/layout.ts
+++ b/packages/nextly/src/domains/widgets/layout.ts
@@ -182,6 +182,17 @@ const PLACEMENT_RULES: ReadonlyArray<
     Number.isFinite(p.order) ? undefined : '"order" must be a finite number',
   p =>
     typeof p.hidden === "boolean" ? undefined : '"hidden" must be a boolean',
+  // 🔴 Optional, because a client written before columns sends none and that is
+  // a supported payload. Present and malformed is a different answer: without a
+  // rule, `column: "2"` fails the "did this state a column" predicate, becomes a
+  // 0, and is then read as an OMISSION -- so a broken client silently has its
+  // card kept where it was, or moved to the first column, instead of being told
+  // its request is malformed. `Number.isFinite` for the reason `order` gives:
+  // NaN and the infinities are numbers JSON cannot carry.
+  p =>
+    p.column === undefined || Number.isFinite(p.column)
+      ? undefined
+      : '"column", when given, must be a finite number',
   p => optionalTextProblem(p.size, "size"),
   p => optionalTextProblem(p.height, "height"),
   p =>


### PR DESCRIPTION
Two defects in the column layout that merged in #1511. Both were found in that PR's last review round and were still uncommitted when it merged, so they did not travel with it.

## A malformed `column` was accepted, then read as an omission

`column` was the one placement field with no shape rule. Every neighbour — `id`, `widgetId`, `order`, `hidden`, `size`, `height`, `config` — has one.

So `column: "2"` passed validation, failed `statesColumn` (which asks whether a placement *stated* a column), became a `0`, and was then treated as an **omission**. The layout endpoint answers an omission by keeping the column the card already had — deliberately, because a client written before columns sends none. A broken client was therefore told nothing and had its card silently kept where it was, or moved to the first column.

Present-and-malformed is now refused. Omitted stays valid, which is the whole reason this is not simply a required field.

## Narrowing the dashboard stored a grid that was no longer on screen

Changing the column count moves no card and changes every answer about where the cards are. Narrowing four columns to two folds two of them into the last, so the cards sharing a column are not the ones they were.

The save renumbered the array it was handed, which stored a reading of the *old* grid — the canonical row-major sequence disagreed with the arrangement the reader was looking at until the next drag. `renumberForColumns` buckets at the count in force before assigning orders, applying the same row-major rule a drop already uses.

## Verification

Four break-verifications, each moving only its own test, and each written against a *wrong implementation* rather than a mutation:

| break | fails |
| --- | --- |
| renumber the array, ignoring the count (what shipped) | the count-in-force test |
| bucket at a fixed count rather than the one in force | the count-in-force test |
| no column rule at all (what shipped) | both refusal tests |
| require a column outright | the "accepts a legacy payload" control |

Local gates on this tree: build 0, check-types 42/42, lint 24/24, `nextly` 11123, `admin` 3881, `ui` 1164, comment convention 0, fallow `pass` at 5 changed files with every `*_introduced` at 0, `changeset status` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Widget layouts now preserve the correct reading order when the dashboard’s column count changes.
  - Saving a layout draft automatically adjusts widget placement to match the selected number of columns.
  - Existing layouts without column information remain supported.
  - Invalid column values, including non-numeric or infinite values, are now rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Also: a collection now offers a TABLE card

The first consumer of the `table` archetype. The admin has been able to draw one since the archetype shipped — [outcome.ts:50](https://github.com/nextlyhq/nextly/blob/main/packages/admin/src/components/features/widgets/outcome.ts#L50) wires `tableAccepts`/`tableBody`, and it has its own suite — and nothing has ever generated one, so no dashboard could show it.

A list is a column of titles with one muted line under each, which suits a narrow card. A table aligns its values so a reader compares them *down* a column — which entries are drafts, what changed most recently. Neither is placed; a reader picks the one their dashboard wants.

**The columns are asked of the source, not assumed.** `status` exists only for a collection declaring `status: true`, and the timestamps only for one that has not turned them off — the source lists exactly those. Selecting a column the rows do not carry is refused by the read path, which would be a refusal about a field nothing declared, on a card the reader did not misconfigure. So: three columns with a status, two without, rather than a fixed shape padded with blanks.

It makes the list card's two refusals as well — no field naming a row, and no `updatedAt` to mean "recent". A table is *worse* than a list in the first case, not better: a column of ids under a heading looks like data.

Four break-verifications on the new behaviour, each moving only its own test:

| break | fails |
| --- | --- |
| select `status` unconditionally | the "omits it when there is none" control |
| never select `status` | the "selects it when the collection has one" test |
| drop the title-field refusal | the no-title test (and the list's) |
| drop the `updatedAt` refusal | the no-timestamp test (and the list's) |

Five existing tests that enumerate the generated set were updated to include the table — the expected consequence of adding a widget, not a behaviour change.