### PR TITLE
feat(blocks-engine): copy a subtree without breaking the links it makes to itself

### DIFF
--- a/.changeset/a-copied-pattern-keeps-its-own-links.md
+++ b/.changeset/a-copied-pattern-keeps-its-own-links.md
@@ -1,0 +1,41 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Copying a block subtree can now keep the links it makes to itself.
+
+A saved pattern whose button links to `#pricing` further down the same pattern
+used to arrive with the link intact and the target gone: copying assigns fresh
+ids and dropped the HTML `id` attributes, because two copies on one page must
+not answer to the same anchor. The link then resolved to whatever `#pricing`
+the destination page happened to own, or to nothing at all, and only on the
+rendered page.
+
+Those ids are now given new values instead of being removed — derived from the
+original, so `pricing` becomes something an author still recognises in a URL,
+a stylesheet and the attribute panel — and the copy reports what each one
+became, so whatever holds the reference can follow it.

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -90,10 +90,16 @@ export {
   removeNode,
   moveNode,
   reidSubtree,
+  reidSubtreeWithMap,
   duplicateNode,
   updateNode,
 } from "./tree";
-export type { NodeLocation, SlotDefaultSource, TreePosition } from "./tree";
+export type {
+  NodeLocation,
+  ReidentifiedSubtree,
+  SlotDefaultSource,
+  TreePosition,
+} from "./tree";
 
 // The node selection every reader of a stored document shares. Public because
 // the page-builder plugin's class-usage record has to stop exactly where the

