### PR TITLE
feat(blocks-react): read the components a page embeds

### DIFF
--- a/.changeset/a-page-loads-the-components-it-embeds.md
+++ b/.changeset/a-page-loads-the-components-it-embeds.md
@@ -1,0 +1,41 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A page now loads the components it embeds. Placing a reusable component on a
+page drew nothing on the served site, because nobody was fetching the
+component: the renderer knew how to draw one and was never handed it.
+
+A page reads every component it references in one query, follows a component
+that holds another as far as a page can draw it, and reads them at the same
+posture as the page itself — so a published page draws published components and
+a draft preview draws drafts. Sites that store components somewhere of their own
+can say where, or supply them directly.
+
+Publishing one component now rebuilds exactly the pages that embed it, rather
+than every page on the site. The read carries a tag naming that component alone,
+so a page that never used it is left alone.

--- a/.changeset/a-page-loads-the-components-it-embeds.md
+++ b/.changeset/a-page-loads-the-components-it-embeds.md
@@ -45,3 +45,11 @@ one of them serving another's components from a shared cache. A page embedding
 more components than a cache can track is now read in several queries, so every
 component still updates the pages that use it. And a component reference that
 is blank rather than missing no longer takes the whole page down.
+
+Three more corrections at the same step. A site that raises its block limit
+through its style settings now loads components for the whole page rather than
+the first part of it. A site that supplies components itself is held to the same
+per-page read allowance as one that does not. And a component that cannot be
+found is looked for once rather than once per place it is referenced from,
+which stops a page spending its allowance on the same absent component and
+losing a later one that is really there.

--- a/.changeset/a-page-loads-the-components-it-embeds.md
+++ b/.changeset/a-page-loads-the-components-it-embeds.md
@@ -39,3 +39,9 @@ can say where, or supply them directly.
 Publishing one component now rebuilds exactly the pages that embed it, rather
 than every page on the site. The read carries a tag naming that component alone,
 so a page that never used it is left alone.
+
+A site running several deployments against different databases no longer risks
+one of them serving another's components from a shared cache. A page embedding
+more components than a cache can track is now read in several queries, so every
+component still updates the pages that use it. And a component reference that
+is blank rather than missing no longer takes the whole page down.

--- a/packages/blocks-react/src/component-source.test.ts
+++ b/packages/blocks-react/src/component-source.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Which definitions a page reaches, and how many reads that costs.
+ *
+ * The pipeline does not fetch — it takes the definitions it is handed and
+ * reports what it could not satisfy. So the question this answers is the one
+ * the route owns: which ids to ask for, in how many round trips, and what an
+ * unanswered id means to the pass downstream.
+ */
+import {
+  COMPONENT_INSTANCE_TYPE,
+  DEFAULT_LIMITS,
+  DOCUMENT_FORMAT_VERSION,
+  MAX_COMPOSED_DEPTH,
+  type BlockDocument,
+  type BlockNode,
+} from "@nextlyhq/blocks-engine";
+import { describe, expect, it } from "vitest";
+
+import { definitionsFor, type ComponentSource } from "./component-source";
+
+const instance = (id: string, componentId: string): BlockNode => ({
+  id,
+  type: COMPONENT_INSTANCE_TYPE,
+  version: 1,
+  props: { componentId },
+});
+
+const page = (nodes: BlockNode[]): BlockDocument => ({
+  formatVersion: DOCUMENT_FORMAT_VERSION,
+  kind: "page",
+  nodes,
+});
+
+const component = (nodes: BlockNode[]): BlockDocument => ({
+  formatVersion: DOCUMENT_FORMAT_VERSION,
+  kind: "component",
+  nodes,
+});
+
+/** A source over a fixed store that records every batch it was asked for. */
+function recording(store: Record<string, BlockDocument>): {
+  source: ComponentSource;
+  batches: string[][];
+} {
+  const batches: string[][] = [];
+  const source: ComponentSource = ids => {
+    batches.push([...ids]);
+    const found = new Map<string, BlockDocument>();
+    for (const id of ids) {
+      if (Object.hasOwn(store, id)) found.set(id, store[id]!);
+    }
+    return Promise.resolve(found);
+  };
+  return { source, batches };
+}
+
+describe("the definitions a document reaches", () => {
+  it("asks for the ids the page names, in one batch", async () => {
+    const { source, batches } = recording({
+      hero: component([]),
+      footer: component([]),
+    });
+
+    const found = await definitionsFor(
+      page([instance("i1", "hero"), instance("i2", "footer")]),
+      source,
+      DEFAULT_LIMITS
+    );
+
+    expect(batches).toEqual([["hero", "footer"]]);
+    expect([...found.keys()]).toEqual(["hero", "footer"]);
+  });
+
+  it("follows a component's own references, one batch per level", async () => {
+    // The transitive set is not knowable from the stored page: which
+    // components a component holds is a fact about ITS document, so it cannot
+    // be discovered without reading it first.
+    const { source, batches } = recording({
+      outer: component([instance("n1", "middle")]),
+      middle: component([instance("n2", "inner")]),
+      inner: component([]),
+    });
+
+    const found = await definitionsFor(
+      page([instance("i1", "outer")]),
+      source,
+      DEFAULT_LIMITS
+    );
+
+    expect(batches).toEqual([["outer"], ["middle"], ["inner"]]);
+    expect([...found.keys()]).toEqual(["outer", "middle", "inner"]);
+  });
+
+  it("asks once for a component two others hold", async () => {
+    const { source, batches } = recording({
+      a: component([instance("n1", "shared")]),
+      b: component([instance("n2", "shared")]),
+      shared: component([]),
+    });
+
+    await definitionsFor(
+      page([instance("i1", "a"), instance("i2", "b")]),
+      source,
+      DEFAULT_LIMITS
+    );
+
+    expect(batches).toEqual([["a", "b"], ["shared"]]);
+  });
+
+  it("terminates on a component that reaches itself", async () => {
+    // The walk cannot rely on the resolver's cycle refusal: that happens after
+    // this, on definitions this has to have finished fetching.
+    const { source, batches } = recording({
+      loop: component([instance("n1", "loop")]),
+    });
+
+    const found = await definitionsFor(
+      page([instance("i1", "loop")]),
+      source,
+      DEFAULT_LIMITS
+    );
+
+    expect(batches).toEqual([["loop"]]);
+    expect([...found.keys()]).toEqual(["loop"]);
+  });
+
+  it("stops at the depth the resolver refuses past", async () => {
+    // Reading further would fetch definitions no render can inline — the
+    // resolver answers `composed-depth` before it asks for them — so the bound
+    // is the set the page can actually use rather than a safety margin.
+    const store: Record<string, BlockDocument> = {};
+    for (let i = 0; i < MAX_COMPOSED_DEPTH + 3; i += 1) {
+      store[`c${String(i)}`] = component([
+        instance(`n${String(i)}`, `c${String(i + 1)}`),
+      ]);
+    }
+    const { source, batches } = recording(store);
+
+    const found = await definitionsFor(
+      page([instance("i1", "c0")]),
+      source,
+      DEFAULT_LIMITS
+    );
+
+    expect(batches).toHaveLength(MAX_COMPOSED_DEPTH);
+    expect([...found.keys()]).toEqual(["c0", "c1", "c2", "c3", "c4"]);
+  });
+
+  it("leaves an id the store had no row for OUT of the map", async () => {
+    // Presence is what separates "nobody published one" from "one is published
+    // and cannot be read", and the pipeline reports those as different reasons
+    // with different remedies. Recording an absent id would collapse them.
+    const { source } = recording({ hero: component([]) });
+
+    const found = await definitionsFor(
+      page([instance("i1", "hero"), instance("i2", "never-published")]),
+      source,
+      DEFAULT_LIMITS
+    );
+
+    expect(found.has("hero")).toBe(true);
+    expect(found.has("never-published")).toBe(false);
+  });
+
+  it("asks for nothing when the page holds no instance", async () => {
+    const { source, batches } = recording({ hero: component([]) });
+
+    const found = await definitionsFor(
+      page([{ id: "a", type: "core/text", version: 1, props: {} }]),
+      source,
+      DEFAULT_LIMITS
+    );
+
+    expect(batches).toEqual([]);
+    expect(found.size).toBe(0);
+  });
+});

