### PR TITLE
fix(blocks-engine): give the slot prepass back what the clone gives back

### DIFF
--- a/.changeset/hidden-blocks-cost-a-page-nothing.md
+++ b/.changeset/hidden-blocks-cost-a-page-nothing.md
@@ -1,0 +1,34 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A page that exactly fills its block limit is no longer refused because of parts
+of a component that were hidden anyway. Hiding a block inside a component costs
+the page nothing, and the step that prepares the page's own content for the
+regions of that component was counting those hidden blocks against the page —
+so a component with several hidden blocks before a region could push an
+otherwise valid page over the limit.

--- a/.changeset/hidden-blocks-cost-a-page-nothing.md
+++ b/.changeset/hidden-blocks-cost-a-page-nothing.md
@@ -32,3 +32,7 @@ the page nothing, and the step that prepares the page's own content for the
 regions of that component was counting those hidden blocks against the page —
 so a component with several hidden blocks before a region could push an
 otherwise valid page over the limit.
+
+Blocks hidden by a visibility CONDITION still count, and they should: the block
+itself is still placed on the page until the condition is evaluated, so the
+page pays for it either way.

--- a/packages/blocks-engine/src/resolve-instances.test.ts
+++ b/packages/blocks-engine/src/resolve-instances.test.ts
@@ -970,6 +970,38 @@ describe("resolveComponentInstances what an instance carries", () => {
     expect(result.referenced).toEqual(["hero"]);
   });
 
