### PR TITLE
feat(nextly): answer "what ships next" from the releases service

### DIFF
--- a/.changeset/what-ships-next-on-the-dashboard.md
+++ b/.changeset/what-ships-next-on-the-dashboard.md
@@ -1,0 +1,54 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The dashboard can show what ships next: `system:releases` is the first widget
+source answered by a domain service rather than compiled to a collection query.
+
+Asking for it honestly needed one change underneath. `findReleases` ordered
+recent-first, which is right for "what happened" and wrong for "what is coming":
+a limited query for the next few releases returned the FURTHEST OUT ones, with
+real rows in a plausible order and nothing in the result to say so. It now takes
+an `order` option, defaulting to the existing recent-first behaviour so no
+current caller changes, and NULLS LAST is stated in both directions — the
+default differs per dialect, so an unscheduled draft would otherwise be the
+"next release" on some databases and not others.
+
+The card asks a fixed question and refuses a `where` or `sort` rather than
+accepting one and discarding it, publishes three of the release row's eleven
+columns, and hands the releases service the caller so that service's own
+`authorize` remains the only rule deciding which releases anyone sees.
+
+Two fixes to the source machinery itself. `POST /api/dashboard/query` decided a
+system source was usable from its KIND alone, which admitted one nothing had
+registered a resolver for — and every message past that point is specific, so an
+undeclared field was answered in detail for a registered source and generically
+for an invented one, distinguishing the two. The endpoint now asks the executor
+the same question the executor asks, from one shared implementation. And the
+boot-time registry reset cleared the widget sources without clearing their
+resolvers, so a removed or renamed system source left its resolver addressable
+for the process lifetime, holding whatever its closure captured.

