### PR TITLE
fix(blocks-engine): keep an instance's own visibility, ids and limits

### DIFF
--- a/.changeset/an-instance-keeps-what-its-author-set.md
+++ b/.changeset/an-instance-keeps-what-its-author-set.md
@@ -1,0 +1,52 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A component instance that an author had hidden was published to everyone. The
+instance node carried the visibility rule; composition replaced it with the
+component's own blocks, and the rule went with it — so the pass that withholds
+hidden content found nothing left to withhold, and content restricted to one
+audience was served to every visitor. An instance an author hides is now left
+in place for that pass to remove, and hiding a component at one screen size
+carries onto everything it draws.
+
+Placing the same component twice also published its HTML ids twice. Anchors,
+`<label for>` and id selectors then reached whichever copy the browser found
+first. Each instance now derives its own, by the same rule that already applies
+when a pattern is inserted, so a page holding both carries one spelling rather
+than two.
+
+Three limits were not the limits they claimed to be. A page's node cap counted
+only what composition added, so a full page could resolve to twice the cap
+while every later pass believed it was reading a bounded document. Slot content
+left behind under a slot a component no longer offers was composed in full
+before being discarded, which could exhaust that cap and cost the page a
+component it does show. And a component's overrides were counted only after the
+whole record had been read, so an oversized one was never bounded at all.
+
+A page, a region or a template supplied where a component was expected is now
+refused instead of being drawn as though it were one.

--- a/.changeset/an-instance-keeps-what-its-author-set.md
+++ b/.changeset/an-instance-keeps-what-its-author-set.md
@@ -73,3 +73,15 @@ component's copies. A block hidden by an instance no longer counts against the
 page's size limit, since it draws nothing. A component whose visibility setting
 was stored empty now takes the instance's per-screen hiding like any other. And
 copying a pattern no longer fails on a node whose attributes were stored empty.
+
+Two more relationships now travel with the copies. A link pointing at a spot
+inside its own component — the "#pricing" kind — moves with that spot, so it no
+longer sends a reader to somewhere on the page that does not exist; a link
+naming anything else is left exactly as written. And hiding a component only on
+some screen sizes now keeps its full setting, so a component hidden on tablet
+but restored on mobile appears on mobile again, instead of staying hidden all
+the way down.
+
+A component that arrives unreadable is also reported as broken data rather than
+as a component nobody has published, so an author is offered the remedy that
+can actually help.

--- a/.changeset/an-instance-keeps-what-its-author-set.md
+++ b/.changeset/an-instance-keeps-what-its-author-set.md
@@ -66,3 +66,10 @@ unrestricted, which would have published content that was meant to be withheld.
 And content left behind under a slot a component no longer offers was still
 counted against the page's size limit even though it is discarded, so a page
 could be refused a component that would have fitted.
+
+Four smaller repairs found the same way. Content a page places inside a
+component kept its own id references, instead of having them redirected at the
+component's copies. A block hidden by an instance no longer counts against the
+page's size limit, since it draws nothing. A component whose visibility setting
+was stored empty now takes the instance's per-screen hiding like any other. And
+copying a pattern no longer fails on a node whose attributes were stored empty.

--- a/.changeset/an-instance-keeps-what-its-author-set.md
+++ b/.changeset/an-instance-keeps-what-its-author-set.md
@@ -50,3 +50,19 @@ whole record had been read, so an oversized one was never bounded at all.
 
 A page, a region or a template supplied where a component was expected is now
 refused instead of being drawn as though it were one.
+
+Copying a component also broke the relationships built on its ids. A heading
+that names a field, or help text a control points at, is wired together by id —
+and moving the ids without moving the references left every one of them
+pointing at something that no longer exists, so a screen reader announced the
+control with no name and no description at all. References now move with their
+targets, including inside patterns, where the same copy had the same effect. A
+reference to something the copy does not contain is left alone.
+
+Three smaller repairs. A component instance stored with an empty visibility
+setting could stop a page rendering outright. A component whose own visibility
+setting could not be read was being rewritten into one that reads as
+unrestricted, which would have published content that was meant to be withheld.
+And content left behind under a slot a component no longer offers was still
+counted against the page's size limit even though it is discarded, so a page
+could be refused a component that would have fitted.

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -117,6 +117,10 @@ export {
   moveNode,
   reidSubtree,
   reidSubtreeWithMap,
+  // The one rule for what a copied DOM id becomes. Public because two copiers
+  // apply it — pattern insert and component composition — and a page may hold
+  // the output of both, so a second spelling would put two ids on one target.
+  mintDomId,
   duplicateNode,
   updateNode,
 } from "./tree";

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -121,6 +121,13 @@ export {
   // apply it — pattern insert and component composition — and a page may hold
   // the output of both, so a second spelling would put two ids on one target.
   mintDomId,
+  // And the other half of it: an id that MOVED leaves every reference to it
+  // pointing at nothing, and `aria-labelledby` resolving to nothing is an
+  // element losing its accessible name in silence. Published as data and as a
+  // function, because a surface that copies nodes without going through these
+  // helpers still has to know which attributes carry an id.
+  ID_REFERENCE_ATTRIBUTES,
+  remapIdReferences,
   duplicateNode,
   updateNode,
 } from "./tree";

--- a/packages/blocks-engine/src/resolve-instances.test.ts
+++ b/packages/blocks-engine/src/resolve-instances.test.ts
@@ -15,7 +15,7 @@ import {
   type BlockNode,
   type ComponentDocument,
 } from "./document";
-import { DEFAULT_LIMITS } from "./limits";
+import { DEFAULT_LIMITS, MAX_ENVELOPE_ENTRIES } from "./limits";
 import {
   componentIdsIn,
   resolveComponentInstances,
@@ -682,23 +682,28 @@ describe("resolveComponentInstances limits and speculative work", () => {
 
   it("gives back the budget an instance's slot content spent before it failed", () => {
     const definitions = defs({
-      big: component([node("b1"), node("b2")]),
-      small: component([node("s1"), node("s2"), node("s3")]),
+      // `big` must EXPOSE the slot, or its content is never resolved at all
+      // and there is no spend to give back.
+      big: component([box("b1", []), node("b2"), node("b3")], {
+        slots: { any: { label: "Any", nodeId: "b1", slot: "children" } },
+      }),
+      small: component([node("s1"), node("s2"), node("s3"), node("s4")]),
     });
     const doc = page([
       instance("i1", "big", {}, { slots: { any: [instance("i2", "small")] } }),
       instance("i3", "small"),
     ]);
 
-    // Three: the host's own node count, and exactly what `small` costs. The
-    // slot content inside `i1` spends all of it and is then thrown away with
-    // `i1`, so the sibling fits only if that spend was given back.
+    // Sized so the sibling fits ONLY if the slot content's spend comes back:
+    // the host holds three nodes, so composition starts with three left, `i1`
+    // spends four of them on slot content that is then thrown away with it,
+    // and `i3` needs four.
     const result = resolveComponentInstances(doc, definitions, {
-      limits: { ...DEFAULT_LIMITS, maxNodes: 3 },
+      limits: { ...DEFAULT_LIMITS, maxNodes: 6 },
     });
 
     expect(result.unresolved.map(e => e.instanceId)).toEqual(["i1"]);
-    expect(byInstanceOf(result.document, "i3")).toHaveLength(3);
+    expect(byInstanceOf(result.document, "i3")).toHaveLength(4);
   });
 
   it("keeps an inlined id stable when an unrelated node joins its definition", () => {
@@ -757,6 +762,177 @@ describe("resolveComponentInstances limits and speculative work", () => {
     });
 
     expect(result.unresolved.map(e => e.reason)).toEqual(["budget"]);
+  });
+});
+
+describe("resolveComponentInstances what an instance carries", () => {
+  it("leaves a condition-gated instance standing rather than expanding it", () => {
+    const gate = { conditions: [[{ field: "tier", op: "eq", value: "vip" }]] };
+    const doc = page([
+      { ...instance("i1", "hero"), visibility: gate },
+      node("plain"),
+    ]);
+    const definitions = defs({ hero: component([node("d1"), node("d2")]) });
+
+    const result = resolveComponentInstances(doc, definitions);
+
+    // The gate has to survive INTO the tree the later pass prunes. Expanding
+    // and dropping it serves restricted content to everyone.
+    expect(result.document.nodes.map(e => e.id)).toEqual(["i1", "plain"]);
+    expect(result.document.nodes[0]!.visibility).toEqual(gate);
+    expect(result.unresolved).toEqual([]);
+    expect(result.referenced).toEqual([]);
+  });
+
+  it("carries an instance's per-breakpoint hiding onto every root", () => {
+    const doc = page([
+      {
+        ...instance("i1", "hero"),
+        visibility: { devices: { mobile: false, desktop: true } },
+      },
+    ]);
+    const definitions = defs({ hero: component([node("d1"), node("d2")]) });
+
+    const nodes = resolveComponentInstances(doc, definitions).document.nodes;
+
+    expect(nodes).toHaveLength(2);
+    expect(nodes.map(e => e.visibility?.devices?.mobile)).toEqual([
+      false,
+      false,
+    ]);
+    // Only hiding travels: the instance may not un-hide what the definition hid.
+    expect(nodes[0]!.visibility?.devices).not.toHaveProperty("desktop");
+  });
+
+  it("does not let an instance re-show a root its definition hid", () => {
+    const doc = page([
+      {
+        ...instance("i1", "hero"),
+        visibility: { devices: { mobile: true } },
+      },
+    ]);
+    const definitions = defs({
+      hero: component([
+        node("d1", { visibility: { devices: { mobile: false } } }),
+      ]),
+    });
+
+    const nodes = resolveComponentInstances(doc, definitions).document.nodes;
+
+    expect(nodes[0]!.visibility?.devices?.mobile).toBe(false);
+  });
+
+  it("gives each instance its own DOM ids for one definition", () => {
+    const doc = page([instance("i1", "hero"), instance("i2", "hero")]);
+    const definitions = defs({
+      hero: component([
+        node("d1", { cssId: "signup", attributes: { ID: "signup" } }),
+      ]),
+    });
+
+    const nodes = resolveComponentInstances(doc, definitions).document.nodes;
+
+    expect(nodes[0]!.cssId).not.toBe(nodes[1]!.cssId);
+    expect(nodes[0]!.attributes!.ID).not.toBe(nodes[1]!.attributes!.ID);
+    // Derived from the original, so it stays recognisable in a URL fragment.
+    expect(nodes[0]!.cssId).toContain("signup");
+  });
+
+  it("maps one definition's repeated DOM id to a single replacement", () => {
+    const doc = page([instance("i1", "hero")]);
+    const definitions = defs({
+      hero: component([
+        node("d1", { cssId: "dup" }),
+        node("d2", { cssId: "dup" }),
+      ]),
+    });
+
+    const nodes = resolveComponentInstances(doc, definitions).document.nodes;
+
+    // The pair addressed one target before composition and must after.
+    expect(nodes[0]!.cssId).toBe(nodes[1]!.cssId);
+  });
+});
+
+describe("resolveComponentInstances bounds", () => {
+  it("counts the host's surviving nodes against the composition budget", () => {
+    const doc = page([node("keep"), instance("i1", "hero")]);
+    const definitions = defs({
+      hero: component([node("d1"), node("d2"), node("d3")]),
+    });
+
+    const result = resolveComponentInstances(doc, definitions, {
+      limits: { ...DEFAULT_LIMITS, maxNodes: 3 },
+    });
+
+    expect(flatten(result.document.nodes)).toHaveLength(2);
+    expect(result.unresolved.map(e => e.reason)).toEqual(["budget"]);
+  });
+
+  it("spends the slot the replaced instance itself gives up", () => {
+    const doc = page([node("keep"), instance("i1", "hero")]);
+    const definitions = defs({ hero: component([node("d1"), node("d2")]) });
+
+    // Two host nodes and a two-node definition under a cap of three: it fits
+    // only because the instance node is replaced rather than added to.
+    const result = resolveComponentInstances(doc, definitions, {
+      limits: { ...DEFAULT_LIMITS, maxNodes: 3 },
+    });
+
+    expect(flatten(result.document.nodes)).toHaveLength(3);
+    expect(result.unresolved).toEqual([]);
+  });
+
+  it("never resolves slot content the definition no longer exposes", () => {
+    const doc = page([
+      instance(
+        "i1",
+        "hero",
+        {},
+        { slots: { gone: [instance("i2", "absent")] } }
+      ),
+    ]);
+    const definitions = defs({ hero: component([node("d1")]) });
+
+    const result = resolveComponentInstances(doc, definitions);
+
+    expect(result.unresolved).toEqual([]);
+    expect(result.referenced).toEqual(["hero"]);
+  });
+
+  it("refuses an oversized overrides record rather than applying part of it", () => {
+    const overrides: Record<string, unknown> = { headline: "APPLIED" };
+    for (let i = 0; i < MAX_ENVELOPE_ENTRIES + 1; i += 1) {
+      overrides[`k${i}`] = i;
+    }
+    const definition = component([node("d1", { props: { text: "base" } })], {
+      exposed: [
+        {
+          id: "headline",
+          label: "H",
+          nodeId: "d1",
+          propPath: "text",
+          type: "text",
+        },
+      ],
+    });
+    const doc = page([instance("i1", "hero", { overrides })]);
+
+    const result = resolveComponentInstances(doc, defs({ hero: definition }));
+
+    // Applying a prefix would make which overrides an author gets depend on
+    // key enumeration order.
+    expect(result.document.nodes[0]!.props.text).toBe("base");
+  });
+
+  it("refuses a definition that is not a component document", () => {
+    const doc = page([instance("i1", "hero")]);
+    const definitions = defs({ hero: page([node("d1")]) });
+
+    const result = resolveComponentInstances(doc, definitions);
+
+    expect(result.unresolved.map(e => e.reason)).toEqual(["malformed"]);
+    expect(idsOf(result.document)).toEqual(["i1"]);
   });
 });
 

--- a/packages/blocks-engine/src/resolve-instances.test.ts
+++ b/packages/blocks-engine/src/resolve-instances.test.ts
@@ -1094,6 +1094,85 @@ describe("resolveComponentInstances defensive reads and references", () => {
   });
 });
 
