### PR TITLE
fix(blocks-engine): stop composing under a gated ancestor, and read a lookup once

### DIFF
--- a/.changeset/a-hidden-block-draws-nothing-below-it.md
+++ b/.changeset/a-hidden-block-draws-nothing-below-it.md
@@ -1,0 +1,42 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A block hidden by a visibility condition no longer draws the components inside
+it. The condition already removed that block and everything under it before a
+reader saw the page, but the components in it were still being loaded and
+counted — so a page could be refused for publishing over a component nobody
+could be shown, and a change to that component still made the page rebuild. A
+component held directly by a hidden block was already treated this way; now a
+component held further down is too.
+
+A component whose stored data cannot be read is described as unreadable rather
+than missing wherever that is reported, so the fix offered is to repair the
+component rather than to publish one that already exists.
+
+A page with an unrecognised note about a component that failed to load no
+longer takes the whole page down with it.

--- a/.changeset/a-hidden-block-draws-nothing-below-it.md
+++ b/.changeset/a-hidden-block-draws-nothing-below-it.md
@@ -40,3 +40,11 @@ component rather than to publish one that already exists.
 
 A page with an unrecognised note about a component that failed to load no
 longer takes the whole page down with it.
+
+The rule holds one level down as well: a hidden block inside a reusable
+component no longer draws the components under it either.
+
+Two places on a page that use the same component now always agree about it.
+Where a site supplies components itself, one that answered differently the
+second time it was asked could draw in one place and report itself broken in
+the other.

--- a/.changeset/a-page-draws-the-components-it-references.md
+++ b/.changeset/a-page-draws-the-components-it-references.md
@@ -57,8 +57,9 @@ the one in front of them.
 
 A component that arrived broken — empty, or not a document at all — brought
 down the whole page, including pages that never used it. Such an entry is now
-skipped and the reference it was for is reported as missing, like any other
-component that could not be found.
+skipped and the reference it was for is reported as unreadable: the component
+is there and its stored data is corrupt, which is a different thing to fix from
+a component nobody has published.
 
 Three more repairs at the same seam. A component that arrives as something
 other than a document — an empty object, or a page saved under a component's

--- a/packages/blocks-engine/src/resolve-instances.test.ts
+++ b/packages/blocks-engine/src/resolve-instances.test.ts
@@ -797,6 +797,36 @@ describe("resolveComponentInstances what an instance carries", () => {
     expect(result.referenced).toEqual([]);
   });
 