--- a/packages/blocks-engine/src/tree.reid-with-map.test.ts
+++ b/packages/blocks-engine/src/tree.reid-with-map.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Re-identifying a subtree while keeping its internal references usable.
+ *
+ * The failure this exists to prevent is silent and only visible on a rendered
+ * page: `reidSubtree` DROPS a copy's DOM ids, so a saved pattern whose button
+ * links to `#pricing` inside itself is inserted with the link intact and the
+ * target gone — and the fragment then resolves to whatever `#pricing` the
+ * destination page happens to own, or to nothing. Every assertion here is about
+ * that pair: the ids must change, and the subtree must still be able to point
+ * at itself.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { BlockNode } from "./document";
+import { reidSubtree, reidSubtreeWithMap, walkNodes } from "./tree";
+
+/** A node with an optional DOM id, and children. */
+function node(
+  id: string,
+  extra: Partial<BlockNode> = {},
+  children: BlockNode[] = []
+): BlockNode {
+  return {
+    id,
+    type: "core/box",
+    version: 1,
+    props: {},
+    ...(children.length > 0 ? { slots: { children } } : {}),
+    ...extra,
+  };
+}
+
+/** Every node in a subtree, flattened. */
+function allNodes(root: BlockNode): BlockNode[] {
+  const out: BlockNode[] = [];
+  walkNodes([root], n => out.push(n));
+  return out;
+}
+
+describe("a re-identified subtree is a different subtree", () => {
+  it("gives every node a fresh id and records the mapping", () => {
+    const tree = node("root", {}, [node("a"), node("b")]);
+    const result = reidSubtreeWithMap(tree);
+
+    const ids = allNodes(result.node).map(n => n.id);
+    // The control: three nodes in, three out — so the assertions below are
+    // about re-identification rather than about a walk that lost the subtree.
+    expect(ids).toHaveLength(3);
+    expect(ids).not.toContain("root");
+
+    // Every original is addressable in the map, which is what lets a caller
+    // rewrite a reference it holds elsewhere.
+    expect([...result.nodeIds.keys()].sort()).toEqual(["a", "b", "root"]);
+    expect(result.nodeIds.get("root")).toBe(result.node.id);
+  });
+});
+
+describe("a DOM id is remapped rather than dropped", () => {
+  it("keeps an id, changes it, and reports the replacement", () => {
+    const result = reidSubtreeWithMap(node("root", { cssId: "pricing" }));
+
+    // Three separate claims, and the middle one is the point. Dropping would
+    // satisfy "not the original"; keeping would satisfy "still has one".
+    expect(result.node.cssId).toBeDefined();
+    expect(result.node.cssId).not.toBe("pricing");
+    expect(result.domIds.get("pricing")).toBe(result.node.cssId);
+  });
+
+  it("derives the replacement from the original", () => {
+    // An author reads and writes this value: it appears in a URL fragment, in a
+    // stylesheet and in the attribute panel. A UUID would be unique and
+    // unusable.
+    const result = reidSubtreeWithMap(node("root", { cssId: "pricing" }));
+
+    expect(result.node.cssId).toMatch(/^pricing-/);
+  });
+
+  it("remaps the attributes escape hatch too, case-insensitively", () => {
+    // A DOM id reaches a page two ways, and a remap that covered one would
+    // leave the other emitting a duplicate.
+    const result = reidSubtreeWithMap(
+      node("root", { attributes: { ID: "pricing", "data-keep": "yes" } })
+    );
+
+    expect(result.node.attributes?.ID).toBe(result.domIds.get("pricing"));
+    // The control: an unrelated attribute is untouched, so this is a remap
+    // rather than a rewrite of everything.
+    expect(result.node.attributes?.["data-keep"]).toBe("yes");
+  });
+
+  it("gives two copies of one subtree different DOM ids", () => {
+    // The collision the remap exists to avoid: two inserts of one pattern on
+    // one page must not emit the same HTML id.
+    const tree = node("root", { cssId: "pricing" });
+
+    expect(reidSubtreeWithMap(tree).node.cssId).not.toBe(
+      reidSubtreeWithMap(tree).node.cssId
+    );
+  });
+
+  it("still drops the id through the plain reidSubtree", () => {
+    // The control for the whole file. `reidSubtree` is unchanged and is still
+    // right where the copy is all anyone will look at — if it had started
+    // remapping, every assertion above would pass for the wrong reason.
+    expect(
+      reidSubtree(node("root", { cssId: "pricing" })).cssId
+    ).toBeUndefined();
+  });
+});
+
+describe("every internal reference round-trips", () => {
+  it("maps each DOM id in the subtree exactly once, whole", () => {
+    // The property the design asks for, stated over a tree rather than a case:
+    // for every id the subtree carried, the map holds an entry, and the
+    // rebuilt tree carries the mapped value. A remap that missed a nested node,
+    // or minted a second replacement for an id it had already seen, breaks one
+    // of the two.
+    const tree = node("root", { cssId: "top" }, [
+      node("a", { cssId: "middle" }, [node("a1", { cssId: "deep" })]),
+      node("b", { attributes: { id: "sidebar" } }),
+    ]);
+
+    const result = reidSubtreeWithMap(tree);
+    const before = ["top", "middle", "deep", "sidebar"];
+
+    expect([...result.domIds.keys()].sort()).toEqual([...before].sort());
+
+    const after = allNodes(result.node).flatMap(n => {
+      const attr = n.attributes?.id;
+      return [
+        ...(typeof n.cssId === "string" ? [n.cssId] : []),
+        ...(typeof attr === "string" ? [attr] : []),
+      ];
+    });
+    expect(after.sort()).toEqual(
+      before.map(id => result.domIds.get(id)!).sort()
+    );
+  });
+
+  it("maps a repeated id to one replacement", () => {
+    // Already malformed — validation reports the duplicate — but the copy must
+    // not make it worse. The pair pointed at one target before, so a reference
+    // to it still reaches one target after.
+    const tree = node("root", { cssId: "dup" }, [node("a", { cssId: "dup" })]);
+    const result = reidSubtreeWithMap(tree);
+
+    const seen = allNodes(result.node).map(n => n.cssId);
+    expect(new Set(seen).size).toBe(1);
+    expect(seen[0]).toBe(result.domIds.get("dup"));
+  });
+
+  it("leaves a subtree carrying no DOM ids with an empty map", () => {
+    // The control for the map itself: it reports what was there, so a function
+    // inventing entries would fail here while passing everything above.
+    const result = reidSubtreeWithMap(node("root", {}, [node("a")]));
+
+    expect(result.domIds.size).toBe(0);
+    expect(result.nodeIds.size).toBe(2);
+  });
+});

