### PR TITLE
fix(blocks-engine): free the room slot content releases before cloning

### DIFF
--- a/.changeset/a-page-that-just-fits-still-fits.md
+++ b/.changeset/a-page-that-just-fits-still-fits.md
@@ -32,3 +32,9 @@ component frees the space the reference itself occupied, and that space was
 only becoming available part-way through drawing — so an otherwise identical
 page could be accepted or refused depending on the order of the blocks around
 the region.
+
+Two more repairs at the same step. A component whose stored blocks are wider
+than the whole page allows is no longer walked in full before the page is
+refused for being too large. And content a page places into a region of a
+component is no longer loaded when the page has already replaced the region
+around it — the blocks it was going into were never going to be drawn.

--- a/.changeset/a-page-that-just-fits-still-fits.md
+++ b/.changeset/a-page-that-just-fits-still-fits.md
@@ -1,0 +1,34 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A page that exactly fills its block limit is no longer refused over where the
+author happened to put a slot. Placing a component into a region of another
+component frees the space the reference itself occupied, and that space was
+only becoming available part-way through drawing — so an otherwise identical
+page could be accepted or refused depending on the order of the blocks around
+the region.

--- a/packages/blocks-engine/src/resolve-instances.test.ts
+++ b/packages/blocks-engine/src/resolve-instances.test.ts
@@ -882,6 +882,35 @@ describe("resolveComponentInstances what an instance carries", () => {
     ).toEqual(["s1"]);
   });
 