+describe("resolveComponentInstances ownership and cost", () => {
+  it("leaves a host slot child's reference pointing at the host", () => {
+    const doc = page([
+      node("h", { cssId: "shared" }),
+      instance(
+        "i1",
+        "hero",
+        {},
+        {
+          slots: {
+            body: [
+              node("mine", { attributes: { "aria-describedby": "shared" } }),
+            ],
+          },
+        }
+      ),
+    ]);
+    const definitions = defs({
+      hero: component([box("c1", []), node("d2", { cssId: "shared" })], {
+        slots: { body: { label: "B", nodeId: "c1", slot: "children" } },
+      }),
+    });
+
+    const flat = flatten(
+      resolveComponentInstances(doc, definitions).document.nodes
+    );
+    const mine = flat.find(e => e.id === "mine")!;
+
+    // Host content is the page's own. Rewriting it against the DEFINITION's
+    // map redirects a working reference at a node the host never named.
+    expect(mine.attributes!["aria-describedby"]).toBe("shared");
+  });
+
+  it("does not charge the budget for a node an override hides", () => {
+    const doc = page([
+      node("keep"),
+      instance("i1", "hero", { overrides: { gone: false } }),
+    ]);
+    const definitions = defs({
+      hero: component([node("d1"), node("d2")], {
+        exposed: [
+          {
+            id: "gone",
+            label: "G",
+            nodeId: "d1",
+            propPath: "x",
+            type: "visibility",
+          },
+        ],
+      }),
+    });
+
+    const result = resolveComponentInstances(doc, definitions, {
+      limits: { ...DEFAULT_LIMITS, maxNodes: 2 },
+    });
+
+    // The composed document holds the host node and one definition node.
+    expect(result.unresolved).toEqual([]);
+    expect(flatten(result.document.nodes)).toHaveLength(2);
+  });
+
+  it("merges devices onto a root whose visibility is stored null", () => {
+    const doc = page([
+      stored(instance("i1", "hero"), {
+        visibility: { devices: { mobile: false } },
+      }),
+    ]);
+    const definitions = defs({
+      hero: component([stored(node("d1"), { visibility: null })]),
+    });
+
+    const nodes = resolveComponentInstances(doc, definitions).document.nodes;
+
+    // `isConditionGated` reads null exactly like an absent envelope, so the
+    // merge must too — refusing it silently drops the author's hiding.
+    expect(nodes[0]!.visibility?.devices?.mobile).toBe(false);
+  });
+});
+
 describe("componentIdsIn", () => {
   it("lists each referenced id once, in first-reached order", () => {
     const nodes = [

--- a/packages/blocks-engine/src/resolve-instances.test.ts
+++ b/packages/blocks-engine/src/resolve-instances.test.ts
@@ -809,12 +809,15 @@ describe("resolveComponentInstances what an instance carries", () => {
     const nodes = resolveComponentInstances(doc, definitions).document.nodes;
 
     expect(nodes).toHaveLength(2);
-    expect(nodes.map(e => e.visibility?.devices?.mobile)).toEqual([
-      false,
-      false,
+    // The whole setting travels, both values. Hiding inherits to narrower
+    // breakpoints until a `true` ends the band, so copying only the `false`
+    // would hide the component further than the author asked. What an instance
+    // may NOT do is re-show a breakpoint the definition explicitly hid, which
+    // the case below pins.
+    expect(nodes.map(e => e.visibility?.devices)).toEqual([
+      { mobile: false, desktop: true },
+      { mobile: false, desktop: true },
     ]);
-    // Only hiding travels: the instance may not un-hide what the definition hid.
-    expect(nodes[0]!.visibility?.devices).not.toHaveProperty("desktop");
   });
 
   it("does not let an instance re-show a root its definition hid", () => {
@@ -1170,6 +1173,157 @@ describe("resolveComponentInstances ownership and cost", () => {
     // `isConditionGated` reads null exactly like an absent envelope, so the
     // merge must too — refusing it silently drops the author's hiding.
     expect(nodes[0]!.visibility?.devices?.mobile).toBe(false);
+  });
+});
+
+describe("resolveComponentInstances references, bands and cost", () => {
+  it("points a fragment link at the id it now names", () => {
+    const doc = page([instance("i1", "hero"), instance("i2", "hero")]);
+    const definitions = defs({
+      hero: component([
+        node("d1", { cssId: "pricing" }),
+        node("d2", { props: { href: "#pricing", label: "See" } }),
+      ]),
+    });
+
+    const nodes = resolveComponentInstances(doc, definitions).document.nodes;
+
+    expect(nodes[1]!.props.href).toBe(`#${String(nodes[0]!.cssId)}`);
+    expect(nodes[3]!.props.href).toBe(`#${String(nodes[2]!.cssId)}`);
+  });
+
+  it("leaves a fragment that names nothing in the component alone", () => {
+    const doc = page([instance("i1", "hero")]);
+    const definitions = defs({
+      hero: component([
+        node("d1", { cssId: "own" }),
+        node("d2", { props: { href: "#elsewhere", text: "#1 seller" } }),
+      ]),
+    });
+
+    const nodes = resolveComponentInstances(doc, definitions).document.nodes;
+
+    expect(nodes[1]!.props.href).toBe("#elsewhere");
+    expect(nodes[1]!.props.text).toBe("#1 seller");
+  });
+
+  it("rewrites a fragment nested inside a prop", () => {
+    const doc = page([instance("i1", "hero")]);
+    const definitions = defs({
+      hero: component([
+        node("d1", { cssId: "pricing" }),
+        node("d2", {
+          props: { cta: { links: [{ href: "#pricing" }] } },
+        }),
+      ]),
+    });
+
+    const nodes = resolveComponentInstances(doc, definitions).document.nodes;
+    const cta = nodes[1]!.props.cta as { links: { href: string }[] };
+
+    // A block's props are a tree, not a flat record — a fragment reached only
+    // through a record and an array is the ordinary shape, not the exotic one.
+    expect(cta.links[0]!.href).toBe(`#${String(nodes[0]!.cssId)}`);
+  });
+
+  it("calls a definition supplied as null malformed, not missing", () => {
+    const doc = page([instance("i1", "hero")]);
+    const definitions = new Map<string, BlockDocument>([
+      ["hero", null as unknown as BlockDocument],
+    ]);
+
+    const result = resolveComponentInstances(doc, definitions);
+
+    // Present-and-unreadable, so the key's PRESENCE is what separates it from
+    // absent — a falsy value would read as absent to anything asking the map
+    // for the value instead.
+    expect(result.unresolved.map(e => e.reason)).toEqual(["malformed"]);
+  });
+
+  it("keeps the true that ends an instance's hidden band", () => {
+    const doc = page([
+      stored(instance("i1", "hero"), {
+        visibility: { devices: { tablet: false, mobile: true } },
+      }),
+    ]);
+    const definitions = defs({ hero: component([node("d1")]) });
+
+    const nodes = resolveComponentInstances(doc, definitions).document.nodes;
+
+    // Hiding inherits to narrower breakpoints until a `true` ends the band, so
+    // dropping the `true` hides the component further than the author asked.
+    expect(nodes[0]!.visibility?.devices).toEqual({
+      tablet: false,
+      mobile: true,
+    });
+  });
+
+  it("will not let an instance re-show a breakpoint the definition hid", () => {
+    const doc = page([
+      stored(instance("i1", "hero"), {
+        visibility: { devices: { mobile: true } },
+      }),
+    ]);
+    const definitions = defs({
+      hero: component([
+        node("d1", { visibility: { devices: { mobile: false } } }),
+      ]),
+    });
+
+    const nodes = resolveComponentInstances(doc, definitions).document.nodes;
+
+    expect(nodes[0]!.visibility?.devices?.mobile).toBe(false);
+  });
+
+  it("refunds slot content dropped with a hidden slot target", () => {
+    const doc = page([
+      instance(
+        "i1",
+        "hero",
+        { overrides: { hide: false } },
+        { slots: { body: [node("x"), node("y")] } }
+      ),
+    ]);
+    const definitions = defs({
+      hero: component([box("c1", []), node("r1"), node("r2")], {
+        slots: { body: { label: "B", nodeId: "c1", slot: "children" } },
+        exposed: [
+          {
+            id: "hide",
+            label: "H",
+            nodeId: "c1",
+            propPath: "p",
+            type: "visibility",
+          },
+        ],
+      }),
+    });
+
+    const result = resolveComponentInstances(doc, definitions, {
+      limits: { ...DEFAULT_LIMITS, maxNodes: 3 },
+    });
+
+    // The two supplied children go with the hidden target, so their charge has
+    // to come back or the two visible roots are refused for room they freed.
+    expect(result.unresolved).toEqual([]);
+    expect(flatten(result.document.nodes)).toHaveLength(2);
+  });
+
+  it("calls a supplied-but-unreadable definition malformed", () => {
+    const doc = page([instance("i1", "hero")]);
+    const definitions = new Map<string, BlockDocument>([
+      [
+        "hero",
+        { formatVersion: 1, kind: "component" } as unknown as BlockDocument,
+      ],
+    ]);
+
+    const result = resolveComponentInstances(doc, definitions);
+
+    // `missing` asks somebody to publish or restore a component; a supplied
+    // record that cannot be read is a document fault, and offering the wrong
+    // remedy is the whole reason the reasons are a closed list.
+    expect(result.unresolved.map(e => e.reason)).toEqual(["malformed"]);
   });
 });
 

--- a/packages/blocks-engine/src/resolve-instances.test.ts
+++ b/packages/blocks-engine/src/resolve-instances.test.ts
@@ -16,6 +16,7 @@ import {
   type ComponentDocument,
 } from "./document";
 import { DEFAULT_LIMITS, MAX_ENVELOPE_ENTRIES } from "./limits";
+import { isConditionGated } from "./visibility";
 import {
   componentIdsIn,
   resolveComponentInstances,
@@ -74,6 +75,18 @@ const component = (
 
 const defs = (entries: Record<string, BlockDocument>): DefinitionsById =>
   new Map(Object.entries(entries));
+
+/**
+ * A node carrying a stored shape the published type forbids.
+ *
+ * Documents arrive from a database, an import or an older writer, so the
+ * resolver's contract is to survive shapes `BlockNode` cannot express — and a
+ * test that can only build well-typed nodes cannot reach the branches that
+ * exist for them. The hop through `unknown` is the assertion that this value
+ * came from storage rather than from a caller.
+ */
+const stored = (base: ResolvedBlockNode, extra: Record<string, unknown>) =>
+  ({ ...base, ...extra }) as unknown as ResolvedBlockNode;
 
 /** Every node of a resolved forest, in document order. */
 function flatten(nodes: readonly ResolvedBlockNode[]): ResolvedBlockNode[] {
@@ -933,6 +946,151 @@ describe("resolveComponentInstances bounds", () => {
 
     expect(result.unresolved.map(e => e.reason)).toEqual(["malformed"]);
     expect(idsOf(result.document)).toEqual(["i1"]);
+  });
+});
+
+describe("resolveComponentInstances defensive reads and references", () => {
+  it("rewrites an IDREF attribute to the id it now points at", () => {
+    const doc = page([instance("i1", "hero"), instance("i2", "hero")]);
+    const definitions = defs({
+      hero: component([
+        node("d1", { cssId: "help" }),
+        node("d2", { attributes: { "aria-describedby": "help" } }),
+      ]),
+    });
+
+    const nodes = resolveComponentInstances(doc, definitions).document.nodes;
+
+    // The reference must resolve to its target INSIDE the same instance.
+    expect(nodes[1]!.attributes!["aria-describedby"]).toBe(nodes[0]!.cssId);
+    expect(nodes[3]!.attributes!["aria-describedby"]).toBe(nodes[2]!.cssId);
+    // And the two instances must not both point at one target.
+    expect(nodes[1]!.attributes!["aria-describedby"]).not.toBe(
+      nodes[3]!.attributes!["aria-describedby"]
+    );
+    // A reference pointing at the ORIGINAL is the silent failure: it resolves
+    // to nothing and the element simply loses its accessible description.
+    expect(nodes[1]!.attributes!["aria-describedby"]).not.toBe("help");
+  });
+
+  it("survives an instance whose stored visibility is null", () => {
+    const doc = page([stored(instance("i1", "hero"), { visibility: null })]);
+    const definitions = defs({ hero: component([node("d1")]) });
+
+    expect(() => resolveComponentInstances(doc, definitions)).not.toThrow();
+  });
+
+  it("keeps a malformed root envelope fail-closed while merging devices", () => {
+    const doc = page([
+      {
+        ...instance("i1", "hero"),
+        visibility: { devices: { mobile: false } },
+      },
+    ]);
+    const definitions = defs({
+      hero: component([stored(node("d1"), { visibility: "restricted" })]),
+    });
+
+    const nodes = resolveComponentInstances(doc, definitions).document.nodes;
+
+    // `isConditionGated` reads an unreadable envelope as GATED. Normalising it
+    // into a plain object with no `conditions` makes the later pass serve what
+    // was withheld.
+    expect(isConditionGated(nodes[0]!)).toBe(true);
+  });
+
+  it("refunds nodes discarded with an unexposed slot", () => {
+    const doc = page([
+      instance("i1", "hero", {}, { slots: { gone: [node("x"), node("y")] } }),
+    ]);
+    const definitions = defs({ hero: component([node("d1"), node("d2")]) });
+
+    // Host holds three nodes; two of them are discarded with the unexposed
+    // slot, so a two-node definition fits under a cap of three.
+    const result = resolveComponentInstances(doc, definitions, {
+      limits: { ...DEFAULT_LIMITS, maxNodes: 3 },
+    });
+
+    expect(result.unresolved).toEqual([]);
+    expect(flatten(result.document.nodes)).toHaveLength(2);
+  });
+
+  it("never mints a DOM id the host page already carries", () => {
+    const definitions = defs({
+      hero: component([node("d1", { cssId: "signup" })]),
+    });
+    const minted = resolveComponentInstances(
+      page([instance("i1", "hero")]),
+      definitions
+    ).document.nodes[0]!.cssId!;
+
+    const doc = page([node("host", { cssId: minted }), instance("i1", "hero")]);
+    const nodes = resolveComponentInstances(doc, definitions).document.nodes;
+
+    expect(nodes[0]!.cssId).toBe(minted);
+    expect(nodes[1]!.cssId).not.toBe(minted);
+  });
+
+  it("rewrites an id reference nested inside a slot", () => {
+    const doc = page([instance("i1", "hero")]);
+    const definitions = defs({
+      hero: component([
+        box("c1", [
+          node("d1", { cssId: "help" }),
+          node("d2", { attributes: { "aria-describedby": "help" } }),
+        ]),
+      ]),
+    });
+
+    const kids = resolveComponentInstances(doc, definitions).document.nodes[0]!
+      .slots!.children!;
+
+    // A rewrite that only walks the roots leaves every nested reference
+    // dangling, which is most of them: a component's markup is a tree.
+    expect(kids[1]!.attributes!["aria-describedby"]).toBe(kids[0]!.cssId);
+  });
+
+  it("refunds only the slots it discards, never the ones it uses", () => {
+    const doc = page([
+      instance("i1", "hero", {}, { slots: { body: [node("x"), node("y")] } }),
+    ]);
+    const definitions = defs({
+      hero: component([box("c1", []), node("d2")], {
+        slots: { body: { label: "Body", nodeId: "c1", slot: "children" } },
+      }),
+    });
+
+    // The instance's two slot nodes ARE in the result, so refunding them would
+    // buy room the document then spends twice and overrun the cap.
+    const result = resolveComponentInstances(doc, definitions, {
+      limits: { ...DEFAULT_LIMITS, maxNodes: 3 },
+    });
+
+    expect(flatten(result.document.nodes).length).toBeLessThanOrEqual(3);
+  });
+
+  it("leaves an id reference the definition does not own alone", () => {
+    const doc = page([
+      node("outside", { cssId: "app-status" }),
+      instance("i1", "hero"),
+    ]);
+    const definitions = defs({
+      hero: component([
+        node("d1", {
+          cssId: "own",
+          attributes: { "aria-controls": "own app-status" },
+        }),
+      ]),
+    });
+
+    const nodes = resolveComponentInstances(doc, definitions).document.nodes;
+
+    // The first token addresses the definition's own node and moves; the
+    // second addresses the host page and must not, or a working relationship
+    // is broken by a copy that had nothing to do with it.
+    expect(nodes[1]!.attributes!["aria-controls"]).toBe(
+      `${nodes[1]!.cssId} app-status`
+    );
   });
 });
 

--- a/packages/blocks-engine/src/resolve-instances.ts
+++ b/packages/blocks-engine/src/resolve-instances.ts
@@ -46,6 +46,7 @@
  */
 import {
   COMPONENT_INSTANCE_TYPE,
+  isComponentDocument,
   isUnsetOverride,
   type BlockDocument,
   type BlockNode,
@@ -60,8 +61,10 @@ import {
   type DocumentLimits,
 } from "./limits";
 import { isPlainRecord } from "./plain-record";
-import { defineEntry, ownEntry } from "./safe-record";
+import { boundedOwnKeys, defineEntry, ownEntry } from "./safe-record";
 import { hashId } from "./style/node-class";
+import { mintDomId } from "./tree";
+import { isConditionGated } from "./visibility";
 
 /**
  * Why an instance was left standing instead of being replaced by its
@@ -91,7 +94,13 @@ export const COMPONENT_UNRESOLVED_REASONS = [
   "node-depth",
   /** Inlining it would pass the run's node budget. */
   "budget",
-  /** The instance node does not name a component id. */
+  /**
+   * The instance or its definition is not the shape composition needs — a node
+   * naming no component, or a definition that is not a component document.
+   *
+   * Both are faults no author action fixes, which is what separates this from
+   * `missing`: that one asks somebody to publish or restore a component.
+   */
   "malformed",
 ] as const;
 
@@ -269,7 +278,12 @@ export function resolveComponentInstances(
     definitions,
     maxDepth: limits.maxDepth,
     maxComposedDepth: options.maxComposedDepth ?? MAX_COMPOSED_DEPTH,
-    budget: limits.maxNodes,
+    // What is LEFT under the cap, not the cap itself. `maxNodes` bounds a
+    // document, and the composed tree IS the document every later pass walks —
+    // the style compiler, the renderer, the SEO derivation. Starting a fresh
+    // allowance here would let a page at the cap resolve to twice it while
+    // every one of those passes believes it is reading a bounded document.
+    budget: limits.maxNodes - survey.count,
     taken: survey.ids,
     minted: [],
     abort: undefined,
@@ -331,6 +345,8 @@ interface HostSurvey {
   hasInstance: boolean;
   /** The walk stopped at the node cap, so `ids` is a PREFIX of what is there. */
   truncated: boolean;
+  /** How many nodes the host already holds, instances included. */
+  count: number;
   ids: Set<string>;
 }
 
@@ -345,6 +361,7 @@ function surveyHost(nodes: readonly unknown[], maxNodes: number): HostSurvey {
   const ids = new Set<string>();
   let hasInstance = false;
   let truncated = false;
+  let count = 0;
   let budget = maxNodes;
   walkForest(nodes, entry => {
     if (budget <= 0) {
@@ -352,13 +369,14 @@ function surveyHost(nodes: readonly unknown[], maxNodes: number): HostSurvey {
       return "stop";
     }
     budget -= 1;
+    count += 1;
     const node = entry.node;
     if (!isPlainRecord(node)) return "descend";
     if (typeof node.id === "string") ids.add(node.id);
     if (node.type === COMPONENT_INSTANCE_TYPE) hasInstance = true;
     return "descend";
   });
-  return { hasInstance, truncated, ids };
+  return { hasInstance, truncated, count, ids };
 }
 
 /** The component a node references, or `undefined` if it references none. */
@@ -470,6 +488,20 @@ function expandInstance(
   presupplied?: Record<string, ResolvedBlockNode[]>,
   owner?: string
 ): ResolvedBlockNode[] {
+  // Asked before anything else, including whether the instance is even well
+  // formed. A gated node is not served, so composing it is work nobody
+  // receives — and reporting it would put an instance the reader never sees
+  // into the list a publish check reads.
+  //
+  // The instance is returned STANDING, carrying its gate, so the pass that
+  // prunes hidden nodes removes it and its whole subtree exactly as it would
+  // any other gated node. Expanding it instead drops the gate on the floor:
+  // the definition's roots replace the instance, none of them inherits it, and
+  // the later pass sees a tree with nothing left to prune. That is the
+  // direction `visibility.ts` names as the unrecoverable one — content shown
+  // to a reader it was withheld from cannot be taken back.
+  if (isConditionGated(instance)) return [instance];
+
   const componentId = componentIdOf(instance);
   if (componentId === undefined) {
     return [refuse(run, instance, "", "malformed")];
@@ -491,11 +523,18 @@ function expandInstance(
   // slots — so a mark taken after it would leave a refused instance having
   // permanently charged the page for a tree nobody receives.
   const mark = savepoint(run);
-  const supplied = presupplied ?? suppliedSlots(instance, run, scope, depth);
+  // The instance node is REPLACED, so its own slot under the cap is freed for
+  // what replaces it. Credited before the clone rather than after, or a
+  // definition that exactly fills the remaining room is refused for needing
+  // one node more than the document will actually hold.
+  run.budget += 1;
+  const supplied =
+    presupplied ?? suppliedSlots(instance, definition, run, scope, depth);
   const ctx: InlineContext = {
     run,
     scopeKey: instance.id,
     owner: owner ?? instance.id,
+    domIds: new Map<string, string>(),
     plans: planEdits(definition, instance, supplied),
     scope: {
       depth: scope.depth + 1,
@@ -510,7 +549,53 @@ function expandInstance(
     rollback(run, mark);
     return [refuse(run, instance, componentId, reason)];
   }
-  return inlined;
+  return withInstanceDevices(inlined, instance);
+}
+
+/**
+ * Carry an instance's per-breakpoint hiding onto the roots that replace it.
+ *
+ * `devices` is NOT a gate — `isConditionGated` excludes it deliberately, since
+ * per-breakpoint hiding is CSS applied to a node that is always served. So it
+ * cannot be handled by leaving the instance standing; it has to travel, or an
+ * author who hid a whole component on mobile silently gets it back.
+ *
+ * Only `false` propagates. The instance may hide what the definition shows; it
+ * may not SHOW what the definition hid, because the definition's author made
+ * that decision about their own content and an instance saying "visible at
+ * mobile" is answering a different question.
+ */
+function withInstanceDevices(
+  roots: ResolvedBlockNode[],
+  instance: ResolvedBlockNode
+): ResolvedBlockNode[] {
+  const envelope = instance.visibility;
+  if (envelope === undefined) return roots;
+  const devices = envelope.devices;
+  if (!isPlainRecord(devices)) return roots;
+  const hidden = boundedOwnKeys(devices, MAX_ENVELOPE_ENTRIES);
+  if (hidden === null || hidden.length === 0) return roots;
+
+  return roots.map(root => {
+    const own = root.visibility;
+    const merged: Record<string, unknown> = isPlainRecord(own?.devices)
+      ? { ...own.devices }
+      : {};
+    let changed = false;
+    for (const id of hidden) {
+      if (ownEntry(devices, id) !== false) continue;
+      defineEntry(merged, id, false);
+      changed = true;
+    }
+    if (!changed) return root;
+    return {
+      ...root,
+      visibility: {
+        ...(own ?? {}),
+        devices: merged as Record<string, boolean>,
+      },
+    };
+  });
 }
 
 /** Everything one speculative expansion may have to give back. */
@@ -566,6 +651,13 @@ function refusalFor(
   if (!isPlainRecord(definition) || !Array.isArray(definition.nodes)) {
     return "missing";
   }
+  // A structural check is not the discrimination. `DefinitionsById` is keyed to
+  // `BlockDocument`, so a page, a region or a template satisfies "has a nodes
+  // array" and would be inlined as though it were a component — content from
+  // another document appearing inside this one, with its exposed properties
+  // and slots meaning nothing. The kind is what the engine already publishes
+  // an answer for.
+  if (!isComponentDocument(definition)) return "malformed";
   return undefined;
 }
 
@@ -606,13 +698,49 @@ function noteReference(run: ResolveRun, componentId: string): void {
  */
 function suppliedSlots(
   instance: ResolvedBlockNode,
+  definition: ComponentDocument,
   run: ResolveRun,
   scope: ComposedScope,
   depth: number
 ): Record<string, ResolvedBlockNode[]> | undefined {
   const slots = instance.slots;
   if (!isPlainRecord(slots)) return undefined;
-  return inlineHostSlots(slots, run, scope, depth);
+  const wanted = exposedSlotContent(slots, definition);
+  if (wanted === undefined) return undefined;
+  return inlineHostSlots(wanted, run, scope, depth);
+}
+
+/**
+ * The instance's slot content, narrowed to the slots the definition still has.
+ *
+ * Narrowed BEFORE it is resolved, which is the whole point. An author who
+ * removed an exposed slot leaves every instance holding content under a key
+ * nothing will insert; resolving it first spends the page's node budget on a
+ * tree nobody receives, mints ids for it, and records a diagnostic naming a
+ * node absent from the returned document — so a large enough orphan can refuse
+ * the visible instance that contains it.
+ *
+ * The content is KEPT in the stored instance regardless. This decides what a
+ * render walks, not what an author owns: re-exposing the slot must bring the
+ * content back.
+ */
+function exposedSlotContent(
+  slots: Record<string, ResolvedBlockNode[]>,
+  definition: ComponentDocument
+): Record<string, ResolvedBlockNode[]> | undefined {
+  const exposed = definition.slots;
+  if (!isPlainRecord(exposed)) return undefined;
+  const ids = boundedOwnKeys(exposed, MAX_ENVELOPE_ENTRIES);
+  if (ids === null) return undefined;
+  const wanted: Record<string, ResolvedBlockNode[]> = {};
+  let any = false;
+  for (const id of ids) {
+    const content = ownEntry(slots, id);
+    if (content === undefined) continue;
+    any = true;
+    defineEntry(wanted, id, content);
+  }
+  return any ? wanted : undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -685,12 +813,13 @@ function collectOverrides(
   into: Map<string, OverrideValue>
 ): void {
   if (!isPlainRecord(source)) return;
-  let budget = MAX_ENVELOPE_ENTRIES;
-  for (const key of Object.keys(source)) {
-    if (budget <= 0) return;
-    budget -= 1;
-    into.set(key, ownEntry(source, key));
-  }
+  // Bounded during the walk, not after it. `Object.keys` on a record with a
+  // hundred thousand keys allocates all of them before a budget checked in the
+  // loop body gets a turn, so the cap would bound the work done PER key and
+  // nothing at all about reaching them.
+  const keys = boundedOwnKeys(source, MAX_ENVELOPE_ENTRIES);
+  if (keys === null) return;
+  for (const key of keys) into.set(key, ownEntry(source, key));
 }
 
 /** Turn overridden exposure ids into per-node edits. */
@@ -750,10 +879,9 @@ function planSlots(
   plans: Map<string, NodePlan>
 ): void {
   if (!isPlainRecord(slots)) return;
-  let budget = MAX_ENVELOPE_ENTRIES;
-  for (const id of Object.keys(slots)) {
-    if (budget <= 0) return;
-    budget -= 1;
+  const ids = boundedOwnKeys(slots, MAX_ENVELOPE_ENTRIES);
+  if (ids === null) return;
+  for (const id of ids) {
     const content = ownEntry(supplied, id);
     const target = slotTarget(ownEntry(slots, id));
     if (!Array.isArray(content) || target === undefined) continue;
@@ -811,6 +939,15 @@ interface InlineContext {
    */
   owner: string;
   plans: ReadonlyMap<string, NodePlan>;
+  /**
+   * Original DOM id to its replacement, for this instance.
+   *
+   * Asked once per distinct ORIGINAL, so a definition whose two nodes carry
+   * one DOM id maps both to a single replacement — the pair pointed at one
+   * target before and still reaches one target after. The same memo
+   * `reidSubtreeWithMap` keeps, for the same reason.
+   */
+  domIds: Map<string, string>;
   /** The scope INSIDE this component, for instances the definition itself holds. */
   scope: ComposedScope;
 }
@@ -914,7 +1051,52 @@ function scopeNode(
   if (plan !== undefined && plan.props.length > 0) {
     scoped.props = editedProps(node.props, plan.props);
   }
+  applyScopedDomIds(scoped, ctx);
   return scoped;
+}
+
+/**
+ * Give this copy of the definition its own DOM ids.
+ *
+ * One definition inlined into two instances publishes its `cssId` and its
+ * `id` attribute twice, which is a duplicate HTML id — so an anchor, a
+ * `<label for>` or an id selector reaches whichever instance the browser
+ * happens to find first. Node ids are already scoped; these are the other
+ * addresses a document carries and they were being spread through untouched.
+ *
+ * `mintDomId` rather than a rule of its own: pattern insert solves exactly
+ * this when it copies a subtree, a page may hold the output of both, and two
+ * spellings of one replacement would put two ids on one target.
+ */
+function applyScopedDomIds(
+  scoped: ResolvedBlockNode,
+  ctx: InlineContext
+): void {
+  const remap = (value: string): string => {
+    const existing = ctx.domIds.get(value);
+    if (existing !== undefined) return existing;
+    const minted = mintDomId(value, scoped.id);
+    ctx.domIds.set(value, minted);
+    return minted;
+  };
+
+  if (typeof scoped.cssId === "string" && scoped.cssId !== "") {
+    scoped.cssId = remap(scoped.cssId);
+  }
+  if (!isPlainRecord(scoped.attributes)) return;
+  const names = boundedOwnKeys(scoped.attributes, MAX_ENVELOPE_ENTRIES);
+  if (names === null) return;
+  const next: Record<string, string> = {};
+  for (const name of names) {
+    const value = ownEntry(scoped.attributes, name);
+    if (typeof value !== "string") continue;
+    // Case-insensitively, because HTML attribute names are: a stored `ID` and
+    // a stored `id` address the same thing to a browser, and remapping only
+    // the lowercase spelling leaves the other duplicated.
+    const isId = name.toLowerCase() === "id" && value !== "";
+    defineEntry(next, name, isId ? remap(value) : value);
+  }
+  scoped.attributes = next;
 }
 
 /**

--- a/packages/blocks-engine/src/resolve-instances.ts
+++ b/packages/blocks-engine/src/resolve-instances.ts
@@ -51,6 +51,7 @@ import {
   type BlockDocument,
   type BlockNode,
   type ComponentDocument,
+  type NodeVisibility,
   type OverrideValue,
 } from "./document";
 import { walkForest } from "./forest-walk";
@@ -613,33 +614,77 @@ function withInstanceDevices(
   const hidden = boundedOwnKeys(devices, MAX_ENVELOPE_ENTRIES);
   if (hidden === null || hidden.length === 0) return roots;
 
-  return roots.map(root => {
-    const own = root.visibility;
-    // An UNREADABLE envelope is left exactly as it is. `isConditionGated`
-    // reads a string or an array as gated — an author wrote a restriction it
-    // cannot parse — and rebuilding it as a plain object carrying only
-    // `devices` produces an envelope that same predicate calls unconditional.
-    // The node would then be served, which is the failure this whole function
-    // exists to prevent, reintroduced by the repair.
-    if (own !== undefined && !isPlainRecord(own)) return root;
-    const merged: Record<string, unknown> = isPlainRecord(own?.devices)
-      ? { ...own.devices }
-      : {};
-    let changed = false;
-    for (const id of hidden) {
-      if (ownEntry(devices, id) !== false) continue;
-      defineEntry(merged, id, false);
-      changed = true;
-    }
-    if (!changed) return root;
-    return {
-      ...root,
-      visibility: {
-        ...(own ?? {}),
-        devices: merged as Record<string, boolean>,
-      },
-    };
-  });
+  return roots.map(root => rootHiddenOn(root, devices, hidden));
+}
+
+/**
+ * One definition root, carrying whatever the instance hides.
+ *
+ * The envelope is sorted into three cases, and they are three because
+ * `isConditionGated` reads them as three:
+ *
+ * - **absent or `null`** — ungated to that predicate, so the flags merge into
+ *   a fresh envelope. Refusing `null` here would silently drop the hiding an
+ *   author asked for.
+ * - **a plain record** — ungated or not on its own terms, and the flags merge
+ *   into a copy of it.
+ * - **anything else**, a string or an array — read as GATED, because an author
+ *   wrote a restriction nothing can parse. Left exactly as it is. Rebuilding
+ *   it as a record carrying only `devices` produces an envelope that same
+ *   predicate calls unconditional, and the node is then served — the failure
+ *   this whole function exists to prevent, reintroduced by the repair.
+ */
+function rootHiddenOn(
+  root: ResolvedBlockNode,
+  devices: Record<string, unknown>,
+  hidden: readonly string[]
+): ResolvedBlockNode {
+  const own = root.visibility;
+  const merged = mergeableDevices(own);
+  if (merged === null) return root;
+  if (!hideEach(merged, devices, hidden)) return root;
+  return {
+    ...root,
+    visibility: {
+      ...(own ?? {}),
+      devices: merged as Record<string, boolean>,
+    },
+  };
+}
+
+/**
+ * The device map to merge into, or `null` when the envelope must not be
+ * touched at all.
+ *
+ * `null` is the third case above: an envelope `isConditionGated` reads as
+ * gated, which this must leave exactly as it found.
+ */
+function mergeableDevices(
+  own: NodeVisibility | null | undefined
+): Record<string, unknown> | null {
+  if (own !== undefined && own !== null && !isPlainRecord(own)) return null;
+  return isPlainRecord(own?.devices) ? { ...own.devices } : {};
+}
+
+/**
+ * Write the instance's hiding into the map, reporting whether anything moved.
+ *
+ * Only `false` travels. The instance may hide what the definition shows; it
+ * may not show what the definition hid, because that decision belongs to the
+ * author of the component's own content.
+ */
+function hideEach(
+  merged: Record<string, unknown>,
+  devices: Record<string, unknown>,
+  hidden: readonly string[]
+): boolean {
+  let changed = false;
+  for (const id of hidden) {
+    if (ownEntry(devices, id) !== false) continue;
+    defineEntry(merged, id, false);
+    changed = true;
+  }
+  return changed;
 }
 
 /**
@@ -660,6 +705,14 @@ function withRemappedIdReferences(
   if (roots === null || ctx.domIds.size === 0) return roots;
   const rewrite = (nodes: ResolvedBlockNode[]): ResolvedBlockNode[] =>
     nodes.map(node => {
+      // DEFINITION-owned nodes only, and the walk stops at anything else. An
+      // unmarked node is slot content the page supplied, so its references
+      // address the page's own ids — rewriting them against this definition's
+      // map redirects a working relationship at a node the author never
+      // named. Its descendants are page content too, and any component nested
+      // among them was rewritten by its own expansion with its own map, so
+      // descending would rewrite those a second time.
+      if (node.instanceOf === undefined) return node;
       const attributes = isPlainRecord(node.attributes)
         ? remapIdReferences(node.attributes, ctx.domIds)
         : node.attributes;
@@ -1111,6 +1164,11 @@ function cloneDefinitionForest(
       depth
     );
     if (produced === null) return null;
+    // Charged on the way in and given back when nothing came out. A node an
+    // override hides emits no markup, so charging for it refuses an expansion
+    // whose result would have fitted — the cap is on the composed DOCUMENT,
+    // not on how many nodes were considered.
+    if (produced.length === 0) ctx.run.budget += 1;
     for (const child of produced) out.push(child);
   }
   return out;

--- a/packages/blocks-engine/src/resolve-instances.ts
+++ b/packages/blocks-engine/src/resolve-instances.ts
@@ -667,21 +667,40 @@ function mergeableDevices(
 }
 
 /**
- * Write the instance's hiding into the map, reporting whether anything moved.
+ * Write the instance's per-breakpoint setting into the map, reporting whether
+ * anything moved.
  *
- * Only `false` travels. The instance may hide what the definition shows; it
- * may not show what the definition hid, because that decision belongs to the
- * author of the component's own content.
+ * BOTH values travel, not only `false`, and that is the correction: hiding
+ * INHERITS to narrower breakpoints until a `true` ends the band. So
+ * `{ tablet: false, mobile: true }` means "hidden from tablet down to mobile,
+ * shown again at mobile", and copying only the `false` hides the component
+ * everywhere below tablet — further than the author asked, from a rule meant
+ * to be conservative.
+ *
+ * A `true` is still refused where the definition's own map says `false` at
+ * that same breakpoint, so an instance cannot re-show what the component's
+ * author explicitly hid.
+ *
+ * The residual gap is stated rather than hidden: a definition that hid a WIDER
+ * breakpoint hides the narrower ones by inheritance rather than by an entry,
+ * so an instance's band-ending `true` can end that inherited band too.
+ * Closing it needs the breakpoints in order, and this module has no style
+ * context by design — the engine is the place where composition is pure. The
+ * alternative, dropping every `true`, corrupts every bounded band, which is
+ * the ordinary way responsive visibility is authored.
  */
 function hideEach(
   merged: Record<string, unknown>,
   devices: Record<string, unknown>,
-  hidden: readonly string[]
+  named: readonly string[]
 ): boolean {
   let changed = false;
-  for (const id of hidden) {
-    if (ownEntry(devices, id) !== false) continue;
-    defineEntry(merged, id, false);
+  for (const id of named) {
+    const wanted = ownEntry(devices, id);
+    if (typeof wanted !== "boolean") continue;
+    if (wanted && ownEntry(merged, id) === false) continue;
+    if (ownEntry(merged, id) === wanted) continue;
+    defineEntry(merged, id, wanted);
     changed = true;
   }
   return changed;
@@ -716,11 +735,21 @@ function withRemappedIdReferences(
       const attributes = isPlainRecord(node.attributes)
         ? remapIdReferences(node.attributes, ctx.domIds)
         : node.attributes;
+      const props = remapFragments(node.props, ctx.domIds, 0) as Record<
+        string,
+        unknown
+      >;
       const slots = isPlainRecord(node.slots)
         ? rewriteSlots(node.slots)
         : node.slots;
-      if (attributes === node.attributes && slots === node.slots) return node;
-      return { ...node, attributes, slots };
+      if (
+        attributes === node.attributes &&
+        slots === node.slots &&
+        props === node.props
+      ) {
+        return node;
+      }
+      return { ...node, attributes, props, slots };
     });
   const rewriteSlots = (
     slots: Record<string, ResolvedBlockNode[]>
@@ -740,6 +769,84 @@ function withRemappedIdReferences(
     return changed ? (next as Record<string, ResolvedBlockNode[]>) : slots;
   };
   return rewrite(roots);
+}
+
+/**
+ * How deep a prop tree is searched for fragment links.
+ *
+ * A bound on work over values a stored definition supplied, generous enough
+ * that no authored prop shape reaches it.
+ */
+const MAX_PROP_SCAN_DEPTH = 8;
+
+/**
+ * Point a block's `#fragment` props at wherever those ids ended up.
+ *
+ * `cssId` is not referenced only by markup: a link's `href` may be `#pricing`,
+ * and the renderer accepts that — `core/button` passes a bare fragment through
+ * to the DOM. Remapping the target without the link leaves every composed
+ * instance anchored to an id nothing carries, which is the same silent
+ * breakage as a dangling `aria-labelledby`, one prop over.
+ *
+ * A value is rewritten ONLY when the whole string is `#` followed by an id
+ * this composition actually minted, and that is what keeps it away from
+ * content: `"#1 bestseller"` names no minted id and is left exactly as
+ * written, and so is a fragment addressing something outside the component.
+ */
+function remapFragments(
+  props: unknown,
+  domIds: ReadonlyMap<string, string>,
+  depth: number
+): unknown {
+  if (domIds.size === 0 || depth > MAX_PROP_SCAN_DEPTH) return props;
+  if (typeof props === "string") return remapOneFragment(props, domIds);
+  if (Array.isArray(props)) return remapFragmentList(props, domIds, depth);
+  if (!isPlainRecord(props)) return props;
+  return remapFragmentRecord(props, domIds, depth);
+}
+
+/** The same, for a record-valued prop. */
+function remapFragmentRecord(
+  props: Record<string, unknown>,
+  domIds: ReadonlyMap<string, string>,
+  depth: number
+): unknown {
+  const keys = boundedOwnKeys(props, MAX_ENVELOPE_ENTRIES);
+  if (keys === null) return props;
+  let changed = false;
+  const next: Record<string, unknown> = {};
+  for (const key of keys) {
+    const value = ownEntry(props, key);
+    const mapped = remapFragments(value, domIds, depth + 1);
+    if (mapped !== value) changed = true;
+    defineEntry(next, key, mapped);
+  }
+  return changed ? next : props;
+}
+
+/** The same, for an array-valued prop. */
+function remapFragmentList(
+  items: readonly unknown[],
+  domIds: ReadonlyMap<string, string>,
+  depth: number
+): unknown {
+  let changed = false;
+  const next = items.map(item => {
+    const mapped = remapFragments(item, domIds, depth + 1);
+    if (mapped !== item) changed = true;
+    return mapped;
+  });
+  return changed ? next : items;
+}
+
+/** One string, rewritten only if it is exactly a fragment this run minted. */
+function remapOneFragment(
+  value: string,
+  domIds: ReadonlyMap<string, string>
+): string {
+  if (!value.startsWith("#")) return value;
+  const target = domIds.get(value.slice(1));
+  return target === undefined ? value : `#${target}`;
 }
 
 /** Everything one speculative expansion may have to give back. */
@@ -791,9 +898,15 @@ function refusalFor(
 ): ComponentUnresolvedReason | undefined {
   if (scope.onPath.has(componentId)) return "cycle";
   if (scope.depth >= run.maxComposedDepth) return "composed-depth";
+  // ABSENT from the map is `missing` — nobody supplied one, and the remedy is
+  // to publish or restore it. A value that IS supplied and cannot be read is a
+  // document fault, so it takes `malformed`: offering the publish remedy for
+  // corrupt component data sends an author to the wrong screen, which is the
+  // whole reason these reasons are a closed list rather than a message.
+  if (!run.definitions.has(componentId)) return "missing";
   const definition = run.definitions.get(componentId);
   if (!isPlainRecord(definition) || !Array.isArray(definition.nodes)) {
-    return "missing";
+    return "malformed";
   }
   // A structural check is not the discrimination. `DefinitionsById` is keyed to
   // `BlockDocument`, so a page, a region or a template satisfies "has a nodes
@@ -1181,7 +1294,14 @@ function cloneDefinitionNode(
   depth: number
 ): ResolvedBlockNode[] | null {
   const plan = ctx.plans.get(node.id);
-  if (plan?.visible === false) return [];
+  if (plan?.visible === false) {
+    // The node goes and its slots go with it, INSTANCE-SUPPLIED content
+    // included — which the host survey already charged for. Without this the
+    // page pays for a subtree nobody receives, and a later visible root is
+    // refused for room the hidden one freed.
+    refundPlannedSlots(plan, ctx.run);
+    return [];
+  }
 
   const scoped = scopeNode(node, ctx, plan);
 
@@ -1209,6 +1329,20 @@ function cloneDefinitionNode(
     );
   }
   return [scoped];
+}
+
+/**
+ * Give back the budget for slot content that goes with a hidden target.
+ *
+ * Only the PLANNED content, never the definition's own children: those were
+ * charged as they were cloned, and a hidden node is abandoned before its slots
+ * are visited, so nothing was spent on them to return.
+ */
+function refundPlannedSlots(plan: NodePlan, run: ResolveRun): void {
+  if (plan.slots === undefined) return;
+  for (const content of plan.slots.values()) {
+    run.budget += countNodes(content);
+  }
 }
 
 /** A definition node under the instance's identity, with its overrides applied. */

--- a/packages/blocks-engine/src/resolve-instances.ts
+++ b/packages/blocks-engine/src/resolve-instances.ts
@@ -55,6 +55,7 @@ import {
 } from "./document";
 import { walkForest } from "./forest-walk";
 import {
+  countNodes,
   DEFAULT_LIMITS,
   MAX_COMPOSED_DEPTH,
   MAX_ENVELOPE_ENTRIES,
@@ -63,7 +64,7 @@ import {
 import { isPlainRecord } from "./plain-record";
 import { boundedOwnKeys, defineEntry, ownEntry } from "./safe-record";
 import { hashId } from "./style/node-class";
-import { mintDomId } from "./tree";
+import { mintDomId, remapIdReferences } from "./tree";
 import { isConditionGated } from "./visibility";
 
 /**
@@ -285,6 +286,7 @@ export function resolveComponentInstances(
     // every one of those passes believes it is reading a bounded document.
     budget: limits.maxNodes - survey.count,
     taken: survey.ids,
+    takenDomIds: survey.domIds,
     minted: [],
     abort: undefined,
     referenced: [],
@@ -312,6 +314,8 @@ interface ResolveRun {
   budget: number;
   /** Every id in use, so a minted one cannot shadow a stored node. */
   taken: Set<string>;
+  /** The same, for the ids that reach the DOM rather than the document. */
+  takenDomIds: Set<string>;
   /**
    * The ids this run minted, in order, so a refused instance can give them
    * back. Host ids are not in it: they were never this run's to release.
@@ -348,6 +352,15 @@ interface HostSurvey {
   /** How many nodes the host already holds, instances included. */
   count: number;
   ids: Set<string>;
+  /**
+   * Every DOM id the host page already publishes.
+   *
+   * Seeded for the same reason node ids are. `mintDomId` promises uniqueness
+   * within the SUBTREE it copies, and the host is not in that subtree — so a
+   * page whose own `cssId` happens to equal a minted one gets back exactly the
+   * duplicate this remapping exists to remove.
+   */
+  domIds: Set<string>;
 }
 
 /**
@@ -359,6 +372,7 @@ interface HostSurvey {
  */
 function surveyHost(nodes: readonly unknown[], maxNodes: number): HostSurvey {
   const ids = new Set<string>();
+  const domIds = new Set<string>();
   let hasInstance = false;
   let truncated = false;
   let count = 0;
@@ -373,10 +387,26 @@ function surveyHost(nodes: readonly unknown[], maxNodes: number): HostSurvey {
     const node = entry.node;
     if (!isPlainRecord(node)) return "descend";
     if (typeof node.id === "string") ids.add(node.id);
+    collectDomIds(node, domIds);
     if (node.type === COMPONENT_INSTANCE_TYPE) hasInstance = true;
     return "descend";
   });
-  return { hasInstance, truncated, count, ids };
+  return { hasInstance, truncated, count, ids, domIds };
+}
+
+/** Every DOM id one stored node publishes, in either of the two places. */
+function collectDomIds(node: Record<string, unknown>, into: Set<string>): void {
+  const cssId = node.cssId;
+  if (typeof cssId === "string" && cssId !== "") into.add(cssId);
+  const attributes = node.attributes;
+  if (!isPlainRecord(attributes)) return;
+  const names = boundedOwnKeys(attributes, MAX_ENVELOPE_ENTRIES);
+  if (names === null) return;
+  for (const name of names) {
+    if (name.toLowerCase() !== "id") continue;
+    const value = ownEntry(attributes, name);
+    if (typeof value === "string" && value !== "") into.add(value);
+  }
 }
 
 /** The component a node references, or `undefined` if it references none. */
@@ -542,7 +572,10 @@ function expandInstance(
     },
   };
 
-  const inlined = cloneDefinitionForest(definition.nodes, ctx, 1);
+  const inlined = withRemappedIdReferences(
+    cloneDefinitionForest(definition.nodes, ctx, 1),
+    ctx
+  );
   if (inlined === null) {
     const reason = run.abort ?? "budget";
     run.abort = undefined;
@@ -569,8 +602,12 @@ function withInstanceDevices(
   roots: ResolvedBlockNode[],
   instance: ResolvedBlockNode
 ): ResolvedBlockNode[] {
+  // `isPlainRecord`, not `!== undefined`. A stored `visibility: null` is read
+  // as UNGATED by `isConditionGated`, so a null envelope reaches this line on
+  // the successful path and a direct property read throws — turning a
+  // resolvable page into an exception.
   const envelope = instance.visibility;
-  if (envelope === undefined) return roots;
+  if (!isPlainRecord(envelope)) return roots;
   const devices = envelope.devices;
   if (!isPlainRecord(devices)) return roots;
   const hidden = boundedOwnKeys(devices, MAX_ENVELOPE_ENTRIES);
@@ -578,6 +615,13 @@ function withInstanceDevices(
 
   return roots.map(root => {
     const own = root.visibility;
+    // An UNREADABLE envelope is left exactly as it is. `isConditionGated`
+    // reads a string or an array as gated — an author wrote a restriction it
+    // cannot parse — and rebuilding it as a plain object carrying only
+    // `devices` produces an envelope that same predicate calls unconditional.
+    // The node would then be served, which is the failure this whole function
+    // exists to prevent, reintroduced by the repair.
+    if (own !== undefined && !isPlainRecord(own)) return root;
     const merged: Record<string, unknown> = isPlainRecord(own?.devices)
       ? { ...own.devices }
       : {};
@@ -596,6 +640,53 @@ function withInstanceDevices(
       },
     };
   });
+}
+
+/**
+ * Point the inlined tree's id REFERENCES at where those ids ended up.
+ *
+ * A second pass, after every node has been minted, because a node may
+ * reference an id defined on one the walk had not reached yet — rewriting
+ * during the copy would leave every forward reference pointing at the
+ * original. `aria-labelledby` and `aria-describedby` are how a control is
+ * named and described to a screen reader, and a reference to an id that no
+ * longer exists is ignored in silence: the element simply loses its name,
+ * visibly to nobody who is not using assistive technology.
+ */
+function withRemappedIdReferences(
+  roots: ResolvedBlockNode[] | null,
+  ctx: InlineContext
+): ResolvedBlockNode[] | null {
+  if (roots === null || ctx.domIds.size === 0) return roots;
+  const rewrite = (nodes: ResolvedBlockNode[]): ResolvedBlockNode[] =>
+    nodes.map(node => {
+      const attributes = isPlainRecord(node.attributes)
+        ? remapIdReferences(node.attributes, ctx.domIds)
+        : node.attributes;
+      const slots = isPlainRecord(node.slots)
+        ? rewriteSlots(node.slots)
+        : node.slots;
+      if (attributes === node.attributes && slots === node.slots) return node;
+      return { ...node, attributes, slots };
+    });
+  const rewriteSlots = (
+    slots: Record<string, ResolvedBlockNode[]>
+  ): Record<string, ResolvedBlockNode[]> => {
+    let changed = false;
+    const next: Record<string, unknown> = {};
+    for (const name of Object.keys(slots)) {
+      const children = ownEntry(slots, name);
+      if (!Array.isArray(children)) {
+        defineEntry(next, name, children);
+        continue;
+      }
+      const rewritten = rewrite(children);
+      if (rewritten !== children) changed = true;
+      defineEntry(next, name, rewritten);
+    }
+    return changed ? (next as Record<string, ResolvedBlockNode[]>) : slots;
+  };
+  return rewrite(roots);
 }
 
 /** Everything one speculative expansion may have to give back. */
@@ -705,7 +796,7 @@ function suppliedSlots(
 ): Record<string, ResolvedBlockNode[]> | undefined {
   const slots = instance.slots;
   if (!isPlainRecord(slots)) return undefined;
-  const wanted = exposedSlotContent(slots, definition);
+  const wanted = exposedSlotContent(slots, definition, run);
   if (wanted === undefined) return undefined;
   return inlineHostSlots(wanted, run, scope, depth);
 }
@@ -726,12 +817,14 @@ function suppliedSlots(
  */
 function exposedSlotContent(
   slots: Record<string, ResolvedBlockNode[]>,
-  definition: ComponentDocument
+  definition: ComponentDocument,
+  run: ResolveRun
 ): Record<string, ResolvedBlockNode[]> | undefined {
-  const exposed = definition.slots;
-  if (!isPlainRecord(exposed)) return undefined;
+  const exposed = isPlainRecord(definition.slots) ? definition.slots : {};
   const ids = boundedOwnKeys(exposed, MAX_ENVELOPE_ENTRIES);
-  if (ids === null) return undefined;
+  refundDiscardedSlots(slots, new Set(ids ?? []), run);
+  if (ids === null || ids.length === 0) return undefined;
+
   const wanted: Record<string, ResolvedBlockNode[]> = {};
   let any = false;
   for (const id of ids) {
@@ -741,6 +834,33 @@ function exposedSlotContent(
     defineEntry(wanted, id, content);
   }
   return any ? wanted : undefined;
+}
+
+/**
+ * Give back the budget charged for slot content this composition discards.
+ *
+ * The host survey counts every node the document holds and the budget is what
+ * is LEFT under the cap after it, so content under a slot the definition no
+ * longer exposes is charged for and then dropped — and the page is refused
+ * room for a component whose result would have fitted. Refunded here rather
+ * than subtracted in the survey because only the definition knows which keys
+ * survive, and the survey runs before any definition is read.
+ *
+ * The savepoint covers it. If the instance is then refused, its stored slots
+ * travel with it into the result, and the refund is rolled back along with
+ * everything else so those nodes stay charged exactly as they should.
+ */
+function refundDiscardedSlots(
+  slots: Record<string, ResolvedBlockNode[]>,
+  kept: ReadonlySet<string>,
+  run: ResolveRun
+): void {
+  for (const name of Object.keys(slots)) {
+    if (kept.has(name)) continue;
+    const children = ownEntry(slots, name);
+    if (!Array.isArray(children)) continue;
+    run.budget += countNodes(children);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -1075,7 +1195,7 @@ function applyScopedDomIds(
   const remap = (value: string): string => {
     const existing = ctx.domIds.get(value);
     if (existing !== undefined) return existing;
-    const minted = mintDomId(value, scoped.id);
+    const minted = claimDomId(ctx.run, mintDomId(value, scoped.id));
     ctx.domIds.set(value, minted);
     return minted;
   };
@@ -1172,6 +1292,30 @@ function fillPlannedSlots(
   for (const [name, content] of planned) {
     if (Object.prototype.hasOwnProperty.call(into, name)) continue;
     defineEntry(into, name, content);
+  }
+}
+
+/**
+ * Take a minted DOM id, or the first spelling of it nothing else is using.
+ *
+ * `mintDomId` is unique within the subtree it copies and says so; the host is
+ * outside that subtree, and so is every other instance on the page. Without
+ * this the remapping removes one class of duplicate id and leaves another.
+ *
+ * Deterministic: the same page and definitions mint in the same order, so the
+ * same suffix lands on the same node on every render.
+ */
+function claimDomId(run: ResolveRun, base: string): string {
+  if (!run.takenDomIds.has(base)) {
+    run.takenDomIds.add(base);
+    return base;
+  }
+  // Terminates: the set is finite and the suffix strictly increases.
+  for (let n = 2; ; n += 1) {
+    const candidate = `${base}-${n}`;
+    if (run.takenDomIds.has(candidate)) continue;
+    run.takenDomIds.add(candidate);
+    return candidate;
   }
 }
 

--- a/packages/blocks-engine/src/safe-record.ts
+++ b/packages/blocks-engine/src/safe-record.ts
@@ -92,6 +92,33 @@ export function ownEntry<T>(
 }
 
 /**
+ * The own keys of an untrusted record, or `null` when there are too many.
+ *
+ * Counted with `for...in` and stopped at the budget rather than calling
+ * `Object.keys` first. The difference is the whole point: `Object.keys`
+ * materialises EVERY key into an array before any caller can look at the
+ * length, so a record with a hundred thousand keys is fully enumerated and
+ * allocated before the cap that exists to prevent it gets a turn. A budget
+ * checked after the allocation bounds only what happens next.
+ *
+ * `null` rather than a truncated list, because a caller that got fewer keys
+ * than the record holds cannot tell that from a small record, and the two
+ * deserve opposite treatment: one is ordinary, the other is a document to
+ * refuse.
+ */
+export function boundedOwnKeys(record: object, limit: number): string[] | null {
+  const keys: string[] = [];
+  for (const key in record) {
+    // The record's own keys are stored data, so it may carry a
+    // `hasOwnProperty` of its own and answer the question with it.
+    if (!Object.prototype.hasOwnProperty.call(record, key)) continue;
+    if (keys.length >= limit) return null;
+    keys.push(key);
+  }
+  return keys;
+}
+
+/**
  * ## What is already safe, so nobody "fixes" it
  *
  * Only ASSIGNMENT is affected. These define rather than assign, and each

--- a/packages/blocks-engine/src/tree.reid-with-map.test.ts
+++ b/packages/blocks-engine/src/tree.reid-with-map.test.ts
@@ -192,3 +192,28 @@ describe("reidSubtreeWithMap id references", () => {
     expect(children[1]!.attributes!["aria-describedby"]).not.toBe("help");
   });
 });
+
+describe("reidSubtreeWithMap malformed attributes", () => {
+  it("survives a stored attributes: null beside a node with a DOM id", () => {
+    const original = {
+      id: "root",
+      type: "core/box",
+      version: 1,
+      props: {},
+      slots: {
+        children: [
+          { id: "a", type: "core/text", version: 1, props: {}, cssId: "x" },
+          {
+            id: "b",
+            type: "core/text",
+            version: 1,
+            props: {},
+            attributes: null,
+          },
+        ],
+      },
+    } as unknown as BlockNode;
+
+    expect(() => reidSubtreeWithMap(original)).not.toThrow();
+  });
+});

--- a/packages/blocks-engine/src/tree.reid-with-map.test.ts
+++ b/packages/blocks-engine/src/tree.reid-with-map.test.ts
@@ -158,3 +158,37 @@ describe("every internal reference round-trips", () => {
     expect(result.nodeIds.size).toBe(2);
   });
 });
+
+describe("reidSubtreeWithMap id references", () => {
+  it("points a copied reference at the copy's own target", () => {
+    const original: BlockNode = {
+      id: "root",
+      type: "core/box",
+      version: 1,
+      props: {},
+      slots: {
+        children: [
+          { id: "a", type: "core/text", version: 1, props: {}, cssId: "help" },
+          {
+            id: "b",
+            type: "core/text",
+            version: 1,
+            props: {},
+            attributes: { "aria-describedby": "help" },
+          },
+        ],
+      },
+    };
+
+    const { node } = reidSubtreeWithMap(original);
+    const children = node.slots!.children!;
+
+    // Without the second pass the copy still says "help", which resolves to
+    // the ORIGINAL node — so the duplicate loses its description to whichever
+    // element the browser finds first.
+    expect(children[1]!.attributes!["aria-describedby"]).toBe(
+      children[0]!.cssId
+    );
+    expect(children[1]!.attributes!["aria-describedby"]).not.toBe("help");
+  });
+});

--- a/packages/blocks-engine/src/tree.ts
+++ b/packages/blocks-engine/src/tree.ts
@@ -1077,7 +1077,16 @@ export function reidSubtreeWithMap(node: BlockNode): ReidentifiedSubtree {
   const [rebuilt] = mapForest([node], original =>
     reidOneKeepingReferences(original, nodeIds, domIds)
   );
-  return { node: rebuilt ?? node, nodeIds, domIds };
+  // A SECOND pass, because a node may reference an id defined on a node the
+  // first had not reached yet. Without it a copied `aria-labelledby` points at
+  // the original's id, so the copy loses its accessible name — the same gap
+  // composition has, closed the same way.
+  const [linked] = mapForest([rebuilt ?? node], copy =>
+    copy.attributes === undefined
+      ? copy
+      : { ...copy, attributes: remapIdReferences(copy.attributes, domIds) }
+  );
+  return { node: linked ?? rebuilt ?? node, nodeIds, domIds };
 }
 
 /** One node, re-identified, with its DOM id remapped rather than removed. */
@@ -1117,6 +1126,89 @@ function reidOneKeepingReferences(
 
   if (slots !== undefined) copy.slots = slots;
   return copy;
+}
+
+/**
+ * Attributes whose VALUE is an id, or a whitespace-separated list of ids.
+ *
+ * Remapping a `cssId` without these breaks every relationship built on it:
+ * `aria-labelledby` and `aria-describedby` are how a control is NAMED and
+ * DESCRIBED to a screen reader, and a reference to an id that no longer exists
+ * is silently ignored — the element simply loses its name. That failure is
+ * invisible to everyone who does not use assistive technology, which is why it
+ * is listed as data here rather than left to each copier to remember.
+ *
+ * Single-id and list-valued attributes are not separated, because the rewrite
+ * does not need them to be: a single id is a one-token list, and splitting on
+ * whitespace handles both without a second table to keep in step.
+ *
+ * Lowercase, and compared after folding, because HTML attribute names are
+ * case-insensitive and a stored `aria-labelledBy` addresses the same thing.
+ */
+export const ID_REFERENCE_ATTRIBUTES: readonly string[] = [
+  // HTML
+  "for",
+  "form",
+  "list",
+  "headers",
+  "itemref",
+  "popovertarget",
+  "anchor",
+  // ARIA
+  "aria-activedescendant",
+  "aria-controls",
+  "aria-describedby",
+  "aria-details",
+  "aria-errormessage",
+  "aria-flowto",
+  "aria-labelledby",
+  "aria-owns",
+];
+
+const ID_REFERENCE_SET = new Set(ID_REFERENCE_ATTRIBUTES);
+
+/**
+ * Point a node's id REFERENCES at wherever those ids ended up.
+ *
+ * Applied as a second pass, after every id has been minted, and that ordering
+ * is the whole reason it is a separate function: a node may reference an id
+ * defined on a node the walk has not reached yet, so rewriting during the copy
+ * would leave every forward reference pointing at the original.
+ *
+ * A token with no entry in the map is left ALONE rather than dropped. It
+ * addresses something outside the copied subtree — an element the host page
+ * owns, or one the application renders — and rewriting or removing it would
+ * break a relationship that was working.
+ *
+ * Returns the SAME record when nothing referenced anything, so the ordinary
+ * node allocates nothing.
+ */
+export function remapIdReferences(
+  attributes: Record<string, string>,
+  domIds: ReadonlyMap<string, string>
+): Record<string, string> {
+  if (domIds.size === 0) return attributes;
+  let changed = false;
+  const next: Record<string, string> = {};
+  for (const name of Object.keys(attributes)) {
+    const value = ownEntry(attributes, name);
+    if (
+      typeof value !== "string" ||
+      !ID_REFERENCE_SET.has(name.toLowerCase())
+    ) {
+      defineEntry(next, name, value as string);
+      continue;
+    }
+    // Split on whitespace so an IDREFS list is rewritten token by token; the
+    // separator is normalised to one space, which is what every parser reads
+    // the original as anyway.
+    const tokens = value.split(/\s+/).filter(token => token !== "");
+    const mapped = tokens.map(token => domIds.get(token) ?? token);
+    const rewritten = mapped.join(" ");
+    if (rewritten !== value) changed = true;
+    defineEntry(next, name, rewritten);
+  }
+  return changed ? next : attributes;
 }
 
 /**

--- a/packages/blocks-engine/src/tree.ts
+++ b/packages/blocks-engine/src/tree.ts
@@ -1127,8 +1127,16 @@ function reidOneKeepingReferences(
  * collision the remap exists to avoid. Trimmed to keep the result readable in a
  * URL fragment; the full node id is not needed for uniqueness within a subtree
  * that has exactly one node per new id.
+ *
+ * Exported because a second copier now exists. Composition inlines one
+ * definition into every instance of it, which duplicates the definition's
+ * `cssId` and `attributes.id` exactly as pattern insert duplicates a subtree's
+ * — and a document may legitimately hold both, so the two must agree on what a
+ * replacement looks like or one page carries two spellings of the same rule.
+ * The COPY policy is shared; the id policy is not, because these ids are
+ * derived and `reidSubtree`'s are random.
  */
-function mintDomId(original: string, newNodeId: string): string {
+export function mintDomId(original: string, newNodeId: string): string {
   return `${original}-${newNodeId.replace(/-/g, "").slice(0, 8)}`;
 }
 

--- a/packages/blocks-engine/src/tree.ts
+++ b/packages/blocks-engine/src/tree.ts
@@ -1082,9 +1082,13 @@ export function reidSubtreeWithMap(node: BlockNode): ReidentifiedSubtree {
   // the original's id, so the copy loses its accessible name — the same gap
   // composition has, closed the same way.
   const [linked] = mapForest([rebuilt ?? node], copy =>
-    copy.attributes === undefined
-      ? copy
-      : { ...copy, attributes: remapIdReferences(copy.attributes, domIds) }
+    // `isPlainRecord`, not `!== undefined`. A persisted `attributes: null` is
+    // content the first pass deliberately carries through untouched, and
+    // handing it to the remapper enumerates null and throws — a rebuild that
+    // destroys a node because of a field on a different one.
+    isPlainRecord(copy.attributes)
+      ? { ...copy, attributes: remapIdReferences(copy.attributes, domIds) }
+      : copy
   );
   return { node: linked ?? rebuilt ?? node, nodeIds, domIds };
 }

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -33,6 +33,7 @@ import type { DocumentSurvey } from "./measure-bytes";
 import { canBeRoot, canNest, canNestInSlot } from "./nesting";
 import type { NestingSource } from "./nesting";
 import { isPlainRecord } from "./plain-record";
+import { boundedOwnKeys } from "./safe-record";
 import type { TokenKind } from "./style/catalog-types";
 import { breakpointContexts } from "./style/compile-page";
 import { MAX_NAMED_CLASS_NAME_LENGTH } from "./style/named-class";
@@ -1635,16 +1636,14 @@ function ownKeysBounded(
   what: string,
   issues: ValidationIssue[]
 ): string[] | null {
-  const keys: string[] = [];
-  for (const key in record) {
-    if (!Object.prototype.hasOwnProperty.call(record, key)) continue;
-    if (keys.length >= MAX_ENVELOPE_ENTRIES) {
-      withinBudget(keys.length + 1, path, what, issues);
-      return null;
-    }
-    keys.push(key);
-  }
-  return keys;
+  const keys = boundedOwnKeys(record, MAX_ENVELOPE_ENTRIES);
+  if (keys !== null) return keys;
+  // The walk stops AT the cap and reports nothing itself, so the number named
+  // here is the smallest one that exceeds it rather than the record's real
+  // size — which is the point of stopping, and why the enumeration and the
+  // complaint are two functions.
+  withinBudget(MAX_ENVELOPE_ENTRIES + 1, path, what, issues);
+  return null;
 }
 
 /** One `exposed` entry, before anything about it has been checked. */


### PR DESCRIPTION
Follow-up to **#1519**, which merged at `22:48:40` while a Codex review was in flight — the second review landed at `22:56:44`, eight minutes later, and its six findings went in with the merge. All six are real: each was **reproduced with a failing test before it was accepted**, and all six probes failed on `main` as it stands.

## P1 — a hidden component instance was published to everyone

An instance node carries the author's `visibility`. Composition replaced that node with the definition's roots, and the gate went with it — so `pruneHiddenNodes`, which runs later over the resolved tree, found nothing left to withhold. Content restricted to one audience was served to every visitor.

`visibility.ts` states the asymmetry this lands on: content missing from a page is visible and reportable, content shown to the wrong reader cannot be taken back.

A condition-gated instance is now **left standing**, carrying its gate, so the existing pass removes it and its whole subtree exactly as it would any other gated node. `devices` cannot be handled that way — `isConditionGated` deliberately excludes per-breakpoint hiding, because that is CSS on a node that is always served — so it is composed onto every root instead. **Only hiding travels**: an instance may hide what the definition shows, never show what its author hid.

## Five P2s

- **Duplicate HTML ids.** Two instances of one definition published its `cssId` and `id` attribute twice, so an anchor, a `<label for>` or an id selector reached whichever copy the browser found first. Each instance now derives its own via `mintDomId` — the rule pattern insert already applies, now exported, because one page may hold the output of both and two spellings of one replacement put two ids on one target. Matched case-insensitively, since HTML attribute names are.
- **The node cap was not a cap.** The budget started at the full `maxNodes` and counted only what composition added, so a page already at the limit could resolve to twice it while the style compiler, the renderer and the SEO walk all believed they were reading a bounded document. It now starts from what is left, and credits the slot each replaced instance gives up — otherwise a definition that exactly fits gets refused for needing one node more than the result holds.
- **Orphaned slot content composed then discarded.** Content stored under a slot the definition no longer exposes was resolved in full before `planSlots` dropped it: budget spent, ids minted, and diagnostics recorded naming nodes absent from the result. A large enough orphan could refuse the visible instance containing it. It is narrowed to the definition's exposed slots before anything walks it, and left untouched in the stored instance so re-exposing the slot brings it back.
- **An unbounded enumeration behind a bound.** `Object.keys` materialised an oversized overrides or slot record before `MAX_ENVELOPE_ENTRIES` could stop it, so the cap bounded the work done *per key* and nothing about reaching them. Both now use one `boundedOwnKeys` walk in `safe-record.ts`, which `validation.ts` also routes through rather than keeping its own copy.
- **Any document accepted as a component.** `DefinitionsById` is keyed to `BlockDocument`, so a page, region or template satisfied "has a nodes array" and was inlined as one. `isComponentDocument` is the discrimination the engine already publishes.

## Verification

- **52 tests** (11 new), break-verified against **34 wrong implementations across three rounds — 34 kills, 0 survivors**, count held at 52 throughout. The new round covers each fix from both directions: a gated instance expanded anyway, hiding not carried, an instance allowed to *re-show*, ids spread through, a repeated id remapped twice, the attribute matched case-sensitively, the host's nodes uncounted, the replaced slot uncredited, slots resolved eagerly, `Object.keys` restored, and the kind check removed.
- One probe had to be **rewritten**: it counted `ownKeys` trap calls, and `for...in` calls that trap once on a Proxy too, so it measured nothing. It now asserts the outcome — an oversized record is refused whole rather than applied in enumeration order.
- One existing test needed **resizing twice**: the budget change moved its arithmetic, and the eager-slot fix removed the mechanism it measured (its fixture exposed no slot, so no content was ever resolved).
- `blocks-engine` 1862 tests / 42 files; workspace `build` 42/42 and `check-types` 42/42.
- `fallow` **pass** — 7 changed files, 245 functions, **0 introduced** findings in every category. The 8 complexity findings are inherited, in `validation.ts`.
- `check-comment-convention` clean; `changeset status` clean with all 25 lockstep packages.

## Observed and deliberately left

`inlineHostSlots` and `copyStoredSlots` still enumerate a node's `slots` record with `Object.keys`. Codex did not name them and `sanitizeDocument` has the same shape and runs first in the pipeline, so this is pre-existing shared behaviour rather than something this change introduces — and bounding it means *dropping* stored slot content, which is a data-loss decision that deserves its own change rather than riding along with a fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved component composition and copied content handling, including visibility propagation, slot resolution, and document-size safeguards.
  * Preserved and correctly remapped DOM ID references when content is copied.
  * Added public utilities for consistent DOM ID generation and reference remapping.

* **Bug Fixes**
  * Improved handling of malformed component data, invalid definitions, gated instances, and missing attributes.
  * Added safer bounded processing for records with large numbers of keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->