### PR TITLE
feat(builder): publish the op vocabulary as a server-safe subpath

### DIFF
--- a/.changeset/builder-ops-are-server-safe.md
+++ b/.changeset/builder-ops-are-server-safe.md
@@ -1,0 +1,42 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The page builder's op vocabulary is now importable without React, from
+`@nextlyhq/builder/ops`.
+
+An op is a change to a document rather than a gesture in a React tree: a server
+action that promotes a selection to a component, and an agent asked to insert a
+section, apply the same ops the canvas applies. Published only from the package
+root, those callers had two options and both were wrong — pull a client
+boundary into a server module, or grow a second implementation that agrees with
+this one until the day it does not.
+
+The subpath is built by the same server-safe configuration that already
+publishes `./geometry` and `./shell-state`, so it carries no `"use client"`
+banner and a Server Component can load it. Nothing that already imports these
+names from the package root has changed.

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -40,6 +40,11 @@
       "types": "./dist/shell-state.d.ts",
       "import": "./dist/shell-state.mjs",
       "default": "./dist/shell-state.mjs"
+    },
+    "./ops": {
+      "types": "./dist/ops.d.ts",
+      "import": "./dist/ops.mjs",
+      "default": "./dist/ops.mjs"
     }
   },
   "files": [

--- a/packages/builder/src/ops-entry.test.ts
+++ b/packages/builder/src/ops-entry.test.ts
@@ -1,0 +1,77 @@
+/**
+ * That `@nextlyhq/builder/ops` is reachable from a server, and stays that way.
+ *
+ * The subpath exists so a server action or an agent can apply the same ops the
+ * canvas applies. Two things have to hold for that, and neither is visible from
+ * reading `ops.ts`:
+ *
+ * - the export map has to ADVERTISE it, and the build has to PRODUCE what is
+ *   advertised. `@nextlyhq/ui` records the failure this prevents: a map naming
+ *   an artifact no config emitted, whose only consumer worked because it
+ *   resolved the package through a tsconfig path mapping to source and never
+ *   loaded the published entry at all.
+ * - the module has to stay free of React. It is built by the server-safe
+ *   config, which adds no `"use client"` banner, so an import of React reaching
+ *   it would not fail the build — it would produce an entry a Server Component
+ *   loads and React refuses at runtime.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { importedSpecifiers } from "@nextlyhq/module-specifiers";
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = resolve(here, "..");
+
+const read = (rel: string) => readFileSync(join(pkgRoot, rel), "utf8");
+
+/** The package's own export map. */
+const exportMap = JSON.parse(read("package.json")).exports as Record<
+  string,
+  { types?: string; import?: string } | string
+>;
+
+/** Entries the server-safe tsup config builds. */
+function serverSafeEntries(): string[] {
+  const config = read("tsup.server-safe.config.ts");
+  const block = /entry:\s*\[([^\]]*)\]/.exec(config);
+  return [...(block?.[1] ?? "").matchAll(/"([^"]+)"/g)].map(m => m[1]);
+}
+
+describe("the ops subpath is published", () => {
+  it("is advertised in the export map", () => {
+    // The control: a subpath the package does not publish must not appear, so
+    // this is a statement about `./ops` rather than about a map that would
+    // accept any key.
+    expect(exportMap["./no-such-subpath"]).toBeUndefined();
+
+    expect(exportMap["./ops"]).toEqual({
+      types: "./dist/ops.d.ts",
+      import: "./dist/ops.mjs",
+      default: "./dist/ops.mjs",
+    });
+  });
+
+  it("is built by the config that adds no client banner", () => {
+    // The whole point of the subpath. Built by the ROOT config it would inherit
+    // the shell's `"use client"` banner, and a Server Component could not apply
+    // an op — for no reason other than how the bundle was assembled.
+    expect(serverSafeEntries()).toContain("src/ops.ts");
+
+    const clientConfig = read("tsup.config.ts");
+    expect(clientConfig).not.toContain("src/ops.ts");
+  });
+});
+
+describe("the ops module stays server-safe", () => {
+  it("imports the engine and nothing else", () => {
+    // Asserted as the WHOLE import list rather than as "no react". A module
+    // that grew an import of the design system, the plugin SDK or a DOM helper
+    // would satisfy a react-only check and still be unloadable on a server.
+    const specifiers = [...importedSpecifiers(read("src/ops.ts"), "ops.ts")];
+
+    expect(specifiers).toEqual(["@nextlyhq/blocks-engine"]);
+  });
+});

--- a/packages/builder/tsup.server-safe.config.ts
+++ b/packages/builder/tsup.server-safe.config.ts
@@ -8,6 +8,15 @@ import { defineConfig } from "tsup";
  * how chrome preferences are read and written. Both are arithmetic and set
  * membership, and neither imports anything at all.
  *