+  it("leaves an instance standing under a gated ANCESTOR too", () => {
+    // Gating is inherited: `pruneHiddenNodes` drops a gated node with its whole
+    // subtree, so an instance under one reaches no reader either way. Reading
+    // its definition here reports a component nobody receives — a publish check
+    // rejects on it and a cache tag tracks it — and reports it differently from
+    // the identical instance gated directly.
+    const gate = { conditions: [[{ field: "tier", op: "eq", value: "vip" }]] };
+    const doc = page([box("wrap", [instance("i1", "hero")], gate)]);
+    const definitions = defs({ hero: component([node("d1"), node("d2")]) });
+
+    const result = resolveComponentInstances(doc, definitions);
+
+    expect(result.unresolved).toEqual([]);
+    expect(result.referenced).toEqual([]);
+    expect(result.document).toBe(doc);
+  });
+
+  it("still composes an instance under an ancestor that is NOT gated", () => {
+    // The control. Without it the rule above passes on an implementation that
+    // refuses to descend into any container at all, which costs every page
+    // every component it holds below the top level.
+    const doc = page([box("wrap", [instance("i1", "hero")])]);
+    const definitions = defs({ hero: component([node("d1"), node("d2")]) });
+
+    const result = resolveComponentInstances(doc, definitions);
+
+    expect(result.referenced).toEqual(["hero"]);
+    expect(flatten(result.document.nodes)).toHaveLength(3);
+  });
+
   it("carries an instance's per-breakpoint hiding onto every root", () => {
     const doc = page([
       {
@@ -1351,8 +1381,29 @@ describe("how a resolution reaches a definition", () => {
       },
     });
 
-    expect(asked).toEqual(["a", "a", "b", "b"]);
+    // Once each, and only for what is reached: `unused` is in the map and is
+    // never asked for.
+    expect(asked).toEqual(["a", "b"]);
     expect(result.unresolved).toEqual([]);
+  });
+
+  it("reads a definition once, so a lookup cannot change under the run", () => {
+    // Nothing in the contract makes a lookup pure, and the source that fetches
+    // is the one most likely not to be: validating one read and expanding a
+    // second means the value that was checked is not the value that is used.
+    let reads = 0;
+    const definition = component([node("d1")]);
+
+    const result = resolveComponentInstances(page([instance("i1", "hero")]), {
+      has: () => true,
+      get: () => {
+        reads += 1;
+        return reads === 1 ? definition : undefined;
+      },
+    });
+
+    expect(result.unresolved).toEqual([]);
+    expect(flatten(result.document.nodes)).toHaveLength(1);
   });
 
   it("takes `has` as the answer even when `get` produces nothing", () => {

--- a/packages/blocks-engine/src/resolve-instances.test.ts
+++ b/packages/blocks-engine/src/resolve-instances.test.ts
@@ -814,6 +814,37 @@ describe("resolveComponentInstances what an instance carries", () => {
     expect(result.document).toBe(doc);
   });
 
+  it("leaves an instance standing under a gated ancestor INSIDE a definition", () => {
+    // Gating is inherited the same way wherever the container sits. A
+    // definition's own gated box is dropped with its subtree by the same pass,
+    // so an instance inside it reaches no reader — and the host walk's rule
+    // means nothing if the definition walk descends anyway.
+    const gate = { conditions: [[{ field: "tier", op: "eq", value: "vip" }]] };
+    const doc = page([instance("i1", "outer")]);
+    const definitions = defs({
+      outer: component([box("d1", [instance("d2", "gone")], gate)]),
+    });
+
+    const result = resolveComponentInstances(doc, definitions);
+
+    expect(result.unresolved).toEqual([]);
+    expect(result.referenced).toEqual(["outer"]);
+  });
+
+  it("still composes an instance under an UNGATED container inside a definition", () => {
+    // The control for the rule above, on the definition side.
+    const doc = page([instance("i1", "outer")]);
+    const definitions = defs({
+      outer: component([box("d1", [instance("d2", "inner")])]),
+      inner: component([node("d3")]),
+    });
+
+    const result = resolveComponentInstances(doc, definitions);
+
+    expect(result.unresolved).toEqual([]);
+    expect(result.referenced).toEqual(["outer", "inner"]);
+  });
+
   it("still composes an instance under an ancestor that is NOT gated", () => {
     // The control. Without it the rule above passes on an implementation that
     // refuses to descend into any container at all, which costs every page
@@ -1404,6 +1435,29 @@ describe("how a resolution reaches a definition", () => {
 
     expect(result.unresolved).toEqual([]);
     expect(flatten(result.document.nodes)).toHaveLength(1);
+  });
+
+  it("gives two instances of one component the SAME answer", () => {
+    // Reading once per instance rather than once per run lets a stateful
+    // lookup contradict itself inside one page: the first instance draws the
+    // component and the second reports it unreadable. Whatever a lookup
+    // answers, a resolution has to answer one thing about one component.
+    const definition = component([node("d1")]);
+    let reads = 0;
+
+    const result = resolveComponentInstances(
+      page([instance("i1", "hero"), instance("i2", "hero")]),
+      {
+        has: () => true,
+        get: () => {
+          reads += 1;
+          return reads === 1 ? definition : undefined;
+        },
+      }
+    );
+
+    expect(result.unresolved).toEqual([]);
+    expect(flatten(result.document.nodes)).toHaveLength(2);
   });
 
   it("takes `has` as the answer even when `get` produces nothing", () => {

--- a/packages/blocks-engine/src/resolve-instances.ts
+++ b/packages/blocks-engine/src/resolve-instances.ts
@@ -501,6 +501,21 @@ function inlineNode(
   if (node.type === COMPONENT_INSTANCE_TYPE) {
     return expandInstance(node, run, scope, depth);
   }
+  // The same rule `expandInstance` applies to an instance's OWN gate, applied
+  // to the node holding one. Gating is inherited — `pruneHiddenNodes` drops a
+  // gated node together with its whole subtree — so an instance under one
+  // reaches no reader either way, and composing it is work nobody receives.
+  //
+  // Without this the two routes to one outcome report differently: the directly
+  // gated instance is left standing with nothing recorded, while the instance
+  // under a gated container is read, tagged and, when it cannot be composed,
+  // listed as unresolved. A publish check then refuses a page over a component
+  // no visitor can be served, and the tags a render invalidates on name it.
+  //
+  // Asked of the node ITSELF rather than tracked down the walk, because
+  // `inlineForest` descends one level per frame: a gated node returns here
+  // before its slots are visited, so nothing below it is ever reached.
+  if (isConditionGated(node)) return null;
   const slots = node.slots;
   if (!isPlainRecord(slots)) return null;
   const next = inlineHostSlots(slots, run, scope, depth);
@@ -572,14 +587,11 @@ function expandInstance(
   }
   noteReference(run, componentId);
 
-  const reason = refusalFor(componentId, run, scope);
-  if (reason !== undefined) {
-    return [refuse(run, instance, componentId, reason)];
+  const found = definitionFor(componentId, run, scope);
+  if (typeof found === "string") {
+    return [refuse(run, instance, componentId, found)];
   }
-
-  // Established by `refusalFor`, which is the only reader that can tell a
-  // missing definition from an unreadable one.
-  const definition = run.definitions.get(componentId) as ComponentDocument;
+  const definition = found;
 
   // Taken before ANY speculative work, `suppliedSlots` included. Resolving an
   // instance's slot content spends budget and mints ids, and a refusal below
@@ -923,12 +935,21 @@ function rollback(run: ResolveRun, mark: Savepoint): void {
   run.minted.length = mark.minted;
 }
 
-/** Why this instance cannot be inlined here, if it cannot. */
-function refusalFor(
+/**
+ * The definition to inline here, or why this instance cannot be.
+ *
+ * One value rather than a verdict the caller then re-reads, because the lookup
+ * is a caller's object and nothing in its contract makes it pure. Validating
+ * one `get` and expanding a second means the document that was checked is not
+ * the document that is used — and the source that FETCHES is the one least
+ * likely to answer twice the same way. Reasons are strings and definitions are
+ * records, so the two are told apart without an envelope per instance.
+ */
+function definitionFor(
   componentId: string,
   run: ResolveRun,
   scope: ComposedScope
-): ComponentUnresolvedReason | undefined {
+): ComponentDocument | ComponentUnresolvedReason {
   if (scope.onPath.has(componentId)) return "cycle";
   if (scope.depth >= run.maxComposedDepth) return "composed-depth";
   // ABSENT from the map is `missing` — nobody supplied one, and the remedy is
@@ -937,6 +958,7 @@ function refusalFor(
   // corrupt component data sends an author to the wrong screen, which is the
   // whole reason these reasons are a closed list rather than a message.
   if (!run.definitions.has(componentId)) return "missing";
+  // Read ONCE and carried out, so expansion never asks again.
   const definition = run.definitions.get(componentId);
   if (!isPlainRecord(definition) || !Array.isArray(definition.nodes)) {
     return "unreadable";
@@ -948,7 +970,7 @@ function refusalFor(
   // and slots meaning nothing. The kind is what the engine already publishes
   // an answer for.
   if (!isComponentDocument(definition)) return "unreadable";
-  return undefined;
+  return definition;
 }
 
 /**

--- a/packages/blocks-engine/src/resolve-instances.ts
+++ b/packages/blocks-engine/src/resolve-instances.ts
@@ -326,6 +326,10 @@ export function resolveComponentInstances(
     referenced: [],
     referencedSeen: new Set<string>(),
     unresolved: [],
+    definitionsRead: new Map<
+      string,
+      ComponentDocument | ComponentUnresolvedReason
+    >(),
   };
   const nodes = inlineForest(document.nodes, run, ROOT_SCOPE, 1);
   return {
@@ -368,6 +372,20 @@ interface ResolveRun {
   referenced: string[];
   referencedSeen: Set<string>;
   unresolved: UnresolvedInstance[];
+  /**
+   * What the lookup answered for each component this run has asked about.
+   *
+   * A resolution has to say ONE thing about one component. Asking per instance
+   * lets a lookup that is not pure contradict itself inside a page — the first
+   * instance draws the component and the second reports it unreadable — and
+   * the contract deliberately admits such a lookup, because the source that
+   * fetches is one.
+   *
+   * Only the id-dependent half is held. `cycle` and `composed-depth` are
+   * properties of WHERE the instance sits, so they are decided per call and
+   * never reach this.
+   */
+  definitionsRead: Map<string, ComponentDocument | ComponentUnresolvedReason>;
 }
 
 /** Where in the composition a forest sits: how deep, and through which components. */
@@ -952,6 +970,24 @@ function definitionFor(
 ): ComponentDocument | ComponentUnresolvedReason {
   if (scope.onPath.has(componentId)) return "cycle";
   if (scope.depth >= run.maxComposedDepth) return "composed-depth";
+  const seen = run.definitionsRead.get(componentId);
+  if (seen !== undefined) return seen;
+  const answer = readDefinition(componentId, run);
+  run.definitionsRead.set(componentId, answer);
+  return answer;
+}
+
+/**
+ * What the lookup says about one component, asked once per run.
+ *
+ * Split from the scope checks above so that only the id-dependent half is
+ * remembered: a component refused for a cycle at one position is perfectly
+ * resolvable at another, and caching that refusal would withhold it there.
+ */
+function readDefinition(
+  componentId: string,
+  run: ResolveRun
+): ComponentDocument | ComponentUnresolvedReason {
   // ABSENT from the map is `missing` — nobody supplied one, and the remedy is
   // to publish or restore it. A value that IS supplied and cannot be read is a
   // document fault, so it takes `unreadable`: offering the publish remedy for
@@ -1359,6 +1395,26 @@ function cloneDefinitionNode(
   }
 
   const scoped = scopeNode(node, ctx, plan);
+
+  // The inherited-gate rule, on the definition side. `inlineNode` applies it to
+  // a host container; a definition's own gated box is dropped by the same pass
+  // with the same subtree, so descending here would report components no reader
+  // can receive — and the host rule would mean nothing for anything a component
+  // holds.
+  //
+  // Asked AFTER `scopeNode` rather than of the stored node, because an
+  // instance's `visibility` override is allowed to remove the gate: asking
+  // first would refuse to compose a region the instance explicitly turned on.
+  // `scopeNode` deletes the envelope for `plan.visible === true`, so by here
+  // the question has one answer.
+  //
+  // The node stands, gated, exactly as the host case leaves it standing — the
+  // pass that prunes it wants it there — and its planned slot content is given
+  // back, because nothing will place it.
+  if (isConditionGated(scoped)) {
+    if (plan !== undefined) refundPlannedSlots(plan, ctx.run);
+    return [scoped];
+  }
 
   // Cloned BEFORE the instance branch, not after it. A component-instance node
   // inside a definition carries slot content like any container, and skipping

--- a/packages/blocks-react/src/block-boundary-marker.test.tsx
+++ b/packages/blocks-react/src/block-boundary-marker.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * What the boundary does with a marker it did not write.
+ *
+ * `BlockBoundary` is published, so a node reaches it that no pipeline pass
+ * touched — an exported document replayed, a tree assembled by a host, content
+ * hand-edited in storage. The composition marker is a render-time fact and
+ * nothing strips it from stored content, so the string beside it is untrusted
+ * input at this boundary even though every string the resolver writes is one of
+ * six.
+ */
+import { COMPONENT_INSTANCE_TYPE } from "@nextlyhq/blocks-engine";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { BlockBoundary } from "./block-boundary";
+import type { PageContext } from "./context";
+import { createBlockResolver } from "./resolver";
+
+function context(): PageContext {
+  return {
+    entry: null,
+    data: { find: () => Promise.resolve({ items: [], total: 0 }) },
+    resolveMedia: () => Promise.resolve(null),
+    resolveEntryPath: () => Promise.resolve(null),
+  };
+}
+
+const marked = (reason: string) =>
+  ({
+    id: "n1",
+    type: COMPONENT_INSTANCE_TYPE,
+    version: 1,
+    props: { componentId: "hero" },
+    unresolvedComponent: reason,
+  }) as never;
+
+describe("an unresolved marker whose reason came from storage", () => {
+  it("draws the placeholder for a reason naming a prototype member", () => {
+    // Read from a plain object, `__proto__` answers `Object.prototype` and
+    // `constructor` answers a function. Either reaches the placeholder as its
+    // detail, and React refuses an object for a child — so the one component
+    // that exists to contain a failure is where the page dies.
+    const html = renderToStaticMarkup(
+      <BlockBoundary
+        node={marked("__proto__")}
+        context={context()}
+        blocks={createBlockResolver([])}
+        classes={{ n1: "nx-node" }}
+      />
+    );
+
+    expect(html).toContain('data-nx-block-placeholder="unresolved-component"');
+  });
+
+  it("draws no explanation for a reason naming an inherited method", () => {
+    // `constructor` answers a function rather than an object, so React renders
+    // nothing for it instead of failing — and the boundary emits an EMPTY
+    // explanation, which tells an author the cause is blank rather than
+    // unrecognised.
+    const html = renderToStaticMarkup(
+      <BlockBoundary
+        node={marked("constructor")}
+        context={context()}
+        blocks={createBlockResolver([])}
+        classes={{ n1: "nx-node" }}
+      />
+    );
+
+    expect(html).not.toContain("<div></div>");
+  });
+
+  it("CONTROL: still explains a reason the resolver actually writes", () => {
+    // Without this the two above pass on a boundary that never shows a detail
+    // at all, which costs an author the sentence naming the remedy.
+    const html = renderToStaticMarkup(
+      <BlockBoundary
+        node={marked("cycle")}
+        context={context()}
+        blocks={createBlockResolver([])}
+        classes={{ n1: "nx-node" }}
+      />
+    );
+
+    expect(html).toContain("This component contains itself");
+  });
+});

--- a/packages/blocks-react/src/block-boundary.tsx
+++ b/packages/blocks-react/src/block-boundary.tsx
@@ -24,26 +24,33 @@ import type { BlockResolver } from "./resolver";
 import { isUnconditional } from "./visibility";
 
 /**
- * What an author is told when a component did not load.
- *
- * Wording per cause, because the remedies are five different things and a
- * single message would send an author looking in the wrong place for four of
- * them. Development only: the production placeholder renders nothing.
- */
-/**
  * The wording for one reason, or nothing when the marker names none.
  *
- * Total over the reason type rather than an index expression, because the
- * predicate that admits a node here asks only for the reserved instance TYPE:
- * a marker carrying an unrecognised reason still reaches this, and indexing
- * would hand React whatever a record answers for a key it does not have.
+ * Asked of a `Map`, and that is the whole point of the indirection. The
+ * predicate that admits a node here reads the reserved instance TYPE, and the
+ * reason beside it is stored content nothing strips — so an unrecognised
+ * string arrives, and `constructor` or `__proto__` indexed on a record answer
+ * with an inherited member rather than with nothing. React refuses an object
+ * for a child, so the page dies inside the one component that exists to
+ * contain a failure. A `Map` holds only what was put in it.
  */
 function unresolvedDetail(
   reason: ComponentUnresolvedReason | undefined
 ): string | undefined {
-  return reason === undefined ? undefined : UNRESOLVED_DETAIL[reason];
+  return reason === undefined ? undefined : DETAIL_BY_REASON.get(reason);
 }
 
+/**
+ * What an author is told when a component did not load.
+ *
+ * Wording per cause, because the remedies are different things and a single
+ * message would send an author looking in the wrong place for most of them.
+ * Development only: the production placeholder renders nothing.
+ *
+ * A record rather than the `Map` it becomes, so the compiler still requires a
+ * wording for every reason the engine publishes — a `Map` literal would accept
+ * one that named five of them and go quiet about the sixth.
+ */
 const UNRESOLVED_DETAIL: Readonly<Record<ComponentUnresolvedReason, string>> = {
   missing: "No published component was found for this reference",
   cycle: "This component contains itself",
@@ -53,6 +60,11 @@ const UNRESOLVED_DETAIL: Readonly<Record<ComponentUnresolvedReason, string>> = {
   malformed: "This instance names no component",
   unreadable: "This component's stored data cannot be read",
 };
+
+/** Derived, so the two cannot name different sets of reasons. */
+const DETAIL_BY_REASON: ReadonlyMap<string, string> = new Map(
+  Object.entries(UNRESOLVED_DETAIL)
+);
 
 /** What a render needs to turn one node into output. */
 export interface BlockBoundaryProps {

--- a/packages/blocks-react/src/prepare-document.ts
+++ b/packages/blocks-react/src/prepare-document.ts
@@ -429,9 +429,12 @@ export function isUnresolvedInstance(node: ResolvedBlockNode): boolean {
  * `missing` for a definition the caller had supplied. Asking here means there
  * is one answer, given at the moment the definition is actually wanted.
  *
- * Memoized, so a component held by two instances is repaired once — and the
- * memo records a definition that could NOT be read as well, or an unreadable
- * one would be re-examined on every reference.
+ * NOT memoized here, and that is deliberate rather than an omission. The
+ * resolver reads the lookup once per component per resolution and holds the
+ * answer for the run — it has to, because a lookup is a caller's object and a
+ * resolution owes one answer about one component. A second cache on this side
+ * would be a second implementation of that guarantee, agreeing on the day it
+ * is written; removing it was measured to change nothing.
  */
 function repairingLookup(
   definitions: DefinitionsById,
@@ -442,7 +445,6 @@ function repairingLookup(
     maxDepth: limits.maxDepth + 1,
     maxNodes: limits.maxNodes + 1,
   };
-  const repaired = new Map<string, BlockDocument | undefined>();
   return {
     // Answered from the SUPPLIED map, never from whether `get` produced a
     // document. Presence is what separates "nobody supplied one" from "one was
@@ -451,18 +453,15 @@ function repairingLookup(
     // repair its stored data.
     has: id => definitions.has(id),
     get: id => {
-      if (repaired.has(id)) return repaired.get(id);
       const stored = definitions.get(id);
       // `undefined` for an envelope this build cannot read, rather than a
       // repaired shell. The shape pass reads `document.nodes` on its first
       // line, so a `null` or a string here throws before any block boundary
       // exists to contain it — and the resolver, which still sees the id in
       // `has`, reports it as unreadable rather than missing.
-      const value = isReadableEnvelope(stored)
+      return isReadableEnvelope(stored)
         ? sanitizeDocument(stored, shapeOnly)
         : undefined;
-      repaired.set(id, value);
-      return value;
     },
   };
 }


### PR DESCRIPTION
Follow-up to #1522. Codex reviewed it at 08:21:27 and it merged at 08:26:33, so these four findings landed on `main` unworked — the same shape as #1519.

Each was reproduced with a failing probe before it was accepted, and each fix was break-verified by writing the wrong implementation.

## Composing under a gated ancestor (P2)

`isConditionGated` answers "this node carries a real restriction", and `pruneHiddenNodes` drops such a node **together with its whole subtree** — no condition evaluator exists yet, and withholding is the recoverable direction. So an instance under a gated container reaches no reader.

The host walk descended into it anyway. `expandInstance` already applies the opposite rule to an instance's *own* gate ("a gated node is not served, so composing it is work nobody receives"), so two routes to one outcome reported differently: the directly gated instance was left standing with nothing recorded, while the one under a gated container was read, added to `referencedComponents`, and — when it could not be composed — listed in `unresolvedInstances`. A publish check can refuse a page over a component no visitor can be served, and a render invalidates on tags naming it.

Measured before the fix: `referenced` came back `["hero"]` for an instance under a gated box. One guard in `inlineNode`, with a control asserting an instance under an **ungated** ancestor still composes — without it the rule passes on an implementation that refuses to descend into any container at all.

## Reading the lookup twice (P2)

`refusalFor` validated `definitions.get(id)` and `expandInstance` called `get` again, casting the second value. Nothing in the `ComponentLookup` contract makes a lookup pure, and the fetch-backed source T-4 slice C introduces is exactly the stateful case. A lookup answering once and then `undefined` passed validation and threw `Cannot read properties of undefined (reading 'nodes')` instead of refusing with `unreadable`.

`refusalFor` is now `definitionFor`, returning the definition it validated. Reasons are strings and definitions are records, so the two are told apart without an envelope per instance. The cast is gone.

## A stored reason indexed on a record (P2)

`unresolvedDetail` read the wording out of a plain object literal, keyed by a reason that comes from **stored content** — the marker is a render-time fact but nothing strips it. `UNRESOLVED_DETAIL["__proto__"]` answers `Object.prototype`, React refuses an object as a child, and the page dies inside the one component that exists to contain a failure.

Worth being precise about the route, because I could not reach it through the pipeline: `prepareDocumentReadStages` always re-marks an instance with the reason the resolver decided, so a stored reason never survives there. The reachable caller is the **published** `BlockBoundary` / `BlockList` — a host rendering a node it assembled or replayed from an export. The probe goes through that.

The lookup now goes through a `Map`; the `Record` stays so the compiler still requires a wording per reason. `constructor` gets its own case — it answers a function, which React renders as an *empty* explanation rather than a crash, telling an author the cause is blank rather than unrecognised.

## A changeset that describes the wrong behaviour (P3)

#1522's changeset still tells users a corrupt definition is "reported as missing". The shipped resolver reports `unreadable`, precisely so the remedy points at the corrupt component rather than at publishing one that already exists. Corrected in place — it has not been released yet.

## Gates

`build` 0 · `check-types` 0 · `lint` 0 · `check:comments` 0 · `fallow` **pass**, 0 introduced across all four dimensions · `changeset status` 0, one changeset, 25 packages.

blocks-engine 1888 (+3) · blocks-react 1125 (+3) · plugin-page-builder 609.

Break-verification, counts held throughout: re-reading the lookup kills 2; removing the gated-ancestor guard kills 1; indexing the record again kills 2.