### PR TITLE
feat(nextly): count what is not live yet, and say where you left off

### DIFF
--- a/.changeset/count-what-is-not-live-yet.md
+++ b/.changeset/count-what-is-not-live-yet.md
@@ -49,9 +49,14 @@ The access decision lives in the resolver, which is the difference from
 caller through and adds nothing; `VersionsService` has no authorization at all,
 and none of its methods takes an actor. A resolver that simply called it would
 answer an install-wide number to a reader entitled to part of it, so the reads
-are bounded by the same permission resolution the collections listing uses --
-where an empty allowlist means no readable collections and answers zero, rather
-than being read as no filter.
+are bounded by asking the access layer per registered entity -- the same
+decision the dashboard's own endpoints take. That is not the same as filtering
+the caller's permission slugs, in either direction: an API key is judged on its
+OWN stamped scope rather than on the roles of whoever minted it, and a
+collection authorized or refused purely in code is decided by its rule rather
+than by a permission row. The answer is always enumerated, so a caller who may
+read nothing gets exactly nothing rather than a value that could be read as no
+filter at all.
 
 The card publishes the document's identity and its instant, never the snapshot:
 that column is the unpublished content itself.

--- a/.changeset/count-what-is-not-live-yet.md
+++ b/.changeset/count-what-is-not-live-yet.md
@@ -1,0 +1,57 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The dashboard can say how much work is waiting: `system:versions` answers how
+many documents hold edits that are not live, and which ones were touched most
+recently.
+
+That needed a capability the data layer did not have. There was no `count`
+anywhere in it -- collection totals go through an access-controlled path built
+for collection tables, and nothing could count a system table, so a caller
+wanting a number selected the rows and measured the array. The adapter now has
+one, with `distinctOn` for the case that makes it worth having: a working draft
+is one row per document per LOCALE, so "14 documents have unpublished changes"
+counted from rows says 42 for an install translating into three languages.
+
+`distinctOn` compiles to `COUNT(*)` over a `SELECT DISTINCT` subquery and never
+to `COUNT(DISTINCT a, b)`. The inline form is not portable and fails in the
+direction hardest to notice -- MySQL accepts it, PostgreSQL needs a row
+constructor, and SQLite rejects it outright -- so a query written against one
+engine is a syntax error on another. It is exercised against all three.
+
+The access decision lives in the resolver, which is the difference from
+`system:releases`. That service authorizes itself, so its resolver hands the
+caller through and adds nothing; `VersionsService` has no authorization at all,
+and none of its methods takes an actor. A resolver that simply called it would
+answer an install-wide number to a reader entitled to part of it, so the reads
+are bounded by the same permission resolution the collections listing uses --
+where an empty allowlist means no readable collections and answers zero, rather
+than being read as no filter.
+
+The card publishes the document's identity and its instant, never the snapshot:
+that column is the unpublished content itself.

--- a/packages/adapter-drizzle/src/adapter.ts
+++ b/packages/adapter-drizzle/src/adapter.ts
@@ -244,6 +244,53 @@ interface UpdateCapableDb {
   };
 }
 
