### PR TITLE
feat(blocks-react): compose component instances in the shared read pipeline

### DIFF
--- a/.changeset/a-page-draws-the-components-it-references.md
+++ b/.changeset/a-page-draws-the-components-it-references.md
@@ -54,3 +54,8 @@ limit is now enforced where it can be reported. And the editor's style
 explanations were computed without the components the page draws, so what an
 author was told about where a value came from described a different page from
 the one in front of them.
+
+A component that arrived broken — empty, or not a document at all — brought
+down the whole page, including pages that never used it. Such an entry is now
+skipped and the reference it was for is reported as missing, like any other
+component that could not be found.

--- a/.changeset/a-page-draws-the-components-it-references.md
+++ b/.changeset/a-page-draws-the-components-it-references.md
@@ -46,3 +46,11 @@ A component that could not be loaded now says so where it sits, instead of
 reading as an unrecognised block. A stored stylesheet is no longer reused once
 composition has added blocks it was never compiled for, which would have left
 every one of them unstyled on a page that looked fine.
+
+Two limits behaved wrongly at the edges. A component larger than the page's
+size limit was quietly trimmed to fit before anything could object, so the page
+published part of a component with nothing to say the rest was missing; the
+limit is now enforced where it can be reported. And the editor's style
+explanations were computed without the components the page draws, so what an
+author was told about where a value came from described a different page from
+the one in front of them.

--- a/.changeset/a-page-draws-the-components-it-references.md
+++ b/.changeset/a-page-draws-the-components-it-references.md
@@ -75,3 +75,13 @@ the references happened to appear in. A component stored in a format this
 version does not understand is now reported rather than reshaped and drawn. And
 the renderer and the page reader now agree about what an unloadable component
 is, so the renderer no longer hides a block the reader returns.
+
+One walk instead of two. Preparing a component and deciding to read one were
+separate passes over the page, and they could disagree — so a component chosen
+by an instance's override, one that survived a definition's own repair, or one
+sitting past a truncated scan was reported as missing even though it had been
+supplied. There is now a single answer, given where the component is actually
+wanted, which also means a page follows a chain of components only as far as it
+can draw it rather than preparing every component the chain names. And a
+component whose stored data cannot be read is now reported as a fault in that
+component, so the message points at it instead of at the page holding it.

--- a/.changeset/a-page-draws-the-components-it-references.md
+++ b/.changeset/a-page-draws-the-components-it-references.md
@@ -68,3 +68,10 @@ could not be loaded. A stored page can no longer claim one of its own blocks is
 an unloadable component and have that believed. And a page now prepares only
 the components it actually uses, following one component's reference to
 another, instead of paying for the whole library on every render.
+
+Three last repairs at the same seam. A page that referenced several components
+it could not find could lose a component it COULD find, depending on the order
+the references happened to appear in. A component stored in a format this
+version does not understand is now reported rather than reshaped and drawn. And
+the renderer and the page reader now agree about what an unloadable component
+is, so the renderer no longer hides a block the reader returns.

--- a/.changeset/a-page-draws-the-components-it-references.md
+++ b/.changeset/a-page-draws-the-components-it-references.md
@@ -1,0 +1,48 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A page could reference a reusable component and nothing drew it. The engine
+knew how to replace the reference with the component's own blocks, but no
+reader ran that step — so the renderer, the stylesheet, the page reader and the
+route helper all worked from a document with a hole in it.
+
+Composition is now a pass of the pipeline every one of those readers already
+shares, so a component resolved for one of them is resolved for all four. It
+runs before migration, so a component authored against an older version of a
+block is brought up to date like any other content rather than handed over as
+stored, and the components themselves are repaired against the same limits the
+page is — an unchecked block inside a component would otherwise reach the page
+through a door the page's own checks had closed.
+
+A page also reports which components it drew and which it could not, so
+whatever fetched them can keep the page up to date when they change.
+
+A component that could not be loaded now says so where it sits, instead of
+reading as an unrecognised block. A stored stylesheet is no longer reused once
+composition has added blocks it was never compiled for, which would have left
+every one of them unstyled on a page that looked fine.

--- a/.changeset/a-page-draws-the-components-it-references.md
+++ b/.changeset/a-page-draws-the-components-it-references.md
@@ -59,3 +59,12 @@ A component that arrived broken — empty, or not a document at all — brought
 down the whole page, including pages that never used it. Such an entry is now
 skipped and the reference it was for is reported as missing, like any other
 component that could not be found.