+ * `ops` is the vocabulary every edit is expressed in and the function that
+ * applies one. It belongs here because an op is a change to a DOCUMENT rather
+ * than a gesture in a React tree: a server action promoting a selection to a
+ * component, and an agent asked to insert a section, apply the same ops the
+ * canvas does. Published only from the root barrel, those callers had two
+ * options and both were wrong — pull a client boundary into a server module,
+ * or grow a second implementation that agrees with this one until the day it
+ * does not. It imports `@nextlyhq/blocks-engine` and nothing else.
+ *
  * Built SEPARATELY from the root entry because that entry carries a
  * `"use client"` banner. The banner is required there — the shell is a client
  * component and Rollup drops per-module directives — but it applies to
@@ -33,7 +42,12 @@ export default defineConfig({
   // `BuilderShellProps` as a TYPE, which is erased. Built by the client config
   // it would have inherited the shell's banner and turned every one of those
   // into a client reference.
-  entry: ["src/index.ts", "src/geometry.ts", "src/shell-state.ts"],
+  entry: [
+    "src/index.ts",
+    "src/geometry.ts",
+    "src/shell-state.ts",
+    "src/ops.ts",
+  ],
   format: ["esm"],
   dts: true,
   clean: false,


### PR DESCRIPTION
Plan 06 T-2. Delivers `decision:pb6-ops-move-to-engine` — by a different route than the decision named, with the founder's agreement and the measurements below.

## What this ships

`@nextlyhq/builder/ops` — the op vocabulary (`BuilderOp`, `applyOp`, `applyOps`, `OpError`, `positionOf`) importable with **no React in the graph**.

An op is a change to a document, not a gesture in a React tree. A server action promoting a selection to a component, and an agent asked to insert a section, apply the same ops the canvas does. Published only from the package root, those callers had two options and both were wrong: pull a client boundary into a server module, or grow a second implementation that agrees with this one until the day it does not.

Two lines of build configuration and an export-map entry. Nothing that already imports these names has changed.

## Why not the file move the decision named

The move **was implemented and works** — engine builds, 0 import cycles, 1,938 engine and 2,602 builder tests green. It cannot open:

- The changed-files gate attributes a moved file's contents as **introduced**: 11 complexity findings, 5 critical, 4 high. The bodies are byte-identical — 152,079 characters, compared programmatically. fallow has no rename detection (`audit --help`: only `--health-baseline`, which would also silence future real findings).
- Decomposing first was measured, not assumed. Extracting the four op handlers took `applyOp` from cyclomatic **50 → 26**, all 2,801 tests passing — and it was **still counted as introduced**, because partial improvement below no threshold counts for nothing. Passing would require ~12 functions each under cyclomatic 10, in the module that validates untrusted ops before they touch a document. Those functions are branchy by design.

The gate is also defensible rather than merely wrong: promoting the codebase's largest hotspot into the package everything depends on deserves objection.

## Why the subpath is the better answer, not just the cheaper one

This package **already** publishes React-free subpaths for exactly this reason. `tsup.server-safe.config.ts` builds `./geometry` and `./shell-state` away from the root entry, and its own docblock explains the split exists so a Server Component can call them — and records the failure it prevents: an export map advertising an artifact no config emitted, whose only consumer worked because it resolved to source and never loaded the published entry.

It is also better layering. `applyOp` is built on the engine's primitives (`insertNode`, `moveNode`, `updateNode`), so the op algebra sits a layer **above** the engine rather than inside it — putting editing semantics in the lowest-level package would have been the compromise, not the goal.

## Verification

- **Loaded in a plain Node process** from a consumer package: `@nextlyhq/builder/ops` resolves and `applyOp`/`applyOps` are functions. That is the decision's goal, proven rather than argued.
- The built artifact carries **no** `"use client"` banner; the control (`dist/shell.mjs`) does.
- Three guard tests: the export map advertises it, the **server-safe** config builds it and the client config does not, and the module imports `@nextlyhq/blocks-engine` and nothing else — asserted as the whole import list rather than "no react", since an import of the design system or the plugin SDK would pass a react-only check and still be unloadable on a server.
- Gates: build 0, check-types 0, lint 0, lint:design 0, comment-convention 0, `changeset status` 0, builder suite 100 files / 2,804 tests, and fallow **`pass`** with **0 introduced in all four categories**.

## Follow-up filed, not forgotten

`applyOp` at cognitive 73 across 568 lines is still the largest hotspot in the codebase and worth decomposing on its own terms — but it is no longer a prerequisite for anything, and `task:pb-ops-decompose` records that it must not be scheduled as one.