### PR TITLE
feat(blocks-engine): resolve component instances into the page that references them

### DIFF
--- a/.changeset/a-page-can-draw-the-components-it-references.md
+++ b/.changeset/a-page-can-draw-the-components-it-references.md
@@ -1,0 +1,46 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A page could reference a reusable component and nothing would draw it. The
+reference is one node holding a component id, a variant name and a set of
+overrides; what a reader has to render is that component's whole tree, with the
+overrides applied and the page's own slot content in place of the component's
+defaults. Nothing turned the first into the second.
+
+The blocks engine now resolves them. Every inlined node is identified from the
+instance and the node it came from, so one page produces the same ids on every
+render and two instances of one component never collide — which is what lets
+styles, editor history and React keys go on addressing them. A variant's values
+apply first and the instance's own beat them, and an override can clear a value
+rather than only replace it, so an author can empty a subtitle the component
+fills in.
+
+A component that cannot be inlined — not published yet, containing itself, or
+nested past the composition limit — costs its own region rather than the page:
+the reference stays where it is, marked with why, and the rest of the page
+renders.

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -88,6 +88,12 @@ export {
   MAX_ENVELOPE_ENTRIES,
   MAX_DEPTH,
   MAX_NODES,
+  // The nesting cap the resolver enforces. Public alongside `MAX_DEPTH`
+  // because it bounds a different thing — how many levels of COMPOSITION a
+  // page may reach, not how deep one stored tree nests — and an editor that
+  // refuses to place an instance has to refuse at the same number the render
+  // does, or it offers a placement that then draws a placeholder.
+  MAX_COMPOSED_DEPTH,
   DEFAULT_MAX_DOCUMENT_BYTES,
   LIMIT_WARNING_RATIO,
   DEFAULT_SLOT,
@@ -134,6 +140,30 @@ export type {
 } from "./select-nodes";
 
 export { measureBytes, surveyDocument } from "./measure-bytes";
+// Resolving linked components. Here rather than beside the renderer because
+// four surfaces need a resolved tree and only one of them renders: the
+// same-document canvas, the class-usage index and SEO derivation all read one
+// without drawing anything. `componentIdsIn` is the other half of the seam —
+// what to FETCH, asked before anything can be resolved.
+export {
+  componentIdsIn,
+  resolveComponentInstances,
+  // Why an instance was left standing. Published because the surfaces that
+  // REPORT one are in other packages — the renderer draws a placeholder, the
+  // editor offers a remedy — and each remedy differs by reason. A consumer
+  // restating the list agrees on the day it is written and silently stops
+  // handling whichever reason is added next.
+  COMPONENT_UNRESOLVED_REASONS,
+} from "./resolve-instances";
+export type {
+  ComponentUnresolvedReason,
+  DefinitionsById,
+  ResolveComponentOptions,
+  ResolvedBlockNode,
+  ResolvedComposition,
+  ResolvedDocument,
+  UnresolvedInstance,
+} from "./resolve-instances";
 // The nesting rule and the types it answers in. Exported together: a caller
 // that can ask the question must be able to name the verdict it gets back, and
 // a refusal reason it cannot name is one it has to re-derive from the boolean.

--- a/packages/blocks-engine/src/limits.ts
+++ b/packages/blocks-engine/src/limits.ts
@@ -12,6 +12,28 @@ export const MAX_DEPTH = 12;
 export const MAX_NODES = 5000;
 
 /**
+ * Maximum levels of component nesting a resolved tree may reach.
+ *
+ * Separate from {@link MAX_DEPTH}, and neither bounds the other. `MAX_DEPTH`
+ * limits one STORED document; an instance is a single node there whatever its
+ * definition holds, so a page at depth 1 can resolve to a tree of any depth.
+ * This is the cap on that expansion.
+ *
+ * Small, because the growth is multiplicative rather than additive: every level
+ * can expand one node into a whole definition, so depth is the exponent on how
+ * much work one page costs. It is not a cap on how much a designer may
+ * compose — a header made of a nav made of a button is three, and past a
+ * handful nobody can predict what editing a definition will change.
+ *
+ * A document that exceeds it fails PER INSTANCE. The instance that would cross
+ * the line is left unresolved and the rest of the page renders, because the
+ * alternative — refusing the page — hands a visitor a blank screen for a
+ * problem in one region of it. Storyblok truncates at depth two and says
+ * nothing; the truncation is the same, the report is the difference.
+ */
+export const MAX_COMPOSED_DEPTH = 5;
+
+/**
  * Maximum entries in one collection of a component's envelope.
  *
  * Its own limit rather than {@link MAX_NODES}, because the envelope is not

--- a/packages/blocks-engine/src/resolve-instances.test.ts
+++ b/packages/blocks-engine/src/resolve-instances.test.ts
@@ -1,0 +1,640 @@
+/**
+ * What a page holds after its linked components have been inlined.
+ *
+ * The properties under test are the ones a consumer cannot re-derive: that an
+ * untouched page is the SAME object, that the ids are the same on every render,
+ * that an instance's own values beat the variant's, and that a component which
+ * cannot be inlined costs its own region rather than the page.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  COMPONENT_INSTANCE_TYPE,
+  DOCUMENT_FORMAT_VERSION,
+  type BlockDocument,
+  type BlockNode,
+  type ComponentDocument,
+} from "./document";
+import { DEFAULT_LIMITS } from "./limits";
+import {
+  componentIdsIn,
+  resolveComponentInstances,
+  type DefinitionsById,
+  type ResolvedBlockNode,
+  type ResolvedDocument,
+} from "./resolve-instances";
+
+const node = (id: string, extra: Partial<BlockNode> = {}): BlockNode => ({
+  id,
+  type: "core/text",
+  version: 1,
+  props: {},
+  ...extra,
+});
+
+const box = (
+  id: string,
+  children: BlockNode[],
+  visibility?: BlockNode["visibility"]
+): BlockNode =>
+  node(id, {
+    type: "core/box",
+    slots: { children },
+    ...(visibility === undefined ? {} : { visibility }),
+  });
+
+const instance = (
+  id: string,
+  componentId: string,
+  props: Record<string, unknown> = {},
+  extra: Partial<BlockNode> = {}
+): BlockNode => ({
+  id,
+  type: COMPONENT_INSTANCE_TYPE,
+  version: 1,
+  props: { componentId, ...props },
+  ...extra,
+});
+
+const page = (nodes: BlockNode[]): BlockDocument => ({
+  formatVersion: DOCUMENT_FORMAT_VERSION,
+  kind: "page",
+  nodes,
+});
+
+const component = (
+  nodes: BlockNode[],
+  envelope: Partial<ComponentDocument> = {}
+): ComponentDocument => ({
+  formatVersion: DOCUMENT_FORMAT_VERSION,
+  kind: "component",
+  nodes,
+  ...envelope,
+});
+
+const defs = (entries: Record<string, BlockDocument>): DefinitionsById =>
+  new Map(Object.entries(entries));
+
+/** Every node of a resolved forest, in document order. */
+function flatten(nodes: readonly ResolvedBlockNode[]): ResolvedBlockNode[] {
+  const out: ResolvedBlockNode[] = [];
+  for (const entry of nodes) {
+    out.push(entry);
+    for (const children of Object.values(entry.slots ?? {})) {
+      out.push(...flatten(children));
+    }
+  }
+  return out;
+}
+
+const idsOf = (doc: ResolvedDocument): string[] =>
+  flatten(doc.nodes).map(entry => entry.id);
+
+const byInstanceOf = (
+  doc: ResolvedDocument,
+  instanceId: string
+): ResolvedBlockNode[] =>
+  flatten(doc.nodes).filter(entry => entry.instanceOf === instanceId);
+
+describe("resolveComponentInstances", () => {
+  it("returns the same document object when the page holds no instance", () => {
+    const doc = page([node("a"), box("b", [node("c")])]);
+
+    const result = resolveComponentInstances(doc, defs({}));
+
+    expect(result.document).toBe(doc);
+    expect(result.referenced).toEqual([]);
+    expect(result.unresolved).toEqual([]);
+  });
+
+  it("composes nothing in a document that is already past the node budget", () => {
+    const doc = page([node("a"), node("b"), instance("i1", "hero")]);
+    const definitions = defs({ hero: component([node("d1")]) });
+
+    const result = resolveComponentInstances(doc, definitions, {
+      limits: { ...DEFAULT_LIMITS, maxNodes: 2 },
+    });
+
+    expect(result.document).toBe(doc);
+    expect(result.unresolved).toEqual([]);
+  });
+
+  it("replaces one instance with every root of its definition", () => {
+    const doc = page([instance("i1", "hero")]);
+    const definitions = defs({
+      hero: component([node("d1"), node("d2")]),
+    });
+
+    const result = resolveComponentInstances(doc, definitions);
+
+    expect(result.document.nodes).toHaveLength(2);
+    expect(result.document.nodes.map(entry => entry.type)).toEqual([
+      "core/text",
+      "core/text",
+    ]);
+    expect(idsOf(result.document)).not.toContain("d1");
+  });
+
+  it("gives two instances of one definition different ids", () => {
+    const doc = page([instance("i1", "hero"), instance("i2", "hero")]);
+    const definitions = defs({ hero: component([node("d1")]) });
+
+    const ids = idsOf(resolveComponentInstances(doc, definitions).document);
+
+    expect(ids).toHaveLength(2);
+    expect(ids[0]).not.toBe(ids[1]);
+  });
+
+  it("mints the same ids on every resolution of one page", () => {
+    const doc = page([instance("i1", "hero"), instance("i2", "hero")]);
+    const definitions = defs({
+      hero: component([box("d1", [node("d2"), node("d3")])]),
+    });
+
+    const first = resolveComponentInstances(doc, definitions).document;
+    const second = resolveComponentInstances(doc, definitions).document;
+
+    expect(idsOf(first)).toEqual(idsOf(second));
+    expect(idsOf(first)).toHaveLength(6);
+  });
+
+  it("never mints an id a node of the host page already carries", () => {
+    // The digest the resolver would mint for this pair, taken from a run whose
+    // host holds nothing that could collide, and then planted in the host.
+    const probe = page([instance("i1", "hero")]);
+    const definitions = defs({ hero: component([node("d1")]) });
+    const minted = idsOf(
+      resolveComponentInstances(probe, definitions).document
+    )[0]!;
+
+    const doc = page([node(minted), instance("i1", "hero")]);
+    const ids = idsOf(resolveComponentInstances(doc, definitions).document);
+
+    expect(ids[0]).toBe(minted);
+    expect(ids[1]).not.toBe(minted);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("marks every inlined node with its instance, not only the roots", () => {
+    const doc = page([instance("i1", "hero")]);
+    const definitions = defs({
+      hero: component([box("d1", [node("d2")])]),
+    });
+
+    const result = resolveComponentInstances(doc, definitions);
+
+    expect(byInstanceOf(result.document, "i1")).toHaveLength(2);
+  });
+
+  it("reports every definition it read, in first-reached order", () => {
+    const doc = page([
+      instance("i1", "hero"),
+      instance("i2", "gone"),
+      instance("i3", "hero"),
+    ]);
+    const definitions = defs({ hero: component([node("d1")]) });
+
+    const result = resolveComponentInstances(doc, definitions);
+
+    expect(result.referenced).toEqual(["hero", "gone"]);
+  });
+});
+
+describe("resolveComponentInstances overrides", () => {
+  const heroWithHeadline = component(
+    [node("d1", { props: { text: "base" } })],
+    {
+      exposed: [
+        {
+          id: "headline",
+          label: "Headline",
+          nodeId: "d1",
+          propPath: "text",
+          type: "text",
+        },
+      ],
+      variants: {
+        loud: { label: "Loud", overrides: { headline: "VARIANT" } },
+      },
+    }
+  );
+
+  it("applies a variant's value when the instance overrides nothing", () => {
+    const doc = page([instance("i1", "hero", { variant: "loud" })]);
+
+    const result = resolveComponentInstances(
+      doc,
+      defs({ hero: heroWithHeadline })
+    );
+
+    expect(result.document.nodes[0]!.props.text).toBe("VARIANT");
+  });
+
+  it("prefers the instance's own value over the variant's", () => {
+    const doc = page([
+      instance("i1", "hero", {
+        variant: "loud",
+        overrides: { headline: "INSTANCE" },
+      }),
+    ]);
+
+    const result = resolveComponentInstances(
+      doc,
+      defs({ hero: heroWithHeadline })
+    );
+
+    expect(result.document.nodes[0]!.props.text).toBe("INSTANCE");
+  });
+
+  it("inherits the definition's value when the id is absent from overrides", () => {
+    const doc = page([instance("i1", "hero", { overrides: { other: "x" } })]);
+
+    const result = resolveComponentInstances(
+      doc,
+      defs({ hero: heroWithHeadline })
+    );
+
+    expect(result.document.nodes[0]!.props.text).toBe("base");
+  });
+
+  it("clears the prop for an unset override rather than inheriting it", () => {
+    const doc = page([
+      instance("i1", "hero", { overrides: { headline: { $unset: true } } }),
+    ]);
+
+    const result = resolveComponentInstances(
+      doc,
+      defs({ hero: heroWithHeadline })
+    );
+
+    expect(result.document.nodes[0]!.props).not.toHaveProperty("text");
+  });
+
+  it("treats a structured value carrying $unset as a value to apply", () => {
+    const doc = page([
+      instance("i1", "hero", {
+        overrides: { headline: { href: "/docs", $unset: true } },
+      }),
+    ]);
+
+    const result = resolveComponentInstances(
+      doc,
+      defs({ hero: heroWithHeadline })
+    );
+
+    expect(result.document.nodes[0]!.props.text).toEqual({
+      href: "/docs",
+      $unset: true,
+    });
+  });
+
+  it("writes a nested prop path without altering the shared definition", () => {
+    const definition = component(
+      [node("d1", { props: { seo: { title: "base", keep: "yes" } } })],
+      {
+        exposed: [
+          {
+            id: "title",
+            label: "Title",
+            nodeId: "d1",
+            propPath: "seo.title",
+            type: "text",
+          },
+        ],
+      }
+    );
+    const doc = page([
+      instance("i1", "hero", { overrides: { title: "one" } }),
+      instance("i2", "hero", { overrides: { title: "two" } }),
+    ]);
+
+    const result = resolveComponentInstances(doc, defs({ hero: definition }));
+
+    expect(result.document.nodes[0]!.props.seo).toEqual({
+      title: "one",
+      keep: "yes",
+    });
+    expect(result.document.nodes[1]!.props.seo).toEqual({
+      title: "two",
+      keep: "yes",
+    });
+    expect(definition.nodes[0]!.props.seo).toEqual({
+      title: "base",
+      keep: "yes",
+    });
+  });
+
+  it("writes a __proto__ path as an own key rather than a prototype", () => {
+    const definition = component([node("d1")], {
+      exposed: [
+        {
+          id: "bad",
+          label: "Bad",
+          nodeId: "d1",
+          propPath: "__proto__",
+          type: "text",
+        },
+      ],
+    });
+    const doc = page([instance("i1", "hero", { overrides: { bad: "x" } })]);
+
+    const props = resolveComponentInstances(doc, defs({ hero: definition }))
+      .document.nodes[0]!.props;
+
+    expect(Object.getPrototypeOf(props)).toBe(Object.prototype);
+    expect(Object.keys(props)).toContain("__proto__");
+  });
+});
+
+describe("resolveComponentInstances visibility", () => {
+  const definition = component([box("d1", [node("d2")]), node("d3")], {
+    exposed: [
+      {
+        id: "showBanner",
+        label: "Banner",
+        nodeId: "d1",
+        propPath: "hidden",
+        type: "visibility",
+      },
+    ],
+  });
+
+  it("drops a node and its subtree when the override hides it", () => {
+    const doc = page([
+      instance("i1", "hero", { overrides: { showBanner: false } }),
+    ]);
+
+    const result = resolveComponentInstances(doc, defs({ hero: definition }));
+
+    expect(flatten(result.document.nodes)).toHaveLength(1);
+  });
+
+  it("removes the definition's own gate when the override shows it", () => {
+    const gated = component(
+      [
+        node("d1", {
+          visibility: { conditions: [[{ field: "tier", op: "eq" }]] },
+        }),
+      ],
+      {
+        exposed: [
+          {
+            id: "showBanner",
+            label: "Banner",
+            nodeId: "d1",
+            propPath: "hidden",
+            type: "visibility",
+          },
+        ],
+      }
+    );
+    const doc = page([
+      instance("i1", "hero", { overrides: { showBanner: true } }),
+    ]);
+
+    const result = resolveComponentInstances(doc, defs({ hero: gated }));
+
+    expect(result.document.nodes[0]).not.toHaveProperty("visibility");
+  });
+
+  it("ignores a visibility override that is not a boolean, either way", () => {
+    const own = { conditions: [[{ field: "tier", op: "eq" }]] };
+    const gated = component([box("d1", [node("d2")], own), node("d3")], {
+      exposed: [
+        {
+          id: "showBanner",
+          label: "Banner",
+          nodeId: "d1",
+          propPath: "hidden",
+          type: "visibility",
+        },
+      ],
+    });
+
+    const truthy = resolveComponentInstances(
+      page([instance("i1", "hero", { overrides: { showBanner: "false" } })]),
+      defs({ hero: gated })
+    );
+    const falsy = resolveComponentInstances(
+      page([instance("i1", "hero", { overrides: { showBanner: 0 } })]),
+      defs({ hero: gated })
+    );
+
+    expect(truthy.document.nodes[0]!.visibility).toEqual(own);
+    expect(flatten(falsy.document.nodes)).toHaveLength(3);
+  });
+});
+
+describe("resolveComponentInstances slots", () => {
+  const definition = component([box("d1", [node("fallback")])], {
+    slots: { body: { label: "Body", nodeId: "d1", slot: "children" } },
+  });
+
+  it("substitutes the instance's slot content for the definition's children", () => {
+    const doc = page([
+      instance("i1", "hero", {}, { slots: { body: [node("mine")] } }),
+    ]);
+
+    const result = resolveComponentInstances(doc, defs({ hero: definition }));
+
+    const children = result.document.nodes[0]!.slots!.children!;
+    expect(children.map(entry => entry.id)).toEqual(["mine"]);
+  });
+
+  it("keeps the definition's children when the instance supplies none", () => {
+    const doc = page([instance("i1", "hero")]);
+
+    const result = resolveComponentInstances(doc, defs({ hero: definition }));
+
+    const children = result.document.nodes[0]!.slots!.children!;
+    expect(children).toHaveLength(1);
+    expect(children[0]!.instanceOf).toBe("i1");
+  });
+
+  it("fills a slot the definition's node stored no entry for", () => {
+    const empty = component([node("d1", { type: "core/box" })], {
+      slots: { body: { label: "Body", nodeId: "d1", slot: "children" } },
+    });
+    const doc = page([
+      instance("i1", "hero", {}, { slots: { body: [node("mine")] } }),
+    ]);
+
+    const result = resolveComponentInstances(doc, defs({ hero: empty }));
+
+    expect(result.document.nodes[0]!.slots!.children!.map(e => e.id)).toEqual([
+      "mine",
+    ]);
+  });
+
+  it("leaves instance slot content unmarked, so the page still owns it", () => {
+    const doc = page([
+      instance("i1", "hero", {}, { slots: { body: [node("mine")] } }),
+    ]);
+
+    const result = resolveComponentInstances(doc, defs({ hero: definition }));
+
+    const mine = flatten(result.document.nodes).find(e => e.id === "mine")!;
+    expect(mine.instanceOf).toBeUndefined();
+  });
+});
+
+describe("resolveComponentInstances refusals", () => {
+  it("keeps an instance whose definition is missing, marked and reported", () => {
+    const doc = page([node("a"), instance("i1", "gone")]);
+
+    const result = resolveComponentInstances(doc, defs({}));
+
+    expect(result.document.nodes[1]!.unresolvedComponent).toBe("missing");
+    expect(result.unresolved).toEqual([
+      { instanceId: "i1", componentId: "gone", reason: "missing" },
+    ]);
+    expect(result.document.nodes[0]!.id).toBe("a");
+  });
+
+  it("marks an instance that names no component as malformed", () => {
+    const doc = page([
+      { id: "i1", type: COMPONENT_INSTANCE_TYPE, version: 1, props: {} },
+    ]);
+
+    const result = resolveComponentInstances(doc, defs({}));
+
+    expect(result.unresolved[0]!.reason).toBe("malformed");
+    expect(result.referenced).toEqual([]);
+  });
+
+  it("refuses a component that reaches itself, and renders the rest", () => {
+    const doc = page([node("a"), instance("i1", "loop")]);
+    const definitions = defs({
+      loop: component([node("d1"), instance("d2", "loop")]),
+    });
+
+    const result = resolveComponentInstances(doc, definitions);
+
+    const flat = flatten(result.document.nodes);
+    expect(flat.map(e => e.unresolvedComponent)).toEqual([
+      undefined,
+      undefined,
+      "cycle",
+    ]);
+    expect(result.unresolved.map(e => e.reason)).toEqual(["cycle"]);
+  });
+
+  it("refuses the instance that would pass the composed-depth cap", () => {
+    const doc = page([instance("i1", "outer")]);
+    const definitions = defs({
+      outer: component([instance("d1", "inner")]),
+      inner: component([node("leaf")]),
+    });
+
+    const atCap = resolveComponentInstances(doc, definitions, {
+      maxComposedDepth: 2,
+    });
+    const belowCap = resolveComponentInstances(doc, definitions, {
+      maxComposedDepth: 1,
+    });
+
+    expect(atCap.unresolved).toEqual([]);
+    expect(flatten(atCap.document.nodes)).toHaveLength(1);
+    expect(belowCap.unresolved.map(e => e.reason)).toEqual(["depth"]);
+  });
+
+  it("refuses a whole instance rather than inlining part of it", () => {
+    const doc = page([instance("i1", "big"), instance("i2", "small")]);
+    const definitions = defs({
+      big: component([node("b1"), node("b2"), node("b3")]),
+      small: component([node("s1")]),
+    });
+
+    const result = resolveComponentInstances(doc, definitions, {
+      limits: { ...DEFAULT_LIMITS, maxNodes: 2 },
+    });
+
+    expect(result.unresolved).toEqual([
+      { instanceId: "i1", componentId: "big", reason: "budget" },
+    ]);
+    expect(result.document.nodes[0]!.unresolvedComponent).toBe("budget");
+    expect(result.document.nodes[1]!.id).not.toBe("i2");
+  });
+
+  it("keeps a refused instance's own slot content untouched", () => {
+    const doc = page([
+      instance("i1", "gone", {}, { slots: { body: [node("mine")] } }),
+    ]);
+
+    const result = resolveComponentInstances(doc, defs({}));
+
+    expect(result.document.nodes[0]!.slots!.body!.map(e => e.id)).toEqual([
+      "mine",
+    ]);
+  });
+});
+
+describe("resolveComponentInstances nesting", () => {
+  it("inlines a component the definition itself references", () => {
+    const doc = page([instance("i1", "outer")]);
+    const definitions = defs({
+      outer: component([box("o1", [instance("o2", "inner")])]),
+      inner: component([node("leaf")]),
+    });
+
+    const result = resolveComponentInstances(doc, definitions);
+
+    const flat = flatten(result.document.nodes);
+    expect(flat).toHaveLength(2);
+    expect(result.referenced).toEqual(["outer", "inner"]);
+    expect(flat[1]!.instanceOf).toBe(flat[0]!.slots!.children![0]!.instanceOf);
+  });
+
+  it("resolves an instance inside supplied slot content in the host's scope", () => {
+    const doc = page([
+      instance(
+        "i1",
+        "shell",
+        {},
+        { slots: { body: [instance("i2", "leafy")] } }
+      ),
+    ]);
+    const definitions = defs({
+      shell: component([box("s1", [])], {
+        slots: { body: { label: "Body", nodeId: "s1", slot: "children" } },
+      }),
+      leafy: component([node("l1")]),
+    });
+
+    // One composed level is all the host content is allowed, and the nested
+    // instance sits in the PAGE rather than inside `shell`, so it resolves.
+    const result = resolveComponentInstances(doc, definitions, {
+      maxComposedDepth: 1,
+    });
+
+    expect(result.unresolved).toEqual([]);
+    expect(flatten(result.document.nodes)).toHaveLength(2);
+  });
+});
+
+describe("componentIdsIn", () => {
+  it("lists each referenced id once, in first-reached order", () => {
+    const nodes = [
+      instance("i1", "b"),
+      box("x", [instance("i2", "a"), instance("i3", "b")]),
+    ];
+
+    expect(componentIdsIn(nodes)).toEqual(["b", "a"]);
+  });
+
+  it("ignores an instance that names no component", () => {
+    const nodes = [
+      { id: "i1", type: COMPONENT_INSTANCE_TYPE, version: 1, props: {} },
+      instance("i2", "a"),
+    ];
+
+    expect(componentIdsIn(nodes)).toEqual(["a"]);
+  });
+
+  it("stops at the node budget rather than walking a whole document", () => {
+    const nodes = [node("a"), node("b"), instance("i1", "late")];
+
+    expect(componentIdsIn(nodes, 2)).toEqual([]);
+    expect(componentIdsIn(nodes, 3)).toEqual(["late"]);
+  });
+});

--- a/packages/blocks-engine/src/resolve-instances.test.ts
+++ b/packages/blocks-engine/src/resolve-instances.test.ts
@@ -535,7 +535,7 @@ describe("resolveComponentInstances refusals", () => {
 
     expect(atCap.unresolved).toEqual([]);
     expect(flatten(atCap.document.nodes)).toHaveLength(1);
-    expect(belowCap.unresolved.map(e => e.reason)).toEqual(["depth"]);
+    expect(belowCap.unresolved.map(e => e.reason)).toEqual(["composed-depth"]);
   });
 
   it("refuses a whole instance rather than inlining part of it", () => {
@@ -582,7 +582,9 @@ describe("resolveComponentInstances nesting", () => {
     const flat = flatten(result.document.nodes);
     expect(flat).toHaveLength(2);
     expect(result.referenced).toEqual(["outer", "inner"]);
-    expect(flat[1]!.instanceOf).toBe(flat[0]!.slots!.children![0]!.instanceOf);
+    // The HOST's instance at both depths, not the inner one, which is not a
+    // node of the resolved document at all.
+    expect(flat.map(e => e.instanceOf)).toEqual(["i1", "i1"]);
   });
 
   it("resolves an instance inside supplied slot content in the host's scope", () => {
@@ -609,6 +611,152 @@ describe("resolveComponentInstances nesting", () => {
 
     expect(result.unresolved).toEqual([]);
     expect(flatten(result.document.nodes)).toHaveLength(2);
+  });
+});
+
+describe("resolveComponentInstances limits and speculative work", () => {
+  const nestedDefs = defs({
+    outer: component(
+      [instance("o1", "inner", {}, { slots: { body: [node("shared")] } })],
+      { slots: { outerBody: { label: "Body", nodeId: "o1", slot: "body" } } }
+    ),
+    inner: component([box("l1", [])], {
+      slots: { body: { label: "Body", nodeId: "l1", slot: "children" } },
+    }),
+  });
+
+  it("re-identifies the slot children of an instance the definition holds", () => {
+    const doc = page([instance("i1", "outer"), instance("i2", "outer")]);
+
+    const result = resolveComponentInstances(doc, nestedDefs);
+    const ids = idsOf(result.document);
+
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(idsOf(result.document)).not.toContain("shared");
+  });
+
+  it("marks a nested instance's default children with the outer instance", () => {
+    const doc = page([instance("i1", "outer")]);
+
+    const result = resolveComponentInstances(doc, nestedDefs);
+
+    expect(byInstanceOf(result.document, "i1")).toHaveLength(2);
+  });
+
+  it("routes page content through a slot exposed on a nested instance", () => {
+    const doc = page([
+      instance("i1", "outer", {}, { slots: { outerBody: [node("fromPage")] } }),
+    ]);
+
+    const result = resolveComponentInstances(doc, nestedDefs);
+
+    const children = result.document.nodes[0]!.slots!.children!;
+    expect(children.map(e => e.id)).toEqual(["fromPage"]);
+  });
+
+  it("composes nothing when the host survey stopped at the node budget", () => {
+    const doc = page([instance("i1", "hero"), node("a"), node("b")]);
+    const definitions = defs({ hero: component([node("d1")]) });
+
+    const result = resolveComponentInstances(doc, definitions, {
+      limits: { ...DEFAULT_LIMITS, maxNodes: 2 },
+    });
+
+    expect(result.document).toBe(doc);
+  });
+
+  it("discards the diagnostics of an instance it then refuses", () => {
+    const doc = page([instance("i1", "outer")]);
+    const definitions = defs({
+      outer: component([instance("o1", "gone"), node("d2"), node("d3")]),
+    });
+
+    const result = resolveComponentInstances(doc, definitions, {
+      limits: { ...DEFAULT_LIMITS, maxNodes: 2 },
+    });
+
+    expect(result.unresolved).toEqual([
+      { instanceId: "i1", componentId: "outer", reason: "budget" },
+    ]);
+  });
+
+  it("gives back the budget an instance's slot content spent before it failed", () => {
+    const definitions = defs({
+      big: component([node("b1"), node("b2")]),
+      small: component([node("s1"), node("s2"), node("s3")]),
+    });
+    const doc = page([
+      instance("i1", "big", {}, { slots: { any: [instance("i2", "small")] } }),
+      instance("i3", "small"),
+    ]);
+
+    // Three: the host's own node count, and exactly what `small` costs. The
+    // slot content inside `i1` spends all of it and is then thrown away with
+    // `i1`, so the sibling fits only if that spend was given back.
+    const result = resolveComponentInstances(doc, definitions, {
+      limits: { ...DEFAULT_LIMITS, maxNodes: 3 },
+    });
+
+    expect(result.unresolved.map(e => e.instanceId)).toEqual(["i1"]);
+    expect(byInstanceOf(result.document, "i3")).toHaveLength(3);
+  });
+
+  it("keeps an inlined id stable when an unrelated node joins its definition", () => {
+    const inner = component([node("n")]);
+    const nested = () => instance("a", "inner");
+    const doc = page([instance("i1", "outer")]);
+
+    // The composed id must be a function of the instances above a node and of
+    // the definition node itself. Deriving it from the HOST instance instead
+    // makes `n` collide with the outer definition's own `n`, and the collision
+    // suffix then lands on whichever was minted second — so adding one node to
+    // the outer component silently rewrites ids inside a component it merely
+    // contains, detaching every rule and overlay keyed to them.
+    const without = resolveComponentInstances(
+      doc,
+      defs({ outer: component([nested(), instance("b", "inner")]), inner })
+    );
+    const with_ = resolveComponentInstances(
+      doc,
+      defs({
+        outer: component([node("n"), nested(), instance("b", "inner")]),
+        inner,
+      })
+    );
+
+    expect(idsOf(without.document)[0]).toBe(idsOf(with_.document)[1]);
+  });
+
+  it("refuses an instance whose definition is deeper than the limits allow", () => {
+    const doc = page([instance("i1", "deep")]);
+    const definitions = defs({
+      deep: component([box("d1", [box("d2", [node("d3")])])]),
+    });
+
+    const result = resolveComponentInstances(doc, definitions, {
+      limits: { ...DEFAULT_LIMITS, maxDepth: 2 },
+    });
+
+    expect(result.unresolved.map(e => e.reason)).toEqual(["node-depth"]);
+    expect(result.document.nodes[0]!.unresolvedComponent).toBe("node-depth");
+  });
+
+  it("counts every entry of a definition against the node budget", () => {
+    const doc = page([instance("i1", "junk")]);
+    const definitions = defs({
+      junk: component([
+        null,
+        null,
+        null,
+        node("d1"),
+      ] as unknown as ResolvedBlockNode[]),
+    });
+
+    const result = resolveComponentInstances(doc, definitions, {
+      limits: { ...DEFAULT_LIMITS, maxNodes: 2 },
+    });
+
+    expect(result.unresolved.map(e => e.reason)).toEqual(["budget"]);
   });
 });
 

--- a/packages/blocks-engine/src/resolve-instances.ts
+++ b/packages/blocks-engine/src/resolve-instances.ts
@@ -79,8 +79,16 @@ export const COMPONENT_UNRESOLVED_REASONS = [
   "missing",
   /** The component reaches itself through its own tree. */
   "cycle",
-  /** Nesting passed `MAX_COMPOSED_DEPTH`. */
-  "depth",
+  /** Components nested inside components passed `MAX_COMPOSED_DEPTH`. */
+  "composed-depth",
+  /**
+   * The definition's OWN tree is deeper than `limits.maxDepth`.
+   *
+   * Its own reason rather than sharing `composed-depth`, because the author's
+   * remedy is the opposite one: flatten this component's content, rather than
+   * stop nesting it inside others.
+   */
+  "node-depth",
   /** Inlining it would pass the run's node budget. */
   "budget",
   /** The instance node does not name a component id. */
@@ -102,13 +110,19 @@ export type ComponentUnresolvedReason =
  */
 export interface ResolvedBlockNode extends BlockNode {
   /**
-   * The component instance this node was inlined for.
+   * The instance node, IN THE HOST DOCUMENT, this node was composed for.
    *
    * Set on every node that came from a definition, never on one an author
    * placed. It is the discrimination the editor cannot make any other way: an
    * instance's slot content is nested INSIDE the inlined tree and is the
    * page's own, so "sits under an inlined root" answers "is this editable?"
    * wrongly for exactly the nodes a marketer is there to edit.
+   *
+   * The HOST's instance at every depth, not the nearest one. A component that
+   * holds another component is replaced by the tree it stands for, so its own
+   * node is not in the resolved document and naming it would hand the editor
+   * an id it cannot select — and the author never placed that inner instance
+   * anyway; they placed the one on the page.
    */
   instanceOf?: string;
   /**
@@ -237,12 +251,18 @@ export function resolveComponentInstances(
 
   const limits = options.limits ?? DEFAULT_LIMITS;
   const survey = surveyHost(document.nodes, limits.maxNodes);
-  // Identity for an ordinary page is guaranteed twice over — `inlineForest`
-  // returns its input array when nothing changed — so this is not what makes
-  // the common case allocation-free. What it decides is the case the survey
-  // could NOT read: a document already past `maxNodes` is composed not at all
-  // rather than up to the cap, because a partial composition mints ids that
-  // stay stable only until someone raises the limit.
+  // A survey that stopped at the cap collected a PREFIX of the document's ids,
+  // so every id minted afterwards would be checked against a set missing
+  // whatever the walk never reached — and an unread later node carrying a
+  // minted id is exactly the duplicate the seeding exists to prevent. A
+  // document past `maxNodes` is therefore composed not at all rather than up
+  // to the cap: proceeding on a partial answer is worse than not composing.
+  if (survey.truncated) return unchanged;
+  // An optimisation, and stated as one because no test can hold it: identity
+  // is already guaranteed by `inlineForest`, which returns its input array
+  // when nothing changed, so removing this line changes no output. What it
+  // saves is building the run and walking the tree at all, which is the whole
+  // cost this module adds to a page that uses no components.
   if (!survey.hasInstance) return unchanged;
 
   const run: ResolveRun = {
@@ -251,6 +271,8 @@ export function resolveComponentInstances(
     maxComposedDepth: options.maxComposedDepth ?? MAX_COMPOSED_DEPTH,
     budget: limits.maxNodes,
     taken: survey.ids,
+    minted: [],
+    abort: undefined,
     referenced: [],
     referencedSeen: new Set<string>(),
     unresolved: [],
@@ -276,6 +298,21 @@ interface ResolveRun {
   budget: number;
   /** Every id in use, so a minted one cannot shadow a stored node. */
   taken: Set<string>;
+  /**
+   * The ids this run minted, in order, so a refused instance can give them
+   * back. Host ids are not in it: they were never this run's to release.
+   */
+  minted: string[];
+  /**
+   * Why the clone in progress gave up, set on the path that returns `null`.
+   *
+   * A field rather than a richer return type because the two failures — the
+   * node budget and the definition's own depth — are raised several frames
+   * below the one that has an instance to mark, and threading a reason back
+   * through every slot and forest frame would put a second meaning on every
+   * one of those returns.
+   */
+  abort: ComponentUnresolvedReason | undefined;
   referenced: string[];
   referencedSeen: Set<string>;
   unresolved: UnresolvedInstance[];
@@ -292,6 +329,8 @@ const ROOT_SCOPE: ComposedScope = { depth: 0, onPath: new Set<string>() };
 /** What the host document holds, read once before anything is rebuilt. */
 interface HostSurvey {
   hasInstance: boolean;
+  /** The walk stopped at the node cap, so `ids` is a PREFIX of what is there. */
+  truncated: boolean;
   ids: Set<string>;
 }
 
@@ -305,9 +344,13 @@ interface HostSurvey {
 function surveyHost(nodes: readonly unknown[], maxNodes: number): HostSurvey {
   const ids = new Set<string>();
   let hasInstance = false;
+  let truncated = false;
   let budget = maxNodes;
   walkForest(nodes, entry => {
-    if (budget <= 0) return "stop";
+    if (budget <= 0) {
+      truncated = true;
+      return "stop";
+    }
     budget -= 1;
     const node = entry.node;
     if (!isPlainRecord(node)) return "descend";
@@ -315,7 +358,7 @@ function surveyHost(nodes: readonly unknown[], maxNodes: number): HostSurvey {
     if (node.type === COMPONENT_INSTANCE_TYPE) hasInstance = true;
     return "descend";
   });
-  return { hasInstance, ids };
+  return { hasInstance, truncated, ids };
 }
 
 /** The component a node references, or `undefined` if it references none. */
@@ -423,7 +466,9 @@ function expandInstance(
   instance: ResolvedBlockNode,
   run: ResolveRun,
   scope: ComposedScope,
-  depth: number
+  depth: number,
+  presupplied?: Record<string, ResolvedBlockNode[]>,
+  owner?: string
 ): ResolvedBlockNode[] {
   const componentId = componentIdOf(instance);
   if (componentId === undefined) {
@@ -439,10 +484,18 @@ function expandInstance(
   // Established by `refusalFor`, which is the only reader that can tell a
   // missing definition from an unreadable one.
   const definition = run.definitions.get(componentId) as ComponentDocument;
-  const supplied = suppliedSlots(instance, run, scope, depth);
+
+  // Taken before ANY speculative work, `suppliedSlots` included. Resolving an
+  // instance's slot content spends budget and mints ids, and a refusal below
+  // discards that content — `refuse` returns the instance with its STORED
+  // slots — so a mark taken after it would leave a refused instance having
+  // permanently charged the page for a tree nobody receives.
+  const mark = savepoint(run);
+  const supplied = presupplied ?? suppliedSlots(instance, run, scope, depth);
   const ctx: InlineContext = {
     run,
-    instanceId: instance.id,
+    scopeKey: instance.id,
+    owner: owner ?? instance.id,
     plans: planEdits(definition, instance, supplied),
     scope: {
       depth: scope.depth + 1,
@@ -450,15 +503,55 @@ function expandInstance(
     },
   };
 
-  const before = run.budget;
   const inlined = cloneDefinitionForest(definition.nodes, ctx, 1);
   if (inlined === null) {
-    // Restored so the page's remaining instances are judged against the budget
-    // this one did not spend. A partially inlined component is not a component.
-    run.budget = before;
-    return [refuse(run, instance, componentId, "budget")];
+    const reason = run.abort ?? "budget";
+    run.abort = undefined;
+    rollback(run, mark);
+    return [refuse(run, instance, componentId, reason)];
   }
   return inlined;
+}
+
+/** Everything one speculative expansion may have to give back. */
+interface Savepoint {
+  budget: number;
+  unresolved: number;
+  minted: number;
+}
+
+/** Where the run stood before an instance was attempted. */
+function savepoint(run: ResolveRun): Savepoint {
+  return {
+    budget: run.budget,
+    unresolved: run.unresolved.length,
+    minted: run.minted.length,
+  };
+}
+
+/**
+ * Undo a whole attempted expansion.
+ *
+ * All three, not the budget alone. A nested instance refused INSIDE an
+ * expansion that is itself then refused has already reported itself, and that
+ * report names a scoped id no node in the returned document carries — a
+ * diagnostic about a tree the reader never receives, which is worse than
+ * silence because a surface will offer the author a remedy for it. The minted
+ * ids go back for the same reason: an id reserved for a node that does not
+ * exist pushes a later, real node onto a disambiguated spelling.
+ *
+ * `referenced` is deliberately NOT rolled back. Its consumer is cache tagging,
+ * and this page's render DID read that definition — a change to it can change
+ * whether this instance fits the budget at all, so the page has to regenerate.
+ * A tag list trimmed to what survived is the list that never recovers.
+ */
+function rollback(run: ResolveRun, mark: Savepoint): void {
+  run.budget = mark.budget;
+  run.unresolved.length = mark.unresolved;
+  for (let i = run.minted.length - 1; i >= mark.minted; i -= 1) {
+    run.taken.delete(run.minted[i]);
+  }
+  run.minted.length = mark.minted;
 }
 
 /** Why this instance cannot be inlined here, if it cannot. */
@@ -468,7 +561,7 @@ function refusalFor(
   scope: ComposedScope
 ): ComponentUnresolvedReason | undefined {
   if (scope.onPath.has(componentId)) return "cycle";
-  if (scope.depth >= run.maxComposedDepth) return "depth";
+  if (scope.depth >= run.maxComposedDepth) return "composed-depth";
   const definition = run.definitions.get(componentId);
   if (!isPlainRecord(definition) || !Array.isArray(definition.nodes)) {
     return "missing";
@@ -698,8 +791,25 @@ function planFor(plans: Map<string, NodePlan>, nodeId: string): NodePlan {
 /** One instance's inlining, in progress. */
 interface InlineContext {
   run: ResolveRun;
-  /** The id every node produced here is scoped to and marked with. */
-  instanceId: string;
+  /**
+   * What ids produced here are derived from: the NEAREST instance.
+   *
+   * Separate from `owner` because they answer different questions. Deriving
+   * from the nearest instance is what keeps two components that happen to
+   * share a node id apart; recording the nearest instance would name a node
+   * the reader cannot find, since a nested instance is itself replaced by the
+   * tree it stands for.
+   */
+  scopeKey: string;
+  /**
+   * What `instanceOf` records: the instance in the HOST DOCUMENT.
+   *
+   * Always a node the stored document contains, which is the whole use — the
+   * editor holds the stored document and needs a click on a composed node to
+   * select something it can address. The nearest-instance answer is unusable
+   * for that at any depth below the first.
+   */
+  owner: string;
   plans: ReadonlyMap<string, NodePlan>;
   /** The scope INSIDE this component, for instances the definition itself holds. */
   scope: ComposedScope;
@@ -718,12 +828,26 @@ function cloneDefinitionForest(
   ctx: InlineContext,
   depth: number
 ): ResolvedBlockNode[] | null {
-  if (depth > ctx.run.maxDepth) return [];
+  // A refusal rather than an empty forest. Returning `[]` publishes a
+  // component whose deeper content is silently gone, with nothing in
+  // `unresolved` to say so — the truncation Storyblok is criticised for in the
+  // design's prior art, arrived at by accident.
+  if (depth > ctx.run.maxDepth) {
+    ctx.run.abort = "node-depth";
+    return null;
+  }
   const out: ResolvedBlockNode[] = [];
   for (const node of nodes) {
-    if (!isPlainRecord(node) || typeof node.id !== "string") continue;
-    if (ctx.run.budget <= 0) return null;
+    // Charged BEFORE the entry is judged, the way `countNodes` counts every
+    // entry including malformed ones. A definition nothing validated can hold
+    // a million nulls, and skipping them free lets it be walked in full under
+    // any cap — then resolve to a partial tree rather than reporting `budget`.
+    if (ctx.run.budget <= 0) {
+      ctx.run.abort = "budget";
+      return null;
+    }
     ctx.run.budget -= 1;
+    if (!isPlainRecord(node) || typeof node.id !== "string") continue;
     const produced = cloneDefinitionNode(
       node as unknown as ResolvedBlockNode,
       ctx,
@@ -745,13 +869,30 @@ function cloneDefinitionNode(
   if (plan?.visible === false) return [];
 
   const scoped = scopeNode(node, ctx, plan);
-  if (scoped.type === COMPONENT_INSTANCE_TYPE) {
-    return expandInstance(scoped, ctx.run, ctx.scope, depth);
-  }
 
+  // Cloned BEFORE the instance branch, not after it. A component-instance node
+  // inside a definition carries slot content like any container, and skipping
+  // this for it left that content holding the DEFINITION's own node ids — so
+  // two instances of the outer component published the same ids — and left a
+  // planned slot substitution aimed at the nested instance unapplied, so
+  // page-supplied content lost to the definition's default.
   const slots = cloneSlots(node, ctx, depth, plan);
   if (slots === null) return null;
   if (slots !== undefined) scoped.slots = slots;
+
+  if (scoped.type === COMPONENT_INSTANCE_TYPE) {
+    // Handed on rather than re-derived: these children are already resolved in
+    // this component's scope, and asking `expandInstance` to read them again
+    // would walk a tree that holds no instance left to expand.
+    return expandInstance(
+      scoped,
+      ctx.run,
+      ctx.scope,
+      depth,
+      slots ?? {},
+      ctx.owner
+    );
+  }
   return [scoped];
 }
 
@@ -763,8 +904,8 @@ function scopeNode(
 ): ResolvedBlockNode {
   const scoped: ResolvedBlockNode = {
     ...node,
-    id: mintScopedId(ctx.run, ctx.instanceId, node.id),
-    instanceOf: ctx.instanceId,
+    id: mintScopedId(ctx.run, ctx.scopeKey, node.id),
+    instanceOf: ctx.owner,
   };
   // Removing the envelope rather than emptying it: `conditions` is only half of
   // what gates a node, and an instance saying "show this" means the reader
@@ -875,6 +1016,7 @@ function mintScopedId(
   const base = `${SCOPED_ID_PREFIX}${hashId(`${instanceId} ${definitionNodeId}`)}`;
   if (!run.taken.has(base)) {
     run.taken.add(base);
+    run.minted.push(base);
     return base;
   }
   // Terminates: `taken` is finite and the suffix strictly increases.
@@ -882,6 +1024,7 @@ function mintScopedId(
     const candidate = `${base}-${n}`;
     if (run.taken.has(candidate)) continue;
     run.taken.add(candidate);
+    run.minted.push(candidate);
     return candidate;
   }
 }

--- a/packages/blocks-engine/src/resolve-instances.ts
+++ b/packages/blocks-engine/src/resolve-instances.ts
@@ -1,0 +1,963 @@
+/**
+ * Inlining a linked component definition into the document that references it.
+ *
+ * A component INSTANCE is one node holding a reference, a variant name and a
+ * set of overrides. What a reader has to draw is the definition's whole tree,
+ * with those overrides applied and the instance's own slot content in place of
+ * the definition's. Turning the first into the second is this module.
+ *
+ * ## Why the engine owns it, and only half of it
+ *
+ * Four consumers need a resolved tree and none of them is the renderer alone:
+ * the canvas renders in the same document as the admin rather than in an
+ * iframe, the class-usage index reads a resolved tree to know which classes a
+ * page really applies, and SEO derivation reads one to find a page's heading.
+ * A resolver living beside any one of them is reimplemented by the other three.
+ *
+ * The FETCH is deliberately not here. Only the stores know whether a caller
+ * wants a draft definition or a published one, and that posture is the whole
+ * difference between the editor's iframe and a served page. This module is
+ * handed definitions and asks no questions about where they came from.
+ *
+ * ## What it guarantees
+ *
+ * - **Identity-preserving.** A document holding no instance comes back as the
+ *   same object, so the ordinary page allocates nothing and a caller comparing
+ *   stages by reference reads "unchanged" rather than "repaired".
+ * - **Deterministic.** Every inlined node's id is derived from the instance and
+ *   the definition node it came from, so two renders of one page produce the
+ *   same ids. Styles, overlays, editor history and React keys all key on node
+ *   ids; ids that changed per render would remount the tree on every request
+ *   and detach every stylesheet rule from the markup it describes.
+ * - **Per-instance failure.** A missing definition, a containment cycle, a
+ *   nesting cap or an exhausted node budget leaves THAT instance unresolved and
+ *   renders the rest of the page. Refusing the page would hand a visitor a
+ *   blank screen for a fault in one region of it.
+ *
+ * ## What it does not do
+ *
+ * It does not evaluate bindings, prune hidden nodes, migrate, dedupe or drop
+ * placeholders. Those are later stages of the read pipeline and they run over
+ * the resolved tree — which is what makes a binding inside a definition resolve
+ * against the HOST document's context, and a `visibility` exposure able to
+ * decide whether a definition's node is served at all.
+ *
+ * @module resolve-instances
+ */
+import {
+  COMPONENT_INSTANCE_TYPE,
+  isUnsetOverride,
+  type BlockDocument,
+  type BlockNode,
+  type ComponentDocument,
+  type OverrideValue,
+} from "./document";
+import { walkForest } from "./forest-walk";
+import {
+  DEFAULT_LIMITS,
+  MAX_COMPOSED_DEPTH,
+  MAX_ENVELOPE_ENTRIES,
+  type DocumentLimits,
+} from "./limits";
+import { isPlainRecord } from "./plain-record";
+import { defineEntry, ownEntry } from "./safe-record";
+import { hashId } from "./style/node-class";
+
+/**
+ * Why an instance was left standing instead of being replaced by its
+ * definition's tree.
+ *
+ * A closed list rather than a message, because each reason has a different
+ * remedy and the surface showing it has to pick one: `missing` asks the author
+ * to publish or restore a component, `cycle` asks them to break a containment
+ * loop, `depth` and `budget` are limits, and `malformed` is a document fault
+ * no author action fixes. A rendered string would carry the same information
+ * in a form nothing can branch on and nothing can translate.
+ */
+export const COMPONENT_UNRESOLVED_REASONS = [
+  /** No definition was supplied for the referenced id. */
+  "missing",
+  /** The component reaches itself through its own tree. */
+  "cycle",
+  /** Nesting passed `MAX_COMPOSED_DEPTH`. */
+  "depth",
+  /** Inlining it would pass the run's node budget. */
+  "budget",
+  /** The instance node does not name a component id. */
+  "malformed",
+] as const;
+
+/** Derived from the list, so the pair cannot be half-changed. */
+export type ComponentUnresolvedReason =
+  (typeof COMPONENT_UNRESOLVED_REASONS)[number];
+
+/**
+ * A node in a RESOLVED tree, which is not a node in a stored one.
+ *
+ * The two extra fields are render-time facts, so they extend `BlockNode`
+ * rather than joining it. `BlockNode`'s key set is the stored format and is
+ * frozen: a field added there is a field every external producer of a document
+ * has to know about and every published schema has to describe, which is
+ * exactly the wrong claim for a marker that never survives a save.
+ */
+export interface ResolvedBlockNode extends BlockNode {
+  /**
+   * The component instance this node was inlined for.
+   *
+   * Set on every node that came from a definition, never on one an author
+   * placed. It is the discrimination the editor cannot make any other way: an
+   * instance's slot content is nested INSIDE the inlined tree and is the
+   * page's own, so "sits under an inlined root" answers "is this editable?"
+   * wrongly for exactly the nodes a marketer is there to edit.
+   */
+  instanceOf?: string;
+  /**
+   * Why a component instance could not be inlined, set on the instance node
+   * itself in place of the subtree it stands for.
+   *
+   * The instance node is KEPT rather than dropped, the way `migrationFailed`
+   * keeps a node whose upgrade failed. A dropped instance is indistinguishable
+   * from a page that never had one — so the editor could not offer "publish
+   * this component", and an author would see a region silently missing with
+   * nothing to act on.
+   */
+  unresolvedComponent?: ComponentUnresolvedReason;
+  slots?: Record<string, ResolvedBlockNode[]>;
+}
+
+/** A document whose component instances have been resolved. */
+export interface ResolvedDocument extends BlockDocument {
+  nodes: ResolvedBlockNode[];
+}
+
+/**
+ * The definitions a resolution may reach, keyed by document id.
+ *
+ * A `Map` rather than a record, and it is not a style preference. The keys are
+ * component ids read from a stored document, and a plain record answers
+ * `constructor` with a function on a key it never had — so a page referencing a
+ * component called `constructor` would resolve against `Object.prototype`'s
+ * method and inline whatever a property read of `.nodes` on it returned.
+ */
+export type DefinitionsById = ReadonlyMap<string, BlockDocument>;
+
+/** How much work one resolution may do. */
+export interface ResolveComponentOptions {
+  /** Node and depth caps for the tree being built. Defaults to {@link DEFAULT_LIMITS}. */
+  limits?: DocumentLimits;
+  /** Levels of component nesting allowed. Defaults to {@link MAX_COMPOSED_DEPTH}. */
+  maxComposedDepth?: number;
+}
+
+/** One instance that was left standing, and why. */
+export interface UnresolvedInstance {
+  /** The instance node's id, as it appears in the returned document. */
+  instanceId: string;
+  /** The component it referenced; empty when the node named none. */
+  componentId: string;
+  reason: ComponentUnresolvedReason;
+}
+
+/** What a resolution produced. */
+export interface ResolvedComposition {
+  /** The document with every resolvable instance inlined. */
+  document: ResolvedDocument;
+  /**
+   * Every definition id this resolution READ, in first-reached order,
+   * unresolvable ones included.
+   *
+   * Unresolvable ones belong in it because the list's consumer is cache
+   * tagging: a page that failed to resolve a component because it is not
+   * published yet must still regenerate when it IS, and a tag list built only
+   * from successes is exactly the list that never recovers.
+   */
+  referenced: readonly string[];
+  /** Every instance that could not be inlined. Empty on a clean resolution. */
+  unresolved: readonly UnresolvedInstance[];
+}
+
+/**
+ * The prefix every inlined node's id wears.
+ *
+ * Deliberately not a UUID shape. Stored ids are UUIDs, so a reader looking at a
+ * resolved tree — in the DOM, in a React warning, in a stylesheet — can tell at
+ * a glance which nodes exist in the stored document and which were composed for
+ * this render, and nothing that persists an id can mistake one for the other.
+ */
+const SCOPED_ID_PREFIX = "cx-";
+
+/**
+ * How many dot segments of a `propPath` are followed.
+ *
+ * A bound on work rather than a design opinion. The path comes from a stored
+ * definition that nothing here validated, and each segment costs a record copy.
+ */
+const MAX_PROP_PATH_SEGMENTS = 16;
+
+/** The component ids a document references directly, in first-reached order. */
+export function componentIdsIn(
+  nodes: readonly unknown[],
+  maxNodes: number = DEFAULT_LIMITS.maxNodes
+): string[] {
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  let budget = maxNodes;
+  walkForest(nodes, entry => {
+    if (budget <= 0) return "stop";
+    budget -= 1;
+    const id = componentIdOf(entry.node);
+    if (id !== undefined && !seen.has(id)) {
+      seen.add(id);
+      ids.push(id);
+    }
+    return "descend";
+  });
+  return ids;
+}
+
+/**
+ * Inline every component instance the document holds.
+ *
+ * @param document the host document, as stored
+ * @param definitions the definitions to inline, at the posture the caller chose
+ */
+export function resolveComponentInstances(
+  document: BlockDocument,
+  definitions: DefinitionsById,
+  options: ResolveComponentOptions = {}
+): ResolvedComposition {
+  const unchanged: ResolvedComposition = {
+    document,
+    referenced: [],
+    unresolved: [],
+  };
+  if (!isPlainRecord(document) || !Array.isArray(document.nodes)) {
+    return unchanged;
+  }
+
+  const limits = options.limits ?? DEFAULT_LIMITS;
+  const survey = surveyHost(document.nodes, limits.maxNodes);
+  // Identity for an ordinary page is guaranteed twice over — `inlineForest`
+  // returns its input array when nothing changed — so this is not what makes
+  // the common case allocation-free. What it decides is the case the survey
+  // could NOT read: a document already past `maxNodes` is composed not at all
+  // rather than up to the cap, because a partial composition mints ids that
+  // stay stable only until someone raises the limit.
+  if (!survey.hasInstance) return unchanged;
+
+  const run: ResolveRun = {
+    definitions,
+    maxDepth: limits.maxDepth,
+    maxComposedDepth: options.maxComposedDepth ?? MAX_COMPOSED_DEPTH,
+    budget: limits.maxNodes,
+    taken: survey.ids,
+    referenced: [],
+    referencedSeen: new Set<string>(),
+    unresolved: [],
+  };
+  const nodes = inlineForest(document.nodes, run, ROOT_SCOPE, 1);
+  return {
+    document: nodes === document.nodes ? document : { ...document, nodes },
+    referenced: run.referenced,
+    unresolved: run.unresolved,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The run
+// ---------------------------------------------------------------------------
+
+/** Everything one resolution accumulates. */
+interface ResolveRun {
+  definitions: DefinitionsById;
+  maxDepth: number;
+  maxComposedDepth: number;
+  /** Nodes this resolution may still produce, across every instance. */
+  budget: number;
+  /** Every id in use, so a minted one cannot shadow a stored node. */
+  taken: Set<string>;
+  referenced: string[];
+  referencedSeen: Set<string>;
+  unresolved: UnresolvedInstance[];
+}
+
+/** Where in the composition a forest sits: how deep, and through which components. */
+interface ComposedScope {
+  depth: number;
+  onPath: ReadonlySet<string>;
+}
+
+const ROOT_SCOPE: ComposedScope = { depth: 0, onPath: new Set<string>() };
+
+/** What the host document holds, read once before anything is rebuilt. */
+interface HostSurvey {
+  hasInstance: boolean;
+  ids: Set<string>;
+}
+
+/**
+ * Whether there is anything to do, and which ids are already spoken for.
+ *
+ * Both answers come from one walk because both are needed before the first node
+ * is minted: the second decides what a minted id may be, and asking for it
+ * lazily would mean minting against a partial set.
+ */
+function surveyHost(nodes: readonly unknown[], maxNodes: number): HostSurvey {
+  const ids = new Set<string>();
+  let hasInstance = false;
+  let budget = maxNodes;
+  walkForest(nodes, entry => {
+    if (budget <= 0) return "stop";
+    budget -= 1;
+    const node = entry.node;
+    if (!isPlainRecord(node)) return "descend";
+    if (typeof node.id === "string") ids.add(node.id);
+    if (node.type === COMPONENT_INSTANCE_TYPE) hasInstance = true;
+    return "descend";
+  });
+  return { hasInstance, ids };
+}
+
+/** The component a node references, or `undefined` if it references none. */
+function componentIdOf(node: unknown): string | undefined {
+  if (!isPlainRecord(node) || node.type !== COMPONENT_INSTANCE_TYPE) {
+    return undefined;
+  }
+  const props = node.props;
+  if (!isPlainRecord(props)) return undefined;
+  const id = props.componentId;
+  return typeof id === "string" && id !== "" ? id : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Walking the host document
+// ---------------------------------------------------------------------------
+
+/**
+ * Rebuild a forest with its instances inlined.
+ *
+ * Recursive, with the depth cap checked before descending — the same shape the
+ * renderer's own sanitizer uses, and for the same reason: this runs over a
+ * document nothing validated, so a chain deeper than the format allows would
+ * otherwise exhaust the call stack inside the helper meant to contain it.
+ *
+ * Returns the ORIGINAL array when nothing changed, which is what makes the
+ * whole resolution identity-preserving for a page holding no instance.
+ */
+function inlineForest(
+  nodes: readonly ResolvedBlockNode[],
+  run: ResolveRun,
+  scope: ComposedScope,
+  depth: number
+): ResolvedBlockNode[] {
+  if (depth > run.maxDepth) return nodes as ResolvedBlockNode[];
+  let changed = false;
+  const out: ResolvedBlockNode[] = [];
+  for (const node of nodes) {
+    const replacement = inlineNode(node, run, scope, depth);
+    if (replacement === null) {
+      out.push(node);
+      continue;
+    }
+    changed = true;
+    for (const produced of replacement) out.push(produced);
+  }
+  return changed ? out : (nodes as ResolvedBlockNode[]);
+}
+
+/** What one host node becomes, or `null` when it is unchanged. */
+function inlineNode(
+  node: ResolvedBlockNode,
+  run: ResolveRun,
+  scope: ComposedScope,
+  depth: number
+): ResolvedBlockNode[] | null {
+  if (!isPlainRecord(node)) return null;
+  if (node.type === COMPONENT_INSTANCE_TYPE) {
+    return expandInstance(node, run, scope, depth);
+  }
+  const slots = node.slots;
+  if (!isPlainRecord(slots)) return null;
+  const next = inlineHostSlots(slots, run, scope, depth);
+  return next === slots ? null : [{ ...node, slots: next }];
+}
+
+/** Every slot of a host node, with its children resolved in the same scope. */
+function inlineHostSlots(
+  slots: Record<string, ResolvedBlockNode[]>,
+  run: ResolveRun,
+  scope: ComposedScope,
+  depth: number
+): Record<string, ResolvedBlockNode[]> {
+  let changed = false;
+  // Read and written through an `unknown` view: a stored `slots` record can
+  // hold anything, and a value that is not an array is PASSED ON rather than
+  // replaced — dropping it would let an edit naming a different node destroy
+  // content this package could not interpret.
+  const stored = slots as Record<string, unknown>;
+  const next: Record<string, unknown> = {};
+  for (const name of Object.keys(stored)) {
+    const children = ownEntry(stored, name);
+    if (!Array.isArray(children)) {
+      defineEntry(next, name, children);
+      continue;
+    }
+    const inlined = inlineForest(
+      children as ResolvedBlockNode[],
+      run,
+      scope,
+      depth + 1
+    );
+    if (inlined !== children) changed = true;
+    defineEntry(next, name, inlined);
+  }
+  return changed ? (next as Record<string, ResolvedBlockNode[]>) : slots;
+}
+
+// ---------------------------------------------------------------------------
+// Expanding one instance
+// ---------------------------------------------------------------------------
+
+/** The definition's tree in place of one instance node, or the marked instance. */
+function expandInstance(
+  instance: ResolvedBlockNode,
+  run: ResolveRun,
+  scope: ComposedScope,
+  depth: number
+): ResolvedBlockNode[] {
+  const componentId = componentIdOf(instance);
+  if (componentId === undefined) {
+    return [refuse(run, instance, "", "malformed")];
+  }
+  noteReference(run, componentId);
+
+  const reason = refusalFor(componentId, run, scope);
+  if (reason !== undefined) {
+    return [refuse(run, instance, componentId, reason)];
+  }
+
+  // Established by `refusalFor`, which is the only reader that can tell a
+  // missing definition from an unreadable one.
+  const definition = run.definitions.get(componentId) as ComponentDocument;
+  const supplied = suppliedSlots(instance, run, scope, depth);
+  const ctx: InlineContext = {
+    run,
+    instanceId: instance.id,
+    plans: planEdits(definition, instance, supplied),
+    scope: {
+      depth: scope.depth + 1,
+      onPath: new Set(scope.onPath).add(componentId),
+    },
+  };
+
+  const before = run.budget;
+  const inlined = cloneDefinitionForest(definition.nodes, ctx, 1);
+  if (inlined === null) {
+    // Restored so the page's remaining instances are judged against the budget
+    // this one did not spend. A partially inlined component is not a component.
+    run.budget = before;
+    return [refuse(run, instance, componentId, "budget")];
+  }
+  return inlined;
+}
+
+/** Why this instance cannot be inlined here, if it cannot. */
+function refusalFor(
+  componentId: string,
+  run: ResolveRun,
+  scope: ComposedScope
+): ComponentUnresolvedReason | undefined {
+  if (scope.onPath.has(componentId)) return "cycle";
+  if (scope.depth >= run.maxComposedDepth) return "depth";
+  const definition = run.definitions.get(componentId);
+  if (!isPlainRecord(definition) || !Array.isArray(definition.nodes)) {
+    return "missing";
+  }
+  return undefined;
+}
+
+/**
+ * Keep the instance node, marked with why it is still standing.
+ *
+ * Kept rather than dropped so the editor has something to attach "publish this
+ * component" to, and so a reader can tell a page that lost a region from one
+ * that never had it. Its stored slot content travels with it untouched: a
+ * placeholder draws no children, and rewriting content that is not being shown
+ * would be an edit made by a failure.
+ */
+function refuse(
+  run: ResolveRun,
+  instance: ResolvedBlockNode,
+  componentId: string,
+  reason: ComponentUnresolvedReason
+): ResolvedBlockNode {
+  run.unresolved.push({ instanceId: instance.id, componentId, reason });
+  return { ...instance, unresolvedComponent: reason };
+}
+
+/** Record a definition this resolution read, once. */
+function noteReference(run: ResolveRun, componentId: string): void {
+  if (run.referencedSeen.has(componentId)) return;
+  run.referencedSeen.add(componentId);
+  run.referenced.push(componentId);
+}
+
+/**
+ * The instance's own slot content, resolved in the scope it was AUTHORED in.
+ *
+ * Resolved before the definition is inlined and in the OUTER scope, because
+ * this content belongs to the page rather than to the component: a component
+ * nested in it is nested in the page, not one level further into the
+ * composition, and re-identifying it would move page nodes to ids the editor
+ * cannot address.
+ */
+function suppliedSlots(
+  instance: ResolvedBlockNode,
+  run: ResolveRun,
+  scope: ComposedScope,
+  depth: number
+): Record<string, ResolvedBlockNode[]> | undefined {
+  const slots = instance.slots;
+  if (!isPlainRecord(slots)) return undefined;
+  return inlineHostSlots(slots, run, scope, depth);
+}
+
+// ---------------------------------------------------------------------------
+// What an instance changes about the definition's nodes
+// ---------------------------------------------------------------------------
+
+/** One override, resolved to the node prop it writes. */
+interface PropEdit {
+  path: string;
+  value: OverrideValue;
+  /** Clear the prop rather than replace it. */
+  unset: boolean;
+}
+
+/** Everything one instance changes about one node of the definition. */
+interface NodePlan {
+  props: PropEdit[];
+  /** `false` drops the node; `true` serves it unconditionally; absent leaves it alone. */
+  visible?: boolean;
+  /** Instance content, keyed by the slot NAME on this node. */
+  slots?: Map<string, ResolvedBlockNode[]>;
+}
+
+/** What each of the definition's nodes gets, keyed by its id in the definition. */
+function planEdits(
+  definition: ComponentDocument,
+  instance: ResolvedBlockNode,
+  supplied: Record<string, ResolvedBlockNode[]> | undefined
+): Map<string, NodePlan> {
+  const plans = new Map<string, NodePlan>();
+  const values = effectiveOverrides(definition, instance);
+  if (values.size > 0) planExposed(definition.exposed, values, plans);
+  if (supplied !== undefined) planSlots(definition.slots, supplied, plans);
+  return plans;
+}
+
+/**
+ * The variant's overrides with the instance's own written over them.
+ *
+ * That order, not the reverse: a variant is a preset the definition offers and
+ * an instance's own value is the author's answer to it. Writing the preset last
+ * would make selecting a variant silently discard edits already made.
+ */
+function effectiveOverrides(
+  definition: ComponentDocument,
+  instance: ResolvedBlockNode
+): Map<string, OverrideValue> {
+  const values = new Map<string, OverrideValue>();
+  const props = isPlainRecord(instance.props) ? instance.props : {};
+  collectOverrides(variantOverrides(definition, props.variant), values);
+  collectOverrides(props.overrides, values);
+  return values;
+}
+
+/** The chosen variant's override record, if the definition offers it. */
+function variantOverrides(
+  definition: ComponentDocument,
+  variant: unknown
+): unknown {
+  if (typeof variant !== "string" || variant === "") return undefined;
+  const variants = definition.variants;
+  if (!isPlainRecord(variants)) return undefined;
+  const chosen = ownEntry(variants as Record<string, unknown>, variant);
+  return isPlainRecord(chosen) ? chosen.overrides : undefined;
+}
+
+/** Fold one override record into the accumulator; later callers win. */
+function collectOverrides(
+  source: unknown,
+  into: Map<string, OverrideValue>
+): void {
+  if (!isPlainRecord(source)) return;
+  let budget = MAX_ENVELOPE_ENTRIES;
+  for (const key of Object.keys(source)) {
+    if (budget <= 0) return;
+    budget -= 1;
+    into.set(key, ownEntry(source, key));
+  }
+}
+
+/** Turn overridden exposure ids into per-node edits. */
+function planExposed(
+  exposed: unknown,
+  values: ReadonlyMap<string, OverrideValue>,
+  plans: Map<string, NodePlan>
+): void {
+  if (!Array.isArray(exposed)) return;
+  const count = Math.min(exposed.length, MAX_ENVELOPE_ENTRIES);
+  for (let i = 0; i < count; i += 1) {
+    const entry: unknown = exposed[i];
+    if (!isPlainRecord(entry)) continue;
+    const id = entry.id;
+    const nodeId = entry.nodeId;
+    if (typeof id !== "string" || !values.has(id)) continue;
+    if (typeof nodeId !== "string" || nodeId === "") continue;
+    applyExposure(planFor(plans, nodeId), entry, values.get(id));
+  }
+}
+
+/** Write one exposure's override into the plan for its node. */
+function applyExposure(
+  plan: NodePlan,
+  entry: Record<string, unknown>,
+  value: OverrideValue
+): void {
+  if (entry.type === "visibility") {
+    const decided = visibilityDecision(value);
+    if (decided !== undefined) plan.visible = decided;
+    return;
+  }
+  const path = entry.propPath;
+  if (typeof path !== "string" || !isUsablePropPath(path)) return;
+  plan.props.push({ path, value, unset: isUnsetOverride(value) });
+}
+
+/**
+ * What a `visibility` override decides, or nothing.
+ *
+ * Booleans only. An override is a value an author's inspector wrote and a
+ * `visibility` control writes `true` or `false`; coercing every other value
+ * would let a stored `"false"` — or an image object left behind when an
+ * exposure changed type — decide whether a region of the page is served.
+ * Clearing it hides, because that is what "renders empty" means for a node.
+ */
+function visibilityDecision(value: OverrideValue): boolean | undefined {
+  if (value === true) return true;
+  if (value === false || isUnsetOverride(value)) return false;
+  return undefined;
+}
+
+/** Route instance slot content to the definition node and slot it fills. */
+function planSlots(
+  slots: unknown,
+  supplied: Record<string, ResolvedBlockNode[]>,
+  plans: Map<string, NodePlan>
+): void {
+  if (!isPlainRecord(slots)) return;
+  let budget = MAX_ENVELOPE_ENTRIES;
+  for (const id of Object.keys(slots)) {
+    if (budget <= 0) return;
+    budget -= 1;
+    const content = ownEntry(supplied, id);
+    const target = slotTarget(ownEntry(slots, id));
+    if (!Array.isArray(content) || target === undefined) continue;
+    const plan = planFor(plans, target.nodeId);
+    const into = plan.slots ?? new Map<string, ResolvedBlockNode[]>();
+    plan.slots = into;
+    into.set(target.slot, content);
+  }
+}
+
+/** The node and slot one exposed-slot declaration points at. */
+function slotTarget(
+  spec: unknown
+): { nodeId: string; slot: string } | undefined {
+  if (!isPlainRecord(spec)) return undefined;
+  const { nodeId, slot } = spec;
+  if (typeof nodeId !== "string" || nodeId === "") return undefined;
+  if (typeof slot !== "string" || slot === "") return undefined;
+  return { nodeId, slot };
+}
+
+/** The plan for one definition node, created on first use. */
+function planFor(plans: Map<string, NodePlan>, nodeId: string): NodePlan {
+  const existing = plans.get(nodeId);
+  if (existing !== undefined) return existing;
+  const created: NodePlan = { props: [] };
+  plans.set(nodeId, created);
+  return created;
+}
+
+// ---------------------------------------------------------------------------
+// Cloning the definition under the instance's identity
+// ---------------------------------------------------------------------------
+
+/** One instance's inlining, in progress. */
+interface InlineContext {
+  run: ResolveRun;
+  /** The id every node produced here is scoped to and marked with. */
+  instanceId: string;
+  plans: ReadonlyMap<string, NodePlan>;
+  /** The scope INSIDE this component, for instances the definition itself holds. */
+  scope: ComposedScope;
+}
+
+/**
+ * A definition's forest, re-identified under one instance.
+ *
+ * `null` means the run's node budget was exhausted, which the caller turns into
+ * a refusal for the whole instance. It is not the same as an empty array: a
+ * definition whose nodes were all hidden by an override legitimately draws
+ * nothing.
+ */
+function cloneDefinitionForest(
+  nodes: readonly unknown[],
+  ctx: InlineContext,
+  depth: number
+): ResolvedBlockNode[] | null {
+  if (depth > ctx.run.maxDepth) return [];
+  const out: ResolvedBlockNode[] = [];
+  for (const node of nodes) {
+    if (!isPlainRecord(node) || typeof node.id !== "string") continue;
+    if (ctx.run.budget <= 0) return null;
+    ctx.run.budget -= 1;
+    const produced = cloneDefinitionNode(
+      node as unknown as ResolvedBlockNode,
+      ctx,
+      depth
+    );
+    if (produced === null) return null;
+    for (const child of produced) out.push(child);
+  }
+  return out;
+}
+
+/** One definition node, scoped, edited, and expanded if it is itself an instance. */
+function cloneDefinitionNode(
+  node: ResolvedBlockNode,
+  ctx: InlineContext,
+  depth: number
+): ResolvedBlockNode[] | null {
+  const plan = ctx.plans.get(node.id);
+  if (plan?.visible === false) return [];
+
+  const scoped = scopeNode(node, ctx, plan);
+  if (scoped.type === COMPONENT_INSTANCE_TYPE) {
+    return expandInstance(scoped, ctx.run, ctx.scope, depth);
+  }
+
+  const slots = cloneSlots(node, ctx, depth, plan);
+  if (slots === null) return null;
+  if (slots !== undefined) scoped.slots = slots;
+  return [scoped];
+}
+
+/** A definition node under the instance's identity, with its overrides applied. */
+function scopeNode(
+  node: ResolvedBlockNode,
+  ctx: InlineContext,
+  plan: NodePlan | undefined
+): ResolvedBlockNode {
+  const scoped: ResolvedBlockNode = {
+    ...node,
+    id: mintScopedId(ctx.run, ctx.instanceId, node.id),
+    instanceOf: ctx.instanceId,
+  };
+  // Removing the envelope rather than emptying it: `conditions` is only half of
+  // what gates a node, and an instance saying "show this" means the reader
+  // should stop asking.
+  if (plan?.visible === true) delete scoped.visibility;
+  if (plan !== undefined && plan.props.length > 0) {
+    scoped.props = editedProps(node.props, plan.props);
+  }
+  return scoped;
+}
+
+/**
+ * A node's slots, with the definition's children cloned and the instance's
+ * substituted where it supplied any.
+ *
+ * `undefined` leaves whatever the node stored in place — which is only reached
+ * for a `slots` that is not a record and that the instance did not fill, and
+ * therefore holds no children to re-identify. Returning `{}` for one would
+ * rewrite stored content during a render.
+ */
+function cloneSlots(
+  node: ResolvedBlockNode,
+  ctx: InlineContext,
+  depth: number,
+  plan: NodePlan | undefined
+): Record<string, ResolvedBlockNode[]> | null | undefined {
+  const stored = node.slots;
+  const planned = plan?.slots;
+  const readable = isPlainRecord(stored);
+  if (!readable && planned === undefined) return undefined;
+
+  const next: Record<string, ResolvedBlockNode[]> = {};
+  if (readable && !copyStoredSlots(stored, next, ctx, depth, planned)) {
+    return null;
+  }
+  if (planned !== undefined) fillPlannedSlots(next, planned);
+  return next;
+}
+
+/** Copy each stored slot, cloning its children unless the instance replaced them. */
+function copyStoredSlots(
+  stored: Record<string, ResolvedBlockNode[]>,
+  into: Record<string, ResolvedBlockNode[]>,
+  ctx: InlineContext,
+  depth: number,
+  planned: ReadonlyMap<string, ResolvedBlockNode[]> | undefined
+): boolean {
+  // Same `unknown` view as `inlineHostSlots`, for the same reason: a stored
+  // slot value that is not an array travels through untouched.
+  const source = stored as Record<string, unknown>;
+  const target = into as Record<string, unknown>;
+  for (const name of Object.keys(source)) {
+    const supplied = planned?.get(name);
+    if (supplied !== undefined) {
+      defineEntry(target, name, supplied);
+      continue;
+    }
+    const children = ownEntry(source, name);
+    if (!Array.isArray(children)) {
+      defineEntry(target, name, children);
+      continue;
+    }
+    const cloned = cloneDefinitionForest(children, ctx, depth + 1);
+    if (cloned === null) return false;
+    defineEntry(target, name, cloned);
+  }
+  return true;
+}
+
+/**
+ * Add instance content for a slot the definition node did not store.
+ *
+ * A container declares its slots in its block definition; an EMPTY one is
+ * absent from the stored node. Without this, filling the one slot a component
+ * exposes would do nothing for every definition whose author left it empty —
+ * which is the ordinary case, since a slot exists to be filled.
+ */
+function fillPlannedSlots(
+  into: Record<string, ResolvedBlockNode[]>,
+  planned: ReadonlyMap<string, ResolvedBlockNode[]>
+): void {
+  for (const [name, content] of planned) {
+    if (Object.prototype.hasOwnProperty.call(into, name)) continue;
+    defineEntry(into, name, content);
+  }
+}
+
+/**
+ * The id one definition node wears inside one instance.
+ *
+ * A DIGEST of the pair, not the pair itself. Figma addresses an instance's
+ * children by the concatenated path, chained once per level, which is
+ * collision-free by construction and readable — and grows by a whole id per
+ * level of nesting. These ids reach the DOM, the stylesheet and every React
+ * key, so at five levels over a large page the paths would outweigh the content
+ * they identify. A digest is the same width at every depth.
+ *
+ * The cost of a digest is that it can collide, so it is disambiguated against
+ * every id already in use, the host document's own included. Deterministic: the
+ * same document and definitions produce the same ids in the same order on every
+ * render, which is the property the whole composition depends on.
+ */
+function mintScopedId(
+  run: ResolveRun,
+  instanceId: string,
+  definitionNodeId: string
+): string {
+  const base = `${SCOPED_ID_PREFIX}${hashId(`${instanceId} ${definitionNodeId}`)}`;
+  if (!run.taken.has(base)) {
+    run.taken.add(base);
+    return base;
+  }
+  // Terminates: `taken` is finite and the suffix strictly increases.
+  for (let n = 2; ; n += 1) {
+    const candidate = `${base}-${n}`;
+    if (run.taken.has(candidate)) continue;
+    run.taken.add(candidate);
+    return candidate;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Writing an override into a node's props
+// ---------------------------------------------------------------------------
+
+/** A node's props with every planned edit applied, leaving the original alone. */
+function editedProps(
+  props: unknown,
+  edits: readonly PropEdit[]
+): Record<string, unknown> {
+  const next: Record<string, unknown> = isPlainRecord(props)
+    ? { ...props }
+    : {};
+  for (const edit of edits) writeEdit(next, edit);
+  return next;
+}
+
+/**
+ * Apply one edit at its dot path, copying each record on the way down.
+ *
+ * Copied rather than mutated because the definition is shared: two instances of
+ * one component are handed the same stored object, and writing through it would
+ * make the first instance's overrides appear inside the second.
+ *
+ * Written with `defineEntry`/`ownEntry` throughout. The path segments come from
+ * a stored definition, and `props.__proto__ = value` sets a prototype instead
+ * of a property while `props.constructor` reads a function from a record that
+ * never had the key.
+ */
+function writeEdit(root: Record<string, unknown>, edit: PropEdit): void {
+  const segments = edit.path.split(".");
+  let target = root;
+  for (let i = 0; i < segments.length - 1; i += 1) {
+    const next = descend(target, segments[i], edit.unset);
+    if (next === undefined) return;
+    target = next;
+  }
+  const last = segments[segments.length - 1];
+  if (!edit.unset) {
+    defineEntry(target, last, edit.value);
+    return;
+  }
+  if (Object.prototype.hasOwnProperty.call(target, last)) delete target[last];
+}
+
+/**
+ * The record one path segment leads to, copied so the original is untouched.
+ *
+ * `undefined` stops the write. Clearing a path that does not exist is already
+ * cleared, and building the records to reach it would ADD the structure the
+ * author asked to remove.
+ */
+function descend(
+  target: Record<string, unknown>,
+  key: string,
+  unset: boolean
+): Record<string, unknown> | undefined {
+  const existing = ownEntry(target, key);
+  if (isPlainRecord(existing)) {
+    const copy = { ...existing };
+    defineEntry(target, key, copy);
+    return copy;
+  }
+  if (unset) return undefined;
+  const created: Record<string, unknown> = {};
+  defineEntry(target, key, created);
+  return created;
+}
+
+/** Whether a stored `propPath` is one this will follow. */
+function isUsablePropPath(path: string): boolean {
+  if (path === "") return false;
+  const segments = path.split(".");
+  if (segments.length > MAX_PROP_PATH_SEGMENTS) return false;
+  return segments.every(segment => segment !== "");
+}


### PR DESCRIPTION
Plan 06 (Phase 5, composition systems) **T-4, slice A** — design §6.3/§6.4.

A component instance is one node holding a component id, a variant name and a set of overrides. Nothing turned that into the tree a reader has to draw, so a page could reference a component and render nothing. This is the pure half of the resolver; the renderer wiring follows separately.

## What it does

`resolveComponentInstances(document, definitions, options)` inlines each instance's definition, applies the variant's overrides and then the instance's own, and substitutes the instance's slot content for the definition's children.

- **Identity-preserving.** A page with no instance comes back as the same object, so a caller comparing pipeline stages by reference reads "unchanged" rather than "repaired".
- **Deterministic ids.** Every inlined node is `digest(instanceId, definitionNodeId)`, disambiguated against every id already in use — the host document's own included. Ids are stable across renders, which is what lets styles, editor history and React keys go on addressing them.
- **Per-instance failure.** A missing definition, a containment cycle, nesting past `MAX_COMPOSED_DEPTH` or an exhausted node budget leaves that reference standing, marked with which of those it was, and the rest of the page renders. The node budget is restored on refusal, so a partially inlined component is never emitted.
- `componentIdsIn` is the other half of the fetch seam: what to read, asked before anything can be resolved.

## Two decisions worth reviewing

**A digest, not the path.** Figma addresses instance children by the concatenated path (`I<instance>;<node>`, chained per level) — collision-free by construction and readable, and it grows by a whole id per nesting level. These ids reach the DOM, the stylesheet and every React key, so at five levels over a large page the paths outweigh the content they identify. The digest is fixed width at every depth; the cost is collisions, handled by disambiguating against the ids in use. Recorded as `research:pb6-t4-scoped-id-strategy`.

**`ResolvedBlockNode`, not two more fields on `BlockNode`.** `instanceOf` and `unresolvedComponent` are render-time facts that never survive a save. Putting them on the stored contract broke `block-document.test-d.ts`'s frozen key set — correctly, since a field there is a claim on every external producer of a document. `packages/blocks-engine/src/document.ts` is byte-identical to `main`.

`MAX_COMPOSED_DEPTH` was deliberately held back from #1514 because nothing enforced it. It ships here, with the code that does.

## Verification

- **33 new tests**, break-verified against **14 wrong implementations** — random ids, variant-last override order, `$unset` as a value, `instanceOf` on roots only, an unseeded id set, a partially-emitted component, supplied slots resolved in the wrong scope, in-place edits on the shared definition, plain assignment for prop paths, `referenced` recorded only on success, dropped planned slots, truthy visibility coercion, no on-path set, and no early return. **14 kills, 0 survivors**, test count held at 33 throughout. Three earlier breaks did NOT kill; each exposed a real gap (a malformed break, a visibility test whose fixture carried no gate to remove, and an identity property reached by a second uncontrolled route) and the tests were repaired.
- `blocks-engine` suite 1843 passed (42 files); workspace `build` 42/42 and `check-types` 42/42.
- `fallow audit --gate new-only --base origin/main`: **pass**, 5 changed files, 100 functions analysed, 0 above threshold, 0 introduced findings.
- `check-comment-convention` clean, with a positive control confirming it reads the new file.
- `changeset status` clean; the frontmatter carries all 25 lockstep packages, derived from `.changeset/config.json`.

## Not in this slice

`prepareDocumentReadStages` wiring, the batched definition fetch with draft/published posture, `entryIdTag` exported from `nextly/runtime`, the page's cache tags, the never-published readiness check, and site-sheet hoisting. The new exports have no production consumer until that lands.