--- a/packages/blocks-engine/src/tree.ts
+++ b/packages/blocks-engine/src/tree.ts
@@ -1022,6 +1022,116 @@ export function reidSubtree(node: BlockNode): BlockNode {
   return rebuilt ?? node;
 }
 
+/**
+ * What re-identifying a subtree produced, when the caller needs to follow it.
+ *
+ * {@link reidSubtree} drops a copy's DOM ids, which is right when the copy is
+ * all anyone will look at. It is wrong when the subtree REFERS to itself: a
+ * link inside a saved pattern pointing at `#pricing` resolves to a node in the
+ * same pattern, and dropping the target's id leaves the copy carrying a link to
+ * nowhere — worse, to whatever `#pricing` the destination page happens to own.
+ *
+ * So the ids are remapped rather than dropped, and both maps are handed back.
+ * The engine cannot rewrite the references itself: a link's target lives in a
+ * block's props, and which prop holds one is a property of the block's
+ * definition rather than of the document format.
+ */
+export interface ReidentifiedSubtree {
+  /** The rebuilt subtree. */
+  node: BlockNode;
+  /** Every node's old id → its new one. */
+  nodeIds: ReadonlyMap<string, string>;
+  /**
+   * Every DOM id the subtree carried → its replacement.
+   *
+   * Keyed by the id as written. A subtree that already used one id on two nodes
+   * is malformed — validation reports it as a duplicate — and appears here once,
+   * mapped to the first replacement minted.
+   */
+  domIds: ReadonlyMap<string, string>;
+}
+
+/**
+ * Deep-clone a subtree with fresh ids, KEEPING its internal references usable.
+ *
+ * The same rebuild as {@link reidSubtree}, differing in what happens to a DOM
+ * id: dropped there, minted afresh here and recorded. Two copies of one pattern
+ * on a page must not emit the same HTML `id`, and a copy's internal anchor must
+ * still reach its own target — remapping is the only answer that satisfies
+ * both.
+ *
+ * The minted id is DERIVED from the original (`pricing` becomes
+ * `pricing-<suffix>`) rather than freshly random, because it is a value authors
+ * read and write: it appears in a URL fragment, in a stylesheet and in the
+ * attribute panel. A UUID would be unique and unusable.
+ *
+ * Uniqueness is guaranteed WITHIN the returned subtree, not against the
+ * document it is going into — this function is given a subtree and cannot see
+ * anything else. A caller inserting into a page it can read should check
+ * {@link ReidentifiedSubtree.domIds} against that page.
+ */
+export function reidSubtreeWithMap(node: BlockNode): ReidentifiedSubtree {
+  const nodeIds = new Map<string, string>();
+  const domIds = new Map<string, string>();
+
+  const [rebuilt] = mapForest([node], original =>
+    reidOneKeepingReferences(original, nodeIds, domIds)
+  );
+  return { node: rebuilt ?? node, nodeIds, domIds };
+}
+
+/** One node, re-identified, with its DOM id remapped rather than removed. */
+function reidOneKeepingReferences(
+  node: BlockNode,
+  nodeIds: Map<string, string>,
+  domIds: Map<string, string>
+): BlockNode {
+  const { slots, ...own } = node;
+  const copy: BlockNode = { ...structuredClone(own), id: newId() };
+  if (typeof node.id === "string") nodeIds.set(node.id, copy.id);
+
+  // `mintDomId` is asked once per distinct ORIGINAL id, so a subtree whose two
+  // nodes carry the same DOM id maps both to one replacement. That preserves
+  // the document's own meaning: the pair pointed at one target before, and a
+  // reference to it still reaches one target after.
+  const remap = (value: string): string => {
+    const existing = domIds.get(value);
+    if (existing !== undefined) return existing;
+    const minted = mintDomId(value, copy.id);
+    domIds.set(value, minted);
+    return minted;
+  };
+
+  if (typeof copy.cssId === "string" && copy.cssId !== "") {
+    copy.cssId = remap(copy.cssId);
+  }
+  if (copy.attributes) {
+    copy.attributes = Object.fromEntries(
+      Object.entries(copy.attributes).map(([key, value]) =>
+        key.toLowerCase() === "id" && typeof value === "string" && value !== ""
+          ? [key, remap(value)]
+          : [key, value]
+      )
+    );
+  }
+
+  if (slots !== undefined) copy.slots = slots;
+  return copy;
+}
+
+/**
+ * A replacement DOM id, derived from the original.
+ *
+ * The suffix comes from the node's NEW id, so the same original inside two
+ * copies of one pattern produces two different replacements — which is the
+ * collision the remap exists to avoid. Trimmed to keep the result readable in a
+ * URL fragment; the full node id is not needed for uniqueness within a subtree
+ * that has exactly one node per new id.
+ */
+function mintDomId(original: string, newNodeId: string): string {
+  return `${original}-${newNodeId.replace(/-/g, "").slice(0, 8)}`;
+}
+
 /** One node's own fields, freshly identified. Slots are the rebuild's job. */
 function reidOne(node: BlockNode): BlockNode {
   // Clone only this node's own fields; descendants are cloned as the rebuild


### PR DESCRIPTION
Plan 06 T-2, third slice — design §6.3. Independent of #1514 (different file), so no stacking.

## The defect

`reidSubtree` assigns fresh node ids and **drops** the copy's DOM ids (`cssId` and the `attributes.id` escape hatch). That is right when the copy is all anyone will look at, and wrong when the subtree refers to itself.

A saved pattern whose button links to `#pricing` further down the same pattern was inserted with the link intact and the target gone. The fragment then resolved to whatever `#pricing` the destination page happened to own, or to nothing — and only on the rendered page, long after the insert.

## What ships

`reidSubtreeWithMap(node)` → `{ node, nodeIds, domIds }`. Same rebuild, differing only in what happens to a DOM id: **remapped** rather than removed, and both mappings returned.

Three decisions worth stating:

- **Derived, not random.** `pricing` becomes `pricing-<suffix>`. An author reads and writes this value — it appears in a URL fragment, in a stylesheet and in the attribute panel — so a UUID would be unique and unusable.
- **The engine does not rewrite the references.** A link's target lives in a block's props, and which prop holds one is a property of the block's *definition*, not of the document format. The map is what lets the caller do it.
- **Uniqueness is within the subtree, not against the destination.** The function is handed a subtree and cannot see the page. The docblock says so, and a caller inserting into a page it can read should check `domIds` against it.

`reidSubtree` is untouched.

## Verification

7 break-verifications, all killing by name, count held at 9:

- dropping the id again, minting a replacement that is not derived, skipping the `attributes` escape hatch, matching that attribute case-sensitively, minting twice for a repeated id, and not recording the node map — each kills its own test.
- The seventh is the control that matters most: making **`reidSubtree` remap too** kills the test asserting it still drops. Without that, every assertion here would pass for the wrong reason if the new behaviour quietly became the only behaviour.

The property test the design asks for is stated over a tree rather than a case: for every DOM id the subtree carried, the map holds one entry and the rebuilt tree carries the mapped value — so a remap that missed a nested node, or minted a second replacement for an id it had already seen, fails one half or the other.

Gates: build 0, check-types 0, lint 0, lint:design 0, comment-convention 0, `changeset status` 0, engine suite 40 files / 1,748 tests, fallow **`pass`** with **0 introduced in all four categories**.