--- a/packages/nextly/src/api/widget-query.test.ts
+++ b/packages/nextly/src/api/widget-query.test.ts
@@ -60,6 +60,10 @@ vi.mock("../auth/entity-read-access", async importOriginal => {
 
 import { requireAuthentication } from "../auth/middleware";
 import { clearSources, registerSource } from "../domains/widgets/sources";
+import {
+  clearSystemResolvers,
+  registerSystemSource,
+} from "../domains/widgets/system-sources";
 import { NextlyError } from "../errors/nextly-error";
 import { setNextlyLogger } from "../observability/logger";
 
@@ -108,6 +112,7 @@ beforeEach(() => {
   executeWidgetQuery.mockResolvedValue({ op: "count", total: 3 });
   canReadEntity.mockResolvedValue(true);
   clearSources();
+  clearSystemResolvers();
   logged.length = 0;
   setNextlyLogger(testLogger);
   containerGet.mockImplementation((name: string) => {
@@ -408,13 +413,20 @@ describe("POST /api/dashboard/query", () => {
     // ENDPOINT's gate, and a resolver would only be consulted past it.
     // `refreshCollectionSources` replaces sources by KIND, so this survives it.
     beforeEach(() => {
-      registerSource({
-        id: "system:releases",
-        label: "Releases",
-        kind: "system",
-        supports: ["count"],
-        fields: [{ name: "title", type: "string" }],
-      });
+      // Through `registerSystemSource`, because the gate now asks the executor
+      // whether anything ANSWERS this source rather than admitting on its kind.
+      // `executeWidgetQuery` is mocked here, so the resolver is never called --
+      // what is under test is the endpoint's gate.
+      registerSystemSource(
+        {
+          id: "system:releases",
+          label: "Releases",
+          kind: "system",
+          supports: ["count"],
+          fields: [{ name: "title", type: "string" }],
+        },
+        vi.fn()
+      );
     });
 
     it("reaches execution rather than being refused as an unexecutable kind", async () => {
@@ -444,6 +456,38 @@ describe("POST /api/dashboard/query", () => {
       );
 
       expect(canReadEntity).not.toHaveBeenCalled();
+    });
+
+    it("refuses a system source NOTHING ANSWERS before field validation", async () => {
+      // 🔴 The kind alone was not enough to admit on. A resolver-less system
+      // source -- registrable through the generic `registerSource` door, which
+      // checks only that the kind agrees with the namespace -- reached
+      // `validateReadWidgetQuery`, and every message from there down is
+      // specific. An undeclared `select` was answered "field ... on
+      // system:orphan", while an invented id got the generic sentence, so the
+      // pair told a caller which system sources exist.
+      registerSource({
+        id: "system:orphan",
+        label: "Orphan",
+        kind: "system",
+        supports: ["count"],
+        fields: [{ name: "title", type: "string" }],
+      });
+
+      const res = await postWidgetQuery(
+        makeReq({
+          queries: [
+            { source: "system:orphan", op: "count", select: ["nope"] },
+            { source: "system:not-registered", op: "count", select: ["nope"] },
+          ],
+        })
+      );
+
+      const [orphan, absent] = await slotsOf(res);
+      expect(orphan.ok).toBe(false);
+      expect(absent.ok).toBe(false);
+      expect(orphan.error).toBe(absent.error);
+      expect(executeWidgetQuery).not.toHaveBeenCalled();
     });
 
     it("still refuses a kind nothing executes", async () => {

--- a/packages/nextly/src/api/widget-query.ts
+++ b/packages/nextly/src/api/widget-query.ts
@@ -19,6 +19,7 @@ import { isErrorResponse, requireAuthentication } from "../auth/middleware";
 import { toNextlyAuthError } from "../auth/middleware/to-nextly-error";
 import { MAX_QUERIES_PER_REQUEST } from "../domains/widgets/batch-limit";
 import { refreshCollectionSources } from "../domains/widgets/collection-sources";
+import { resolveExecutableSource } from "../domains/widgets/executable-source";
 import { executeWidgetQuery } from "../domains/widgets/execute";
 import {
   readWidgetQuery,
@@ -153,15 +154,25 @@ const GENERIC_SLOT_ERROR = "An unexpected error occurred.";
  * through that domain's REST route by any authenticated caller. So admitting
  * these sources tells a caller nothing a collection refusal was protecting.
  *
- * A `system:` source nothing answers is still refused, with the shared string,
- * by `resolveExecutableSource` -- so "registered but unanswerable" stays
- * indistinguishable from "does not exist".
+ * 🔴 A `system:` source nothing answers is refused HERE, by asking
+ * `resolveExecutableSource` -- the executor's own decision, called rather than
+ * restated, so the two cannot answer differently. Admitting on the kind alone
+ * was not enough: a resolver-less system source registered through the generic
+ * `registerSource` door reached field-level validation, and every message below
+ * this point is specific. A caller sending an undeclared `select` was told
+ * which field was undeclared ON that source, while an invented id got the
+ * generic sentence -- so the pair distinguished a registered system source from
+ * a nonexistent one, which is the enumeration oracle this gate exists to close.
  */
 async function assertSourceReadable(
   source: WidgetSource,
   mayRead: (slug: string) => Promise<boolean>
 ): Promise<void> {
-  if (source.kind === "system") return;
+  if (source.kind === "system") {
+    // Throws the same shared refusal for a system source with no resolver.
+    resolveExecutableSource(source.id);
+    return;
+  }
   if (source.kind !== "collection") {
     failUnavailableSourceOrOp(
       `source "${source.id}" has kind "${source.kind}", which is not executable yet; only collections and system sources are`

--- a/packages/nextly/src/di/__tests__/register-widgets-boot-wiring.test.ts
+++ b/packages/nextly/src/di/__tests__/register-widgets-boot-wiring.test.ts
@@ -83,7 +83,10 @@ describe("widget-registry reset at boot", () => {
     // can only be explained by the widget wiring having run and completed
     // before the later failure, not by `registerServices` having finished.
     expect(getSource("plugin:stripe/revenue")).toBeUndefined();
-    expect(listSources()).toHaveLength(0);
+    // Core's own system source is what boot itself writes, so the store is not
+    // empty afterwards -- the same reason the widget assertion below names ids
+    // rather than a count.
+    expect(listSources().map(source => source.id)).toEqual(["system:releases"]);
     // The previous boot's widget is gone; core's own cards are what boot
     // itself writes, so the store is not empty afterwards and asserting that
     // it was would only have held while core declared no widget.

--- a/packages/nextly/src/di/__tests__/register-widgets.test.ts
+++ b/packages/nextly/src/di/__tests__/register-widgets.test.ts
@@ -24,9 +24,15 @@ import {
 } from "../../domains/widgets/registry";
 import {
   clearSources,
+  getSource,
   listSources,
   registerSource,
 } from "../../domains/widgets/sources";
+import {
+  registerSystemSource,
+  systemResolver,
+} from "../../domains/widgets/system-sources";
+import { RELEASES_SOURCE_ID } from "../../domains/releases/releases-widget-source";
 import { resetWidgetRegistries } from "../registrations/register-widgets";
 
 beforeEach(() => {
@@ -58,16 +64,51 @@ function seedWidget(id: string): void {
 }
 
 describe("resetWidgetRegistries", () => {
-  it("empties the source registry so a reload cannot collide with itself", () => {
+  it("drops the previous boot's sources so a reload cannot collide with itself", () => {
     seedSource("plugin:stripe/revenue");
     expect(listSources()).toHaveLength(1);
 
     resetWidgetRegistries();
 
-    expect(listSources()).toHaveLength(0);
+    // The property is that nothing SURVIVES a boot, not that the store ends
+    // empty -- core publishes its own system source in this same function, so
+    // an emptiness assertion would only have held while it published none.
+    expect(getSource("plugin:stripe/revenue")).toBeUndefined();
+    expect(listSources().map(source => source.id)).toEqual([
+      RELEASES_SOURCE_ID,
+    ]);
     // The proof that the clear is what made room: the same id registers again
     // without the conflict `registerSource` raises for a duplicate.
     expect(() => seedSource("plugin:stripe/revenue")).not.toThrow();
+  });
+
+  it("drops a resolver whose source did not survive the boot", () => {
+    // 🔴 The discriminating case, and it is NOT the reset republishing its own
+    // source: that id is written again either way, so a resolver store left
+    // uncleared is simply overwritten and nothing observable changes. What only
+    // a cleared store gets right is an id the new boot does NOT republish --
+    // a source removed or renamed between reloads. Its resolver is addressable
+    // for the lifetime of the process, holding every service its closure
+    // captured, and republishing that id through the generic `registerSource`
+    // door makes the stale one executable again.
+    registerSystemSource(
+      {
+        id: "system:from-previous-boot",
+        label: "Gone",
+        kind: "system",
+        supports: ["list"],
+        fields: [{ name: "title", type: "string" }],
+      },
+      () => Promise.resolve({ op: "list" as const, items: [] })
+    );
+    expect(systemResolver("system:from-previous-boot")).toBeDefined();
+
+    resetWidgetRegistries();
+
+    expect(systemResolver("system:from-previous-boot")).toBeUndefined();
+    // The control: the source core DOES republish is still answerable, so this
+    // cannot pass by clearing everything and registering nothing.
+    expect(systemResolver(RELEASES_SOURCE_ID)).toBeDefined();
   });
 
   it("drops the previous boot's widgets and leaves core's own", () => {

--- a/packages/nextly/src/di/registrations/register-widgets.ts
+++ b/packages/nextly/src/di/registrations/register-widgets.ts
@@ -37,10 +37,12 @@
  * @module di/registrations/register-widgets
  */
 
+import { registerReleasesWidgetSource } from "../../domains/releases/releases-widget-source";
 import { setContributedWidgets } from "../../domains/widgets/canonical";
 import { CORE_WIDGETS } from "../../domains/widgets/core-widgets";
 import { clearWidgets, registerWidget } from "../../domains/widgets/registry";
 import { clearSources } from "../../domains/widgets/sources";
+import { clearSystemResolvers } from "../../domains/widgets/system-sources";
 import type { PluginDefinition } from "../../plugins/plugin-context";
 import { contributedWidgetSummaries } from "../../plugins/validate-admin-widgets";
 
@@ -49,6 +51,13 @@ export function resetWidgetRegistries(
 ): void {
   clearWidgets();
   clearSources();
+  // 🔴 Cleared WITH the source store, never apart from it. The two are halves
+  // of one registration and both are pinned to `globalThis`, so a reset that
+  // took only the sources left every previous boot's resolver addressable —
+  // holding the domain services its closure captured for the process lifetime,
+  // and ready to answer again the moment anything republished that id through
+  // the generic `registerSource` door.
+  clearSystemResolvers();
 
   // The OTHER channel a widget arrives by. A contribution never passes through
   // `registerWidget`, so without this the server's canonical set holds core's
@@ -61,4 +70,11 @@ export function resetWidgetRegistries(
   for (const definition of CORE_WIDGETS) {
     registerWidget(definition);
   }
+
+  // The domains that answer a source of their own publish it here, after the
+  // stores are empty. PUSHED from the composition root rather than pulled by
+  // the widgets domain, which knows nothing about releases and must not have to
+  // import it — that inversion is what would make the widgets package depend on
+  // most of the codebase in order to offer a card.
+  registerReleasesWidgetSource();
 }

--- a/packages/nextly/src/domains/releases/__tests__/releases-repository.integration.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/releases-repository.integration.test.ts
@@ -69,11 +69,10 @@ describe.each(getConfiguredTestDialects())(
   "ReleasesRepository (%s)",
   dialect => {
     it("takes the SOONEST releases when a limited query asks for them", async () => {
-      // 🔴 The oracle has to be real rows in a real order. The defect this
-      // guards is not a wrong row set but a wrong END of the right one: under
-      // the recent-first default, "the next two releases" returns the two
-      // furthest out — real releases, plausibly ordered, with nothing in the
-      // result to say the answer is backwards.
+      // 🔴 Schedule order and creation order differ here on purpose, and the
+      // rows are inserted in neither. What separates a correct limited query
+      // from a reversed one is WHICH END of the window it keeps: both return
+      // real releases in a plausible order, and only the titles say which.
       const app = await boot(dialect);
       const repo = new ReleasesRepository(app.adapter);
 

--- a/packages/nextly/src/domains/releases/__tests__/releases-repository.integration.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/releases-repository.integration.test.ts
@@ -68,6 +68,64 @@ const FUTURE = new Date("2099-01-01T00:00:00Z");
 describe.each(getConfiguredTestDialects())(
   "ReleasesRepository (%s)",
   dialect => {
+    it("takes the SOONEST releases when a limited query asks for them", async () => {
+      // 🔴 The oracle has to be real rows in a real order. The defect this
+      // guards is not a wrong row set but a wrong END of the right one: under
+      // the recent-first default, "the next two releases" returns the two
+      // furthest out — real releases, plausibly ordered, with nothing in the
+      // result to say the answer is backwards.
+      const app = await boot(dialect);
+      const repo = new ReleasesRepository(app.adapter);
+
+      const soon = new Date("2099-01-01T00:00:00Z");
+      const later = new Date("2099-06-01T00:00:00Z");
+      const latest = new Date("2099-12-01T00:00:00Z");
+      // Created in an order that does NOT match the schedule, so a result that
+      // merely preserved insertion order cannot pass.
+      for (const [title, at] of [
+        ["Later", later],
+        ["Latest", latest],
+        ["Soon", soon],
+      ] as const) {
+        const release = await repo.createRelease({ title });
+        await repo.scheduleRelease(release.id, at, "UTC");
+      }
+
+      const next = await repo.findReleases({
+        state: "scheduled",
+        order: "soonest",
+        limit: 2,
+      });
+      expect(next.map(row => row.title)).toEqual(["Soon", "Later"]);
+
+      // The control, and the reason `order` is an option rather than a change:
+      // the default must still answer the other question. Without this, making
+      // the order unconditionally ascending passes the assertion above.
+      const recent = await repo.findReleases({
+        state: "scheduled",
+        limit: 2,
+      });
+      expect(recent.map(row => row.title)).toEqual(["Latest", "Later"]);
+    });
+
+    it("keeps an unscheduled draft out of BOTH ends of the timeline", async () => {
+      // A null instant orders differently per dialect and the direction flips
+      // which end it lands on, so this is asserted in both. A draft is not the
+      // next thing to ship, and it is not the most recent one either.
+      const app = await boot(dialect);
+      const repo = new ReleasesRepository(app.adapter);
+
+      await repo.createRelease({ title: "Unscheduled draft" });
+      const scheduled = await repo.createRelease({ title: "Real release" });
+      await repo.scheduleRelease(scheduled.id, FUTURE, "UTC");
+
+      const soonest = await repo.findReleases({ order: "soonest", limit: 1 });
+      expect(soonest.map(row => row.title)).toEqual(["Real release"]);
+
+      const latest = await repo.findReleases({ limit: 1 });
+      expect(latest.map(row => row.title)).toEqual(["Real release"]);
+    });
+
     it("stores a release and its members", async () => {
       const app = await boot(dialect);
       const repo = new ReleasesRepository(app.adapter);

--- a/packages/nextly/src/domains/releases/__tests__/releases-service.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/releases-service.test.ts
@@ -11,6 +11,7 @@
  */
 import { describe, expect, it, vi } from "vitest";
 
+import { RELEASE_LIST_ORDERS } from "../releases-repository";
 import { ReleasesService } from "../services/releases-service";
 import type {
   ReleaseAuthority,
@@ -442,6 +443,36 @@ describe("ReleasesService refuses input the database would answer differently", 
       svc.schedule("r1", new Date(), "x".repeat(65), ADMIN)
     ).rejects.toMatchObject({ code: "INVALID_INPUT" });
     expect(repo.scheduleRelease).not.toHaveBeenCalled();
+  });
+
+  it("refuses an order it does not recognise, rather than defaulting", async () => {
+    // 🔴 The failure this closes is quieter than a bad `state`. A typo in
+    // `state` reaches a WHERE clause and answers with an empty list -- wrong,
+    // but visibly so. A typo in `order` reaches a ternary and selects the
+    // DEFAULT end, so `"soonestt"` answers with real releases in the exact
+    // reverse of what was asked, and nothing in the result says so.
+    const { svc, repo } = service({ holds: ["read"] });
+    await expect(
+      svc.find(
+        { order: "soonestt" } as unknown as Parameters<typeof svc.find>[0],
+        ADMIN
+      )
+    ).rejects.toMatchObject({ code: "INVALID_INPUT" });
+    expect(repo.findReleases).not.toHaveBeenCalled();
+  });
+
+  it("accepts both orders the vocabulary declares", async () => {
+    // The control, driven FROM the vocabulary rather than from a literal pair:
+    // a validator checking against a hand-copied list would pass this while
+    // rejecting a value the type admits, and adding a third order later would
+    // not widen this test.
+    for (const order of RELEASE_LIST_ORDERS) {
+      const { svc, repo } = service({ holds: ["read"] });
+      await svc.find({ order }, ADMIN);
+      expect(repo.findReleases).toHaveBeenCalledWith(
+        expect.objectContaining({ order })
+      );
+    }
   });
 
   it("refuses `order` alongside `containing`, rather than ignoring it", async () => {

--- a/packages/nextly/src/domains/releases/__tests__/releases-service.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/releases-service.test.ts
@@ -446,11 +446,11 @@ describe("ReleasesService refuses input the database would answer differently", 
   });
 
   it("refuses an order it does not recognise, rather than defaulting", async () => {
-    // 🔴 The failure this closes is quieter than a bad `state`. A typo in
-    // `state` reaches a WHERE clause and answers with an empty list -- wrong,
-    // but visibly so. A typo in `order` reaches a ternary and selects the
-    // DEFAULT end, so `"soonestt"` answers with real releases in the exact
-    // reverse of what was asked, and nothing in the result says so.
+    // 🔴 An unrecognised `order` fails more quietly than an unrecognised
+    // `state`. `state` reaches a WHERE clause, so a typo answers with an empty
+    // list -- wrong, but visibly so. `order` reaches a ternary, so `"soonestt"`
+    // selects the DEFAULT end and answers with real releases in the exact
+    // reverse of what was asked, with nothing in the result to say so.
     const { svc, repo } = service({ holds: ["read"] });
     await expect(
       svc.find(

--- a/packages/nextly/src/domains/releases/__tests__/releases-service.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/releases-service.test.ts
@@ -40,6 +40,10 @@ function repository() {
     liveAuthors: vi.fn(async (ids: string[]) => new Set(ids)),
     scheduleRelease: vi.fn(async () => true),
     cancelRelease: vi.fn(async () => true),
+    // The `containing` listing's own read. Present so a test can drive that
+    // branch to completion rather than dying on a missing collaborator, which
+    // would fail for a reason unrelated to the property under test.
+    findDueMembersFor: vi.fn(async () => new Map<string, unknown[]>()),
   };
 }
 
@@ -438,6 +442,72 @@ describe("ReleasesService refuses input the database would answer differently", 
       svc.schedule("r1", new Date(), "x".repeat(65), ADMIN)
     ).rejects.toMatchObject({ code: "INVALID_INPUT" });
     expect(repo.scheduleRelease).not.toHaveBeenCalled();
+  });
+
+  it("refuses `order` alongside `containing`, rather than ignoring it", async () => {
+    // 🔴 `containing` routes to a different query whose soonest-first order is
+    // its CONTRACT: `resolveReleaseEffect` reads the last row as the final
+    // state, so applying a caller's order there hands the winner's place to the
+    // loser. Accepting the field and dropping it would answer a different
+    // question than the one asked, with rows that look right.
+    const { svc, repo } = service({ holds: ["read"] });
+    await expect(
+      svc.find(
+        {
+          containing: {
+            scopeKind: "collection",
+            scopeSlug: "posts",
+            entryId: "e1",
+            locale: null,
+          },
+          order: "latest",
+          // Through `unknown`, because the type REFUSES the direct cast -- the
+          // compiler saying the two shapes do not overlap is the type-level
+          // exclusion working, and this test exists for the callers a type
+          // cannot bind: JavaScript, and a cast exactly like this one.
+        } as unknown as Parameters<typeof svc.find>[0],
+        ADMIN
+      )
+    ).rejects.toMatchObject({ code: "INVALID_INPUT" });
+    expect(repo.findDueMembersFor).not.toHaveBeenCalled();
+    expect(repo.findReleases).not.toHaveBeenCalled();
+  });
+
+  it("forwards `order` to the repository when nothing narrows by document", async () => {
+    // 🔴 The other half of the guard above, and it had NO coverage: refusing
+    // every query carrying `order` broke nothing, because the widget resolver's
+    // test mocks `find` and the ordering integration test calls the repository
+    // directly. Nothing exercised this routing.
+    //
+    // Asserting the forwarded query rather than the rows is right at THIS seam:
+    // the service's job here is to route, and what the ordering actually does to
+    // real rows is covered against a database in
+    // `releases-repository.integration.test.ts`.
+    const { svc, repo } = service({ holds: ["read"] });
+    await svc.find({ order: "soonest", limit: 3 }, ADMIN);
+    expect(repo.findReleases).toHaveBeenCalledWith(
+      expect.objectContaining({ order: "soonest", limit: 3 })
+    );
+  });
+
+  it("still answers `containing` on its own", async () => {
+    // The control. A guard keyed on `containing` alone would satisfy the case
+    // above and break every document-releases banner.
+    const { svc, repo } = service({ holds: ["read"] });
+    await expect(
+      svc.find(
+        {
+          containing: {
+            scopeKind: "collection",
+            scopeSlug: "posts",
+            entryId: "e1",
+            locale: null,
+          },
+        },
+        ADMIN
+      )
+    ).resolves.toEqual([]);
+    expect(repo.findDueMembersFor).toHaveBeenCalled();
   });
 
   it("refuses a negative limit, which SQLite reads as NO limit", async () => {

--- a/packages/nextly/src/domains/releases/__tests__/releases-widget-source.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/releases-widget-source.test.ts
@@ -88,6 +88,20 @@ describe("what it asks the service", () => {
     });
   });
 
+  it("forwards the caller's ROLES", async () => {
+    // 🔴 `ReleaseActor.userRoles` is what a code-defined access rule reads. An
+    // actor built without it evaluates that rule against an empty list, so a
+    // reader authorized by their roles is refused here while the REST route and
+    // the Direct API — which both forward it — admit them.
+    await executeWidgetQuery(
+      { source: RELEASES_SOURCE_ID, op: "list" },
+      caller
+    );
+
+    const [, actor] = find.mock.calls[0] as [unknown, Record<string, unknown>];
+    expect(actor.userRoles).toEqual(["editor"]);
+  });
+
   it("does not invent an authenticatedScope for a session caller", async () => {
     // A present-but-undefined key wins a spread, so an unconditional one would
     // stamp a session caller with an empty scope and have it judged as a
@@ -147,6 +161,50 @@ describe("what it refuses", () => {
       )
     ).rejects.toThrow(/unavailable source or unsupported op/);
     expect(find).not.toHaveBeenCalled();
+  });
+
+  it("refuses a `status` selector, rather than ignoring it", async () => {
+    // The validator accepts `status` for every source, and this resolver
+    // hard-codes `state: "scheduled"`. Accepting the selector and dropping it
+    // answers a question the caller did not ask, with plausible rows.
+    await expect(
+      executeWidgetQuery(
+        { source: RELEASES_SOURCE_ID, op: "list", status: "draft" },
+        caller
+      )
+    ).rejects.toThrow(/unavailable source or unsupported op/);
+    expect(find).not.toHaveBeenCalled();
+  });
+
+  it("refuses EVERY unconsumed field, named together", async () => {
+    // 🔴 The property is the boundary, not the three fields. A resolver that
+    // checked them one at a time is what let `status` through, so this asserts
+    // that a query carrying several is refused as a whole.
+    await expect(
+      executeWidgetQuery(
+        {
+          source: RELEASES_SOURCE_ID,
+          op: "list",
+          status: "draft",
+          sort: "-scheduledAt",
+          where: { state: { equals: "draft" } },
+        },
+        caller
+      )
+    ).rejects.toThrow(/unavailable source or unsupported op/);
+    expect(find).not.toHaveBeenCalled();
+  });
+
+  it("still answers a query that carries only consumed fields", async () => {
+    // The control. A refusal keyed on "any field present" would satisfy every
+    // case above and refuse the card's own query.
+    await expect(
+      executeWidgetQuery(
+        { source: RELEASES_SOURCE_ID, op: "list", select: ["title"], limit: 2 },
+        caller
+      )
+    ).resolves.toBeDefined();
+    expect(find).toHaveBeenCalledTimes(1);
   });
 
   it("refuses a `sort`, rather than ignoring it", async () => {

--- a/packages/nextly/src/domains/releases/__tests__/releases-widget-source.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/releases-widget-source.test.ts
@@ -1,0 +1,169 @@
+/**
+ * `system:releases` — what the dashboard asks the releases service, and what it
+ * refuses to answer.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const find = vi.fn();
+const has = vi.fn();
+
+vi.mock("../../../di/container", () => ({
+  container: {
+    has: (name: string) => has(name) as boolean,
+    get: () => ({ find }),
+  },
+}));
+
+import { executeWidgetQuery } from "../../widgets/execute";
+import { clearSources } from "../../widgets/sources";
+import { clearSystemResolvers } from "../../widgets/system-sources";
+import {
+  RELEASES_SOURCE_ID,
+  registerReleasesWidgetSource,
+} from "../releases-widget-source";
+
+const caller = { user: { id: "user-1", roles: ["editor"] } };
+
+const row = {
+  id: "r1",
+  title: "Spring launch",
+  description: "notes",
+  scheduledAt: new Date("2099-01-01T00:00:00Z"),
+  timezone: "UTC",
+  state: "scheduled",
+  publishedAt: null,
+  createdBy: "someone-else",
+  createdAt: new Date("2020-01-01T00:00:00Z"),
+  updatedAt: new Date("2020-01-01T00:00:00Z"),
+  revision: 3,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  has.mockReturnValue(true);
+  find.mockResolvedValue([row]);
+  clearSources();
+  clearSystemResolvers();
+  registerReleasesWidgetSource();
+});
+
+describe("what it asks the service", () => {
+  it("asks for the SOONEST scheduled releases still ahead", async () => {
+    // 🔴 All three together are the question. `order: "soonest"` alone under a
+    // missing `scheduledAfter` includes releases that already shipped; the
+    // window alone under the default order returns the furthest-out ones.
+    await executeWidgetQuery(
+      { source: RELEASES_SOURCE_ID, op: "list", limit: 3 },
+      caller
+    );
+
+    const [query] = find.mock.calls[0] as [Record<string, unknown>];
+    expect(query.state).toBe("scheduled");
+    expect(query.order).toBe("soonest");
+    expect(query.limit).toBe(3);
+    expect(query.scheduledAfter).toBeInstanceOf(Date);
+  });
+
+  it("hands the service the CALLER, and never overrides access", async () => {
+    // 🔴 The resolver adds no rule of its own, so the service's `authorize` is
+    // the only thing standing between a reader and every release in the
+    // install. It can only run on a caller it was given.
+    await executeWidgetQuery(
+      { source: RELEASES_SOURCE_ID, op: "list" },
+      {
+        ...caller,
+        authenticatedScope: {
+          actorType: "apiKey" as const,
+          permissions: ["releases:read"],
+        },
+      }
+    );
+
+    const [, actor] = find.mock.calls[0] as [unknown, Record<string, unknown>];
+    expect(actor.userId).toBe("user-1");
+    expect(actor.overrideAccess).toBeUndefined();
+    expect(actor.authenticatedScope).toEqual({
+      actorType: "apiKey",
+      permissions: ["releases:read"],
+    });
+  });
+
+  it("does not invent an authenticatedScope for a session caller", async () => {
+    // A present-but-undefined key wins a spread, so an unconditional one would
+    // stamp a session caller with an empty scope and have it judged as a
+    // narrowly scoped key rather than by its roles.
+    await executeWidgetQuery(
+      { source: RELEASES_SOURCE_ID, op: "list" },
+      caller
+    );
+
+    const [, actor] = find.mock.calls[0] as [unknown, Record<string, unknown>];
+    expect("authenticatedScope" in actor).toBe(false);
+  });
+});
+
+describe("what it answers with", () => {
+  it("publishes only its DECLARED fields", async () => {
+    // 🔴 A release row carries `createdBy`, `revision` and `publishedAt`. The
+    // source's field list is the allowlist a query is checked against, so a row
+    // returned whole would hand every reader columns the source never declared
+    // and nothing downstream would refuse them.
+    const result = await executeWidgetQuery(
+      { source: RELEASES_SOURCE_ID, op: "list" },
+      caller
+    );
+
+    const [item] = (result as { items: Record<string, unknown>[] }).items;
+    expect(Object.keys(item).sort()).toEqual(["scheduledAt", "state", "title"]);
+  });
+
+  it("heads only the columns the query selected", async () => {
+    const result = await executeWidgetQuery(
+      { source: RELEASES_SOURCE_ID, op: "list", select: ["title"] },
+      caller
+    );
+
+    expect((result as { fields?: unknown }).fields).toEqual([
+      { name: "title", label: "Release" },
+    ]);
+    const [item] = (result as { items: Record<string, unknown>[] }).items;
+    expect(Object.keys(item)).toEqual(["title"]);
+  });
+});
+
+describe("what it refuses", () => {
+  it("refuses a `where`, rather than ignoring it", async () => {
+    // 🔴 The declared fields make a `where` expressible, and this resolver asks
+    // one fixed question. Accepting the filter and discarding it answers a
+    // DIFFERENT question than the one asked, with rows that look right.
+    await expect(
+      executeWidgetQuery(
+        {
+          source: RELEASES_SOURCE_ID,
+          op: "list",
+          where: { state: { equals: "draft" } },
+        },
+        caller
+      )
+    ).rejects.toThrow(/unavailable source or unsupported op/);
+    expect(find).not.toHaveBeenCalled();
+  });
+
+  it("refuses a `sort`, rather than ignoring it", async () => {
+    await expect(
+      executeWidgetQuery(
+        { source: RELEASES_SOURCE_ID, op: "list", sort: "-scheduledAt" },
+        caller
+      )
+    ).rejects.toThrow(/unavailable source or unsupported op/);
+    expect(find).not.toHaveBeenCalled();
+  });
+
+  it("says nothing specific when the service is not registered", async () => {
+    has.mockReturnValue(false);
+
+    await expect(
+      executeWidgetQuery({ source: RELEASES_SOURCE_ID, op: "list" }, caller)
+    ).rejects.toThrow(/unexpected error|internal/i);
+  });
+});

--- a/packages/nextly/src/domains/releases/releases-repository.ts
+++ b/packages/nextly/src/domains/releases/releases-repository.ts
@@ -124,7 +124,17 @@ export interface DocumentRef {
  * `"soonest"` serves "what ships next". A `soonestFirst: false` would read as
  * the absence of a preference rather than as the other choice.
  */
-export type ReleaseListOrder = "soonest" | "latest";
+export const RELEASE_LIST_ORDERS = ["soonest", "latest"] as const;
+
+/**
+ * Declared as a const array with the type DERIVED from it, the way this
+ * codebase spells every other closed vocabulary. A bare type union has no
+ * runtime form, so nothing can check a value against it -- and this particular
+ * field fails silently when unchecked: an unrecognised order does not throw and
+ * does not return nothing, it returns the OPPOSITE END of the schedule, which
+ * reads as a working query.
+ */
+export type ReleaseListOrder = (typeof RELEASE_LIST_ORDERS)[number];
 
 export interface ReleaseRow {
   id: string;

--- a/packages/nextly/src/domains/releases/releases-repository.ts
+++ b/packages/nextly/src/domains/releases/releases-repository.ts
@@ -116,6 +116,16 @@ export interface DocumentRef {
   locale: string | null;
 }
 
+/**
+ * Which end of the scheduled timeline a release listing is taken from.
+ *
+ * Named rather than a boolean, because both ends are real questions and neither
+ * is the negation of the other: `"latest"` serves "what happened recently",
+ * `"soonest"` serves "what ships next". A `soonestFirst: false` would read as
+ * the absence of a preference rather than as the other choice.
+ */
+export type ReleaseListOrder = "soonest" | "latest";
+
 export interface ReleaseRow {
   id: string;
   title: string;
@@ -554,6 +564,7 @@ export class ReleasesRepository {
     scheduledAfter?: Date;
     scheduledBefore?: Date;
     limit?: number;
+    order?: ReleaseListOrder;
   }): Promise<ReleaseRow[]> {
     const conditions: VersionsWhereCondition[] = [];
     // An explicitly EMPTY id list means "none of them", which is not the same
@@ -584,21 +595,36 @@ export class ReleasesRepository {
         value: query.scheduledBefore,
       });
     }
+    // 🔴 The direction decides WHICH END of the window a `limit` keeps, so it
+    // belongs to the caller's question rather than to this method. Descending
+    // answers "what happened recently" and stays the default, so every existing
+    // caller is unchanged; ascending answers "what ships next", which under the
+    // descending order returns the FURTHEST-OUT releases while looking correct.
+    const direction = query.order === "soonest" ? "asc" : "desc";
     return this.db.select<ReleaseRow>(RELEASES, {
       where: conditions.length > 0 ? { and: conditions } : undefined,
       orderBy: [
-        // NULLS LAST, stated rather than defaulted. An unscheduled draft has a
-        // null instant, and the default differs per dialect — on PostgreSQL a
-        // descending order puts nulls first, so a limited "what ships next"
-        // query would return drafts and omit every scheduled release.
-        { column: "scheduledAt", direction: "desc", nulls: "last" },
-        { column: "createdAt", direction: "desc" },
+        // NULLS LAST in BOTH directions, stated rather than defaulted. An
+        // unscheduled draft has a null instant, and the default differs per
+        // dialect — on PostgreSQL a descending order puts nulls first, so a
+        // limited "what ships next" query would return drafts and omit every
+        // scheduled release. Ascending is no safer left implicit: PostgreSQL
+        // puts nulls last there while SQLite and MySQL put them first, so the
+        // same query would answer differently per dialect. A draft is not the
+        // next thing to ship under either direction.
+        { column: "scheduledAt", direction, nulls: "last" },
+        { column: "createdAt", direction },
         // `id` last, so the order is actually total. `createdAt` is not unique
         // and is stored coarsely enough for concurrent releases to tie —
         // especially on SQLite — and two drafts tie on a null `scheduledAt` as
         // well, so without this a limited page can return different rows across
         // query plans and dialects.
-        { column: "id", direction: "desc" },
+        //
+        // Both tiebreakers follow `direction` rather than staying descending,
+        // so a tie breaks toward the same end the primary key does: under
+        // "soonest" the earlier-created of two releases sharing an instant
+        // comes first, which is the one a reader means by "next".
+        { column: "id", direction },
       ],
       limit: query.limit,
     });

--- a/packages/nextly/src/domains/releases/releases-widget-source.ts
+++ b/packages/nextly/src/domains/releases/releases-widget-source.ts
@@ -1,0 +1,210 @@
+/**
+ * `system:releases` — the dashboard's view of what ships next.
+ *
+ * The first source answered by a DOMAIN SERVICE rather than compiled to a
+ * collection query, and it is here rather than in the widgets domain because
+ * the registration is PUSHED: widgets knows nothing about releases, so a domain
+ * can publish a source without editing a file it does not own, and the widgets
+ * package does not acquire a dependency on most of the codebase to offer a card.
+ *
+ * 🔴 The resolver adds no access rule of its own. `ReleasesService.find` calls
+ * its own `authorize` before it reads, so every row this returns has already
+ * been judged by the rule that owns it. A filter applied here would be a second
+ * implementation of that rule, agreeing on the day it is written and drifting
+ * afterwards — which is what `domains/widgets/system-sources.ts` exists to
+ * prevent, and what Strapi's homepage widgets got wrong (strapi#22921).
+ *
+ * @module domains/releases/releases-widget-source
+ */
+
+import { container } from "../../di/container";
+import { NextlyError } from "../../errors/nextly-error";
+import type { ReadCaller } from "../../services/dashboard/readable-resources";
+import type { WidgetQuery } from "../widgets/query";
+import type { WidgetResult, WidgetResultField } from "../widgets/result";
+import { failUnavailableSourceOrOp } from "../widgets/sources";
+import { registerSystemSource } from "../widgets/system-sources";
+
+import type { ReleaseRow } from "./releases-repository";
+import type {
+  ReleaseActor,
+  ReleasesService,
+} from "./services/releases-service";
+
+export const RELEASES_SOURCE_ID = "system:releases";
+
+/**
+ * How many releases the card reads when the query names no limit.
+ *
+ * A cap rather than a page size: `find` is bounded by `scheduledAfter` as well,
+ * so this only decides how much of an unusually crowded schedule a card draws.
+ */
+const DEFAULT_LIMIT = 5;
+
+/**
+ * The fields this source publishes, and the ONLY names a query may reference.
+ *
+ * Deliberately three of `ReleaseRow`'s eleven. `createdBy`, `revision`,
+ * `publishedAt` and the rest are either an internal identifier or a fact about
+ * a release that has already shipped, and a source's field list is the
+ * allowlist every `select` is checked against — so publishing a column here is
+ * publishing it to every reader who may see the source at all.
+ */
+const RELEASE_FIELDS = [
+  { name: "title", type: "string" as const, label: "Release" },
+  { name: "state", type: "string" as const, label: "State" },
+  { name: "scheduledAt", type: "date" as const, label: "Scheduled" },
+];
+
+/**
+ * The service, resolved at CALL time rather than at registration.
+ *
+ * `registerReleasesWidgetSource` runs during boot's registry reset, before the
+ * container necessarily holds `releasesService`; a resolver that captured the
+ * instance would either fail at boot or pin the first one built and survive a
+ * hot reload holding it. This is the same lookup `direct-api/namespaces/releases`
+ * makes, including the `has` guard, for the same reason.
+ */
+function service(): ReleasesService {
+  if (!container.has("releasesService")) {
+    // The public sentence stays the uniform internal-error one; the reason an
+    // operator needs goes to the log rather than into a body a client reads.
+    throw NextlyError.internal({
+      logContext: { reason: "releases-service-unregistered" },
+    });
+  }
+  return container.get<ReleasesService>("releasesService");
+}
+
+/**
+ * The dashboard caller, as the releases domain spells one.
+ *
+ * `overrideAccess` is deliberately never set: this is a reader's request, and
+ * the service must judge it as one. The API key's own stamped scope travels
+ * when present, because a narrowly scoped key must be judged on that scope
+ * rather than on the roles of whoever minted it.
+ */
+function actorFor(caller: ReadCaller): ReleaseActor {
+  return {
+    userId: caller.user.id,
+    ...(caller.authenticatedScope !== undefined && {
+      authenticatedScope: caller.authenticatedScope,
+    }),
+  };
+}
+
+/** A release row reduced to the fields this source declares. */
+function projected(row: ReleaseRow, names: readonly string[]) {
+  const full: Record<string, unknown> = {
+    title: row.title,
+    state: row.state,
+    scheduledAt: row.scheduledAt,
+  };
+  return Object.fromEntries(names.map(name => [name, full[name]]));
+}
+
+/**
+ * The columns to head a list with, when the query chose them.
+ *
+ * Mirrors the collection path: `fields` is present only when the query declared
+ * `select`, because without one the rows carry whatever the source holds and
+ * there are no columns the widget chose.
+ */
+function describeFields(
+  select: readonly string[] | undefined
+): WidgetResultField[] | undefined {
+  if (!select || select.length === 0) return undefined;
+  const labels = new Map(RELEASE_FIELDS.map(f => [f.name, f.label]));
+  const seen = new Set<string>();
+  const described: WidgetResultField[] = [];
+  for (const name of select) {
+    if (seen.has(name)) continue;
+    seen.add(name);
+    const label = labels.get(name);
+    if (label !== undefined) described.push({ name, label });
+  }
+  return described.length > 0 ? described : undefined;
+}
+
+/**
+ * Answer "what ships next", soonest first.
+ *
+ * 🔴 `order: "soonest"` is what makes the limit keep the right end. The
+ * repository's default is recent-first, which is correct for "what happened"
+ * and returns the FURTHEST-OUT releases for this question — with real rows, in
+ * a plausible order, so nothing in the result says it is wrong.
+ *
+ * `scheduledAfter: now` rather than a fixed window: a release scheduled for
+ * next year is still the next one when nothing is closer, and a window would
+ * make the card empty rather than say so.
+ *
+ * `where` and `sort` are REFUSED rather than ignored. The source's declared
+ * fields are the allowlist a query's `where` is validated against, so a caller
+ * may express one — and this resolver asks a fixed question, so honouring the
+ * validation while discarding the filter would answer a different question than
+ * the one asked and look correct doing it. Refused with the shared string, the
+ * way every other dead end here answers.
+ */
+async function resolveReleases(
+  query: WidgetQuery,
+  caller: ReadCaller
+): Promise<WidgetResult> {
+  if (query.where !== undefined) {
+    failUnavailableSourceOrOp(
+      `source "${RELEASES_SOURCE_ID}" does not support a "where" filter`
+    );
+  }
+  if (query.sort !== undefined) {
+    failUnavailableSourceOrOp(
+      `source "${RELEASES_SOURCE_ID}" answers in schedule order and cannot be sorted`
+    );
+  }
+
+  const rows = await service().find(
+    {
+      state: "scheduled",
+      scheduledAfter: new Date(),
+      order: "soonest",
+      limit: query.limit ?? DEFAULT_LIMIT,
+    },
+    actorFor(caller)
+  );
+
+  const names = query.select?.length
+    ? query.select.filter(name => RELEASE_FIELDS.some(f => f.name === name))
+    : RELEASE_FIELDS.map(f => f.name);
+
+  return {
+    op: "list",
+    items: rows.map(row => projected(row, names)),
+    ...(describeFields(query.select) && {
+      fields: describeFields(query.select),
+    }),
+  };
+}
+
+/**
+ * Publish the source and the function that answers it.
+ *
+ * Called from the boot-time registry reset, which is the one choke point both
+ * boot paths funnel through — so a dev-server hot reload republishes exactly
+ * once rather than colliding with the previous boot's registration.
+ *
+ * `supports` names `list` and nothing else. There is no count endpoint on the
+ * releases service, and counting by fetching every row is the full scan
+ * `find`'s own limit docblock warns against; declaring an op this source cannot
+ * answer would put the refusal in front of a reader rather than here.
+ */
+export function registerReleasesWidgetSource(): void {
+  registerSystemSource(
+    {
+      id: RELEASES_SOURCE_ID,
+      label: "Upcoming releases",
+      kind: "system",
+      titleField: "title",
+      supports: ["list"],
+      fields: RELEASE_FIELDS,
+    },
+    resolveReleases
+  );
+}

--- a/packages/nextly/src/domains/releases/releases-widget-source.ts
+++ b/packages/nextly/src/domains/releases/releases-widget-source.ts
@@ -87,6 +87,13 @@ function service(): ReleasesService {
 function actorFor(caller: ReadCaller): ReleaseActor {
   return {
     userId: caller.user.id,
+    // 🔴 Forwarded, because `ReleaseActor.userRoles` exists precisely so a
+    // code-defined access rule evaluates against the real user rather than
+    // against an empty list. Both other constructors of this actor already send
+    // it — `direct-api/namespaces/releases` and `api/releases` — so omitting it
+    // here would make this the one caller whose roles vanish, and a rule that
+    // reads them would deny a reader the other two admit.
+    ...(caller.user.roles !== undefined && { userRoles: caller.user.roles }),
     ...(caller.authenticatedScope !== undefined && {
       authenticatedScope: caller.authenticatedScope,
     }),
@@ -127,6 +134,58 @@ function describeFields(
 }
 
 /**
+ * What this resolver does with each field of a widget query.
+ *
+ * 🔴 An exhaustive `Record` over `keyof WidgetQuery`, not a list of fields to
+ * reject. This resolver asks ONE fixed question, so any field it does not
+ * consume would otherwise be accepted by `validateReadWidgetQuery` and then
+ * quietly dropped — answering a different question than the caller asked, with
+ * rows that look entirely right. Listing the rejects instead is what let
+ * `status` through: `where` and `sort` were named and the third was not.
+ *
+ * Keyed on the TYPE, so adding a field to `WidgetQuery` fails `check-types`
+ * here until someone decides what it means for this source. That is a
+ * deliberate, visible coupling; the alternative is a silent one, and the silent
+ * one has already produced this defect once.
+ */
+const QUERY_FIELD_USE: Record<keyof WidgetQuery, "consumed" | "refused"> = {
+  source: "consumed",
+  op: "consumed",
+  select: "consumed",
+  limit: "consumed",
+  where: "refused",
+  sort: "refused",
+  status: "refused",
+};
+
+/**
+ * Refuse a query carrying anything this source cannot honour.
+ *
+ * Refused with the shared string every other dead end here uses; the field
+ * names travel in the log rather than the response, which is careful not to
+ * describe a source the caller may not be able to see.
+ *
+ * A key present but `undefined` is not carried input: `readWidgetQuery` reads
+ * every property once into a fresh object, so an absent field can arrive as an
+ * own key holding `undefined`, and treating that as supplied would refuse an
+ * ordinary query.
+ */
+function refuseUnconsumed(query: WidgetQuery): void {
+  const carried = Object.entries(query)
+    .filter(
+      ([name, value]) =>
+        value !== undefined &&
+        QUERY_FIELD_USE[name as keyof WidgetQuery] === "refused"
+    )
+    .map(([name]) => name);
+  if (carried.length > 0) {
+    failUnavailableSourceOrOp(
+      `source "${RELEASES_SOURCE_ID}" answers a fixed question and cannot honour: ${carried.join(", ")}`
+    );
+  }
+}
+
+/**
  * Answer "what ships next", soonest first.
  *
  * 🔴 `order: "soonest"` is what makes the limit keep the right end. The
@@ -138,27 +197,18 @@ function describeFields(
  * next year is still the next one when nothing is closer, and a window would
  * make the card empty rather than say so.
  *
- * `where` and `sort` are REFUSED rather than ignored. The source's declared
- * fields are the allowlist a query's `where` is validated against, so a caller
- * may express one — and this resolver asks a fixed question, so honouring the
- * validation while discarding the filter would answer a different question than
- * the one asked and look correct doing it. Refused with the shared string, the
- * way every other dead end here answers.
+ * Every field this source does not consume is REFUSED rather than ignored —
+ * see `QUERY_FIELD_USE`. The declared fields are the allowlist a `where` is
+ * checked against and `status` is accepted by the validator for every source,
+ * so a caller may express either; this resolver asks a fixed question, so
+ * honouring the validation while discarding the selector would answer a
+ * different question than the one asked and look correct doing it.
  */
 async function resolveReleases(
   query: WidgetQuery,
   caller: ReadCaller
 ): Promise<WidgetResult> {
-  if (query.where !== undefined) {
-    failUnavailableSourceOrOp(
-      `source "${RELEASES_SOURCE_ID}" does not support a "where" filter`
-    );
-  }
-  if (query.sort !== undefined) {
-    failUnavailableSourceOrOp(
-      `source "${RELEASES_SOURCE_ID}" answers in schedule order and cannot be sorted`
-    );
-  }
+  refuseUnconsumed(query);
 
   const rows = await service().find(
     {

--- a/packages/nextly/src/domains/releases/services/releases-service.ts
+++ b/packages/nextly/src/domains/releases/services/releases-service.ts
@@ -311,7 +311,8 @@ export interface ReleaseBlocker {
   entryId: string;
 }
 
-export interface FindReleasesQuery {
+/** The filters every release listing accepts, whichever ordering it uses. */
+interface FindReleasesFilters {
   /**
    * Restrict to one lifecycle state.
    *
@@ -330,20 +331,6 @@ export interface FindReleasesQuery {
   scheduledAfter?: Date;
   scheduledBefore?: Date;
   /**
-   * Only releases that CONTAIN this document.
-   *
-   * The inverse of `listMembers`, and the question a document editor asks: what
-   * is going to happen to the thing I am looking at. Expressed as a filter on
-   * the release list rather than a route of its own, because that is what it is
-   * — the same resource, narrowed — and because a literal path segment under
-   * `/api/releases` would be read as a release id.
-   *
-   * Answers about SCHEDULED releases only. A draft membership changes nothing on
-   * its own, and the question this serves is whether the document will change
-   * without anyone touching it again.
-   */
-  containing?: DocumentRef;
-  /**
    * How many rows at most. Must be a non-negative integer when given.
    *
    * There is no `offset`: the select port this reads through exposes `where`,
@@ -354,17 +341,57 @@ export interface FindReleasesQuery {
    * move as releases publish.
    */
   limit?: number;
-  /**
-   * Which end of the timeline a `limit` keeps.
-   *
-   * Defaults to `"latest"`, the recent-first order every caller before the
-   * dashboard wanted. `"soonest"` exists because the two are not the same
-   * question narrowed differently: asking for the next five releases under the
-   * recent-first order returns the five FURTHEST OUT, and answers with real
-   * rows in a plausible order, so nothing about the result says it is wrong.
-   */
-  order?: ReleaseListOrder;
 }
+
+/**
+ * What a release listing asks for.
+ *
+ * 🔴 A union on `containing` rather than one flat shape, because the two
+ * listings do not offer the same thing. `containing` routes to a different
+ * query whose order is part of its CONTRACT -- soonest first, the order the
+ * releases will actually be applied to that document -- and `resolveReleaseEffect`
+ * reads the last row as the final state. Honouring a caller's `order` there
+ * would reverse that and hand the winner's place to the loser.
+ *
+ * So the combination is unrepresentable rather than merely refused: an author
+ * writing `{ containing, order }` learns at compile time, which is where the
+ * public docblock on `ReleasesNamespace.find` has always said this. `find`
+ * refuses it at runtime too, because a type binds neither JavaScript nor a cast.
+ */
+export type FindReleasesQuery = FindReleasesFilters &
+  (
+    | {
+        /**
+         * Only releases that CONTAIN this document.
+         *
+         * The inverse of `listMembers`, and the question a document editor asks: what
+         * is going to happen to the thing I am looking at. Expressed as a filter on
+         * the release list rather than a route of its own, because that is what it is
+         * — the same resource, narrowed — and because a literal path segment under
+         * `/api/releases` would be read as a release id.
+         *
+         * Answers about SCHEDULED releases only. A draft membership changes nothing on
+         * its own, and the question this serves is whether the document will change
+         * without anyone touching it again.
+         */
+        containing?: DocumentRef;
+        /** Always soonest-first; see above. */
+        order?: never;
+      }
+    | {
+        containing?: undefined;
+        /**
+         * Which end of the timeline a `limit` keeps.
+         *
+         * Defaults to `"latest"`, the recent-first order every caller before the
+         * dashboard wanted. `"soonest"` exists because the two are not the same
+         * question narrowed differently: asking for the next five releases under the
+         * recent-first order returns the five FURTHEST OUT, and answers with real
+         * rows in a plausible order, so nothing about the result says it is wrong.
+         */
+        order?: ReleaseListOrder;
+      }
+  );
 
 /**
  * The document scopes a release can actually materialise.
@@ -669,6 +696,26 @@ export class ReleasesService {
       throw NextlyError.invalidInput({
         message: "`limit` must be a non-negative integer.",
         logContext: { reason: "invalid-limit", limit: query.limit },
+      });
+    }
+    // Read through a widened view, deliberately: the type above makes this
+    // combination unrepresentable, and a type binds neither a JavaScript caller
+    // nor a cast. Refused rather than honoured, because `findContaining`'s
+    // soonest-first order is its contract -- `resolveReleaseEffect` takes the
+    // LAST row as the final state -- so applying a caller's order there would
+    // hand the winner's place to the loser. Refused rather than ignored,
+    // because accepting an ordering and not applying it answers a different
+    // question than the one asked, with rows that look right.
+    const asked: FindReleasesFilters & {
+      containing?: DocumentRef;
+      order?: ReleaseListOrder;
+    } = query;
+    if (asked.containing !== undefined && asked.order !== undefined) {
+      throw NextlyError.invalidInput({
+        message:
+          "`order` is not available with `containing`: that listing is always " +
+          "soonest first, the order the releases will be applied to the document.",
+        logContext: { reason: "order-with-containing", order: asked.order },
       });
     }
     if (query.containing !== undefined) {

--- a/packages/nextly/src/domains/releases/services/releases-service.ts
+++ b/packages/nextly/src/domains/releases/services/releases-service.ts
@@ -69,6 +69,7 @@ import { documentRefKey } from "../releases-repository";
 import type {
   DocumentRef,
   NewRelease,
+  ReleaseListOrder,
   ReleaseMemberRow,
   ReleaseRow,
   ReleasesRepository,
@@ -353,6 +354,16 @@ export interface FindReleasesQuery {
    * move as releases publish.
    */
   limit?: number;
+  /**
+   * Which end of the timeline a `limit` keeps.
+   *
+   * Defaults to `"latest"`, the recent-first order every caller before the
+   * dashboard wanted. `"soonest"` exists because the two are not the same
+   * question narrowed differently: asking for the next five releases under the
+   * recent-first order returns the five FURTHEST OUT, and answers with real
+   * rows in a plausible order, so nothing about the result says it is wrong.
+   */
+  order?: ReleaseListOrder;
 }
 
 /**

--- a/packages/nextly/src/domains/releases/services/releases-service.ts
+++ b/packages/nextly/src/domains/releases/services/releases-service.ts
@@ -65,7 +65,7 @@ import {
 } from "../../../schemas/releases/types";
 import type { VersionScopeKind } from "../../../schemas/versions/types";
 import { isUniqueViolation } from "../../../shared/lib/unique-violation";
-import { documentRefKey } from "../releases-repository";
+import { documentRefKey, RELEASE_LIST_ORDERS } from "../releases-repository";
 import type {
   DocumentRef,
   NewRelease,
@@ -710,6 +710,22 @@ export class ReleasesService {
       containing?: DocumentRef;
       order?: ReleaseListOrder;
     } = query;
+    // 🔴 An unrecognised order is not a smaller mistake than an unrecognised
+    // state. `state` reaches a WHERE clause, so a typo answers with an empty
+    // list -- wrong, but visibly so. `order` reaches a ternary, so a typo
+    // selects the DEFAULT end and answers with real rows in the exact reverse
+    // of what was asked. Checked against the vocabulary's runtime form rather
+    // than trusted from the type, because the public Direct API is reachable
+    // from JavaScript and from a cast.
+    if (
+      asked.order !== undefined &&
+      !RELEASE_LIST_ORDERS.includes(asked.order)
+    ) {
+      throw NextlyError.invalidInput({
+        message: `\`order\` must be one of: ${RELEASE_LIST_ORDERS.join(", ")}.`,
+        logContext: { reason: "invalid-order", order: asked.order },
+      });
+    }
     if (asked.containing !== undefined && asked.order !== undefined) {
       throw NextlyError.invalidInput({
         message:

--- a/packages/nextly/src/domains/widgets/executable-source.ts
+++ b/packages/nextly/src/domains/widgets/executable-source.ts
@@ -1,0 +1,83 @@
+/**
+ * Whether a source can be executed at all, and by WHAT.
+ *
+ * Its own module because two callers need the same answer and must not derive
+ * it twice: the executor, which runs the query, and `api/widget-query`'s gate,
+ * which decides whether the caller is told anything specific about the source.
+ * The gate answered this question on the source's KIND alone, and that admitted
+ * a system source nobody had registered a resolver for -- which then reached
+ * field-level validation, where every message is specific. An undeclared
+ * `select` named the field AND the source, while an invented id got the generic
+ * refusal, so the pair distinguished a registered source from a nonexistent
+ * one: the enumeration oracle that gate exists to close.
+ *
+ * Extracted rather than exported from `execute.ts` for the same reason
+ * `result.ts` was. The endpoint mocks the executor in its own tests, and a
+ * module mock is a closed literal -- so importing this from there left it
+ * `undefined` at the call site, which threw a `TypeError` and was reported as
+ * an internal error rather than a refusal. Nothing here needs the Direct API,
+ * so nothing here should drag it in.
+ *
+ * @module domains/widgets/executable-source
+ */
+
+import {
+  failUnavailableSourceOrOp,
+  getSource,
+  type WidgetSource,
+} from "./sources";
+import { systemResolver, type SystemSourceResolver } from "./system-sources";
+
+/**
+ * A resolved source together with HOW it is answered.
+ *
+ * 🔴 The two travel as one value because they must never be decided
+ * separately. Asking the resolver store "is there an entry for this id?" and
+ * asking the source "what kind are you?" are two questions with two answers,
+ * and a dispatch that took the first would send a query wherever the map
+ * happened to point -- so an entry left under a collection id, by any route,
+ * would divert that collection's rows away from the access-controlled Direct
+ * API. Deciding once, on the KIND, and carrying the resolver out of that same
+ * branch makes the disagreement unrepresentable rather than merely unlikely.
+ */
+export type ExecutableSource =
+  | { kind: "system"; source: WidgetSource; resolve: SystemSourceResolver }
+  | { kind: "collection"; source: WidgetSource };
+
+/**
+ * Resolves `sourceId` against the live registry, or fails loudly.
+ *
+ * Every refusal goes through `failUnavailableSourceOrOp`, so a source that does
+ * not exist and one that exists but is not executable answer the caller
+ * identically -- the second would otherwise confirm the source is real. The
+ * distinction survives in the log.
+ */
+export function resolveExecutableSource(sourceId: string): ExecutableSource {
+  // Re-resolve rather than trusting the caller's copy: a source can be
+  // deregistered between configuration and execution, and a query pointing at
+  // a source that no longer exists must fail rather than fall through.
+  const source = getSource(sourceId);
+  if (!source) {
+    failUnavailableSourceOrOp(`unknown source "${sourceId}" at execution`);
+  }
+  // A SYSTEM source is executable exactly when something registered a resolver
+  // for it. The two halves are published together, so a source with no
+  // resolver means a registration that never completed rather than a caller
+  // asking for something reasonable -- and it answers like every other dead
+  // end, because saying which is which would confirm the source exists.
+  if (source.kind === "system") {
+    const resolve = systemResolver(source.id);
+    if (!resolve) {
+      failUnavailableSourceOrOp(
+        `system source "${sourceId}" has no registered resolver`
+      );
+    }
+    return { kind: "system", source, resolve };
+  }
+  if (source.kind !== "collection") {
+    failUnavailableSourceOrOp(
+      `source "${sourceId}" has kind "${source.kind}", which is not executable yet; only collections and system sources are`
+    );
+  }
+  return { kind: "collection", source };
+}

--- a/packages/nextly/src/domains/widgets/execute.ts
+++ b/packages/nextly/src/domains/widgets/execute.ts
@@ -24,15 +24,14 @@ import type { FindArgs } from "../../direct-api/types/collections";
 import type { ReadCaller } from "../../services/dashboard/readable-resources";
 import type { WhereFilter } from "../collections/query/query-operators";
 
+import { resolveExecutableSource } from "./executable-source";
 import type { WidgetQuery } from "./query";
 import type { WidgetResult, WidgetResultField } from "./result";
 import {
   failUnavailableSourceOrOp,
-  getSource,
   sourceTarget,
   type WidgetSource,
 } from "./sources";
-import { systemResolver, type SystemSourceResolver } from "./system-sources";
 
 export type { WidgetResult, WidgetResultField };
 
@@ -42,60 +41,6 @@ function toSelect(
 ): Record<string, boolean> | undefined {
   if (!fields || fields.length === 0) return undefined;
   return Object.fromEntries(fields.map(field => [field, true]));
-}
-
-/**
- * A resolved source together with HOW it is answered.
- *
- * 🔴 The two travel as one value because they must never be decided
- * separately. Asking the resolver store "is there an entry for this id?" and
- * asking the source "what kind are you?" are two questions with two answers,
- * and a dispatch that took the first would send a query wherever the map
- * happened to point -- so an entry left under a collection id, by any route,
- * would divert that collection's rows away from the access-controlled Direct
- * API. Deciding once, on the KIND, and carrying the resolver out of that same
- * branch makes the disagreement unrepresentable rather than merely unlikely.
- */
-type ExecutableSource =
-  | { kind: "system"; source: WidgetSource; resolve: SystemSourceResolver }
-  | { kind: "collection"; source: WidgetSource };
-
-/**
- * Resolves `query.source` against the live registry, or fails loudly.
- *
- * Every refusal goes through `failUnavailableSourceOrOp`, so a source that does
- * not exist and one that exists but is not executable answer the caller
- * identically -- the second would otherwise confirm the source is real. The
- * distinction survives in the log.
- */
-function resolveExecutableSource(sourceId: string): ExecutableSource {
-  // Re-resolve rather than trusting the caller's copy: a source can be
-  // deregistered between configuration and execution, and a query pointing at
-  // a source that no longer exists must fail rather than fall through.
-  const source = getSource(sourceId);
-  if (!source) {
-    failUnavailableSourceOrOp(`unknown source "${sourceId}" at execution`);
-  }
-  // A SYSTEM source is executable exactly when something registered a resolver
-  // for it. The two halves are published together, so a source with no
-  // resolver means a registration that never completed rather than a caller
-  // asking for something reasonable -- and it answers like every other dead
-  // end, because saying which is which would confirm the source exists.
-  if (source.kind === "system") {
-    const resolve = systemResolver(source.id);
-    if (!resolve) {
-      failUnavailableSourceOrOp(
-        `system source "${sourceId}" has no registered resolver`
-      );
-    }
-    return { kind: "system", source, resolve };
-  }
-  if (source.kind !== "collection") {
-    failUnavailableSourceOrOp(
-      `source "${sourceId}" has kind "${source.kind}", which is not executable yet; only collections and system sources are`
-    );
-  }
-  return { kind: "collection", source };
 }
 
 /**


### PR DESCRIPTION
## What this does

The dashboard can answer **what ships next**. `system:releases` is the first
widget source answered by a domain service rather than compiled to a collection
query — the mechanism #1518 built, now with a real consumer.

The resolver hands the question to `ReleasesService.find` **with the caller**
and adds no rule of its own, so that service's `authorize` remains the only
thing deciding which releases anyone sees.

## The ordering change, and why it was needed

`findReleases` orders `scheduledAt DESC NULLS LAST`. That is right for "what
happened recently" and wrong for "what is coming": a limited query for the next
few releases returned the **furthest-out** ones — real rows, in a plausible
order, with nothing in the result to say the answer was backwards.

It takes an `order` option now, defaulting to the existing recent-first
behaviour, so no current caller changes.

Worth noting where this came from rather than presenting it as a free choice:
the existing `nulls: "last"` was added by someone already reasoning about this
caller —

> on PostgreSQL a descending order puts nulls first, so a limited "what ships
> next" query would return drafts and omit every scheduled release

— so the ordering was designed with this question in mind and got half of it.
`NULLS LAST` is now stated in **both** directions, because PostgreSQL puts nulls
last under `ASC` while SQLite and MySQL put them first, and a draft is not the
next thing to ship under either.

## Two fixes to the source machinery

Both were found by codex on #1518 **after** it merged.

1. **The endpoint decided a system source was usable from its kind alone.** That
   admitted one nothing had registered a resolver for, which then reached
   field-level validation — where every message names the source. An undeclared
   `select` was answered in detail for a registered source and generically for
   an invented id, so the pair distinguished the two. That is the enumeration
   oracle the gate exists to close. The endpoint now asks the same question the
   executor asks, from one implementation.

   It lives in a new `executable-source.ts` rather than being exported from
   `execute.ts`: the endpoint mocks the executor in its own tests, and a module
   mock is a closed literal — so the import came back `undefined`, threw a
   `TypeError`, and was reported as an internal error rather than a refusal.
   Found by a test, not by review.

2. **The boot registry reset cleared sources but not their resolvers.** A system
   source removed or renamed between reloads left its resolver addressable for
   the process lifetime, holding whatever its closure captured, and ready to
   answer again if anything republished that id.

## Deliberately not here

**Readiness on the card.** Catalogue #4 says "upcoming releases + readiness", and
`blockingReasons` costs two queries per release (`listMembers` + `liveAuthors`),
so a five-row card would be a 10-query dashboard read. It wants a batched
`blockersFor(ids)` on the repository first; that is a separate, honest piece of
work rather than something to bolt on here.

## Evidence

Every behaviour change is break-verified against a **wrong implementation**, not
a mutation of the new code. Each break moves exactly the named test, with
controls run before and after:

| break | test that moves |
| --- | --- |
| always recent-first (the pre-fix code) | "takes the SOONEST releases when a limited query asks for them" |
| always ascending (fix applied unconditionally) | the same test's control half |
| `nulls: "first"` | "keeps an unscheduled draft out of BOTH ends of the timeline" |
| drop `order: "soonest"` | "asks for the SOONEST scheduled releases still ahead" |
| return the release row whole | "publishes only its DECLARED fields" |
| ignore `where`/`sort` instead of refusing | both refusal tests |
| pass `overrideAccess: true` | "hands the service the CALLER, and never overrides access" |
| reset without `clearSystemResolvers` | "drops a resolver whose source did not survive the boot" |
| admit a system source on kind alone | three refusal tests, incl. the oracle one |

The ordering is verified **against a real database**, in
`releases-repository.integration.test.ts` — an in-memory assertion on the
`orderBy` argument would only have proved the call was made, not that rows came
back in that order.

One break initially passed: asserting the reset republishes its own resolver
could not fail, because that id is rewritten either way. The discriminating case
is a source the new boot does **not** republish; the test asserts that instead.

Local: build, check-types, lint, `nextly` 878 files / 11160 tests, integration
(sqlite) 247 files / 1496 tests, `admin` 3893, `ui` 1164, comment convention,
`changeset status`, and fallow `pass` — 13 changed files against `origin/main`,
every `*_introduced` at 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a releases widget source showing upcoming scheduled releases with title, status, and scheduled date.
  * Added support for ordering releases by soonest scheduled date or latest release.
  * The releases widget preserves caller access scope and supports selected fields.

* **Bug Fixes**
  * Unscheduled draft releases are excluded from release timelines.
  * Unsupported release query options and invalid ordering values are rejected.
  * Unavailable or unregistered widget sources are refused consistently.
  * Widget registry resets now restore the core releases source correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->