### PR TITLE
feat(blocks-engine): the component definition envelope and its pointer checks

### DIFF
--- a/.changeset/blocks-engine-component-envelope.md
+++ b/.changeset/blocks-engine-component-envelope.md
@@ -1,0 +1,49 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A component definition can now say which of its properties an instance may
+override, and which regions an instance may fill.
+
+A `component` document carries an `exposed` list — each entry pointing at a
+node in its own tree and the prop on it an instance may replace — and a `slots`
+map naming the regions an instance may put its own blocks into. Named variants
+preset those values. A component that exposes nothing is still a component: a
+footer nobody may edit is the point of one, not an unfinished definition.
+
+Every pointer is checked when the document is validated, and one that does not
+resolve is refused rather than stored. Deleting a node, renaming a container's
+slot or removing an exposure leaves a definition that still loads and still
+renders — the fault only appears later, as an author editing a property and
+seeing nothing change on any page carrying the component. The refusal names the
+node or slot it could not find, and what the node declares instead.
+
+Component instances gained `overrides`, which distinguishes three states rather
+than two: a property absent from the map inherits what the definition or
+variant provides, one set to `{ $unset: true }` renders empty, and any other
+value replaces. Without the middle state an author could not clear a subtitle
+their definition fills in.

--- a/.changeset/blocks-engine-component-envelope.md
+++ b/.changeset/blocks-engine-component-envelope.md
@@ -43,6 +43,13 @@ renders — the fault only appears later, as an author editing a property and
 seeing nothing change on any page carrying the component. The refusal names the
 node or slot it could not find, and what the node declares instead.
 
+A variant states the label its picker shows and the overrides it presets, and
+an exposed slot states the label the layers panel shows and the block types it
+accepts. A variant cannot carry slot content yet: that content is a second node
+forest, and the one place a forest is checked for malformed nodes, duplicate
+ids and depth is the walk over the document's own nodes — so it lands with the
+resolver that inlines it, rather than being stored unchecked.
+
 Component instances gained `overrides`, which distinguishes three states rather
 than two: a property absent from the map inherits what the definition or
 variant provides, one set to `{ $unset: true }` renders empty, and any other

--- a/.changeset/blocks-engine-component-envelope.md
+++ b/.changeset/blocks-engine-component-envelope.md
@@ -43,9 +43,11 @@ renders — the fault only appears later, as an author editing a property and
 seeing nothing change on any page carrying the component. The refusal names the
 node or slot it could not find, and what the node declares instead.
 
-A variant states the label its picker shows and the overrides it presets, and
-an exposed slot states the label the layers panel shows and the block types it
-accepts. A variant cannot carry slot content yet: that content is a second node
+A variant states the label its picker shows and at least one override it
+presets — one that presets nothing is a picker entry that does nothing when
+chosen. An exposed slot needs a usable id, and the block types it accepts are
+held to the same grammar a node's own type is. And
+an exposed slot states the label the layers panel shows. A variant cannot carry slot content yet: that content is a second node
 forest, and the one place a forest is checked for malformed nodes, duplicate
 ids and depth is the walk over the document's own nodes — so it lands with the
 resolver that inlines it, rather than being stored unchecked.

--- a/.changeset/blocks-engine-component-envelope.md
+++ b/.changeset/blocks-engine-component-envelope.md
@@ -31,7 +31,8 @@ override, and which regions an instance may fill.
 
 A `component` document carries an `exposed` list — each entry pointing at a
 node in its own tree and the prop on it an instance may replace — and a `slots`
-map naming the regions an instance may put its own blocks into. Named variants
+map — keyed by slot id — naming the regions an instance may put its own
+blocks into. Named variants
 preset those values. A component that exposes nothing is still a component: a
 footer nobody may edit is the point of one, not an unfinished definition.
 

--- a/packages/blocks-engine/src/component-envelope.test.ts
+++ b/packages/blocks-engine/src/component-envelope.test.ts
@@ -17,6 +17,7 @@ import { describe, expect, it } from "vitest";
 import type { BlockDocument, BlockNode } from "./document";
 import { isUnsetOverride } from "./document";
 import type { ValidationContext } from "./validation";
+import { MAX_ENVELOPE_ENTRIES } from "./limits";
 import { validate } from "./validation";
 
 /** A container node with one named slot, so slot pointers have a target. */
@@ -584,24 +585,155 @@ describe("the unset sentinel is an exact shape", () => {
 });
 
 describe("a huge envelope is bounded whatever the survey measured", () => {
-  it("refuses an exposed list longer than the document may have nodes", () => {
+  const exposure = (i: number) => ({
+    id: `e${i}`,
+    label: "L",
+    nodeId: "box",
+    propPath: "heading",
+    type: "text",
+  });
+
+  it("refuses a collection past the envelope limit", () => {
     // The survey measures what `JSON.stringify` would emit, so a field with a
     // `toJSON` returning `[]` is measured as two bytes while this walk reads
     // the real array. The envelope bounds what it actually reads.
-    const exposed = Array.from({ length: 12 }, (_, i) => ({
-      id: `e${i}`,
-      label: "L",
-      nodeId: "box",
-      propPath: "heading",
-      type: "text",
-    }));
-    const issues = validate(componentDoc({ exposed }), {
-      ...context("strict"),
-      limits: { maxDepth: 12, maxNodes: 10, maxBytes: 2_097_152 },
-    });
+    const exposed = Array.from({ length: MAX_ENVELOPE_ENTRIES + 1 }, (_, i) =>
+      exposure(i)
+    );
+    const issues = issuesFrom(componentDoc({ exposed }));
 
     expect(issues.map(i => i.code)).toEqual(["component-envelope-invalid"]);
-    expect(issues[0].message).toContain("12 exposed properties");
+    expect(issues[0].message).toContain(String(MAX_ENVELOPE_ENTRIES));
+  });
+
+  it("refuses an oversized keyed map without listing it first", () => {
+    // The map is counted with `for...in` and stopped at the budget rather than
+    // materialized through `Object.keys`, which would allocate the whole list
+    // before anything could refuse it — the allocation the budget exists to
+    // prevent.
+    const slots: Record<string, unknown> = {};
+    for (let i = 0; i <= MAX_ENVELOPE_ENTRIES; i += 1) {
+      slots[`s${i}`] = { label: "L", nodeId: "box", slot: "children" };
+    }
+    const issues = issuesFrom(componentDoc({ slots }));
+
+    expect(issues.map(i => i.code)).toEqual(["component-envelope-invalid"]);
+    expect(issues[0].path).toBe("/slots");
+  });
+
+  it("does not tie the envelope to how many nodes the document may hold", () => {
+    // Several exposures may legitimately address ONE node, so the node cap is
+    // not a bound on the envelope. Tying them refused a valid one-node
+    // component for exposing two of its own props.
+    const doc = componentDoc({
+      exposed: [
+        { ...exposure(1), propPath: "heading" },
+        { ...exposure(2), propPath: "subtitle" },
+      ],
+    });
+
+    expect(
+      validate(doc, {
+        ...context("strict"),
+        limits: { maxDepth: 12, maxNodes: 1, maxBytes: 2_097_152 },
+      })
+    ).toEqual([]);
+  });
+
+  it("reports rather than throwing when an array shadows forEach", () => {
+    // The array is a caller's object. Its `forEach` may be anything, and this
+    // function's whole contract is to RETURN issues about malformed input
+    // rather than throw on it.
+    const exposed: unknown[] = [exposure(1)];
+    (exposed as { forEach?: unknown }).forEach = null;
+
+    expect(() => codesFrom(componentDoc({ exposed }))).not.toThrow();
+  });
+});
+
+describe("a malformed node does not crash the envelope", () => {
+  it("reports rather than throwing when a node stores a null slots map", () => {
+    // `hasOwnProperty.call(null, ...)` throws. A malformed import is what this
+    // function exists to describe, so turning one into a crash describes
+    // nothing — and the main node walk is what reports the bad map itself.
+    const doc = {
+      formatVersion: 1,
+      kind: "component",
+      nodes: [
+        { id: "box", type: "core/box", version: 1, props: {}, slots: null },
+      ],
+      slots: { body: { label: "Body", nodeId: "box", slot: "children" } },
+    } as unknown as BlockDocument;
+
+    expect(() => issuesFrom(doc)).not.toThrow();
+  });
+
+  it.each([
+    ["missing", undefined],
+    ["a number", 7],
+    ["empty", ""],
+  ])(
+    "refuses a slot name that is %s, even on an empty container",
+    (_l, bad) => {
+      // The node question was answered first, so an empty container accepted
+      // `undefined` as its region name — the one value the contract promises a
+      // consumer will never see.
+      const doc = {
+        formatVersion: 1,
+        kind: "component",
+        nodes: [{ id: "box", type: "core/box", version: 1, props: {} }],
+        slots: { body: { label: "Body", nodeId: "box", slot: bad } },
+      } as unknown as BlockDocument;
+
+      // `toContain`, because a missing key is ALSO a JSON loss the survey
+      // reports as `document-lossy` — a separate and correct signal, not a
+      // second complaint about the slot.
+      expect(codesFrom(doc)).toContain("exposed-slot-missing");
+    }
+  );
+});
+
+describe("a select offers each value once", () => {
+  it("refuses two options sharing a value", () => {
+    // An override stores only the value, so the two are indistinguishable
+    // after the author chooses: the menu shows two labels and both resolve
+    // identically, with nothing recording which was picked.
+    const issues = issuesFrom(
+      componentDoc({
+        exposed: [
+          {
+            ...goodExposure,
+            type: "select",
+            options: [
+              { value: "a", label: "First" },
+              { value: "a", label: "Second" },
+            ],
+          },
+        ],
+      })
+    );
+
+    expect(issues.map(i => i.code)).toEqual(["exposed-options-invalid"]);
+    expect(issues[0].path).toBe("/exposed/0/options/1");
+  });
+
+  it("accepts distinct values with distinct labels", () => {
+    expect(
+      codesFrom(
+        componentDoc({
+          exposed: [
+            {
+              ...goodExposure,
+              type: "select",
+              options: [
+                { value: "a", label: "First" },
+                { value: "b", label: "Second" },
+              ],
+            },
+          ],
+        })
+      )
+    ).toEqual([]);
   });
 });
 

--- a/packages/blocks-engine/src/component-envelope.test.ts
+++ b/packages/blocks-engine/src/component-envelope.test.ts
@@ -1,0 +1,308 @@
+/**
+ * What a component definition's envelope must satisfy.
+ *
+ * Every assertion here is written against a definition that LOADS. None of
+ * these faults throws, none is visible in the tree, and each produces the same
+ * downstream symptom — an author edits an exposed property and nothing changes
+ * on the page — reached from a different cause. A test asserting only that a
+ * well-formed envelope validates would pass on all of them.
+ *
+ * The pointers are the subject rather than the shapes, because a pointer is
+ * the only part of this envelope that can be broken by editing something else.
+ * Deleting a node, renaming a slot or removing an exposure leaves the
+ * definition well formed and the reference dangling.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { BlockDocument, BlockNode } from "./document";
+import { isUnsetOverride } from "./document";
+import type { ValidationContext } from "./validation";
+import { validate } from "./validation";
+
+/** A container node with one named slot, so slot pointers have a target. */
+function container(id: string, slot = "children"): BlockNode {
+  return {
+    id,
+    type: "core/box",
+    version: 1,
+    props: { heading: "Hello" },
+    slots: { [slot]: [] },
+  };
+}
+
+/** A component document carrying whatever envelope the caller is testing. */
+function componentDoc(envelope: Record<string, unknown>): BlockDocument {
+  return {
+    formatVersion: 1,
+    kind: "component",
+    nodes: [container("box")],
+    ...envelope,
+  } as BlockDocument;
+}
+
+/**
+ * The validation context these cases run under.
+ *
+ * One helper rather than an object literal per call, because `mode` is the only
+ * field any of them varies and the rest are required: literals let one call
+ * site drift from the next, and the compiler is the only thing that notices —
+ * which vitest alone does not run.
+ */
+const context = (mode: "strict" | "forgiving"): ValidationContext => ({
+  breakpoints: { viewport: [{ id: "base", label: "Desktop" }], container: [] },
+  mode,
+});
+
+const issuesFrom = (
+  doc: BlockDocument,
+  mode: "strict" | "forgiving" = "strict"
+) => validate(doc, context(mode));
+
+const codesFrom = (
+  doc: BlockDocument,
+  mode: "strict" | "forgiving" = "strict"
+) => issuesFrom(doc, mode).map(issue => issue.code);
+
+/** One well-formed exposure, which every negative case below mutates. */
+const goodExposure = {
+  id: "heading",
+  label: "Heading",
+  nodeId: "box",
+  propPath: "heading",
+  type: "text",
+};
+
+describe("a component's exposed properties must resolve", () => {
+  it("accepts an exposure pointing at a node in its own tree", () => {
+    // The positive control. Every refusal below is equally satisfied by a
+    // validator that refuses every component document, and this is the only
+    // assertion that can tell the two apart.
+    expect(codesFrom(componentDoc({ exposed: [goodExposure] }))).toEqual([]);
+  });
+
+  it("accepts a component that exposes nothing at all", () => {
+    // A locked, reusable block — a footer nobody may edit — is a legitimate
+    // definition, not an incomplete one.
+    expect(codesFrom(componentDoc({}))).toEqual([]);
+  });
+
+  it("refuses an exposure whose node is not in the document", () => {
+    // The named failure this row exists to close. The definition renders, the
+    // inspector offers the property, and writing it stores an override keyed
+    // to a pointer that resolves to nothing — on every instance in the site.
+    const issues = issuesFrom(
+      componentDoc({ exposed: [{ ...goodExposure, nodeId: "deleted" }] })
+    );
+
+    expect(issues.map(i => i.code)).toEqual(["exposed-node-missing"]);
+    // The message has to name the node, because the author is looking at a
+    // list of exposures that all look alike.
+    expect(issues[0].message).toContain("deleted");
+    expect(issues[0].path).toBe("/exposed/0/nodeId");
+  });
+
+  it("refuses a dangling pointer in forgiving mode too", () => {
+    // Forgiving mode keeps a document READABLE when a newer build wrote
+    // something this one does not understand. A pointer into this document's
+    // own tree is not a future value, so tolerating it would only delay the
+    // report to the moment an author cannot explain it.
+    expect(
+      codesFrom(
+        componentDoc({ exposed: [{ ...goodExposure, nodeId: "deleted" }] }),
+        "forgiving"
+      )
+    ).toEqual(["exposed-node-missing"]);
+  });
+
+  it("refuses a prop path that is not a field chain", () => {
+    expect(
+      codesFrom(
+        componentDoc({ exposed: [{ ...goodExposure, propPath: "a.b()" }] })
+      )
+    ).toEqual(["exposed-path-invalid"]);
+  });
+
+  it("refuses two exposures sharing one id", () => {
+    // An override addresses an exposure by id, so a duplicate makes the pair
+    // unaddressable rather than merely untidy.
+    expect(
+      codesFrom(
+        componentDoc({
+          exposed: [goodExposure, { ...goodExposure, propPath: "other" }],
+        })
+      )
+    ).toContain("exposed-duplicate-id");
+  });
+
+  it("refuses an unknown exposure type", () => {
+    expect(
+      codesFrom(
+        componentDoc({ exposed: [{ ...goodExposure, type: "colour" }] })
+      )
+    ).toEqual(["exposed-property-invalid"]);
+  });
+});
+
+describe("a select exposure carries the choices it offers", () => {
+  it("refuses a select with no options", () => {
+    // A select with nothing to choose reads to an author as a broken editor
+    // rather than as an unfinished definition.
+    expect(
+      codesFrom(
+        componentDoc({ exposed: [{ ...goodExposure, type: "select" }] })
+      )
+    ).toEqual(["exposed-options-invalid"]);
+  });
+
+  it("refuses options on an exposure that is not a select", () => {
+    // Dead configuration: the inspector never reads it, so nothing would ever
+    // report that the author's choices are not being offered.
+    expect(
+      codesFrom(
+        componentDoc({
+          exposed: [{ ...goodExposure, options: [{ value: "a", label: "A" }] }],
+        })
+      )
+    ).toEqual(["exposed-options-invalid"]);
+  });
+
+  it("accepts a select that names its options", () => {
+    expect(
+      codesFrom(
+        componentDoc({
+          exposed: [
+            {
+              ...goodExposure,
+              type: "select",
+              options: [{ value: "a", label: "A" }],
+            },
+          ],
+        })
+      )
+    ).toEqual([]);
+  });
+});
+
+describe("a component's exposed slots must resolve", () => {
+  const goodSlot = {
+    id: "body",
+    label: "Body",
+    nodeId: "box",
+    slot: "children",
+  };
+
+  it("accepts a slot naming a region its node declares", () => {
+    expect(codesFrom(componentDoc({ slots: { body: goodSlot } }))).toEqual([]);
+  });
+
+  it("refuses a slot whose node is not in the document", () => {
+    expect(
+      codesFrom(
+        componentDoc({ slots: { body: { ...goodSlot, nodeId: "gone" } } })
+      )
+    ).toEqual(["exposed-node-missing"]);
+  });
+
+  it("refuses a slot the node does not declare", () => {
+    // The node exists and the definition still loads. This is what a renamed
+    // container leaves behind, and it is invisible in the tree.
+    const issues = issuesFrom(
+      componentDoc({ slots: { body: { ...goodSlot, slot: "renamed" } } })
+    );
+
+    expect(issues.map(i => i.code)).toEqual(["exposed-slot-missing"]);
+    // Names what the node DOES declare, since the author's next question is
+    // "then what is it called".
+    expect(issues[0].suggestion).toContain("children");
+  });
+});
+
+describe("a variant may only preset what the component exposes", () => {
+  it("accepts a variant overriding an exposed property", () => {
+    expect(
+      codesFrom(
+        componentDoc({
+          exposed: [goodExposure],
+          variants: {
+            compact: { label: "Compact", overrides: { heading: "Hi" } },
+          },
+        })
+      )
+    ).toEqual([]);
+  });
+
+  it("refuses a variant overriding something nothing exposes", () => {
+    // Selecting the variant would change nothing, and the definition would
+    // look broken rather than misconfigured.
+    expect(
+      codesFrom(
+        componentDoc({
+          exposed: [goodExposure],
+          variants: {
+            compact: { label: "Compact", overrides: { missing: "x" } },
+          },
+        })
+      )
+    ).toEqual(["variant-unknown-target"]);
+  });
+
+  it("refuses a variant filling a slot nothing exposes", () => {
+    expect(
+      codesFrom(
+        componentDoc({
+          slots: {
+            body: {
+              id: "body",
+              label: "Body",
+              nodeId: "box",
+              slot: "children",
+            },
+          },
+          variants: {
+            compact: { label: "Compact", overrides: {}, slots: { other: [] } },
+          },
+        })
+      )
+    ).toEqual(["variant-unknown-target"]);
+  });
+});
+
+describe("the envelope is a component's alone", () => {
+  it("does not check exposed pointers on a page document", () => {
+    // A page carrying a stray `exposed` field is not a broken component. If
+    // this checked every kind, the rules would fire on documents that have no
+    // definition semantics at all — and the report would name a fault the
+    // author cannot act on.
+    const page = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [container("box")],
+      exposed: [{ ...goodExposure, nodeId: "deleted" }],
+    } as unknown as BlockDocument;
+
+    expect(codesFrom(page)).toEqual([]);
+  });
+});
+
+describe("an override distinguishes clearing from inheriting", () => {
+  // The whole reason the sentinel is an object. An author clearing a subtitle
+  // the definition fills in needs a third state: absent inherits, this clears,
+  // anything else replaces. Every primitive an author might otherwise mean is
+  // a legitimate value for some exposed property, so a sentinel that collided
+  // with one could not be told apart from it later.
+  it("recognises the unset sentinel", () => {
+    expect(isUnsetOverride({ $unset: true })).toBe(true);
+  });
+
+  it.each([
+    ["an empty string", ""],
+    ["null", null],
+    ["zero", 0],
+    ["false", false],
+    ["a plain object", { text: "hi" }],
+    ["a lookalike whose flag is false", { $unset: false }],
+    ["a lookalike whose flag is a string", { $unset: "true" }],
+  ])("does not mistake %s for it", (_label, value) => {
+    expect(isUnsetOverride(value)).toBe(false);
+  });
+});

--- a/packages/blocks-engine/src/component-envelope.test.ts
+++ b/packages/blocks-engine/src/component-envelope.test.ts
@@ -122,6 +122,23 @@ describe("a component's exposed properties must resolve", () => {
     ).toEqual(["exposed-path-invalid"]);
   });
 