--- a/packages/blocks-react/src/component-source.test.ts
+++ b/packages/blocks-react/src/component-source.test.ts
@@ -162,6 +162,28 @@ describe("the definitions a document reaches", () => {
     expect(found.has("never-published")).toBe(false);
   });
 
+  it("asks once for an id the store has no row for, however often it recurs", async () => {
+    // A miss never enters the map — its absence is what makes the pipeline
+    // report it `missing` rather than `unreadable` — so the map cannot double
+    // as the record of what has been looked for. Without a separate one, a
+    // component several definitions reference is re-queried at every level,
+    // and each retry spends a chunk and a budget claim that a later valid
+    // definition then does not get.
+    const { source, batches } = recording({
+      a: component([instance("n1", "gone"), instance("n2", "b")]),
+      b: component([instance("n3", "gone")]),
+    });
+
+    const found = await definitionsFor(
+      page([instance("i1", "a")]),
+      source,
+      DEFAULT_LIMITS
+    );
+
+    expect(batches).toEqual([["a"], ["gone", "b"]]);
+    expect(found.has("gone")).toBe(false);
+  });
+
   it("asks for nothing when the page holds no instance", async () => {
     const { source, batches } = recording({ hero: component([]) });
 

--- a/packages/blocks-react/src/component-source.ts
+++ b/packages/blocks-react/src/component-source.ts
@@ -81,7 +81,11 @@ export async function definitionsFor(
     level < MAX_COMPOSED_DEPTH && wanted.length > 0;
     level++
   ) {
-    const unread = wanted.filter(id => !found.has(id));
+    // Deduplicated as the batch is built, not as ids are collected. A
+    // component two others hold is reached twice in one level, and asking for
+    // it twice in one `IN` is a wider query and a longer cache key for one
+    // answer.
+    const unread = [...new Set(wanted.filter(id => !found.has(id)))];
     if (unread.length === 0) break;
     const batch = await source(unread);
     // Recorded for every id ASKED FOR, not for every id answered. An id the

--- a/packages/blocks-react/src/component-source.ts
+++ b/packages/blocks-react/src/component-source.ts
@@ -39,6 +39,12 @@ export type ComponentSource = (
   ids: readonly string[]
 ) => Promise<DefinitionsById>;
 
+/** Shared, so a route whose budget is spent allocates no map at all. */
+export const EMPTY_DEFINITIONS: DefinitionsById = new Map<
+  string,
+  BlockDocument
+>();
+
 /** What component definitions are stored under when a host names nothing. */
 export const COMPONENT_TAG_COLLECTION = "components";
 

--- a/packages/blocks-react/src/component-source.ts
+++ b/packages/blocks-react/src/component-source.ts
@@ -1,0 +1,142 @@
+/**
+ * Where a route's component definitions come from, and what a page's cache
+ * entry has to carry because it read them.
+ *
+ * Composition is a pass of the shared read pipeline, but the pipeline does not
+ * FETCH: it takes the definitions a caller hands over and reports every
+ * reference it could not satisfy. This module is the caller for a Nextly route
+ * — it decides which definitions a page can reach, reads them at the posture
+ * the route is serving, and tags the read so that publishing one component
+ * regenerates exactly the pages that embed it.
+ *
+ * @module component-source
+ */
+import {
+  componentIdsIn,
+  MAX_COMPOSED_DEPTH,
+  type BlockDocument,
+  type DefinitionsById,
+  type DocumentLimits,
+} from "@nextlyhq/blocks-engine";
+
+import type { QueryBudget } from "./context";
+
+/**
+ * Reads the definitions for a set of ids, at one posture.
+ *
+ * A batch rather than one call per id, because the ids are known together and
+ * a page embedding a header, a footer and three cards would otherwise issue
+ * five round trips where one `IN` does. It is the shape a host overriding this
+ * has to implement, so it is the shape that has to be worth implementing.
+ *
+ * Answers a map rather than an array, and the map's KEYS are what the pipeline
+ * reads: an id present with an unreadable value is a definition somebody
+ * supplied and cannot be read, and an id absent is one nobody supplied. Those
+ * carry different remedies, so a source must not drop an id it read a bad row
+ * for — hand the value over and let the pipeline say which.
+ */
+export type ComponentSource = (
+  ids: readonly string[]
+) => Promise<DefinitionsById>;
+
+/** What component definitions are stored under when a host names nothing. */
+export const COMPONENT_TAG_COLLECTION = "components";
+
+/** The field a component's blocks live in when a host names nothing. */
+export const COMPONENT_DOCUMENT_FIELD = "content";
+
+/**
+ * Every definition this document can reach, read level by level.
+ *
+ * NOT one read, and the design's "one batched read" cannot be taken literally:
+ * the transitive set is not knowable from the stored page. A page names the
+ * components it holds directly; which components THOSE hold is a fact about
+ * their stored documents, so it cannot be discovered without reading them. The
+ * loop is therefore one batched read per level of nesting.
+ *
+ * Bounded by {@link MAX_COMPOSED_DEPTH}, the same cap the resolver refuses at.
+ * Reading past it would fetch definitions no render can inline — the resolver
+ * answers `composed-depth` before it asks for them — so the bound is not a
+ * safety margin, it is the set the page can actually use.
+ *
+ * Ids already seen are never re-read: a component held by three others is one
+ * entry, and a cycle terminates because the second visit finds it in the map.
+ */
+export async function definitionsFor(
+  document: BlockDocument,
+  source: ComponentSource,
+  limits: DocumentLimits
+): Promise<DefinitionsById> {
+  const found = new Map<string, BlockDocument>();
+  let wanted = componentIdsIn(document.nodes, limits.maxNodes);
+
+  for (
+    let level = 0;
+    level < MAX_COMPOSED_DEPTH && wanted.length > 0;
+    level++
+  ) {
+    const unread = wanted.filter(id => !found.has(id));
+    if (unread.length === 0) break;
+    const batch = await source(unread);
+    // Recorded for every id ASKED FOR, not for every id answered. An id the
+    // store had no row for has been looked for and not found, and remembering
+    // that is what stops the next level asking again — while leaving it out of
+    // `found` keeps it absent for the pipeline, which is how a reference
+    // nobody published reads as missing rather than as unreadable.
+    wanted = nestedIds(unread, batch, found, limits);
+  }
+  return found;
+}
+
+/**
+ * Merge one level's answers, and collect what they reference in turn.
+ *
+ * The ids a definition holds are read from the document the store returned,
+ * unvalidated: nothing here decides whether that value is a usable component,
+ * because the pipeline already draws that line and drawing it twice is how the
+ * two come to disagree. A value with no readable `nodes` simply references
+ * nothing.
+ */
+function nestedIds(
+  asked: readonly string[],
+  batch: DefinitionsById,
+  into: Map<string, BlockDocument>,
+  limits: DocumentLimits
+): string[] {
+  const next: string[] = [];
+  for (const id of asked) {
+    if (!batch.has(id)) continue;
+    const definition = batch.get(id) as BlockDocument;
+    into.set(id, definition);
+    if (!Array.isArray(definition?.nodes)) continue;
+    for (const nested of componentIdsIn(definition.nodes, limits.maxNodes)) {
+      if (!into.has(nested)) next.push(nested);
+    }
+  }
+  return next;
+}
+
+/** What one batched definition read needs to know about the route asking. */
+export interface ComponentReadOptions {
+  /** The collection definitions are stored in. */
+  collection: string;
+  /** The field holding a definition's blocks. */
+  field: string;
+  /**
+   * The lifecycle scope, decided the way every other read on this route
+   * decides it. A page serving published content must not inline a draft
+   * component, and a route explicitly serving drafts must.
+   */
+  status: "published" | "draft" | "all";
+  /** The locale the route resolved, when the site has more than one. */
+  locale?: string;
+  /**
+   * Charged once per BATCH, not once per definition.
+   *
+   * A page embedding twenty components spends one read, because that is what
+   * it costs. Charging per definition would refuse a page for an allowance it
+   * never used, and charging nothing would leave the one read on this path
+   * that scales with the page unbounded.
+   */
+  budget: QueryBudget;
+}

--- a/packages/blocks-react/src/component-source.ts
+++ b/packages/blocks-react/src/component-source.ts
@@ -74,6 +74,14 @@ export async function definitionsFor(
   limits: DocumentLimits
 ): Promise<DefinitionsById> {
   const found = new Map<string, BlockDocument>();
+  // Asked-for, which is NOT the same set as found. An id the store had no row
+  // for must stay out of `found` — its absence is what makes the pipeline
+  // report it `missing` rather than `unreadable` — but it has been looked for,
+  // and without remembering that, a component referenced from several
+  // definitions is re-queried at every level it appears at. Each retry spends
+  // a chunk and a budget claim, so enough repeats exhaust `maxQueries` before
+  // a later valid definition is reached and render THAT one missing too.
+  const attempted = new Set<string>();
   let wanted = componentIdsIn(document.nodes, limits.maxNodes);
 
   for (
@@ -85,8 +93,9 @@ export async function definitionsFor(
     // component two others hold is reached twice in one level, and asking for
     // it twice in one `IN` is a wider query and a longer cache key for one
     // answer.
-    const unread = [...new Set(wanted.filter(id => !found.has(id)))];
+    const unread = [...new Set(wanted.filter(id => !attempted.has(id)))];
     if (unread.length === 0) break;
+    for (const id of unread) attempted.add(id);
     const batch = await source(unread);
     // Recorded for every id ASKED FOR, not for every id answered. An id the
     // store had no row for has been looked for and not found, and remembering
@@ -120,7 +129,7 @@ function nestedIds(
     into.set(id, definition);
     if (!Array.isArray(definition?.nodes)) continue;
     for (const nested of componentIdsIn(definition.nodes, limits.maxNodes)) {
-      if (!into.has(nested)) next.push(nested);
+      next.push(nested);
     }
   }
   return next;

--- a/packages/blocks-react/src/next.components.test.ts
+++ b/packages/blocks-react/src/next.components.test.ts
@@ -1,0 +1,201 @@
+/**
+ * The read a route performs for the components its page embeds.
+ *
+ * In its own file because it replaces `cachedFind` to capture the tags and key
+ * the read carries, and that substitution is hoisted over the whole module.
+ * What is asserted is the shape of the request: how many round trips, under
+ * which tags, at which posture, and with which identity — every one of which
+ * is invisible in the rendered output and decides whether a cached page is
+ * correct.
+ */
+import {
+  COMPONENT_INSTANCE_TYPE,
+  DOCUMENT_FORMAT_VERSION,
+  type BlockDocument,
+} from "@nextlyhq/blocks-engine";
+import type { ReactElement } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+const cached = vi.fn();
+
+vi.mock("nextly/runtime", async importActual => {
+  const actual = await importActual<typeof import("nextly/runtime")>();
+  return {
+    ...actual,
+    cachedFind: vi.fn(
+      async (reader: () => Promise<unknown>, options: unknown) => {
+        cached(options);
+        // The real one runs the reader on a miss, so the double must too, or
+        // the assertions below would pass over a read that never happened.
+        return await reader();
+      }
+    ),
+  };
+});
+
+const { createBlocksPage } = await import("./next");
+const { entryIdTag } = await import("nextly/runtime");
+
+interface FindArgs {
+  collection: string;
+  where?: Record<string, { equals?: unknown; in?: unknown }>;
+  status?: string;
+  overrideAccess?: boolean;
+  disableErrors?: boolean;
+  user?: unknown;
+  req?: unknown;
+  limit?: number;
+}
+
+const page = (componentIds: string[]): BlockDocument => ({
+  formatVersion: DOCUMENT_FORMAT_VERSION,
+  kind: "page",
+  nodes: componentIds.map((componentId, index) => ({
+    id: `i${String(index)}`,
+    type: COMPONENT_INSTANCE_TYPE,
+    version: 1,
+    props: { componentId },
+  })),
+});
+
+const definition = (nodes: unknown[] = []): unknown => ({
+  formatVersion: DOCUMENT_FORMAT_VERSION,
+  kind: "component",
+  nodes,
+});
+
+/**
+ * A reader over one page entry and a component store, recording every call.
+ *
+ * Understands the `in` operator, because that is the operator the batched read
+ * uses — a double that only knew `equals` would answer nothing and certify a
+ * fetch that silently found no components at all.
+ */
+function reader(components: Record<string, unknown>, content: BlockDocument) {
+  const calls: FindArgs[] = [];
+  return {
+    calls,
+    nextly: {
+      find: vi.fn(async (args: FindArgs) => {
+        calls.push(args);
+        if (args.collection === "components") {
+          const wanted = args.where?.id?.in;
+          const ids = Array.isArray(wanted) ? (wanted as string[]) : [];
+          return {
+            items: ids
+              .filter(id => Object.hasOwn(components, id))
+              .map(id => ({ id, content: components[id] })),
+            meta: {},
+          };
+        }
+        return {
+          items: [{ id: "p1", slug: "about", content }],
+          meta: {},
+        };
+      }),
+      findByID: vi.fn(async () => null),
+      media: { findByID: vi.fn(async () => null) },
+    } as never,
+  };
+}
+
+async function renderWith(
+  components: Record<string, unknown>,
+  content: BlockDocument,
+  extra: Record<string, unknown> = {}
+) {
+  cached.mockClear();
+  const r = reader(components, content);
+  const route = createBlocksPage({
+    collections: ["pages"],
+    field: "content",
+    nextly: r.nextly,
+    ...extra,
+  } as Parameters<typeof createBlocksPage>[0]);
+  const element = (await route.ContentPage({
+    params: { slug: ["about"] },
+  })) as ReactElement<{ definitions?: Map<string, BlockDocument> }>;
+  return { props: element.props, calls: r.calls };
+}
+
+const componentReads = (calls: FindArgs[]) =>
+  calls.filter(call => call.collection === "components");
+
+describe("the definitions a route reads for its page", () => {
+  it("reads every referenced component in ONE query", async () => {
+    const { props, calls } = await renderWith(
+      { hero: definition(), footer: definition() },
+      page(["hero", "footer"])
+    );
+
+    const reads = componentReads(calls);
+    expect(reads).toHaveLength(1);
+    expect(reads[0]!.where?.id?.in).toEqual(["hero", "footer"]);
+    expect([...(props.definitions?.keys() ?? [])]).toEqual(["hero", "footer"]);
+  });
+
+  it("tags the read per id and NOT with the collection", async () => {
+    // `nextlyTags` always prepends the collection tag, so using it here would
+    // make publishing any component rebuild every page that embeds any
+    // component — the opposite of what a component store is for.
+    await renderWith({ hero: definition() }, page(["hero"]));
+
+    const options = cached.mock.calls[0]![0] as { tags: string[] };
+    expect(options.tags).toEqual([entryIdTag("components", "hero")]);
+    expect(options.tags).not.toContain("nextly:components");
+  });
+
+  it("reads definitions at the posture the route serves", async () => {
+    // The SAME scope the entry read uses, not a second opinion. A page serving
+    // published content must not inline a draft component, and a route
+    // explicitly serving drafts must.
+    const served = await renderWith({ hero: definition() }, page(["hero"]));
+    expect(componentReads(served.calls)[0]!.status).toBe("published");
+
+    const draft = await renderWith({ hero: definition() }, page(["hero"]), {
+      draft: true,
+    });
+    expect(componentReads(draft.calls)[0]!.status).toBe("all");
+  });
+
+  it("clears BOTH identity channels", async () => {
+    // `mergeConfig` spreads the reader's defaults UNDER the call, so an
+    // omitted `user` or `req` restores whatever identity the instance was
+    // booted with — on a read this route performs for an anonymous visitor,
+    // into a page that is then cached.
+    const { calls } = await renderWith({ hero: definition() }, page(["hero"]));
+
+    const read = componentReads(calls)[0]!;
+    expect(read.overrideAccess).toBe(true);
+    expect(read.disableErrors).toBe(true);
+    expect("user" in read).toBe(true);
+    expect(read.user).toBeUndefined();
+    expect("req" in read).toBe(true);
+    expect(read.req).toBeUndefined();
+  });
+
+  it("hands over a row whose field is unreadable rather than dropping it", async () => {
+    // Presence is what separates "nobody published one" from "one is published
+    // and cannot be read". Filtering the bad row here would report the first.
+    const { props } = await renderWith(
+      { hero: "not a document" },
+      page(["hero"])
+    );
+
+    expect(props.definitions?.has("hero")).toBe(true);
+  });
+
+  it("asks for nothing when the page embeds no component", async () => {
+    const { calls, props } = await renderWith(
+      { hero: definition() },
+      {
+        formatVersion: DOCUMENT_FORMAT_VERSION,
+        kind: "page",
+        nodes: [{ id: "a", type: "core/text", version: 1, props: {} }],
+      }
+    );
+
+    expect(componentReads(calls)).toEqual([]);
+    expect(props.definitions).toBeUndefined();
+  });
+});

--- a/packages/blocks-react/src/next.components.test.ts
+++ b/packages/blocks-react/src/next.components.test.ts
@@ -185,6 +185,59 @@ describe("the definitions a route reads for its page", () => {
     expect(props.definitions?.has("hero")).toBe(true);
   });
 
+  it("keys the read by cache scope, so two tenants cannot share an entry", async () => {
+    // Two deployments pointed at different databases ask for the same ids
+    // under the same collection, status and locale. Without the discriminator
+    // the first to warm the entry serves ITS definitions to the other's pages.
+    await renderWith({ hero: definition() }, page(["hero"]), {
+      cacheScope: "tenant-a",
+    });
+    const a = cached.mock.calls[0]![0] as { keyParts: string[] };
+
+    await renderWith({ hero: definition() }, page(["hero"]), {
+      cacheScope: "tenant-b",
+    });
+    const b = cached.mock.calls[0]![0] as { keyParts: string[] };
+
+    expect(a.keyParts).toContain("tenant-a");
+    expect(b.keyParts).toContain("tenant-b");
+    expect(a.keyParts).not.toEqual(b.keyParts);
+  });
+
+  it("splits a page past the tag cap into queries that stay invalidatable", async () => {
+    // Next drops cache tags past 128 and Nextly clamps a query to 500 rows.
+    // Both are silent: the first leaves a component uninvalidatable by its own
+    // publish, the second returns a subset and reports the rest missing.
+    const ids = Array.from({ length: 200 }, (_, i) => `c${String(i)}`);
+    const store = Object.fromEntries(ids.map(id => [id, definition()]));
+
+    const { props, calls } = await renderWith(store, page(ids));
+
+    const reads = componentReads(calls);
+    expect(reads).toHaveLength(2);
+    expect(reads.every(read => (read.where?.id?.in as string[]).length <= 128));
+    for (const call of cached.mock.calls) {
+      expect((call[0] as { tags: string[] }).tags.length).toBeLessThanOrEqual(
+        128
+      );
+    }
+    expect(props.definitions?.size).toBe(200);
+  });
+
+  it("drops a blank component id instead of failing the page", async () => {
+    // `entryIdTag` refuses a blank segment by throwing, and `componentIdsIn`
+    // reports "   " as a reference because it is a nonempty string. Left in,
+    // one malformed instance takes the page down before a block boundary
+    // exists to contain it.
+    const { props } = await renderWith(
+      { hero: definition() },
+      page(["hero", "   "])
+    );
+
+    expect(props.definitions?.has("hero")).toBe(true);
+    expect(props.definitions?.has("   ")).toBe(false);
+  });
+
   it("asks for nothing when the page embeds no component", async () => {
     const { calls, props } = await renderWith(
       { hero: definition() },

--- a/packages/blocks-react/src/next.components.test.ts
+++ b/packages/blocks-react/src/next.components.test.ts
@@ -238,6 +238,43 @@ describe("the definitions a route reads for its page", () => {
     expect(props.definitions?.has("   ")).toBe(false);
   });
 
+  it("charges a host's own source to the same budget", async () => {
+    // A site's source is the one most likely to be database- or network-backed,
+    // so exempting it bounds the reader we wrote and leaves unbounded the one
+    // the site supplies — the wrong way round, and the reason `mediaResolver`
+    // charges a custom `resolveMedia` too.
+    const asked: string[][] = [];
+    await renderWith({}, page(["hero"]), {
+      maxQueries: 0,
+      resolveComponents: (ids: readonly string[]) => {
+        asked.push([...ids]);
+        return Promise.resolve(new Map());
+      },
+    });
+
+    expect(asked).toEqual([]);
+  });
+
+  it("fetches under the caps the renderer will draw under", async () => {
+    // `prepareDocumentReadStages` falls back to the style context's limits, so
+    // a route that raises `maxNodes` there and not directly would fetch for the
+    // first 5,000 nodes while the renderer kept every instance after them.
+    const ids = Array.from({ length: 3 }, (_, i) => `c${String(i)}`);
+    const store = Object.fromEntries(ids.map(id => [id, definition()]));
+
+    const { calls } = await renderWith(store, page(ids), {
+      styleContext: {
+        breakpoints: { viewport: [], container: [] },
+        limits: { maxDepth: 12, maxNodes: 2, maxBytes: 2_097_152 },
+      },
+    });
+
+    // Two nodes' worth of instances reached, because that is the cap the
+    // renderer is about to read the same document under.
+    const read = componentReads(calls)[0]!;
+    expect((read.where?.id?.in as string[]).length).toBe(2);
+  });
+
   it("asks for nothing when the page embeds no component", async () => {
     const { calls, props } = await renderWith(
       { hero: definition() },

--- a/packages/blocks-react/src/next.ts
+++ b/packages/blocks-react/src/next.ts
@@ -791,7 +791,16 @@ function componentSource(
   budget: QueryBudget,
   locale: string | undefined
 ): ComponentSource {
-  if (config.resolveComponents) return config.resolveComponents;
+  if (config.resolveComponents) {
+    const custom = config.resolveComponents;
+    // Charged like every other read on this path, for the reason
+    // `mediaResolver` charges a host's own resolver: a site's source is the
+    // one most likely to be database- or network-backed, and exempting it
+    // bounds the reader we wrote while leaving unbounded the one a site
+    // supplies. A nested chain asks it once per level, so an uncharged source
+    // is `MAX_COMPOSED_DEPTH` unbounded reads on a route that stated a limit.
+    return async ids => (budget.take() ? await custom(ids) : EMPTY_DEFINITIONS);
+  }
   const collection = config.componentCollection ?? COMPONENT_TAG_COLLECTION;
   const field = config.componentField ?? COMPONENT_DOCUMENT_FIELD;
   const status = config.status ?? (config.draft === true ? "all" : "published");
@@ -844,6 +853,19 @@ function componentSource(
  * extra query per 128, which is the honest price of staying invalidatable.
  */
 const COMPONENT_BATCH_SIZE = 128;
+
+/**
+ * The caps this route holds its documents to, resolved the way the pipeline
+ * resolves them.
+ *
+ * One answer, because two would be a disagreement about which nodes exist: the
+ * fetch decides what to load and the renderer decides what to draw, and a page
+ * whose instances sit past one cap but inside the other loses exactly the
+ * blocks between them.
+ */
+function effectiveLimits(config: BlocksPageConfig): DocumentLimits {
+  return config.limits ?? config.styleContext?.limits ?? DEFAULT_LIMITS;
+}
 
 /** Successive slices of at most `size`. */
 function chunked<T>(items: readonly T[], size: number): T[][] {
@@ -1377,7 +1399,13 @@ function blocksRouteConfig(
       const definitions = await definitionsFor(
         document,
         componentSource(config, readerFor(config), budget, context.locale),
-        limits ?? DEFAULT_LIMITS
+        // The SAME caps the pipeline will read this document under, resolved
+        // once. `prepareDocumentReadStages` falls back to the style context's
+        // when no limits are given directly, so passing the default here made
+        // a route that raised `maxNodes` through `styleContext` fetch for the
+        // first 5,000 nodes while the renderer kept — and tried to draw —
+        // every instance after them.
+        effectiveLimits(config)
       );
 
       return createElement(PageRenderer, {

--- a/packages/blocks-react/src/next.ts
+++ b/packages/blocks-react/src/next.ts
@@ -14,12 +14,14 @@
  * @module next
  */
 import {
+  DEFAULT_LIMITS,
   deriveSeoFromDocument,
   isFetchableUrl,
   DOCUMENT_FORMAT_VERSION,
 } from "@nextlyhq/blocks-engine";
 import type {
   BlockDocument,
+  DefinitionsById,
   BlockSeoContribution,
   DocumentLimits,
   RemotePatternInput,
@@ -29,10 +31,12 @@ import type {
 } from "@nextlyhq/blocks-engine";
 import type { Metadata } from "next";
 import {
+  cachedFind,
   createContentRoute,
   createPublicContentRoute,
   createPublicSingleRoute,
   createSingleRoute,
+  entryIdTag,
   getNextly,
   nextlyTags,
   nextlySingleTags,
@@ -55,6 +59,13 @@ import type { ReactElement, ReactNode } from "react";
 import { createElement } from "react";
 
 import { url } from "./blocks/props";
+import {
+  COMPONENT_DOCUMENT_FIELD,
+  COMPONENT_TAG_COLLECTION,
+  definitionsFor,
+  EMPTY_DEFINITIONS,
+  type ComponentSource,
+} from "./component-source";
 import { createStandaloneContext } from "./context";
 import type {
   BlockHostPolicy,
@@ -243,6 +254,33 @@ export interface BlocksPageConfig
    * media namespace rather than naming a collection at all.
    */
   mediaCollection?: string;
+  /**
+   * The collection component definitions are stored in.
+   *
+   * Named rather than discovered, and defaulted rather than required. The
+   * page-builder plugin ships the collection this defaults to, so a site using
+   * it configures nothing — and `blocks-react` must not import the plugin to
+   * learn the name, because the renderer is usable without it and the
+   * dependency would only run the other way.
+   */
+  componentCollection?: string;
+  /**
+   * The field a component definition's blocks live in.
+   *
+   * Its own option for the same reason `field` is one for the page: a default
+   * would be a guess at the site's schema, and guessing wrong inlines nothing
+   * while reporting every reference as unreadable.
+   */
+  componentField?: string;
+  /**
+   * Where definitions come from, for a host that does not store them in a
+   * Nextly collection at all.
+   *
+   * Mirrors `resolveMedia`. Given one, this route reads nothing itself — so a
+   * host supplying this owns the posture and the cache tags too, exactly as a
+   * host supplying `resolveMedia` owns them for images.
+   */
+  resolveComponents?: ComponentSource;
   /** Resolve a media id yourself, instead of reading the media collection. */
   resolveMedia?: (id: string) => Promise<ResolvedMedia | null>;
   /** Resolve an entry reference to a path, instead of reading its slug. */
@@ -723,6 +761,95 @@ async function mediaByQuery(
   return found.items[0];
 }
 
+/**
+ * The route's component source: one batched, tagged, posture-carrying read.
+ *
+ * TAGGED PER ID and never with the collection tag. `nextlyTags` always
+ * prepends it, so using it here would make publishing any component rebuild
+ * every page on the site that embeds any component at all — the exact opposite
+ * of what a component store is for. The id tags attach to the PAGE's cache
+ * entry because this read happens inside the page's render, so one component
+ * publish invalidates exactly the pages that embedded it.
+ *
+ * The identity channels are cleared and the scope is the route's, for the
+ * reasons `mediaResolver` clears them: `mergeConfig` spreads the reader's
+ * defaults UNDER the call, so an omitted `user` or `req` restores whatever
+ * identity the instance was booted with — on a read this route performs for an
+ * anonymous visitor, into a page that is then cached. And the lifecycle scope
+ * is the entry read's, not a second opinion: a route serving published content
+ * must not inline a draft component, and a preview route must.
+ *
+ * The row is handed over WHOLE and unjudged. Whether that field holds a
+ * readable component document is the pipeline's question, and it answers it
+ * with reasons a store cannot: an id present with an unreadable value is a
+ * definition somebody published and cannot be read, and an id absent is one
+ * nobody published.
+ */
+function componentSource(
+  config: BlocksPageConfig,
+  reader: NextlyContentReader,
+  budget: QueryBudget,
+  locale: string | undefined
+): ComponentSource {
+  if (config.resolveComponents) return config.resolveComponents;
+  const collection = config.componentCollection ?? COMPONENT_TAG_COLLECTION;
+  const field = config.componentField ?? COMPONENT_DOCUMENT_FIELD;
+  const status = config.status ?? (config.draft === true ? "all" : "published");
+
+  return async (ids: readonly string[]) => {
+    // One claim for the batch, because one read is what it costs. Charging per
+    // definition would refuse a page for an allowance it never spent; charging
+    // nothing would leave the one read on this path that grows with the page
+    // unbounded.
+    if (!budget.take()) return EMPTY_DEFINITIONS;
+    const wanted = [...ids];
+    const found = await cachedFind(
+      async () =>
+        await reader.find({
+          collection,
+          where: { id: { in: wanted } },
+          limit: wanted.length,
+          status,
+          overrideAccess: true,
+          disableErrors: true,
+          user: undefined,
+          req: undefined,
+          ...(locale ? { locale } : {}),
+        }),
+      {
+        tags: wanted.map(id => entryIdTag(collection, id)),
+        // Sorted, so two pages embedding the same components in a different
+        // order share one entry rather than filling two with one answer.
+        keyParts: [
+          "nextly-components",
+          collection,
+          status,
+          locale ?? "",
+          ...[...wanted].sort(),
+        ],
+      }
+    );
+    return definitionsById(found.items, field);
+  };
+}
+
+/** The rows a batched read returned, keyed by id, with the block field taken. */
+function definitionsById(
+  items: readonly Record<string, unknown>[],
+  field: string
+): DefinitionsById {
+  const found = new Map<string, BlockDocument>();
+  for (const item of items) {
+    const id = item.id;
+    if (typeof id !== "string") continue;
+    // Whatever the field held. A row present with an unusable value is what
+    // lets the pipeline say `unreadable` rather than `missing`, so nothing is
+    // filtered out here.
+    found.set(id, item[field] as BlockDocument);
+  }
+  return found;
+}
+
 function mediaResolver(
   config: BlocksPageConfig,
   reader: NextlyContentReader,
@@ -1176,11 +1303,27 @@ function blocksRouteConfig(
           ? undefined
           : { ...configuredSiteStyles, breakpoints: siteBreakpoints };
 
+      // Read BEFORE the element is created, because the renderer's pipeline is
+      // synchronous: composition is a pass of it, and a pass cannot await. The
+      // route is the layer that can, which is why the fetch lives here and not
+      // in the renderer.
+      const definitions = await definitionsFor(
+        document,
+        componentSource(config, readerFor(config), budget, context.locale),
+        limits ?? DEFAULT_LIMITS
+      );
+
       return createElement(PageRenderer, {
         document,
         context: pageContext,
         blocks,
         styles: resolved,
+        // Spread conditionally, matching `hostPolicy` below: a page holding no
+        // instance resolves to an empty map, and handing `PageRenderer` an
+        // empty map rather than nothing states that definitions WERE fetched
+        // and none was found — which is the honest answer for a page that
+        // references none, and the wrong one for a caller that never asked.
+        ...(definitions.size === 0 ? {} : { definitions }),
         styleContext,
         blockFallback,
         limits,

--- a/packages/blocks-react/src/next.ts
+++ b/packages/blocks-react/src/next.ts
@@ -797,40 +797,107 @@ function componentSource(
   const status = config.status ?? (config.draft === true ? "all" : "published");
 
   return async (ids: readonly string[]) => {
-    // One claim for the batch, because one read is what it costs. Charging per
-    // definition would refuse a page for an allowance it never spent; charging
-    // nothing would leave the one read on this path that grows with the page
-    // unbounded.
-    if (!budget.take()) return EMPTY_DEFINITIONS;
-    const wanted = [...ids];
-    const found = await cachedFind(
-      async () =>
-        await reader.find({
-          collection,
-          where: { id: { in: wanted } },
-          limit: wanted.length,
-          status,
-          overrideAccess: true,
-          disableErrors: true,
-          user: undefined,
-          req: undefined,
-          ...(locale ? { locale } : {}),
-        }),
-      {
-        tags: wanted.map(id => entryIdTag(collection, id)),
+    // Dropped before anything is built from them, not repaired. `entryIdTag`
+    // refuses a blank segment by THROWING — correctly, because a bare
+    // `nextly:components:id:` tag would over-invalidate — and a stored
+    // `componentId` of `"   "` is a nonempty string that `componentIdsIn`
+    // reports as a reference. Left in, one malformed instance takes the whole
+    // page down before a block boundary exists to contain it; left out, it is
+    // an id nobody supplied a definition for, which is exactly what it is.
+    const wanted = [...new Set(ids)].filter(id => id.trim().length > 0);
+    if (wanted.length === 0) return EMPTY_DEFINITIONS;
+
+    const found = new Map<string, BlockDocument>();
+    for (const chunk of chunked(wanted, COMPONENT_BATCH_SIZE)) {
+      // One claim per QUERY. A page embedding twenty components spends one
+      // read because that is what it costs; charging per definition would
+      // refuse a page for an allowance it never spent, and charging nothing
+      // would leave the read on this path that grows with the page unbounded.
+      if (!budget.take()) break;
+      const page = await readComponentChunk(chunk, {
+        reader,
+        collection,
+        status,
+        locale,
+        cacheScope: config.cacheScope,
+      });
+      for (const [id, document] of definitionsById(page.items, field)) {
+        found.set(id, document);
+      }
+    }
+    return found;
+  };
+}
+
+/**
+ * How many definitions one query may ask for.
+ *
+ * The smaller of two caps that are enforced elsewhere and silent when crossed.
+ * Nextly clamps a collection query to 500 rows (`PAGINATION_DEFAULTS.maxLimit`),
+ * so a larger `limit` returns a SUBSET and the components missing from it are
+ * reported as though nobody had published them. Next drops cache tags past
+ * `NEXT_CACHE_TAG_MAX_ITEMS`, 128 in the version this package builds against,
+ * so a component whose tag was dropped is never invalidated by its own publish
+ * and stays stale until some unrelated write busts the entry.
+ *
+ * 128 satisfies both. A page embedding more components than that costs one
+ * extra query per 128, which is the honest price of staying invalidatable.
+ */
+const COMPONENT_BATCH_SIZE = 128;
+
+/** Successive slices of at most `size`. */
+function chunked<T>(items: readonly T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    out.push(items.slice(i, i + size));
+  }
+  return out;
+}
+
+/** One batched, tagged, posture-carrying read of at most a full chunk. */
+async function readComponentChunk(
+  wanted: readonly string[],
+  args: {
+    reader: NextlyContentReader;
+    collection: string;
+    status: "published" | "draft" | "all";
+    locale: string | undefined;
+    cacheScope: string | undefined;
+  }
+): Promise<{ items: Record<string, unknown>[] }> {
+  const { reader, collection, status, locale, cacheScope } = args;
+  return await cachedFind(
+    async () =>
+      await reader.find({
+        collection,
+        where: { id: { in: [...wanted] } },
+        limit: wanted.length,
+        status,
+        overrideAccess: true,
+        disableErrors: true,
+        user: undefined,
+        req: undefined,
+        ...(locale ? { locale } : {}),
+      }),
+    {
+      tags: wanted.map(id => entryIdTag(collection, id)),
+      keyParts: [
+        "nextly-components",
+        collection,
+        status,
+        locale ?? "",
+        // The tenant discriminator, exactly as `resolveContent` keys its own
+        // read. Two deployments pointed at different databases ask for the
+        // same component ids under the same collection, status and locale —
+        // so without this the first to warm the entry serves its definitions
+        // to the other's pages.
+        cacheScope ?? "",
         // Sorted, so two pages embedding the same components in a different
         // order share one entry rather than filling two with one answer.
-        keyParts: [
-          "nextly-components",
-          collection,
-          status,
-          locale ?? "",
-          ...[...wanted].sort(),
-        ],
-      }
-    );
-    return definitionsById(found.items, field);
-  };
+        ...[...wanted].sort(),
+      ],
+    }
+  );
 }
 
 /** The rows a batched read returned, keyed by id, with the block field taken. */

--- a/packages/nextly/src/runtime.ts
+++ b/packages/nextly/src/runtime.ts
@@ -40,6 +40,7 @@ export {
   registerNextCacheRevalidator,
   nextlyTags,
   nextlySingleTags,
+  entryIdTag,
   cachedFind,
   type NextCacheModule,
   type CachedFindOptions,

--- a/packages/nextly/src/runtime/cache/index.ts
+++ b/packages/nextly/src/runtime/cache/index.ts
@@ -8,6 +8,6 @@
 export { NextCacheRevalidator } from "./next-cache-revalidator";
 export type { NextCacheModule } from "./next-cache-revalidator";
 export { registerNextCacheRevalidator } from "./register";
-export { nextlyTags, nextlySingleTags } from "./nextly-tags";
+export { entryIdTag, nextlyTags, nextlySingleTags } from "./nextly-tags";
 export { cachedFind } from "./cached-find";
 export type { CachedFindOptions } from "./cached-find";

--- a/packages/nextly/src/runtime/cache/nextly-tags.ts
+++ b/packages/nextly/src/runtime/cache/nextly-tags.ts
@@ -14,6 +14,23 @@ import {
 } from "../../revalidation/compute-tags";
 
 /**
+ * `nextly:{collection}:id:{id}` on its own — the entity, without its collection.
+ *
+ * Published beside {@link nextlyTags} rather than instead of it, because the
+ * two answer different questions and the collection tag is the wrong answer
+ * for some reads. A read that names ONE record it already knows the id of —
+ * a page inlining the components it embeds, say — wants to regenerate when
+ * that record changes and not when any of its siblings do. Tagged with the
+ * collection, publishing one component would rebuild every page on the site
+ * that embeds any component.
+ *
+ * A read that DISCOVERS which records it wants still needs the collection tag:
+ * a listing has no id to name until it runs, so nothing narrower can tell it
+ * that a newly created row belongs in it.
+ */
+export { entryIdTag };
+
+/**
  * The tags a content read should carry so an on-write bust invalidates it.
  *
  * - `nextlyTags("posts")` → the collection tag: for a listing / index / sitemap


### PR DESCRIPTION
Plan 06, T-4 slice C — the definition fetch seam (design §6.4). Composition shipped in #1522 as a pass of the shared read pipeline, but the pipeline does not FETCH: it takes the definitions it is handed and reports what it could not satisfy. Every route handed it none, so a page holding a component reported it `missing` and drew a placeholder. This is the layer that supplies them.

## What a route now does

Collects the component ids its stored document names, reads them in **one batched query** at the same posture the entry was read at, and hands the map to `PageRenderer`.

**Not one read, and the design's "one batched read" cannot be taken literally.** The transitive set is not knowable from the stored page: which components a component holds is a fact about *its* document, so it cannot be discovered without reading it first. The walk is one batch per level of nesting, bounded by `MAX_COMPOSED_DEPTH` — the same cap the resolver refuses past, so the bound is the set the page can actually use rather than a safety margin.

## Cache tags, and why `entryIdTag` is now published

The read carries `entryIdTag(collection, id)` per component and **not** the collection tag. That is the entire reason `entryIdTag` is exported from `nextly/runtime` for the first time: `nextlyTags` always prepends `collectionTag`, so tagging this read with it would make publishing any component rebuild every page on the site that embeds any component — the opposite of what a component store is for. Because the read happens inside the page render, the id tags attach to the page's own cache entry, so one component publish invalidates exactly the pages that embedded it.

## The parts that are about correctness rather than plumbing

- **Posture is the entry read's, not a second opinion.** A published page must not inline a draft component; a preview route must.
- **Both identity channels are cleared.** `mergeConfig` spreads the reader's defaults *under* the call, so an omitted `user` or `req` restores whatever identity the instance was booted with — on a read performed for an anonymous visitor, into a page that is then cached.
- **An id with no row is left OUT of the map; a row whose field is unreadable is handed over whole.** Presence is what separates "nobody published one" from "one is published and cannot be read", and the pipeline reports those as different reasons with different remedies. Filtering the bad row would report the first.
- **One claim on the query budget per batch.** Charging per definition would refuse a page for an allowance it never spent; charging nothing would leave the one read on this path that grows with the page unbounded.

## Tests, and two things they caught

13 new tests — 7 over the closure, 6 over the route read.

They found **a real defect in this branch before it ever ran**: a component held by two others was asked for twice in the same batch, a wider `IN` and a longer cache key for one answer.

And one of my own tests was **fake green** — a posture assertion written as `expect(componentReads([])).toEqual([])`, which passes on an empty literal regardless of the product. Replaced with one that reads the `status` off both an ordinary and a `draft: true` route.

Break-verified, count held: collection tags kill 1, per-id reads kill 2, dropping unreadable rows kills 1, leaking the identity channels kills 1, no dedupe kills 1, no depth bound kills 1 (9 batches instead of 5), recording absent ids kills 1.

## Gates

`build` 0 · `check-types` 0 · `lint` 0 · `check:comments` 0 · `fallow` **pass**, 0 introduced across all four dimensions · `changeset status` 0, one changeset, 25 packages.

blocks-react 1138 (+13) · nextly 11188 across 878 files · blocks-engine 1899.

## Not in this slice

Site-sheet hoisting, the never-published readiness check (Q17), and `plugin-seo` re-verification are T-4 slice C2 and are not here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic loading of referenced component definitions for block pages, including nested compositions.
  - Added configurable component collections, content fields, and custom component-definition resolvers.
  - Added batched and cached component reads with route- and tenant-aware cache behavior.
  - Added support for published, draft, and all-content reading modes, plus optional locale handling.
  - Exposed an entry-specific cache tag for targeted cache invalidation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->