### PR TITLE
fix(blocks-react): ask the resolver what it reaches instead of predicting it

### DIFF
--- a/.changeset/a-swapped-component-is-the-one-that-loads.md
+++ b/.changeset/a-swapped-component-is-the-one-that-loads.md
@@ -1,0 +1,37 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A page draws a component chosen through a component's own settings. When one
+component let a page swap which component sits inside it, the page loaded the
+original and drew a placeholder where the chosen one should be — because the
+step that loads components was reading the stored page while the step that
+draws them was reading the page's settings.
+
+The two now agree by construction: loading asks the drawing step what it needs
+rather than working it out separately, so a component reached by any route the
+renderer understands is loaded, including routes added later.

--- a/packages/blocks-react/src/component-source.test.ts
+++ b/packages/blocks-react/src/component-source.test.ts
@@ -227,6 +227,12 @@ describe("the definitions a document reaches", () => {
 
     expect(found.has("chosen")).toBe(true);
     expect(batches.flat()).toContain("chosen");
+    // And the stored default is never asked for. Without this the test passes
+    // on a discovery that fetches BOTH — which resolves the page correctly and
+    // pays for a definition no render inlines, so the assertion that the
+    // override was FOLLOWED cannot be told from one that it was merely added.
+    expect(found.has("default")).toBe(false);
+    expect(batches.flat()).not.toContain("default");
   });
 
   it("asks for nothing when the page holds no instance", async () => {

--- a/packages/blocks-react/src/component-source.test.ts
+++ b/packages/blocks-react/src/component-source.test.ts
@@ -235,6 +235,24 @@ describe("the definitions a document reaches", () => {
     expect(batches.flat()).not.toContain("default");
   });
 
+  it("keeps discovering on a page whose node cap is smaller than its component count", async () => {
+    // `maxNodes` bounds nodes in the composed OUTPUT; discovery counts
+    // definitions TRAVERSED. They are unrelated quantities, and tying one to
+    // the other stops the walk on a page that composes perfectly well: one
+    // node, one component, and one empty component inside it.
+    const { source } = recording({
+      a: component([instance("n1", "b")]),
+      b: component([]),
+    });
+
+    const found = await definitionsFor(page([instance("i1", "a")]), source, {
+      ...DEFAULT_LIMITS,
+      maxNodes: 1,
+    });
+
+    expect([...found.keys()]).toEqual(["a", "b"]);
+  });
+
   it("asks for nothing when the page holds no instance", async () => {
     const { source, batches } = recording({ hero: component([]) });
 

--- a/packages/blocks-react/src/component-source.test.ts
+++ b/packages/blocks-react/src/component-source.test.ts
@@ -184,6 +184,51 @@ describe("the definitions a document reaches", () => {
     expect(found.has("gone")).toBe(false);
   });
 
+  it("fetches the component an OVERRIDE names, not the one stored", async () => {
+    // The case a raw walk cannot see. `outer` stores an instance of `default`
+    // and exposes its `componentId`; the page overrides it to `chosen`. A scan
+    // of stored props finds `default` and the resolver asks for `chosen`, so
+    // the page renders a component it was given as missing.
+    const { source, batches } = recording({
+      outer: {
+        formatVersion: DOCUMENT_FORMAT_VERSION,
+        kind: "component",
+        nodes: [instance("n1", "default")],
+        exposed: [
+          {
+            id: "which",
+            label: "Which",
+            nodeId: "n1",
+            propPath: "componentId",
+            type: "text",
+          },
+        ],
+      } as unknown as BlockDocument,
+      default: component([]),
+      chosen: component([]),
+    });
+
+    const found = await definitionsFor(
+      {
+        formatVersion: DOCUMENT_FORMAT_VERSION,
+        kind: "page",
+        nodes: [
+          {
+            id: "i1",
+            type: COMPONENT_INSTANCE_TYPE,
+            version: 1,
+            props: { componentId: "outer", overrides: { which: "chosen" } },
+          },
+        ],
+      },
+      source,
+      DEFAULT_LIMITS
+    );
+
+    expect(found.has("chosen")).toBe(true);
+    expect(batches.flat()).toContain("chosen");
+  });
+
   it("asks for nothing when the page holds no instance", async () => {
     const { source, batches } = recording({ hero: component([]) });
 

--- a/packages/blocks-react/src/component-source.test.ts
+++ b/packages/blocks-react/src/component-source.test.ts
@@ -253,6 +253,83 @@ describe("the definitions a document reaches", () => {
     expect([...found.keys()]).toEqual(["a", "b"]);
   });
 
+  it("never asks for a component the resolver will not reach", async () => {
+    // A condition-gated instance is dropped with its whole subtree before a
+    // reader sees it, so the resolver never asks for its component. A walk of
+    // the stored nodes reports it anyway — which is both a read nobody needs
+    // and, on a page with many of them, an allowance spent before the visible
+    // component is reached.
+    const gate = { conditions: [[{ field: "tier", op: "eq", value: "vip" }]] };
+    const { source, batches } = recording({
+      shown: component([]),
+      hidden: component([]),
+    });
+
+    const found = await definitionsFor(
+      page([
+        instance("i1", "shown"),
+        { ...instance("i2", "hidden"), visibility: gate },
+      ]),
+      source,
+      DEFAULT_LIMITS
+    );
+
+    expect(batches).toEqual([["shown"]]);
+    expect(found.has("hidden")).toBe(false);
+  });
+
+  it("keeps a definition answered under an id nobody asked for", async () => {
+    // A source answers with the id it read off the row, and an `afterRead`
+    // hook may rewrite that. Merging an answer filed under an unrequested key
+    // lets one component's document stand in for another's, and the reference
+    // that really named it is never fetched.
+    const batches: string[][] = [];
+    const source: ComponentSource = ids => {
+      batches.push([...ids]);
+      const found = new Map<string, BlockDocument>();
+      // Answers `outer` correctly, and smuggles a second entry under a key
+      // that was not requested.
+      if (ids.includes("outer")) {
+        found.set("outer", component([instance("n1", "inner")]));
+        found.set(
+          "inner",
+          component([{ id: "wrong", type: "core/text", version: 1, props: {} }])
+        );
+      }
+      return Promise.resolve(found);
+    };
+
+    const found = await definitionsFor(
+      page([instance("i1", "outer")]),
+      source,
+      DEFAULT_LIMITS
+    );
+
+    // `inner` is fetched by the round that actually asks for it, never taken
+    // from the answer that volunteered it.
+    expect(batches).toEqual([["outer"], ["inner"]]);
+    expect(found.has("inner")).toBe(false);
+  });
+
+  it("stops at the discovery allowance even when one round exceeds it", async () => {
+    // The allowance has to CLAMP the batch, not merely be checked before it.
+    // A single round can expose more ids than the cap — a page naming twelve
+    // hundred components does — so a check in front of an unbounded batch caps
+    // nothing at all.
+    const store: Record<string, BlockDocument> = {};
+    const roots: BlockNode[] = [];
+    for (let i = 0; i < 1200; i += 1) {
+      store[`c${String(i)}`] = component([]);
+      roots.push(instance(`i${String(i)}`, `c${String(i)}`));
+    }
+    const { source, batches } = recording(store);
+
+    const found = await definitionsFor(page(roots), source, DEFAULT_LIMITS);
+
+    expect(batches.flat().length).toBeLessThanOrEqual(1000);
+    expect(found.size).toBeLessThanOrEqual(1000);
+  });
+
   it("asks for nothing when the page holds no instance", async () => {
     const { source, batches } = recording({ hero: component([]) });
 

--- a/packages/blocks-react/src/component-source.ts
+++ b/packages/blocks-react/src/component-source.ts
@@ -12,7 +12,6 @@
  * @module component-source
  */
 import {
-  componentIdsIn,
   resolveComponentInstances,
   type BlockDocument,
   type ComponentLookup,
@@ -115,7 +114,14 @@ export async function definitionsFor(
   // an entry's value is fixed once set.
   const lookup = repairedOnce(found, limits);
 
-  let wanted = componentIdsIn(sanitized.nodes, limits.maxNodes);
+  // The FIRST round asks the resolver too, over a lookup holding nothing, so
+  // every instance it can reach reports `missing` and names itself. Seeding
+  // this from a walk of the stored nodes left one parallel traversal in place
+  // — the one this function exists to delete — and it disagreed in the usual
+  // direction: a condition-gated instance, or one in slot content the chosen
+  // definition discards, is an id the walk reports and the resolver never
+  // asks for.
+  let wanted = stillMissing(sanitized, lookup, limits);
   // Until a FIXED POINT, not for a fixed number of rounds. Nesting depth is
   // not the bound: fetching a definition changes the resolver's node-budget
   // decisions, so a definition that composes to less than the instance it
@@ -131,11 +137,23 @@ export async function definitionsFor(
   // this bounds definitions TRAVERSED — and tying them stopped discovery on a
   // one-node page holding one component that holds one more.
   while (attempted.size < MAX_DISCOVERED_COMPONENTS) {
-    const unread = [...new Set(wanted)].filter(id => !attempted.has(id));
+    // Clamped to what is LEFT of the allowance, not merely checked against it.
+    // A round can expose more ids than the cap in one go — a page naming a
+    // thousand components does — and a check before an unbounded batch caps
+    // nothing.
+    const unread = [...new Set(wanted)]
+      .filter(id => !attempted.has(id))
+      .slice(0, MAX_DISCOVERED_COMPONENTS - attempted.size);
     if (unread.length === 0) break;
+    const asked = new Set(unread);
     for (const id of unread) attempted.add(id);
     for (const [id, definition] of await source(unread)) {
-      found.set(id, definition);
+      // Only what was ASKED for. A source answers with the id it read off the
+      // row, and an `afterRead` hook may rewrite that — so an answer filed
+      // under a key nobody requested would let one component's document stand
+      // in for another's, and the reference that really named it would never
+      // be fetched.
+      if (asked.has(id)) found.set(id, definition);
     }
     wanted = stillMissing(sanitized, lookup, limits);
   }

--- a/packages/blocks-react/src/component-source.ts
+++ b/packages/blocks-react/src/component-source.ts
@@ -13,9 +13,9 @@
  */
 import {
   componentIdsIn,
-  MAX_COMPOSED_DEPTH,
   resolveComponentInstances,
   type BlockDocument,
+  type ComponentLookup,
   type DefinitionsById,
   type DocumentLimits,
 } from "@nextlyhq/blocks-engine";
@@ -78,14 +78,21 @@ export const COMPONENT_DOCUMENT_FIELD = "content";
  *
  * Composition here is the ENGINE's function over a sanitized document, not the
  * whole read pipeline — a pure walk of a document already bounded by
- * `maxNodes`. The renderer composes again for its own purposes; that is one
- * extra pass over a capped tree, and it buys exact agreement.
+ * `maxNodes`.
  *
- * Terminates because a component is asked for at most once. `attempted` is
- * separate from what was found: an id the store had no row for must stay out
- * of the returned map — its absence is what makes the pipeline report
- * `missing` rather than `unreadable` — while a component that is genuinely
- * gone must not be re-queried once per place it is referenced from.
+ * WHAT IT COSTS, stated honestly rather than optimistically. One composition
+ * per ROUND, and a round happens whenever a fetch revealed an id nobody had
+ * asked for — so a page whose components nest five deep composes about five
+ * times here before the renderer composes once more. Each definition is
+ * repaired once for the whole discovery rather than once per round, which is
+ * the part that would otherwise grow fastest: repair sanitizes a whole
+ * definition, and without the memo every round re-sanitized everything reached
+ * so far.
+ *
+ * `attempted` is separate from what was found: an id the store had no row for
+ * must stay out of the returned map — its absence is what makes the pipeline
+ * report `missing` rather than `unreadable` — while a component that is
+ * genuinely gone must not be re-queried once per place it is referenced from.
  */
 export async function definitionsFor(
   document: BlockDocument,
@@ -99,18 +106,36 @@ export async function definitionsFor(
   // repair-dropped node consume budget the resolver never spends.
   const sanitized = sanitizeDocument(document, limits);
 
+  // Repaired ONCE for the whole discovery, not once per round. The pipeline's
+  // lookup deliberately holds no memo — the resolver reads each definition
+  // once per composition, so a second cache there could never be observed —
+  // but discovery composes several times over a growing map, and without this
+  // every round re-sanitizes every definition reached so far. Sound because a
+  // definition's repaired form never changes: `found` only gains entries, and
+  // an entry's value is fixed once set.
+  const lookup = repairedOnce(found, limits);
+
   let wanted = componentIdsIn(sanitized.nodes, limits.maxNodes);
-  // One round per level of nesting at most, which is also the deepest the
-  // resolver will compose — past it every instance is refused `composed-depth`
-  // and names a definition no render can inline.
-  for (let round = 0; round <= MAX_COMPOSED_DEPTH; round += 1) {
+  // Until a FIXED POINT, not for a fixed number of rounds. Nesting depth is
+  // not the bound: fetching a definition changes the resolver's node-budget
+  // decisions, so a definition that composes to less than the instance it
+  // replaces frees room and can reveal further missing ids at the SAME depth.
+  // A page of sibling components can therefore need more rounds than anything
+  // in it is deep, and stopping at the composition cap would report published
+  // components as missing on a tree that fits.
+  //
+  // It terminates on its own: a round proceeds only when it has an id nobody
+  // has asked for yet, and every id it asks for enters `attempted`, which is
+  // never emptied. The cap below bounds WORK on a store that keeps offering
+  // new ids, not correctness.
+  while (attempted.size < limits.maxNodes) {
     const unread = [...new Set(wanted)].filter(id => !attempted.has(id));
     if (unread.length === 0) break;
     for (const id of unread) attempted.add(id);
     for (const [id, definition] of await source(unread)) {
       found.set(id, definition);
     }
-    wanted = stillMissing(sanitized, found, limits);
+    wanted = stillMissing(sanitized, lookup, limits);
   }
   return found;
 }
@@ -126,17 +151,43 @@ export async function definitionsFor(
  */
 function stillMissing(
   document: BlockDocument,
-  found: DefinitionsById,
+  lookup: ComponentLookup,
   limits: DocumentLimits
 ): string[] {
-  const composed = resolveComponentInstances(
-    document,
-    repairingLookup(found, limits),
-    { limits }
-  );
+  const composed = resolveComponentInstances(document, lookup, { limits });
   return composed.unresolved
     .filter(entry => entry.reason === "missing")
     .map(entry => entry.componentId);
+}
+
+/**
+ * The pipeline's own view of a definitions map, with each repair kept.
+ *
+ * The repair itself is not reimplemented — `repairingLookup` is asked, so
+ * discovery composes through exactly the view the renderer will. What is added
+ * is the memo, which the pipeline has no use for and discovery does: one
+ * composition reads a definition once, and discovery performs several.
+ *
+ * `has` is answered from the SUPPLIED map rather than from whether `get`
+ * produced something, for the reason the pipeline's own lookup answers it that
+ * way: presence separates a component nobody published from one published and
+ * unreadable, and the resolver reports those as different reasons.
+ */
+function repairedOnce(
+  found: DefinitionsById,
+  limits: DocumentLimits
+): ComponentLookup {
+  const base = repairingLookup(found, limits);
+  const repaired = new Map<string, BlockDocument | undefined>();
+  return {
+    has: id => found.has(id),
+    get: id => {
+      if (repaired.has(id)) return repaired.get(id);
+      const value = base.get(id);
+      repaired.set(id, value);
+      return value;
+    },
+  };
 }
 
 /** What one batched definition read needs to know about the route asking. */

--- a/packages/blocks-react/src/component-source.ts
+++ b/packages/blocks-react/src/component-source.ts
@@ -126,9 +126,11 @@ export async function definitionsFor(
   //
   // It terminates on its own: a round proceeds only when it has an id nobody
   // has asked for yet, and every id it asks for enters `attempted`, which is
-  // never emptied. The cap below bounds WORK on a store that keeps offering
-  // new ids, not correctness.
-  while (attempted.size < limits.maxNodes) {
+  // never emptied. The cap is its OWN number rather than the node cap, because
+  // those count unrelated things — `maxNodes` bounds the composed OUTPUT and
+  // this bounds definitions TRAVERSED — and tying them stopped discovery on a
+  // one-node page holding one component that holds one more.
+  while (attempted.size < MAX_DISCOVERED_COMPONENTS) {
     const unread = [...new Set(wanted)].filter(id => !attempted.has(id));
     if (unread.length === 0) break;
     for (const id of unread) attempted.add(id);
@@ -189,6 +191,23 @@ function repairedOnce(
     },
   };
 }
+
+/**
+ * How many distinct definitions one page may pull in before discovery gives up.
+ *
+ * A bound on WORK, not a statement about design. Discovery stops on its own
+ * when a composition asks for nothing new; this only matters for a store that
+ * keeps answering with definitions naming further ones, so the number sits far
+ * above any page a person would build and far below anything that could hold a
+ * request open.
+ *
+ * Deliberately NOT derived from `limits.maxNodes`. That bounds nodes in the
+ * composed output; this bounds definitions traversed, and the two have no
+ * relation — a single-node page can legitimately reach a chain of components
+ * that each compose to almost nothing. Tying them together stopped discovery on
+ * exactly that page.
+ */
+const MAX_DISCOVERED_COMPONENTS = 1000;
 
 /** What one batched definition read needs to know about the route asking. */
 export interface ComponentReadOptions {

--- a/packages/blocks-react/src/component-source.ts
+++ b/packages/blocks-react/src/component-source.ts
@@ -14,12 +14,15 @@
 import {
   componentIdsIn,
   MAX_COMPOSED_DEPTH,
+  resolveComponentInstances,
   type BlockDocument,
   type DefinitionsById,
   type DocumentLimits,
 } from "@nextlyhq/blocks-engine";
 
 import type { QueryBudget } from "./context";
+import { repairingLookup } from "./prepare-document";
+import { sanitizeDocument } from "./sanitize";
 
 /**
  * Reads the definitions for a set of ids, at one posture.
@@ -52,21 +55,37 @@ export const COMPONENT_TAG_COLLECTION = "components";
 export const COMPONENT_DOCUMENT_FIELD = "content";
 
 /**
- * Every definition this document can reach, read level by level.
+ * Every definition this document reaches, discovered by ASKING the resolver.
  *
- * NOT one read, and the design's "one batched read" cannot be taken literally:
- * the transitive set is not knowable from the stored page. A page names the
- * components it holds directly; which components THOSE hold is a fact about
- * their stored documents, so it cannot be discovered without reading them. The
- * loop is therefore one batched read per level of nesting.
+ * The obvious implementation walks the stored document for `componentId`
+ * props and follows each definition the same way. It is wrong, and it was
+ * wrong here in three separate ways, because a raw walk PREDICTS reachability
+ * and the resolver DECIDES it:
  *
- * Bounded by {@link MAX_COMPOSED_DEPTH}, the same cap the resolver refuses at.
- * Reading past it would fetch definitions no render can inline — the resolver
- * answers `composed-depth` before it asks for them — so the bound is not a
- * safety margin, it is the set the page can actually use.
+ * - an instance's override may name a different component than the one its
+ *   definition stored, so the walk fetches the default and the resolver asks
+ *   for the override;
+ * - shape repair drops malformed nodes before resolution, so a walk over the
+ *   stored tree spends its node budget on entries the resolver never sees and
+ *   can stop before an instance that does survive;
+ * - anything added later that changes which instances are expanded — a new
+ *   override kind, a variant, a gate — silently reopens the same gap.
  *
- * Ids already seen are never re-read: a component held by three others is one
- * entry, and a cycle terminates because the second visit finds it in the map.
+ * So this does not walk. It composes with what it has, reads back the
+ * instances the resolver reported as `missing`, fetches exactly those, and
+ * composes again. Reachability is therefore whatever the pass that performs it
+ * says it is, and a future change to that pass cannot leave discovery behind.
+ *
+ * Composition here is the ENGINE's function over a sanitized document, not the
+ * whole read pipeline — a pure walk of a document already bounded by
+ * `maxNodes`. The renderer composes again for its own purposes; that is one
+ * extra pass over a capped tree, and it buys exact agreement.
+ *
+ * Terminates because a component is asked for at most once. `attempted` is
+ * separate from what was found: an id the store had no row for must stay out
+ * of the returned map — its absence is what makes the pipeline report
+ * `missing` rather than `unreadable` — while a component that is genuinely
+ * gone must not be re-queried once per place it is referenced from.
  */
 export async function definitionsFor(
   document: BlockDocument,
@@ -74,65 +93,50 @@ export async function definitionsFor(
   limits: DocumentLimits
 ): Promise<DefinitionsById> {
   const found = new Map<string, BlockDocument>();
-  // Asked-for, which is NOT the same set as found. An id the store had no row
-  // for must stay out of `found` — its absence is what makes the pipeline
-  // report it `missing` rather than `unreadable` — but it has been looked for,
-  // and without remembering that, a component referenced from several
-  // definitions is re-queried at every level it appears at. Each retry spends
-  // a chunk and a budget claim, so enough repeats exhaust `maxQueries` before
-  // a later valid definition is reached and render THAT one missing too.
   const attempted = new Set<string>();
-  let wanted = componentIdsIn(document.nodes, limits.maxNodes);
+  // The same first pass the pipeline runs, so the tree composed here is the
+  // tree it will compose. Discovering over the STORED document instead let a
+  // repair-dropped node consume budget the resolver never spends.
+  const sanitized = sanitizeDocument(document, limits);
 
-  for (
-    let level = 0;
-    level < MAX_COMPOSED_DEPTH && wanted.length > 0;
-    level++
-  ) {
-    // Deduplicated as the batch is built, not as ids are collected. A
-    // component two others hold is reached twice in one level, and asking for
-    // it twice in one `IN` is a wider query and a longer cache key for one
-    // answer.
-    const unread = [...new Set(wanted.filter(id => !attempted.has(id)))];
+  let wanted = componentIdsIn(sanitized.nodes, limits.maxNodes);
+  // One round per level of nesting at most, which is also the deepest the
+  // resolver will compose — past it every instance is refused `composed-depth`
+  // and names a definition no render can inline.
+  for (let round = 0; round <= MAX_COMPOSED_DEPTH; round += 1) {
+    const unread = [...new Set(wanted)].filter(id => !attempted.has(id));
     if (unread.length === 0) break;
     for (const id of unread) attempted.add(id);
-    const batch = await source(unread);
-    // Recorded for every id ASKED FOR, not for every id answered. An id the
-    // store had no row for has been looked for and not found, and remembering
-    // that is what stops the next level asking again — while leaving it out of
-    // `found` keeps it absent for the pipeline, which is how a reference
-    // nobody published reads as missing rather than as unreadable.
-    wanted = nestedIds(unread, batch, found, limits);
+    for (const [id, definition] of await source(unread)) {
+      found.set(id, definition);
+    }
+    wanted = stillMissing(sanitized, found, limits);
   }
   return found;
 }
 
 /**
- * Merge one level's answers, and collect what they reference in turn.
+ * The components a composition asked for and did not get.
  *
- * The ids a definition holds are read from the document the store returned,
- * unvalidated: nothing here decides whether that value is a usable component,
- * because the pipeline already draws that line and drawing it twice is how the
- * two come to disagree. A value with no readable `nodes` simply references
- * nothing.
+ * `missing` and nothing else. The other refusals are decisions rather than
+ * gaps — a cycle, a depth, a budget, a definition supplied and unreadable —
+ * and fetching in response to any of them would ask for a component the
+ * resolver already holds or has already refused on grounds a second read
+ * cannot change.
  */
-function nestedIds(
-  asked: readonly string[],
-  batch: DefinitionsById,
-  into: Map<string, BlockDocument>,
+function stillMissing(
+  document: BlockDocument,
+  found: DefinitionsById,
   limits: DocumentLimits
 ): string[] {
-  const next: string[] = [];
-  for (const id of asked) {
-    if (!batch.has(id)) continue;
-    const definition = batch.get(id) as BlockDocument;
-    into.set(id, definition);
-    if (!Array.isArray(definition?.nodes)) continue;
-    for (const nested of componentIdsIn(definition.nodes, limits.maxNodes)) {
-      next.push(nested);
-    }
-  }
-  return next;
+  const composed = resolveComponentInstances(
+    document,
+    repairingLookup(found, limits),
+    { limits }
+  );
+  return composed.unresolved
+    .filter(entry => entry.reason === "missing")
+    .map(entry => entry.componentId);
 }
 
 /** What one batched definition read needs to know about the route asking. */

--- a/packages/blocks-react/src/entry-surface.test.ts
+++ b/packages/blocks-react/src/entry-surface.test.ts
@@ -312,11 +312,20 @@ const SOURCE_MODULES: ReadonlyArray<{
     // is precisely how the renderer came to hide a node the exported reader
     // returns. A consumer never holds a resolved node without also holding the
     // stages that explain it, so there is nothing here to offer.
+    //
+    // `repairingLookup` is the view of the definitions map this pipeline
+    // composes through. It crosses to the pass that FETCHES definitions, which
+    // asks the resolver what it would reach and must ask through the same
+    // lookup — repair drops malformed nodes, so a fetch that built its own
+    // view would predict a different tree than the one that renders. Exported
+    // to delete that second view, not to offer one: a consumer holding a
+    // definitions map wants `prepareDocumentForRead`, which builds this itself.
     internal: [
       "isUnresolvedInstance",
       "prepareDocumentReadStages",
       "pruneKnownPlaceholders",
       "readingViewOf",
+      "repairingLookup",
     ],
   },
   {

--- a/packages/blocks-react/src/prepare-document.ts
+++ b/packages/blocks-react/src/prepare-document.ts
@@ -429,6 +429,11 @@ export function isUnresolvedInstance(node: ResolvedBlockNode): boolean {
  * `missing` for a definition the caller had supplied. Asking here means there
  * is one answer, given at the moment the definition is actually wanted.
  *
+ * Published so the pass that FETCHES definitions can ask the resolver what it
+ * would reach through exactly this lookup. Discovery that built its own view
+ * of a definition would be predicting the pipeline rather than asking it, and
+ * repair is one of the three places the two used to disagree.
+ *
  * NOT memoized here, and that is deliberate rather than an omission. The
  * resolver reads the lookup once per component per resolution and holds the
  * answer for the run — it has to, because a lookup is a caller's object and a
@@ -436,7 +441,7 @@ export function isUnresolvedInstance(node: ResolvedBlockNode): boolean {
  * would be a second implementation of that guarantee, agreeing on the day it
  * is written; removing it was measured to change nothing.
  */
-function repairingLookup(
+export function repairingLookup(
   definitions: DefinitionsById,
   limits: DocumentLimits
 ): ComponentLookup {


### PR DESCRIPTION
Takes `task:pb6-t4c-reachability-from-the-resolver`, the architectural one of the five deferred from #1529.

## The defect

`componentIdsIn` scanned **stored** props. The resolver applies overrides first. So a definition that exposes a nested instance's `componentId`, on a page that overrides it, had the *default* fetched and the *override* asked for — and rendered as missing a component the caller had supplied. Shape repair disagreed the same way, dropping malformed nodes the raw walk had already spent budget on.

Reproduced before fixing, and the fixture is now a test.

## Why the #1522 remedy does not transfer

That was the same class, and there the fix was to stop predicting and repair **lazily at the resolver's lookup**. Unavailable here: the fetch is async and the pipeline is synchronous, so the fetch must precede resolution and cannot move inside it.

## The design, and the one I rejected

**Discovery no longer walks.** It sanitizes once — the pipeline's own first pass, which closes the repair half — composes with what it holds, reads back the instances the resolver reported `missing`, fetches exactly those, and composes again. Bounded by `MAX_COMPOSED_DEPTH`; terminates because `attempted` is tracked apart from `found`, so a genuinely absent component is asked for once.

**I rejected teaching the walk about `componentId` overrides.** It closes the case Codex named and leaves the class open: every future change to what the resolver expands — a new override kind, a variant, a gate — silently reopens the same gap. A predictor must be updated in lockstep with the thing it predicts. An oracle cannot drift, and that is the property worth paying for.

**The cost, measured rather than assumed.** `PageRenderer` runs the whole pipeline internally, so the naive reading is a double pipeline per page. It is not: discovery needs only `sanitizeDocument` and `resolveComponentInstances`, both pure over a document already bounded by `maxNodes`. One extra compose per page in the common case; a second fetch happens only where round one actually leaves something missing.

## The seam

`repairingLookup` is now exported from `prepare-document` and classified `internal` with its reason. Discovery has to compose through **the same lookup** the pipeline uses — repair drops malformed nodes, so a fetch that built its own view would predict a different tree than the one that renders, which is this same defect one layer up.

## Gates

`build` 0 · `check-types` 0 · `lint` 0 · `check:comments` 0 · `fallow` **pass**, 0 introduced · `changeset status` 0, 25 packages.

blocks-react 1146 (+1) · nextly 11265 across 884 files · blocks-engine 1899.

Break-verified: restoring the raw walk over fetched definitions kills two tests — the override case and the depth bound.

The export-surface guard caught the new export and demanded a classification, which is the check doing its job rather than an obstacle.

## Still deferred

`pb6-t4c-draft-posture` and `pb6-t4c-working-draft-definitions` (a pair; the first needs `ResolvedContext` to carry the resolved draft grant, which is a `nextly` change and wants a ruling) and `pb6-t4c-release-bounded-component-cache`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Component overrides are now honored when resolving page content, ensuring the selected component is used instead of the document’s default component.
  - Component references that are missing during initial discovery are now resolved more reliably, including references nested across multiple levels.
  - Document preparation and component discovery now use consistent resolution behavior, improving the reliability of rendered pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->