### PR TITLE
fix(blocks-engine): compose slot content where it is placed, not where it is picked

### DIFF
--- a/.changeset/nothing-is-loaded-for-a-part-that-is-hidden.md
+++ b/.changeset/nothing-is-loaded-for-a-part-that-is-hidden.md
@@ -1,0 +1,34 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Content a page places inside a hidden part of a component is no longer loaded.
+The blocks were never going to be shown — the part holding them is hidden, so
+they and everything in them were already being dropped — but any component
+among them was still being fetched and counted. A page could be refused for
+publishing over a component in there, and a change to that component still
+rebuilt the page.

--- a/packages/blocks-engine/src/resolve-instances.test.ts
+++ b/packages/blocks-engine/src/resolve-instances.test.ts
@@ -831,6 +831,85 @@ describe("resolveComponentInstances what an instance carries", () => {
     expect(result.referenced).toEqual(["outer"]);
   });
 
+  it("does not resolve slot content aimed at a gated target", () => {
+    // The instance's own content, handed to a region the definition gates. The
+    // node it was placed in is dropped with its subtree, so the content reaches
+    // no reader — and resolving it first records the components inside it as
+    // read and as unresolvable, which is the same publish rejection and the
+    // same cache tag, arrived at from the page's side instead of the
+    // definition's.
+    const gate = { conditions: [[{ field: "tier", op: "eq", value: "vip" }]] };
+    const definition = component([box("d1", [node("fallback")], gate)], {
+      slots: { body: { label: "Body", nodeId: "d1", slot: "children" } },
+    });
+    const doc = page([
+      instance("i1", "hero", {}, { slots: { body: [instance("s1", "gone")] } }),
+    ]);
+
+    const result = resolveComponentInstances(doc, defs({ hero: definition }));
+
+    expect(result.unresolved).toEqual([]);
+    expect(result.referenced).toEqual(["hero"]);
+  });
+
+  it("still resolves slot content aimed at a target that survives", () => {
+    // The control. Without it the rule above passes on an implementation that
+    // drops instance slot content altogether, which is the whole feature.
+    const definition = component([box("d1", [node("fallback")])], {
+      slots: { body: { label: "Body", nodeId: "d1", slot: "children" } },
+    });
+    const doc = page([
+      instance(
+        "i1",
+        "hero",
+        {},
+        { slots: { body: [instance("s1", "inner")] } }
+      ),
+    ]);
+
+    const result = resolveComponentInstances(
+      doc,
+      defs({ hero: definition, inner: component([node("d9")]) })
+    );
+
+    expect(result.unresolved).toEqual([]);
+    expect(result.referenced).toEqual(["hero", "inner"]);
+    // Composed, and recorded as belonging to the page's own instance node —
+    // the content is the PAGE's, so `instanceOf` names `s1` rather than the
+    // component that received it.
+    expect(
+      result.document.nodes[0]!.slots!.children!.map(e => e.instanceOf)
+    ).toEqual(["s1"]);
+  });
+
+  it("composes the page's slot content ONCE, however deep it is placed", () => {
+    // The page supplies content to a slot that `outer` forwards into a nested
+    // component. Composing where it is placed means it passes through two
+    // expansions, and the second must leave it alone: content already composed
+    // still holds any instance that could not be resolved, so composing it
+    // again refuses that instance a second time and reports it twice.
+    const inner = component([box("d2", [node("fb")])], {
+      slots: { region: { label: "Region", nodeId: "d2", slot: "children" } },
+    });
+    const outer = component([instance("n1", "inner")], {
+      slots: { body: { label: "Body", nodeId: "n1", slot: "region" } },
+    });
+    const doc = page([
+      instance(
+        "i1",
+        "outer",
+        {},
+        { slots: { body: [instance("s1", "gone")] } }
+      ),
+    ]);
+
+    const result = resolveComponentInstances(doc, defs({ outer, inner }));
+
+    expect(result.unresolved).toEqual([
+      { instanceId: "s1", componentId: "gone", reason: "missing" },
+    ]);
+  });
+
   it("still composes an instance under an UNGATED container inside a definition", () => {
     // The control for the rule above, on the definition side.
     const doc = page([instance("i1", "outer")]);

--- a/packages/blocks-engine/src/resolve-instances.ts
+++ b/packages/blocks-engine/src/resolve-instances.ts
@@ -1042,13 +1042,20 @@ function noteReference(run: ResolveRun, componentId: string): void {
 }
 
 /**
- * The instance's own slot content, resolved in the scope it was AUTHORED in.
+ * The instance's own slot content, PICKED and not composed.
  *
- * Resolved before the definition is inlined and in the OUTER scope, because
- * this content belongs to the page rather than to the component: a component
- * nested in it is nested in the page, not one level further into the
- * composition, and re-identifying it would move page nodes to ids the editor
- * cannot address.
+ * The name says whose content this is, not what state it is in, so the state
+ * has to be said here: what comes back is stored nodes. `placedContent`
+ * composes them, and only once the node they are bound for has survived —
+ * content aimed at a gated or overridden-away target is discarded, and
+ * composing it first spends the page's budget on a tree nobody receives, mints
+ * ids for it, and records the components inside it as read and as
+ * unresolvable.
+ *
+ * Composed in the OUTER scope when it is composed, because this content
+ * belongs to the page rather than to the component: a component nested in it
+ * is nested in the page, not one level further into the composition, and
+ * re-identifying it would move page nodes to ids the editor cannot address.
  */
 function suppliedSlots(
   instance: ResolvedBlockNode,
@@ -1479,6 +1486,10 @@ function cloneDefinitionNode(
  * Only the PLANNED content, never the definition's own children: those were
  * charged as they were cloned, and a hidden node is abandoned before its slots
  * are visited, so nothing was spent on them to return.
+ *
+ * What is given back is what the HOST SURVEY charged — the stored size of the
+ * content, which is what `nodes` holds until something places it. Refunding a
+ * composed size credited a number the survey never took, in either direction.
  */
 function refundPlannedSlots(plan: NodePlan, run: ResolveRun): void {
   if (plan.slots === undefined) return;

--- a/packages/blocks-engine/src/resolve-instances.ts
+++ b/packages/blocks-engine/src/resolve-instances.ts
@@ -622,18 +622,24 @@ function expandInstance(
   // definition that exactly fills the remaining room is refused for needing
   // one node more than the document will actually hold.
   run.budget += 1;
-  const supplied =
-    presupplied ?? suppliedSlots(instance, definition, run, scope, depth);
+  // Picked, NOT composed. The page's slot content is composed where it is
+  // PLACED, because a node the definition gates or an override hides discards
+  // it — and composing first records the components inside it as read and as
+  // unresolvable, for content no reader can receive. Nested content arrives
+  // already composed and says so.
+  const supplied = presupplied ?? suppliedSlots(instance, definition, run);
   const ctx: InlineContext = {
     run,
     scopeKey: instance.id,
     owner: owner ?? instance.id,
     domIds: new Map<string, string>(),
-    plans: planEdits(definition, instance, supplied),
+    plans: planEdits(definition, instance, supplied, presupplied !== undefined),
     scope: {
       depth: scope.depth + 1,
       onPath: new Set(scope.onPath).add(componentId),
     },
+    hostScope: scope,
+    hostDepth: depth,
   };
 
   const inlined = withRemappedIdReferences(
@@ -1047,15 +1053,11 @@ function noteReference(run: ResolveRun, componentId: string): void {
 function suppliedSlots(
   instance: ResolvedBlockNode,
   definition: ComponentDocument,
-  run: ResolveRun,
-  scope: ComposedScope,
-  depth: number
+  run: ResolveRun
 ): Record<string, ResolvedBlockNode[]> | undefined {
   const slots = instance.slots;
   if (!isPlainRecord(slots)) return undefined;
-  const wanted = exposedSlotContent(slots, definition, run);
-  if (wanted === undefined) return undefined;
-  return inlineHostSlots(wanted, run, scope, depth);
+  return exposedSlotContent(slots, definition, run);
 }
 
 /**
@@ -1138,19 +1140,38 @@ interface NodePlan {
   /** `false` drops the node; `true` serves it unconditionally; absent leaves it alone. */
   visible?: boolean;
   /** Instance content, keyed by the slot NAME on this node. */
-  slots?: Map<string, ResolvedBlockNode[]>;
+  slots?: Map<string, PlannedSlot>;
+}
+
+/**
+ * Content bound for one slot, and whether it has been composed yet.
+ *
+ * The flag exists because two different things arrive here. The PAGE's own
+ * slot content is stored and has to be composed in the host's scope — and is
+ * composed only if the node it is bound for survives, since a gated or
+ * overridden-away target discards it and composing it first records the
+ * components inside it as read and as unresolvable, for content no reader
+ * receives. A NESTED instance's content arrives already composed in its
+ * component's scope, and composing it again would re-mint every id in it.
+ */
+interface PlannedSlot {
+  nodes: ResolvedBlockNode[];
+  composed: boolean;
 }
 
 /** What each of the definition's nodes gets, keyed by its id in the definition. */
 function planEdits(
   definition: ComponentDocument,
   instance: ResolvedBlockNode,
-  supplied: Record<string, ResolvedBlockNode[]> | undefined
+  supplied: Record<string, ResolvedBlockNode[]> | undefined,
+  composed: boolean
 ): Map<string, NodePlan> {
   const plans = new Map<string, NodePlan>();
   const values = effectiveOverrides(definition, instance);
   if (values.size > 0) planExposed(definition.exposed, values, plans);
-  if (supplied !== undefined) planSlots(definition.slots, supplied, plans);
+  if (supplied !== undefined) {
+    planSlots(definition.slots, supplied, plans, composed);
+  }
   return plans;
 }
 
@@ -1253,7 +1274,8 @@ function visibilityDecision(value: OverrideValue): boolean | undefined {
 function planSlots(
   slots: unknown,
   supplied: Record<string, ResolvedBlockNode[]>,
-  plans: Map<string, NodePlan>
+  plans: Map<string, NodePlan>,
+  composed: boolean
 ): void {
   if (!isPlainRecord(slots)) return;
   const ids = boundedOwnKeys(slots, MAX_ENVELOPE_ENTRIES);
@@ -1263,9 +1285,9 @@ function planSlots(
     const target = slotTarget(ownEntry(slots, id));
     if (!Array.isArray(content) || target === undefined) continue;
     const plan = planFor(plans, target.nodeId);
-    const into = plan.slots ?? new Map<string, ResolvedBlockNode[]>();
+    const into = plan.slots ?? new Map<string, PlannedSlot>();
     plan.slots = into;
-    into.set(target.slot, content);
+    into.set(target.slot, { nodes: content, composed });
   }
 }
 
@@ -1327,6 +1349,15 @@ interface InlineContext {
   domIds: Map<string, string>;
   /** The scope INSIDE this component, for instances the definition itself holds. */
   scope: ComposedScope;
+  /**
+   * Where the HOST document's own slot content composes.
+   *
+   * The page's content stays the page's wherever the definition places it, so
+   * it is composed at the host's scope and depth rather than the component's —
+   * the same answer the eager pass gave, arrived at later.
+   */
+  hostScope: ComposedScope;
+  hostDepth: number;
 }
 
 /**
@@ -1452,7 +1483,7 @@ function cloneDefinitionNode(
 function refundPlannedSlots(plan: NodePlan, run: ResolveRun): void {
   if (plan.slots === undefined) return;
   for (const content of plan.slots.values()) {
-    run.budget += countNodes(content);
+    run.budget += countNodes(content.nodes);
   }
 }
 
@@ -1546,7 +1577,7 @@ function cloneSlots(
   if (readable && !copyStoredSlots(stored, next, ctx, depth, planned)) {
     return null;
   }
-  if (planned !== undefined) fillPlannedSlots(next, planned);
+  if (planned !== undefined) fillPlannedSlots(next, planned, ctx);
   return next;
 }
 
@@ -1556,7 +1587,7 @@ function copyStoredSlots(
   into: Record<string, ResolvedBlockNode[]>,
   ctx: InlineContext,
   depth: number,
-  planned: ReadonlyMap<string, ResolvedBlockNode[]> | undefined
+  planned: ReadonlyMap<string, PlannedSlot> | undefined
 ): boolean {
   // Same `unknown` view as `inlineHostSlots`, for the same reason: a stored
   // slot value that is not an array travels through untouched.
@@ -1565,7 +1596,7 @@ function copyStoredSlots(
   for (const name of Object.keys(source)) {
     const supplied = planned?.get(name);
     if (supplied !== undefined) {
-      defineEntry(target, name, supplied);
+      defineEntry(target, name, placedContent(supplied, ctx));
       continue;
     }
     const children = ownEntry(source, name);
@@ -1590,12 +1621,39 @@ function copyStoredSlots(
  */
 function fillPlannedSlots(
   into: Record<string, ResolvedBlockNode[]>,
-  planned: ReadonlyMap<string, ResolvedBlockNode[]>
+  planned: ReadonlyMap<string, PlannedSlot>,
+  ctx: InlineContext
 ): void {
   for (const [name, content] of planned) {
     if (Object.prototype.hasOwnProperty.call(into, name)) continue;
-    defineEntry(into, name, content);
+    defineEntry(into, name, placedContent(content, ctx));
   }
+}
+
+/**
+ * One planned slot's nodes, composed if this is the first time they are placed.
+ *
+ * The single place either kind of planned content becomes output, so the
+ * "compose the page's content, leave a nested component's alone" rule is
+ * stated once. Reached only from a node that survived, which is what makes
+ * discarded content cost nothing.
+ */
+function placedContent(
+  content: PlannedSlot,
+  ctx: InlineContext
+): ResolvedBlockNode[] {
+  if (content.composed) return content.nodes;
+  const composed = inlineForest(
+    content.nodes,
+    ctx.run,
+    ctx.hostScope,
+    ctx.hostDepth + 1
+  );
+  // Held, so a definition placing one slot's content into two of its own slots
+  // composes it once and mints one set of ids rather than two.
+  content.nodes = composed;
+  content.composed = true;
+  return composed;
 }
 
 /**


### PR DESCRIPTION
Follow-up to #1524. Codex submitted this at 08:59:42 and the PR merged at 09:33, so it landed on `main` unworked — the third time in this lane a review has arrived at a head that then merged before it was read. Worth flagging as a pattern rather than three accidents.

## The finding

An instance's slot content was composed by `suppliedSlots` before any definition node was cloned. `cloneDefinitionNode` then discarded it for a node the definition gates, or one an override hides, and refunded only the **node budget** — the components inside it stayed in `referenced` and their unresolvable instances stayed in `unresolved`.

That is the same publish rejection and the same cache tag as the gated-ancestor case #1524 closed, reached from the page's side instead of the definition's. The `plan.visible === false` path had the same hole before this lane touched it; the gate check gave it a second trigger.

Reproduced first: a page supplying `[instance("s1", "gone")]` to a slot whose target the definition gates came back with no slot content and `unresolved: [{s1, gone, missing}]`.

## The fix

Compose where the content is **placed**, not where it is picked. `suppliedSlots` now only picks; a planned slot carries `{nodes, composed}`; `placedContent` composes on first placement — and it is reached only from a node that survived, so discarded content costs no budget, no diagnostics and no minted ids.

Two things fall out of that:

- **The refund was already wrong.** `refundPlannedSlots` credited back the **resolved** size of content the host survey had charged at its **stored** size, so the credit could differ from the charge in either direction. It now counts what was counted.
- **Nested content must not be composed twice.** It arrives already composed in its component's scope, and the `composed` flag is what stops a second pass re-minting its ids.

## The break-verification found a gap, and the gap is the interesting part

Setting `composed: false` unconditionally killed **nothing** — because `inlineForest` returns its input by identity when there is no instance left to expand, so recomposing finished content is usually a no-op. It is observable only when composed content still holds a **refused** instance, which stays a component-instance node.

So there is now a test for exactly that: a page forwards slot content through `outer` into a nested `inner`, and the content holds an instance of a missing component. With the flag wrong, that instance is refused twice and reported twice. It fails on the wrong implementation and passes on this one.

Both new rules also carry controls: slot content aimed at a target that **survives** is still composed and still recorded as the page's own (`instanceOf: "s1"`), so neither rule can pass on an implementation that simply drops instance slot content.

## Gates

`build` 0 · `check-types` 0 · `lint` 0 · `check:comments` 0 · `fallow` **pass**, 0 introduced across all four dimensions · `changeset status` 0, one changeset, 25 packages.

blocks-engine 1894 (+3) · blocks-react 1125 · plugin-page-builder 609. Break-verification with counts held at 82: eager composition kills 1, the wrong `composed` flag kills 1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected slot-content resolution for gated or hidden component instances.
  * Prevented slot content from being resolved when its target is not rendered.
  * Ensured content forwarded through nested components is composed only once.
  * Prevented duplicate reporting of unresolvable instances.
  * Preserved correct resolution and page-instance association for content targeting visible components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->