### PR TITLE
fix(blocks-react): derive metadata from the components the page renders

### DIFF
--- a/.changeset/a-shared-link-shows-the-page-you-see.md
+++ b/.changeset/a-shared-link-shows-the-page-you-see.md
@@ -1,0 +1,33 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A page's title, description and link preview now come from the same page a
+visitor sees. When a heading or an image lived inside a reusable component, the
+page showed it and the metadata did not — so a search result or a shared link
+described the page as though that content were not there, on exactly the pages
+built out of components.

--- a/packages/blocks-react/src/next.components.test.ts
+++ b/packages/blocks-react/src/next.components.test.ts
@@ -14,6 +14,8 @@ import {
   type BlockDocument,
 } from "@nextlyhq/blocks-engine";
 import type { ReactElement } from "react";
+import { coreBlocks } from "./blocks";
+import { createBlockResolver } from "./resolver";
 import { describe, expect, it, vi } from "vitest";
 
 const cached = vi.fn();
@@ -273,6 +275,37 @@ describe("the definitions a route reads for its page", () => {
     // renderer is about to read the same document under.
     const read = componentReads(calls)[0]!;
     expect((read.where?.id?.in as string[]).length).toBe(2);
+  });
+
+  it("derives metadata from the SAME components the page renders", async () => {
+    // The heading a visitor sees comes from a component. Without the
+    // definitions, the metadata preparation replaces that instance with a
+    // placeholder and derives a title from a document the page does not show —
+    // for exactly the pages components exist to build.
+    const heading = {
+      id: "h",
+      type: "core/heading",
+      version: 1,
+      props: { text: "Composed title", level: 1 },
+    };
+    const r = reader({ hero: definition([heading]) }, page(["hero"]));
+    const route = createBlocksPage({
+      collections: ["pages"],
+      field: "content",
+      nextly: r.nextly,
+      blocks: createBlockResolver(coreBlocks),
+      // `metadata`, not `buildMetadata` — the latter is the route's own hook,
+      // which cannot see the document and would bypass the derivation entirely.
+      metadata: (
+        _entry: unknown,
+        _context: unknown,
+        derived: { title?: string }
+      ) => ({ title: derived.title ?? "NO TITLE" }),
+    } as Parameters<typeof createBlocksPage>[0]);
+
+    const meta = await route.generateMetadata({ params: { slug: ["about"] } });
+
+    expect(meta.title).toBe("Composed title");
   });
 
   it("asks for nothing when the page embeds no component", async () => {

--- a/packages/blocks-react/src/next.ts
+++ b/packages/blocks-react/src/next.ts
@@ -482,7 +482,17 @@ async function derivePageSeo(
    * Open Graph tags, where every crawler and chat client that unfurls the link
    * then fetches it.
    */
-  remotePatterns: readonly RemotePatternInput[] | undefined
+  remotePatterns: readonly RemotePatternInput[] | undefined,
+  /**
+   * The components this page embeds, resolved by the caller.
+   *
+   * Handed in rather than fetched here, because this function is synchronous
+   * about content by design and the caller already owns a query budget. What
+   * matters is that it is the SAME set the render inlines: the preparation
+   * below is shared with the renderer precisely so the two describe one page,
+   * and definitions are the one input that can differ while every pass agrees.
+   */
+  definitions: DefinitionsById | undefined
 ): Promise<DerivedPageSeo> {
   const resolver = blocks ?? registeredBlocks();
   // Spread rather than assigned, so an unaddressable slug OMITS the key instead
@@ -500,6 +510,12 @@ async function derivePageSeo(
     resolver,
     limits,
     styleContext,
+    // Spread conditionally, matching the renderer: an absent map says the
+    // caller never fetched, an empty one says it fetched and found none, and
+    // the pipeline reports those differently.
+    ...(definitions === undefined || definitions.size === 0
+      ? {}
+      : { definitions }),
   });
   // Nothing readable means nothing to describe. The page renders a placeholder,
   // and metadata claiming a title it does not show would be worse than silence.
@@ -1307,19 +1323,35 @@ function blocksRouteConfig(
             const document = readDocument(entry, field, context);
             // Its own budget: metadata generation and the render are separate
             // invocations, so sharing one counter would let the page's reads
-            // starve the preview image, or the reverse.
+            // starve the preview image, or the reverse. Shared BETWEEN the two
+            // reads this invocation makes, because they are one page's cost.
+            const budget = createQueryBudget(
+              config.maxQueries ?? DEFAULT_MAX_QUERIES
+            );
+            // The same components the render will inline. Without them the
+            // preparation below replaces every instance with a placeholder, so
+            // a page whose heading or hero image comes from a component
+            // published a title and a preview picture that its own HTML
+            // contradicts — for exactly the pages components exist to build.
+            const definitions = await definitionsFor(
+              document,
+              componentSource(
+                config,
+                readerFor(config),
+                budget,
+                context.locale
+              ),
+              effectiveLimits(config)
+            );
             const derived = await derivePageSeo(
               document,
               blocks,
-              mediaResolver(
-                config,
-                readerFor(config),
-                createQueryBudget(config.maxQueries ?? DEFAULT_MAX_QUERIES)
-              ),
+              mediaResolver(config, readerFor(config), budget),
               context.slug,
               limits,
               styleContext,
-              config.hostPolicy?.remotePatterns
+              config.hostPolicy?.remotePatterns,
+              definitions
             );
             return metadata(entry, context, derived);
           },


### PR DESCRIPTION
Takes `task:pb6-t4c-metadata-composes-too`, the first of the five findings deferred from #1529.

## The defect

`buildMetadata` called `derivePageSeo` with no definitions, so `prepareDocumentForRead` inside it replaced every component instance with a placeholder. A page whose heading or hero image lives in a component published a title and a preview picture that its own HTML contradicts — **for exactly the pages components exist to build**.

Reproduced before fixing: a heading inside a component gives `title: "NO TITLE"` while the rendered page shows it.

## Why it is worth reading rather than just patching

`derivePageSeo` already carries a docblock about this precise failure class:

> One authoritative preparation, shared with the renderer rather than restated here. Hand-copying the passes is what let metadata describe a different page than the HTML.

And the passes *were* shared — the warning was heeded. Definitions are an **input** to those passes that the metadata path did not have, so the same failure returned through a door the comment did not cover. A shared implementation is not the same as shared inputs, and that distinction is now written where the next person meets it.

## The change

`derivePageSeo` takes `definitions` and spreads them into the preparation **conditionally**, matching the renderer: an absent map says the caller never fetched, an empty one says it fetched and found none, and the pipeline reports those differently.

`buildMetadata` fetches them with the budget it already creates. That budget is now **shared between the media and component reads**, because they are one page's cost — while the render keeps a separate one, because that is a separate invocation. The existing comment already drew the second line; this adds the first.

## Gates

`build` 0 · `check-types` 0 · `lint` 0 · `check:comments` 0 · `fallow` **pass**, 0 introduced on all four dimensions (back from the `warn` on #1529 — no new duplication here) · `changeset status` 0, one changeset, 25 packages.

blocks-react 1145 (+1). Break-verified: passing `undefined` for definitions returns `NO TITLE`, which is the shipped behaviour.

## A test trap worth naming

My first fixture set `buildMetadata` on `BlocksPageConfig`. That is the **route's** hook, which bypasses the derivation wrapper entirely; the field that reaches it is `metadata`. The symptom was a `TypeError` on an undefined third argument — which reads like a broken test rather than a wrong config key, and is the kind of thing that gets a test deleted instead of corrected.

## Still deferred from #1529

`pb6-t4c-reachability-from-the-resolver`, `pb6-t4c-draft-posture`, `pb6-t4c-working-draft-definitions`, `pb6-t4c-release-bounded-component-cache` — all filed with reasons.