+
+Three more repairs at the same seam. A component that arrives as something
+other than a document — an empty object, or a page saved under a component's
+name — used to compose to nothing at all, so its whole region vanished from the
+page with nothing to say why; it is now reported like any other component that
+could not be loaded. A stored page can no longer claim one of its own blocks is
+an unloadable component and have that believed. And a page now prepares only
+the components it actually uses, following one component's reference to
+another, instead of paying for the whole library on every render.

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -167,6 +167,7 @@ export {
   COMPONENT_UNRESOLVED_REASONS,
 } from "./resolve-instances";
 export type {
+  ComponentLookup,
   ComponentUnresolvedReason,
   DefinitionsById,
   ResolveComponentOptions,

--- a/packages/blocks-engine/src/resolve-instances.test.ts
+++ b/packages/blocks-engine/src/resolve-instances.test.ts
@@ -941,13 +941,15 @@ describe("resolveComponentInstances bounds", () => {
     expect(result.document.nodes[0]!.props.text).toBe("base");
   });
 
-  it("refuses a definition that is not a component document", () => {
+  it("calls a definition that is not a component document unreadable", () => {
     const doc = page([instance("i1", "hero")]);
     const definitions = defs({ hero: page([node("d1")]) });
 
     const result = resolveComponentInstances(doc, definitions);
 
-    expect(result.unresolved.map(e => e.reason)).toEqual(["malformed"]);
+    // A page filed under a component's id is a fault in THAT document, not in
+    // the instance naming it — the discrimination `malformed` cannot make.
+    expect(result.unresolved.map(e => e.reason)).toEqual(["unreadable"]);
     expect(idsOf(result.document)).toEqual(["i1"]);
   });
 });
@@ -1226,7 +1228,7 @@ describe("resolveComponentInstances references, bands and cost", () => {
     expect(cta.links[0]!.href).toBe(`#${String(nodes[0]!.cssId)}`);
   });
 
-  it("calls a definition supplied as null malformed, not missing", () => {
+  it("calls a definition supplied as null unreadable, not missing", () => {
     const doc = page([instance("i1", "hero")]);
     const definitions = new Map<string, BlockDocument>([
       ["hero", null as unknown as BlockDocument],
@@ -1237,7 +1239,7 @@ describe("resolveComponentInstances references, bands and cost", () => {
     // Present-and-unreadable, so the key's PRESENCE is what separates it from
     // absent — a falsy value would read as absent to anything asking the map
     // for the value instead.
-    expect(result.unresolved.map(e => e.reason)).toEqual(["malformed"]);
+    expect(result.unresolved.map(e => e.reason)).toEqual(["unreadable"]);
   });
 
   it("keeps the true that ends an instance's hidden band", () => {
@@ -1309,7 +1311,7 @@ describe("resolveComponentInstances references, bands and cost", () => {
     expect(flatten(result.document.nodes)).toHaveLength(2);
   });
 
-  it("calls a supplied-but-unreadable definition malformed", () => {
+  it("calls a supplied-but-unreadable definition unreadable", () => {
     const doc = page([instance("i1", "hero")]);
     const definitions = new Map<string, BlockDocument>([
       [
@@ -1323,7 +1325,47 @@ describe("resolveComponentInstances references, bands and cost", () => {
     // `missing` asks somebody to publish or restore a component; a supplied
     // record that cannot be read is a document fault, and offering the wrong
     // remedy is the whole reason the reasons are a closed list.
-    expect(result.unresolved.map(e => e.reason)).toEqual(["malformed"]);
+    expect(result.unresolved.map(e => e.reason)).toEqual(["unreadable"]);
+  });
+});
+
+describe("how a resolution reaches a definition", () => {
+  it("asks a lookup for a definition only when it is about to read one", () => {
+    // A caller that prepares its definitions cannot predict which ones a
+    // resolution will read — an override may name a different component than
+    // the definition stored, and the composition cap stops a chain long before
+    // a catalog does. Asking here is what makes preparation and reachability
+    // one answer instead of two that disagree.
+    const asked: string[] = [];
+    const stored = new Map<string, BlockDocument>([
+      ["a", component([instance("n1", "b")])],
+      ["b", component([node("d1")])],
+      ["unused", component([node("d2")])],
+    ]);
+
+    const result = resolveComponentInstances(page([instance("i1", "a")]), {
+      has: id => stored.has(id),
+      get: id => {
+        asked.push(id);
+        return stored.get(id);
+      },
+    });
+
+    expect(asked).toEqual(["a", "a", "b", "b"]);
+    expect(result.unresolved).toEqual([]);
+  });
+
+  it("takes `has` as the answer even when `get` produces nothing", () => {
+    // The two are different questions. A lookup that answered presence from
+    // whether a document came back would report a corrupt definition as one
+    // nobody supplied, and send whoever is debugging to publish a component
+    // that is already there.
+    const result = resolveComponentInstances(page([instance("i1", "hero")]), {
+      has: () => true,
+      get: () => undefined,
+    });
+
+    expect(result.unresolved.map(e => e.reason)).toEqual(["unreadable"]);
   });
 });
 

--- a/packages/blocks-engine/src/resolve-instances.ts
+++ b/packages/blocks-engine/src/resolve-instances.ts
@@ -75,9 +75,9 @@ import { isConditionGated } from "./visibility";
  * A closed list rather than a message, because each reason has a different
  * remedy and the surface showing it has to pick one: `missing` asks the author
  * to publish or restore a component, `cycle` asks them to break a containment
- * loop, `depth` and `budget` are limits, and `malformed` is a document fault
- * no author action fixes. A rendered string would carry the same information
- * in a form nothing can branch on and nothing can translate.
+ * loop, `depth` and `budget` are limits, and `malformed` and `unreadable` are
+ * document faults no author action fixes. A rendered string would carry the
+ * same information in a form nothing can branch on and nothing can translate.
  */
 export const COMPONENT_UNRESOLVED_REASONS = [
   /** No definition was supplied for the referenced id. */
@@ -96,14 +96,20 @@ export const COMPONENT_UNRESOLVED_REASONS = [
   "node-depth",
   /** Inlining it would pass the run's node budget. */
   "budget",
-  /**
-   * The instance or its definition is not the shape composition needs — a node
-   * naming no component, or a definition that is not a component document.
-   *
-   * Both are faults no author action fixes, which is what separates this from
-   * `missing`: that one asks somebody to publish or restore a component.
-   */
+  /** The instance node names no component at all. */
   "malformed",
+  /**
+   * A definition WAS supplied under this id and cannot be read — an envelope
+   * this build does not understand, or a document that is not a component.
+   *
+   * Its own reason rather than sharing `malformed`, because the two point at
+   * different documents. `malformed` is a fault in the page holding the
+   * instance; this is a fault in the component the instance correctly names,
+   * and a surface that cannot tell them apart sends whoever is debugging to
+   * the healthy one. Both differ from `missing`, which asks somebody to
+   * publish or restore a component that was never supplied.
+   */
+  "unreadable",
 ] as const;
 
 /** Derived from the list, so the pair cannot be half-changed. */
@@ -165,6 +171,33 @@ export interface ResolvedDocument extends BlockDocument {
  * method and inline whatever a property read of `.nodes` on it returned.
  */
 export type DefinitionsById = ReadonlyMap<string, BlockDocument>;
+
+/**
+ * How a resolution reaches a definition.
+ *
+ * A lookup rather than the map itself, so that PREPARING a definition and
+ * DECIDING to read one are the same act. A caller that repairs its definitions
+ * up front has to predict which ones this run will reach, and reachability is
+ * decided here: after an instance's overrides have chosen a component, under
+ * the composition cap, over the tree the caller's own shape pass retained.
+ * Every one of those is a place a second traversal answers differently, and a
+ * disagreement costs the page a definition that WAS supplied.
+ *
+ * `has` and `get` are separate questions and both are asked. Absence means
+ * nobody supplied a definition; a value that cannot be read means one was
+ * supplied and is corrupt, and the reasons this module reports keep them
+ * apart — so a lookup must not answer `has` from whether `get` produced
+ * something.
+ *
+ * A `ReadonlyMap` satisfies it, which is what every caller holding its
+ * definitions in memory passes.
+ */
+export interface ComponentLookup {
+  /** Whether anybody supplied a definition under this id. */
+  has(id: string): boolean;
+  /** That definition, or nothing when it cannot be read. */
+  get(id: string): BlockDocument | undefined;
+}
 
 /** How much work one resolution may do. */
 export interface ResolveComponentOptions {
@@ -248,7 +281,7 @@ export function componentIdsIn(
  */
 export function resolveComponentInstances(
   document: BlockDocument,
-  definitions: DefinitionsById,
+  definitions: ComponentLookup,
   options: ResolveComponentOptions = {}
 ): ResolvedComposition {
   const unchanged: ResolvedComposition = {
@@ -308,7 +341,7 @@ export function resolveComponentInstances(
 
 /** Everything one resolution accumulates. */
 interface ResolveRun {
-  definitions: DefinitionsById;
+  definitions: ComponentLookup;
   maxDepth: number;
   maxComposedDepth: number;
   /** Nodes this resolution may still produce, across every instance. */
@@ -900,13 +933,13 @@ function refusalFor(
   if (scope.depth >= run.maxComposedDepth) return "composed-depth";
   // ABSENT from the map is `missing` — nobody supplied one, and the remedy is
   // to publish or restore it. A value that IS supplied and cannot be read is a
-  // document fault, so it takes `malformed`: offering the publish remedy for
+  // document fault, so it takes `unreadable`: offering the publish remedy for
   // corrupt component data sends an author to the wrong screen, which is the
   // whole reason these reasons are a closed list rather than a message.
   if (!run.definitions.has(componentId)) return "missing";
   const definition = run.definitions.get(componentId);
   if (!isPlainRecord(definition) || !Array.isArray(definition.nodes)) {
-    return "malformed";
+    return "unreadable";
   }
   // A structural check is not the discrimination. `DefinitionsById` is keyed to
   // `BlockDocument`, so a page, a region or a template satisfies "has a nodes
@@ -914,7 +947,7 @@ function refusalFor(
   // another document appearing inside this one, with its exposed properties
   // and slots meaning nothing. The kind is what the engine already publishes
   // an answer for.
-  if (!isComponentDocument(definition)) return "malformed";
+  if (!isComponentDocument(definition)) return "unreadable";
   return undefined;
 }
 

--- a/packages/blocks-react/src/block-boundary.tsx
+++ b/packages/blocks-react/src/block-boundary.tsx
@@ -9,6 +9,11 @@ import { Suspense, cloneElement, isValidElement, type ReactNode } from "react";
 
 import type { BlockHostPolicy, PageContext } from "./context";
 import { BlockPlaceholder } from "./placeholder";
+// The SAME predicate the pipeline uses. Asking the question twice is how the
+// renderer came to hide a node the exported reader returns: the pipeline kept
+// a block carrying a stored `unresolvedComponent` key and this boundary drew a
+// placeholder over it, so one document had two readings.
+import { isUnresolvedInstance } from "./prepare-document";
 import {
   createsNoHostElement,
   describeThrown,
@@ -25,6 +30,20 @@ import { isUnconditional } from "./visibility";
  * single message would send an author looking in the wrong place for four of
  * them. Development only: the production placeholder renders nothing.
  */
+/**
+ * The wording for one reason, or nothing when the marker names none.
+ *
+ * Total over the reason type rather than an index expression, because the
+ * predicate that admits a node here asks only for the reserved instance TYPE:
+ * a marker carrying an unrecognised reason still reaches this, and indexing
+ * would hand React whatever a record answers for a key it does not have.
+ */
+function unresolvedDetail(
+  reason: ComponentUnresolvedReason | undefined
+): string | undefined {
+  return reason === undefined ? undefined : UNRESOLVED_DETAIL[reason];
+}
+
 const UNRESOLVED_DETAIL: Readonly<Record<ComponentUnresolvedReason, string>> = {
   missing: "No published component was found for this reference",
   cycle: "This component contains itself",
@@ -939,13 +958,13 @@ export function BlockBoundary({
   // no registered block: falling through would draw "no block is registered
   // for this type", which is true, tells an author nothing, and hides the one
   // fact they can act on — that a component they placed did not load.
-  if (node.unresolvedComponent !== undefined) {
+  if (isUnresolvedInstance(node)) {
     return (
       <BlockPlaceholder
         reason="unresolved-component"
         type={node.type}
         id={node.id}
-        detail={UNRESOLVED_DETAIL[node.unresolvedComponent]}
+        detail={unresolvedDetail(node.unresolvedComponent)}
       />
     );
   }

--- a/packages/blocks-react/src/block-boundary.tsx
+++ b/packages/blocks-react/src/block-boundary.tsx
@@ -51,6 +51,7 @@ const UNRESOLVED_DETAIL: Readonly<Record<ComponentUnresolvedReason, string>> = {
   "node-depth": "This component's own content is nested too deeply",
   budget: "This page is already at its node limit",
   malformed: "This instance names no component",
+  unreadable: "This component's stored data cannot be read",
 };
 
 /** What a render needs to turn one node into output. */

--- a/packages/blocks-react/src/block-boundary.tsx
+++ b/packages/blocks-react/src/block-boundary.tsx
@@ -2,6 +2,8 @@ import {
   blockPartClassName,
   blockTypeClassName,
   type BlockNode,
+  type ComponentUnresolvedReason,
+  type ResolvedBlockNode,
 } from "@nextlyhq/blocks-engine";
 import { Suspense, cloneElement, isValidElement, type ReactNode } from "react";
 
@@ -16,9 +18,31 @@ import {
 import type { BlockResolver } from "./resolver";
 import { isUnconditional } from "./visibility";
 
+/**
+ * What an author is told when a component did not load.
+ *
+ * Wording per cause, because the remedies are five different things and a
+ * single message would send an author looking in the wrong place for four of
+ * them. Development only: the production placeholder renders nothing.
+ */
+const UNRESOLVED_DETAIL: Readonly<Record<ComponentUnresolvedReason, string>> = {
+  missing: "No published component was found for this reference",
+  cycle: "This component contains itself",
+  "composed-depth": "This component is nested inside too many components",
+  "node-depth": "This component's own content is nested too deeply",
+  budget: "This page is already at its node limit",
+  malformed: "This instance names no component",
+};
+
 /** What a render needs to turn one node into output. */
 export interface BlockBoundaryProps {
-  node: BlockNode;
+  /**
+   * A node of the RESOLVED tree. Widened from `BlockNode` rather than narrowed
+   * to it: every stored node already satisfies this, so no caller changes, and
+   * the boundary is the one place that has to tell a composed node apart from
+   * an authored one.
+   */
+  node: ResolvedBlockNode;
   context: PageContext;
   blocks: BlockResolver;
   /** Node id to generated class, from the compiled stylesheet. */
@@ -911,6 +935,21 @@ export function BlockBoundary({
   // `=== true`, not truthy. A stored `"false"` or `{}` is truthy and would drop
   // public content that never failed anything; the repair pass normalises
   // structure but leaves this control flag as written.
+  // Asked before the definition lookup, because the reserved instance type has
+  // no registered block: falling through would draw "no block is registered
+  // for this type", which is true, tells an author nothing, and hides the one
+  // fact they can act on — that a component they placed did not load.
+  if (node.unresolvedComponent !== undefined) {
+    return (
+      <BlockPlaceholder
+        reason="unresolved-component"
+        type={node.type}
+        id={node.id}
+        detail={UNRESOLVED_DETAIL[node.unresolvedComponent]}
+      />
+    );
+  }
+
   if (node.migrationFailed === true) {
     return (
       <BlockPlaceholder

--- a/packages/blocks-react/src/entry-surface.test.ts
+++ b/packages/blocks-react/src/entry-surface.test.ts
@@ -305,7 +305,15 @@ const SOURCE_MODULES: ReadonlyArray<{
     // turn stages into something a reader presents must apply identically. It
     // is exported to delete the second copy, not to be called on its own: it
     // takes stages, and a consumer holding stages is already past this surface.
+    //
+    // `isUnresolvedInstance` is the same shape as `pruneKnownPlaceholders`: it
+    // crosses to the block boundary so that ONE reading of the marker decides
+    // both what the pipeline keeps and what the renderer draws. Two readings
+    // is precisely how the renderer came to hide a node the exported reader
+    // returns. A consumer never holds a resolved node without also holding the
+    // stages that explain it, so there is nothing here to offer.
     internal: [
+      "isUnresolvedInstance",
       "prepareDocumentReadStages",
       "pruneKnownPlaceholders",
       "readingViewOf",

--- a/packages/blocks-react/src/index.ts
+++ b/packages/blocks-react/src/index.ts
@@ -279,6 +279,14 @@ export type {
   SlotLock,
   SlotSpec,
   BreakpointContextOptions,
+  // Composition. `PrepareDocumentArgs` names the definitions map in a
+  // parameter position and the stages name what came back, so a host that
+  // cannot write these down cannot annotate the call it is required to make.
+  ComponentUnresolvedReason,
+  DefinitionsById,
+  ResolvedBlockNode,
+  ResolvedDocument,
+  UnresolvedInstance,
   StyleCompileContext,
   StyleOrigin,
   StyleState,

--- a/packages/blocks-react/src/page-renderer.tsx
+++ b/packages/blocks-react/src/page-renderer.tsx
@@ -5,6 +5,7 @@ import {
   PAGE_ROOT_CLASS,
   resolveSiteTokens,
   type BlockDocument,
+  type DefinitionsById,
   type DocumentLimits,
   type SiteSheetInput,
   type StyleCompileContext,
@@ -48,6 +49,17 @@ export interface PageRendererProps {
   context?: PageContext;
   /** Where block definitions come from. Defaults to the process registry. */
   blocks?: BlockResolver;
+  /**
+   * The component definitions this page may inline, at the posture the caller
+   * chose — drafts for the editor, published for a served page.
+   *
+   * Passed through to the shared pipeline rather than resolved here, so this
+   * renderer and every other reader of the same document compose it the same
+   * way. Absent, an instance renders the marker that says its component could
+   * not be loaded, which is the honest answer for a reader that did not fetch
+   * one.
+   */
+  definitions?: DefinitionsById;
   /**
    * The stylesheet compiled when the document was saved, with the class each
    * node was assigned. Supplying it is the normal path.
@@ -453,6 +465,7 @@ export function PageRenderer({
   document,
   context,
   blocks,
+  definitions,
   styles,
   styleContext,
   siteStyles,
@@ -519,6 +532,7 @@ export function PageRenderer({
     resolver,
     limits,
     styleContext,
+    definitions,
   });
   // `null` here means only an unreadable ENVELOPE, which the two guards above
   // already answered. Kept because unreachability is a property of the current
@@ -531,7 +545,13 @@ export function PageRenderer({
       </div>
     );
   }
-  const { sanitized, migrated: doc, gated: pruned, deduped: visible } = stages;
+  const {
+    sanitized,
+    resolved,
+    migrated: doc,
+    gated: pruned,
+    deduped: visible,
+  } = stages;
 
   // The scope comes from whichever input supplied the stylesheet, never from a
   // separate prop. Two inputs would have to agree, and when they did not the
@@ -644,6 +664,17 @@ export function PageRenderer({
   // answer for that one.
   const repairedDocument =
     sanitized !== document ||
+    // Composition is a sixth, and the only one that ADDS nodes rather than
+    // removing them: a stored sheet names the page's own ids, and an inlined
+    // component's are not among them.
+    //
+    // Redundant today with the artifact's own unaccounted-node check, for the
+    // reason recorded beside the same clause in `read-page.ts` — every node
+    // gets a class, so a replaced instance always trips that one first. Kept
+    // because the redundancy is a property of class assignment rather than of
+    // composition, and inheriting a guarantee from something that never
+    // promised it is how one lapses without a failing test.
+    resolved !== sanitized ||
     (pruned !== doc && !gatingCoveredByArtifact) ||
     visible !== pruned ||
     (drawlessInput !== visible && !drawlessCoveredByArtifact) ||

--- a/packages/blocks-react/src/page-style-trace.ts
+++ b/packages/blocks-react/src/page-style-trace.ts
@@ -21,6 +21,7 @@
 import type {
   BlockDocument,
   BlockNode,
+  DefinitionsById,
   DocumentLimits,
   RemotePatternInput,
   SiteSheetInput,
@@ -55,6 +56,16 @@ export interface PageStyleTraceInput {
   readonly blocks?: BlockResolver;
   /** The host's fetch policy, so a refused `url(...)` is refused here too. */
   readonly remotePatterns?: readonly RemotePatternInput[];
+  /**
+   * The component definitions the page renders with.
+   *
+   * Forwarded for exactly the reason `limits` is, one entry below: they change
+   * what EXISTS. A trace run without them marks every instance unresolved and
+   * drops it, so the provenance an editor shows describes a tree the page is
+   * not rendering — and the disagreement is silent, because a trace of a
+   * smaller tree is a perfectly well formed trace.
+   */
+  readonly definitions?: DefinitionsById;
   /**
    * The caps the renderer prepares and compiles under.
    *
@@ -222,6 +233,7 @@ export function pageStyleTrace(
     resolver,
     ...(input.limits === undefined ? {} : { limits: input.limits }),
     styleContext: context,
+    definitions: input.definitions,
   });
   // An unreadable ENVELOPE, which is a real answer: nothing can be compiled from
   // a document this format does not recognise.

--- a/packages/blocks-react/src/placeholder.tsx
+++ b/packages/blocks-react/src/placeholder.tsx
@@ -6,6 +6,19 @@ export type PlaceholderReason =
   | "unknown-block"
   /** The node could not be upgraded to its block's current schema version. */
   | "migration-failed"
+  /**
+   * A component instance could not be replaced by the tree it stands for.
+   *
+   * ONE member for five causes — the component is missing, it reaches itself,
+   * it is nested too deep, its own tree is too deep, or the node names no
+   * component at all. Which one it was travels in `DocumentReadStages`
+   * instead, because that is the channel with a reader who can act: the
+   * publish readiness check lists the components a page embeds that are not
+   * published yet, and it needs the cause per instance, not per page. The DOM
+   * marker's audience is monitoring, and "a component did not resolve, here"
+   * is what monitoring can do something with.
+   */
+  | "unresolved-component"
   /** The node was saved against a newer definition than this app has. */
   | "version-ahead"
   /** The whole document is in a format version this renderer does not know. */
@@ -32,6 +45,7 @@ export interface BlockPlaceholderProps {
 const REASON_TEXT: Readonly<Record<PlaceholderReason, string>> = {
   "unknown-block": "No block is registered for this type",
   "migration-failed": "This block could not be upgraded to its current version",
+  "unresolved-component": "This component could not be loaded",
   "version-ahead": "This block was saved by a newer version of the app",
   "unsupported-format": "This page is stored in a format this app cannot read",
   "render-error": "This block failed to render",

--- a/packages/blocks-react/src/prepare-compose.test.tsx
+++ b/packages/blocks-react/src/prepare-compose.test.tsx
@@ -267,7 +267,7 @@ describe("a definitions map that is not what it claims", () => {
     expect(stages!.prepared.nodes[0]!.props.value).toBe("Hi");
   });
 
-  it("reports a supplied but unreadable definition as malformed", () => {
+  it("reports a supplied but unreadable definition as unreadable", () => {
     const definitions = new Map<string, BlockDocument>([
       ["hero", null as unknown as BlockDocument],
       ["absent-control", component([node("d1", "x")])],
@@ -282,7 +282,7 @@ describe("a definitions map that is not what it claims", () => {
     // to publish a component, the other says the component data is corrupt.
     expect(
       stages!.unresolvedInstances.map(e => `${e.componentId}:${e.reason}`)
-    ).toEqual(["hero:malformed", "never-supplied:missing"]);
+    ).toEqual(["hero:unreadable", "never-supplied:missing"]);
   });
 });
 
@@ -512,5 +512,123 @@ describe("a stored stylesheet after composition", () => {
 
     expect(read.referencedComponents).toEqual(["hero", "gone"]);
     expect(read.unresolvedInstances.map(e => e.reason)).toEqual(["missing"]);
+  });
+});
+
+/**
+ * Preparing a definition and deciding to read one are ONE question.
+ *
+ * The pass that repairs definitions has to know which ones the render will
+ * reach, and reachability is decided by the resolver — after overrides, under
+ * its own composition cap, over the tree its own shape pass retained. A second
+ * traversal answering that question separately answers it differently, and
+ * every disagreement costs the page content it was supplied.
+ */
+describe("which definitions a render prepares", () => {
+  /** A definition envelope with exposed properties. */
+  const exposing = (nodes: unknown[], exposed: unknown[]): BlockDocument =>
+    ({
+      formatVersion: DOCUMENT_FORMAT_VERSION,
+      kind: "component",
+      nodes,
+      exposed,
+    }) as unknown as BlockDocument;
+
+  /** An instance node carrying overrides. */
+  const overriding = (
+    id: string,
+    componentId: string,
+    overrides: Record<string, unknown>
+  ): BlockNode => ({
+    id,
+    type: COMPONENT_INSTANCE_TYPE,
+    version: 1,
+    props: { componentId, overrides },
+  });
+
+  it("composes a nested component the instance's override selected", () => {
+    const stages = stagesOf(
+      page([overriding("i1", "outer", { which: "chosen" })]),
+      defs({
+        outer: exposing(
+          [instance("n1", "default")],
+          [{ id: "which", nodeId: "n1", propPath: "componentId" }]
+        ),
+        default: component([node("d1", "Default")]),
+        chosen: component([node("d2", "Chosen")]),
+      })
+    );
+
+    expect(stages!.unresolvedInstances).toEqual([]);
+    expect(stages!.prepared.nodes.map(n => n.props.value)).toEqual(["Chosen"]);
+  });
+
+  it("composes a nested instance the definition's shape pass retained", () => {
+    // The host's cap admits four nodes. The definition stores four entries
+    // nothing can read and then an instance: a scan of the STORED nodes
+    // spends its budget on the four and never reaches the fifth, while the
+    // shape pass drops all four and hands the resolver the instance.
+    const limits = { maxDepth: 12, maxNodes: 4, maxBytes: 2_097_152 };
+    const stages = prepareDocumentReadStages(page([instance("i1", "outer")]), {
+      resolver,
+      limits,
+      definitions: defs({
+        outer: component([null, null, null, null, instance("n1", "inner")]),
+        inner: component([node("d1", "Inner")]),
+      }),
+    });
+
+    expect(stages!.unresolvedInstances).toEqual([]);
+    expect(stages!.prepared.nodes.map(n => n.props.value)).toEqual(["Inner"]);
+  });
+
+  it("reads no definition deeper than the composition cap can compose", () => {
+    // A chain of ten. The resolver refuses past `MAX_COMPOSED_DEPTH`, so the
+    // definitions below that line cannot change one pixel of this page — and
+    // repairing them is per-render work an author can grow without bound by
+    // publishing a longer chain.
+    class Counting extends Map<string, BlockDocument> {
+      readonly reads: string[] = [];
+      override get(id: string): BlockDocument | undefined {
+        this.reads.push(id);
+        return super.get(id);
+      }
+    }
+    const chain = new Counting();
+    for (let i = 0; i < 10; i += 1) {
+      chain.set(
+        `c${String(i)}`,
+        i === 9
+          ? component([node("leaf", "End")])
+          : component([instance(`n${String(i)}`, `c${String(i + 1)}`)])
+      );
+    }
+
+    const stages = stagesOf(page([instance("i1", "c0")]), chain);
+
+    expect(stages!.unresolvedInstances.map(e => e.reason)).toEqual([
+      "composed-depth",
+    ]);
+    expect(chain.reads).toEqual(["c0", "c1", "c2", "c3", "c4"]);
+  });
+});
+
+describe("what an unresolved instance tells whoever is debugging it", () => {
+  it("names the DEFINITION as the fault when the instance is sound", () => {
+    // Both faults are document faults no author action fixes, but they are
+    // faults in two different documents: one sends whoever is debugging to
+    // this page, the other to the component it correctly names.
+    const stages = stagesOf(
+      page([
+        instance("i1", "hero"),
+        { id: "i2", type: COMPONENT_INSTANCE_TYPE, version: 1, props: {} },
+      ]),
+      defs({ hero: page([node("d1", "A page, not a component")]) })
+    );
+
+    expect(stages!.unresolvedInstances).toEqual([
+      { instanceId: "i1", componentId: "hero", reason: "unreadable" },
+      { instanceId: "i2", componentId: "", reason: "malformed" },
+    ]);
   });
 });

--- a/packages/blocks-react/src/prepare-compose.test.tsx
+++ b/packages/blocks-react/src/prepare-compose.test.tsx
@@ -212,6 +212,45 @@ describe("where composition sits in the order", () => {
   });
 });
 
+describe("composition and the limits around it", () => {
+  it("lets the resolver refuse a definition past the node cap", () => {
+    const stages = prepareDocumentReadStages(page([instance("i1", "hero")]), {
+      resolver,
+      limits: { maxDepth: 12, maxNodes: 2, maxBytes: 2_097_152 },
+      definitions: defs({
+        hero: component([node("a", "1"), node("b", "2"), node("c", "3")]),
+      }),
+    });
+
+    // Repair must not be the thing that enforces the limit: truncating the
+    // definition first publishes a component missing part of itself with
+    // nothing in `unresolvedInstances` to say so.
+    expect(stages!.unresolvedInstances.map(e => e.reason)).toEqual(["budget"]);
+  });
+
+  it("traces the styles of a component the page renders", async () => {
+    const { pageStyleTrace } = await import("./page-style-trace");
+    const traceInput = {
+      document: page([instance("i1", "hero")]),
+      styleContext: context,
+      site: undefined,
+      blocks: resolver,
+    };
+    const definitions = defs({ hero: component([node("d1", "Hi")]) });
+
+    const composed = pageStyleTrace({ ...traceInput, definitions });
+    const without = pageStyleTrace(traceInput);
+
+    // The trace must describe the tree that RENDERS. Without the definitions
+    // it marks the instance unresolved and drops it, so an editor's style
+    // provenance describes a page that is not the one in front of the author.
+    expect(composed?.nodes.map(n => n.props.value)).toEqual(["Hi"]);
+    // The control: the same call is genuinely empty without them, so the
+    // assertion above is about forwarding rather than about the trace working.
+    expect(without?.nodes).toEqual([]);
+  });
+});
+
 describe("an instance nothing could resolve", () => {
   // `rendersOwnMarkup` returning false for one is NOT asserted here. The
   // engine refuses to register the reserved instance name

--- a/packages/blocks-react/src/prepare-compose.test.tsx
+++ b/packages/blocks-react/src/prepare-compose.test.tsx
@@ -1,0 +1,291 @@
+/**
+ * Composition as a pass of the shared read pipeline.
+ *
+ * The pipeline is where five readers meet — the renderer, the style resolver,
+ * the exported page reader, the style trace and the route helper — so a
+ * component resolved for one of them is resolved for all five. What is pinned
+ * here is what a caller cannot see for itself: that composition happens BEFORE
+ * migration, that a definition is repaired against the same caps the host is,
+ * that a stored stylesheet is refused once the tree it described has grown,
+ * and that an instance nothing could resolve draws a marker naming the cause.
+ */
+import {
+  COMPONENT_INSTANCE_TYPE,
+  DOCUMENT_FORMAT_VERSION,
+  type BlockDocument,
+  type BlockNode,
+  type ComponentDocument,
+  type StyleCompileContext,
+} from "@nextlyhq/blocks-engine";
+import type { ReactElement } from "react";
+import { renderToReadableStream } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { defineBlock } from "./context";
+import { PageRenderer } from "./page-renderer";
+import {
+  prepareDocumentReadStages,
+  rendersOwnMarkup,
+} from "./prepare-document";
+import { preparePageForRead } from "./read-page";
+import { createBlockResolver } from "./resolver";
+import { resolvePageStyles } from "./styles";
+
+const text = defineBlock<{ value: string }>({
+  name: "test/text",
+  version: 1,
+  description: "Text.",
+  example: { props: { value: "x" } },
+  defaultProps: { value: "" },
+  render: ({ props, className }) => <p className={className}>{props.value}</p>,
+});
+
+/** A block whose current schema is version 2, so a stored v1 node migrates. */
+const aged = defineBlock<{ value: string }>({
+  name: "test/aged",
+  version: 2,
+  description: "Text whose props moved at version 2.",
+  example: { props: { value: "x" } },
+  defaultProps: { value: "" },
+  // Keyed by the version migrated FROM, not to: `migrateProps` walks
+  // `for (v = from; v < to; v++)` and looks up `map[v]`.
+  migrate: {
+    1: props => ({ value: `migrated:${String(props.value)}` }),
+  },
+  render: ({ props, className }) => <p className={className}>{props.value}</p>,
+});
+
+const resolver = createBlockResolver([text, aged]);
+
+const context: StyleCompileContext = {
+  breakpoints: { viewport: [{ id: "base", label: "Desktop" }], container: [] },
+  blockBases: { "test/text": { base: { base: { fontSize: "16px" } } } },
+};
+
+const node = (
+  id: string,
+  value: string,
+  extra: Partial<BlockNode> = {}
+): BlockNode => ({
+  id,
+  type: "test/text",
+  version: 1,
+  props: { value },
+  ...extra,
+});
+
+const instance = (id: string, componentId: string): BlockNode => ({
+  id,
+  type: COMPONENT_INSTANCE_TYPE,
+  version: 1,
+  props: { componentId },
+});
+
+const page = (nodes: BlockNode[]): BlockDocument => ({
+  formatVersion: DOCUMENT_FORMAT_VERSION,
+  kind: "page",
+  nodes,
+});
+
+const component = (nodes: unknown[]): ComponentDocument =>
+  ({
+    formatVersion: DOCUMENT_FORMAT_VERSION,
+    kind: "component",
+    nodes,
+  }) as unknown as ComponentDocument;
+
+const defs = (entries: Record<string, BlockDocument>) =>
+  new Map(Object.entries(entries));
+
+const stagesOf = (
+  doc: BlockDocument,
+  definitions?: Map<string, BlockDocument>
+) => prepareDocumentReadStages(doc, { resolver, definitions });
+
+/** Streamed rather than statically rendered, matching the renderer's own tests. */
+async function renderToHtml(element: ReactElement): Promise<string> {
+  const stream = await renderToReadableStream(element, {
+    onError(error) {
+      throw error;
+    },
+  });
+  await stream.allReady;
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let html = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    html += decoder.decode(value, { stream: true });
+  }
+  return html;
+}
+
+describe("the composition pass", () => {
+  it("replaces an instance with its definition's tree", () => {
+    const stages = stagesOf(
+      page([instance("i1", "hero")]),
+      defs({ hero: component([node("d1", "Hi")]) })
+    );
+
+    expect(stages!.prepared.nodes).toHaveLength(1);
+    expect(stages!.prepared.nodes[0]!.props.value).toBe("Hi");
+    expect(stages!.referencedComponents).toEqual(["hero"]);
+    expect(stages!.unresolvedInstances).toEqual([]);
+  });
+
+  it("leaves a document holding no instance exactly as it was", () => {
+    const stages = stagesOf(
+      page([node("a", "Plain")]),
+      defs({ hero: component([node("d1", "Hi")]) })
+    );
+
+    expect(stages!.resolved).toBe(stages!.sanitized);
+    expect(stages!.referencedComponents).toEqual([]);
+  });
+
+  it("reports an instance as unresolved when no definitions were supplied", () => {
+    const stages = stagesOf(page([instance("i1", "hero")]));
+
+    expect(stages!.unresolvedInstances).toEqual([
+      { instanceId: "i1", componentId: "hero", reason: "missing" },
+    ]);
+    expect(stages!.referencedComponents).toEqual(["hero"]);
+  });
+});
+
+describe("where composition sits in the order", () => {
+  it("migrates the nodes it inlined, so a definition is not read at its stored version", () => {
+    // The whole point of composing BEFORE migration. A definition authored
+    // against version 1 reaches a renderer holding version 2, and it has to be
+    // upgraded like any other content — otherwise the renderer reads props
+    // shaped for a schema it no longer speaks, which is the failure
+    // `migrationFailed` exists to name.
+    const stages = stagesOf(
+      page([instance("i1", "hero")]),
+      defs({
+        hero: component([
+          { id: "d1", type: "test/aged", version: 1, props: { value: "old" } },
+        ]),
+      })
+    );
+
+    expect(stages!.prepared.nodes[0]!.props.value).toBe("migrated:old");
+    expect(stages!.prepared.nodes[0]!.version).toBe(2);
+  });
+
+  it("CONTROL: the same node stored on the page migrates identically", () => {
+    // Without this the case above passes on an implementation that migrates
+    // nothing and happens to carry the string through, and it proves the
+    // fixture's block really does have a version-2 step to run.
+    const stages = stagesOf(
+      page([
+        { id: "a", type: "test/aged", version: 1, props: { value: "old" } },
+      ])
+    );
+
+    expect(stages!.prepared.nodes[0]!.props.value).toBe("migrated:old");
+  });
+
+  it("repairs a definition against the same caps the host is repaired against", async () => {
+    // Asserted through a RENDER, because the prepared tree cannot tell the two
+    // apart: an unrepaired node whose `type` is not a string has no registered
+    // block either way, so it is pruned from `prepared` either way. The
+    // renderer walks the deduped tree instead, and there the difference is
+    // total — the placeholder writes that value into a data attribute and into
+    // text, and React throws inside the component that exists to contain a
+    // failure, taking the whole page with it.
+    const html = await renderToHtml(
+      <PageRenderer
+        document={page([instance("i1", "hero")])}
+        blocks={resolver}
+        definitions={defs({
+          hero: component([
+            { id: "bad", type: {}, version: 1, props: {} },
+            node("good", "Kept"),
+          ]),
+        })}
+      />
+    );
+
+    expect(html).toContain("Kept");
+  });
+});
+
+describe("an instance nothing could resolve", () => {
+  // `rendersOwnMarkup` returning false for one is NOT asserted here. The
+  // engine refuses to register the reserved instance name
+  // (`registry.ts:RESERVED_BLOCK_NAMES`), so the unregistered-type fallthrough
+  // already answers false and no fixture can separate the two. The guard is
+  // kept in the source as a cheap statement of intent; a test over it would
+  // pass with the guard deleted, which reads as coverage and is not.
+
+  it("draws a marker naming composition rather than an unknown block", async () => {
+    // Without the check it falls through to `unknown-block`, which is true —
+    // the reserved instance type registers no block — and tells an author
+    // nothing they can act on.
+    const html = await renderToHtml(
+      <PageRenderer
+        document={page([instance("i1", "hero")])}
+        blocks={createBlockResolver([text, aged])}
+      />
+    );
+
+    expect(html).toContain('data-nx-block-placeholder="unresolved-component"');
+    expect(html).toContain('data-nx-block-id="i1"');
+  });
+});
+
+describe("a stored stylesheet after composition", () => {
+  const composedPage = page([instance("i1", "hero")]);
+  const plainPage = page([node("a", "Plain")]);
+  const definitions = defs({ hero: component([node("d1", "Hi")]) });
+
+  it("is refused, because it names none of the inlined nodes", () => {
+    // Compiled from the page as STORED — one instance node and nothing else —
+    // which is exactly the artifact a site would have persisted before the
+    // component was resolvable.
+    const stored = resolvePageStyles(
+      composedPage,
+      undefined,
+      context,
+      resolver
+    );
+
+    const read = preparePageForRead(composedPage, {
+      resolver,
+      definitions,
+      styles: stored,
+      styleContext: context,
+    });
+
+    expect(read.styles.css).not.toBe(stored.css);
+    expect(read.styles.css).toContain("font-size: 16px");
+  });
+
+  it("CONTROL: a page with nothing to compose keeps its stored sheet", () => {
+    // Without this the case above passes on an implementation that withholds
+    // every stored sheet unconditionally, which is the opposite defect and
+    // costs every page its styling.
+    const stored = resolvePageStyles(plainPage, undefined, context, resolver);
+
+    const read = preparePageForRead(plainPage, {
+      resolver,
+      definitions,
+      styles: stored,
+      styleContext: context,
+    });
+
+    expect(read.styles.css).toBe(stored.css);
+  });
+
+  it("carries the composed definitions out for the caller that must tag them", () => {
+    const read = preparePageForRead(
+      page([instance("i1", "hero"), instance("i2", "gone")]),
+      { resolver, definitions }
+    );
+
+    expect(read.referencedComponents).toEqual(["hero", "gone"]);
+    expect(read.unresolvedInstances.map(e => e.reason)).toEqual(["missing"]);
+  });
+});

--- a/packages/blocks-react/src/prepare-compose.test.tsx
+++ b/packages/blocks-react/src/prepare-compose.test.tsx
@@ -267,17 +267,22 @@ describe("a definitions map that is not what it claims", () => {
     expect(stages!.prepared.nodes[0]!.props.value).toBe("Hi");
   });
 
-  it("reports a malformed definition as a missing component", () => {
+  it("reports a supplied but unreadable definition as malformed", () => {
     const definitions = new Map<string, BlockDocument>([
       ["hero", null as unknown as BlockDocument],
+      ["absent-control", component([node("d1", "x")])],
     ]);
 
-    const stages = prepareDocumentReadStages(page([instance("i1", "hero")]), {
-      resolver,
-      definitions,
-    });
+    const stages = prepareDocumentReadStages(
+      page([instance("i1", "hero"), instance("i2", "never-supplied")]),
+      { resolver, definitions }
+    );
 
-    expect(stages!.unresolvedInstances.map(e => e.reason)).toEqual(["missing"]);
+    // The two are different facts with different remedies: one asks somebody
+    // to publish a component, the other says the component data is corrupt.
+    expect(
+      stages!.unresolvedInstances.map(e => `${e.componentId}:${e.reason}`)
+    ).toEqual(["hero:malformed", "never-supplied:missing"]);
   });
 });
 
@@ -365,6 +370,70 @@ describe("what the pipeline trusts and what it repairs", () => {
     expect(untouched).toBe(0);
     // ...and one referencing a single component pays for that one, not fifty.
     expect(catalog.reads).toBeLessThanOrEqual(3);
+  });
+});
+
+describe("discovery, envelopes and one reading of a marker", () => {
+  it("finds a supplied component behind more absent ones", () => {
+    const definitions = new Map<string, BlockDocument>([
+      ["hero", component([node("d1", "Hi")])],
+    ]);
+    const doc = page([
+      instance("i1", "hero"),
+      instance("i2", "gone1"),
+      instance("i3", "gone2"),
+    ]);
+
+    const stages = prepareDocumentReadStages(doc, { resolver, definitions });
+
+    // Absent ids must not consume the discovery budget: three references and
+    // one supplied definition still has to reach that definition.
+    expect(stages!.unresolvedInstances.map(e => e.componentId)).toEqual([
+      "gone1",
+      "gone2",
+    ]);
+  });
+
+  it("refuses a definition stored in a format this build cannot read", () => {
+    const definitions = new Map<string, BlockDocument>([
+      [
+        "hero",
+        {
+          formatVersion: 99,
+          kind: "component",
+          nodes: [node("d1", "Hi")],
+        } as unknown as BlockDocument,
+      ],
+    ]);
+
+    const stages = prepareDocumentReadStages(page([instance("i1", "hero")]), {
+      resolver,
+      definitions,
+    });
+
+    // The host is refused outright for an unknown format; a definition whose
+    // nodes may not even be nodes must not be repaired and inlined instead.
+    expect(stages!.unresolvedInstances).toHaveLength(1);
+  });
+
+  it("does not draw a placeholder for a stored marker on a real block", async () => {
+    const stored = page([
+      {
+        id: "a",
+        type: "test/text",
+        version: 1,
+        props: { value: "Real" },
+        unresolvedComponent: "missing",
+      } as unknown as BlockNode,
+    ]);
+
+    const html = await renderToHtml(
+      <PageRenderer document={stored} blocks={resolver} />
+    );
+
+    // The pipeline keeps the node; the boundary must agree, or the renderer
+    // hides content the exported reader returns.
+    expect(html).toContain("Real");
   });
 });
 

--- a/packages/blocks-react/src/prepare-compose.test.tsx
+++ b/packages/blocks-react/src/prepare-compose.test.tsx
@@ -281,6 +281,93 @@ describe("a definitions map that is not what it claims", () => {
   });
 });
 
+describe("what the pipeline trusts and what it repairs", () => {
+  it("does not report an empty record as a composed component", () => {
+    const definitions = new Map<string, BlockDocument>([
+      ["hero", {} as unknown as BlockDocument],
+    ]);
+
+    const stages = prepareDocumentReadStages(page([instance("i1", "hero")]), {
+      resolver,
+      definitions,
+    });
+
+    // Repair turns a missing `nodes` into `[]`, so the instance composes
+    // "successfully" to nothing and the whole region disappears with no marker
+    // saying anything went wrong.
+    expect(stages!.unresolvedInstances).toHaveLength(1);
+  });
+
+  it("follows a reference a component makes to another component", () => {
+    const definitions = new Map<string, BlockDocument>([
+      ["outer", component([instance("o1", "inner")])],
+      ["inner", component([node("d1", "Nested")])],
+      ["unused", component([node("d2", "Never")])],
+    ]);
+
+    const stages = prepareDocumentReadStages(page([instance("i1", "outer")]), {
+      resolver,
+      definitions,
+    });
+
+    // Repairing only what the PAGE names would leave `inner` unrepaired and
+    // therefore unreachable, so the outer component would compose to an
+    // unresolved reference rather than to its content.
+    expect(stages!.prepared.nodes[0]!.props.value).toBe("Nested");
+    expect(stages!.unresolvedInstances).toEqual([]);
+    expect(stages!.referencedComponents).toEqual(["outer", "inner"]);
+  });
+
+  it("does not trust an unresolved marker that came from storage", () => {
+    const stored = page([
+      {
+        id: "a",
+        type: "test/text",
+        version: 1,
+        props: { value: "Real" },
+        unresolvedComponent: "missing",
+      } as unknown as BlockNode,
+    ]);
+
+    const stages = prepareDocumentReadStages(stored, { resolver });
+
+    // The marker is a render-time fact. A hand-edited, legacy or corrupt
+    // document carrying the key must not replace real content with a
+    // placeholder — nothing validates unknown node keys away.
+    expect(stages!.prepared.nodes).toHaveLength(1);
+  });
+
+  it("repairs only the definitions the page reaches", () => {
+    class CountingMap extends Map<string, BlockDocument> {
+      reads = 0;
+      override get(key: string): BlockDocument | undefined {
+        this.reads += 1;
+        return super.get(key);
+      }
+    }
+    const catalog = new CountingMap();
+    for (let i = 0; i < 50; i += 1) {
+      catalog.set(`c${i}`, component([node(`n${i}`, "x")]));
+    }
+
+    prepareDocumentReadStages(page([node("a", "Plain")]), {
+      resolver,
+      definitions: catalog,
+    });
+    const untouched = catalog.reads;
+
+    prepareDocumentReadStages(page([instance("i1", "c7")]), {
+      resolver,
+      definitions: catalog,
+    });
+
+    // A page referencing nothing must not pay for the catalog...
+    expect(untouched).toBe(0);
+    // ...and one referencing a single component pays for that one, not fifty.
+    expect(catalog.reads).toBeLessThanOrEqual(3);
+  });
+});
+
 describe("an instance nothing could resolve", () => {
   // `rendersOwnMarkup` returning false for one is NOT asserted here. The
   // engine refuses to register the reserved instance name

--- a/packages/blocks-react/src/prepare-compose.test.tsx
+++ b/packages/blocks-react/src/prepare-compose.test.tsx
@@ -251,6 +251,36 @@ describe("composition and the limits around it", () => {
   });
 });
 
+describe("a definitions map that is not what it claims", () => {
+  it("survives a malformed entry in the definitions map", () => {
+    const definitions = new Map<string, BlockDocument>([
+      ["broken", null as unknown as BlockDocument],
+      ["hero", component([node("d1", "Hi")])],
+    ]);
+
+    const stages = prepareDocumentReadStages(page([instance("i1", "hero")]), {
+      resolver,
+      definitions,
+    });
+
+    // An entry nothing on this page even references must not cost the page.
+    expect(stages!.prepared.nodes[0]!.props.value).toBe("Hi");
+  });
+
+  it("reports a malformed definition as a missing component", () => {
+    const definitions = new Map<string, BlockDocument>([
+      ["hero", null as unknown as BlockDocument],
+    ]);
+
+    const stages = prepareDocumentReadStages(page([instance("i1", "hero")]), {
+      resolver,
+      definitions,
+    });
+
+    expect(stages!.unresolvedInstances.map(e => e.reason)).toEqual(["missing"]);
+  });
+});
+
 describe("an instance nothing could resolve", () => {
   // `rendersOwnMarkup` returning false for one is NOT asserted here. The
   // engine refuses to register the reserved instance name

--- a/packages/blocks-react/src/prepare-document.ts
+++ b/packages/blocks-react/src/prepare-document.ts
@@ -370,6 +370,26 @@ export function prepareDocumentReadStages(
  * component that exists to contain a failure. Inlining an unrepaired
  * definition into a repaired host reintroduces that a level down.
  *
+ * Repaired against HEADROOM rather than against the caps themselves, and that
+ * is the whole subtlety. The repair pass TRUNCATES what it finds past a limit
+ * — silently, because for a stored page truncation is the answer — while the
+ * resolver REFUSES an oversized definition and says which instance and why.
+ * Repairing at the caps would let the truncation happen first, so a page would
+ * publish a component missing part of itself with nothing in
+ * `unresolvedInstances` to report it: the silent truncation the resolver was
+ * built to replace, reintroduced one layer up.
+ *
+ * One node and one level of headroom is all it takes. Anything the resolver
+ * would accept passes through untouched; anything it would refuse survives
+ * repair intact and reaches the refusal that names it.
+ *
+ * The DEPTH headroom is currently unobservable and is here anyway. It matters
+ * exactly when the resolver refuses an over-deep definition rather than
+ * returning an empty branch for it — while it truncates, repairing at the cap
+ * and repairing above it produce the same tree, so no test can separate them.
+ * Splitting the rule to match what is observable today would leave the gap
+ * open on the day the refusal arrives, and that gap is silent content loss.
+ *
  * Returns the SAME map when every definition was already sound, so the
  * ordinary page allocates nothing — `sanitizeDocument` returns its input when
  * it repaired nothing, which is what makes the comparison meaningful.
@@ -380,10 +400,15 @@ function repairedDefinitions(
 ): DefinitionsById {
   if (definitions === undefined || definitions.size === 0)
     return EMPTY_DEFINITIONS;
+  const shapeOnly: DocumentLimits = {
+    ...limits,
+    maxDepth: limits.maxDepth + 1,
+    maxNodes: limits.maxNodes + 1,
+  };
   let changed = false;
   const repaired = new Map<string, BlockDocument>();
   for (const [id, definition] of definitions) {
-    const sound = sanitizeDocument(definition, limits);
+    const sound = sanitizeDocument(definition, shapeOnly);
     if (sound !== definition) changed = true;
     repaired.set(id, sound);
   }

--- a/packages/blocks-react/src/prepare-document.ts
+++ b/packages/blocks-react/src/prepare-document.ts
@@ -378,7 +378,7 @@ export function prepareDocumentReadStages(
  * any other type is stored data claiming to be a render-time fact, which is
  * exactly what this refuses.
  */
-function isUnresolvedInstance(node: ResolvedBlockNode): boolean {
+export function isUnresolvedInstance(node: ResolvedBlockNode): boolean {
   return (
     node.type === COMPONENT_INSTANCE_TYPE &&
     node.unresolvedComponent !== undefined
@@ -439,6 +439,11 @@ function repairedDefinitions(
   };
   const repaired = new Map<string, BlockDocument>();
   for (const id of wanted) {
+    // An id the caller never supplied is left OUT, so the resolver reports it
+    // as missing. Setting it with an empty value would put the key in the map,
+    // and presence is exactly what separates "nobody supplied one" from "one
+    // was supplied and cannot be read".
+    if (!definitions.has(id)) continue;
     const definition = definitions.get(id);
     // PASSED THROUGH unrepaired rather than omitted. The shape pass reads
     // `document.nodes` on its first line, so a `null` or a string here throws
@@ -447,22 +452,51 @@ function repairedDefinitions(
     // distinguish that from a definition supplied and unreadable. Handing the
     // value straight to the resolver lets it say which.
     //
-    // A record that merely LOOKS like a document is the sharper case: repair
-    // turns an absent `nodes` into an empty array, so the instance composes
-    // successfully to nothing and its whole region disappears with no marker.
-    //
-    // Passing through rather than omitting is currently unobservable — the
-    // resolver reports both an absent and an unreadable definition the same
-    // way — and is done anyway, because the reasons it reports distinguish
-    // them the moment it can, and omitting here would make that distinction
-    // unreachable from this layer for good.
-    if (!isPlainRecord(definition) || !Array.isArray(definition.nodes)) {
-      repaired.set(id, definition as BlockDocument);
+    // The KEY is kept and the VALUE replaced, because the two say different
+    // things: presence means somebody supplied a definition, and the
+    // unreadable value is what makes the resolver call it malformed rather
+    // than missing. Omitting the entry collapses those into one.
+    if (!isReadableEnvelope(definition)) {
+      repaired.set(id, UNREADABLE);
       continue;
     }
     repaired.set(id, sanitizeDocument(definition, shapeOnly));
   }
   return repaired;
+}
+
+/**
+ * What this build hands the resolver for a definition it cannot read.
+ *
+ * A value rather than an omission, because omitting collapses "supplied and
+ * unreadable" into "never supplied", and those have different remedies. The
+ * resolver refuses anything that is not a plain record, so this is the
+ * shortest thing it is guaranteed to refuse; the cast states plainly that a
+ * map of documents is deliberately carrying a non-document here.
+ */
+const UNREADABLE = undefined as unknown as BlockDocument;
+
+/**
+ * Whether a definition is a document THIS BUILD can read.
+ *
+ * The format version is the half nothing else checks. An unreadable envelope
+ * refuses the whole HOST document one function up, for the reason given
+ * there — nothing below it can be trusted to mean what it says — and a
+ * definition gets the same treatment rather than being repaired into shape,
+ * because repair would normalise nodes written to a schema this build has
+ * never seen.
+ *
+ * The KIND is deliberately not checked. The engine's resolver asks
+ * `isComponentDocument` and reports a page or a region filed under a
+ * component's id as malformed, so asking again would be a second answer to one
+ * question — and a second answer is the one that goes stale.
+ */
+function isReadableEnvelope(definition: unknown): definition is BlockDocument {
+  return (
+    isPlainRecord(definition) &&
+    definition.formatVersion === DOCUMENT_FORMAT_VERSION &&
+    Array.isArray(definition.nodes)
+  );
 }
 
 /**
@@ -485,13 +519,21 @@ function referencedIds(
 ): Set<string> {
   const wanted = new Set<string>();
   const pending = componentIdsIn(host.nodes, limits.maxNodes);
-  while (pending.length > 0 && wanted.size <= definitions.size) {
+  // No count bounds this loop, deliberately. Bounding it by the map's size
+  // counted ABSENT ids against the budget, so a page referencing more missing
+  // components than the map holds stopped before reaching a supplied one — and
+  // the last-in-first-out order decided which, so valid content disappeared
+  // according to where a reference happened to sit.
+  //
+  // It terminates on its own: every id pushed comes from expanding a
+  // definition, and a definition joins `wanted` before it is expanded, so each
+  // is expanded at most once and the work is the map's size times the cap.
+  while (pending.length > 0) {
     const id = pending.pop();
     if (id === undefined || wanted.has(id)) continue;
     wanted.add(id);
-    const definition = definitions.get(id);
-    if (!isPlainRecord(definition) || !Array.isArray(definition.nodes))
-      continue;
+    if (!isReadableEnvelope(definitions.get(id))) continue;
+    const definition = definitions.get(id) as BlockDocument;
     for (const nested of componentIdsIn(definition.nodes, limits.maxNodes)) {
       pending.push(nested);
     }

--- a/packages/blocks-react/src/prepare-document.ts
+++ b/packages/blocks-react/src/prepare-document.ts
@@ -49,6 +49,7 @@
 import {
   DEFAULT_LIMITS,
   DOCUMENT_FORMAT_VERSION,
+  isPlainRecord,
   migrateDocument,
   resolveComponentInstances,
 } from "@nextlyhq/blocks-engine";
@@ -408,6 +409,16 @@ function repairedDefinitions(
   let changed = false;
   const repaired = new Map<string, BlockDocument>();
   for (const [id, definition] of definitions) {
+    // OMITTED rather than repaired, and the omission is the repair. The shape
+    // pass reads `document.nodes` on its first line, so a `null` or a string
+    // in this map throws before any block boundary exists to contain it — and
+    // this loop walks every entry, so one bad definition would cost a page
+    // that never referenced it. Left out, the resolver reports the reference
+    // as `missing`, which is what it is.
+    if (!isPlainRecord(definition)) {
+      changed = true;
+      continue;
+    }
     const sound = sanitizeDocument(definition, shapeOnly);
     if (sound !== definition) changed = true;
     repaired.set(id, sound);

--- a/packages/blocks-react/src/prepare-document.ts
+++ b/packages/blocks-react/src/prepare-document.ts
@@ -48,7 +48,6 @@
  */
 import {
   COMPONENT_INSTANCE_TYPE,
-  componentIdsIn,
   DEFAULT_LIMITS,
   DOCUMENT_FORMAT_VERSION,
   isPlainRecord,
@@ -57,6 +56,7 @@ import {
 } from "@nextlyhq/blocks-engine";
 import type {
   BlockDocument,
+  ComponentLookup,
   DefinitionsById,
   DocumentLimits,
   MigratedNode,
@@ -314,7 +314,9 @@ export function prepareDocumentReadStages(
   const sanitized = sanitizeDocument(document, limits);
   const composed = resolveComponentInstances(
     sanitized,
-    repairedDefinitions(sanitized, args.definitions, limits),
+    args.definitions === undefined || args.definitions.size === 0
+      ? EMPTY_DEFINITIONS
+      : repairingLookup(args.definitions, limits),
     { limits }
   );
   const { doc, rewritten } = migrateDocument(
@@ -386,15 +388,15 @@ export function isUnresolvedInstance(node: ResolvedBlockNode): boolean {
 }
 
 /**
- * The definitions, shape-repaired against the same caps the host was.
+ * The definitions, shape-repaired ON DEMAND against the same caps the host was.
  *
- * Not defensive tidiness. The resolver asks only that a definition node be a
- * record with a string id, while the repair pass additionally requires a
- * string type and a whole version and DROPS a node failing either — and the
- * reason it does is one this renderer has already paid for: a node whose
- * `type` is an object reaches the unknown-block placeholder, which writes that
- * value into a data attribute and into text, and React throws inside the one
- * component that exists to contain a failure. Inlining an unrepaired
+ * Repair is not defensive tidiness. The resolver asks only that a definition
+ * node be a record with a string id, while the repair pass additionally
+ * requires a string type and a whole version and DROPS a node failing either —
+ * and the reason it does is one this renderer has already paid for: a node
+ * whose `type` is an object reaches the unknown-block placeholder, which writes
+ * that value into a data attribute and into text, and React throws inside the
+ * one component that exists to contain a failure. Inlining an unrepaired
  * definition into a repaired host reintroduces that a level down.
  *
  * Repaired against HEADROOM rather than against the caps themselves, and that
@@ -417,64 +419,53 @@ export function isUnresolvedInstance(node: ResolvedBlockNode): boolean {
  * Splitting the rule to match what is observable today would leave the gap
  * open on the day the refusal arrives, and that gap is silent content loss.
  *
- * Returns the SAME map when every definition was already sound, so the
- * ordinary page allocates nothing — `sanitizeDocument` returns its input when
- * it repaired nothing, which is what makes the comparison meaningful.
+ * ON DEMAND rather than over a set computed up front, and that is not an
+ * optimisation. Repairing ahead of the resolver means predicting which
+ * definitions it will read, and it is the resolver that decides: an instance's
+ * overrides may name a different component than the definition stored, its
+ * composition cap stops the chain long before the catalog does, and the nodes
+ * it walks are the ones repair itself retained. A separate traversal answering
+ * that question disagreed on all three, and each disagreement handed the page
+ * `missing` for a definition the caller had supplied. Asking here means there
+ * is one answer, given at the moment the definition is actually wanted.
+ *
+ * Memoized, so a component held by two instances is repaired once — and the
+ * memo records a definition that could NOT be read as well, or an unreadable
+ * one would be re-examined on every reference.
  */
-function repairedDefinitions(
-  host: BlockDocument,
-  definitions: DefinitionsById | undefined,
+function repairingLookup(
+  definitions: DefinitionsById,
   limits: DocumentLimits
-): DefinitionsById {
-  if (definitions === undefined || definitions.size === 0)
-    return EMPTY_DEFINITIONS;
-
-  const wanted = referencedIds(host, definitions, limits);
-  if (wanted.size === 0) return EMPTY_DEFINITIONS;
-
+): ComponentLookup {
   const shapeOnly: DocumentLimits = {
     ...limits,
     maxDepth: limits.maxDepth + 1,
     maxNodes: limits.maxNodes + 1,
   };
-  const repaired = new Map<string, BlockDocument>();
-  for (const id of wanted) {
-    // An id the caller never supplied is left OUT, so the resolver reports it
-    // as missing. Setting it with an empty value would put the key in the map,
-    // and presence is exactly what separates "nobody supplied one" from "one
-    // was supplied and cannot be read".
-    if (!definitions.has(id)) continue;
-    const definition = definitions.get(id);
-    // PASSED THROUGH unrepaired rather than omitted. The shape pass reads
-    // `document.nodes` on its first line, so a `null` or a string here throws
-    // before any block boundary exists to contain it — but omitting it makes
-    // the reference read as one nobody supplied, and the resolver's reasons
-    // distinguish that from a definition supplied and unreadable. Handing the
-    // value straight to the resolver lets it say which.
-    //
-    // The KEY is kept and the VALUE replaced, because the two say different
-    // things: presence means somebody supplied a definition, and the
-    // unreadable value is what makes the resolver call it malformed rather
-    // than missing. Omitting the entry collapses those into one.
-    if (!isReadableEnvelope(definition)) {
-      repaired.set(id, UNREADABLE);
-      continue;
-    }
-    repaired.set(id, sanitizeDocument(definition, shapeOnly));
-  }
-  return repaired;
+  const repaired = new Map<string, BlockDocument | undefined>();
+  return {
+    // Answered from the SUPPLIED map, never from whether `get` produced a
+    // document. Presence is what separates "nobody supplied one" from "one was
+    // supplied and cannot be read", and the resolver reports those as
+    // different reasons with different remedies — publish the component, or
+    // repair its stored data.
+    has: id => definitions.has(id),
+    get: id => {
+      if (repaired.has(id)) return repaired.get(id);
+      const stored = definitions.get(id);
+      // `undefined` for an envelope this build cannot read, rather than a
+      // repaired shell. The shape pass reads `document.nodes` on its first
+      // line, so a `null` or a string here throws before any block boundary
+      // exists to contain it — and the resolver, which still sees the id in
+      // `has`, reports it as unreadable rather than missing.
+      const value = isReadableEnvelope(stored)
+        ? sanitizeDocument(stored, shapeOnly)
+        : undefined;
+      repaired.set(id, value);
+      return value;
+    },
+  };
 }
-
-/**
- * What this build hands the resolver for a definition it cannot read.
- *
- * A value rather than an omission, because omitting collapses "supplied and
- * unreadable" into "never supplied", and those have different remedies. The
- * resolver refuses anything that is not a plain record, so this is the
- * shortest thing it is guaranteed to refuse; the cast states plainly that a
- * map of documents is deliberately carrying a non-document here.
- */
-const UNREADABLE = undefined as unknown as BlockDocument;
 
 /**
  * Whether a definition is a document THIS BUILD can read.
@@ -488,8 +479,8 @@ const UNREADABLE = undefined as unknown as BlockDocument;
  *
  * The KIND is deliberately not checked. The engine's resolver asks
  * `isComponentDocument` and reports a page or a region filed under a
- * component's id as malformed, so asking again would be a second answer to one
- * question — and a second answer is the one that goes stale.
+ * component's id as unreadable, so asking again would be a second answer to
+ * one question — and a second answer is the one that goes stale.
  */
 function isReadableEnvelope(definition: unknown): definition is BlockDocument {
   return (
@@ -497,48 +488,6 @@ function isReadableEnvelope(definition: unknown): definition is BlockDocument {
     definition.formatVersion === DOCUMENT_FORMAT_VERSION &&
     Array.isArray(definition.nodes)
   );
-}
-
-/**
- * The definitions this document can actually reach, transitively.
- *
- * Repairing the whole map was work proportional to the site's entire component
- * catalog on every render, paid even by a page that references nothing — and an
- * unbounded catalog multiplies the per-definition node cap into unbounded
- * request work. Only what the page reaches is repaired.
- *
- * Transitive because a component may hold another, and the closure is taken
- * over the SUPPLIED map: nothing here fetches, so a definition the caller did
- * not hand over is simply not reached and its reference resolves as missing.
- * Bounded by the map's own size, since no id outside it can enter the set.
- */
-function referencedIds(
-  host: BlockDocument,
-  definitions: DefinitionsById,
-  limits: DocumentLimits
-): Set<string> {
-  const wanted = new Set<string>();
-  const pending = componentIdsIn(host.nodes, limits.maxNodes);
-  // No count bounds this loop, deliberately. Bounding it by the map's size
-  // counted ABSENT ids against the budget, so a page referencing more missing
-  // components than the map holds stopped before reaching a supplied one — and
-  // the last-in-first-out order decided which, so valid content disappeared
-  // according to where a reference happened to sit.
-  //
-  // It terminates on its own: every id pushed comes from expanding a
-  // definition, and a definition joins `wanted` before it is expanded, so each
-  // is expanded at most once and the work is the map's size times the cap.
-  while (pending.length > 0) {
-    const id = pending.pop();
-    if (id === undefined || wanted.has(id)) continue;
-    wanted.add(id);
-    if (!isReadableEnvelope(definitions.get(id))) continue;
-    const definition = definitions.get(id) as BlockDocument;
-    for (const nested of componentIdsIn(definition.nodes, limits.maxNodes)) {
-      pending.push(nested);
-    }
-  }
-  return wanted;
 }
 
 /** Shared so a page with no components allocates no map at all. */

--- a/packages/blocks-react/src/prepare-document.ts
+++ b/packages/blocks-react/src/prepare-document.ts
@@ -47,6 +47,8 @@
  * @module prepare-document
  */
 import {
+  COMPONENT_INSTANCE_TYPE,
+  componentIdsIn,
   DEFAULT_LIMITS,
   DOCUMENT_FORMAT_VERSION,
   isPlainRecord,
@@ -126,7 +128,7 @@ export function rendersOwnMarkup(
   // asked FIRST, because the reserved instance type has no registered block
   // and would otherwise fall through to the unknown-block answer, which is
   // true and tells an author nothing they can act on.
-  if (node.unresolvedComponent !== undefined) return false;
+  if (isUnresolvedInstance(node)) return false;
   if (node.migrationFailed === true) return false;
   const definition = resolver.get(node.type);
   if (definition === undefined) return false;
@@ -312,7 +314,7 @@ export function prepareDocumentReadStages(
   const sanitized = sanitizeDocument(document, limits);
   const composed = resolveComponentInstances(
     sanitized,
-    repairedDefinitions(args.definitions, limits),
+    repairedDefinitions(sanitized, args.definitions, limits),
     { limits }
   );
   const { doc, rewritten } = migrateDocument(
@@ -360,6 +362,30 @@ export function prepareDocumentReadStages(
 }
 
 /**
+ * Whether a node is an instance THIS RUN could not compose.
+ *
+ * The marker is a render-time fact and nothing removes it from stored content:
+ * node validation does not reject unknown keys, so a hand-edited, imported or
+ * legacy document can carry `unresolvedComponent` on an ordinary block. Read
+ * as a resolver marker, that would replace real content with a placeholder —
+ * and where it is the page's only node, the reading view answers `null` and
+ * the page is withheld entirely.
+ *
+ * The TYPE is what carries the discrimination, and checking the reason
+ * against the engine's list as well was measured to add none: a node wearing
+ * the reserved name is an instance whatever string sits beside it, and no
+ * block may register that name, so the two answers never differ. A marker on
+ * any other type is stored data claiming to be a render-time fact, which is
+ * exactly what this refuses.
+ */
+function isUnresolvedInstance(node: ResolvedBlockNode): boolean {
+  return (
+    node.type === COMPONENT_INSTANCE_TYPE &&
+    node.unresolvedComponent !== undefined
+  );
+}
+
+/**
  * The definitions, shape-repaired against the same caps the host was.
  *
  * Not defensive tidiness. The resolver asks only that a definition node be a
@@ -396,34 +422,81 @@ export function prepareDocumentReadStages(
  * it repaired nothing, which is what makes the comparison meaningful.
  */
 function repairedDefinitions(
+  host: BlockDocument,
   definitions: DefinitionsById | undefined,
   limits: DocumentLimits
 ): DefinitionsById {
   if (definitions === undefined || definitions.size === 0)
     return EMPTY_DEFINITIONS;
+
+  const wanted = referencedIds(host, definitions, limits);
+  if (wanted.size === 0) return EMPTY_DEFINITIONS;
+
   const shapeOnly: DocumentLimits = {
     ...limits,
     maxDepth: limits.maxDepth + 1,
     maxNodes: limits.maxNodes + 1,
   };
-  let changed = false;
   const repaired = new Map<string, BlockDocument>();
-  for (const [id, definition] of definitions) {
-    // OMITTED rather than repaired, and the omission is the repair. The shape
-    // pass reads `document.nodes` on its first line, so a `null` or a string
-    // in this map throws before any block boundary exists to contain it — and
-    // this loop walks every entry, so one bad definition would cost a page
-    // that never referenced it. Left out, the resolver reports the reference
-    // as `missing`, which is what it is.
-    if (!isPlainRecord(definition)) {
-      changed = true;
+  for (const id of wanted) {
+    const definition = definitions.get(id);
+    // PASSED THROUGH unrepaired rather than omitted. The shape pass reads
+    // `document.nodes` on its first line, so a `null` or a string here throws
+    // before any block boundary exists to contain it — but omitting it makes
+    // the reference read as one nobody supplied, and the resolver's reasons
+    // distinguish that from a definition supplied and unreadable. Handing the
+    // value straight to the resolver lets it say which.
+    //
+    // A record that merely LOOKS like a document is the sharper case: repair
+    // turns an absent `nodes` into an empty array, so the instance composes
+    // successfully to nothing and its whole region disappears with no marker.
+    //
+    // Passing through rather than omitting is currently unobservable — the
+    // resolver reports both an absent and an unreadable definition the same
+    // way — and is done anyway, because the reasons it reports distinguish
+    // them the moment it can, and omitting here would make that distinction
+    // unreachable from this layer for good.
+    if (!isPlainRecord(definition) || !Array.isArray(definition.nodes)) {
+      repaired.set(id, definition as BlockDocument);
       continue;
     }
-    const sound = sanitizeDocument(definition, shapeOnly);
-    if (sound !== definition) changed = true;
-    repaired.set(id, sound);
+    repaired.set(id, sanitizeDocument(definition, shapeOnly));
   }
-  return changed ? repaired : definitions;
+  return repaired;
+}
+
+/**
+ * The definitions this document can actually reach, transitively.
+ *
+ * Repairing the whole map was work proportional to the site's entire component
+ * catalog on every render, paid even by a page that references nothing — and an
+ * unbounded catalog multiplies the per-definition node cap into unbounded
+ * request work. Only what the page reaches is repaired.
+ *
+ * Transitive because a component may hold another, and the closure is taken
+ * over the SUPPLIED map: nothing here fetches, so a definition the caller did
+ * not hand over is simply not reached and its reference resolves as missing.
+ * Bounded by the map's own size, since no id outside it can enter the set.
+ */
+function referencedIds(
+  host: BlockDocument,
+  definitions: DefinitionsById,
+  limits: DocumentLimits
+): Set<string> {
+  const wanted = new Set<string>();
+  const pending = componentIdsIn(host.nodes, limits.maxNodes);
+  while (pending.length > 0 && wanted.size <= definitions.size) {
+    const id = pending.pop();
+    if (id === undefined || wanted.has(id)) continue;
+    wanted.add(id);
+    const definition = definitions.get(id);
+    if (!isPlainRecord(definition) || !Array.isArray(definition.nodes))
+      continue;
+    for (const nested of componentIdsIn(definition.nodes, limits.maxNodes)) {
+      pending.push(nested);
+    }
+  }
+  return wanted;
 }
 
 /** Shared so a page with no components allocates no map at all. */

--- a/packages/blocks-react/src/prepare-document.ts
+++ b/packages/blocks-react/src/prepare-document.ts
@@ -17,21 +17,28 @@
  * 2. **Shape repair**, against the caps the SITE configured — a site that
  *    raised `maxNodes` for long pages must not have its content truncated
  *    against the default.
- * 3. **Migration**, so a node behind its definition is read as its current
+ * 3. **Composition**, which replaces each component instance with the tree its
+ *    definition describes. Before migration, so a definition written against
+ *    an older block version is upgraded like any other content rather than
+ *    reaching the renderer at whatever version it was authored at. Its
+ *    definitions are shape-repaired first, for the reason pass 2 exists: an
+ *    unsanitized node inlined into a sanitized host reintroduces one level
+ *    down exactly what the host was repaired to remove.
+ * 4. **Migration**, so a node behind its definition is read as its current
  *    props rather than its stored ones.
- * 4. **Condition gating**, which removes a node and its whole subtree from the
+ * 5. **Condition gating**, which removes a node and its whole subtree from the
  *    output. This is the one whose absence leaks: a gated node is deliberately
  *    withheld, so anything derived from it publishes what was withheld.
- * 5. **Address repair**, which drops later duplicates of a repeated id — so a
+ * 6. **Address repair**, which drops later duplicates of a repeated id — so a
  *    duplicate that never renders cannot speak for the page.
- * 6. **Known placeholders**, whose subtrees the renderer replaces wholesale. A
+ * 7. **Known placeholders**, whose subtrees the renderer replaces wholesale. A
  *    node whose migration failed, whose type nothing registered, or whose
  *    stored version is ahead of its definition emits a placeholder and none of
  *    its content.
  *
  * Gathering the passes here does not by itself make two readers agree. Each
  * pass's ARGUMENTS are as much of the contract as the pass and its position:
- * the same six calls made with a different predicate or different caps is a
+ * the same calls made with a different predicate or different caps is a
  * COPY of this pipeline rather than a use of it, and it diverges exactly as a
  * hand-written sequence would. The placeholder predicate handed to the address
  * repair is the sharp one, because omitting it is silent and changes which
@@ -43,13 +50,17 @@ import {
   DEFAULT_LIMITS,
   DOCUMENT_FORMAT_VERSION,
   migrateDocument,
+  resolveComponentInstances,
 } from "@nextlyhq/blocks-engine";
 import type {
   BlockDocument,
-  BlockNode,
+  DefinitionsById,
   DocumentLimits,
   MigratedNode,
+  ResolvedBlockNode,
+  ResolvedDocument,
   StyleCompileContext,
+  UnresolvedInstance,
 } from "@nextlyhq/blocks-engine";
 
 import type { BlockResolver } from "./resolver";
@@ -64,6 +75,19 @@ export interface PrepareDocumentArgs {
   limits?: DocumentLimits;
   /** Consulted for `limits` when none was given directly. */
   styleContext?: StyleCompileContext;
+  /**
+   * The component definitions this document may inline, at whatever posture
+   * the caller chose — a draft one for the editor, a published one for a
+   * served page.
+   *
+   * Optional, and its absence is not the same as an empty map only in what it
+   * SAYS: both compose nothing, but a caller that never fetched has a page
+   * whose components are all reported unresolved, which is the honest answer
+   * for a reader that did not ask for them. Every existing caller omits it and
+   * keeps exactly the behaviour it had, because a document holding no instance
+   * is returned unchanged.
+   */
+  definitions?: DefinitionsById;
 }
 
 /**
@@ -93,9 +117,15 @@ export interface PrepareDocumentArgs {
  * different design than compiling the document once up front.
  */
 export function rendersOwnMarkup(
-  node: BlockNode,
+  node: ResolvedBlockNode,
   resolver: BlockResolver
 ): boolean {
+  // An instance nothing could inline stands for a subtree that is not here, so
+  // it is a placeholder for the same reason a failed migration is — and it is
+  // asked FIRST, because the reserved instance type has no registered block
+  // and would otherwise fall through to the unknown-block answer, which is
+  // true and tells an author nothing they can act on.
+  if (node.unresolvedComponent !== undefined) return false;
   if (node.migrationFailed === true) return false;
   const definition = resolver.get(node.type);
   if (definition === undefined) return false;
@@ -115,8 +145,8 @@ export function pruneKnownPlaceholders(
 ): BlockDocument {
   let changed = false;
 
-  const walk = (nodes: BlockNode[]): BlockNode[] => {
-    const kept: BlockNode[] = [];
+  const walk = (nodes: ResolvedBlockNode[]): ResolvedBlockNode[] => {
+    const kept: ResolvedBlockNode[] = [];
     for (const node of nodes) {
       // The whole subtree goes: a placeholder replaces the node AND everything
       // it would have contained, so a healthy child of a broken parent never
@@ -143,7 +173,7 @@ export function pruneKnownPlaceholders(
       const declared = resolver.get(node.type)?.slots ?? {};
       const slotKeys = Object.keys(node.slots);
       let slotsChanged = false;
-      const slots: Record<string, BlockNode[]> = {};
+      const slots: Record<string, ResolvedBlockNode[]> = {};
       // Iterated in DECLARATION order, not stored order. The renderer asks for
       // its slots by calling `renderSlot` once per declaration, so declaration
       // order is the order the page presents — and this tree is documented as
@@ -215,6 +245,21 @@ export function pruneKnownPlaceholders(
 export interface DocumentReadStages {
   /** After the caps pass. */
   sanitized: BlockDocument;
+  /** After component instances are replaced by the trees they stand for. */
+  resolved: ResolvedDocument;
+  /**
+   * Every component definition this document READ, unresolvable ones included.
+   *
+   * Carried out of the pipeline because its consumer is cache tagging, which
+   * is several layers up and cannot re-derive it: the transitive set is only
+   * known once the composition has walked. An id that failed to resolve
+   * belongs in it for the same reason it belongs in the resolver's own list —
+   * a page that could not draw a component because it is not published yet
+   * must regenerate when it is.
+   */
+  referencedComponents: readonly string[];
+  /** Every instance left standing, and why. Empty on a clean composition. */
+  unresolvedInstances: readonly UnresolvedInstance[];
   /** After migration to the current format. */
   migrated: BlockDocument;
   /**
@@ -264,8 +309,13 @@ export function prepareDocumentReadStages(
 
   const limits = args.limits ?? args.styleContext?.limits ?? DEFAULT_LIMITS;
   const sanitized = sanitizeDocument(document, limits);
-  const { doc, rewritten } = migrateDocument(
+  const composed = resolveComponentInstances(
     sanitized,
+    repairedDefinitions(args.definitions, limits),
+    { limits }
+  );
+  const { doc, rewritten } = migrateDocument(
+    composed.document,
     migrationSourceFor(args.resolver)
   );
   // The predicate matters as much as the pass: a placeholder replaces its whole
@@ -297,6 +347,9 @@ export function prepareDocumentReadStages(
   // gating and then turned out to be unrenderable is a placeholder-only page.
   return {
     sanitized,
+    resolved: composed.document,
+    referencedComponents: composed.referenced,
+    unresolvedInstances: composed.unresolved,
     migrated: doc,
     rewritten,
     gated,
@@ -304,6 +357,41 @@ export function prepareDocumentReadStages(
     prepared,
   };
 }
+
+/**
+ * The definitions, shape-repaired against the same caps the host was.
+ *
+ * Not defensive tidiness. The resolver asks only that a definition node be a
+ * record with a string id, while the repair pass additionally requires a
+ * string type and a whole version and DROPS a node failing either — and the
+ * reason it does is one this renderer has already paid for: a node whose
+ * `type` is an object reaches the unknown-block placeholder, which writes that
+ * value into a data attribute and into text, and React throws inside the one
+ * component that exists to contain a failure. Inlining an unrepaired
+ * definition into a repaired host reintroduces that a level down.
+ *
+ * Returns the SAME map when every definition was already sound, so the
+ * ordinary page allocates nothing — `sanitizeDocument` returns its input when
+ * it repaired nothing, which is what makes the comparison meaningful.
+ */
+function repairedDefinitions(
+  definitions: DefinitionsById | undefined,
+  limits: DocumentLimits
+): DefinitionsById {
+  if (definitions === undefined || definitions.size === 0)
+    return EMPTY_DEFINITIONS;
+  let changed = false;
+  const repaired = new Map<string, BlockDocument>();
+  for (const [id, definition] of definitions) {
+    const sound = sanitizeDocument(definition, limits);
+    if (sound !== definition) changed = true;
+    repaired.set(id, sound);
+  }
+  return changed ? repaired : definitions;
+}
+
+/** Shared so a page with no components allocates no map at all. */
+const EMPTY_DEFINITIONS: DefinitionsById = new Map<string, BlockDocument>();
 
 /**
  * The tree a READER should present, or `null` when it should present none.

--- a/packages/blocks-react/src/read-page.ts
+++ b/packages/blocks-react/src/read-page.ts
@@ -22,6 +22,7 @@ import type {
   BlockDocument,
   RemotePatternInput,
   StyleCompileContext,
+  UnresolvedInstance,
 } from "@nextlyhq/blocks-engine";
 
 import type {
@@ -76,6 +77,16 @@ export interface PreparedPage {
   document: BlockDocument | null;
   /** The stylesheet for that tree. */
   styles: PageStyles;
+  /**
+   * Every component definition this page read, unresolvable ones included.
+   *
+   * Surfaced here because the caller that fetched those definitions is the one
+   * that has to tag the page with them, and it cannot re-derive the transitive
+   * set — only the composition knows what a definition itself referenced.
+   */
+  referencedComponents: readonly string[];
+  /** Every instance that could not be composed, and why. */
+  unresolvedInstances: readonly UnresolvedInstance[];
 }
 
 /**
@@ -133,6 +144,19 @@ function storedSheetCannotDescribe(
     gatedMapCoversPrunedNodes(stages.migrated, stages.gated, gatedRules);
   return (
     stages.sanitized !== document ||
+    // Composition. A stored sheet was compiled from the page's OWN nodes;
+    // inlining a component adds nodes whose ids that sheet never named, so
+    // each of them would render unstyled while the sheet looked intact.
+    //
+    // Covered TODAY by the unaccounted-node clause below, and stated here
+    // anyway because that coverage is incidental rather than structural: it
+    // holds only because the compiler assigns a class to EVERY node, so
+    // removing the instance always leaves the artifact naming one the document
+    // no longer has. Measured, not assumed — and a change to sparse class
+    // assignment would remove it silently, which is the wrong way for a
+    // stylesheet guarantee to lapse. No test can separate the two while both
+    // hold; break-verified as a survivor rather than left looking covered.
+    stages.resolved !== stages.sanitized ||
     hasDuplicateNodeIds(stages.migrated) ||
     (stages.gated !== stages.migrated && !gatingCovered) ||
     stages.prepared !== stages.deduped ||
@@ -166,6 +190,8 @@ export function preparePageForRead(
     return {
       document: null,
       styles: { css: "", classes: {} },
+      referencedComponents: [],
+      unresolvedInstances: [],
     };
   }
 
@@ -193,5 +219,10 @@ export function preparePageForRead(
   // is not worth showing, but its scope and class names are still the ones the
   // rest of the system expects, and rebuilding them from an empty document would
   // hand the caller a sheet for a page that does not exist.
-  return { document: readingViewOf(stages), styles };
+  return {
+    document: readingViewOf(stages),
+    styles,
+    referencedComponents: stages.referencedComponents,
+    unresolvedInstances: stages.unresolvedInstances,
+  };
 }


### PR DESCRIPTION
> [!NOTE]
> **#1521 has merged and this branch has merged `main`,** so the resolver it calls is the fixed one. The order mattered while both were open: this PR is what makes the read pipeline call the resolver, and #1521 closed two content leaks and a cap violation inside it.

Plan 06 **T-4, slice B** — design §6.4. Slice A shipped the pure resolver (#1519); this runs it. Slice C is the fetch seam, the cache tags and the readiness check.

The engine could replace a component instance with the tree it stands for, and **no reader ran that step** — so the renderer, the style resolver, the exported page reader, the style trace and the route helper all worked from a document with a hole in it.

## Where it goes, and why there

Composition is now a pass of `prepareDocumentReadStages`, which those **five call sites already share**, so a component resolved for one of them is resolved for all five. It sits between shape repair and migration, and both edges are load-bearing:

- **After repair**, with each definition repaired against the same caps. The resolver asks only for a record with a string id; the repair pass also requires a string `type` and a whole `version`, and drops a node failing either. An unrepaired node inlined into a repaired host reintroduces one level down exactly what the host was repaired to remove — and such a node reaches the placeholder, which writes its `type` into a data attribute *and into text*, so React throws inside the component that exists to contain a failure.
- **Before migration**, so a definition authored against an older version of a block is upgraded like any other content instead of being handed to a renderer that no longer speaks its schema.

## What comes out

`DocumentReadStages` carries the resolved tree, every definition the document read, and every instance left standing. Both lists are surfaced on `PreparedPage` too, because the caller that fetched those definitions is the one that must tag the page with them — and it cannot re-derive the transitive set, since only the composition knows what a definition itself referenced.

An instance nothing could resolve draws its own marker. Without it the reserved instance type registers no block, so it fell through to *"no block is registered for this type"* — true, and nothing an author can act on. Which of the six causes it was travels in the stages rather than in the DOM: the reader who can act on the cause is the publish readiness check, not monitoring.

`PageRenderer` takes the definitions and passes them through rather than resolving its own, so it cannot drift from the readers it shares a pipeline with.

## Verification

- **1107 tests pass, 11 of them new.** The other 1096 passed unchanged before and after — the argument is optional and every existing caller omits it, so this is additive by measurement rather than by claim.
- Break-verified against **8 wrong implementations; 6 kill**. Composition never running, running after migration, definitions inlined unrepaired, results not leaving the pipeline, results not reaching the caller, and the marker falling through.
- **Two survivors, both reported rather than papered over.** The stored-sheet checks I added in `read-page.ts` and `page-renderer.tsx` cannot be killed independently: I measured that the compiler assigns a class to **every** node, so a replaced instance always trips the existing unaccounted-node check first. They are kept, and their comments now say exactly that — the redundancy is a property of class assignment, not of composition, and a move to sparse classes would remove the guarantee silently.
- **Two of my own tests were repaired mid-review rather than kept as false coverage.** A `rendersOwnMarkup` assertion could not fail, because `registry.ts:RESERVED_BLOCK_NAMES` refuses to register the reserved instance name so the unregistered-type fallthrough already answers `false`; it is deleted, with the reason recorded in the file. And the definition-repair assertion could not fail through the prepared tree, since an unrepaired node is pruned either way — it now asserts through a **render**, where the difference is the whole page.
- One fixture bug found by its own control: `migrate` is keyed by the version migrated **from**, not to. The test and the control failed identically, which is what said "fixture, not product".
- `type-surface.test.ts` caught the DX half on the pre-push hook and refused the push: a package that names a type in its public API owes that type to its callers, so `DefinitionsById`, `ResolvedBlockNode`, `ResolvedDocument`, `UnresolvedInstance` and `ComponentUnresolvedReason` are re-exported.
- Workspace `build` 42/42 and `check-types` 42/42; `fallow` **pass**, 0 introduced findings; comment convention clean; `changeset status` clean.

## Noted, not resolved here

Design §6.4 lists visibility pruning **before** migration; the shipped pipeline migrates first. Only the resolver-before-migrate constraint is new, so the existing order is left exactly as it was rather than reordered under cover of this row.