+  it("reports only the id when an exposure has none", () => {
+    // An entry with no usable id cannot be NAMED, and every other message about
+    // it reads `Exposed property "<id>"`. Without stopping, the author gets
+    // three more issues all describing a property called "undefined", and the
+    // one telling them what to do is buried among them. The nodeId and prop
+    // path below are both broken on purpose: they are the messages that must
+    // not appear.
+    const issues = issuesFrom(
+      componentDoc({
+        exposed: [{ label: "Heading", nodeId: "deleted", propPath: "a.b()" }],
+      })
+    );
+
+    expect(issues.map(i => i.code)).toEqual(["exposed-property-invalid"]);
+    expect(JSON.stringify(issues)).not.toContain("undefined");
+  });
+
   it("refuses two exposures sharing one id", () => {
     // An override addresses an exposure by id, so a duplicate makes the pair
     // unaddressable rather than merely untidy.
@@ -185,11 +202,24 @@ describe("a select exposure carries the choices it offers", () => {
 
 describe("a component's exposed slots must resolve", () => {
   const goodSlot = {
-    id: "body",
     label: "Body",
     nodeId: "box",
     slot: "children",
   };
+
+  it("cannot represent two slots sharing one id", () => {
+    // Not a validation rule — a shape fact. The slot id IS the key of the map,
+    // so a duplicate cannot be written down. This is pinned because the
+    // alternative shape (a record whose values also carry an `id`) states the
+    // identity twice and lets the two disagree, and only a test naming the
+    // guarantee explains why the field is absent.
+    const doc = componentDoc({
+      slots: { body: goodSlot, other: { ...goodSlot, label: "Other" } },
+    }) as unknown as { slots: Record<string, object> };
+
+    expect(Object.keys(doc.slots)).toEqual(["body", "other"]);
+    expect(doc.slots.body).not.toHaveProperty("id");
+  });
 
   it("accepts a slot naming a region its node declares", () => {
     expect(codesFrom(componentDoc({ slots: { body: goodSlot } }))).toEqual([]);
@@ -244,6 +274,23 @@ describe("a variant may only preset what the component exposes", () => {
         })
       )
     ).toEqual(["variant-unknown-target"]);
+  });
+
+  it("accepts a variant filling a slot the component exposes", () => {
+    // The control for the refusal below. Without it a validator that treated
+    // EVERY slot as unexposed would satisfy that assertion while refusing
+    // every legitimate variant — and the slot ids come from the map keys, so
+    // "no slot is ever exposed" is a single-line mistake away.
+    expect(
+      codesFrom(
+        componentDoc({
+          slots: { body: { label: "Body", nodeId: "box", slot: "children" } },
+          variants: {
+            compact: { label: "Compact", overrides: {}, slots: { body: [] } },
+          },
+        })
+      )
+    ).toEqual([]);
   });
 
   it("refuses a variant filling a slot nothing exposes", () => {

--- a/packages/blocks-engine/src/component-envelope.test.ts
+++ b/packages/blocks-engine/src/component-envelope.test.ts
@@ -285,9 +285,14 @@ describe("a variant may only preset what the component exposes", () => {
     // it and can be walked by the same machinery.
     const issues = issuesFrom(
       componentDoc({
+        exposed: [goodExposure],
         slots: { body: { label: "Body", nodeId: "box", slot: "children" } },
         variants: {
-          compact: { label: "Compact", overrides: {}, slots: { body: [] } },
+          compact: {
+            label: "Compact",
+            overrides: { heading: "Hi" },
+            slots: { body: [] },
+          },
         },
       })
     );
@@ -301,9 +306,17 @@ describe("a variant states what a picker and a resolver need", () => {
   it("refuses a variant with no label", () => {
     // The picker renders the label. Without one it offers a row reading
     // "undefined", which is indistinguishable from a rendering bug.
-    expect(
-      codesFrom(componentDoc({ variants: { compact: { overrides: {} } } }))
-    ).toEqual(["component-envelope-invalid"]);
+    const issues = issuesFrom(
+      componentDoc({
+        exposed: [goodExposure],
+        variants: { compact: { overrides: { heading: "Hi" } } },
+      })
+    );
+
+    // Asserted at the label, not merely by code: `component-envelope-invalid`
+    // covers every shape fault in this envelope, so a code-only assertion
+    // would pass on a document refused for something else entirely.
+    expect(issues.map(i => i.path)).toEqual(["/variants/compact/label"]);
   });
 
   it("refuses a variant with no overrides map", () => {
@@ -486,6 +499,109 @@ describe("an over-limit document does not pay for its envelope", () => {
     expect(
       underLimit.filter(i => i.code === "exposed-node-missing")
     ).toHaveLength(400);
+  });
+});
+
+describe("a slot exposure survives a container the author has not filled", () => {
+  it("accepts a slot on a node that stores no slots at all", () => {
+    // `makeNode` sets `slots` only when a caller supplies content, and
+    // `expandSlotDefaults` returns nothing for a container with no seeded
+    // children — so a declared, still-empty region is stored as an ABSENT map.
+    // Refusing that rejects a sound definition for exposing a slot the author
+    // has not filled yet, which is the state of every container the moment it
+    // is created.
+    const doc = {
+      formatVersion: 1,
+      kind: "component",
+      nodes: [{ id: "box", type: "core/box", version: 1, props: {} }],
+      slots: { body: { label: "Body", nodeId: "box", slot: "children" } },
+    } as unknown as BlockDocument;
+
+    expect(codesFrom(doc)).toEqual([]);
+  });
+});
+
+describe("an exposed slot id is usable", () => {
+  it("refuses an empty slot id", () => {
+    // Instance content is stored under this id in the instance node's own
+    // slots, and the builder's operation boundary refuses an empty slot name —
+    // so an exposure accepted here is one no author could ever fill.
+    expect(
+      codesFrom(
+        componentDoc({
+          slots: { "": { label: "Body", nodeId: "box", slot: "children" } },
+        })
+      )
+    ).toEqual(["component-envelope-invalid"]);
+  });
+});
+
+describe("an allow entry is held to the block-type grammar", () => {
+  it("refuses a string that is not a block type", () => {
+    // Every non-empty string used to pass, in the one field whose whole
+    // purpose is naming block types. `isBlockType` is the predicate the rest
+    // of this file holds a node's own `type` to.
+    expect(
+      codesFrom(
+        componentDoc({
+          slots: {
+            body: {
+              label: "Body",
+              nodeId: "box",
+              slot: "children",
+              allow: ["not a block"],
+            },
+          },
+        })
+      )
+    ).toEqual(["component-envelope-invalid"]);
+  });
+});
+
+describe("a variant presets something", () => {
+  it("refuses a variant whose overrides map is empty", () => {
+    // The picker would offer a control that does nothing when chosen.
+    expect(
+      codesFrom(
+        componentDoc({
+          exposed: [goodExposure],
+          variants: { compact: { label: "Compact", overrides: {} } },
+        })
+      )
+    ).toEqual(["component-envelope-invalid"]);
+  });
+});
+
+describe("the unset sentinel is an exact shape", () => {
+  it("does not clear a structured value that carries the marker", () => {
+    // A link value of `{ href: "/docs", $unset: true }` is a value to APPLY.
+    // Matching on the marker alone would clear the property instead of setting
+    // it, and override values are unconstrained, so a richer object may
+    // legitimately hold a key of that name.
+    expect(isUnsetOverride({ href: "/docs", $unset: true })).toBe(false);
+    expect(isUnsetOverride({ $unset: true })).toBe(true);
+  });
+});
+
+describe("a huge envelope is bounded whatever the survey measured", () => {
+  it("refuses an exposed list longer than the document may have nodes", () => {
+    // The survey measures what `JSON.stringify` would emit, so a field with a
+    // `toJSON` returning `[]` is measured as two bytes while this walk reads
+    // the real array. The envelope bounds what it actually reads.
+    const exposed = Array.from({ length: 12 }, (_, i) => ({
+      id: `e${i}`,
+      label: "L",
+      nodeId: "box",
+      propPath: "heading",
+      type: "text",
+    }));
+    const issues = validate(componentDoc({ exposed }), {
+      ...context("strict"),
+      limits: { maxDepth: 12, maxNodes: 10, maxBytes: 2_097_152 },
+    });
+
+    expect(issues.map(i => i.code)).toEqual(["component-envelope-invalid"]);
+    expect(issues[0].message).toContain("12 exposed properties");
   });
 });
 

--- a/packages/blocks-engine/src/component-envelope.test.ts
+++ b/packages/blocks-engine/src/component-envelope.test.ts
@@ -539,9 +539,10 @@ describe("an exposed slot id is usable", () => {
 
 describe("an allow entry is held to the block-type grammar", () => {
   it("refuses a string that is not a block type", () => {
-    // Every non-empty string used to pass, in the one field whose whole
-    // purpose is naming block types. `isBlockType` is the predicate the rest
-    // of this file holds a node's own `type` to.
+    // `allow` names block types, so an entry is held to the same grammar a
+    // node's own `type` is — `isBlockType`, which bounds the length and
+    // applies the namespaced-name pattern. A bare string check would accept
+    // this value in the one field whose whole purpose is naming block types.
     expect(
       codesFrom(
         componentDoc({
@@ -621,6 +622,25 @@ describe("a huge envelope is bounded whatever the survey measured", () => {
     expect(issues[0].path).toBe("/slots");
   });
 
+  it("refuses one variant whose override map is past the limit", () => {
+    // `variants` being within the budget says nothing about ONE variant's
+    // overrides. Bounded only at the outer map, a single variant holding more
+    // keys than the cap allows was enumerated twice — once to ask whether it
+    // presets anything, once per key to check the target — through a limit
+    // that had already passed.
+    const overrides: Record<string, unknown> = {};
+    for (let i = 0; i <= MAX_ENVELOPE_ENTRIES; i += 1) overrides[`k${i}`] = "x";
+    const issues = issuesFrom(
+      componentDoc({
+        exposed: [goodExposure],
+        variants: { compact: { label: "Compact", overrides } },
+      })
+    );
+
+    expect(issues.map(i => i.code)).toEqual(["component-envelope-invalid"]);
+    expect(issues[0].path).toBe("/variants/compact/overrides");
+  });
+
   it("does not tie the envelope to how many nodes the document may hold", () => {
     // Several exposures may legitimately address ONE node, so the node cap is
     // not a bound on the envelope. Tying them refused a valid one-node
@@ -675,9 +695,10 @@ describe("a malformed node does not crash the envelope", () => {
   ])(
     "refuses a slot name that is %s, even on an empty container",
     (_l, bad) => {
-      // The node question was answered first, so an empty container accepted
-      // `undefined` as its region name — the one value the contract promises a
-      // consumer will never see.
+      // The NAME is judged before the node. A slot field that is missing,
+      // numeric or empty is wrong whatever the node holds, so an empty
+      // container — which is passed, since it stores no slots to check against
+      // — must not carry an unusable region name past this point.
       const doc = {
         formatVersion: 1,
         kind: "component",

--- a/packages/blocks-engine/src/component-envelope.test.ts
+++ b/packages/blocks-engine/src/component-envelope.test.ts
@@ -276,41 +276,216 @@ describe("a variant may only preset what the component exposes", () => {
     ).toEqual(["variant-unknown-target"]);
   });
 
-  it("accepts a variant filling a slot the component exposes", () => {
-    // The control for the refusal below. Without it a validator that treated
-    // EVERY slot as unexposed would satisfy that assertion while refusing
-    // every legitimate variant — and the slot ids come from the map keys, so
-    // "no slot is ever exposed" is a single-line mistake away.
+  it("refuses a variant that carries slot content", () => {
+    // The format does not carry it. A variant's slot content is a second node
+    // forest, and the one place a forest is checked — for malformed nodes,
+    // duplicate ids, depth and node count — is the walk over `nodes`. Accepting
+    // it here would store an unchecked tree under the name of a validated
+    // document, so it is refused until it lands with the resolver that inlines
+    // it and can be walked by the same machinery.
+    const issues = issuesFrom(
+      componentDoc({
+        slots: { body: { label: "Body", nodeId: "box", slot: "children" } },
+        variants: {
+          compact: { label: "Compact", overrides: {}, slots: { body: [] } },
+        },
+      })
+    );
+
+    expect(issues.map(i => i.code)).toEqual(["component-envelope-invalid"]);
+    expect(issues[0].path).toBe("/variants/compact/slots");
+  });
+});
+
+describe("a variant states what a picker and a resolver need", () => {
+  it("refuses a variant with no label", () => {
+    // The picker renders the label. Without one it offers a row reading
+    // "undefined", which is indistinguishable from a rendering bug.
+    expect(
+      codesFrom(componentDoc({ variants: { compact: { overrides: {} } } }))
+    ).toEqual(["component-envelope-invalid"]);
+  });
+
+  it("refuses a variant with no overrides map", () => {
+    // A variant is a preset. One that presets nothing is a control that does
+    // nothing when chosen, which is a defect in the definition rather than a
+    // variant with no opinions — and it leaves resolution with no map to read.
+    expect(
+      codesFrom(componentDoc({ variants: { compact: { label: "Compact" } } }))
+    ).toEqual(["component-envelope-invalid"]);
+  });
+});
+
+describe("an exposed slot states what the layers panel needs", () => {
+  const at = { nodeId: "box", slot: "children" };
+
+  it("refuses a slot with no label", () => {
+    expect(codesFrom(componentDoc({ slots: { body: at } }))).toEqual([
+      "component-envelope-invalid",
+    ]);
+  });
+
+  it("refuses an allow list that is a bare string", () => {
+    // Iterated character by character, a string permits nothing and reports
+    // nothing — the slot silently accepts no block at all.
     expect(
       codesFrom(
         componentDoc({
-          slots: { body: { label: "Body", nodeId: "box", slot: "children" } },
-          variants: {
-            compact: { label: "Compact", overrides: {}, slots: { body: [] } },
-          },
+          slots: { body: { ...at, label: "Body", allow: "core/text" } },
+        })
+      )
+    ).toEqual(["component-envelope-invalid"]);
+  });
+
+  it.each([
+    ["a number", 7],
+    ["an empty string", ""],
+    ["null", null],
+  ])("refuses %s inside the allow list", (_label, bad) => {
+    // The array being an array is not the same question as its entries being
+    // block types. A list holding a number permits nothing that node could
+    // hold, and reports nothing about why.
+    const issues = issuesFrom(
+      componentDoc({
+        slots: { body: { ...at, label: "Body", allow: ["core/text", bad] } },
+      })
+    );
+
+    expect(issues.map(i => i.code)).toEqual(["component-envelope-invalid"]);
+    // Addressed at the entry, not at the list, so a long allow-list names the
+    // one entry to fix.
+    expect(issues[0].path).toBe("/slots/body/allow/1");
+  });
+
+  it("accepts an allow list of block types", () => {
+    expect(
+      codesFrom(
+        componentDoc({
+          slots: { body: { ...at, label: "Body", allow: ["core/text"] } },
         })
       )
     ).toEqual([]);
   });
 
-  it("refuses a variant filling a slot nothing exposes", () => {
+  it("refuses a slot named after an inherited object member", () => {
+    // `"toString" in node.slots` is true of every node, so a membership test
+    // would pass here and then resolve to nothing — exactly the dangling
+    // reference this check exists to refuse.
     expect(
       codesFrom(
         componentDoc({
-          slots: {
-            body: {
-              id: "body",
-              label: "Body",
-              nodeId: "box",
-              slot: "children",
-            },
-          },
-          variants: {
-            compact: { label: "Compact", overrides: {}, slots: { other: [] } },
-          },
+          slots: { body: { ...at, label: "Body", slot: "toString" } },
         })
       )
-    ).toEqual(["variant-unknown-target"]);
+    ).toEqual(["exposed-slot-missing"]);
+  });
+});
+
+describe("every reported path is a resolvable JSON Pointer", () => {
+  it("addresses an unknown override one segment at a time", () => {
+    // `pointer` escapes its token whole, so one call with "overrides/missing"
+    // emits `overrides~1missing` — a pointer that resolves to nothing, in the
+    // field whose only purpose is letting a machine find the value.
+    const issues = issuesFrom(
+      componentDoc({
+        exposed: [goodExposure],
+        variants: { compact: { label: "C", overrides: { missing: "x" } } },
+      })
+    );
+
+    expect(issues[0].path).toBe("/variants/compact/overrides/missing");
+  });
+
+  it("addresses a bad select option one segment at a time", () => {
+    const issues = issuesFrom(
+      componentDoc({
+        exposed: [{ ...goodExposure, type: "select", options: [{}] }],
+      })
+    );
+
+    expect(issues[0].path).toBe("/exposed/0/options/0");
+  });
+});
+
+describe("an instance's override map is a map", () => {
+  /** A page holding one component instance with the given props. */
+  const pageWithInstance = (props: Record<string, unknown>) =>
+    ({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "nextly/component-instance",
+          version: 1,
+          props: { componentId: "c1", ...props },
+        },
+      ],
+    }) as unknown as BlockDocument;
+
+  it("accepts an instance that overrides nothing", () => {
+    // The ordinary state of a freshly placed component, and the control for
+    // the refusals below.
+    expect(codesFrom(pageWithInstance({}))).toEqual([]);
+  });
+
+  it("accepts a record of overrides", () => {
+    expect(
+      codesFrom(pageWithInstance({ overrides: { heading: "Hi" } }))
+    ).toEqual([]);
+  });
+
+  it.each([
+    ["null", null],
+    ["a string", "heading"],
+    ["an array", ["heading"]],
+  ])("refuses overrides given as %s", (_label, value) => {
+    // A resolver enumerating these either throws, or reads their indices as
+    // exposure ids and applies values to properties nobody named.
+    expect(codesFrom(pageWithInstance({ overrides: value }))).toEqual([
+      "invalid-component-instance",
+    ]);
+  });
+});
+
+describe("an over-limit document does not pay for its envelope", () => {
+  it("stops before walking an oversized exposed list", () => {
+    // A document the survey could not traverse is refused already. Without the
+    // guard an imported definition with a million exposures is walked in full,
+    // and appends an issue per entry, to add nothing to a refusal that has
+    // already been made.
+    const exposed = Array.from({ length: 400 }, (_, i) => ({
+      id: `e${i}`,
+      label: "L",
+      nodeId: "missing",
+      propPath: "a",
+      type: "text",
+    }));
+    const doc = {
+      formatVersion: 1,
+      kind: "component",
+      nodes: Array.from({ length: 40 }, (_, i) => ({
+        id: `n${i}`,
+        type: "core/box",
+        version: 1,
+        props: {},
+      })),
+      exposed,
+    } as unknown as BlockDocument;
+
+    // Over the node cap, so the survey stops short and the envelope is skipped.
+    const overLimit = validate(doc, {
+      ...context("strict"),
+      limits: { maxDepth: 12, maxNodes: 5, maxBytes: 2_097_152 },
+    });
+    expect(overLimit.some(i => i.code === "exposed-node-missing")).toBe(false);
+
+    // The control: under the cap the very same document reports every dangling
+    // exposure, so the guard is skipping work rather than losing the check.
+    const underLimit = validate(doc, context("strict"));
+    expect(
+      underLimit.filter(i => i.code === "exposed-node-missing")
+    ).toHaveLength(400);
   });
 });
 

--- a/packages/blocks-engine/src/document.ts
+++ b/packages/blocks-engine/src/document.ts
@@ -715,8 +715,17 @@ export interface ExposedProperty {
  * node through copy, duplication, pattern-save and export.
  */
 export interface ExposedSlot {
-  /** Stable slug, minted once, for the same reason {@link ExposedProperty.id} is. */
-  id: string;
+  /**
+   * No `id` field: the KEY of {@link ComponentDocument.slots} is the id.
+   *
+   * A record keyed by id whose values also carry one states the same identity
+   * twice, and nothing reconciles them — a definition whose key says `body`
+   * and whose field says `header` is well formed under both readings, and
+   * which one an instance's slot content is addressed by depends on which the
+   * next reader happened to use. One spelling makes the disagreement
+   * unrepresentable rather than merely detectable.
+   */
+
   /** What the layers panel calls it. */
   label: string;
   /** The container node in THIS document's tree. Validated to exist. */

--- a/packages/blocks-engine/src/document.ts
+++ b/packages/blocks-engine/src/document.ts
@@ -736,14 +736,22 @@ export interface ExposedSlot {
   allow?: readonly string[];
 }
 
-/** A named preset of override values, offered alongside the definition. */
+/**
+ * A named preset of override values, offered alongside the definition.
+ *
+ * No slot content. A variant that supplied its own children would be handing
+ * the validator a second node forest, and the one place a forest is checked —
+ * for malformed nodes, duplicated ids, depth and node count — is the walk over
+ * `nodes`. Declaring the field without reaching it there would accept an
+ * arbitrary tree at the persistence gate under the name of a validated
+ * document, so it lands with the resolver that inlines it, checked by the same
+ * walk. A document carrying one today is refused rather than quietly stored.
+ */
 export interface Variant {
   /** What the inspector calls it. */
   label: string;
   /** Values keyed by {@link ExposedProperty.id}, applied before the instance's own. */
   overrides: Record<string, OverrideValue>;
-  /** Slot content keyed by {@link ExposedSlot.id}. */
-  slots?: Record<string, BlockNode[]>;
 }
 
 /**

--- a/packages/blocks-engine/src/document.ts
+++ b/packages/blocks-engine/src/document.ts
@@ -571,8 +571,21 @@ export const MAX_CLASSES_PER_NODE = 64;
 /**
  * The node type marking a linked component instance. The node's `props` carry
  * the reference; instance-provided slot content lives in `node.slots` like any
- * container. Resolution (definition lookup, variant application, per-instance
- * overrides) happens where components are stored and rendered, not here.
+ * container.
+ *
+ * PURE resolution — inlining a definition, applying a variant then the
+ * instance's overrides, re-identifying the inlined nodes — belongs in this
+ * package. Only the FETCH belongs to the stores, which alone know whether a
+ * caller wants the draft or the published definition.
+ *
+ * This paragraph previously said the opposite: that resolution happens "where
+ * components are stored and rendered, not here". That was written while the
+ * canvas was an iframe running the renderer, so "the renderer" and "the
+ * editor" were one place. They are not any more — the canvas renders in the
+ * same document as the admin — so a resolver living with the renderer would be
+ * a second implementation for the canvas, and the class-usage index and SEO
+ * derivation would each need a third. One pure resolver here is what keeps
+ * those four answering the same question.
  */
 export const COMPONENT_INSTANCE_TYPE = "nextly/component-instance";
 
@@ -582,11 +595,191 @@ export interface ComponentInstanceProps {
   componentId: string;
   /** The selected variant name, when the component defines variants. */
   variant?: string;
+  /**
+   * Per-instance values for the definition's exposed properties, keyed by
+   * {@link ExposedProperty.id}.
+   *
+   * Three states, not two, and the third is the reason this is not simply an
+   * optional value. An id ABSENT from this record inherits whatever the
+   * definition (or the selected variant) provides; an id mapped to
+   * {@link OverrideUnset} renders empty; any other value replaces. Without the
+   * middle state an author could not clear a subtitle the definition fills in
+   * — writing `""` or `null` is a value the definition may itself treat as
+   * meaningful, and omitting the key means "inherit", which is what they are
+   * trying not to do.
+   */
+  overrides?: Record<string, OverrideValue>;
+}
+
+/**
+ * The sentinel that clears an exposed property instead of inheriting it.
+ *
+ * A wrapper object rather than a reserved primitive, because every primitive
+ * an author might otherwise mean — `null`, `""`, `0`, `false` — is a legitimate
+ * value for some exposed property, and a sentinel that collides with a real
+ * value is one that cannot be distinguished from it later.
+ */
+export interface OverrideUnset {
+  $unset: true;
+}
+
+/**
+ * What an instance may store against one exposed property.
+ *
+ * `unknown`, not a union with {@link OverrideUnset}. An override replaces a
+ * node prop and props are unconstrained (`BlockNode.props` is
+ * `Record<string, unknown>`), so writing the union would widen straight back
+ * to `unknown` while reading as though the sentinel were discriminable at
+ * compile time — a type that documents a guarantee it does not provide. The
+ * sentinel is one of the values this may hold and is recognised at runtime by
+ * {@link isUnsetOverride}.
+ */
+export type OverrideValue = unknown;
+
+/** True if an override clears its property rather than replacing it. */
+export function isUnsetOverride(value: OverrideValue): value is OverrideUnset {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { $unset?: unknown }).$unset === true
+  );
 }
 
 /** True if a node is a linked component instance. */
 export function isComponentInstance(node: BlockNode): boolean {
   return node.type === COMPONENT_INSTANCE_TYPE;
+}
+
+// ---------------------------------------------------------------------------
+// Component definitions — the envelope a `kind: "component"` document carries
+// ---------------------------------------------------------------------------
+
+/** The value shapes an exposed property may be edited as. */
+export const EXPOSED_PROPERTY_TYPES = [
+  "text",
+  "richText",
+  "image",
+  "link",
+  "visibility",
+  "select",
+] as const;
+
+/**
+ * Derived from the list for the same reason {@link DocumentKind} is: a
+ * hand-written union and a runtime list are two declarations that happen to
+ * agree, and the pair can be half-changed without either side failing.
+ */
+export type ExposedPropertyType = (typeof EXPOSED_PROPERTY_TYPES)[number];
+
+/**
+ * One property of a definition that an instance may override.
+ *
+ * A POINTER into the definition's own tree, not a copy of the value. The value
+ * lives on the node where the author designed it, so the definition renders
+ * correctly on its own, and an instance that overrides nothing is identical to
+ * the definition.
+ */
+export interface ExposedProperty {
+  /**
+   * Stable slug, minted once.
+   *
+   * Never derived from `nodeId` or `label`, and this is the whole reason it
+   * exists as a separate field: instances address their overrides by this id,
+   * so a derived one would silently re-point every override the moment an
+   * author renamed the label or the exposure moved to a different node.
+   */
+  id: string;
+  /** What the inspector calls it. */
+  label: string;
+  /** The node in THIS document's tree carrying the value. Validated to exist. */
+  nodeId: string;
+  /** Dot path into that node's props, in the binding-path grammar. */
+  propPath: string;
+  /** How the inspector edits it. */
+  type: ExposedPropertyType;
+  /**
+   * The choices, for `select` only.
+   *
+   * An option's value may be a named class or a token reference, which is how
+   * a definition offers constrained STYLE choices without exposing the style
+   * system to the instance author.
+   */
+  options?: readonly { value: string; label: string }[];
+}
+
+/**
+ * A region of a definition an instance may fill with its own children.
+ *
+ * Points at a slot on a container node in the definition's tree. Instance
+ * content lives in the instance node's own `slots`, so it travels with the
+ * node through copy, duplication, pattern-save and export.
+ */
+export interface ExposedSlot {
+  /** Stable slug, minted once, for the same reason {@link ExposedProperty.id} is. */
+  id: string;
+  /** What the layers panel calls it. */
+  label: string;
+  /** The container node in THIS document's tree. Validated to exist. */
+  nodeId: string;
+  /** Which of that node's slots. Validated to exist on the node. */
+  slot: string;
+  /** Block types this slot accepts; unset accepts whatever the container does. */
+  allow?: readonly string[];
+}
+
+/** A named preset of override values, offered alongside the definition. */
+export interface Variant {
+  /** What the inspector calls it. */
+  label: string;
+  /** Values keyed by {@link ExposedProperty.id}, applied before the instance's own. */
+  overrides: Record<string, OverrideValue>;
+  /** Slot content keyed by {@link ExposedSlot.id}. */
+  slots?: Record<string, BlockNode[]>;
+}
+
+/**
+ * A document that defines a reusable component.
+ *
+ * An extension of {@link BlockDocument} rather than a member of a union with
+ * it, deliberately. Every existing consumer reads a stored document as a
+ * `BlockDocument` and none of them can narrow, so a union would make the whole
+ * package's type surface a breaking change to gain a discrimination only two
+ * call sites need. The narrowing is available where it matters through
+ * {@link isComponentDocument}, and the envelope is validated per kind
+ * regardless of which type the reader used.
+ */
+export interface ComponentDocument extends BlockDocument {
+  kind: "component";
+  /**
+   * Properties an instance may override. Absent exposes none.
+   *
+   * Optional rather than a required empty array, matching every other
+   * "absent means none" field in this contract (`settings`, `BlockNode.slots`,
+   * `variants`). A component that exposes nothing is not a malformed one — it
+   * is a locked, reusable block, which is the whole point of a footer — so
+   * requiring the empty array would refuse a legitimate definition and force a
+   * migration over every stored component to add a field meaning what its
+   * absence already means.
+   */
+  exposed?: ExposedProperty[];
+  /** Regions an instance may fill, keyed by slot id. Absent exposes none. */
+  slots?: Record<string, ExposedSlot>;
+  /** Named override presets, keyed by variant name. */
+  variants?: Record<string, Variant>;
+}
+
+/**
+ * True if a document declares itself a component definition.
+ *
+ * Reads the KIND only. Whether its envelope is well formed is a question for
+ * validation, and answering it here would make a malformed definition read as
+ * "not a component" — which is how a document with a dangling pointer gets
+ * quietly treated as an ordinary page instead of being reported.
+ */
+export function isComponentDocument(
+  doc: BlockDocument
+): doc is ComponentDocument {
+  return doc.kind === "component";
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/blocks-engine/src/document.ts
+++ b/packages/blocks-engine/src/document.ts
@@ -578,14 +578,11 @@ export const MAX_CLASSES_PER_NODE = 64;
  * package. Only the FETCH belongs to the stores, which alone know whether a
  * caller wants the draft or the published definition.
  *
- * This paragraph previously said the opposite: that resolution happens "where
- * components are stored and rendered, not here". That was written while the
- * canvas was an iframe running the renderer, so "the renderer" and "the
- * editor" were one place. They are not any more — the canvas renders in the
- * same document as the admin — so a resolver living with the renderer would be
- * a second implementation for the canvas, and the class-usage index and SEO
- * derivation would each need a third. One pure resolver here is what keeps
- * those four answering the same question.
+ * Four consumers need that resolution and none of them is the renderer alone:
+ * the canvas renders in the same document as the admin rather than in an
+ * iframe, and the class-usage index and SEO derivation each read a resolved
+ * tree without rendering at all. A resolver living beside any one of them
+ * would be reimplemented by the other three.
  */
 export const COMPONENT_INSTANCE_TYPE = "nextly/component-instance";
 
@@ -636,13 +633,22 @@ export interface OverrideUnset {
  */
 export type OverrideValue = unknown;
 
-/** True if an override clears its property rather than replacing it. */
+/**
+ * True if an override clears its property rather than replacing it.
+ *
+ * The EXACT shape, not merely an object carrying the marker. Override values
+ * are unconstrained, so a structured one may legitimately hold a `$unset` key
+ * of its own — a link value of `{ href: "/docs", $unset: true }` is a value to
+ * apply, and matching on the marker alone would clear the property instead of
+ * setting it. Requiring the sentinel to be its own sole key leaves every
+ * richer object a value.
+ */
 export function isUnsetOverride(value: OverrideValue): value is OverrideUnset {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    (value as { $unset?: unknown }).$unset === true
-  );
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const keys = Object.keys(value);
+  return keys.length === 1 && (value as { $unset?: unknown }).$unset === true;
 }
 
 /** True if a node is a linked component instance. */

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -80,6 +80,7 @@ export type {
 } from "./document";
 
 export {
+  MAX_ENVELOPE_ENTRIES,
   MAX_DEPTH,
   MAX_NODES,
   DEFAULT_MAX_DOCUMENT_BYTES,

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -15,6 +15,7 @@ export {
   BINDING_FORMAT_TYPES,
   DEFAULT_BINDING_SOURCE,
   COMPONENT_INSTANCE_TYPE,
+  EXPOSED_PROPERTY_TYPES,
   STYLE_STATES,
   MAX_BREAKPOINTS_PER_AXIS,
   // Public for exactly the reason the per-axis cap is. A definition whose id is
@@ -37,7 +38,9 @@ export {
   isBindingSource,
   isBlockType,
   MAX_BLOCK_TYPE_LENGTH,
+  isComponentDocument,
   isComponentInstance,
+  isUnsetOverride,
 } from "./document";
 export type {
   BlockDocument,
@@ -50,7 +53,14 @@ export type {
   BreakpointDef,
   BreakpointId,
   BreakpointSet,
+  ComponentDocument,
   ComponentInstanceProps,
+  ExposedProperty,
+  ExposedPropertyType,
+  ExposedSlot,
+  OverrideUnset,
+  OverrideValue,
+  Variant,
   Condition,
   DocumentFormatVersion,
   DocumentKind,

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -15,6 +15,10 @@ export {
   BINDING_FORMAT_TYPES,
   DEFAULT_BINDING_SOURCE,
   COMPONENT_INSTANCE_TYPE,
+  // The component-definition contract, published so the stores and the admin
+  // DERIVE the vocabulary rather than restating it. A schema branch or a
+  // picker that listed these values itself would agree on the day it was
+  // written and accept a type this engine refuses the day one is added.
   EXPOSED_PROPERTY_TYPES,
   STYLE_STATES,
   MAX_BREAKPOINTS_PER_AXIS,

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -80,6 +80,11 @@ export type {
 } from "./document";
 
 export {
+  // The cap on one collection of a component's envelope — its exposed
+  // properties, its slots, its variants, one variant's overrides. Published
+  // because a store or an admin form validating an envelope before it reaches
+  // the engine has to refuse at the same number: a form that accepted more
+  // than this would offer an author a definition the write path then rejects.
   MAX_ENVELOPE_ENTRIES,
   MAX_DEPTH,
   MAX_NODES,

--- a/packages/blocks-engine/src/limits.ts
+++ b/packages/blocks-engine/src/limits.ts
@@ -11,6 +11,22 @@ export const MAX_DEPTH = 12;
 /** Maximum total nodes in one document. */
 export const MAX_NODES = 5000;
 
+/**
+ * Maximum entries in one collection of a component's envelope.
+ *
+ * Its own limit rather than {@link MAX_NODES}, because the envelope is not
+ * bounded by the tree it points into: several exposed properties, slots and
+ * variants may legitimately address ONE node, so a host configuring a small
+ * node cap would otherwise see a valid one-node component refused for exposing
+ * two of its props.
+ *
+ * Generous, because it is a bound on work rather than a design opinion — an
+ * author who has designated a thousand editable properties on one component
+ * has built something no inspector can present, and every number past that
+ * only decides how long a malformed import is walked before it is refused.
+ */
+export const MAX_ENVELOPE_ENTRIES = 1000;
+
 /** Default maximum serialized document size in bytes (2 MiB). */
 // Written as a literal rather than as `2 * 1024 * 1024`, because the literal
 // TYPE is what the freeze asserts. TypeScript does not fold the arithmetic when

--- a/packages/blocks-engine/src/validation.fixtures.ts
+++ b/packages/blocks-engine/src/validation.fixtures.ts
@@ -835,7 +835,68 @@ const KIND_FIXTURES: ValidationFixture[] = DOCUMENT_KINDS.map(kind => ({
   expected: [],
 }));
 
+// --- The component definition envelope -------------------------------------
+// In the CORPUS rather than only in the envelope's own suite, because the
+// corpus is what asserts two properties no single test states: that every code
+// a fixture emits is documented in ISSUE_CODES, and that every path emitted
+// resolves as a JSON Pointer into the document it came from. The envelope's
+// paths reach into `/exposed/0/nodeId` and `/slots/<id>/slot`, which are the
+// first pointers in this format that address a document field outside `nodes`.
+
+const COMPONENT_ENVELOPE_FIXTURES: ValidationFixture[] = [
+  {
+    name: "a component exposing a property of its own tree validates",
+    mode: "strict",
+    doc: {
+      formatVersion: 1,
+      kind: "component",
+      nodes: [
+        {
+          id: "box",
+          type: "core/box",
+          version: 1,
+          props: { heading: "Hello" },
+          slots: { children: [] },
+        },
+      ],
+      exposed: [
+        {
+          id: "heading",
+          label: "Heading",
+          nodeId: "box",
+          propPath: "heading",
+          type: "text",
+        },
+      ],
+      slots: {
+        body: { id: "body", label: "Body", nodeId: "box", slot: "children" },
+      },
+    } as unknown as BlockDocument,
+    expected: [],
+  },
+  {
+    name: "a component exposing a node it does not contain is refused",
+    mode: "strict",
+    doc: invalid({
+      formatVersion: 1,
+      kind: "component",
+      nodes: [{ id: "box", type: "core/box", version: 1, props: {} }],
+      exposed: [
+        {
+          id: "heading",
+          label: "Heading",
+          nodeId: "deleted",
+          propPath: "heading",
+          type: "text",
+        },
+      ],
+    }),
+    expected: [{ path: "/exposed/0/nodeId", code: "exposed-node-missing" }],
+  },
+];
+
 VALIDATION_FIXTURES.push(
+  ...COMPONENT_ENVELOPE_FIXTURES,
   ...LIMIT_FIXTURES,
   ...HOSTILE_PROP_FIXTURES,
   ...WRITING_SYSTEM_FIXTURES,

--- a/packages/blocks-engine/src/validation.fixtures.ts
+++ b/packages/blocks-engine/src/validation.fixtures.ts
@@ -869,7 +869,7 @@ const COMPONENT_ENVELOPE_FIXTURES: ValidationFixture[] = [
         },
       ],
       slots: {
-        body: { id: "body", label: "Body", nodeId: "box", slot: "children" },
+        body: { label: "Body", nodeId: "box", slot: "children" },
       },
     } as unknown as BlockDocument,
     expected: [],

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -15,6 +15,7 @@ import {
   COMPONENT_INSTANCE_TYPE,
   DOCUMENT_FORMAT_VERSION,
   DOCUMENT_KINDS,
+  EXPOSED_PROPERTY_TYPES,
   MAX_CLASSES_PER_NODE,
   STYLE_STATES,
   isBindingSource,
@@ -43,6 +44,7 @@ import {
   validateStyleValues,
 } from "./style/validate-style-value";
 import type { ReadyStyleIssueBudget } from "./style/validate-style-value";
+import { walkNodes } from "./tree";
 
 /** Severity of a validation issue. `error` blocks a strict publish. */
 export type IssueSeverity = "error" | "warning";
@@ -175,6 +177,22 @@ export const ISSUE_CODES = {
   "invalid-format-version":
     "The document formatVersion is not the supported version.",
   "invalid-kind": "The document kind is not one of the known kinds.",
+  "component-envelope-invalid":
+    "A component document's exposed list or slot map is not the right shape.",
+  "exposed-property-invalid":
+    "An exposed property is missing a required field or declares an unknown type.",
+  "exposed-duplicate-id":
+    "Two exposed properties or slots share one id, so an override cannot address either.",
+  "exposed-node-missing":
+    "An exposed property or slot points at a node this document does not contain.",
+  "exposed-path-invalid":
+    "An exposed property's prop path is not a dot-joined chain of field identifiers.",
+  "exposed-options-invalid":
+    "An exposed property declares options without being a select, or a select declares none.",
+  "exposed-slot-missing":
+    "An exposed slot names a slot the node it points at does not declare.",
+  "variant-unknown-target":
+    "A variant names an exposed property or slot the definition does not expose.",
   "invalid-document": "The document is not an object.",
   "nodes-not-array": "The document nodes field is not an array.",
   "invalid-node": "A node is not an object.",
@@ -407,6 +425,19 @@ export function validateDocument(
     });
     // Nothing further to check without a node forest.
     return { issues, survey };
+  }
+
+  // Per-kind rules. Only `component` has any today, and it is the kind whose
+  // extra fields nothing else in the document can check: `exposed` and `slots`
+  // are pointers INTO the tree that was just confirmed to be an array, so this
+  // is the first point at which they can be resolved at all.
+  if (kind === "component") {
+    validateComponentEnvelope(
+      rawDoc,
+      rawDoc.nodes as BlockNode[],
+      limits,
+      issues
+    );
   }
 
   checkLimits(survey, issues);
@@ -1491,6 +1522,383 @@ function isConditionsShapeValid(conditions: unknown): boolean {
     }
   }
   return true;
+}
+
+// ---------------------------------------------------------------------------
+// The component definition envelope (`kind: "component"`)
+// ---------------------------------------------------------------------------
+
+/**
+ * Every node in the forest, by id.
+ *
+ * Its own bounded walk rather than a share of the main one. The envelope needs
+ * the WHOLE index before it can judge its first pointer, while the main walk
+ * reports as it goes — so reusing it would mean either checking pointers
+ * against a half-built index, or holding the envelope's issues back to the end
+ * and reordering the report. A second walk of a component document, bounded by
+ * the same node cap, costs less than either.
+ */
+function nodesById(nodes: BlockNode[], limits: DocumentLimits) {
+  const index = new Map<string, BlockNode>();
+  walkNodes(
+    nodes,
+    node => {
+      // First writer wins. A forest with a duplicated id is already reported by
+      // the main walk, and overwriting here would make the envelope's answer
+      // depend on traversal order for a document that is being refused anyway.
+      if (!index.has(node.id)) index.set(node.id, node);
+    },
+    { maxNodes: limits.maxNodes }
+  );
+  return index;
+}
+
+/** One `exposed` entry, before anything about it has been checked. */
+type RawExposed = Record<string, unknown>;
+
+/**
+ * Check a component definition's exposed properties, slots and variants.
+ *
+ * Every rule here is about a POINTER resolving, because that is the class of
+ * fault the envelope introduces and the one nothing downstream can report. A
+ * definition whose pointer names a node that was deleted still loads, still
+ * renders, and still offers the property in the inspector — where editing it
+ * writes an override keyed to an id that resolves to nothing, on every instance
+ * in the site. The failure surfaces as "my change did nothing", far from the
+ * definition that caused it.
+ *
+ * Errors, not warnings, and in both modes. Forgiving mode exists to keep a
+ * document READABLE when a future build wrote something this one does not
+ * understand; a dangling pointer is not a future value, it is a broken
+ * reference to this document's own tree.
+ */
+function validateComponentEnvelope(
+  doc: Record<string, unknown>,
+  nodes: BlockNode[],
+  limits: DocumentLimits,
+  issues: ValidationIssue[]
+): void {
+  const index = nodesById(nodes, limits);
+  const exposedIds = new Set<string>();
+
+  const exposed = doc.exposed;
+  if (exposed !== undefined && !Array.isArray(exposed)) {
+    issues.push({
+      path: "/exposed",
+      code: "component-envelope-invalid",
+      severity: "error",
+      message: "A component's exposed field must be an array.",
+    });
+  } else {
+    (exposed ?? []).forEach((entry: unknown, i: number) => {
+      checkExposedProperty(entry, `/exposed/${i}`, index, exposedIds, issues);
+    });
+  }
+
+  const slotIds = new Set<string>();
+  const slots = doc.slots;
+  if (slots !== undefined && !isPlainRecord(slots)) {
+    issues.push({
+      path: "/slots",
+      code: "component-envelope-invalid",
+      severity: "error",
+      message: "A component's slots field must be an object keyed by slot id.",
+    });
+  } else {
+    for (const [id, entry] of Object.entries(slots ?? {})) {
+      checkExposedSlot(entry, id, `/slots/${id}`, index, slotIds, issues);
+    }
+  }
+
+  checkVariants(doc.variants, exposedIds, slotIds, issues);
+}
+
+/** One exposed property: its shape, its id, its pointer and its options. */
+function checkExposedProperty(
+  entry: unknown,
+  path: string,
+  index: Map<string, BlockNode>,
+  seen: Set<string>,
+  issues: ValidationIssue[]
+): void {
+  if (!isPlainRecord(entry)) {
+    issues.push({
+      path,
+      code: "exposed-property-invalid",
+      severity: "error",
+      message: "An exposed property must be an object.",
+    });
+    return;
+  }
+
+  const raw: RawExposed = entry;
+  const id = raw.id;
+  const nodeId = raw.nodeId;
+  const propPath = raw.propPath;
+  const type = raw.type;
+
+  if (typeof id !== "string" || id === "") {
+    issues.push({
+      path: pointer(path, "id"),
+      code: "exposed-property-invalid",
+      severity: "error",
+      message: "An exposed property needs a non-empty id.",
+    });
+    return;
+  }
+
+  // Before the pointer checks, so a duplicate is reported once against the
+  // second entry rather than twice against a pair that reads as unrelated.
+  if (seen.has(id)) {
+    issues.push({
+      path: pointer(path, "id"),
+      code: "exposed-duplicate-id",
+      severity: "error",
+      message: `Two exposed properties share the id "${id}".`,
+      suggestion: "Give each exposed property its own id.",
+    });
+  }
+  seen.add(id);
+
+  if (typeof raw.label !== "string" || raw.label === "") {
+    issues.push({
+      path: pointer(path, "label"),
+      code: "exposed-property-invalid",
+      severity: "error",
+      message: `Exposed property "${id}" needs a non-empty label.`,
+    });
+  }
+
+  if (
+    !EXPOSED_PROPERTY_TYPES.includes(
+      type as (typeof EXPOSED_PROPERTY_TYPES)[number]
+    )
+  ) {
+    issues.push({
+      path: pointer(path, "type"),
+      code: "exposed-property-invalid",
+      severity: "error",
+      message: `Exposed property "${id}" declares an unknown type ${describeValue(type)}.`,
+      suggestion: `Use one of: ${EXPOSED_PROPERTY_TYPES.join(", ")}.`,
+    });
+  }
+
+  if (typeof nodeId !== "string" || !index.has(nodeId)) {
+    issues.push({
+      path: pointer(path, "nodeId"),
+      code: "exposed-node-missing",
+      severity: "error",
+      message: `Exposed property "${id}" points at node ${describeValue(nodeId)}, which this document does not contain.`,
+      suggestion:
+        "Point it at a node in this component's tree, or remove the exposure.",
+    });
+  }
+
+  if (typeof propPath !== "string" || !BIND_PATH_RE.test(propPath)) {
+    issues.push({
+      path: pointer(path, "propPath"),
+      code: "exposed-path-invalid",
+      severity: "error",
+      message: `Exposed property "${id}" has prop path ${describeValue(propPath)}.`,
+      suggestion: 'Use a dot-joined chain of field identifiers, e.g. "text".',
+    });
+  }
+
+  checkExposedOptions(raw.options, type, id, path, issues);
+}
+
+/**
+ * The options list, which only a `select` may carry.
+ *
+ * Checked in both directions. Options on a non-select are dead configuration
+ * the inspector will not read, and a select WITHOUT them offers a control with
+ * nothing to choose — which reads to an author as a broken editor rather than
+ * as an incomplete definition.
+ */
+function checkExposedOptions(
+  options: unknown,
+  type: unknown,
+  id: string,
+  path: string,
+  issues: ValidationIssue[]
+): void {
+  const isSelect = type === "select";
+
+  if (!isSelect) {
+    if (options !== undefined) {
+      issues.push({
+        path: pointer(path, "options"),
+        code: "exposed-options-invalid",
+        severity: "error",
+        message: `Exposed property "${id}" declares options but is not a select.`,
+      });
+    }
+    return;
+  }
+
+  if (!Array.isArray(options) || options.length === 0) {
+    issues.push({
+      path: pointer(path, "options"),
+      code: "exposed-options-invalid",
+      severity: "error",
+      message: `Exposed property "${id}" is a select and needs at least one option.`,
+    });
+    return;
+  }
+
+  options.forEach((option: unknown, i: number) => {
+    if (
+      isPlainRecord(option) &&
+      typeof option.value === "string" &&
+      typeof option.label === "string"
+    ) {
+      return;
+    }
+    issues.push({
+      path: pointer(path, `options/${i}`),
+      code: "exposed-options-invalid",
+      severity: "error",
+      message: `An option of exposed property "${id}" needs a string value and label.`,
+    });
+  });
+}
+
+/** One exposed slot: its pointer, and that the node actually declares the slot. */
+function checkExposedSlot(
+  entry: unknown,
+  id: string,
+  path: string,
+  index: Map<string, BlockNode>,
+  seen: Set<string>,
+  issues: ValidationIssue[]
+): void {
+  if (!isPlainRecord(entry)) {
+    issues.push({
+      path,
+      code: "component-envelope-invalid",
+      severity: "error",
+      message: `Exposed slot "${id}" must be an object.`,
+    });
+    return;
+  }
+
+  if (seen.has(id)) {
+    issues.push({
+      path,
+      code: "exposed-duplicate-id",
+      severity: "error",
+      message: `Two exposed slots share the id "${id}".`,
+    });
+  }
+  seen.add(id);
+
+  const nodeId = entry.nodeId;
+  const slot = entry.slot;
+  const node = typeof nodeId === "string" ? index.get(nodeId) : undefined;
+
+  if (node === undefined) {
+    issues.push({
+      path: pointer(path, "nodeId"),
+      code: "exposed-node-missing",
+      severity: "error",
+      message: `Exposed slot "${id}" points at node ${describeValue(nodeId)}, which this document does not contain.`,
+    });
+    return;
+  }
+
+  // The node exists; the SLOT on it is a separate question, and the one that a
+  // renamed container silently breaks. `slots` is undefined on a node with no
+  // children yet, which is an ordinary state for a container an author has not
+  // filled — so an absent map is judged the same as a map without the key
+  // rather than skipped.
+  if (typeof slot !== "string" || !(slot in (node.slots ?? {}))) {
+    issues.push({
+      path: pointer(path, "slot"),
+      code: "exposed-slot-missing",
+      severity: "error",
+      message: `Exposed slot "${id}" names slot ${describeValue(slot)}, which node "${node.id}" does not declare.`,
+      suggestion: `Name one of: ${Object.keys(node.slots ?? {}).join(", ") || "(none)"}.`,
+    });
+  }
+}
+
+/**
+ * Variants, checked against what the definition actually exposes.
+ *
+ * A variant is a preset of overrides, so every key it sets has to name
+ * something an instance could set itself. A key naming nothing is applied by no
+ * one and reported by nothing: the variant appears in the picker, selecting it
+ * changes nothing, and the definition looks broken rather than misconfigured.
+ */
+function checkVariants(
+  variants: unknown,
+  exposedIds: ReadonlySet<string>,
+  slotIds: ReadonlySet<string>,
+  issues: ValidationIssue[]
+): void {
+  if (variants === undefined) return;
+  if (!isPlainRecord(variants)) {
+    issues.push({
+      path: "/variants",
+      code: "component-envelope-invalid",
+      severity: "error",
+      message: "A component's variants field must be an object keyed by name.",
+    });
+    return;
+  }
+
+  for (const [name, variant] of Object.entries(variants)) {
+    const at = `/variants/${name}`;
+    if (!isPlainRecord(variant)) {
+      issues.push({
+        path: at,
+        code: "component-envelope-invalid",
+        severity: "error",
+        message: `Variant "${name}" must be an object.`,
+      });
+      continue;
+    }
+
+    const overrides = variant.overrides;
+    if (overrides !== undefined && !isPlainRecord(overrides)) {
+      issues.push({
+        path: pointer(at, "overrides"),
+        code: "component-envelope-invalid",
+        severity: "error",
+        message: `Variant "${name}" overrides must be an object keyed by exposed id.`,
+      });
+    } else {
+      for (const key of Object.keys(overrides ?? {})) {
+        if (exposedIds.has(key)) continue;
+        issues.push({
+          path: pointer(at, `overrides/${key}`),
+          code: "variant-unknown-target",
+          severity: "error",
+          message: `Variant "${name}" overrides "${key}", which this component does not expose.`,
+        });
+      }
+    }
+
+    const variantSlots = variant.slots;
+    if (variantSlots !== undefined && !isPlainRecord(variantSlots)) {
+      issues.push({
+        path: pointer(at, "slots"),
+        code: "component-envelope-invalid",
+        severity: "error",
+        message: `Variant "${name}" slots must be an object keyed by exposed slot id.`,
+      });
+      continue;
+    }
+    for (const key of Object.keys(variantSlots ?? {})) {
+      if (slotIds.has(key)) continue;
+      issues.push({
+        path: pointer(at, `slots/${key}`),
+        code: "variant-unknown-target",
+        severity: "error",
+        message: `Variant "${name}" fills slot "${key}", which this component does not expose.`,
+      });
+    }
+  }
 }
 
 /**

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -22,7 +22,11 @@ import {
   isBlockType,
 } from "./document";
 import { describeValue, pointer } from "./issue-text";
-import { DEFAULT_LIMITS, LIMIT_WARNING_RATIO } from "./limits";
+import {
+  DEFAULT_LIMITS,
+  LIMIT_WARNING_RATIO,
+  MAX_ENVELOPE_ENTRIES,
+} from "./limits";
 import type { DocumentLimits } from "./limits";
 import { surveyDocument } from "./measure-bytes";
 import type { DocumentSurvey } from "./measure-bytes";
@@ -1570,35 +1574,77 @@ function nodesById(nodes: BlockNode[], maxNodes: number) {
 }
 
 /**
- * Whether a collection is small enough to be worth walking, reporting once
- * when it is not.
+ * Walk an untrusted array, bounded, without calling a method on it.
  *
- * Its OWN budget rather than a share of the survey's verdict. The survey
- * measures what `JSON.stringify` would emit, so a field carrying a `toJSON`
- * that returns `[]` is measured as two bytes while the walks below read the
- * real array by ordinary property access — a document that passes a 200-byte
- * survey can still hold a hundred thousand entries here. The envelope has to
- * bound the collection it actually reads.
+ * Two hazards in one helper, because the envelope reads arrays a caller
+ * supplied and both apply to every one of them.
  *
- * The node cap is the bound because the envelope POINTS INTO the node forest:
- * more exposures than the document may contain nodes describes pointers that
- * cannot all resolve, whatever else is wrong with it.
+ * BOUNDED, on the collection's own terms. The survey measures what
+ * `JSON.stringify` would emit, so a field carrying a `toJSON` returning `[]`
+ * is measured as two bytes while this reads the real array by ordinary
+ * property access — a document that passes a 200-byte survey can still hold a
+ * hundred thousand entries. Nothing upstream bounds what is read here.
+ *
+ * BY INDEX, never `forEach`. The array is a caller's object, so its `forEach`
+ * may be shadowed with a non-function, and validation would throw where its
+ * whole contract is to RETURN issues about malformed input.
+ *
+ * @returns false when the collection was refused for its size, so a caller
+ * skips the work rather than reporting a fault per entry on top of it.
  */
-function withinBudget(
+function eachBounded(
   items: readonly unknown[],
   path: string,
   what: string,
-  maxNodes: number,
+  issues: ValidationIssue[],
+  visit: (entry: unknown, index: number) => void
+): boolean {
+  if (!withinBudget(items.length, path, what, issues)) return false;
+  for (let i = 0; i < items.length; i += 1) visit(items[i], i);
+  return true;
+}
+
+/** Report once when a collection is too large to be worth walking. */
+function withinBudget(
+  size: number,
+  path: string,
+  what: string,
   issues: ValidationIssue[]
 ): boolean {
-  if (items.length <= maxNodes) return true;
+  if (size <= MAX_ENVELOPE_ENTRIES) return true;
   issues.push({
     path,
     code: "component-envelope-invalid",
     severity: "error",
-    message: `A component declares ${items.length} ${what}, more than the ${maxNodes} nodes a document may contain.`,
+    message: `A component declares ${size} ${what}, more than the ${MAX_ENVELOPE_ENTRIES} an envelope may hold.`,
   });
   return false;
+}
+
+/**
+ * The own keys of an untrusted record, or `null` when there are too many.
+ *
+ * Counted with `for...in` and stopped at the budget rather than materializing
+ * `Object.keys` first: a map with a hundred thousand keys would otherwise be
+ * enumerated into an array in full before anything could refuse it, which is
+ * the allocation the budget exists to prevent.
+ */
+function ownKeysBounded(
+  record: object,
+  path: string,
+  what: string,
+  issues: ValidationIssue[]
+): string[] | null {
+  const keys: string[] = [];
+  for (const key in record) {
+    if (!Object.prototype.hasOwnProperty.call(record, key)) continue;
+    if (keys.length >= MAX_ENVELOPE_ENTRIES) {
+      withinBudget(keys.length + 1, path, what, issues);
+      return null;
+    }
+    keys.push(key);
+  }
+  return keys;
 }
 
 /** One `exposed` entry, before anything about it has been checked. */
@@ -1632,9 +1678,9 @@ function validateComponentEnvelope(
   issues: ValidationIssue[]
 ): void {
   const index = nodesById(nodes, maxNodes);
-  const exposedIds = checkExposedList(doc.exposed, index, maxNodes, issues);
-  checkExposedSlots(doc.slots, index, maxNodes, issues);
-  checkVariants(doc.variants, exposedIds, maxNodes, issues);
+  const exposedIds = checkExposedList(doc.exposed, index, issues);
+  checkExposedSlots(doc.slots, index, issues);
+  checkVariants(doc.variants, exposedIds, issues);
 }
 
 /**
@@ -1647,7 +1693,6 @@ function validateComponentEnvelope(
 function checkExposedList(
   exposed: unknown,
   index: Map<string, BlockNode>,
-  maxNodes: number,
   issues: ValidationIssue[]
 ): ReadonlySet<string> {
   const exposedIds = new Set<string>();
@@ -1663,13 +1708,7 @@ function checkExposedList(
     return exposedIds;
   }
 
-  if (
-    !withinBudget(exposed, "/exposed", "exposed properties", maxNodes, issues)
-  ) {
-    return exposedIds;
-  }
-
-  exposed.forEach((entry: unknown, i: number) => {
+  eachBounded(exposed, "/exposed", "exposed properties", issues, (entry, i) => {
     checkExposedProperty(entry, `/exposed/${i}`, index, exposedIds, issues);
   });
   return exposedIds;
@@ -1679,7 +1718,6 @@ function checkExposedList(
 function checkExposedSlots(
   slots: unknown,
   index: Map<string, BlockNode>,
-  maxNodes: number,
   issues: ValidationIssue[]
 ): void {
   if (slots === undefined) return;
@@ -1694,8 +1732,8 @@ function checkExposedSlots(
     return;
   }
 
-  const ids = Object.keys(slots);
-  if (!withinBudget(ids, "/slots", "exposed slots", maxNodes, issues)) return;
+  const ids = ownKeysBounded(slots, "/slots", "exposed slots", issues);
+  if (ids === null) return;
 
   for (const id of ids) {
     checkExposedSlot(slots[id], id, pointer("/slots", id), index, issues);
@@ -1877,24 +1915,40 @@ function checkExposedOptions(
   }
 
   const at = pointer(path, "options");
-  options.forEach((option: unknown, i: number) => {
+  const seen = new Set<string>();
+  eachBounded(options, at, "select options", issues, (option, i) => {
     if (
-      isPlainRecord(option) &&
-      typeof option.value === "string" &&
-      typeof option.label === "string"
+      !isPlainRecord(option) ||
+      typeof option.value !== "string" ||
+      typeof option.label !== "string"
     ) {
+      issues.push({
+        // One segment per call. `pointer` escapes its token whole, so a single
+        // call with "options/0" emits `options~10` — a pointer that resolves
+        // to nothing, in the field whose purpose is to let a machine locate
+        // the value.
+        path: pointer(at, i),
+        code: "exposed-options-invalid",
+        severity: "error",
+        message: `An option of exposed property "${id}" needs a string value and label.`,
+      });
       return;
     }
-    issues.push({
-      // One segment per call. `pointer` escapes its token whole, so a single
-      // call with "options/0" emits `options~10` — a pointer that resolves to
-      // nothing, in the field whose purpose is to let a machine locate the
-      // value.
-      path: pointer(at, i),
-      code: "exposed-options-invalid",
-      severity: "error",
-      message: `An option of exposed property "${id}" needs a string value and label.`,
-    });
+
+    // An override stores only the VALUE, so two options sharing one cannot be
+    // told apart after the author chooses: the menu shows two labels and both
+    // resolve identically, with nothing recording which was picked.
+    if (seen.has(option.value)) {
+      issues.push({
+        path: pointer(at, i),
+        code: "exposed-options-invalid",
+        severity: "error",
+        message: `Exposed property "${id}" offers the value "${option.value}" twice.`,
+        suggestion: "Give each option its own value.",
+      });
+      return;
+    }
+    seen.add(option.value);
   });
 }
 
@@ -1983,7 +2037,7 @@ function checkExposedSlotMetadata(
   }
 
   const at = pointer(path, "allow");
-  allow.forEach((type: unknown, i: number) => {
+  eachBounded(allow, at, "allowed block types", issues, (type, i) => {
     // The same predicate the rest of this file holds a node's `type` to. A
     // second, weaker definition here would accept `"not-a-block"` as a block
     // type in the one place the field's whole purpose is naming block types.
@@ -2026,15 +2080,34 @@ function checkSlotOnNode(
   path: string,
   issues: ValidationIssue[]
 ): void {
+  // The NAME first, before any question about the node. A slot field that is
+  // missing, numeric or empty is wrong whatever the node holds, and answering
+  // the node question first let an empty container accept `undefined` as a
+  // region name — handing a consumer the one value the contract promises it
+  // will never see.
+  if (typeof slot !== "string" || slot === "") {
+    issues.push({
+      path: pointer(path, "slot"),
+      code: "exposed-slot-missing",
+      severity: "error",
+      message: `Exposed slot "${id}" names ${describeValue(slot)}, which is not a slot name.`,
+    });
+    return;
+  }
+
+  // A stored `slots` that is not a record is the main node walk's to report as
+  // `invalid-slots`. Reading it here first would reach `hasOwnProperty.call`
+  // with `null` and throw — turning a malformed import, which this function
+  // exists to describe, into a crash that describes nothing.
   const declared = node.slots;
-  if (declared === undefined) return;
-  if (typeof slot === "string" && declares(declared, slot)) return;
+  if (!isPlainRecord(declared)) return;
+  if (declares(declared, slot)) return;
 
   issues.push({
     path: pointer(path, "slot"),
     code: "exposed-slot-missing",
     severity: "error",
-    message: `Exposed slot "${id}" names slot ${describeValue(slot)}, which node "${node.id}" does not hold.`,
+    message: `Exposed slot "${id}" names slot "${slot}", which node "${node.id}" does not hold.`,
     suggestion: `Name one of: ${Object.keys(declared).join(", ") || "(none)"}.`,
   });
 }
@@ -2051,7 +2124,6 @@ function checkSlotOnNode(
 function checkVariants(
   variants: unknown,
   exposedIds: ReadonlySet<string>,
-  maxNodes: number,
   issues: ValidationIssue[]
 ): void {
   if (variants === undefined) return;
@@ -2065,20 +2137,11 @@ function checkVariants(
     return;
   }
 
-  if (
-    !withinBudget(
-      Object.keys(variants),
-      "/variants",
-      "variants",
-      maxNodes,
-      issues
-    )
-  ) {
-    return;
-  }
+  const names = ownKeysBounded(variants, "/variants", "variants", issues);
+  if (names === null) return;
 
-  for (const [name, variant] of Object.entries(variants)) {
-    checkVariant(name, variant, exposedIds, issues);
+  for (const name of names) {
+    checkVariant(name, variants[name], exposedIds, issues);
   }
 }
 

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -1569,6 +1569,38 @@ function nodesById(nodes: BlockNode[], maxNodes: number) {
   return index;
 }
 
+/**
+ * Whether a collection is small enough to be worth walking, reporting once
+ * when it is not.
+ *
+ * Its OWN budget rather than a share of the survey's verdict. The survey
+ * measures what `JSON.stringify` would emit, so a field carrying a `toJSON`
+ * that returns `[]` is measured as two bytes while the walks below read the
+ * real array by ordinary property access — a document that passes a 200-byte
+ * survey can still hold a hundred thousand entries here. The envelope has to
+ * bound the collection it actually reads.
+ *
+ * The node cap is the bound because the envelope POINTS INTO the node forest:
+ * more exposures than the document may contain nodes describes pointers that
+ * cannot all resolve, whatever else is wrong with it.
+ */
+function withinBudget(
+  items: readonly unknown[],
+  path: string,
+  what: string,
+  maxNodes: number,
+  issues: ValidationIssue[]
+): boolean {
+  if (items.length <= maxNodes) return true;
+  issues.push({
+    path,
+    code: "component-envelope-invalid",
+    severity: "error",
+    message: `A component declares ${items.length} ${what}, more than the ${maxNodes} nodes a document may contain.`,
+  });
+  return false;
+}
+
 /** One `exposed` entry, before anything about it has been checked. */
 type RawExposed = Record<string, unknown>;
 
@@ -1600,37 +1632,74 @@ function validateComponentEnvelope(
   issues: ValidationIssue[]
 ): void {
   const index = nodesById(nodes, maxNodes);
-  const exposedIds = new Set<string>();
+  const exposedIds = checkExposedList(doc.exposed, index, maxNodes, issues);
+  checkExposedSlots(doc.slots, index, maxNodes, issues);
+  checkVariants(doc.variants, exposedIds, maxNodes, issues);
+}
 
-  const exposed = doc.exposed;
-  if (exposed !== undefined && !Array.isArray(exposed)) {
+/**
+ * The `exposed` list, returning the ids it declared.
+ *
+ * The ids are the return value because the variants below address them: a
+ * variant preset naming something nothing exposes is applied by no one, and
+ * only this pass knows what was named.
+ */
+function checkExposedList(
+  exposed: unknown,
+  index: Map<string, BlockNode>,
+  maxNodes: number,
+  issues: ValidationIssue[]
+): ReadonlySet<string> {
+  const exposedIds = new Set<string>();
+  if (exposed === undefined) return exposedIds;
+
+  if (!Array.isArray(exposed)) {
     issues.push({
       path: "/exposed",
       code: "component-envelope-invalid",
       severity: "error",
       message: "A component's exposed field must be an array.",
     });
-  } else {
-    (exposed ?? []).forEach((entry: unknown, i: number) => {
-      checkExposedProperty(entry, `/exposed/${i}`, index, exposedIds, issues);
-    });
+    return exposedIds;
   }
 
-  const slots = doc.slots;
-  if (slots !== undefined && !isPlainRecord(slots)) {
+  if (
+    !withinBudget(exposed, "/exposed", "exposed properties", maxNodes, issues)
+  ) {
+    return exposedIds;
+  }
+
+  exposed.forEach((entry: unknown, i: number) => {
+    checkExposedProperty(entry, `/exposed/${i}`, index, exposedIds, issues);
+  });
+  return exposedIds;
+}
+
+/** The `slots` map, keyed by the id an instance addresses its content with. */
+function checkExposedSlots(
+  slots: unknown,
+  index: Map<string, BlockNode>,
+  maxNodes: number,
+  issues: ValidationIssue[]
+): void {
+  if (slots === undefined) return;
+
+  if (!isPlainRecord(slots)) {
     issues.push({
       path: "/slots",
       code: "component-envelope-invalid",
       severity: "error",
       message: "A component's slots field must be an object keyed by slot id.",
     });
-  } else {
-    for (const [id, entry] of Object.entries(slots ?? {})) {
-      checkExposedSlot(entry, id, pointer("/slots", id), index, issues);
-    }
+    return;
   }
 
-  checkVariants(doc.variants, exposedIds, issues);
+  const ids = Object.keys(slots);
+  if (!withinBudget(ids, "/slots", "exposed slots", maxNodes, issues)) return;
+
+  for (const id of ids) {
+    checkExposedSlot(slots[id], id, pointer("/slots", id), index, issues);
+  }
 }
 
 /**
@@ -1837,6 +1906,20 @@ function checkExposedSlot(
   index: Map<string, BlockNode>,
   issues: ValidationIssue[]
 ): void {
+  // The map KEY is the slot's id, and an empty one is unusable rather than
+  // merely odd: instance content is stored under it in the instance node's own
+  // `slots`, and the builder's operation boundary refuses an empty slot name —
+  // so an exposure accepted here is one no author can ever fill.
+  if (id === "") {
+    issues.push({
+      path,
+      code: "component-envelope-invalid",
+      severity: "error",
+      message: "An exposed slot needs a non-empty id.",
+    });
+    return;
+  }
+
   if (!isPlainRecord(entry)) {
     issues.push({
       path,
@@ -1901,7 +1984,10 @@ function checkExposedSlotMetadata(
 
   const at = pointer(path, "allow");
   allow.forEach((type: unknown, i: number) => {
-    if (typeof type === "string" && type !== "") return;
+    // The same predicate the rest of this file holds a node's `type` to. A
+    // second, weaker definition here would accept `"not-a-block"` as a block
+    // type in the one place the field's whole purpose is naming block types.
+    if (isBlockType(type)) return;
     issues.push({
       path: pointer(at, i),
       code: "component-envelope-invalid",
@@ -1912,18 +1998,26 @@ function checkExposedSlotMetadata(
 }
 
 /**
- * That the node actually declares the named region.
+ * That the node holds the named region.
  *
- * A separate question from whether the node exists, and the one a renamed
- * container leaves behind: the node is still there, the definition still
- * loads, and nothing in the tree looks wrong.
+ * Answered from the node's STORED slots, which is what this package can see: a
+ * block's declared slots live in its definition, and validation is given a
+ * `BlockTypeLookup` that answers `has(type)` and nothing else. So this catches
+ * the case it can — a slot key the node's own content does not use, which is
+ * what a renamed container leaves behind — and cannot catch a slot that the
+ * block definition no longer declares but whose content is still stored.
  *
- * An OWN property. `slots` is an ordinary object, so `"toString" in slots` is
- * true of every node — a slot by that name would pass here and then resolve to
- * nothing, which is precisely the dangling reference this check exists to
- * refuse. `slots` is also undefined on a container an author has not filled
- * yet, which is an ordinary state, so an absent map is judged the same as a
- * map without the key rather than skipped.
+ * A node with NO slots map is passed, deliberately. `makeNode` sets `slots`
+ * only when a caller supplies content and `expandSlotDefaults` returns nothing
+ * for a container with no seeded children, so a declared, still-empty region
+ * is stored as an absent map — indistinguishable from a region that never
+ * existed. Refusing that would reject a sound definition for exposing a slot
+ * the author has not filled yet, which is the ordinary state of a container
+ * the moment it is created.
+ *
+ * An OWN property when there is a map. `slots` is an ordinary object, so
+ * `"toString" in slots` is true of every node, and a slot by that name would
+ * otherwise pass and then resolve to nothing.
  */
 function checkSlotOnNode(
   slot: unknown,
@@ -1932,14 +2026,15 @@ function checkSlotOnNode(
   path: string,
   issues: ValidationIssue[]
 ): void {
-  const declared = node.slots ?? {};
+  const declared = node.slots;
+  if (declared === undefined) return;
   if (typeof slot === "string" && declares(declared, slot)) return;
 
   issues.push({
     path: pointer(path, "slot"),
     code: "exposed-slot-missing",
     severity: "error",
-    message: `Exposed slot "${id}" names slot ${describeValue(slot)}, which node "${node.id}" does not declare.`,
+    message: `Exposed slot "${id}" names slot ${describeValue(slot)}, which node "${node.id}" does not hold.`,
     suggestion: `Name one of: ${Object.keys(declared).join(", ") || "(none)"}.`,
   });
 }
@@ -1956,6 +2051,7 @@ function checkSlotOnNode(
 function checkVariants(
   variants: unknown,
   exposedIds: ReadonlySet<string>,
+  maxNodes: number,
   issues: ValidationIssue[]
 ): void {
   if (variants === undefined) return;
@@ -1966,6 +2062,18 @@ function checkVariants(
       severity: "error",
       message: "A component's variants field must be an object keyed by name.",
     });
+    return;
+  }
+
+  if (
+    !withinBudget(
+      Object.keys(variants),
+      "/variants",
+      "variants",
+      maxNodes,
+      issues
+    )
+  ) {
     return;
   }
 
@@ -2001,15 +2109,24 @@ function checkVariant(
     });
   }
 
-  // Required, not optional. A variant is a preset, and the picker offering one
-  // that presets nothing is a control that does nothing when chosen — which is
-  // a defect in the definition rather than a variant with no opinions.
+  // Required AND non-empty. A variant is a preset, and the picker offering one
+  // that presets nothing is a control that does nothing when chosen. An empty
+  // map is that control exactly, so checking only the type would state the
+  // invariant in the comment and enforce a weaker one in the code.
   if (!isPlainRecord(variant.overrides)) {
     issues.push({
       path: pointer(at, "overrides"),
       code: "component-envelope-invalid",
       severity: "error",
       message: `Variant "${name}" needs an overrides object keyed by exposed id.`,
+    });
+  } else if (Object.keys(variant.overrides).length === 0) {
+    issues.push({
+      path: pointer(at, "overrides"),
+      code: "component-envelope-invalid",
+      severity: "error",
+      message: `Variant "${name}" presets nothing, so selecting it would change nothing.`,
+      suggestion: "Give it at least one override, or remove the variant.",
     });
   } else {
     checkVariantTargets(

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -1595,7 +1595,6 @@ function validateComponentEnvelope(
     });
   }
 
-  const slotIds = new Set<string>();
   const slots = doc.slots;
   if (slots !== undefined && !isPlainRecord(slots)) {
     issues.push({
@@ -1606,14 +1605,28 @@ function validateComponentEnvelope(
     });
   } else {
     for (const [id, entry] of Object.entries(slots ?? {})) {
-      checkExposedSlot(entry, id, `/slots/${id}`, index, slotIds, issues);
+      checkExposedSlot(entry, id, `/slots/${id}`, index, issues);
     }
   }
 
+  // The KEYS are the slot ids, which is what a variant addresses. Derived here
+  // rather than accumulated during the walk above, so a slot whose entry was
+  // malformed still counts as declared — otherwise one broken slot would make
+  // every variant filling it report a second, misleading "nothing exposes
+  // this" on top of the fault the author actually has to fix.
+  const slotIds = new Set(Object.keys(isPlainRecord(slots) ? slots : {}));
   checkVariants(doc.variants, exposedIds, slotIds, issues);
 }
 
-/** One exposed property: its shape, its id, its pointer and its options. */
+/**
+ * One exposed property.
+ *
+ * Split three ways — identity, pointer, options — rather than checked in one
+ * pass, because the id has to be established before anything else can be
+ * REPORTED. Every message below names the exposure, and an entry with no
+ * usable id is one the author cannot pick out of a list whose entries
+ * otherwise look alike.
+ */
 function checkExposedProperty(
   entry: unknown,
   path: string,
@@ -1632,11 +1645,26 @@ function checkExposedProperty(
   }
 
   const raw: RawExposed = entry;
-  const id = raw.id;
-  const nodeId = raw.nodeId;
-  const propPath = raw.propPath;
-  const type = raw.type;
+  const id = checkExposedIdentity(raw, path, seen, issues);
+  if (id === undefined) return;
 
+  checkExposedPointer(raw, id, path, index, issues);
+  checkExposedOptions(raw.options, raw.type, id, path, issues);
+}
+
+/**
+ * The id, its uniqueness and the label; returns the id when it is usable.
+ *
+ * `undefined` stops the caller rather than letting it report the remaining
+ * faults against an entry it has no way to name.
+ */
+function checkExposedIdentity(
+  raw: RawExposed,
+  path: string,
+  seen: Set<string>,
+  issues: ValidationIssue[]
+): string | undefined {
+  const id = raw.id;
   if (typeof id !== "string" || id === "") {
     issues.push({
       path: pointer(path, "id"),
@@ -1644,11 +1672,11 @@ function checkExposedProperty(
       severity: "error",
       message: "An exposed property needs a non-empty id.",
     });
-    return;
+    return undefined;
   }
 
-  // Before the pointer checks, so a duplicate is reported once against the
-  // second entry rather than twice against a pair that reads as unrelated.
+  // Reported against the SECOND entry, so one message names one thing to fix
+  // rather than two that each read as unrelated.
   if (seen.has(id)) {
     issues.push({
       path: pointer(path, "id"),
@@ -1669,6 +1697,18 @@ function checkExposedProperty(
     });
   }
 
+  return id;
+}
+
+/** Where the exposure points: its type, its node, and the prop path on it. */
+function checkExposedPointer(
+  raw: RawExposed,
+  id: string,
+  path: string,
+  index: Map<string, BlockNode>,
+  issues: ValidationIssue[]
+): void {
+  const type = raw.type;
   if (
     !EXPOSED_PROPERTY_TYPES.includes(
       type as (typeof EXPOSED_PROPERTY_TYPES)[number]
@@ -1683,6 +1723,7 @@ function checkExposedProperty(
     });
   }
 
+  const nodeId = raw.nodeId;
   if (typeof nodeId !== "string" || !index.has(nodeId)) {
     issues.push({
       path: pointer(path, "nodeId"),
@@ -1694,6 +1735,7 @@ function checkExposedProperty(
     });
   }
 
+  const propPath = raw.propPath;
   if (typeof propPath !== "string" || !BIND_PATH_RE.test(propPath)) {
     issues.push({
       path: pointer(path, "propPath"),
@@ -1703,8 +1745,6 @@ function checkExposedProperty(
       suggestion: 'Use a dot-joined chain of field identifiers, e.g. "text".',
     });
   }
-
-  checkExposedOptions(raw.options, type, id, path, issues);
 }
 
 /**
@@ -1763,13 +1803,12 @@ function checkExposedOptions(
   });
 }
 
-/** One exposed slot: its pointer, and that the node actually declares the slot. */
+/** One exposed slot: that its node exists, and that the node declares the region. */
 function checkExposedSlot(
   entry: unknown,
   id: string,
   path: string,
   index: Map<string, BlockNode>,
-  seen: Set<string>,
   issues: ValidationIssue[]
 ): void {
   if (!isPlainRecord(entry)) {
@@ -1782,20 +1821,8 @@ function checkExposedSlot(
     return;
   }
 
-  if (seen.has(id)) {
-    issues.push({
-      path,
-      code: "exposed-duplicate-id",
-      severity: "error",
-      message: `Two exposed slots share the id "${id}".`,
-    });
-  }
-  seen.add(id);
-
   const nodeId = entry.nodeId;
-  const slot = entry.slot;
   const node = typeof nodeId === "string" ? index.get(nodeId) : undefined;
-
   if (node === undefined) {
     issues.push({
       path: pointer(path, "nodeId"),
@@ -1806,29 +1833,48 @@ function checkExposedSlot(
     return;
   }
 
-  // The node exists; the SLOT on it is a separate question, and the one that a
-  // renamed container silently breaks. `slots` is undefined on a node with no
-  // children yet, which is an ordinary state for a container an author has not
-  // filled — so an absent map is judged the same as a map without the key
-  // rather than skipped.
-  if (typeof slot !== "string" || !(slot in (node.slots ?? {}))) {
-    issues.push({
-      path: pointer(path, "slot"),
-      code: "exposed-slot-missing",
-      severity: "error",
-      message: `Exposed slot "${id}" names slot ${describeValue(slot)}, which node "${node.id}" does not declare.`,
-      suggestion: `Name one of: ${Object.keys(node.slots ?? {}).join(", ") || "(none)"}.`,
-    });
-  }
+  checkSlotOnNode(entry.slot, node, id, path, issues);
+}
+
+/**
+ * That the node actually declares the named region.
+ *
+ * A separate question from whether the node exists, and the one a renamed
+ * container leaves behind: the node is still there, the definition still
+ * loads, and nothing in the tree looks wrong.
+ *
+ * `slots` is undefined on a container an author has not filled yet, which is an
+ * ordinary state — so an absent map is judged the same as a map without the
+ * key rather than skipped, which would let the pointer go unchecked exactly
+ * when the container is empty.
+ */
+function checkSlotOnNode(
+  slot: unknown,
+  node: BlockNode,
+  id: string,
+  path: string,
+  issues: ValidationIssue[]
+): void {
+  const declared = node.slots ?? {};
+  if (typeof slot === "string" && slot in declared) return;
+
+  issues.push({
+    path: pointer(path, "slot"),
+    code: "exposed-slot-missing",
+    severity: "error",
+    message: `Exposed slot "${id}" names slot ${describeValue(slot)}, which node "${node.id}" does not declare.`,
+    suggestion: `Name one of: ${Object.keys(declared).join(", ") || "(none)"}.`,
+  });
 }
 
 /**
  * Variants, checked against what the definition actually exposes.
  *
  * A variant is a preset of overrides, so every key it sets has to name
- * something an instance could set itself. A key naming nothing is applied by no
- * one and reported by nothing: the variant appears in the picker, selecting it
- * changes nothing, and the definition looks broken rather than misconfigured.
+ * something an instance could set itself. A key naming nothing is applied by
+ * no one and reported by nothing: the variant appears in the picker, selecting
+ * it changes nothing, and the definition looks broken rather than
+ * misconfigured.
  */
 function checkVariants(
   variants: unknown,
@@ -1848,56 +1894,91 @@ function checkVariants(
   }
 
   for (const [name, variant] of Object.entries(variants)) {
-    const at = `/variants/${name}`;
-    if (!isPlainRecord(variant)) {
-      issues.push({
-        path: at,
-        code: "component-envelope-invalid",
-        severity: "error",
-        message: `Variant "${name}" must be an object.`,
-      });
-      continue;
-    }
+    checkVariant(name, variant, exposedIds, slotIds, issues);
+  }
+}
 
-    const overrides = variant.overrides;
-    if (overrides !== undefined && !isPlainRecord(overrides)) {
-      issues.push({
-        path: pointer(at, "overrides"),
-        code: "component-envelope-invalid",
-        severity: "error",
-        message: `Variant "${name}" overrides must be an object keyed by exposed id.`,
-      });
-    } else {
-      for (const key of Object.keys(overrides ?? {})) {
-        if (exposedIds.has(key)) continue;
-        issues.push({
-          path: pointer(at, `overrides/${key}`),
-          code: "variant-unknown-target",
-          severity: "error",
-          message: `Variant "${name}" overrides "${key}", which this component does not expose.`,
-        });
-      }
-    }
+/** One variant: its shape, its override targets and its slot targets. */
+function checkVariant(
+  name: string,
+  variant: unknown,
+  exposedIds: ReadonlySet<string>,
+  slotIds: ReadonlySet<string>,
+  issues: ValidationIssue[]
+): void {
+  const at = `/variants/${name}`;
+  if (!isPlainRecord(variant)) {
+    issues.push({
+      path: at,
+      code: "component-envelope-invalid",
+      severity: "error",
+      message: `Variant "${name}" must be an object.`,
+    });
+    return;
+  }
 
-    const variantSlots = variant.slots;
-    if (variantSlots !== undefined && !isPlainRecord(variantSlots)) {
-      issues.push({
-        path: pointer(at, "slots"),
-        code: "component-envelope-invalid",
-        severity: "error",
-        message: `Variant "${name}" slots must be an object keyed by exposed slot id.`,
-      });
-      continue;
-    }
-    for (const key of Object.keys(variantSlots ?? {})) {
-      if (slotIds.has(key)) continue;
-      issues.push({
-        path: pointer(at, `slots/${key}`),
-        code: "variant-unknown-target",
-        severity: "error",
-        message: `Variant "${name}" fills slot "${key}", which this component does not expose.`,
-      });
-    }
+  checkVariantTargets({
+    map: variant.overrides,
+    known: exposedIds,
+    at,
+    field: "overrides",
+    issues,
+    shapeMessage: `Variant "${name}" overrides must be an object keyed by exposed id.`,
+    unknownMessage: key =>
+      `Variant "${name}" overrides "${key}", which this component does not expose.`,
+  });
+
+  checkVariantTargets({
+    map: variant.slots,
+    known: slotIds,
+    at,
+    field: "slots",
+    issues,
+    shapeMessage: `Variant "${name}" slots must be an object keyed by exposed slot id.`,
+    unknownMessage: key =>
+      `Variant "${name}" fills slot "${key}", which this component does not expose.`,
+  });
+}
+
+/**
+ * One of a variant's two keyed maps, against the ids the definition exposes.
+ *
+ * Both maps ask the identical question of different vocabularies, so they are
+ * one function taking the vocabulary. Written twice they drifted immediately —
+ * the slots half lost its shape check to an early `continue` on the first
+ * draft, which no test would have caught because a malformed map has no keys
+ * to report.
+ */
+function checkVariantTargets(args: {
+  map: unknown;
+  known: ReadonlySet<string>;
+  at: string;
+  field: "overrides" | "slots";
+  issues: ValidationIssue[];
+  shapeMessage: string;
+  unknownMessage: (key: string) => string;
+}): void {
+  const { map, known, at, field, issues } = args;
+  if (map === undefined) return;
+
+  if (!isPlainRecord(map)) {
+    issues.push({
+      path: pointer(at, field),
+      code: "component-envelope-invalid",
+      severity: "error",
+      message: args.shapeMessage,
+    });
+    return;
+  }
+
+  for (const key of Object.keys(map)) {
+    if (known.has(key)) continue;
+    issues.push({
+      path: pointer(at, `${field}/${key}`),
+      code: "variant-unknown-target",
+      severity: "error",
+      message: args.unknownMessage(key),
+    });
   }
 }
 

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -427,19 +427,6 @@ export function validateDocument(
     return { issues, survey };
   }
 
-  // Per-kind rules. Only `component` has any today, and it is the kind whose
-  // extra fields nothing else in the document can check: `exposed` and `slots`
-  // are pointers INTO the tree that was just confirmed to be an array, so this
-  // is the first point at which they can be resolved at all.
-  if (kind === "component") {
-    validateComponentEnvelope(
-      rawDoc,
-      rawDoc.nodes as BlockNode[],
-      limits,
-      issues
-    );
-  }
-
   checkLimits(survey, issues);
   //
   // `document-unwritable` belongs here for a sharper reason than tidiness: the
@@ -467,6 +454,30 @@ export function validateDocument(
   // back changed. It is a measurement that STOPPED SHORT which leaves nothing
   // bounded, and that is exactly what `traversed` reports.
   const overLimits = !survey.traversed;
+
+  // Per-kind rules. Only `component` has any today, and it is the kind whose
+  // extra fields nothing else in the document can check: `exposed` and `slots`
+  // are pointers INTO the node forest, so this is the first point at which
+  // they can be resolved at all.
+  //
+  // After the limits verdict, and skipped once it is negative, for the same
+  // reason the per-value work below is: a document the survey could not
+  // traverse is refused already, and an envelope with a million entries would
+  // otherwise be walked in full — and produce an issue per entry — to add
+  // nothing to a refusal that has already been made.
+  if (kind === "component" && !overLimits) {
+    // The SURVEY's snapshot, not `limits`. `DocumentLimits` is an ordinary
+    // object a caller may back with a getter, and `surveyDocument` snapshots
+    // it precisely so two readings cannot disagree. Re-reading here would let
+    // a shrinking limit report a node the survey counted as missing from the
+    // index, which surfaces as `exposed-node-missing` on a sound definition.
+    validateComponentEnvelope(
+      rawDoc,
+      rawDoc.nodes as BlockNode[],
+      survey.limits.maxNodes,
+      issues
+    );
+  }
 
   const styleBudget = newStyleIssueBudget();
   const nodeState: NodeCheckState = {
@@ -1536,10 +1547,15 @@ function isConditionsShapeValid(conditions: unknown): boolean {
  * reports as it goes — so reusing it would mean either checking pointers
  * against a half-built index, or holding the envelope's issues back to the end
  * and reordering the report. A second walk of a component document, bounded by
- * the same node cap, costs less than either.
+ * the same snapshotted node cap, costs less than either.
  */
-function nodesById(nodes: BlockNode[], limits: DocumentLimits) {
+function nodesById(nodes: BlockNode[], maxNodes: number) {
   const index = new Map<string, BlockNode>();
+  // Bounded even though the caller has already refused an over-limit document.
+  // The bound is unreachable through that path today and is not asserted by
+  // any test, because there is no input that reaches it — it is here so the
+  // function is safe read on its own terms, and so moving the caller's guard
+  // cannot silently make an unbounded walk.
   walkNodes(
     nodes,
     node => {
@@ -1548,7 +1564,7 @@ function nodesById(nodes: BlockNode[], limits: DocumentLimits) {
       // depend on traversal order for a document that is being refused anyway.
       if (!index.has(node.id)) index.set(node.id, node);
     },
-    { maxNodes: limits.maxNodes }
+    { maxNodes }
   );
   return index;
 }
@@ -1556,16 +1572,21 @@ function nodesById(nodes: BlockNode[], limits: DocumentLimits) {
 /** One `exposed` entry, before anything about it has been checked. */
 type RawExposed = Record<string, unknown>;
 
+/** True when a record declares `key` itself rather than inheriting it. */
+function declares(record: object, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}
+
 /**
  * Check a component definition's exposed properties, slots and variants.
  *
- * Every rule here is about a POINTER resolving, because that is the class of
- * fault the envelope introduces and the one nothing downstream can report. A
- * definition whose pointer names a node that was deleted still loads, still
- * renders, and still offers the property in the inspector — where editing it
- * writes an override keyed to an id that resolves to nothing, on every instance
- * in the site. The failure surfaces as "my change did nothing", far from the
- * definition that caused it.
+ * Every rule here is about a POINTER resolving or a field being present,
+ * because those are the faults the envelope introduces and the ones nothing
+ * downstream can report. A definition whose pointer names a deleted node still
+ * loads, still renders, and still offers the property in the inspector — where
+ * editing it writes an override keyed to an id that resolves to nothing, on
+ * every instance in the site. The failure surfaces as "my change did nothing",
+ * far from the definition that caused it.
  *
  * Errors, not warnings, and in both modes. Forgiving mode exists to keep a
  * document READABLE when a future build wrote something this one does not
@@ -1575,10 +1596,10 @@ type RawExposed = Record<string, unknown>;
 function validateComponentEnvelope(
   doc: Record<string, unknown>,
   nodes: BlockNode[],
-  limits: DocumentLimits,
+  maxNodes: number,
   issues: ValidationIssue[]
 ): void {
-  const index = nodesById(nodes, limits);
+  const index = nodesById(nodes, maxNodes);
   const exposedIds = new Set<string>();
 
   const exposed = doc.exposed;
@@ -1605,17 +1626,11 @@ function validateComponentEnvelope(
     });
   } else {
     for (const [id, entry] of Object.entries(slots ?? {})) {
-      checkExposedSlot(entry, id, `/slots/${id}`, index, issues);
+      checkExposedSlot(entry, id, pointer("/slots", id), index, issues);
     }
   }
 
-  // The KEYS are the slot ids, which is what a variant addresses. Derived here
-  // rather than accumulated during the walk above, so a slot whose entry was
-  // malformed still counts as declared — otherwise one broken slot would make
-  // every variant filling it report a second, misleading "nothing exposes
-  // this" on top of the fault the author actually has to fix.
-  const slotIds = new Set(Object.keys(isPlainRecord(slots) ? slots : {}));
-  checkVariants(doc.variants, exposedIds, slotIds, issues);
+  checkVariants(doc.variants, exposedIds, issues);
 }
 
 /**
@@ -1735,6 +1750,12 @@ function checkExposedPointer(
     });
   }
 
+  // The GRAMMAR only. Whether the path names a prop the node's block actually
+  // declares is a question about the block's schema, and the schema is not
+  // reachable from here — `BlockTypeLookup` answers `has(type)` and nothing
+  // else. Checking the path against `node.props` instead would refuse a sound
+  // exposure of any prop whose value comes from the block's default, since a
+  // defaulted prop is absent from the stored node.
   const propPath = raw.propPath;
   if (typeof propPath !== "string" || !BIND_PATH_RE.test(propPath)) {
     issues.push({
@@ -1786,6 +1807,7 @@ function checkExposedOptions(
     return;
   }
 
+  const at = pointer(path, "options");
   options.forEach((option: unknown, i: number) => {
     if (
       isPlainRecord(option) &&
@@ -1795,7 +1817,11 @@ function checkExposedOptions(
       return;
     }
     issues.push({
-      path: pointer(path, `options/${i}`),
+      // One segment per call. `pointer` escapes its token whole, so a single
+      // call with "options/0" emits `options~10` — a pointer that resolves to
+      // nothing, in the field whose purpose is to let a machine locate the
+      // value.
+      path: pointer(at, i),
       code: "exposed-options-invalid",
       severity: "error",
       message: `An option of exposed property "${id}" needs a string value and label.`,
@@ -1803,7 +1829,7 @@ function checkExposedOptions(
   });
 }
 
-/** One exposed slot: that its node exists, and that the node declares the region. */
+/** One exposed slot: its metadata, its node, and the region on that node. */
 function checkExposedSlot(
   entry: unknown,
   id: string,
@@ -1821,6 +1847,8 @@ function checkExposedSlot(
     return;
   }
 
+  checkExposedSlotMetadata(entry, id, path, issues);
+
   const nodeId = entry.nodeId;
   const node = typeof nodeId === "string" ? index.get(nodeId) : undefined;
   if (node === undefined) {
@@ -1837,16 +1865,65 @@ function checkExposedSlot(
 }
 
 /**
+ * The label the layers panel shows, and the block types the slot accepts.
+ *
+ * Both are read straight out of the stored envelope by consumers that treat
+ * the declared types as guarantees: a missing label renders as `undefined` in
+ * the panel, and an `allow` that is a bare string is iterated character by
+ * character, silently permitting nothing.
+ */
+function checkExposedSlotMetadata(
+  entry: Record<string, unknown>,
+  id: string,
+  path: string,
+  issues: ValidationIssue[]
+): void {
+  if (typeof entry.label !== "string" || entry.label === "") {
+    issues.push({
+      path: pointer(path, "label"),
+      code: "component-envelope-invalid",
+      severity: "error",
+      message: `Exposed slot "${id}" needs a non-empty label.`,
+    });
+  }
+
+  const allow = entry.allow;
+  if (allow === undefined) return;
+  if (!Array.isArray(allow)) {
+    issues.push({
+      path: pointer(path, "allow"),
+      code: "component-envelope-invalid",
+      severity: "error",
+      message: `Exposed slot "${id}" allow must be an array of block types.`,
+    });
+    return;
+  }
+
+  const at = pointer(path, "allow");
+  allow.forEach((type: unknown, i: number) => {
+    if (typeof type === "string" && type !== "") return;
+    issues.push({
+      path: pointer(at, i),
+      code: "component-envelope-invalid",
+      severity: "error",
+      message: `Exposed slot "${id}" allows ${describeValue(type)}, which is not a block type.`,
+    });
+  });
+}
+
+/**
  * That the node actually declares the named region.
  *
  * A separate question from whether the node exists, and the one a renamed
  * container leaves behind: the node is still there, the definition still
  * loads, and nothing in the tree looks wrong.
  *
- * `slots` is undefined on a container an author has not filled yet, which is an
- * ordinary state — so an absent map is judged the same as a map without the
- * key rather than skipped, which would let the pointer go unchecked exactly
- * when the container is empty.
+ * An OWN property. `slots` is an ordinary object, so `"toString" in slots` is
+ * true of every node — a slot by that name would pass here and then resolve to
+ * nothing, which is precisely the dangling reference this check exists to
+ * refuse. `slots` is also undefined on a container an author has not filled
+ * yet, which is an ordinary state, so an absent map is judged the same as a
+ * map without the key rather than skipped.
  */
 function checkSlotOnNode(
   slot: unknown,
@@ -1856,7 +1933,7 @@ function checkSlotOnNode(
   issues: ValidationIssue[]
 ): void {
   const declared = node.slots ?? {};
-  if (typeof slot === "string" && slot in declared) return;
+  if (typeof slot === "string" && declares(declared, slot)) return;
 
   issues.push({
     path: pointer(path, "slot"),
@@ -1879,7 +1956,6 @@ function checkSlotOnNode(
 function checkVariants(
   variants: unknown,
   exposedIds: ReadonlySet<string>,
-  slotIds: ReadonlySet<string>,
   issues: ValidationIssue[]
 ): void {
   if (variants === undefined) return;
@@ -1894,19 +1970,18 @@ function checkVariants(
   }
 
   for (const [name, variant] of Object.entries(variants)) {
-    checkVariant(name, variant, exposedIds, slotIds, issues);
+    checkVariant(name, variant, exposedIds, issues);
   }
 }
 
-/** One variant: its shape, its override targets and its slot targets. */
+/** One variant: its label, and the exposures its overrides address. */
 function checkVariant(
   name: string,
   variant: unknown,
   exposedIds: ReadonlySet<string>,
-  slotIds: ReadonlySet<string>,
   issues: ValidationIssue[]
 ): void {
-  const at = `/variants/${name}`;
+  const at = pointer("/variants", name);
   if (!isPlainRecord(variant)) {
     issues.push({
       path: at,
@@ -1917,71 +1992,76 @@ function checkVariant(
     return;
   }
 
-  checkVariantTargets({
-    map: variant.overrides,
-    known: exposedIds,
-    at,
-    field: "overrides",
-    issues,
-    shapeMessage: `Variant "${name}" overrides must be an object keyed by exposed id.`,
-    unknownMessage: key =>
-      `Variant "${name}" overrides "${key}", which this component does not expose.`,
-  });
+  if (typeof variant.label !== "string" || variant.label === "") {
+    issues.push({
+      path: pointer(at, "label"),
+      code: "component-envelope-invalid",
+      severity: "error",
+      message: `Variant "${name}" needs a non-empty label.`,
+    });
+  }
 
-  checkVariantTargets({
-    map: variant.slots,
-    known: slotIds,
-    at,
-    field: "slots",
-    issues,
-    shapeMessage: `Variant "${name}" slots must be an object keyed by exposed slot id.`,
-    unknownMessage: key =>
-      `Variant "${name}" fills slot "${key}", which this component does not expose.`,
-  });
+  // Required, not optional. A variant is a preset, and the picker offering one
+  // that presets nothing is a control that does nothing when chosen — which is
+  // a defect in the definition rather than a variant with no opinions.
+  if (!isPlainRecord(variant.overrides)) {
+    issues.push({
+      path: pointer(at, "overrides"),
+      code: "component-envelope-invalid",
+      severity: "error",
+      message: `Variant "${name}" needs an overrides object keyed by exposed id.`,
+    });
+  } else {
+    checkVariantTargets(
+      variant.overrides,
+      exposedIds,
+      pointer(at, "overrides"),
+      key =>
+        `Variant "${name}" overrides "${key}", which this component does not expose.`,
+      issues
+    );
+  }
+
+  // `slots` carries no content in this format yet, so a variant naming one can
+  // only be addressing a slot id — see `Variant` in `document.ts`.
+  if (variant.slots !== undefined) {
+    issues.push({
+      path: pointer(at, "slots"),
+      code: "component-envelope-invalid",
+      severity: "error",
+      message: `Variant "${name}" declares slot content, which this format version does not carry.`,
+      suggestion: "Put the content in the instance's own slots.",
+    });
+  }
 }
 
 /**
- * One of a variant's two keyed maps, against the ids the definition exposes.
+ * A variant's override map, against the ids the definition exposes.
  *
- * Both maps ask the identical question of different vocabularies, so they are
- * one function taking the vocabulary. Written twice they drifted immediately —
- * the slots half lost its shape check to an early `continue` on the first
- * draft, which no test would have caught because a malformed map has no keys
- * to report.
+ * The keys are the whole check: a value may be anything an exposed property
+ * holds, and props are unconstrained, so there is nothing narrower to say
+ * about one than that its key names something.
  */
-function checkVariantTargets(args: {
-  map: unknown;
-  known: ReadonlySet<string>;
-  at: string;
-  field: "overrides" | "slots";
-  issues: ValidationIssue[];
-  shapeMessage: string;
-  unknownMessage: (key: string) => string;
-}): void {
-  const { map, known, at, field, issues } = args;
-  if (map === undefined) return;
-
-  if (!isPlainRecord(map)) {
-    issues.push({
-      path: pointer(at, field),
-      code: "component-envelope-invalid",
-      severity: "error",
-      message: args.shapeMessage,
-    });
-    return;
-  }
-
+function checkVariantTargets(
+  map: Record<string, unknown>,
+  known: ReadonlySet<string>,
+  at: string,
+  message: (key: string) => string,
+  issues: ValidationIssue[]
+): void {
   for (const key of Object.keys(map)) {
     if (known.has(key)) continue;
     issues.push({
-      path: pointer(at, `${field}/${key}`),
+      // One segment per call: `pointer` escapes its token whole, so passing
+      // "overrides/missing" emits `overrides~1missing`, which resolves to
+      // nothing.
+      path: pointer(at, key),
       code: "variant-unknown-target",
       severity: "error",
-      message: args.unknownMessage(key),
+      message: message(key),
     });
   }
 }
-
 /**
  * A binding path is a dot-joined chain of field identifiers, e.g. "title" or
  * "author.name". This rejects expression-like or otherwise malformed strings so
@@ -2092,6 +2172,24 @@ function validateComponentInstance(
       severity: "error",
       message:
         "A component-instance node must set props.componentId to the component's id.",
+    });
+  }
+
+  // `overrides` is a MAP keyed by exposed id, and only the shape is checkable
+  // here: which ids exist is a property of a definition this document does not
+  // carry. The shape still has to be refused, because a resolver enumerating
+  // it either throws on a string and an array, or reads their indices as
+  // exposure ids and applies values to properties nobody named.
+  //
+  // Only when present. Absent means the instance overrides nothing, which is
+  // the ordinary state of a freshly placed component.
+  const overrides = node.props.overrides;
+  if (overrides !== undefined && !isPlainRecord(overrides)) {
+    issues.push({
+      path: pointer(pointer(path, "props"), "overrides"),
+      code: "invalid-component-instance",
+      severity: "error",
+      message: `A component instance's props.overrides must be an object keyed by exposed id, not ${describeValue(overrides)}.`,
     });
   }
 }

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -1555,11 +1555,11 @@ function isConditionsShapeValid(conditions: unknown): boolean {
  */
 function nodesById(nodes: BlockNode[], maxNodes: number) {
   const index = new Map<string, BlockNode>();
-  // Bounded even though the caller has already refused an over-limit document.
-  // The bound is unreachable through that path today and is not asserted by
-  // any test, because there is no input that reaches it — it is here so the
-  // function is safe read on its own terms, and so moving the caller's guard
-  // cannot silently make an unbounded walk.
+  // The snapshotted node bound, so this walk and the survey that measured the
+  // document agree on how many nodes there are. A caller may back
+  // `DocumentLimits` with a getter, and two readings that disagree would build
+  // an index missing a node the survey counted — reported as a sound exposure
+  // pointing at nothing.
   walkNodes(
     nodes,
     node => {
@@ -2183,17 +2183,32 @@ function checkVariant(
       severity: "error",
       message: `Variant "${name}" needs an overrides object keyed by exposed id.`,
     });
-  } else if (Object.keys(variant.overrides).length === 0) {
-    issues.push({
-      path: pointer(at, "overrides"),
-      code: "component-envelope-invalid",
-      severity: "error",
-      message: `Variant "${name}" presets nothing, so selecting it would change nothing.`,
-      suggestion: "Give it at least one override, or remove the variant.",
-    });
   } else {
-    checkVariantTargets(
+    // Bounded HERE, not only at the variant map. `variants` being within the
+    // budget says nothing about one variant's overrides, so a single variant
+    // holding a hundred thousand keys reached both the emptiness check and the
+    // per-key walk below — twice — through a cap that had already passed.
+    const overrideKeys = ownKeysBounded(
       variant.overrides,
+      pointer(at, "overrides"),
+      "variant overrides",
+      issues
+    );
+    if (overrideKeys === null) return;
+
+    if (overrideKeys.length === 0) {
+      issues.push({
+        path: pointer(at, "overrides"),
+        code: "component-envelope-invalid",
+        severity: "error",
+        message: `Variant "${name}" presets nothing, so selecting it would change nothing.`,
+        suggestion: "Give it at least one override, or remove the variant.",
+      });
+      return;
+    }
+
+    checkVariantTargets(
+      overrideKeys,
       exposedIds,
       pointer(at, "overrides"),
       key =>
@@ -2223,13 +2238,16 @@ function checkVariant(
  * about one than that its key names something.
  */
 function checkVariantTargets(
-  map: Record<string, unknown>,
+  keys: readonly string[],
   known: ReadonlySet<string>,
   at: string,
   message: (key: string) => string,
   issues: ValidationIssue[]
 ): void {
-  for (const key of Object.keys(map)) {
+  // Takes the KEYS a bounded read already produced, rather than the map. Given
+  // the map it would enumerate a second time, so one collection would be
+  // counted once and walked twice — and the second walk had no bound at all.
+  for (const key of keys) {
     if (known.has(key)) continue;
     issues.push({
       // One segment per call: `pointer` escapes its token whole, so passing

--- a/packages/nextly/src/plugins/codegen/block-document.test-d.ts
+++ b/packages/nextly/src/plugins/codegen/block-document.test-d.ts
@@ -205,11 +205,17 @@ expectTypeOf<BindingFormat["type"]>().toEqualTypeOf<BindingFormatType>();
  * else: the runtime schema treats `props` as an open record on purpose, so
  * renaming `componentId` would pass every parse test while silently orphaning
  * every stored instance. The key set is pinned here for the same reason the
- * envelope's is, and the value types are pinned too because both fields are
- * identifiers rather than open content.
+ * envelope's is, and the identifier fields' value types are pinned too because
+ * they are identifiers rather than open content.
+ *
+ * `overrides` is deliberately NOT pinned to a value type. It holds whatever an
+ * exposed property holds, and props are unconstrained, so any pin here would
+ * be `unknown` — an assertion that cannot fail and therefore reports nothing.
+ * Its KEY is pinned like the others, because that is the part a rename would
+ * orphan.
  */
 expectTypeOf<keyof ComponentInstanceProps>().toEqualTypeOf<
-  "componentId" | "variant"
+  "componentId" | "variant" | "overrides"
 >();
 expectTypeOf<ComponentInstanceProps["componentId"]>().toEqualTypeOf<string>();
 expectTypeOf<ComponentInstanceProps["variant"]>().toEqualTypeOf<


### PR DESCRIPTION
Plan 06 T-2, first slice — design §6.3. The critical path after T-1.

## What this ships

A `kind: "component"` document may now declare what an instance may change:

- **`exposed`** — properties an instance may override. Each entry points at a node in the definition's own tree and the prop on it, so the definition renders correctly on its own and an instance that overrides nothing is identical to it.
- **`slots`** — regions an instance may fill with its own blocks, keyed by slot id.
- **`variants`** — named presets over both.
- **`ComponentInstanceProps.overrides`** — tri-state, keyed by exposed id: absent inherits, `{ $unset: true }` clears, anything else replaces. The middle state is what lets an author empty a subtitle the definition fills in; every primitive they might otherwise mean (`""`, `null`, `0`, `false`) is a legitimate value for some property.

**Every pointer resolves or the document is refused.** A dangling `nodeId`, a slot the node does not declare, a duplicated exposed id, and a variant naming something nothing exposes all leave a definition that loads and renders. Each surfaces much later as "editing this property does nothing", far from the definition that caused it.

## Deliberate departures from the design doc, and why

- **`exposed` and `slots` are optional, not required.** A component that exposes nothing is a locked reusable block — a footer nobody may edit — not a malformed one. Requiring an empty array would refuse a legitimate definition and force a migration over every stored component to add a field meaning what its absence already means. Matches every other "absent means none" field in the contract.
- **`ExposedSlot` carries no `id`.** The map key is the id. A record keyed by id whose values also carry one states the identity twice with nothing reconciling them; one spelling makes the disagreement unrepresentable rather than merely detectable.
- **`MAX_COMPOSED_DEPTH` is not here.** It has no consumer until the resolver, and a cap nothing enforces is a docblock describing behaviour the code does not have. It ships with its enforcement.
- **`ComponentDocument extends BlockDocument`** rather than joining a union with it. Every existing consumer reads a stored document as a `BlockDocument` and none can narrow, so a union would make the package's whole type surface a breaking change to gain a discrimination two call sites need. `isComponentDocument` narrows where it matters.

## Not in this slice

The planners and the ops move (gated on `decision:pb6-ops-move-to-engine`, still pending), `reidSubtreeWithMap`, the contiguity predicate, and the resolver. Each is its own slice — T-2 as written is XL, and an XL PR is what produced four review rounds on #1512.

## The docblock rewrite

`document.ts` said resolution "happens where components are stored and rendered, not here". That was written while the canvas was an iframe running the renderer, so the renderer and the editor were one place. They are not any more, so a resolver living with the renderer would be a second implementation for the canvas, and the class-usage index and SEO derivation would each need a third. Rewritten to say the engine owns the pure resolution and the stores own the fetch. Design §6.3 calls for this explicitly.

## Verification

- **13 break-verifications**, each written as the wrong implementation rather than a token mutation; every one kills its intended test by name, test count held at 28 throughout. Three initially did **not** kill and each exposed a real gap: a test that was never written (an edit aborted before saving), a missing positive control for a variant filling a declared slot, and a weak mutation that changed message text instead of logic. All three closed.
- Two fixtures added to the shared corpus, so the "every emitted code is documented" and "every emitted path resolves as a JSON Pointer" tests cover the new paths — these are the first pointers in this format addressing a document field outside `nodes`.
- The `ComponentInstanceProps` key set is a deliberately frozen pin in `block-document.test-d.ts`; it is updated rather than loosened, and `overrides` is pinned by key but not by value type, since any value pin would be `unknown` and could not fail.
- Gates: build 0, check-types 0, lint 0, lint:design 0, comment-convention 0, `changeset status` 0, full engine suite 1769 passed, pre-push full suite 11167 tests green.
- fallow (run with the repo's own config and gate): `warn`, `complexity_introduced: 0`. The first draft was `fail` with 3 introduced — the three new checks were over the threshold and were decomposed along the boundaries their reports already had. The remaining `duplication_introduced: 2` is line-shift attribution: every duplicated fragment exists verbatim on `origin/main`, and my diff to that file is one union key and a docblock.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for component definitions with exposed properties, configurable slots, and reusable variants.
  * Added component-instance overrides to inherit, replace, or clear exposed values.
  * Expanded the public API with component definition types, validation helpers, and envelope limits.

* **Bug Fixes**
  * Improved validation for component definitions and instances, including invalid references, paths, duplicate identifiers, unsupported options, and unknown variant targets.

* **Tests**
  * Added comprehensive coverage and fixtures for component envelope validation and override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->