+  it("fits a composition whose slot content releases the room it needs", () => {
+    // Two nodes stored — the instance and the content it supplies — and two
+    // nodes composed. The supplied instance resolves to an empty component, so
+    // replacing it FREES the slot it occupied, and the definition's own two
+    // nodes fit exactly. Whether that room arrives before or after the
+    // definition's siblings are cloned is an ordering detail of this module,
+    // and a page must not be refused over it.
+    const outer = component([node("sib"), box("d1", [])], {
+      slots: { body: { label: "Body", nodeId: "d1", slot: "children" } },
+    });
+    const doc = page([
+      instance(
+        "i1",
+        "outer",
+        {},
+        { slots: { body: [instance("s1", "inner")] } }
+      ),
+    ]);
+
+    const result = resolveComponentInstances(
+      doc,
+      defs({ outer, inner: component([]) }),
+      { limits: { ...DEFAULT_LIMITS, maxNodes: 2 } }
+    );
+
+    expect(result.unresolved).toEqual([]);
+    expect(flatten(result.document.nodes)).toHaveLength(2);
+  });
+
   it("composes the page's slot content ONCE, however deep it is placed", () => {
     // The page supplies content to a slot that `outer` forwards into a nested
     // component. Composing where it is placed means it passes through two

--- a/packages/blocks-engine/src/resolve-instances.test.ts
+++ b/packages/blocks-engine/src/resolve-instances.test.ts
@@ -909,6 +909,11 @@ describe("resolveComponentInstances what an instance carries", () => {
 
     expect(result.unresolved).toEqual([]);
     expect(flatten(result.document.nodes)).toHaveLength(2);
+    // An empty component contributes nothing either way, so the node count
+    // alone cannot tell composition from DISCARDING the supplied content —
+    // which is the plausible wrong implementation, and the one that costs a
+    // page its content. Only a record of having read `inner` separates them.
+    expect(result.referenced).toEqual(["outer", "inner"]);
   });
 
   it("composes the page's slot content ONCE, however deep it is placed", () => {
@@ -937,6 +942,66 @@ describe("resolveComponentInstances what an instance carries", () => {
     expect(result.unresolved).toEqual([
       { instanceId: "s1", componentId: "gone", reason: "missing" },
     ]);
+  });
+
+  it("stops the slot prepass at the cap the clone will refuse at", () => {
+    // A definition wider than the page's whole node allowance, with the slot
+    // target last. The depth bound says nothing about BREADTH, so without a
+    // work bound the prepass walks every sibling — hundreds of thousands of
+    // them in a definition nothing validated — to prepare content the clone
+    // refuses a moment later for `budget`.
+    const definition = component(
+      [node("a"), node("b"), node("c"), node("d"), box("target", [])],
+      { slots: { tail: { label: "Tail", nodeId: "target", slot: "children" } } }
+    );
+    const doc = page([
+      instance("i1", "hero", {}, { slots: { tail: [instance("s1", "deep")] } }),
+    ]);
+
+    const result = resolveComponentInstances(
+      doc,
+      defs({ hero: definition, deep: component([]) }),
+      { limits: { ...DEFAULT_LIMITS, maxNodes: 4 } }
+    );
+
+    // The instance is refused either way — the definition cannot fit. What is
+    // asserted is that `deep` was never READ to find that out.
+    expect(result.unresolved.map(e => e.reason)).toEqual(["budget"]);
+    expect(result.referenced).toEqual(["hero"]);
+  });
+
+  it("does not compose content bound for a default subtree the page replaced", () => {
+    // Two exposed slots: one on a container, one on a node sitting inside that
+    // container's DEFAULT children. Filling the outer slot replaces those
+    // children wholesale, so the inner target is never placed — and the clone
+    // knows that, because it stops copying a stored slot the plan replaces.
+    const definition = component(
+      [box("outer-box", [box("inner-box", [node("fb")])])],
+      {
+        slots: {
+          shell: { label: "Shell", nodeId: "outer-box", slot: "children" },
+          buried: { label: "Buried", nodeId: "inner-box", slot: "children" },
+        },
+      }
+    );
+    const doc = page([
+      instance(
+        "i1",
+        "hero",
+        {},
+        {
+          slots: {
+            shell: [node("mine")],
+            buried: [instance("s1", "gone")],
+          },
+        }
+      ),
+    ]);
+
+    const result = resolveComponentInstances(doc, defs({ hero: definition }));
+
+    expect(result.unresolved).toEqual([]);
+    expect(result.referenced).toEqual(["hero"]);
   });
 
   it("still composes an instance under an UNGATED container inside a definition", () => {

--- a/packages/blocks-engine/src/resolve-instances.ts
+++ b/packages/blocks-engine/src/resolve-instances.ts
@@ -627,13 +627,16 @@ function expandInstance(
   // it — and composing first records the components inside it as read and as
   // unresolvable, for content no reader can receive. Nested content arrives
   // already composed and says so.
-  const supplied = presupplied ?? suppliedSlots(instance, definition, run);
+  const owned = presupplied === undefined;
+  const supplied = owned
+    ? suppliedSlots(instance, definition, run)
+    : presupplied;
   const ctx: InlineContext = {
     run,
     scopeKey: instance.id,
     owner: owner ?? instance.id,
     domIds: new Map<string, string>(),
-    plans: planEdits(definition, instance, supplied, presupplied !== undefined),
+    plans: planEdits(definition, instance, supplied, !owned),
     scope: {
       depth: scope.depth + 1,
       onPath: new Set(scope.onPath).add(componentId),
@@ -642,6 +645,10 @@ function expandInstance(
     hostDepth: depth,
   };
 
+  // Before the clone rather than during it, so the room this content releases
+  // is available to the whole definition instead of only to the nodes after
+  // the slot. Nested content arrives composed already and needs no pass.
+  composeOwnedSlots(definition, ctx, supplied, owned);
   const inlined = withRemappedIdReferences(
     cloneDefinitionForest(definition.nodes, ctx, 1),
     ctx
@@ -1449,7 +1456,7 @@ function cloneDefinitionNode(
   // The node stands, gated, exactly as the host case leaves it standing — the
   // pass that prunes it wants it there — and its planned slot content is given
   // back, because nothing will place it.
-  if (isConditionGated(scoped)) {
+  if (!survivesGating(node, plan)) {
     if (plan !== undefined) refundPlannedSlots(plan, ctx.run);
     return [scoped];
   }
@@ -1478,6 +1485,106 @@ function cloneDefinitionNode(
     );
   }
   return [scoped];
+}
+
+/**
+ * Compose the page's slot content for every target the clone will reach.
+ *
+ * Deferring composition to the moment content is PLACED is what stops a gated
+ * or hidden target from paying for a tree nobody receives — but placement
+ * happens partway through cloning the definition, and replacing an instance
+ * RELEASES budget. So a page whose composed tree fits exactly was refused for
+ * `budget` when a sibling cloned before the slot target spent the room the
+ * content was about to give back, and whether it fit depended on where the
+ * author happened to put the slot in the definition.
+ *
+ * Composing the surviving targets' content up front restores that order
+ * without restoring the waste: survivorship is decided by `survivesGating`,
+ * which is the same question the clone asks, so discarded content is still
+ * never composed. `placedContent` marks what it composes, so the clone reuses
+ * this work rather than repeating it.
+ *
+ * Bounded by the definition's own depth, mirroring the clone. A definition
+ * deeper than the cap stops here and the clone refuses it a moment later.
+ */
+function composeSurvivingSlots(
+  nodes: readonly ResolvedBlockNode[],
+  ctx: InlineContext,
+  depth: number
+): void {
+  if (depth > ctx.run.maxDepth) return;
+  for (const node of nodes) {
+    if (!isPlainRecord(node) || typeof node.id !== "string") continue;
+    const plan = ctx.plans.get(node.id);
+    if (!survivesGating(node, plan)) continue;
+    composePlannedFor(plan, ctx);
+    composeSlotsUnder(node, ctx, depth);
+  }
+}
+
+/** The content bound for one surviving node, composed where it will be placed. */
+function composePlannedFor(
+  plan: NodePlan | undefined,
+  ctx: InlineContext
+): void {
+  if (plan?.slots === undefined) return;
+  for (const content of plan.slots.values()) placedContent(content, ctx);
+}
+
+/** The same question, asked of every child forest a surviving node holds. */
+function composeSlotsUnder(
+  node: ResolvedBlockNode,
+  ctx: InlineContext,
+  depth: number
+): void {
+  const slots = node.slots;
+  if (!isPlainRecord(slots)) return;
+  // The same `unknown` view the clone takes: a stored slot value that is not
+  // an array holds no nodes to reach.
+  const stored = slots as Record<string, unknown>;
+  for (const name of Object.keys(stored)) {
+    const children = ownEntry(stored, name);
+    if (!Array.isArray(children)) continue;
+    composeSurvivingSlots(children as ResolvedBlockNode[], ctx, depth + 1);
+  }
+}
+
+/**
+ * Compose this instance's OWN slot content before the definition is cloned.
+ *
+ * Nested content arrives composed in its component's scope and needs no pass;
+ * an instance supplying nothing has no plan to walk for.
+ */
+function composeOwnedSlots(
+  definition: ComponentDocument,
+  ctx: InlineContext,
+  supplied: Record<string, ResolvedBlockNode[]> | undefined,
+  owned: boolean
+): void {
+  if (!owned || supplied === undefined) return;
+  composeSurvivingSlots(definition.nodes, ctx, 1);
+}
+
+/**
+ * Whether this definition node and everything under it reaches a reader.
+ *
+ * ONE predicate, because two passes ask it about the same node and a
+ * disagreement between them is silent: the pass that composes the page's slot
+ * content would prepare a region the clone then drops, or withhold one the
+ * clone then serves and leave it empty.
+ *
+ * An override that SHOWS the node answers the gate for it — `scopeNode`
+ * removes the envelope for `plan.visible === true`, so asking
+ * `isConditionGated` of the scoped copy gives the same answer this does of the
+ * stored one.
+ */
+function survivesGating(
+  node: ResolvedBlockNode,
+  plan: NodePlan | undefined
+): boolean {
+  if (plan?.visible === false) return false;
+  if (plan?.visible === true) return true;
+  return !isConditionGated(node);
 }
 
 /**

--- a/packages/blocks-engine/src/resolve-instances.ts
+++ b/packages/blocks-engine/src/resolve-instances.ts
@@ -312,6 +312,7 @@ export function resolveComponentInstances(
   const run: ResolveRun = {
     definitions,
     maxDepth: limits.maxDepth,
+    maxNodes: limits.maxNodes,
     maxComposedDepth: options.maxComposedDepth ?? MAX_COMPOSED_DEPTH,
     // What is LEFT under the cap, not the cap itself. `maxNodes` bounds a
     // document, and the composed tree IS the document every later pass walks —
@@ -347,6 +348,12 @@ export function resolveComponentInstances(
 interface ResolveRun {
   definitions: ComponentLookup;
   maxDepth: number;
+  /**
+   * The document cap, kept beside the remaining budget rather than derived
+   * from it. `budget` is what is LEFT, so a pass that needs to bound its own
+   * work by the cap — the slot prepass does — cannot recover the cap from it.
+   */
+  maxNodes: number;
   maxComposedDepth: number;
   /** Nodes this resolution may still produce, across every instance. */
   budget: number;
@@ -1510,16 +1517,37 @@ function cloneDefinitionNode(
 function composeSurvivingSlots(
   nodes: readonly ResolvedBlockNode[],
   ctx: InlineContext,
-  depth: number
+  depth: number,
+  work: WorkBudget
 ): void {
   if (depth > ctx.run.maxDepth) return;
   for (const node of nodes) {
+    // Charged before the entry is judged, the way the clone charges. A
+    // definition nothing validated can hold a million siblings, and the depth
+    // bound says nothing about breadth — so without this the pass walks all of
+    // them to prepare content the clone refuses a moment later for `budget`.
+    if (work.left <= 0) return;
+    work.left -= 1;
     if (!isPlainRecord(node) || typeof node.id !== "string") continue;
     const plan = ctx.plans.get(node.id);
     if (!survivesGating(node, plan)) continue;
     composePlannedFor(plan, ctx);
-    composeSlotsUnder(node, ctx, depth);
+    composeSlotsUnder(node, plan, ctx, depth, work);
   }
+}
+
+/**
+ * How many entries the slot prepass may still visit.
+ *
+ * Its own counter rather than the run's node budget, because they measure
+ * different things: the run's is what the composed DOCUMENT may still hold,
+ * and spending it here would refuse a page for nodes it never produced.
+ * Running out is safe — the content it did not reach is composed at placement
+ * as it was before, so the bound costs the ordering benefit for that content
+ * and never the content itself.
+ */
+interface WorkBudget {
+  left: number;
 }
 
 /** The content bound for one surviving node, composed where it will be placed. */
@@ -1531,11 +1559,22 @@ function composePlannedFor(
   for (const content of plan.slots.values()) placedContent(content, ctx);
 }
 
-/** The same question, asked of every child forest a surviving node holds. */
+/**
+ * The same question, asked of every child forest a surviving node still holds.
+ *
+ * A slot the instance FILLS is skipped, mirroring `copyStoredSlots`: the plan
+ * replaces those children wholesale, so the clone never reaches them and
+ * nothing bound for a node inside them is ever placed. Walking them anyway
+ * composed content for a target the page had already replaced, which put a
+ * component nobody can receive into `referenced` and its unresolvable
+ * instances into `unresolved`.
+ */
 function composeSlotsUnder(
   node: ResolvedBlockNode,
+  plan: NodePlan | undefined,
   ctx: InlineContext,
-  depth: number
+  depth: number,
+  work: WorkBudget
 ): void {
   const slots = node.slots;
   if (!isPlainRecord(slots)) return;
@@ -1543,9 +1582,15 @@ function composeSlotsUnder(
   // an array holds no nodes to reach.
   const stored = slots as Record<string, unknown>;
   for (const name of Object.keys(stored)) {
+    if (plan?.slots?.has(name) === true) continue;
     const children = ownEntry(stored, name);
     if (!Array.isArray(children)) continue;
-    composeSurvivingSlots(children as ResolvedBlockNode[], ctx, depth + 1);
+    composeSurvivingSlots(
+      children as ResolvedBlockNode[],
+      ctx,
+      depth + 1,
+      work
+    );
   }
 }
 
@@ -1562,7 +1607,7 @@ function composeOwnedSlots(
   owned: boolean
 ): void {
   if (!owned || supplied === undefined) return;
-  composeSurvivingSlots(definition.nodes, ctx, 1);
+  composeSurvivingSlots(definition.nodes, ctx, 1, { left: ctx.run.maxNodes });
 }
 
 /**


### PR DESCRIPTION
Follow-up to #1525, closing the P2 Codex raised on it. Reproduced, and confirmed as a **regression #1525 introduced** rather than a pre-existing fault: the same fixture passes on the eager implementation and fails on the deferred one.

## The finding

Composing the page's slot content at **placement** is what stopped a gated target paying for a tree nobody receives. But it also moved *when* the room that content releases arrives. Replacing an instance frees the node it occupied, and placement happens part-way through cloning the definition — so a sibling cloned before the slot target could spend that room first.

With `maxNodes: 2`, a host holding one instance plus one node of supplied content, an outer definition of `[sibling, slot-target]`, and an empty inner definition: the composed tree is exactly two nodes and fits, but the clone charged for `sibling`, hit zero, and refused the whole instance with `budget`. Whether a page fit depended on where the author happened to put the slot in the definition.

## The fix

Compose the surviving targets' content **before** the clone, so the room is available to the whole definition rather than only to the nodes after the slot.

The discard is kept: survivorship is decided by `survivesGating`, which is now the **one** predicate both passes ask. That mattered enough to extract — two passes answering "does this subtree reach a reader" separately fail silently in both directions, either preparing a region the clone drops or withholding one the clone serves and leaving it empty. An override that *shows* a node answers the gate for it, since `scopeNode` removes the envelope for `plan.visible === true`.

`placedContent` marks what it composes, so the clone reuses this work instead of repeating it, and nested content — already composed in its own scope — needs no pass at all.

## fallow caught the first attempt

The pre-pass landed at cyclomatic 12 / cognitive 19 (CRAP 43.1) and pushed `expandInstance` to 10, so `fallow` failed with `complexity_introduced: 2`. Refactored rather than suppressed: the walk is now `composeSurvivingSlots` / `composePlannedFor` / `composeSlotsUnder`, and hoisting `owned` out of `expandInstance` put it back where it was. Now `pass` with 0 introduced on all four dimensions.

## Gates

`build` 0 · `check-types` 0 · `lint` 0 · `check:comments` 0 · `fallow` **pass**, 0 introduced · `changeset status` 0, one changeset, 25 packages.

blocks-engine 1895 (+1) · blocks-react 1125 · plugin-page-builder 609. Break-verification with counts held at 83: dropping the pre-pass kills the budget test; letting the pre-pass ignore gating kills the gated-target test.