+/** The one-column shape a count projection selects. */
+interface CountRow {
+  value: unknown;
+}
+
+/**
+ * A `$dynamic()` count select, whose WHERE is applied only when there is one.
+ *
+ * Both branches are awaitable, which is the property that makes the conditional
+ * work: the statement is a complete query with or without a condition, so
+ * neither arm is a builder still waiting for something.
+ */
+interface CountableSelect extends PromiseLike<CountRow[]> {
+  where(condition: unknown): PromiseLike<CountRow[]>;
+}
+
+/**
+ * A `SELECT DISTINCT` that can still be named as a subquery after a WHERE.
+ *
+ * `where` returns the same shape rather than a thenable, because this select is
+ * never executed on its own — it is aliased and counted over.
+ */
+interface AliasableSelect {
+  where(condition: unknown): AliasableSelect;
+  as(alias: string): unknown;
+}
+
+/**
+ * The fragment of Drizzle's select builder `count` uses, spelled dialect-neutrally.
+ *
+ * Declared for the same reason as {@link UpdateCapableDb}: the three dialects' builders carry
+ * different type parameters but agree on these chains, so naming just the chains keeps the compiler
+ * checking the calls while leaving the parts that genuinely differ outside the contract. Casting to
+ * `any` instead would compile whatever it was handed, so a dialect changing one of these signatures
+ * would break counts at runtime with nothing failing at build time.
+ */
+interface CountCapableDb {
+  select(projection: Record<string, unknown>): {
+    from(source: unknown): PromiseLike<CountRow[]> & {
+      $dynamic(): CountableSelect;
+    };
+  };
+  selectDistinct(projection: Record<string, unknown>): {
+    from(table: unknown): { $dynamic(): AliasableSelect };
+  };
+}
+
 export abstract class DrizzleAdapter {
   // ============================================================
   // Abstract Methods (MUST be implemented by subclasses)
@@ -863,6 +910,27 @@ export abstract class DrizzleAdapter {
     ) {
       return undefined;
     }
+    const { projection } = this.resolveColumns(tableObj, names);
+    return Object.keys(projection).length ? projection : undefined;
+  }
+
+  /**
+   * The requested column names split into what this table has and what it does not.
+   *
+   * One resolution, reported both ways, because two callers need different halves
+   * of the same answer: a projection drops what it cannot find, while a distinct
+   * count has to REFUSE it. Resolving twice would let the two disagree about what
+   * "found" means — the SQL-name alias below is exactly the kind of detail a
+   * second implementation gets wrong — and the count would then reject a column
+   * the projection happily uses.
+   *
+   * Both spellings resolve: a caller may name the Drizzle property or the SQL
+   * column, and either maps to the same projection key.
+   */
+  protected resolveColumns(
+    tableObj: unknown,
+    names: readonly string[]
+  ): { projection: Record<string, unknown>; unresolved: string[] } {
     const cols = getColumns(tableObj as never);
     const byAnyName: Record<string, { jsName: string; col: unknown }> = {};
     for (const [jsName, col] of Object.entries(cols)) {
@@ -871,11 +939,13 @@ export abstract class DrizzleAdapter {
       if (typeof sqlName === "string") byAnyName[sqlName] = { jsName, col };
     }
     const projection: Record<string, unknown> = {};
+    const unresolved: string[] = [];
     for (const name of names) {
       const hit = byAnyName[name];
       if (hit) projection[hit.jsName] = hit.col;
+      else unresolved.push(name);
     }
-    return Object.keys(projection).length ? projection : undefined;
+    return { projection, unresolved };
   }
 
   // ============================================================
@@ -1178,26 +1248,34 @@ export abstract class DrizzleAdapter {
   /**
    * The columns a distinct count groups by, or `undefined` for a row count.
    *
-   * 🔴 A `distinctOn` naming no column this table has resolves to no
-   * projection, and falling through to a row count there would answer a
-   * DIFFERENT question than the caller asked -- silently, and larger. Refused
-   * instead, where the mistake was made.
+   * 🔴 EVERY named column must resolve, not merely one of them. A `distinctOn`
+   * naming no column this table has would fall through to a row count, and one
+   * naming a valid column beside a misspelled or since-removed column would
+   * count distinct over a NARROWER key than the caller asked for. Both answer a
+   * different question than the one asked, silently; the second is the worse of
+   * the two, because a subset key groups more rows together and so UNDERCOUNTS,
+   * which reads as a plausible number rather than as a fault. Refused here,
+   * where the mistake was made, rather than surfacing as a wrong figure.
    */
   private countProjection(
     tableObj: unknown,
     table: string,
     options: CountOptions | undefined
   ): Record<string, unknown> | undefined {
-    const projection = this.buildColumnProjection(
+    const distinctOn = options?.distinctOn;
+    if (!distinctOn?.length) return undefined;
+    const { projection, unresolved } = this.resolveColumns(
       tableObj,
-      options?.distinctOn
+      distinctOn
     );
-    if (projection || !options?.distinctOn?.length) return projection;
-    throw this.createDatabaseError(
-      "query",
-      `None of the distinctOn columns exist on "${table}": ${options.distinctOn.join(", ")}`,
-      undefined
-    );
+    if (unresolved.length > 0) {
+      throw this.createDatabaseError(
+        "query",
+        `distinctOn names ${unresolved.length === 1 ? "a column" : "columns"} that do not exist on "${table}": ${unresolved.join(", ")}`,
+        undefined
+      );
+    }
+    return projection;
   }
 
   /**
@@ -1209,16 +1287,14 @@ export abstract class DrizzleAdapter {
    * before a reader would have.
    */
   private async countDistinctRows(
-    db: unknown,
+    db: CountCapableDb,
     tableObj: unknown,
     projection: Record<string, unknown>,
     where: unknown
   ): Promise<number> {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const client = db as any;
-    const inner = client.selectDistinct(projection).from(tableObj).$dynamic();
+    const inner = db.selectDistinct(projection).from(tableObj).$dynamic();
     const distinctRows = where ? inner.where(where) : inner;
-    const [row] = await client
+    const [row] = await db
       .select({ value: count() })
       .from(distinctRows.as("nextly_distinct"));
     return Number(row?.value ?? 0);
@@ -1226,13 +1302,11 @@ export abstract class DrizzleAdapter {
 
   /** `COUNT(*)` over the table itself. */
   private async countAllRows(
-    db: unknown,
+    db: CountCapableDb,
     tableObj: unknown,
     where: unknown
   ): Promise<number> {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const client = db as any;
-    const base = client.select({ value: count() }).from(tableObj).$dynamic();
+    const base = db.select({ value: count() }).from(tableObj).$dynamic();
     const [row] = await (where ? base.where(where) : base);
     return Number(row?.value ?? 0);
   }
@@ -1262,8 +1336,11 @@ export abstract class DrizzleAdapter {
   ): Promise<number> {
     const tableObj = this.requireTableObject(table);
     try {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const db = executor ?? this.getDrizzle<any>();
+      // Transaction executor when supplied, otherwise the pooled instance —
+      // narrowed to the fragment of the select builder these two counts use,
+      // the same seam `update` takes with `UpdateCapableDb`.
+      const db = (executor ??
+        this.getDrizzle<CountCapableDb>()) as CountCapableDb;
       const where = options?.where
         ? buildDrizzleWhere(tableObj as never, options.where)
         : undefined;

--- a/packages/adapter-drizzle/src/adapter.ts
+++ b/packages/adapter-drizzle/src/adapter.ts
@@ -11,7 +11,7 @@
  * @packageDocumentation
  */
 
-import { getColumns } from "drizzle-orm";
+import { count, getColumns } from "drizzle-orm";
 import type { AnyRelations, SQL } from "drizzle-orm";
 
 import { buildDrizzleOrderBy } from "./drizzle-order";
@@ -24,6 +24,7 @@ import type {
   SupportedDialect,
   SqlParam,
   WhereClause,
+  CountOptions,
   SelectOptions,
   InsertOptions,
   UpdateOptions,
@@ -1163,6 +1164,118 @@ export abstract class DrizzleAdapter {
    * });
    * ```
    */
+  /** The registered table object, or a refusal naming what is missing. */
+  private requireTableObject(table: string): unknown {
+    const tableObj = this.getTableObject(table);
+    if (tableObj) return tableObj;
+    throw this.createDatabaseError(
+      "query",
+      `Table "${table}" not found in schema registry. Ensure setTableResolver() has been called during boot.`,
+      undefined
+    );
+  }
+
+  /**
+   * The columns a distinct count groups by, or `undefined` for a row count.
+   *
+   * 🔴 A `distinctOn` naming no column this table has resolves to no
+   * projection, and falling through to a row count there would answer a
+   * DIFFERENT question than the caller asked -- silently, and larger. Refused
+   * instead, where the mistake was made.
+   */
+  private countProjection(
+    tableObj: unknown,
+    table: string,
+    options: CountOptions | undefined
+  ): Record<string, unknown> | undefined {
+    const projection = this.buildColumnProjection(
+      tableObj,
+      options?.distinctOn
+    );
+    if (projection || !options?.distinctOn?.length) return projection;
+    throw this.createDatabaseError(
+      "query",
+      `None of the distinctOn columns exist on "${table}": ${options.distinctOn.join(", ")}`,
+      undefined
+    );
+  }
+
+  /**
+   * `COUNT(*)` over a `SELECT DISTINCT` subquery.
+   *
+   * Its own function because it is a genuinely different query from the plain
+   * count rather than a variation on one, and because building both inline made
+   * the public method a chain of decisions the complexity gate objected to
+   * before a reader would have.
+   */
+  private async countDistinctRows(
+    db: unknown,
+    tableObj: unknown,
+    projection: Record<string, unknown>,
+    where: unknown
+  ): Promise<number> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const client = db as any;
+    const inner = client.selectDistinct(projection).from(tableObj).$dynamic();
+    const distinctRows = where ? inner.where(where) : inner;
+    const [row] = await client
+      .select({ value: count() })
+      .from(distinctRows.as("nextly_distinct"));
+    return Number(row?.value ?? 0);
+  }
+
+  /** `COUNT(*)` over the table itself. */
+  private async countAllRows(
+    db: unknown,
+    tableObj: unknown,
+    where: unknown
+  ): Promise<number> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const client = db as any;
+    const base = client.select({ value: count() }).from(tableObj).$dynamic();
+    const [row] = await (where ? base.where(where) : base);
+    return Number(row?.value ?? 0);
+  }
+
+  /**
+   * How many rows match, or how many DISTINCT combinations of some columns do.
+   *
+   * The data layer had no count at all: collection totals go through
+   * `countEntries`, an access-controlled path built for collection tables, and
+   * nothing could count a system table. A caller wanting one selected the rows
+   * and measured the array, which transfers every row to learn a number and
+   * cannot be bounded without making the number wrong.
+   *
+   * 🔴 `distinctOn` compiles to `COUNT(*)` over a `SELECT DISTINCT` SUBQUERY,
+   * never to `COUNT(DISTINCT a, b)`. The inline form is not portable and fails
+   * in the direction that is hardest to notice -- MySQL accepts it, PostgreSQL
+   * needs a row constructor, and SQLite rejects it outright with "wrong number
+   * of arguments to function count()" -- so a query written against one engine
+   * is a syntax error on another. The subquery is the single form all three
+   * accept, and building it here rather than at each call site is what keeps
+   * the answer identical per dialect.
+   */
+  async count(
+    table: string,
+    options?: CountOptions,
+    executor?: unknown
+  ): Promise<number> {
+    const tableObj = this.requireTableObject(table);
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const db = executor ?? this.getDrizzle<any>();
+      const where = options?.where
+        ? buildDrizzleWhere(tableObj as never, options.where)
+        : undefined;
+      const projection = this.countProjection(tableObj, table, options);
+      return projection
+        ? await this.countDistinctRows(db, tableObj, projection, where)
+        : await this.countAllRows(db, tableObj, where);
+    } catch (error) {
+      throw this.handleQueryError(error, "count", table);
+    }
+  }
+
   async selectOne<T = unknown>(
     table: string,
     options?: SelectOptions,

--- a/packages/adapter-drizzle/src/types/crud.ts
+++ b/packages/adapter-drizzle/src/types/crud.ts
@@ -15,6 +15,31 @@ import type { WhereClause, OrderBySpec, JoinSpec } from "./query";
  *
  * @public
  */
+/**
+ * What a COUNT asks for.
+ *
+ * 🔴 `distinctOn` is a column LIST rather than a boolean, and the difference is
+ * the whole reason this option exists: counting rows and counting the things
+ * those rows are about are different questions whenever a thing can own more
+ * than one row. A document holding a pending edit in three languages is one
+ * document and three version rows.
+ */
+export interface CountOptions {
+  /** Filter conditions, the same vocabulary `select` takes. */
+  where?: WhereClause;
+  /**
+   * Count DISTINCT combinations of these columns instead of rows.
+   *
+   * Compiled as `COUNT(*)` over a `SELECT DISTINCT` subquery rather than as
+   * `COUNT(DISTINCT a, b)`, because the latter is not portable: MySQL accepts
+   * it, PostgreSQL requires a row constructor, and SQLite rejects it outright
+   * with "wrong number of arguments to function count()". The subquery is the
+   * one form all three engines agree on, and it is what this compiles to on
+   * every dialect so the number cannot differ by engine.
+   */
+  distinctOn?: string[];
+}
+
 export interface SelectOptions {
   /** Specific columns to select (default: all columns) */
   columns?: string[];

--- a/packages/adapter-drizzle/src/types/index.ts
+++ b/packages/adapter-drizzle/src/types/index.ts
@@ -56,6 +56,7 @@ export { WHERE_OPERATORS } from "./query";
 // CRUD Operation Types
 // ============================================================
 export type {
+  CountOptions,
   SelectOptions,
   InsertOptions,
   UpdateOptions,

--- a/packages/nextly/src/api/authenticated-read.ts
+++ b/packages/nextly/src/api/authenticated-read.ts
@@ -15,7 +15,6 @@
  * @module api/authenticated-read
  */
 
-import type { ReadAccessCaller } from "../auth/entity-read-access";
 import type { AuthContext } from "../auth/middleware";
 import { isErrorResponse, requireAuthentication } from "../auth/middleware";
 import { toNextlyAuthError } from "../auth/middleware/to-nextly-error";
@@ -128,29 +127,10 @@ export async function readCaller(auth: AuthContext): Promise<ReadCaller> {
 }
 
 /**
- * The same caller, in the shape an ENTITY-LEVEL read decision reads.
- *
- * Derived from {@link ReadCaller} rather than rebuilt from the `AuthContext`,
- * and that is the whole point: `readCaller` has already resolved role IDs to
- * slugs, and resolving them a second time is both an extra database read per
- * request and a second chance to resolve them differently. One question, one
- * resolution — the narrower view is derived from the richer one.
- *
- * `authenticatedScope` is present only for an API key, so its presence IS the
- * auth method. Reading `actorType` rather than mere presence keeps that true if
- * a future actor kind starts carrying a scope: a non-key actor must not be
- * judged by `canReadEntity`'s api-key branch, which reads
- * `permissions` as the key's own `{action}-{resource}` grants.
+ * Re-exported from `auth/entity-read-access`, where it now lives beside the
+ * `ReadAccessCaller` it constructs and the decisions that consume it. Kept
+ * reachable here because every HTTP read endpoint arrives via this module, and
+ * because a domain module — which must not import from `api/` — needs the same
+ * conversion to bound a cross-entity read by its caller.
  */
-export function readAccessCaller(caller: ReadCaller): ReadAccessCaller {
-  const isApiKey = caller.authenticatedScope?.actorType === "apiKey";
-  return {
-    userId: caller.user.id,
-    authMethod: isApiKey ? "api-key" : "session",
-    // A session caller carries none here on purpose: its grants are resolved
-    // from the database by `checkAccess`. Handing it the key vocabulary would
-    // answer "denied" for every check.
-    permissions: isApiKey ? (caller.authenticatedScope?.permissions ?? []) : [],
-    roles: caller.user.roles ?? [],
-  };
-}
+export { readAccessCaller } from "../auth/entity-read-access";

--- a/packages/nextly/src/api/dashboard.test.ts
+++ b/packages/nextly/src/api/dashboard.test.ts
@@ -20,11 +20,14 @@ vi.mock("../init", () => ({
   getCachedNextly: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock("../di", () => ({
-  container: {
-    get: vi.fn(),
-  },
-}));
+const { containerGet } = vi.hoisted(() => ({ containerGet: vi.fn() }));
+// BOTH specifiers, because they are two module records: the handlers reach the
+// container through the barrel and `registered-content-slugs` through the
+// narrow module, so mocking one leaves the other reading the real container --
+// which answers nothing here and takes the registry read's `catch` branch,
+// reporting an empty candidate list as though the install had no collections.
+vi.mock("../di", () => ({ container: { get: containerGet } }));
+vi.mock("../di/container", () => ({ container: { get: containerGet } }));
 
 vi.mock("../services/lib/permissions", () => ({
   // `readCaller` (via `authenticated-read.ts`) resolves this to build the
@@ -41,7 +44,16 @@ vi.mock("../services/lib/permissions", () => ({
 const { readableEntities } = vi.hoisted(() => ({
   readableEntities: vi.fn(),
 }));
-vi.mock("../auth/entity-read-access", () => ({ readableEntities }));
+// Spread from the real module rather than replaced by a literal: this module
+// also publishes `readAccessCaller`, which the handlers use to derive the
+// identity a decision is taken under. A closed literal supplies only what it
+// names, so that conversion would arrive as `undefined` and every handler would
+// answer 500 -- a failure about the mock's shape wearing the costume of a
+// defect in the code under test.
+vi.mock("../auth/entity-read-access", async importOriginal => ({
+  ...(await importOriginal<typeof import("../auth/entity-read-access")>()),
+  readableEntities,
+}));
 
 import { isErrorResponse, requireAuthentication } from "../auth/middleware";
 import { container } from "../di";
@@ -100,23 +112,21 @@ function decidingCaller(): Record<string, unknown> {
 beforeEach(() => {
   vi.clearAllMocks();
   serviceStub = {};
-  (container.get as ReturnType<typeof vi.fn>).mockImplementation(
-    (name: string) => {
-      if (name === "collectionRegistryService") {
-        return {
-          getAllCollections: vi
-            .fn()
-            .mockResolvedValue([{ slug: "posts" }, { slug: "pages" }]),
-        };
-      }
-      if (name === "singleRegistryService") {
-        return {
-          getAllSingles: vi.fn().mockResolvedValue([{ slug: "site-settings" }]),
-        };
-      }
-      return serviceStub;
+  containerGet.mockImplementation((name: string) => {
+    if (name === "collectionRegistryService") {
+      return {
+        getAllCollections: vi
+          .fn()
+          .mockResolvedValue([{ slug: "posts" }, { slug: "pages" }]),
+      };
     }
-  );
+    if (name === "singleRegistryService") {
+      return {
+        getAllSingles: vi.fn().mockResolvedValue([{ slug: "site-settings" }]),
+      };
+    }
+    return serviceStub;
+  });
   // Admits everything by default, so a test that cares about the scope states
   // its own verdict and the rest are unaffected by it.
   readableEntities.mockImplementation(

--- a/packages/nextly/src/api/dashboard.ts
+++ b/packages/nextly/src/api/dashboard.ts
@@ -31,6 +31,7 @@ import {
   type ReadableResources,
   type ReadCaller,
 } from "../services/dashboard/readable-resources";
+import { registeredContentSlugs } from "../services/lib/registered-content-slugs";
 
 import { readAccessCaller, readCaller } from "./authenticated-read";
 import { respondData } from "./response-shapes";
@@ -54,9 +55,11 @@ async function getActivityLogService(): Promise<ActivityLogService> {
 /**
  * Every name the dashboard can describe, offered for a read decision.
  *
- * Three sources, and the third is the one that is easy to miss. The two content
- * registries give the collections and singles, so the set being authorized is
- * the set that would be counted. But the scope also bounds `/activity` and
+ * Three sources, and the third is the one that is easy to miss.
+ * {@link registeredContentSlugs} gives the collections and singles, so the set
+ * being authorized is the set that would be counted -- it is shared with the
+ * `system:versions` widget source, which bounds its cross-document read by the
+ * same candidates. But the scope also bounds `/activity` and
  * `recentChanges24h`, which filter `activity_log.collection` -- and that column
  * is a FREE STRING whose namespace is deliberately wider than the registries.
  * `recordSettingsActivity` files settings mutations under names that are
@@ -74,35 +77,9 @@ async function getActivityLogService(): Promise<ActivityLogService> {
  * `getRegisteredCollections` filters the registry list BY this scope, and
  * `filterByResource` can only ever narrow it -- a name that is not in the
  * registry cannot be added to it by appearing in the scope.
- *
- * A registry that cannot be reached contributes NOTHING rather than an
- * unbounded list -- an empty scope admits nothing, which is visible and
- * reportable; the alternative is a dashboard that widens when the container is
- * degraded.
  */
 async function registeredEntitySlugs(): Promise<string[]> {
-  const slugs: string[] = [...SETTINGS_ACTIVITY_NAMESPACES];
-  try {
-    const collections = await container
-      .get<{
-        getAllCollections: () => Promise<Array<{ slug: string }>>;
-      }>("collectionRegistryService")
-      .getAllCollections();
-    for (const collection of collections) slugs.push(String(collection.slug));
-  } catch {
-    // Unreachable registry: contribute nothing rather than guess.
-  }
-  try {
-    const singles = await container
-      .get<{
-        getAllSingles: () => Promise<Array<{ slug: string }>>;
-      }>("singleRegistryService")
-      .getAllSingles();
-    for (const single of singles) slugs.push(String(single.slug));
-  } catch {
-    // As above.
-  }
-  return slugs;
+  return [...SETTINGS_ACTIVITY_NAMESPACES, ...(await registeredContentSlugs())];
 }
 
 /**

--- a/packages/nextly/src/auth/entity-read-access.ts
+++ b/packages/nextly/src/auth/entity-read-access.ts
@@ -17,6 +17,7 @@ import { container } from "../di/container";
 import type { RBACAccessControlService } from "../domains/auth/services/rbac-access-control-service";
 import { NextlyError } from "../errors/nextly-error";
 import { parsePermissionSlug } from "../plugins/routes/permission-slug";
+import type { ReadCaller } from "../services/dashboard/readable-resources";
 import type {
   AccessControlContext,
   CollectionAccessControl,
@@ -38,6 +39,41 @@ export interface ReadAccessCaller {
   permissions: string[];
   /** Role slugs, already normalized (session roles arrive as ids). */
   roles: string[];
+}
+
+/**
+ * The same caller a read endpoint resolved, in the shape an ENTITY-LEVEL read
+ * decision reads.
+ *
+ * Derived from {@link ReadCaller} rather than rebuilt from the `AuthContext`,
+ * and that is the whole point: `readCaller` has already resolved role IDs to
+ * slugs, and resolving them a second time is both an extra database read per
+ * request and a second chance to resolve them differently. One question, one
+ * resolution — the narrower view is derived from the richer one.
+ *
+ * `authenticatedScope` is present only for an API key, so its presence IS the
+ * auth method. Reading `actorType` rather than mere presence keeps that true if
+ * a future actor kind starts carrying a scope: a non-key actor must not be
+ * judged by {@link canReadEntity}'s api-key branch, which reads `permissions` as
+ * the key's own `{action}-{resource}` grants.
+ *
+ * Here rather than in `api/authenticated-read`, where it began, because a DOMAIN
+ * module needs it too — `system:versions` bounds a cross-document read by what
+ * its caller may see — and `domains/` must not import from `api/`. Reproducing
+ * the conversion there instead would be a second implementation of an access
+ * decision, which is the failure this module exists to prevent.
+ */
+export function readAccessCaller(caller: ReadCaller): ReadAccessCaller {
+  const isApiKey = caller.authenticatedScope?.actorType === "apiKey";
+  return {
+    userId: caller.user.id,
+    authMethod: isApiKey ? "api-key" : "session",
+    // A session caller carries none here on purpose: its grants are resolved
+    // from the database by `checkAccess`. Handing it the key vocabulary would
+    // answer "denied" for every check.
+    permissions: isApiKey ? (caller.authenticatedScope?.permissions ?? []) : [],
+    roles: caller.user.roles ?? [],
+  };
 }
 
 /** The RBAC service, or undefined before the container is initialized. */

--- a/packages/nextly/src/database/__tests__/adapter-count.integration.test.ts
+++ b/packages/nextly/src/database/__tests__/adapter-count.integration.test.ts
@@ -137,4 +137,26 @@ describe.each(getConfiguredTestDialects())("adapter.count (%s)", dialect => {
       app.adapter.count(VERSIONS_TABLE, { distinctOn: ["not_a_column"] })
     ).rejects.toThrow(/distinctOn/);
   });
+
+  it("refuses a distinctOn where only SOME columns resolve", async () => {
+    // 🔴 The worse of the two, and the one a partial projection admits. A valid
+    // column beside a misspelled one counts distinct over a NARROWER key than
+    // was asked for, which groups more rows together and UNDERCOUNTS -- a
+    // plausible number rather than a visible fault. Here the accepted subset
+    // would answer 1 while the requested key answers 2.
+    const app = await boot(dialect);
+
+    for (const row of [
+      versionRow({ entryId: "e1", locale: "en" }),
+      versionRow({ entryId: "e2", locale: "en" }),
+    ]) {
+      await app.adapter.insert(VERSIONS_TABLE, row);
+    }
+
+    await expect(
+      app.adapter.count(VERSIONS_TABLE, {
+        distinctOn: ["scopeSlug", "entryIdd"],
+      })
+    ).rejects.toThrow(/entryIdd/);
+  });
 });

--- a/packages/nextly/src/database/__tests__/adapter-count.integration.test.ts
+++ b/packages/nextly/src/database/__tests__/adapter-count.integration.test.ts
@@ -1,0 +1,140 @@
+/**
+ * The adapter's COUNT primitive, against a real database.
+ *
+ * Only an integration test can establish this. `distinctOn` compiles to a
+ * `SELECT DISTINCT` subquery specifically because the inline
+ * `COUNT(DISTINCT a, b)` is not portable -- MySQL accepts it, PostgreSQL needs a
+ * row constructor, and SQLite rejects it with "wrong number of arguments to
+ * function count()". A unit test over a fake would assert the shape this file
+ * was written to avoid depending on, and would pass on a query no engine runs.
+ *
+ * Runs against whichever dialects the integration run configures; CI covers
+ * SQLite, Postgres and MySQL.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../../config";
+import {
+  createTestNextly,
+  getConfiguredTestDialects,
+  type TestDialect,
+  type TestNextly,
+} from "../../plugins/test-nextly";
+import { VERSIONS_TABLE } from "../../schemas/versions/types";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+async function boot(dialect: TestDialect): Promise<TestNextly> {
+  current = await createTestNextly({
+    dialect,
+    collections: [
+      defineCollection({
+        slug: "posts",
+        versions: { drafts: true },
+        fields: [text({ name: "title" })],
+      }),
+    ],
+  });
+  return current;
+}
+
+/** One version row: the columns the count reads, with the rest defaulted. */
+function versionRow(patch: {
+  entryId: string;
+  locale: string | null;
+  scopeSlug?: string;
+}) {
+  return {
+    id: crypto.randomUUID(),
+    scopeKind: "collection",
+    scopeSlug: patch.scopeSlug ?? "posts",
+    entryId: patch.entryId,
+    versionNo: null,
+    status: "draft",
+    isAutosave: false,
+    snapshot: JSON.stringify({}),
+    label: null,
+    locale: patch.locale,
+    sourceVersionNo: null,
+    createdBy: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+describe.each(getConfiguredTestDialects())("adapter.count (%s)", dialect => {
+  it("counts rows, and counts DISTINCT documents differently", async () => {
+    // 🔴 The two answers must differ, or the test cannot tell the primitive
+    // apart from one that ignores `distinctOn`. Three rows over two
+    // documents: one document edited in two locales, one in a single locale.
+    const app = await boot(dialect);
+    const adapter = app.adapter;
+
+    for (const row of [
+      versionRow({ entryId: "e1", locale: "en" }),
+      versionRow({ entryId: "e1", locale: "fr" }),
+      versionRow({ entryId: "e2", locale: "en" }),
+    ]) {
+      await adapter.insert(VERSIONS_TABLE, row);
+    }
+
+    expect(await adapter.count(VERSIONS_TABLE)).toBe(3);
+    expect(
+      await adapter.count(VERSIONS_TABLE, {
+        distinctOn: ["scopeKind", "scopeSlug", "entryId"],
+      })
+    ).toBe(2);
+  });
+
+  it("applies the filter to BOTH forms", async () => {
+    // The control on the where clause. A distinct count that dropped the
+    // filter would answer 2 here and look plausible.
+    const app = await boot(dialect);
+    const adapter = app.adapter;
+
+    for (const row of [
+      versionRow({ entryId: "e1", locale: "en" }),
+      versionRow({ entryId: "e1", locale: "fr" }),
+      versionRow({ entryId: "e2", locale: "en", scopeSlug: "pages" }),
+    ]) {
+      await adapter.insert(VERSIONS_TABLE, row);
+    }
+
+    const where = {
+      and: [{ column: "scopeSlug", op: "=" as const, value: "posts" }],
+    };
+    expect(await adapter.count(VERSIONS_TABLE, { where })).toBe(2);
+    expect(
+      await adapter.count(VERSIONS_TABLE, {
+        where,
+        distinctOn: ["scopeKind", "scopeSlug", "entryId"],
+      })
+    ).toBe(1);
+  });
+
+  it("counts zero without throwing when nothing matches", async () => {
+    const app = await boot(dialect);
+    expect(
+      await app.adapter.count(VERSIONS_TABLE, {
+        where: {
+          and: [{ column: "scopeSlug", op: "=" as const, value: "nope" }],
+        },
+        distinctOn: ["entryId"],
+      })
+    ).toBe(0);
+  });
+
+  it("refuses a distinctOn naming no column this table has", async () => {
+    // Counting rows there would answer a DIFFERENT question than the caller
+    // asked -- silently, and larger.
+    const app = await boot(dialect);
+    await expect(
+      app.adapter.count(VERSIONS_TABLE, { distinctOn: ["not_a_column"] })
+    ).rejects.toThrow(/distinctOn/);
+  });
+});

--- a/packages/nextly/src/di/__tests__/register-widgets-boot-wiring.test.ts
+++ b/packages/nextly/src/di/__tests__/register-widgets-boot-wiring.test.ts
@@ -86,7 +86,11 @@ describe("widget-registry reset at boot", () => {
     // Core's own system source is what boot itself writes, so the store is not
     // empty afterwards -- the same reason the widget assertion below names ids
     // rather than a count.
-    expect(listSources().map(source => source.id)).toEqual(["system:releases"]);
+    expect(
+      listSources()
+        .map(source => source.id)
+        .sort()
+    ).toEqual(["system:releases", "system:versions"]);
     // The previous boot's widget is gone; core's own cards are what boot
     // itself writes, so the store is not empty afterwards and asserting that
     // it was would only have held while core declared no widget.

--- a/packages/nextly/src/di/__tests__/register-widgets.test.ts
+++ b/packages/nextly/src/di/__tests__/register-widgets.test.ts
@@ -140,6 +140,27 @@ describe("resetWidgetRegistries", () => {
     expect(listWidgets()).toHaveLength(CORE_WIDGETS.length);
   });
 
+  it("leaves no core card querying a source nothing serves", () => {
+    // 🔴 A definition naming an unregistered source is a legal definition: it
+    // is refused at QUERY time, and only for the reader unlucky enough to hold
+    // the card. So renaming a source is silent on both sides -- the source and
+    // its own tests keep passing, and the card keeps naming what used to serve
+    // it. Sharing one declaration is what makes that impossible; this is what
+    // makes it CHECKED, since a future card could still spell the id by hand.
+    resetWidgetRegistries();
+
+    const queried = CORE_WIDGETS.filter(widget => widget.query).map(
+      widget => widget.query?.source
+    );
+    // The population, asserted before the verdict: with no querying card at all
+    // the loop below is vacuously satisfied, which is the shape of a check
+    // reporting on nothing.
+    expect(queried.length).toBeGreaterThan(0);
+    for (const source of queried) {
+      expect(getSource(String(source))).toBeDefined();
+    }
+  });
+
   it("still refuses a genuine duplicate WITHIN one boot", () => {
     // The negative control for both cases above. Clearing between boots must
     // not turn into clearing between registrations: two plugins claiming one

--- a/packages/nextly/src/di/__tests__/register-widgets.test.ts
+++ b/packages/nextly/src/di/__tests__/register-widgets.test.ts
@@ -33,6 +33,7 @@ import {
   systemResolver,
 } from "../../domains/widgets/system-sources";
 import { RELEASES_SOURCE_ID } from "../../domains/releases/releases-widget-source";
+import { VERSIONS_SOURCE_ID } from "../../domains/versions/versions-widget-source";
 import { resetWidgetRegistries } from "../registrations/register-widgets";
 
 beforeEach(() => {
@@ -74,9 +75,11 @@ describe("resetWidgetRegistries", () => {
     // empty -- core publishes its own system source in this same function, so
     // an emptiness assertion would only have held while it published none.
     expect(getSource("plugin:stripe/revenue")).toBeUndefined();
-    expect(listSources().map(source => source.id)).toEqual([
-      RELEASES_SOURCE_ID,
-    ]);
+    expect(
+      listSources()
+        .map(source => source.id)
+        .sort()
+    ).toEqual([RELEASES_SOURCE_ID, VERSIONS_SOURCE_ID].sort());
     // The proof that the clear is what made room: the same id registers again
     // without the conflict `registerSource` raises for a duplicate.
     expect(() => seedSource("plugin:stripe/revenue")).not.toThrow();

--- a/packages/nextly/src/di/registrations/register-versions.ts
+++ b/packages/nextly/src/di/registrations/register-versions.ts
@@ -11,12 +11,24 @@ import type { RegistrationContext } from "./types";
 
 /** Register the versions read service as a singleton. */
 export function registerVersionServices(ctx: RegistrationContext): void {
-  const { adapter } = ctx;
+  const { adapter, config } = ctx;
+
+  // A working draft is one row per document per LOCALE, so the configured
+  // locale count is how many rows one document can contribute to a
+  // cross-document read. The service needs it to bound the scan behind the
+  // recent-edits card; an install with no localization configured has exactly
+  // one, which is the default the service applies when this is absent.
+  const localeCount = config.localization?.locales.length;
 
   container.registerSingleton<VersionsService>(
     "versionsService",
     // The adapter satisfies VersionsDbApi structurally; reads run on the pool
     // (in-transaction capture passes its own tx context instead).
-    () => new VersionsService(adapter)
+    () =>
+      new VersionsService(adapter, {
+        ...(localeCount !== undefined && {
+          maxWorkingDraftsPerDocument: localeCount,
+        }),
+      })
   );
 }

--- a/packages/nextly/src/di/registrations/register-widgets.ts
+++ b/packages/nextly/src/di/registrations/register-widgets.ts
@@ -38,6 +38,7 @@
  */
 
 import { registerReleasesWidgetSource } from "../../domains/releases/releases-widget-source";
+import { registerVersionsWidgetSource } from "../../domains/versions/versions-widget-source";
 import { setContributedWidgets } from "../../domains/widgets/canonical";
 import { CORE_WIDGETS } from "../../domains/widgets/core-widgets";
 import { clearWidgets, registerWidget } from "../../domains/widgets/registry";
@@ -77,4 +78,5 @@ export function resetWidgetRegistries(
   // import it — that inversion is what would make the widgets package depend on
   // most of the codebase in order to offer a card.
   registerReleasesWidgetSource();
+  registerVersionsWidgetSource();
 }

--- a/packages/nextly/src/domains/releases/releases-widget-source.ts
+++ b/packages/nextly/src/domains/releases/releases-widget-source.ts
@@ -23,6 +23,7 @@ import type { ReadCaller } from "../../services/dashboard/readable-resources";
 import type { WidgetQuery } from "../widgets/query";
 import type { WidgetResult, WidgetResultField } from "../widgets/result";
 import { failUnavailableSourceOrOp } from "../widgets/sources";
+import { RELEASES_SOURCE_ID } from "../widgets/system-source-ids";
 import { registerSystemSource } from "../widgets/system-sources";
 
 import type { ReleaseRow } from "./releases-repository";
@@ -31,7 +32,7 @@ import type {
   ReleasesService,
 } from "./services/releases-service";
 
-export const RELEASES_SOURCE_ID = "system:releases";
+export { RELEASES_SOURCE_ID };
 
 /**
  * How many releases the card reads when the query names no limit.

--- a/packages/nextly/src/domains/versions/__tests__/pending-edits.integration.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/pending-edits.integration.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Counting and listing pending edits across collections, against a real database.
+ *
+ * The distinctness is the whole claim and only a database can settle it: a
+ * working draft is one row per document per LOCALE, so "14 documents have
+ * unpublished changes" counted from rows says 42 for an install translating
+ * into three languages.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../../../config";
+import {
+  createTestNextly,
+  getConfiguredTestDialects,
+  type TestDialect,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import { VERSIONS_TABLE } from "../../../schemas/versions/types";
+import { VersionsRepository } from "../versions-repository";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+async function boot(dialect: TestDialect): Promise<TestNextly> {
+  current = await createTestNextly({
+    dialect,
+    collections: [
+      defineCollection({
+        slug: "posts",
+        versions: { drafts: true },
+        fields: [text({ name: "title" })],
+      }),
+    ],
+  });
+  return current;
+}
+
+function draft(patch: {
+  entryId: string;
+  locale: string | null;
+  scopeSlug?: string;
+  isAutosave?: boolean;
+  updatedAt?: Date;
+}) {
+  return {
+    id: crypto.randomUUID(),
+    scopeKind: "collection",
+    scopeSlug: patch.scopeSlug ?? "posts",
+    entryId: patch.entryId,
+    versionNo: null,
+    status: "draft",
+    isAutosave: patch.isAutosave ?? false,
+    snapshot: JSON.stringify({ secret: "unpublished body" }),
+    label: null,
+    locale: patch.locale,
+    sourceVersionNo: null,
+    createdBy: null,
+    createdAt: new Date("2020-01-01T00:00:00Z"),
+    updatedAt: patch.updatedAt ?? new Date("2026-01-01T00:00:00Z"),
+  };
+}
+
+describe.each(getConfiguredTestDialects())("pending edits (%s)", dialect => {
+  it("counts DOCUMENTS, not the rows their locales create", async () => {
+    // 🔴 The distinguishing case. One document translated into two languages is
+    // one thing an editor must publish; counting rows reports two, and the
+    // number a dashboard shows would grow with the install's locale count
+    // rather than with its unpublished work.
+    const app = await boot(dialect);
+    const repo = new VersionsRepository(app.adapter);
+
+    for (const row of [
+      draft({ entryId: "e1", locale: "en" }),
+      draft({ entryId: "e1", locale: "fr" }),
+      draft({ entryId: "e2", locale: "en" }),
+    ]) {
+      await app.adapter.insert(VERSIONS_TABLE, row);
+    }
+
+    expect(await repo.countDocumentsWithPendingEdits(undefined)).toBe(2);
+  });
+
+  it("ignores autosaves, which are not pending edits", async () => {
+    // An autosave is the editor's in-flight buffer, not a change awaiting
+    // publication. Counting it tells a reader to publish something nobody
+    // decided to keep.
+    const app = await boot(dialect);
+    const repo = new VersionsRepository(app.adapter);
+
+    await app.adapter.insert(
+      VERSIONS_TABLE,
+      draft({ entryId: "e1", locale: null })
+    );
+    await app.adapter.insert(
+      VERSIONS_TABLE,
+      draft({ entryId: "e2", locale: null, isAutosave: true })
+    );
+
+    expect(await repo.countDocumentsWithPendingEdits(undefined)).toBe(1);
+  });
+
+  it("counts and lists only the collections the caller may read", async () => {
+    const app = await boot(dialect);
+    const repo = new VersionsRepository(app.adapter);
+
+    await app.adapter.insert(
+      VERSIONS_TABLE,
+      draft({ entryId: "e1", locale: null })
+    );
+    await app.adapter.insert(
+      VERSIONS_TABLE,
+      draft({ entryId: "e2", locale: null, scopeSlug: "secrets" })
+    );
+
+    expect(await repo.countDocumentsWithPendingEdits(["posts"])).toBe(1);
+    const listed = await repo.findRecentPendingEdits({
+      slugs: ["posts"],
+      limit: 10,
+    });
+    expect(listed.map(r => r.scopeSlug)).toEqual(["posts"]);
+  });
+
+  it("answers ZERO and an empty list for a caller who may read nothing", async () => {
+    // 🔴 `[]` is not "no filter". Reading it that way hands every document to a
+    // caller granted none, which is the widest possible wrong answer.
+    const app = await boot(dialect);
+    const repo = new VersionsRepository(app.adapter);
+    await app.adapter.insert(
+      VERSIONS_TABLE,
+      draft({ entryId: "e1", locale: null })
+    );
+
+    expect(await repo.countDocumentsWithPendingEdits([])).toBe(0);
+    expect(await repo.findRecentPendingEdits({ slugs: [], limit: 10 })).toEqual(
+      []
+    );
+  });
+
+  it("lists the most recently touched first, and never the snapshot", async () => {
+    const app = await boot(dialect);
+    const repo = new VersionsRepository(app.adapter);
+
+    await app.adapter.insert(
+      VERSIONS_TABLE,
+      draft({
+        entryId: "old",
+        locale: null,
+        updatedAt: new Date("2020-06-01T00:00:00Z"),
+      })
+    );
+    await app.adapter.insert(
+      VERSIONS_TABLE,
+      draft({
+        entryId: "new",
+        locale: null,
+        updatedAt: new Date("2026-06-01T00:00:00Z"),
+      })
+    );
+
+    const rows = await repo.findRecentPendingEdits({
+      slugs: undefined,
+      limit: 10,
+    });
+    expect(rows.map(r => r.entryId)).toEqual(["new", "old"]);
+    // The snapshot is the document's unpublished content and the largest column
+    // in the table; a card listing titles has no use for it.
+    expect(rows.every(r => !("snapshot" in r))).toBe(true);
+  });
+});

--- a/packages/nextly/src/domains/versions/__tests__/pending-edits.integration.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/pending-edits.integration.test.ts
@@ -81,7 +81,7 @@ describe.each(getConfiguredTestDialects())("pending edits (%s)", dialect => {
       await app.adapter.insert(VERSIONS_TABLE, row);
     }
 
-    expect(await repo.countDocumentsWithPendingEdits(undefined)).toBe(2);
+    expect(await repo.countDocumentsWithPendingEdits(["posts"])).toBe(2);
   });
 
   it("ignores autosaves, which are not pending edits", async () => {
@@ -100,7 +100,7 @@ describe.each(getConfiguredTestDialects())("pending edits (%s)", dialect => {
       draft({ entryId: "e2", locale: null, isAutosave: true })
     );
 
-    expect(await repo.countDocumentsWithPendingEdits(undefined)).toBe(1);
+    expect(await repo.countDocumentsWithPendingEdits(["posts"])).toBe(1);
   });
 
   it("counts and lists only the collections the caller may read", async () => {
@@ -120,13 +120,16 @@ describe.each(getConfiguredTestDialects())("pending edits (%s)", dialect => {
     const listed = await repo.findRecentPendingEdits({
       slugs: ["posts"],
       limit: 10,
+      maxPerDocument: 1,
     });
     expect(listed.map(r => r.scopeSlug)).toEqual(["posts"]);
   });
 
   it("answers ZERO and an empty list for a caller who may read nothing", async () => {
-    // 🔴 `[]` is not "no filter". Reading it that way hands every document to a
-    // caller granted none, which is the widest possible wrong answer.
+    // 🔴 `[]` means exactly nothing, and it is the only empty answer the
+    // allowlist has — there is no value meaning "no filter". Reading it as
+    // unfiltered hands every document to a caller granted none, which is the
+    // widest possible wrong answer.
     const app = await boot(dialect);
     const repo = new VersionsRepository(app.adapter);
     await app.adapter.insert(
@@ -135,9 +138,53 @@ describe.each(getConfiguredTestDialects())("pending edits (%s)", dialect => {
     );
 
     expect(await repo.countDocumentsWithPendingEdits([])).toBe(0);
-    expect(await repo.findRecentPendingEdits({ slugs: [], limit: 10 })).toEqual(
-      []
-    );
+    expect(
+      await repo.findRecentPendingEdits({
+        slugs: [],
+        limit: 10,
+        maxPerDocument: 1,
+      })
+    ).toEqual([]);
+  });
+
+  it("lists one row per DOCUMENT, so locales cannot crowd out other work", async () => {
+    // 🔴 The separating case for the collapse. A document translated into two
+    // languages is two rows, so limiting the query alone gives one document both
+    // slots and the second document never appears -- while the count beside it,
+    // being document-based, says two. The card's `select` omits `locale`, so
+    // those two rows render as the same line twice.
+    const app = await boot(dialect);
+    const repo = new VersionsRepository(app.adapter);
+
+    for (const row of [
+      draft({
+        entryId: "translated",
+        locale: "en",
+        updatedAt: new Date("2026-06-03T00:00:00Z"),
+      }),
+      draft({
+        entryId: "translated",
+        locale: "fr",
+        updatedAt: new Date("2026-06-02T00:00:00Z"),
+      }),
+      draft({
+        entryId: "other",
+        locale: "en",
+        updatedAt: new Date("2026-06-01T00:00:00Z"),
+      }),
+    ]) {
+      await app.adapter.insert(VERSIONS_TABLE, row);
+    }
+
+    const rows = await repo.findRecentPendingEdits({
+      slugs: ["posts"],
+      limit: 2,
+      maxPerDocument: 2,
+    });
+    expect(rows.map(r => r.entryId)).toEqual(["translated", "other"]);
+    // The row kept is the document's LATEST instant, which is what makes the
+    // list agree with the order it claims.
+    expect(rows[0]?.locale).toBe("en");
   });
 
   it("lists the most recently touched first, and never the snapshot", async () => {
@@ -162,8 +209,9 @@ describe.each(getConfiguredTestDialects())("pending edits (%s)", dialect => {
     );
 
     const rows = await repo.findRecentPendingEdits({
-      slugs: undefined,
+      slugs: ["posts"],
       limit: 10,
+      maxPerDocument: 1,
     });
     expect(rows.map(r => r.entryId)).toEqual(["new", "old"]);
     // The snapshot is the document's unpublished content and the largest column

--- a/packages/nextly/src/domains/versions/__tests__/versions-widget-source.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/versions-widget-source.test.ts
@@ -1,0 +1,148 @@
+/**
+ * `system:versions` — what it asks, and who it asks it for.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const countPendingEdits = vi.fn();
+const recentPendingEdits = vi.fn();
+const has = vi.fn();
+const allowlist = vi.fn();
+
+vi.mock("../../../di/container", () => ({
+  container: {
+    has: (name: string) => has(name) as boolean,
+    get: () => ({ countPendingEdits, recentPendingEdits }),
+  },
+}));
+vi.mock("../../../services/lib/readable-slug-allowlist", () => ({
+  readableSlugAllowlist: (id: string | undefined) => allowlist(id) as unknown,
+}));
+
+import { executeWidgetQuery } from "../../widgets/execute";
+import { clearSources } from "../../widgets/sources";
+import { clearSystemResolvers } from "../../widgets/system-sources";
+import {
+  VERSIONS_SOURCE_ID,
+  registerVersionsWidgetSource,
+} from "../versions-widget-source";
+
+const caller = { user: { id: "user-1", roles: ["editor"] } };
+
+const row = {
+  id: "v1",
+  scopeKind: "collection",
+  scopeSlug: "posts",
+  entryId: "e1",
+  locale: "en",
+  updatedAt: new Date("2026-01-01T00:00:00Z"),
+  versionNo: null,
+  status: "draft",
+  isAutosave: false,
+  label: null,
+  sourceVersionNo: null,
+  createdBy: "someone-else",
+  createdAt: new Date("2020-01-01T00:00:00Z"),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  has.mockReturnValue(true);
+  countPendingEdits.mockResolvedValue(14);
+  recentPendingEdits.mockResolvedValue([row]);
+  allowlist.mockResolvedValue(["posts"]);
+  clearSources();
+  clearSystemResolvers();
+  registerVersionsWidgetSource();
+});
+
+describe("who the numbers are for", () => {
+  it("bounds the COUNT to the collections this caller may read", async () => {
+    // 🔴 The access decision lives here, unlike `system:releases`, because
+    // `VersionsService` has no authorization of its own -- none of its methods
+    // takes an actor. A resolver that simply called it would answer an
+    // install-wide number to a reader entitled to part of it.
+    await executeWidgetQuery(
+      { source: VERSIONS_SOURCE_ID, op: "count" },
+      caller
+    );
+
+    expect(allowlist).toHaveBeenCalledWith("user-1");
+    expect(countPendingEdits).toHaveBeenCalledWith(["posts"]);
+  });
+
+  it("bounds the LIST the same way", async () => {
+    await executeWidgetQuery(
+      { source: VERSIONS_SOURCE_ID, op: "list" },
+      caller
+    );
+
+    expect(recentPendingEdits).toHaveBeenCalledWith(
+      expect.objectContaining({ readableSlugs: ["posts"] })
+    );
+  });
+
+  it("passes an EMPTY allowlist through, rather than reading it as no filter", async () => {
+    // 🔴 The three answers stay distinct. `[]` means "no readable collections"
+    // and must reach the repository as `[]`; reading it as "no filter" is one
+    // `?.length` away and hands every document to a caller granted none.
+    allowlist.mockResolvedValue([]);
+    await executeWidgetQuery(
+      { source: VERSIONS_SOURCE_ID, op: "count" },
+      caller
+    );
+
+    expect(countPendingEdits).toHaveBeenCalledWith([]);
+  });
+
+  it("passes undefined through for a caller with no filter at all", async () => {
+    // The control: a super admin resolves to `undefined`, which must NOT become
+    // `[]` on the way -- that would answer zero for the one caller who may see
+    // everything.
+    allowlist.mockResolvedValue(undefined);
+    await executeWidgetQuery(
+      { source: VERSIONS_SOURCE_ID, op: "count" },
+      caller
+    );
+
+    expect(countPendingEdits).toHaveBeenCalledWith(undefined);
+  });
+
+  it("resolves the allowlist ONCE per query", async () => {
+    // Two resolutions of one caller's permissions are two chances to disagree,
+    // and each is a database read.
+    await executeWidgetQuery(
+      { source: VERSIONS_SOURCE_ID, op: "list" },
+      caller
+    );
+    expect(allowlist).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("what it answers with", () => {
+  it("publishes only its declared fields, never the snapshot", async () => {
+    // 🔴 A version row's snapshot IS the document's unpublished content. The
+    // source's field list is the allowlist a query is checked against, so a row
+    // returned whole would hand every reader the draft body of every document.
+    const result = await executeWidgetQuery(
+      { source: VERSIONS_SOURCE_ID, op: "list" },
+      caller
+    );
+    const [item] = (result as { items: Record<string, unknown>[] }).items;
+    expect(Object.keys(item).sort()).toEqual([
+      "entryId",
+      "locale",
+      "scopeSlug",
+      "updatedAt",
+    ]);
+  });
+
+  it("refuses a field it cannot honour, rather than dropping it", async () => {
+    await expect(
+      executeWidgetQuery(
+        { source: VERSIONS_SOURCE_ID, op: "list", status: "draft" },
+        caller
+      )
+    ).rejects.toThrow(/unavailable source or unsupported op/);
+    expect(recentPendingEdits).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nextly/src/domains/versions/__tests__/versions-widget-source.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/versions-widget-source.test.ts
@@ -6,7 +6,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const countPendingEdits = vi.fn();
 const recentPendingEdits = vi.fn();
 const has = vi.fn();
-const allowlist = vi.fn();
+const readable = vi.fn();
+const registeredSlugs = vi.fn();
 
 vi.mock("../../../di/container", () => ({
   container: {
@@ -14,8 +15,19 @@ vi.mock("../../../di/container", () => ({
     get: () => ({ countPendingEdits, recentPendingEdits }),
   },
 }));
-vi.mock("../../../services/lib/readable-slug-allowlist", () => ({
-  readableSlugAllowlist: (id: string | undefined) => allowlist(id) as unknown,
+// `readAccessCaller` is kept REAL and only the decision is replaced, so what
+// these tests assert is the caller shape the source actually derives —
+// substituting the conversion too would let the source pass anything and still
+// satisfy an expectation written from the same wrong idea.
+vi.mock("../../../auth/entity-read-access", async importOriginal => ({
+  ...(await importOriginal<
+    typeof import("../../../auth/entity-read-access")
+  >()),
+  readableEntities: (slugs: readonly string[], caller: unknown) =>
+    readable(slugs, caller) as unknown,
+}));
+vi.mock("../../../services/lib/registered-content-slugs", () => ({
+  registeredContentSlugs: () => registeredSlugs() as unknown,
 }));
 
 import { executeWidgetQuery } from "../../widgets/execute";
@@ -49,14 +61,15 @@ beforeEach(() => {
   has.mockReturnValue(true);
   countPendingEdits.mockResolvedValue(14);
   recentPendingEdits.mockResolvedValue([row]);
-  allowlist.mockResolvedValue(["posts"]);
+  readable.mockResolvedValue(new Set(["posts"]));
+  registeredSlugs.mockResolvedValue(["posts", "secrets"]);
   clearSources();
   clearSystemResolvers();
   registerVersionsWidgetSource();
 });
 
 describe("who the numbers are for", () => {
-  it("bounds the COUNT to the collections this caller may read", async () => {
+  it("bounds the COUNT to the entities this caller may read", async () => {
     // 🔴 The access decision lives here, unlike `system:releases`, because
     // `VersionsService` has no authorization of its own -- none of its methods
     // takes an actor. A resolver that simply called it would answer an
@@ -66,7 +79,10 @@ describe("who the numbers are for", () => {
       caller
     );
 
-    expect(allowlist).toHaveBeenCalledWith("user-1");
+    expect(readable).toHaveBeenCalledWith(
+      ["posts", "secrets"],
+      expect.objectContaining({ userId: "user-1" })
+    );
     expect(countPendingEdits).toHaveBeenCalledWith(["posts"]);
   });
 
@@ -81,11 +97,35 @@ describe("who the numbers are for", () => {
     );
   });
 
-  it("passes an EMPTY allowlist through, rather than reading it as no filter", async () => {
-    // 🔴 The three answers stay distinct. `[]` means "no readable collections"
-    // and must reach the repository as `[]`; reading it as "no filter" is one
-    // `?.length` away and hands every document to a caller granted none.
-    allowlist.mockResolvedValue([]);
+  it("judges an API KEY on its OWN stamped scope, not its owner's roles", async () => {
+    // 🔴 The separating case. Resolving the OWNER's role-derived slugs hands a
+    // narrowly scoped key everything its minter can read -- and a key minted by
+    // a super admin the whole install, since that bypass belongs to the session
+    // path. The whole caller has to reach the decision, not just an id.
+    await executeWidgetQuery(
+      { source: VERSIONS_SOURCE_ID, op: "count" },
+      {
+        user: { id: "owner-1", roles: ["super-admin"] },
+        authenticatedScope: {
+          actorType: "apiKey" as const,
+          permissions: ["read-posts"],
+        },
+      }
+    );
+
+    expect(readable).toHaveBeenCalledWith(["posts", "secrets"], {
+      userId: "owner-1",
+      authMethod: "api-key",
+      permissions: ["read-posts"],
+      roles: ["super-admin"],
+    });
+  });
+
+  it("answers a caller who may read nothing with an EMPTY list, not everything", async () => {
+    // 🔴 There is no value meaning "no filter" any more: the answer is always
+    // enumerated, so nothing readable arrives as `[]` and the service reads it
+    // as exactly nothing.
+    readable.mockResolvedValue(new Set());
     await executeWidgetQuery(
       { source: VERSIONS_SOURCE_ID, op: "count" },
       caller
@@ -94,27 +134,14 @@ describe("who the numbers are for", () => {
     expect(countPendingEdits).toHaveBeenCalledWith([]);
   });
 
-  it("passes undefined through for a caller with no filter at all", async () => {
-    // The control: a super admin resolves to `undefined`, which must NOT become
-    // `[]` on the way -- that would answer zero for the one caller who may see
-    // everything.
-    allowlist.mockResolvedValue(undefined);
-    await executeWidgetQuery(
-      { source: VERSIONS_SOURCE_ID, op: "count" },
-      caller
-    );
-
-    expect(countPendingEdits).toHaveBeenCalledWith(undefined);
-  });
-
-  it("resolves the allowlist ONCE per query", async () => {
+  it("asks the access layer ONCE per query", async () => {
     // Two resolutions of one caller's permissions are two chances to disagree,
-    // and each is a database read.
+    // and each is a round of database reads.
     await executeWidgetQuery(
       { source: VERSIONS_SOURCE_ID, op: "list" },
       caller
     );
-    expect(allowlist).toHaveBeenCalledTimes(1);
+    expect(readable).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -134,6 +161,41 @@ describe("what it answers with", () => {
       "scopeSlug",
       "updatedAt",
     ]);
+  });
+
+  it("describes the fields in the order the QUERY asked for them", async () => {
+    // 🔴 The table archetype draws its columns straight off this array, so
+    // rebuilding it in declaration order renders the reverse of what the
+    // widget's author wrote -- with nothing anywhere reporting a disagreement.
+    const result = await executeWidgetQuery(
+      {
+        source: VERSIONS_SOURCE_ID,
+        op: "list",
+        select: ["updatedAt", "scopeSlug"],
+      },
+      caller
+    );
+
+    expect(
+      (result as { fields: { name: string }[] }).fields.map(f => f.name)
+    ).toEqual(["updatedAt", "scopeSlug"]);
+  });
+
+  it("collapses a repeated selection into one column", async () => {
+    // A legal selection whose projection is one value; two descriptors would
+    // have a table draw two columns for it.
+    const result = await executeWidgetQuery(
+      {
+        source: VERSIONS_SOURCE_ID,
+        op: "list",
+        select: ["scopeSlug", "scopeSlug"],
+      },
+      caller
+    );
+
+    expect(
+      (result as { fields: { name: string }[] }).fields.map(f => f.name)
+    ).toEqual(["scopeSlug"]);
   });
 
   it("refuses a field it cannot honour, rather than dropping it", async () => {

--- a/packages/nextly/src/domains/versions/db-api.ts
+++ b/packages/nextly/src/domains/versions/db-api.ts
@@ -95,6 +95,21 @@ export interface VersionsDbApi {
    * by both the adapter and the transaction context, whose wider `where` and
    * extra optional arguments remain assignable to this narrower shape.
    */
+  /**
+   * How many rows match, or how many DISTINCT column combinations do.
+   *
+   * 🔴 OPTIONAL, and that is not timidity about the feature. This port is
+   * satisfied structurally by two different things: the pooled adapter, which
+   * has this, and the transaction context, which does not -- and the releases
+   * and jobs repositories are typed against the same port. A required method
+   * would make every one of them stop satisfying it for a capability none of
+   * them uses. A caller that needs it asks and refuses when absent, which is
+   * the same shape `dialect?` above already takes.
+   */
+  count?(
+    table: string,
+    options?: { where?: VersionsWhere; distinctOn?: string[] }
+  ): Promise<number>;
   delete(table: string, where: VersionsWhere): Promise<number>;
   /**
    * Update rows matching `where`.

--- a/packages/nextly/src/domains/versions/versions-repository.ts
+++ b/packages/nextly/src/domains/versions/versions-repository.ts
@@ -247,6 +247,93 @@ export class VersionsRepository {
   }
 
   /**
+   * The working-draft predicate WITHOUT a document scope.
+   *
+   * 🔴 The same three conditions `workingDraftWhere` applies, factored out so
+   * the per-document read and the cross-document reads cannot disagree about
+   * what a pending edit IS. Two spellings of "non-autosave, no version number,
+   * draft" would answer the same question differently the first time one of
+   * them changed, and the disagreement would show as a dashboard number that
+   * does not match the document it points at.
+   */
+  private pendingEditWhere(
+    slugs: readonly string[] | undefined
+  ): VersionsWhere {
+    const and: VersionsWhereCondition[] = [
+      { column: "isAutosave", op: "=", value: false },
+      { column: "versionNo", op: "IS NULL" },
+      { column: "status", op: "=", value: "draft" },
+    ];
+    // An explicitly EMPTY list means "no readable collections", which is not
+    // the same question as "no filter" -- answering it with every collection
+    // would be the widest possible wrong answer, and this read is bounded by
+    // what its caller may see.
+    if (slugs !== undefined) {
+      and.push({ column: "scopeSlug", op: "IN", value: [...new Set(slugs)] });
+    }
+    return { and };
+  }
+
+  /** The count capability, or a refusal naming why it is absent. */
+  private counter(): NonNullable<VersionsDbApi["count"]> {
+    const count = this.db.count?.bind(this.db);
+    if (!count) {
+      // The pooled adapter has it; a transaction context does not. A read path
+      // reaching here on a tx handle is a wiring mistake, not a caller's.
+      throw NextlyError.internal({
+        logContext: { reason: "versions-count-unsupported" },
+      });
+    }
+    return count;
+  }
+
+  /**
+   * How many DOCUMENTS hold a pending edit, within the given collections.
+   *
+   * 🔴 Documents, not rows. A working draft is one row per document per LOCALE,
+   * so a document edited in three languages is one thing to fix and three rows
+   * -- and "14 documents have unpublished changes" counted from rows says 42.
+   * The distinct combination is the document's identity, which is why the
+   * adapter's `distinctOn` exists rather than a row count here.
+   */
+  async countDocumentsWithPendingEdits(
+    slugs: readonly string[] | undefined
+  ): Promise<number> {
+    if (slugs?.length === 0) return 0;
+    return this.counter()(TABLE, {
+      where: this.pendingEditWhere(slugs),
+      distinctOn: ["scopeKind", "scopeSlug", "entryId"],
+    });
+  }
+
+  /**
+   * The documents most recently left with a pending edit, newest first.
+   *
+   * Reads the working drafts rather than every version row, and that is what
+   * makes the list honest without a de-duplication pass: a unique index keeps
+   * one working draft per document per locale, so a document saved fifty times
+   * appears once at its latest instant instead of crowding out the rest.
+   *
+   * The snapshot is projected away. It is the largest column in the table and a
+   * card that lists titles has no use for it.
+   */
+  async findRecentPendingEdits(input: {
+    slugs: readonly string[] | undefined;
+    limit: number;
+  }): Promise<VersionMeta[]> {
+    if (input.slugs?.length === 0) return [];
+    return this.db.select<VersionMeta>(TABLE, {
+      columns: [...VERSION_META_COLUMNS],
+      where: this.pendingEditWhere(input.slugs),
+      // `nulls` is stated for the reason the module's other ordered read states
+      // it: the default differs per dialect, and a limited list must not return
+      // different rows per engine.
+      orderBy: [{ column: "updatedAt", direction: "desc", nulls: "last" }],
+      limit: input.limit,
+    });
+  }
+
+  /**
    * Insert or update the coalesced working draft for a document in one locale.
    *
    * There is exactly one working draft per (document, locale): editing a

--- a/packages/nextly/src/domains/versions/versions-repository.ts
+++ b/packages/nextly/src/domains/versions/versions-repository.ts
@@ -29,6 +29,26 @@ import { workingDraftKey } from "./working-draft-key";
 
 const TABLE = VERSIONS_TABLE;
 
+/**
+ * What makes a row a WORKING DRAFT, independent of which document it belongs to.
+ *
+ * 🔴 The single declaration of "pending edit", spread by both the per-document
+ * predicate and the cross-document ones. It is one value rather than one comment
+ * asking two predicates to agree: a working draft is the only non-autosave row
+ * carrying no version number (durable history rows always take a sequence
+ * number; autosave rows set `isAutosave = true`), and the day that definition
+ * changes it must change for the document read and the dashboard together. Two
+ * spellings would keep answering, and the disagreement would surface as a count
+ * that does not match the documents it points at.
+ *
+ * Never mutated -- both consumers spread it into a fresh `and` array.
+ */
+const WORKING_DRAFT_SHAPE: readonly VersionsWhereCondition[] = [
+  { column: "isAutosave", op: "=", value: false },
+  { column: "versionNo", op: "IS NULL" },
+  { column: "status", op: "=", value: "draft" },
+];
+
 // Ids deleted per statement. Each id binds one parameter and SQLite's default
 // SQLITE_MAX_VARIABLE_NUMBER is 999 (the lowest across supported dialects), so
 // this stays well under it rather than tracking per-dialect capabilities.
@@ -52,6 +72,59 @@ const VERSION_META_COLUMNS = [
   "createdAt",
   "updatedAt",
 ] as const;
+
+/**
+ * The largest number of rows a recent-edits scan will read.
+ *
+ * A ceiling on the over-fetch, not on the answer. It only binds when
+ * `limit * maxPerDocument` exceeds it -- a 5-row card needs it past 100
+ * configured locales -- and when it does the card returns FEWER documents rather
+ * than wrong ones. Worth having because `maxPerDocument` is the configured
+ * locale count, and rows written under a locale later removed from the config
+ * are not bounded by it.
+ */
+const MAX_PENDING_EDIT_SCAN = 500;
+
+/** How many rows to read to be sure of finding `limit` distinct documents. */
+function scanBound(limit: number, maxPerDocument: number): number {
+  return Math.min(limit * Math.max(maxPerDocument, 1), MAX_PENDING_EDIT_SCAN);
+}
+
+/**
+ * A document's identity across locales.
+ *
+ * NUL-joined rather than concatenated, so a slug ending in the separator cannot
+ * spell the same key as a different slug and entry id pair -- the columns are
+ * free strings and a delimiter that can occur inside one is a collision waiting
+ * for the install that names a collection unusually.
+ */
+function documentKey(row: VersionMeta): string {
+  return [row.scopeKind, row.scopeSlug, row.entryId].join("\u0000");
+}
+
+/**
+ * One row per document -- its newest -- keeping at most `limit` of them.
+ *
+ * Relies on the caller's `updatedAt DESC` ordering: the first row seen for a
+ * document IS its latest instant, so keeping the first and dropping the rest
+ * needs no comparison. Stops at `limit`, which is what makes the scan bound
+ * above sufficient rather than merely generous.
+ */
+function newestPerDocument(
+  rows: readonly VersionMeta[],
+  limit: number
+): VersionMeta[] {
+  const seen = new Set<string>();
+  const newest: VersionMeta[] = [];
+  for (const row of rows) {
+    const key = documentKey(row);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    newest.push(row);
+    if (newest.length === limit) break;
+  }
+  return newest;
+}
 
 /** Identifies the document a version belongs to. */
 export interface VersionRef {
@@ -238,9 +311,7 @@ export class VersionsRepository {
     return {
       and: [
         ...this.docWhere(ref),
-        { column: "isAutosave", op: "=", value: false },
-        { column: "versionNo", op: "IS NULL" },
-        { column: "status", op: "=", value: "draft" },
+        ...WORKING_DRAFT_SHAPE,
         this.localeCondition(locale),
       ],
     };
@@ -249,29 +320,24 @@ export class VersionsRepository {
   /**
    * The working-draft predicate WITHOUT a document scope.
    *
-   * 🔴 The same three conditions `workingDraftWhere` applies, factored out so
-   * the per-document read and the cross-document reads cannot disagree about
-   * what a pending edit IS. Two spellings of "non-autosave, no version number,
-   * draft" would answer the same question differently the first time one of
-   * them changed, and the disagreement would show as a dashboard number that
-   * does not match the document it points at.
+   * 🔴 Derived from {@link WORKING_DRAFT_SHAPE}, the same value
+   * `workingDraftWhere` spreads, so the per-document read and the cross-document
+   * reads cannot disagree about what a pending edit IS. Two spellings of
+   * "non-autosave, no version number, draft" would answer the same question
+   * differently the first time one of them changed, and the disagreement would
+   * show as a dashboard number that does not match the document it points at.
    */
-  private pendingEditWhere(
-    slugs: readonly string[] | undefined
-  ): VersionsWhere {
-    const and: VersionsWhereCondition[] = [
-      { column: "isAutosave", op: "=", value: false },
-      { column: "versionNo", op: "IS NULL" },
-      { column: "status", op: "=", value: "draft" },
-    ];
-    // An explicitly EMPTY list means "no readable collections", which is not
-    // the same question as "no filter" -- answering it with every collection
-    // would be the widest possible wrong answer, and this read is bounded by
-    // what its caller may see.
-    if (slugs !== undefined) {
-      and.push({ column: "scopeSlug", op: "IN", value: [...new Set(slugs)] });
-    }
-    return { and };
+  private pendingEditWhere(slugs: readonly string[]): VersionsWhere {
+    return {
+      and: [
+        ...WORKING_DRAFT_SHAPE,
+        // Always applied, because this read is bounded by what its caller may
+        // see and the allowlist is enumerated for every caller -- a super admin
+        // included. An empty list therefore means exactly nothing, and the
+        // callers below short-circuit it rather than emitting `IN ()`.
+        { column: "scopeSlug", op: "IN", value: [...new Set(slugs)] },
+      ],
+    };
   }
 
   /** The count capability, or a refusal naming why it is absent. */
@@ -297,9 +363,9 @@ export class VersionsRepository {
    * adapter's `distinctOn` exists rather than a row count here.
    */
   async countDocumentsWithPendingEdits(
-    slugs: readonly string[] | undefined
+    slugs: readonly string[]
   ): Promise<number> {
-    if (slugs?.length === 0) return 0;
+    if (slugs.length === 0) return 0;
     return this.counter()(TABLE, {
       where: this.pendingEditWhere(slugs),
       distinctOn: ["scopeKind", "scopeSlug", "entryId"],
@@ -307,30 +373,45 @@ export class VersionsRepository {
   }
 
   /**
-   * The documents most recently left with a pending edit, newest first.
+   * The DOCUMENTS most recently left with a pending edit, newest first.
    *
-   * Reads the working drafts rather than every version row, and that is what
-   * makes the list honest without a de-duplication pass: a unique index keeps
-   * one working draft per document per locale, so a document saved fifty times
-   * appears once at its latest instant instead of crowding out the rest.
+   * 🔴 Documents, not rows, and the difference is visible on the dashboard. A
+   * working draft is one row per document per LOCALE, so a page edited in three
+   * languages is three rows -- and limiting the query alone let one document
+   * take three of a five-row card while other recent work fell off the end. The
+   * count beside it is document-based, so the list also disagreed with the
+   * number it sits under, and because the card's `select` omits `locale` the
+   * extra rows rendered as indistinguishable duplicates rather than as anything
+   * a reader could explain.
+   *
+   * Over-fetch then collapse, because the data port has no GROUP BY and adding
+   * one for a single card would widen every adapter. The bound is exact rather
+   * than a guess: rows arrive newest-first, so a document's FIRST row is its
+   * latest instant, and every row preceding it belongs to a document at least as
+   * recent. At most `maxPerDocument` rows can come from any one of those, so the
+   * newest `limit` documents are all represented within
+   * `limit * maxPerDocument` rows. See {@link scanBound} for the cap and what it
+   * costs.
    *
    * The snapshot is projected away. It is the largest column in the table and a
    * card that lists titles has no use for it.
    */
   async findRecentPendingEdits(input: {
-    slugs: readonly string[] | undefined;
+    slugs: readonly string[];
     limit: number;
+    maxPerDocument: number;
   }): Promise<VersionMeta[]> {
-    if (input.slugs?.length === 0) return [];
-    return this.db.select<VersionMeta>(TABLE, {
+    if (input.slugs.length === 0 || input.limit <= 0) return [];
+    const rows = await this.db.select<VersionMeta>(TABLE, {
       columns: [...VERSION_META_COLUMNS],
       where: this.pendingEditWhere(input.slugs),
       // `nulls` is stated for the reason the module's other ordered read states
       // it: the default differs per dialect, and a limited list must not return
       // different rows per engine.
       orderBy: [{ column: "updatedAt", direction: "desc", nulls: "last" }],
-      limit: input.limit,
+      limit: scanBound(input.limit, input.maxPerDocument),
     });
+    return newestPerDocument(rows, input.limit);
   }
 
   /**

--- a/packages/nextly/src/domains/versions/versions-service.ts
+++ b/packages/nextly/src/domains/versions/versions-service.ts
@@ -39,38 +39,57 @@ export interface VersionListOptions {
   locale?: string;
 }
 
+/** Construction-time facts this service cannot derive from its database handle. */
+export interface VersionsServiceOptions {
+  /**
+   * How many working drafts one document can hold — the install's configured
+   * locale count, since a working draft is one row per document per locale.
+   *
+   * Read by the recent-edits list to bound the rows it must scan to find a full
+   * page of distinct DOCUMENTS. Defaults to 1, which is exactly right for an
+   * install with no localization configured and merely conservative otherwise:
+   * too low returns fewer documents than asked, never wrong ones.
+   */
+  maxWorkingDraftsPerDocument?: number;
+}
+
 export class VersionsService {
   private readonly repo: VersionsRepository;
+  private readonly maxWorkingDraftsPerDocument: number;
 
-  constructor(db: VersionsDbApi) {
+  constructor(db: VersionsDbApi, options: VersionsServiceOptions = {}) {
     this.repo = new VersionsRepository(db);
+    this.maxWorkingDraftsPerDocument = Math.max(
+      Math.trunc(options.maxWorkingDraftsPerDocument ?? 1) || 1,
+      1
+    );
   }
 
   /**
    * How many documents hold a pending edit, within collections the caller reads.
    *
-   * 🔴 The allowlist is REQUIRED, not optional, and `undefined` means "every
-   * collection" rather than "unfiltered by accident". This service has no
-   * authorization of its own -- unlike `ReleasesService`, none of its methods
-   * takes an actor -- so the bound has to arrive from the caller, and a
-   * parameter that could be forgotten would produce an install-wide number for
-   * a reader entitled to part of it. Naming it in the signature makes the
-   * decision visible at every call site.
+   * 🔴 The allowlist is REQUIRED and ENUMERATED — `[]` means exactly nothing,
+   * and there is no value meaning "no filter". This service has no authorization
+   * of its own (unlike `ReleasesService`, none of its methods takes an actor) so
+   * the bound has to arrive from the caller, and an optional parameter would
+   * produce an install-wide number for a reader entitled to part of it the first
+   * time somebody forgot it. The one caller resolves the list through
+   * `readableEntities`, which answers every registered entity for a super admin
+   * rather than a bypass, so nothing here needs a wider case.
    */
-  async countPendingEdits(
-    readableSlugs: readonly string[] | undefined
-  ): Promise<number> {
+  async countPendingEdits(readableSlugs: readonly string[]): Promise<number> {
     return this.repo.countDocumentsWithPendingEdits(readableSlugs);
   }
 
   /** The documents most recently left with a pending edit, newest first. */
   async recentPendingEdits(input: {
-    readableSlugs: readonly string[] | undefined;
+    readableSlugs: readonly string[];
     limit: number;
   }): Promise<VersionMeta[]> {
     return this.repo.findRecentPendingEdits({
       slugs: input.readableSlugs,
       limit: input.limit,
+      maxPerDocument: this.maxWorkingDraftsPerDocument,
     });
   }
 

--- a/packages/nextly/src/domains/versions/versions-service.ts
+++ b/packages/nextly/src/domains/versions/versions-service.ts
@@ -46,6 +46,34 @@ export class VersionsService {
     this.repo = new VersionsRepository(db);
   }
 
+  /**
+   * How many documents hold a pending edit, within collections the caller reads.
+   *
+   * 🔴 The allowlist is REQUIRED, not optional, and `undefined` means "every
+   * collection" rather than "unfiltered by accident". This service has no
+   * authorization of its own -- unlike `ReleasesService`, none of its methods
+   * takes an actor -- so the bound has to arrive from the caller, and a
+   * parameter that could be forgotten would produce an install-wide number for
+   * a reader entitled to part of it. Naming it in the signature makes the
+   * decision visible at every call site.
+   */
+  async countPendingEdits(
+    readableSlugs: readonly string[] | undefined
+  ): Promise<number> {
+    return this.repo.countDocumentsWithPendingEdits(readableSlugs);
+  }
+
+  /** The documents most recently left with a pending edit, newest first. */
+  async recentPendingEdits(input: {
+    readableSlugs: readonly string[] | undefined;
+    limit: number;
+  }): Promise<VersionMeta[]> {
+    return this.repo.findRecentPendingEdits({
+      slugs: input.readableSlugs,
+      limit: input.limit,
+    });
+  }
+
   /** Version metadata for one document, newest-first. Never loads snapshots. */
   async list(
     ref: VersionRef,

--- a/packages/nextly/src/domains/versions/versions-widget-source.ts
+++ b/packages/nextly/src/domains/versions/versions-widget-source.ts
@@ -6,30 +6,53 @@
  * hands the caller through and adds nothing. `VersionsService` has no
  * authorization at all — none of its methods takes an actor — so a resolver
  * that simply called it would answer an install-wide number to a reader
- * entitled to part of it. The bound is `readableSlugAllowlist`, the same
- * resolution the collections listing uses, so a caller sees pending edits in
- * exactly the collections they may read.
+ * entitled to part of it.
  *
- * `undefined` from that helper means "no filter" (a super admin), `[]` means
- * "no readable collections" and must answer zero rather than everything. The
- * repository keeps those three answers distinct; reading `[]` as "no filter" is
- * one `?.length` away and hands every document to a caller granted none.
+ * The bound is `readableEntities`, asked once per registered entity, and NOT a
+ * filter over the caller's permission slugs. The two look equivalent and are
+ * not, in both directions:
+ *
+ * - An API key is judged on its OWN stamped scope. Resolving the owner's
+ *   role-derived slugs instead hands a narrowly scoped key everything its
+ *   minter can read — and a key minted by a super admin every document in the
+ *   install, since the bypass belongs to the session path alone.
+ * - A collection whose code-defined `access.read` REFUSES this caller still has
+ *   the permission row a slug filter admits it on, and one authorized purely in
+ *   code has no row to find at all.
+ *
+ * That is the same call `/api/dashboard/stats` and the widget layout endpoint
+ * make, so this card describes the collections whose documents the caller could
+ * actually open — which is the only definition of "in reach" that cannot drift
+ * from what a row read would answer.
+ *
+ * The result is an ENUMERATED set, never "no filter". A super admin gets every
+ * registered entity rather than an unbounded read, so a version row naming a
+ * collection that is no longer registered belongs to nobody — the same
+ * deliberate consequence `resolveReadableResources` documents. It is what lets
+ * the service take a required `readonly string[]`, with `[]` meaning exactly
+ * nothing, instead of the three-way `undefined | [] | list` whose collapse hands
+ * every document to a caller granted none.
  *
  * @module domains/versions/versions-widget-source
  */
 
+import {
+  readAccessCaller,
+  readableEntities,
+} from "../../auth/entity-read-access";
 import { container } from "../../di/container";
 import { NextlyError } from "../../errors/nextly-error";
 import type { ReadCaller } from "../../services/dashboard/readable-resources";
-import { readableSlugAllowlist } from "../../services/lib/readable-slug-allowlist";
+import { registeredContentSlugs } from "../../services/lib/registered-content-slugs";
 import type { WidgetQuery } from "../widgets/query";
 import type { WidgetResult } from "../widgets/result";
 import { failUnavailableSourceOrOp } from "../widgets/sources";
+import { VERSIONS_SOURCE_ID } from "../widgets/system-source-ids";
 import { registerSystemSource } from "../widgets/system-sources";
 
 import type { VersionsService } from "./versions-service";
 
-export const VERSIONS_SOURCE_ID = "system:versions";
+export { VERSIONS_SOURCE_ID };
 
 /** How many rows the list card draws when the query names no limit. */
 const DEFAULT_LIMIT = 5;
@@ -110,6 +133,46 @@ function projected(
   return Object.fromEntries(names.map(name => [name, full[name]]));
 }
 
+/**
+ * The fields to answer with, in the order the query asked for them.
+ *
+ * 🔴 Order comes from `select`, not from `VERSION_FIELDS`. The table archetype
+ * draws its columns straight off `WidgetResult.fields`, so rebuilding the list
+ * in declaration order renders `select: ["updatedAt", "scopeSlug"]` as
+ * Collection then Edited — the reverse of what its author wrote, with nothing
+ * anywhere reporting a disagreement. The collection path derives it this way
+ * for the same reason.
+ *
+ * Unknown names are dropped rather than refused, because the source's field list
+ * is the allowlist every query is checked against and a name outside it has no
+ * value to answer with. Duplicates are collapsed first: `["title", "title"]` is
+ * a legal selection whose projection is one value, so emitting two descriptors
+ * would have a table draw two columns for it.
+ */
+function selectedNames(query: WidgetQuery): string[] {
+  if (!query.select?.length) return VERSION_FIELDS.map(field => field.name);
+  return [
+    ...new Set(
+      query.select.filter(name =>
+        VERSION_FIELDS.some(field => field.name === name)
+      )
+    ),
+  ];
+}
+
+/** Each selected name paired with the label this source publishes for it. */
+function describe(
+  names: readonly string[]
+): { name: string; label?: string }[] {
+  const labels = new Map(
+    VERSION_FIELDS.map(field => [field.name, field.label])
+  );
+  return names.map(name => {
+    const label = labels.get(name);
+    return { name, ...(label !== undefined && { label }) };
+  });
+}
+
 async function resolveVersions(
   query: WidgetQuery,
   caller: ReadCaller
@@ -119,7 +182,12 @@ async function resolveVersions(
   // Resolved ONCE per query and passed down, rather than each read asking
   // again: the two ops answer about the same set, and two resolutions of one
   // caller's permissions are two chances to disagree.
-  const readableSlugs = await readableSlugAllowlist(caller.user.id);
+  const readableSlugs = [
+    ...(await readableEntities(
+      await registeredContentSlugs(),
+      readAccessCaller(caller)
+    )),
+  ];
 
   if (query.op === "count") {
     return {
@@ -132,15 +200,8 @@ async function resolveVersions(
     readableSlugs,
     limit: query.limit ?? DEFAULT_LIMIT,
   });
-  const names = query.select?.length
-    ? query.select.filter(name => VERSION_FIELDS.some(f => f.name === name))
-    : VERSION_FIELDS.map(f => f.name);
-  const fields = query.select?.length
-    ? VERSION_FIELDS.filter(f => names.includes(f.name)).map(f => ({
-        name: f.name,
-        label: f.label,
-      }))
-    : undefined;
+  const names = selectedNames(query);
+  const fields = query.select?.length ? describe(names) : undefined;
 
   return {
     op: "list",

--- a/packages/nextly/src/domains/versions/versions-widget-source.ts
+++ b/packages/nextly/src/domains/versions/versions-widget-source.ts
@@ -1,0 +1,171 @@
+/**
+ * `system:versions` — the documents carrying edits that are not live.
+ *
+ * 🔴 The access decision is made HERE, and that is the difference from
+ * `system:releases`. `ReleasesService` authorizes itself, so that resolver
+ * hands the caller through and adds nothing. `VersionsService` has no
+ * authorization at all — none of its methods takes an actor — so a resolver
+ * that simply called it would answer an install-wide number to a reader
+ * entitled to part of it. The bound is `readableSlugAllowlist`, the same
+ * resolution the collections listing uses, so a caller sees pending edits in
+ * exactly the collections they may read.
+ *
+ * `undefined` from that helper means "no filter" (a super admin), `[]` means
+ * "no readable collections" and must answer zero rather than everything. The
+ * repository keeps those three answers distinct; reading `[]` as "no filter" is
+ * one `?.length` away and hands every document to a caller granted none.
+ *
+ * @module domains/versions/versions-widget-source
+ */
+
+import { container } from "../../di/container";
+import { NextlyError } from "../../errors/nextly-error";
+import type { ReadCaller } from "../../services/dashboard/readable-resources";
+import { readableSlugAllowlist } from "../../services/lib/readable-slug-allowlist";
+import type { WidgetQuery } from "../widgets/query";
+import type { WidgetResult } from "../widgets/result";
+import { failUnavailableSourceOrOp } from "../widgets/sources";
+import { registerSystemSource } from "../widgets/system-sources";
+
+import type { VersionsService } from "./versions-service";
+
+export const VERSIONS_SOURCE_ID = "system:versions";
+
+/** How many rows the list card draws when the query names no limit. */
+const DEFAULT_LIMIT = 5;
+
+/**
+ * The fields this source publishes.
+ *
+ * Deliberately the document's identity and its instant, and nothing from the
+ * snapshot: a source's field list is the allowlist every query is checked
+ * against, so publishing a column here publishes it to every reader who may see
+ * the source. The snapshot is the document's unpublished content.
+ */
+const VERSION_FIELDS = [
+  { name: "scopeSlug", type: "string" as const, label: "Collection" },
+  { name: "entryId", type: "string" as const, label: "Document" },
+  { name: "locale", type: "string" as const, label: "Language" },
+  { name: "updatedAt", type: "date" as const, label: "Edited" },
+];
+
+function service(): VersionsService {
+  if (!container.has("versionsService")) {
+    throw NextlyError.internal({
+      logContext: { reason: "versions-service-unregistered" },
+    });
+  }
+  return container.get<VersionsService>("versionsService");
+}
+
+/**
+ * What this source does with each field of a widget query.
+ *
+ * Exhaustive over `keyof WidgetQuery`, so adding a field there fails
+ * `check-types` here until someone decides what it means for this source —
+ * rather than the field being accepted by validation and then silently dropped,
+ * which answers a different question than the caller asked.
+ */
+const QUERY_FIELD_USE: Record<keyof WidgetQuery, "consumed" | "refused"> = {
+  source: "consumed",
+  op: "consumed",
+  select: "consumed",
+  limit: "consumed",
+  where: "refused",
+  sort: "refused",
+  status: "refused",
+};
+
+function refuseUnconsumed(query: WidgetQuery): void {
+  const carried = Object.entries(query)
+    .filter(
+      ([name, value]) =>
+        value !== undefined &&
+        QUERY_FIELD_USE[name as keyof WidgetQuery] === "refused"
+    )
+    .map(([name]) => name);
+  if (carried.length > 0) {
+    failUnavailableSourceOrOp(
+      `source "${VERSIONS_SOURCE_ID}" answers a fixed question and cannot honour: ${carried.join(", ")}`
+    );
+  }
+}
+
+/** A version row reduced to the fields this source declares. */
+function projected(
+  row: {
+    scopeSlug: string;
+    entryId: string;
+    locale: string | null;
+    updatedAt: Date;
+  },
+  names: readonly string[]
+): Record<string, unknown> {
+  const full: Record<string, unknown> = {
+    scopeSlug: row.scopeSlug,
+    entryId: row.entryId,
+    locale: row.locale,
+    updatedAt: row.updatedAt,
+  };
+  return Object.fromEntries(names.map(name => [name, full[name]]));
+}
+
+async function resolveVersions(
+  query: WidgetQuery,
+  caller: ReadCaller
+): Promise<WidgetResult> {
+  refuseUnconsumed(query);
+
+  // Resolved ONCE per query and passed down, rather than each read asking
+  // again: the two ops answer about the same set, and two resolutions of one
+  // caller's permissions are two chances to disagree.
+  const readableSlugs = await readableSlugAllowlist(caller.user.id);
+
+  if (query.op === "count") {
+    return {
+      op: "count",
+      total: await service().countPendingEdits(readableSlugs),
+    };
+  }
+
+  const rows = await service().recentPendingEdits({
+    readableSlugs,
+    limit: query.limit ?? DEFAULT_LIMIT,
+  });
+  const names = query.select?.length
+    ? query.select.filter(name => VERSION_FIELDS.some(f => f.name === name))
+    : VERSION_FIELDS.map(f => f.name);
+  const fields = query.select?.length
+    ? VERSION_FIELDS.filter(f => names.includes(f.name)).map(f => ({
+        name: f.name,
+        label: f.label,
+      }))
+    : undefined;
+
+  return {
+    op: "list",
+    items: rows.map(row => projected(row, names)),
+    ...(fields?.length ? { fields } : {}),
+  };
+}
+
+/**
+ * Publish the source and the function that answers it.
+ *
+ * `supports` names both ops because both are genuinely answerable: the count is
+ * one aggregate over the versions table, and the list is one bounded read of
+ * the same set. That is why this source is worth its own kind rather than being
+ * two unrelated cards.
+ */
+export function registerVersionsWidgetSource(): void {
+  registerSystemSource(
+    {
+      id: VERSIONS_SOURCE_ID,
+      label: "Pending edits",
+      kind: "system",
+      supports: ["count", "list"],
+      fields: VERSION_FIELDS,
+    },
+    resolveVersions
+  );
+}

--- a/packages/nextly/src/domains/widgets/core-widgets.ts
+++ b/packages/nextly/src/domains/widgets/core-widgets.ts
@@ -101,4 +101,27 @@ export const CORE_WIDGETS: readonly WidgetDefinition[] = [
     defaultOrder: 30,
     component: "core#TeamSummary",
   },
+  {
+    id: "core/pending-edits",
+    title: "Unpublished changes",
+    description: "Documents holding edits that are not live yet",
+    archetype: "metric",
+    defaultSize: "sm",
+    defaultOrder: 25,
+    query: { source: "system:versions", op: "count" },
+  },
+  {
+    id: "core/recently-edited",
+    title: "Recently edited",
+    description: "Where you left off, across every collection",
+    archetype: "list",
+    defaultSize: "md",
+    defaultOrder: 35,
+    query: {
+      source: "system:versions",
+      op: "list",
+      select: ["scopeSlug", "entryId", "updatedAt"],
+      limit: 5,
+    },
+  },
 ] as const;

--- a/packages/nextly/src/domains/widgets/core-widgets.ts
+++ b/packages/nextly/src/domains/widgets/core-widgets.ts
@@ -32,6 +32,7 @@
  */
 
 import type { WidgetDefinition } from "./definition";
+import { VERSIONS_SOURCE_ID } from "./system-source-ids";
 
 /**
  * The prefix core's dashboard components resolve under.
@@ -108,17 +109,18 @@ export const CORE_WIDGETS: readonly WidgetDefinition[] = [
     archetype: "metric",
     defaultSize: "sm",
     defaultOrder: 25,
-    query: { source: "system:versions", op: "count" },
+    query: { source: VERSIONS_SOURCE_ID, op: "count" },
   },
   {
     id: "core/recently-edited",
     title: "Recently edited",
-    description: "Where you left off, across every collection",
+    description:
+      "The documents most recently left with unpublished edits, newest first.",
     archetype: "list",
     defaultSize: "md",
     defaultOrder: 35,
     query: {
-      source: "system:versions",
+      source: VERSIONS_SOURCE_ID,
       op: "list",
       select: ["scopeSlug", "entryId", "updatedAt"],
       limit: 5,

--- a/packages/nextly/src/domains/widgets/system-source-ids.ts
+++ b/packages/nextly/src/domains/widgets/system-source-ids.ts
@@ -1,0 +1,23 @@
+/**
+ * The identifiers of the `system:` sources core ships, declared ONCE.
+ *
+ * 🔴 A card's `query.source` and the registration that answers it are two halves
+ * of one name, and nothing checks that they agree: a definition naming an
+ * unregistered source is a legal definition, refused only at query time and only
+ * for the reader unlucky enough to hold the card. Renaming a source with the
+ * literal repeated in `core-widgets.ts` therefore leaves both cards querying an
+ * id nothing serves while the source and every one of its own tests still pass.
+ *
+ * Its own module rather than an export of each source, because `core-widgets.ts`
+ * would otherwise import the registration modules for their constants alone --
+ * pulling a domain's service wiring into the definition list, and making the
+ * widget domain depend on every domain that publishes a source.
+ *
+ * @module domains/widgets/system-source-ids
+ */
+
+/** What ships next: the releases the caller may see. */
+export const RELEASES_SOURCE_ID = "system:releases";
+
+/** The documents carrying edits that are not live. */
+export const VERSIONS_SOURCE_ID = "system:versions";

--- a/packages/nextly/src/services/lib/registered-content-slugs.ts
+++ b/packages/nextly/src/services/lib/registered-content-slugs.ts
@@ -1,0 +1,69 @@
+/**
+ * Every content entity an install has registered, as slugs to be authorized.
+ *
+ * The candidate list for any read decision that spans the whole installation
+ * rather than one named collection: the dashboard's readable-resources scope
+ * asks it, and so does the `system:versions` widget source, which has to bound
+ * a cross-document read by what its caller may see.
+ *
+ * 🔴 Candidates, not an answer. Nothing here decides anything -- each slug still
+ * goes to `canReadEntity`, which is what makes the set agree with what a row
+ * read would give. Filtering these names by permission SLUGS instead is the
+ * mistake `readableEntities` documents: a collection authorized purely in code
+ * has no permission row to find, and one REFUSED in code still has the row a
+ * slug filter admits it on.
+ *
+ * A registry that cannot be reached contributes NOTHING rather than an unbounded
+ * list. An empty candidate set admits nothing, which is visible and reportable;
+ * the alternative is a surface that widens when the container is degraded.
+ *
+ * @module services/lib/registered-content-slugs
+ */
+
+import { container } from "../../di/container";
+
+/** The registered collection slugs, or none when the registry is unreachable. */
+async function collectionSlugs(): Promise<string[]> {
+  try {
+    const collections = await container
+      .get<{
+        getAllCollections: () => Promise<Array<{ slug: string }>>;
+      }>("collectionRegistryService")
+      .getAllCollections();
+    return collections.map(collection => String(collection.slug));
+  } catch {
+    // Unreachable registry: contribute nothing rather than guess.
+    return [];
+  }
+}
+
+/** The registered single slugs, or none when the registry is unreachable. */
+async function singleSlugs(): Promise<string[]> {
+  try {
+    const singles = await container
+      .get<{
+        getAllSingles: () => Promise<Array<{ slug: string }>>;
+      }>("singleRegistryService")
+      .getAllSingles();
+    return singles.map(single => String(single.slug));
+  } catch {
+    // As above.
+    return [];
+  }
+}
+
+/**
+ * The collections and singles this install has registered.
+ *
+ * Both registries, because a `scopeKind` of `single` names a slug that lives in
+ * the second one -- enumerating collections alone would drop every single's
+ * documents from a cross-entity read while reporting a smaller number as if it
+ * were the whole answer.
+ */
+export async function registeredContentSlugs(): Promise<string[]> {
+  const [collections, singles] = await Promise.all([
+    collectionSlugs(),
+    singleSlugs(),
+  ]);
+  return [...collections, ...singles];
+}


### PR DESCRIPTION
## What this does

Roadmap row 5, first source. `system:versions` answers **how many documents hold
edits that are not live**, and **which ones you touched most recently** — two
cards over one predicate.

## The plan's estimate for row 5 was wrong, and this corrects it

Row 5 says each remaining system source is "a declaration once the source
exists". That is true for a domain shaped like releases and false here, and the
difference is worth stating because it changes what the rest of row 5 costs:

| | releases | versions |
| --- | --- | --- |
| service authorizes itself | yes (`authorize()` per call) | **no — no method takes an actor** |
| cross-document query | `find()` | **none — every method takes one `VersionRef`** |
| count available | n/a | **none in the entire data layer** |

So this needed a capability the core did not have.

## The core extension

**There was no `count` anywhere in the data layer.** Collection totals go
through `countEntries`, an access-controlled path built for collection tables;
nothing could count a system table. A caller wanting a number selected the rows
and measured the array — which transfers every row to learn one, and cannot be
bounded without making the number wrong.

The adapter has one now, with `distinctOn`, because rows are not the thing being
counted: **a working draft is one row per document per LOCALE**, so "14 documents
have unpublished changes" counted from rows says 42 for a trilingual install.

**`distinctOn` compiles to `COUNT(*)` over a `SELECT DISTINCT` subquery, never
to `COUNT(DISTINCT a, b)`** — researched, not assumed:

```
$ sqlite> select count(distinct a, b) from t;
Parse error: wrong number of arguments to function count()
```

MySQL accepts the inline form, PostgreSQL needs a row constructor, SQLite
rejects it outright. A query written against one engine is a syntax error on
another. **Substituting the inline form makes the integration suite fail on
SQLite**, so the portability reasoning is tested rather than asserted in a
comment.

**On the port it is OPTIONAL, deliberately.** `VersionsDbApi` is satisfied
structurally by the pooled adapter, which has this, and by the transaction
context, which does not — and the releases and jobs repositories are typed
against the same port. A required method would make every one of them stop
satisfying it for a capability none of them uses.

## Where the access decision lives, and why it moved

In the resolver, not the service — the opposite of `system:releases`. That
service authorizes itself, so its resolver hands the caller through and adds
nothing. `VersionsService` has none, so a resolver that simply called it would
answer an install-wide number to a reader entitled to part of it.

Both reads are bounded by `readableSlugAllowlist`, the same resolution the
collections listing already uses, resolved **once per query** — two resolutions
of one caller's permissions are two chances to disagree. Its three answers stay
distinct: `undefined` is no filter, `[]` is no readable collections and answers
zero, a list is exactly those.

The card publishes the document's identity and its instant and **never the
snapshot** — that column is the unpublished content itself.

## Evidence

Nine breaks, each against a wrong implementation, each moving exactly the test
that names it, controls before and after:

| break | test that moves |
| --- | --- |
| ignore `distinctOn` at the adapter | "counts rows, and counts DISTINCT documents differently" |
| **the inline `COUNT(DISTINCT a,b)` form** | same test — **fails on SQLite** |
| drop the filter from the distinct subquery | "applies the filter to BOTH forms" |
| accept an unknown `distinctOn` column | "refuses a distinctOn naming no column" |
| drop `distinctOn` in the repository | "counts DOCUMENTS, not the rows their locales create" |
| include autosaves | "ignores autosaves, which are not pending edits" |
| read `[]` as no filter | "answers ZERO … for a caller who may read nothing" |
| order ascending | "lists the most recently touched first" |
| drop the access bound in the resolver | three bounding tests |

Two of those were gaps rather than confirmations. Dropping `distinctOn` in the
**repository** initially moved nothing — the adapter test covered the primitive,
nothing covered the repository using it. And the autosave break's first mutation
never applied (the predicate string occurs twice), so its green was unmodified
code, not evidence; re-scoped, it fails correctly.

Local: build, check-types, lint, `nextly` 11,195 unit + 1,505 integration
(sqlite), `adapter-drizzle` 160, `admin` 3,907, `ui` 1,164, comment convention,
`changeset status`, fallow `pass` with every `*_introduced` at 0 — that last
after reducing the new `count` from cc 17 to under the gate by extracting its
two query shapes and its two guards, rather than raising anything.