+  it("keeps condition-gated nodes charged against the prepass cap", () => {
+    // A gate and an override both stop a node being served, and the clone
+    // treats them differently: it emits NOTHING for an override that hides,
+    // and gives the charge back — but it emits the node itself, still gated,
+    // for a condition, and keeps the charge. A prepass that refunds both reads
+    // an arbitrarily wide definition for free.
+    const gate = { conditions: [[{ field: "tier", op: "eq", value: "vip" }]] };
+    const definition = component(
+      [
+        node("g1", { visibility: gate }),
+        node("g2", { visibility: gate }),
+        node("g3", { visibility: gate }),
+        node("g4", { visibility: gate }),
+        node("sib"),
+        box("target", []),
+      ],
+      { slots: { tail: { label: "Tail", nodeId: "target", slot: "children" } } }
+    );
+    const doc = page([
+      instance("i1", "hero", {}, { slots: { tail: [instance("s1", "deep")] } }),
+    ]);
+
+    const result = resolveComponentInstances(
+      doc,
+      defs({ hero: definition, deep: component([]) }),
+      { limits: { ...DEFAULT_LIMITS, maxNodes: 2 } }
+    );
+
+    expect(result.unresolved.map(e => e.reason)).toEqual(["budget"]);
+    expect(result.referenced).toEqual(["hero"]);
+  });
+
   it("crosses nodes an override removed to reach a later slot target", () => {
     // The clone gives back the charge for a node that emits nothing, so four
     // overridden-away roots cost the composed document nothing and the result

--- a/packages/blocks-engine/src/resolve-instances.test.ts
+++ b/packages/blocks-engine/src/resolve-instances.test.ts
@@ -970,6 +970,54 @@ describe("resolveComponentInstances what an instance carries", () => {
     expect(result.referenced).toEqual(["hero"]);
   });
 
+  it("crosses nodes an override removed to reach a later slot target", () => {
+    // The clone gives back the charge for a node that emits nothing, so four
+    // overridden-away roots cost the composed document nothing and the result
+    // fits. A prepass counter that charges them anyway stops before the slot
+    // target, the content is composed at placement instead, and the ordering
+    // this pass exists to fix comes back — as a refusal.
+    const definition = component(
+      [
+        node("h1"),
+        node("h2"),
+        node("h3"),
+        node("h4"),
+        node("sib"),
+        box("target", []),
+      ],
+      {
+        exposed: ["h1", "h2", "h3", "h4"].map((nodeId, index) => ({
+          id: `x${String(index + 1)}`,
+          label: `Show ${nodeId}`,
+          nodeId,
+          // Carried because the published type requires it of every exposure;
+          // a `visibility` one decides whether the node is served at all, so
+          // `applyExposure` answers before it reads a path.
+          propPath: "hidden",
+          type: "visibility" as const,
+        })),
+        slots: { tail: { label: "Tail", nodeId: "target", slot: "children" } },
+      }
+    );
+    const doc = page([
+      instance(
+        "i1",
+        "hero",
+        { overrides: { x1: false, x2: false, x3: false, x4: false } },
+        { slots: { tail: [instance("s1", "empty")] } }
+      ),
+    ]);
+
+    const result = resolveComponentInstances(
+      doc,
+      defs({ hero: definition, empty: component([]) }),
+      { limits: { ...DEFAULT_LIMITS, maxNodes: 2 } }
+    );
+
+    expect(result.unresolved).toEqual([]);
+    expect(result.referenced).toEqual(["hero", "empty"]);
+  });
+
   it("does not compose content bound for a default subtree the page replaced", () => {
     // Two exposed slots: one on a container, one on a node sitting inside that
     // container's DEFAULT children. Filling the outer slot replaces those

--- a/packages/blocks-engine/src/resolve-instances.ts
+++ b/packages/blocks-engine/src/resolve-instances.ts
@@ -1530,7 +1530,16 @@ function composeSurvivingSlots(
     work.left -= 1;
     if (!isPlainRecord(node) || typeof node.id !== "string") continue;
     const plan = ctx.plans.get(node.id);
-    if (!survivesGating(node, plan)) continue;
+    if (!survivesGating(node, plan)) {
+      // Given back, exactly as the clone gives back the budget for a node that
+      // emits nothing. A definition whose leading nodes are all overridden away
+      // costs the composed document nothing, so charging this pass for them
+      // stopped it before a later slot target — and the content it did not
+      // reach was composed at placement, which is the ordering this pass exists
+      // to fix, arriving back as a refusal.
+      work.left += 1;
+      continue;
+    }
     composePlannedFor(plan, ctx);
     composeSlotsUnder(node, plan, ctx, depth, work);
   }

--- a/packages/blocks-engine/src/resolve-instances.ts
+++ b/packages/blocks-engine/src/resolve-instances.ts
@@ -1531,13 +1531,20 @@ function composeSurvivingSlots(
     if (!isPlainRecord(node) || typeof node.id !== "string") continue;
     const plan = ctx.plans.get(node.id);
     if (!survivesGating(node, plan)) {
-      // Given back, exactly as the clone gives back the budget for a node that
-      // emits nothing. A definition whose leading nodes are all overridden away
-      // costs the composed document nothing, so charging this pass for them
-      // stopped it before a later slot target — and the content it did not
-      // reach was composed at placement, which is the ordering this pass exists
-      // to fix, arriving back as a refusal.
-      work.left += 1;
+      // Refunded for the OVERRIDE only, because that is the one the clone
+      // refunds. The two ways a node stops being served end differently there:
+      // an override that hides emits nothing and the charge comes back, while
+      // a condition-gated node is emitted STANDING — the pass that prunes it
+      // wants it there — and its charge stays spent.
+      //
+      // Mirroring the wrong one is not a rounding error in either direction.
+      // Refunding neither stops this pass before a slot target in a definition
+      // whose leading nodes are all overridden away, and the content it did
+      // not reach is composed at placement — the ordering this pass exists to
+      // fix, arriving back as a refusal. Refunding both lets an arbitrarily
+      // wide gated definition be read for free, which is the breadth bound
+      // gone.
+      if (plan?.visible === false) work.left += 1;
       continue;
     }
     composePlannedFor(plan, ctx);


### PR DESCRIPTION
Follow-up to #1526, which merged at 10:22 while a Codex review submitted at 10:27 was still landing. Two P1s, and they got different answers — one is a real regression, the other is not.

## Fixed: the prepass counter starved by hidden nodes (P1)

The work counter charged for every entry visited, including nodes an override removes. The clone **refunds** those — a node that emits nothing costs the composed document nothing — so a definition whose leading nodes are all hidden stopped the prepass before a later slot target. The content it did not reach was then composed at placement, which is the ordering the pass exists to fix, arriving back as a refusal for `budget`.

Reproduced with `maxNodes: 2`, four overridden-away roots, a sibling and a slot target: `{i1, hero, budget}` for a two-node result that fits. The counter now mirrors the clone exactly — charged before the entry is judged, given back when the node will emit nothing.

*(My first fixture did not reproduce it, because I left out the sibling Codex named. Adding it reproduced immediately — worth saying, since a non-reproducing probe is a reason to re-read the report, not to dismiss the finding.)*

## Not fixed, because it is not a regression: slot composition order (P1)

The finding is **real as a property** and I could not confirm the part that made it a regression. It says reversing the key order "succeeds on the parent implementation"; I built the scenario and ran it against both.

- Current implementation, growing slot declared first: refused for `budget`.
- Current implementation, order reversed: composes.
- **Parent implementation (eager composition restored), growing slot first: also refused for `budget`.**

So order-dependence is not something this lane introduced — it is a property of a greedy budget, where the same items both consume and release room, and the parent has it identically on this input. My first attempt at that control was worthless, incidentally: the patch that was supposed to restore the parent failed its assertion, so the "control" ran against unmodified source and agreed with itself. The result above is from a run where the restoration was verified in both the source and the rebuilt `dist`.

Making it order-independent means releasing all replaceable content before composing any expansion — a change to how the budget is accounted, not a patch to this pass, and it would want its own tests and its own review. Filed as `task:pb6-slot-budget-order-independence` rather than smuggled into a fix PR. Happy to take it next if you would rather have it now.

## Gates

`build` 0 · `check-types` 0 · `lint` 0 · `check:comments` 0 · `fallow` **pass**, 0 introduced · `changeset status` 0, one changeset, 25 packages.

blocks-engine 1898 (+1) · blocks-react 1125. Break-verification with the count held at 86: charging the prepass for a node the clone refunds kills the new test.

`check-types` caught the fixture too — a `visibility` exposure still owes `label` and `propPath`, which vitest was happy to run without.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed slot resolution so content hidden by visibility overrides no longer consumes processing capacity unnecessarily.
  - Preserved budget usage for condition-gated content, ensuring later slots are correctly blocked when appropriate.

- **Tests**
  - Added coverage for budget handling with condition-gated and visibility-overridden content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->