### PR TITLE
fix(nextly): filter collections by permission before paging them

### DIFF
--- a/.changeset/collections-filter-before-paging.md
+++ b/.changeset/collections-filter-before-paging.md
@@ -1,0 +1,43 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Listing collections filters by permission BEFORE it pages, so the count
+describes the rows the caller can see.
+
+Filtering the already-fetched page instead left the rows and the meta
+describing different sets: `total` became the number of survivors on ONE page,
+so `totalPages` collapsed to 1 and `hasNext` was false however many pages the
+reader could actually reach. A client reading that stops at the first page and
+every collection past it is unreachable -- and the pre-filter count it replaced
+reported how many collections exist that the reader may not see.
+
+The registry now takes a `slugAllowlist` and puts it in the WHERE clause, so
+the COUNT and the page read the same rows. `readableSlugAllowlist` resolves it
+once for both the collections and the singles listings, which had two copies of
+that resolution; its three answers stay distinct -- no filter, no rows, or
+exactly these slugs.

--- a/packages/nextly/src/dispatcher/handlers/__tests__/collection-dispatcher-list-allowlist.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/collection-dispatcher-list-allowlist.test.ts
@@ -1,0 +1,134 @@
+/**
+ * The permission filter for `listCollections` is a QUERY CONDITION, not a pass
+ * over the rows that came back.
+ *
+ * Filtering the returned page instead makes the rows and the meta describe
+ * different sets: `total` becomes the count of one filtered page, `totalPages`
+ * collapses to 1, and a client reading "there is no next page" stops with the
+ * rest of what it may see unreachable.
+ *
+ * @module dispatcher/handlers/__tests__/collection-dispatcher-list-allowlist
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ServiceContainer } from "../../../services";
+import { readableSlugAllowlist } from "../../../services/lib/readable-slug-allowlist";
+import { dispatchCollections } from "../collection-dispatcher";
+
+// Mocked at the SHARED resolver, which is the seam the handler calls. Mocking
+// the helpers underneath it would keep passing after the handler stopped
+// asking them, which is the drift the extraction removed.
+vi.mock("../../../services/lib/readable-slug-allowlist", () => ({
+  readableSlugAllowlist: vi.fn(),
+}));
+
+const allowlistFor = vi.mocked(readableSlugAllowlist);
+
+function containerReturning(listCollections: ReturnType<typeof vi.fn>) {
+  return { collections: { listCollections } } as unknown as ServiceContainer;
+}
+
+/** The legacy envelope the metadata service answers with. */
+function serviceResult(slugs: string[], total = slugs.length) {
+  return {
+    success: true,
+    statusCode: 200,
+    message: "Collections fetched successfully",
+    data: slugs.map(slug => ({ slug, name: slug })),
+    meta: { total, page: 1, limit: 10, totalPages: Math.ceil(total / 10) },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("listCollections resolves its allowlist before querying", () => {
+  it("passes the reader's readable slugs INTO the query", async () => {
+    // 🔴 The allowlist has to reach the service, because only there can it
+    // reach the WHERE clause that both the count and the page read. Handed the
+    // rows afterwards, no amount of filtering can repair a total that was
+    // computed over a different set.
+    allowlistFor.mockResolvedValue(["pages", "posts"]);
+    const listCollections = vi.fn().mockResolvedValue(serviceResult(["posts"]));
+
+    await dispatchCollections(
+      containerReturning(listCollections),
+      "listCollections",
+      { page: "1", limit: "10", _authenticatedUserId: "u1" },
+      undefined
+    );
+
+    const passed = listCollections.mock.calls[0][0];
+    expect([...passed.slugAllowlist].sort()).toEqual(["pages", "posts"]);
+    // Asked about THIS caller, so a handler passing a constant fails here
+    // rather than merely passing something list-shaped.
+    expect(allowlistFor).toHaveBeenCalledWith("u1");
+  });
+
+  it("passes NO allowlist for a super admin", async () => {
+    // The control in the permissive direction: a super admin sees everything,
+    // and `undefined` is how the registry is told not to filter. An empty
+    // array here would hide every collection from them.
+    allowlistFor.mockResolvedValue(undefined);
+    const listCollections = vi.fn().mockResolvedValue(serviceResult(["posts"]));
+
+    await dispatchCollections(
+      containerReturning(listCollections),
+      "listCollections",
+      { page: "1", limit: "10", _authenticatedUserId: "admin" },
+      undefined
+    );
+
+    expect(listCollections.mock.calls[0][0].slugAllowlist).toBeUndefined();
+  });
+
+  it("passes an EMPTY allowlist for a reader granted nothing", async () => {
+    // 🔴 Distinct from the super-admin case above, and the distinction is the
+    // whole gate: `undefined` means "no filter", `[]` means "nothing is
+    // visible". Collapsing them shows every collection to a reader with no
+    // grants at all.
+    allowlistFor.mockResolvedValue([]);
+    const listCollections = vi.fn().mockResolvedValue(serviceResult([], 0));
+
+    await dispatchCollections(
+      containerReturning(listCollections),
+      "listCollections",
+      { page: "1", limit: "10", _authenticatedUserId: "u2" },
+      undefined
+    );
+
+    expect(listCollections.mock.calls[0][0].slugAllowlist).toEqual([]);
+  });
+
+  it("SHIPS the meta the service returned, rather than recomputing it", async () => {
+    // 🔴 The defect this replaces. The handler used to rebuild `total` and
+    // `totalPages` from the filtered page, so a reader with rows on later
+    // pages was told there was one page of them. The service counted with the
+    // allowlist applied, so its meta is the answer.
+    allowlistFor.mockResolvedValue(["pages", "posts"]);
+    const listCollections = vi.fn().mockResolvedValue({
+      success: true,
+      statusCode: 200,
+      message: "ok",
+      data: [{ slug: "posts", name: "posts" }],
+      meta: { total: 42, page: 1, limit: 1, totalPages: 42 },
+    });
+
+    const result = (await dispatchCollections(
+      containerReturning(listCollections),
+      "listCollections",
+      { page: "1", limit: "1", _authenticatedUserId: "u1" },
+      undefined
+    )) as Response;
+
+    const body = (await result.json()) as {
+      meta: { total: number; totalPages: number; hasNext: boolean };
+    };
+    expect(body.meta.total).toBe(42);
+    expect(body.meta.totalPages).toBe(42);
+    // The consequence a client acts on: there IS a next page, and the old
+    // rebuild reported false here for every reader who was not a super admin.
+    expect(body.meta.hasNext).toBe(true);
+  });
+});

--- a/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
@@ -77,10 +77,7 @@ import {
 import type { ServiceContainer } from "../../services";
 import type { WhereFilter } from "../../services/collections/query-operators";
 import type { CollectionsHandler } from "../../services/collections-handler";
-import {
-  isSuperAdmin,
-  listEffectivePermissions,
-} from "../../services/lib/permissions";
+import { readableSlugAllowlist } from "../../services/lib/readable-slug-allowlist";
 import { SKIP_TIMEZONE_FORMAT_HEADER } from "../../shared/lib/date-formatting";
 import {
   readAuthenticatedActor,
@@ -402,11 +399,26 @@ const COLLECTIONS_METHODS: Record<
   },
   listCollections: {
     // Translates the legacy CollectionServiceResult `{ data, meta }`
-    // envelope to the canonical `{ items, meta }` body. Permission
-    // filtering (non-super-admins only see collections they can read)
-    // runs after unwrap so the meta we ship reflects the FILTERED
-    // counts, not the pre-filter totals.
+    // envelope to the canonical `{ items, meta }` body.
+    //
+    // 🔴 Permission filtering runs BEFORE the query, as a slug allowlist the
+    // registry puts in its WHERE clause. Filtering the returned page instead
+    // made the meta describe a different set from the rows: `total` became the
+    // count of one filtered page, so `totalPages` collapsed to 1 and `hasNext`
+    // was false however many pages the reader could actually see. A client
+    // reading that stops at the first page, and everything past it is
+    // unreachable. The singles dispatcher resolves its allowlist the same way.
     execute: async (svc, p) => {
+      const userId = p._authenticatedUserId
+        ? String(p._authenticatedUserId)
+        : undefined;
+
+      // The SHARED resolver, which the singles listing asks too. `undefined`
+      // means no filter — an unauthenticated caller, gated at the route layer,
+      // or a super admin. An empty list means nothing is visible, which the
+      // registry short-circuits to a zero-row, zero-total answer.
+      const slugAllowlist = await readableSlugAllowlist(userId);
+
       const result = await svc.listCollections({
         page: toNumber(p.page),
         limit: toNumber(p.limit),
@@ -418,6 +430,7 @@ const COLLECTIONS_METHODS: Record<
           | "updatedAt"
           | undefined,
         sortOrder: p.sortOrder as "asc" | "desc" | undefined,
+        slugAllowlist,
       });
       // Service returns legacy { success, data, meta }. Unwrap throws on
       // failure (which the dispatcher converts to a NextlyError response).
@@ -445,46 +458,9 @@ const COLLECTIONS_METHODS: Record<
             : 1,
       };
 
-      const userId = p._authenticatedUserId
-        ? String(p._authenticatedUserId)
-        : undefined;
-      if (!userId) {
-        return respondList(items, toPaginationMeta(baseMeta));
-      }
-
-      const superAdmin = await isSuperAdmin(userId);
-      if (superAdmin) {
-        return respondList(items, toPaginationMeta(baseMeta));
-      }
-
-      // Non-super-admin: filter the page to collections this user can
-      // actually read. We rebuild total + totalPages on the filtered
-      // array so the admin's pagination footer matches what the user
-      // actually sees.
-      const permissionPairs = await listEffectivePermissions(userId);
-      const readableResources = new Set(
-        permissionPairs
-          .filter(pair => pair.endsWith(":read"))
-          .map(pair => pair.split(":")[0])
-      );
-
-      type CollectionItem = { slug?: string; name?: string };
-      const filtered = (items as CollectionItem[]).filter(collection => {
-        const slug = collection?.slug ?? collection?.name;
-        return slug ? readableResources.has(String(slug)) : false;
-      });
-
-      const filteredMeta = {
-        total: filtered.length,
-        page: baseMeta.page,
-        limit: baseMeta.limit,
-        totalPages:
-          baseMeta.limit > 0
-            ? Math.max(1, Math.ceil(filtered.length / baseMeta.limit))
-            : 1,
-      };
-
-      return respondList(filtered, toPaginationMeta(filteredMeta));
+      // The rows and the meta now describe one set, because the allowlist was
+      // a condition on the query that produced both.
+      return respondList(items, toPaginationMeta(baseMeta));
     },
   },
   getCollection: {

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -81,10 +81,7 @@ import { withSessionCacheHeaders } from "../../routeHandler";
 import { getProductionNotifier } from "../../runtime/notifications/index";
 import { isReservedResourceSlug } from "../../schemas/_zod/rbac";
 import type { FieldDefinition } from "../../schemas/dynamic-collections";
-import {
-  isSuperAdmin,
-  listEffectivePermissions,
-} from "../../services/lib/permissions";
+import { readableSlugAllowlist } from "../../services/lib/readable-slug-allowlist";
 import { assertGlobalResourceSlugAvailable } from "../../services/lib/resource-slug-guard";
 import { SKIP_TIMEZONE_FORMAT_HEADER } from "../../shared/lib/date-formatting";
 import {
@@ -480,26 +477,13 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
         ? String(p._authenticatedUserId)
         : undefined;
 
-      // Resolve the per-user readable-slug allowlist BEFORE the registry
-      // call. Super admins (and unauthenticated callers, who are gated at
-      // the route layer) pass through with `slugAllowlist: undefined`,
-      // which means "no filter". Authenticated non-super-admins get an
-      // explicit list (possibly empty); the registry short-circuits an
-      // empty list to a zero-row, zero-total response.
-      let slugAllowlist: string[] | undefined;
-      if (userId) {
-        const superAdmin = await isSuperAdmin(userId);
-        if (!superAdmin) {
-          const permissionPairs = await listEffectivePermissions(userId);
-          slugAllowlist = Array.from(
-            new Set(
-              permissionPairs
-                .filter(pair => pair.endsWith(":read"))
-                .map(pair => pair.split(":")[0])
-            )
-          );
-        }
-      }
+      // Resolved BEFORE the registry call, through the SHARED resolver the
+      // collections listing asks too. Super admins and unauthenticated callers
+      // (gated at the route layer) pass through with `undefined`, which means
+      // "no filter"; an authenticated non-super-admin gets an explicit list,
+      // possibly empty, which the registry short-circuits to a zero-row,
+      // zero-total response.
+      const slugAllowlist = await readableSlugAllowlist(userId);
 
       const result = await svc.registry.listSingles({
         source: p.source as "code" | "ui" | "built-in" | undefined,

--- a/packages/nextly/src/domains/collections/services/collection-metadata-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-metadata-service.ts
@@ -496,6 +496,11 @@ export class CollectionMetadataService extends BaseService {
     sortBy?: "name" | "slug" | "createdAt" | "updatedAt";
     sortOrder?: "asc" | "desc";
     includeSchema?: boolean;
+    /**
+     * Restrict results to these slugs, applied as a query condition so the
+     * `total` this returns counts only rows the caller may see.
+     */
+    slugAllowlist?: string[];
   }): Promise<MetadataServiceResult> {
     try {
       // Include schema by default since the UI needs field counts

--- a/packages/nextly/src/domains/dynamic-collections/__tests__/dynamic-collection-registry-service.allowlist.integration.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/__tests__/dynamic-collection-registry-service.allowlist.integration.test.ts
@@ -1,0 +1,186 @@
+// The permission allowlist has to be a CONDITION on the query, because the
+// `total` this returns is what a client pages by.
+//
+// Filtering the returned page in application code instead makes the rows and
+// the meta describe different sets: the total becomes the count of one
+// filtered page, so `totalPages` collapses to 1 and a client reading "there is
+// no next page" stops with the rest of what it may see unreachable. It also
+// reports how many rows exist that the reader is not allowed to see.
+
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { describe, expect, it, afterEach, beforeEach } from "vitest";
+
+import { sqliteTableDdl } from "../../../__tests__/fixtures/sqlite-table-ddl";
+import { dynamicCollectionsSqlite } from "../../../schemas/dynamic-collections/sqlite";
+import { DynamicCollectionRegistryService } from "../services/dynamic-collection-registry-service";
+
+// The constructor's own parameter type, read off the class rather than
+// restated: a logger shape written out here would keep compiling after the
+// real one gained a method, and this fixture would then stand in for something
+// production no longer accepts.
+type RegistryLogger = ConstructorParameters<
+  typeof DynamicCollectionRegistryService
+>[1];
+
+const noopLogger: RegistryLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+} as unknown as RegistryLogger;
+
+describe("DynamicCollectionRegistryService.listCollections — slugAllowlist", () => {
+  let sqlite: Database.Database;
+  let registry: DynamicCollectionRegistryService;
+
+  beforeEach(() => {
+    sqlite = new Database(":memory:");
+    sqlite.pragma("foreign_keys = OFF");
+
+    // Built from the schema the service reads, so this fixture cannot fall
+    // behind the table it stands in for — which matters because every case
+    // here asks for a projection, and the wide one names every column.
+    for (const statement of sqliteTableDdl(dynamicCollectionsSqlite)) {
+      sqlite.exec(statement);
+    }
+
+    // Insert three rows with deliberately non-alphabetical createdAt order so
+    // sort-by-createdAt and sort-by-name diverge:
+    //   created in this order: zebra (oldest), alpha (middle), mango (newest)
+    //   alphabetical by slug:  alpha, mango, zebra
+    const baseTime = 1_700_000_000;
+    const insert = sqlite.prepare(
+      `INSERT INTO dynamic_collections
+         (id, slug, table_name, labels, fields, timestamps, status, localized,
+          source, locked, schema_hash, schema_version, migration_status,
+          created_at, updated_at)
+       VALUES (@id, @slug, @tableName, @labels, '[]', 1, 0, 0,
+          'ui', 0, @schemaHash, 1, 'pending',
+          @createdAt, @createdAt)`
+    );
+    const seed = (slug: string, schemaHash: string, createdAt: number) =>
+      insert.run({
+        id: `id-${slug}`,
+        slug,
+        tableName: `dc_${slug}`,
+        labels: JSON.stringify({ singular: slug, plural: `${slug}s` }),
+        schemaHash,
+        createdAt,
+      });
+    seed("zebra", "h1", baseTime);
+    seed("alpha", "h2", baseTime + 100);
+    seed("mango", "h3", baseTime + 200);
+
+    const db = drizzle({ client: sqlite });
+    const adapter = {
+      getDrizzle: <T>() => db as T,
+      // The values @nextlyhq/adapter-sqlite reports. A fixture that claims a
+      // capability the real adapter does not have steers the query builder
+      // down a branch production never takes.
+      getCapabilities: () => ({
+        dialect: "sqlite" as const,
+        supportsJsonb: false,
+        supportsJson: true,
+        supportsArrays: false,
+        supportsGeneratedColumns: true,
+        supportsFts: true,
+        supportsIlike: false,
+        supportsReturning: true,
+        supportsSavepoints: true,
+        supportsOnConflict: true,
+        maxParamsPerQuery: 999,
+        maxIdentifierLength: 128,
+      }),
+    } satisfies Pick<DrizzleAdapter, "getDrizzle" | "getCapabilities">;
+
+    // `satisfies` checks the two members the registry reaches for against the
+    // adapter's own declarations, so a signature change fails here rather than
+    // leaving this suite exercising a shape production no longer accepts.
+    registry = new DynamicCollectionRegistryService(
+      adapter as unknown as DrizzleAdapter,
+      noopLogger
+    );
+  });
+
+  afterEach(() => {
+    // better-sqlite3 holds a native handle per in-memory database, and this
+    // suite opens one per test.
+    sqlite.close();
+  });
+
+  it("counts only the collections the allowlist names", async () => {
+    // 🔴 The property that was broken. `total` is what a client turns into
+    // pages, so counting rows the reader may not see reports pages that hold
+    // nothing for them -- and, filtered after the fact instead, reports ONE
+    // page however many there really are.
+    const result = await registry.listCollections({
+      slugAllowlist: ["alpha", "mango"],
+      limit: 10,
+    });
+
+    expect(result.collections.map(c => c.slug).sort()).toEqual([
+      "alpha",
+      "mango",
+    ]);
+    expect(result.total).toBe(2);
+  });
+
+  it("pages the ALLOWED rows, so a second page exists when it should", async () => {
+    // 🔴 The consequence, asserted as the reader meets it. With the filter
+    // applied after a page was fetched, `totalPages` is computed from one
+    // page's worth of survivors and comes out as 1 -- so this second page is
+    // unreachable, and the collection on it cannot be opened from the list.
+    const first = await registry.listCollections({
+      slugAllowlist: ["alpha", "mango"],
+      limit: 1,
+      page: 1,
+      sortBy: "slug",
+      sortOrder: "asc",
+    });
+    const second = await registry.listCollections({
+      slugAllowlist: ["alpha", "mango"],
+      limit: 1,
+      page: 2,
+      sortBy: "slug",
+      sortOrder: "asc",
+    });
+
+    expect(first.totalPages).toBe(2);
+    expect(first.collections.map(c => c.slug)).toEqual(["alpha"]);
+    expect(second.collections.map(c => c.slug)).toEqual(["mango"]);
+  });
+
+  it("answers an EMPTY allowlist with nothing, rather than everything", async () => {
+    // 🔴 The direction that would be a disclosure, and it is one character
+    // away: `if (slugAllowlist?.length)` reads an empty list as "no filter"
+    // and hands back every collection in the install to a reader allowed none.
+    //
+    // This asserts the OUTCOME rather than the early return above it. That
+    // short-circuit exists to skip a pointless round trip and to avoid
+    // emitting `WHERE slug IN ()`, whose meaning is dialect-specific — neither
+    // of which is visible in the result, so removing it moves nothing here.
+    const result = await registry.listCollections({
+      slugAllowlist: [],
+      limit: 10,
+    });
+
+    expect(result.collections).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+
+  it("applies NO filter when the allowlist is absent", async () => {
+    // The control. A registry that always filtered would satisfy every case
+    // above and hide every collection from the super-admin path, which passes
+    // no allowlist precisely because it may see them all.
+    const result = await registry.listCollections({ limit: 10 });
+
+    expect(result.total).toBe(3);
+    expect(result.collections.map(c => c.slug).sort()).toEqual([
+      "alpha",
+      "mango",
+      "zebra",
+    ]);
+  });
+});

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-registry-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-registry-service.ts
@@ -1,5 +1,5 @@
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
-import { eq, and, or, like, asc, desc, count } from "drizzle-orm";
+import { eq, and, or, like, asc, desc, count, inArray } from "drizzle-orm";
 
 import { NextlyError } from "../../../errors";
 import type { RevalidateConfig } from "../../../revalidation/types";
@@ -102,6 +102,21 @@ export interface ListCollectionsOptions {
   sortOrder?: "asc" | "desc";
   includeSchema?: boolean;
   source?: "code" | "ui" | "built-in";
+  /**
+   * Restrict results to collections whose `slug` is in this list.
+   *
+   * 🔴 Applied in the WHERE clause, so the COUNT and the page see the same
+   * rows. A caller that filters the returned page in application code instead
+   * gets a `total` describing rows the reader may not see -- which both leaks
+   * how many exist and collapses `totalPages` to 1, because the recomputed
+   * total is at most one page. The consumer then reads "there is no next page"
+   * and stops, with the rest of what it may see unreachable.
+   *
+   * `undefined` means no allowlist. `[]` means nothing is visible and
+   * short-circuits, rather than emitting `WHERE slug IN ()`, whose meaning
+   * differs by dialect.
+   */
+  slugAllowlist?: string[];
 }
 
 export interface ListCollectionsResponse<
@@ -345,9 +360,30 @@ export class DynamicCollectionRegistryService extends BaseService {
       sortOrder = "desc",
       includeSchema = true as TIncludeSchema,
       source,
+      slugAllowlist,
     } = options || {};
 
+    // An empty allowlist means the caller may see nothing. Answered here
+    // rather than as a query, because `WHERE slug IN ()` is a dialect-specific
+    // footgun and because a zero-row read is work nobody needs done.
+    if (slugAllowlist && slugAllowlist.length === 0) {
+      return {
+        collections: [],
+        total: 0,
+        page,
+        limit,
+        totalPages: 0,
+      };
+    }
+
     const conditions = [];
+
+    // 🔴 A CONDITION, not a filter over the result. Both the count below and
+    // the page query read `whereClause`, so the total describes exactly the
+    // rows this caller may see and `totalPages` counts pages of those.
+    if (slugAllowlist) {
+      conditions.push(inArray(this.dynamicCollections.slug, slugAllowlist));
+    }
 
     if (search) {
       const searchPattern = `%${search}%`;

--- a/packages/nextly/src/services/collections-handler.ts
+++ b/packages/nextly/src/services/collections-handler.ts
@@ -429,6 +429,12 @@ export class CollectionsHandler {
     sortBy?: "name" | "slug" | "createdAt" | "updatedAt";
     sortOrder?: "asc" | "desc";
     includeSchema?: boolean;
+    /**
+     * Restrict results to these slugs. Carried through to the registry's WHERE
+     * clause, so the `total` and `totalPages` this returns count only rows the
+     * caller may see.
+     */
+    slugAllowlist?: string[];
   }) {
     return this.metadataService.listCollections(options);
   }

--- a/packages/nextly/src/services/lib/readable-slug-allowlist.test.ts
+++ b/packages/nextly/src/services/lib/readable-slug-allowlist.test.ts
@@ -1,0 +1,72 @@
+/**
+ * The allowlist has THREE answers, and collapsing any two is a defect.
+ *
+ * Both list endpoints that scope by permission read this, and the registries
+ * turn its result into a WHERE clause — so `undefined` and `[]` are not two
+ * spellings of "nothing to filter by". One means every row, the other means no
+ * rows, and a caller that treats them alike shows a reader with no grants the
+ * entire install.
+ *
+ * @module services/lib/readable-slug-allowlist.test
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const isSuperAdmin = vi.fn();
+const listEffectivePermissions = vi.fn();
+
+// The two collaborators are stubbed; the resolver under test is the real one.
+// It lives in its own module precisely so this substitution works — a function
+// calling its neighbours through module-local references cannot have them
+// replaced, and the test would then drive the real permission service.
+vi.mock("./permissions", () => ({ isSuperAdmin, listEffectivePermissions }));
+
+const { readableSlugAllowlist } = await import("./readable-slug-allowlist");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("which slugs a caller may read", () => {
+  it("answers UNDEFINED for a super admin, which means no filter", async () => {
+    isSuperAdmin.mockResolvedValue(true);
+
+    await expect(readableSlugAllowlist("admin")).resolves.toBeUndefined();
+    // The grants are never read: a super admin's answer does not depend on
+    // them, and asking would be a query per listing for a decided outcome.
+    expect(listEffectivePermissions).not.toHaveBeenCalled();
+  });
+
+  it("answers UNDEFINED for no caller at all", async () => {
+    // Unauthenticated callers are gated at the route layer; reaching here with
+    // no id is not a licence to filter by an empty set.
+    await expect(readableSlugAllowlist(undefined)).resolves.toBeUndefined();
+    expect(isSuperAdmin).not.toHaveBeenCalled();
+  });
+
+  it("answers an EMPTY LIST for a caller granted no reads", async () => {
+    // 🔴 Distinct from `undefined`, and this is the whole gate. Returning
+    // `undefined` here would mean "no filter" and hand every collection and
+    // single in the install to a caller holding none.
+    isSuperAdmin.mockResolvedValue(false);
+    listEffectivePermissions.mockResolvedValue(["media:write", "users:update"]);
+
+    await expect(readableSlugAllowlist("u1")).resolves.toEqual([]);
+  });
+
+  it("keeps only the READ half of each grant, de-duplicated", async () => {
+    // A write grant is not a read grant, and the resource is the half before
+    // the colon. Passing pairs through whole would filter on strings no slug
+    // column ever holds, which reads as "this caller may see nothing".
+    isSuperAdmin.mockResolvedValue(false);
+    listEffectivePermissions.mockResolvedValue([
+      "posts:read",
+      "pages:read",
+      "posts:read",
+      "posts:delete",
+    ]);
+
+    const allowlist = await readableSlugAllowlist("u1");
+
+    expect([...(allowlist ?? [])].sort()).toEqual(["pages", "posts"]);
+  });
+});

--- a/packages/nextly/src/services/lib/readable-slug-allowlist.ts
+++ b/packages/nextly/src/services/lib/readable-slug-allowlist.ts
@@ -1,0 +1,48 @@
+/**
+ * The slugs a caller may READ, as a registry allowlist.
+ *
+ * 🔴 One implementation, because two list endpoints ask it and a disagreement
+ * between them is a disclosure rather than a cosmetic difference. Collections
+ * and singles both scope their listing by this, and the registries turn it
+ * into a WHERE clause so the row COUNT describes the same set as the rows —
+ * which is the property that breaks when a caller filters the page instead.
+ *
+ * Its own module rather than a member of `permissions`, because that is what
+ * makes it testable: a function calling its neighbours through module-local
+ * references cannot have them substituted, so a test would exercise the real
+ * permission service and answer from a container it has no business needing.
+ *
+ * @module services/lib/readable-slug-allowlist
+ */
+import { isSuperAdmin, listEffectivePermissions } from "./permissions";
+
+/**
+ * `undefined` for no filter, `[]` for nothing visible, or the readable slugs.
+ *
+ * The three answers are distinct and collapsing any two is a defect:
+ *
+ * - `undefined` — no filter. An unauthenticated caller, gated at the route
+ *   layer, and a super admin, who may see everything.
+ * - `[]` — nothing is visible. A caller holding no read grant at all. Returned
+ *   as an empty list rather than as `undefined`, because the registries read
+ *   the difference: one means "every row", the other means "no rows".
+ * - a non-empty list — exactly the resources this caller may read.
+ *
+ * Derived from the `{resource}:{action}` pairs the permission service already
+ * publishes, so a change to how a grant is spelled reaches both endpoints.
+ */
+export async function readableSlugAllowlist(
+  userId: string | undefined
+): Promise<string[] | undefined> {
+  if (!userId) return undefined;
+  if (await isSuperAdmin(userId)) return undefined;
+
+  const permissionPairs = await listEffectivePermissions(userId);
+  return Array.from(
+    new Set(
+      permissionPairs
+        .filter(pair => pair.endsWith(":read"))
+        .map(pair => pair.split(":")[0])
+    )
+  );
+}


### PR DESCRIPTION
Listing collections fetched a page and *then* removed the rows the caller may not read, rebuilding `total` and `totalPages` from what survived.

The rows and the meta then described different sets. `total` became the number of survivors on **one** page, so `totalPages` collapsed to 1 and `hasNext` was `false` however many pages the reader could actually reach. A client reads that as "there is no next page" and stops — leaving every collection past the first page unreachable for any non-super-admin. The pre-filter count it replaced had the opposite problem: it reported how many collections exist that the reader is *not* allowed to see.

You cannot page first and filter second and report honest totals.

## The fix

The registry takes a `slugAllowlist` and puts it in the `WHERE` clause, so the `COUNT` and the page query read the same rows. The handler resolves the list before calling and ships the meta the service returned.

**This mechanism already existed.** `BaseListOptions.slugAllowlist` has carried it for the singles listing all along, and its docblock describes this exact failure:

> *"callers that filter rows in application code after a paginated fetch end up with an inflated `total` (leaks counts of hidden records) and `hasNext` flags that drive clients into wasted pagination loops."*

The collections path simply never used it. `DynamicCollectionRegistryService` is a separate Drizzle implementation from the base registry, so it needed the option adding — but the singles dispatcher's shape was the model to copy.

## One resolver, not two

Both listings had their own copy of "which slugs may this caller read". `readableSlugAllowlist` is now that question, once.

It lives in its own module deliberately: a function calling its neighbours through module-local references cannot have them substituted, so a test would drive the real permission service. Moving it made the seam testable — the first version of its test failed for exactly that reason rather than passing vacuously.

Its **three** answers stay distinct, and collapsing any two is the defect:

| answer | meaning |
| --- | --- |
| `undefined` | no filter — unauthenticated (gated upstream) or super admin |
| `[]` | **no rows visible** — a caller holding no read grant |
| `["posts", …]` | exactly these |

Reading `[]` as "no filter" is one `?.length` away and hands every collection in the install to a caller granted none.

## Verification

Twelve tests across three levels, each break-verified against a wrong implementation:

| level | break | fails |
| --- | --- | --- |
| registry (integration, real SQLite) | filter after the query instead of in `WHERE` | the count and the second-page tests |
| registry | `if (slugAllowlist?.length)` — the truthiness slip | the empty-allowlist test |
| registry | filter always, even with no allowlist | the no-filter control |
| handler | previous behaviour: no allowlist, rebuild the meta | 3 of 4 |
| handler | treat a super admin like anyone else | the super-admin control |
| handler | keep every grant, not only `:read` | 2 of 4 |
| resolver | collapse `[]` into `undefined` | the empty-list test |
| resolver | super admin gets `[]` | the no-filter test |

One honest note: the registry's empty-allowlist short-circuit is an optimisation whose absence is *not* observable in the result — removing it moves no test. The test asserts the outcome instead, and says so.

Local gates: build 0, check-types 42/42, lint 24/24, `nextly` 11137, integration 1494, `admin` 3893, comment convention 0, `changeset status` clean, fallow `pass` with every `*_introduced` at 0.