### PR TITLE
fix(nextly): obey a collection's stored read rule in the pending-edit cards

### DIFF
--- a/.changeset/pending-edits-obey-document-rules.md
+++ b/.changeset/pending-edits-obey-document-rules.md
@@ -1,0 +1,49 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The dashboard's pending-edit cards obey a collection's stored read rule.
+
+Entity-level access answers whether a collection is in reach; it does not
+decide which of its documents are. A collection carrying a stored `owner-only`
+or `custom` read rule admits every editor at that check while the ordinary read
+path narrows to a subset — so counting and listing version rows filtered by
+collection name alone reported one author's documents to another, handing back
+their entry ids, languages and the instants they were last edited.
+
+The cards now ask the ordinary read path which of the candidate documents the
+caller may actually see, rather than reproducing a rule that can be an arbitrary
+function. Singles are asked per language, because a localized Single is a
+different document per language and a rule can answer differently for each. A
+row whose scope is neither a collection nor a single is dropped rather than
+admitted, since nothing can judge it.
+
+That answer cannot be computed in SQL — the rule lives on the collection, the
+candidates live in the version table, and the data layer has no join — so an
+exact count means considering candidates in memory, which is bounded. Past that
+bound the count refuses rather than reporting a number that is quietly too
+small.

--- a/.changeset/pending-edits-obey-document-rules.md
+++ b/.changeset/pending-edits-obey-document-rules.md
@@ -42,6 +42,19 @@ different document per language and a rule can answer differently for each. A
 row whose scope is neither a collection nor a single is dropped rather than
 admitted, since nothing can judge it.
 
+A localized document is authorized per LANGUAGE, so the rows reach that
+decision one per locale and are collapsed to one per document only afterwards.
+Collapsing first offered each document's newest locale alone: where that one was
+denied and an older one readable, the document vanished from a card its reader
+was entitled to see.
+
+Nothing sizes the read from configuration either. The row bound used to be the
+install's current locale count, which does not describe the data — working
+drafts written under a locale since removed are still rows — so it could fetch
+too few rows to find the documents asked for while every check said the answer
+was exact. The read is paged instead, and the only bound is how many documents
+the caller wants.
+
 That answer cannot be computed in SQL — the rule lives on the collection, the
 candidates live in the version table, and the data layer has no join — so an
 exact count means considering candidates in memory, which is bounded. Past that

--- a/.changeset/pending-edits-obey-document-rules.md
+++ b/.changeset/pending-edits-obey-document-rules.md
@@ -42,8 +42,10 @@ different document per language and a rule can answer differently for each. A
 row whose scope is neither a collection nor a single is dropped rather than
 admitted, since nothing can judge it.
 
-A localized document is authorized per LANGUAGE, so the rows reach that
-decision one per locale and are collapsed to one per document only afterwards.
+A localized document is authorized per LANGUAGE — collections as well as
+Singles, because a stored rule is a predicate over the collection's own fields
+and a localized field answers differently per language. Rows reach that decision
+one per locale and are collapsed to one per document only afterwards.
 Collapsing first offered each document's newest locale alone: where that one was
 denied and an older one readable, the document vanished from a card its reader
 was entitled to see.
@@ -54,6 +56,16 @@ drafts written under a locale since removed are still rows — so it could fetch
 too few rows to find the documents asked for while every check said the answer
 was exact. The read is paged instead, and the only bound is how many documents
 the caller wants.
+
+A pending row for a Single is checked against the live document's id, resolved
+without materializing it. Version rows outlive the documents they describe, so a
+Single deleted and recreated leaves rows naming its predecessor — and the read
+probe goes through a path that auto-creates a missing Single, which would have
+made loading a dashboard perform a write.
+
+Paged reads order by a unique key as well as the instant. `updatedAt` alone is
+not a total order, and paging one with OFFSET can return a row twice and skip
+another, losing a document that nothing downstream can notice is missing.
 
 That answer cannot be computed in SQL — the rule lives on the collection, the
 candidates live in the version table, and the data layer has no join — so an

--- a/.changeset/pending-edits-obey-document-rules.md
+++ b/.changeset/pending-edits-obey-document-rules.md
@@ -63,7 +63,14 @@ Single deleted and recreated leaves rows naming its predecessor — and the read
 probe goes through a path that auto-creates a missing Single, which would have
 made loading a dashboard perform a write.
 
-Paged reads order by a unique key as well as the instant. `updatedAt` alone is
+A row whose language is no longer configured, or whose scope kind no longer
+matches the registry, is dropped rather than guessed at: forwarding an
+unconfigured locale silently authorizes the default one, and a slug freed by a
+deleted collection and taken over by a Single would send an orphaned row to a
+read path that cannot answer about it.
+
+Paged reads use a cursor anchored to the last row read, and order by a unique key
+as well as the instant. `updatedAt` alone is
 not a total order, and paging one with OFFSET can return a row twice and skip
 another, losing a document that nothing downstream can notice is missing.
 

--- a/.changeset/pending-edits-obey-document-rules.md
+++ b/.changeset/pending-edits-obey-document-rules.md
@@ -75,7 +75,21 @@ not a total order, and paging one with OFFSET can return a row twice and skip
 another, losing a document that nothing downstream can notice is missing.
 
 That answer cannot be computed in SQL — the rule lives on the collection, the
-candidates live in the version table, and the data layer has no join — so an
-exact count means considering candidates in memory, which is bounded. Past that
-bound the count refuses rather than reporting a number that is quietly too
-small.
+candidates live in the version table, and the data layer has no join — so the
+count walks candidates and authorizes them, which is bounded work. Past that
+bound it reports `atLeast` and the card renders `N+`, rather than failing or
+showing a number that is quietly too small.
+
+It is a floor rather than a refusal because every mechanism that tried to keep
+the promise of exactness past a bound produced a wrong answer instead: a
+document quota could not tell "exactly this many" from "more than this many",
+and a shortcut on documents already seen conflated encountering a document with
+deciding it, since authorization is per language. The bound is also on rows the
+CALLER reads, not on a count of candidates taken before the rules narrow them —
+that made one reader's card depend on data they cannot see, and disclosed which
+side of the threshold that unseen population sat on.
+
+The count enumerates by row id rather than by recency. `updatedAt` advances
+every time somebody types, so a draft not yet read can move ahead of a
+recency cursor and be skipped for the rest of the walk; a working-draft update
+never rewrites the id.

--- a/packages/admin/src/components/features/widgets/archetypes/metric.tsx
+++ b/packages/admin/src/components/features/widgets/archetypes/metric.tsx
@@ -59,6 +59,17 @@ export const metricBody: ArchetypeBody = (result, definition) => {
         className="text-2xl font-bold leading-none tabular-nums tracking-tight text-foreground"
       >
         {result.total.toLocaleString()}
+        {result.atLeast === true ? (
+          <>
+            {/* A floor, said in the number itself. The card cannot know the
+                whole figure -- the rows behind it are filtered by a rule the
+                database cannot apply -- and a bare number would claim it does.
+                Announced to assistive technology in words, since a trailing
+                "+" is punctuation a screen reader may not voice. */}
+            <span aria-hidden="true">+</span>
+            <span className="sr-only"> or more</span>
+          </>
+        ) : null}
       </p>
     ),
   };

--- a/packages/admin/src/hooks/queries/useWidgetQueries.ts
+++ b/packages/admin/src/hooks/queries/useWidgetQueries.ts
@@ -269,21 +269,34 @@ function asResultFields(value: unknown): WidgetResultField[] | undefined {
  * field to a result would drop it before the plugin saw it, so this function is
  * the place that has to grow when the result contract does.
  */
+/**
+ * A count result, or `undefined` when the payload does not carry one.
+ *
+ * `atLeast` is carried through rather than dropped: it says the total is a
+ * FLOOR, and a card that loses it renders a partial figure as though it were the
+ * whole answer.
+ */
+function asCount(total: unknown, atLeast: unknown): WidgetResult | undefined {
+  if (typeof total !== "number" || !Number.isFinite(total)) return undefined;
+  return {
+    op: "count",
+    total,
+    ...(atLeast === true ? { atLeast: true } : {}),
+  };
+}
+
 function asResult(value: unknown): WidgetResult | undefined {
   if (!isObject(value)) return undefined;
 
   const result = value as {
     op?: unknown;
     total?: unknown;
+    atLeast?: unknown;
     items?: unknown;
     fields?: unknown;
   };
 
-  if (result.op === "count") {
-    return typeof result.total === "number" && Number.isFinite(result.total)
-      ? { op: "count", total: result.total }
-      : undefined;
-  }
+  if (result.op === "count") return asCount(result.total, result.atLeast);
 
   if (result.op === "list") {
     // The MEMBERS as well as the array, because a row is dereferenced per field

--- a/packages/admin/src/types/dashboard/widgets.ts
+++ b/packages/admin/src/types/dashboard/widgets.ts
@@ -46,7 +46,20 @@ export interface WidgetResultField {
 }
 
 export type WidgetResult =
-  | { op: "count"; total: number }
+  | {
+      op: "count";
+      total: number;
+      /**
+       * `total` is a FLOOR, not the whole answer.
+       *
+       * Some counts cannot be computed in the database: where a source's rows
+       * are filtered by a rule the query cannot express, the only honest count
+       * walks candidates and authorizes them, which is bounded work. Past that
+       * bound the card says `N+` rather than failing or showing a number that
+       * is quietly too small.
+       */
+      atLeast?: boolean;
+    }
   | {
       op: "list";
       items: Record<string, unknown>[];

--- a/packages/nextly/src/api/versions-access.ts
+++ b/packages/nextly/src/api/versions-access.ts
@@ -21,6 +21,7 @@ import { getService } from "../di";
 import { container } from "../di/container";
 import type { FieldGroupDataService } from "../domains/field-groups/services/field-group-data-service";
 import {
+  resolveSingleDocumentId,
   singleDocumentEditable,
   singleDocumentReadable,
 } from "../domains/singles/services/single-document-access";
@@ -310,27 +311,12 @@ async function canReadLiveSingle(
 }
 
 /**
- * The id of a Single's live document, or `null` when it has not been
- * materialized yet.
- *
- * A Single's URL carries no entry id (there is only ever one document), so
- * callers must resolve it from the backing row rather than trusting a
- * client-supplied value — otherwise the id check that stops a recreated Single
- * exposing its predecessor's snapshots could simply be bypassed. Reads the row
- * directly instead of going through `SingleEntryService.get`, which would
- * materialize a missing Single as a side effect of a read.
+ * Re-exported from the Singles domain, where it now lives beside the read probe
+ * it guards. A DOMAIN module needs the same resolution — the dashboard's
+ * pending-edit cards must not materialize a Single while deciding what to show —
+ * and `domains/` must not import from `api/`.
  */
-export async function resolveSingleDocumentId(
-  slug: string
-): Promise<string | null> {
-  const registry = getService("singleRegistryService");
-  const record = await registry.getSingleBySlug(slug);
-  if (!record?.tableName) return null;
-
-  const adapter = getService("adapter");
-  const row = await adapter.selectOne<{ id?: unknown }>(record.tableName, {});
-  return typeof row?.id === "string" ? row.id : null;
-}
+export { resolveSingleDocumentId };
 
 /**
  * Collapse a live-read result into "may the caller see this document".

--- a/packages/nextly/src/di/registrations/register-versions.ts
+++ b/packages/nextly/src/di/registrations/register-versions.ts
@@ -11,24 +11,12 @@ import type { RegistrationContext } from "./types";
 
 /** Register the versions read service as a singleton. */
 export function registerVersionServices(ctx: RegistrationContext): void {
-  const { adapter, config } = ctx;
-
-  // A working draft is one row per document per LOCALE, so the configured
-  // locale count is how many rows one document can contribute to a
-  // cross-document read. The service needs it to bound the scan behind the
-  // recent-edits card; an install with no localization configured has exactly
-  // one, which is the default the service applies when this is absent.
-  const localeCount = config.localization?.locales.length;
+  const { adapter } = ctx;
 
   container.registerSingleton<VersionsService>(
     "versionsService",
     // The adapter satisfies VersionsDbApi structurally; reads run on the pool
     // (in-transaction capture passes its own tx context instead).
-    () =>
-      new VersionsService(adapter, {
-        ...(localeCount !== undefined && {
-          maxWorkingDraftsPerDocument: localeCount,
-        }),
-      })
+    () => new VersionsService(adapter)
   );
 }

--- a/packages/nextly/src/domains/singles/services/single-document-access.ts
+++ b/packages/nextly/src/domains/singles/services/single-document-access.ts
@@ -161,3 +161,26 @@ export async function singleDocumentEditable(
   });
   return denied === null;
 }
+
+/**
+ * The id of a Single's live document, or `null` when it has not been
+ * materialized yet.
+ *
+ * A Single's URL carries no entry id (there is only ever one document), so
+ * callers must resolve it from the backing row rather than trusting a
+ * client-supplied value — otherwise the id check that stops a recreated Single
+ * exposing its predecessor's snapshots could simply be bypassed. Reads the row
+ * directly instead of going through `SingleEntryService.get`, which would
+ * materialize a missing Single as a side effect of a read.
+ */
+export async function resolveSingleDocumentId(
+  slug: string
+): Promise<string | null> {
+  const registry = getService("singleRegistryService");
+  const record = await registry.getSingleBySlug(slug);
+  if (!record?.tableName) return null;
+
+  const adapter = getService("adapter");
+  const row = await adapter.selectOne<{ id?: unknown }>(record.tableName, {});
+  return typeof row?.id === "string" ? row.id : null;
+}

--- a/packages/nextly/src/domains/versions/__tests__/pending-edit-paging.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/pending-edit-paging.test.ts
@@ -1,0 +1,68 @@
+/**
+ * The ordering a paged pending-edit read emits.
+ *
+ * 🔴 Asserted on the emitted ORDER rather than on rows returned, deliberately.
+ * The failure is that OFFSET paging over a non-total order may return one row
+ * twice and skip another — but whether a database actually does that depends on
+ * the engine and the plan it chooses, and it could not be reproduced on SQLite,
+ * which orders these tied rows stably. A behavioural test therefore passes with
+ * and without the tiebreaker, which is worse than no test: it reads as coverage
+ * for a property it never exercised. The cause is what is checkable here, so the
+ * cause is what this pins.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import type { VersionsDbApi, VersionsSelectOptions } from "../db-api";
+import { VersionsRepository } from "../versions-repository";
+
+function stubDb() {
+  const selects: VersionsSelectOptions[] = [];
+  const db = {
+    insert: vi.fn(),
+    select: vi.fn(async (_t: string, options: VersionsSelectOptions) => {
+      selects.push(options);
+      return [] as never;
+    }),
+    update: vi.fn(),
+    delete: vi.fn(),
+  } as unknown as VersionsDbApi;
+  return { db, selects };
+}
+
+describe("paged pending-edit reads", () => {
+  it("orders by a UNIQUE key as well as the instant", async () => {
+    // `updatedAt` alone is not total — SQLite stores whole seconds, so drafts
+    // saved together tie — and a database may order tied rows differently
+    // between two queries. Paging an unstable order loses a document silently:
+    // the caller de-duplicates the row it saw twice and never learns of the one
+    // it did not see.
+    const { db, selects } = stubDb();
+
+    await new VersionsRepository(db).findPendingEditRows({
+      slugs: ["posts"],
+      limit: 10,
+      offset: 20,
+    });
+
+    expect(selects).toHaveLength(1);
+    expect(selects[0]?.orderBy).toEqual([
+      { column: "updatedAt", direction: "desc", nulls: "last" },
+      { column: "id", direction: "desc" },
+    ]);
+  });
+
+  it("passes the caller's window through untouched", async () => {
+    // The control: an ordering assertion says nothing if the window it orders
+    // is not the one the caller asked for.
+    const { db, selects } = stubDb();
+
+    await new VersionsRepository(db).findPendingEditRows({
+      slugs: ["posts"],
+      limit: 10,
+      offset: 20,
+    });
+
+    expect(selects[0]?.limit).toBe(10);
+    expect(selects[0]?.offset).toBe(20);
+  });
+});

--- a/packages/nextly/src/domains/versions/__tests__/pending-edit-paging.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/pending-edit-paging.test.ts
@@ -38,6 +38,7 @@ describe("paged pending-edit reads", () => {
 
     await new VersionsRepository(db).findPendingEditRows({
       slugs: ["posts"],
+      order: "recency" as const,
       limit: 10,
     });
 
@@ -61,6 +62,7 @@ describe("paged pending-edit reads", () => {
 
     await new VersionsRepository(db).findPendingEditRows({
       slugs: ["posts"],
+      order: "recency" as const,
       limit: 10,
       after: cursor,
     });
@@ -79,6 +81,7 @@ describe("paged pending-edit reads", () => {
 
     await new VersionsRepository(db).findPendingEditRows({
       slugs: ["posts"],
+      order: "recency" as const,
       limit: 10,
     });
 
@@ -90,6 +93,7 @@ describe("paged pending-edit reads", () => {
 
     await new VersionsRepository(db).findPendingEditRows({
       slugs: ["posts"],
+      order: "recency" as const,
       limit: 10,
     });
 

--- a/packages/nextly/src/domains/versions/__tests__/pending-edit-paging.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/pending-edit-paging.test.ts
@@ -32,16 +32,13 @@ function stubDb() {
 describe("paged pending-edit reads", () => {
   it("orders by a UNIQUE key as well as the instant", async () => {
     // `updatedAt` alone is not total — SQLite stores whole seconds, so drafts
-    // saved together tie — and a database may order tied rows differently
-    // between two queries. Paging an unstable order loses a document silently:
-    // the caller de-duplicates the row it saw twice and never learns of the one
-    // it did not see.
+    // saved together tie — and a cursor over a non-unique key cannot say WHICH
+    // of the tied rows a page ended on.
     const { db, selects } = stubDb();
 
     await new VersionsRepository(db).findPendingEditRows({
       slugs: ["posts"],
       limit: 10,
-      offset: 20,
     });
 
     expect(selects).toHaveLength(1);
@@ -51,18 +48,51 @@ describe("paged pending-edit reads", () => {
     ]);
   });
 
-  it("passes the caller's window through untouched", async () => {
-    // The control: an ordering assertion says nothing if the window it orders
-    // is not the one the caller asked for.
+  it("pages by CURSOR, never by offset", async () => {
+    // 🔴 These rows are the most mutable in the system: a working draft's
+    // `updatedAt` advances every time somebody types. Under OFFSET a row
+    // updated between two pages moves ahead of the offset, so the next page
+    // repeats a row already read and SKIPS one that never was — and the skipped
+    // document is lost, because de-duplicating what arrived cannot reveal what
+    // did not. Anchoring to the last row read keeps the pages disjoint whatever
+    // moves behind them.
+    const { db, selects } = stubDb();
+    const cursor = { updatedAt: new Date("2026-01-01T00:00:00Z"), id: "v-9" };
+
+    await new VersionsRepository(db).findPendingEditRows({
+      slugs: ["posts"],
+      limit: 10,
+      after: cursor,
+    });
+
+    expect(selects[0]?.offset).toBeUndefined();
+    // Two branches, not a row constructor: `(a, b) < (x, y)` is not portable
+    // across the three dialects this has to run on.
+    expect(JSON.stringify(selects[0]?.where)).toContain('"or"');
+    expect(JSON.stringify(selects[0]?.where)).toContain('"v-9"');
+  });
+
+  it("asks WITHOUT a cursor clause for the first page", async () => {
+    // The control: a cursor assertion means nothing if the same clause is
+    // emitted when no cursor was given, which would drop the first page's rows.
     const { db, selects } = stubDb();
 
     await new VersionsRepository(db).findPendingEditRows({
       slugs: ["posts"],
       limit: 10,
-      offset: 20,
+    });
+
+    expect(JSON.stringify(selects[0]?.where)).not.toContain('"or"');
+  });
+
+  it("passes the caller's page size through untouched", async () => {
+    const { db, selects } = stubDb();
+
+    await new VersionsRepository(db).findPendingEditRows({
+      slugs: ["posts"],
+      limit: 10,
     });
 
     expect(selects[0]?.limit).toBe(10);
-    expect(selects[0]?.offset).toBe(20);
   });
 });

--- a/packages/nextly/src/domains/versions/__tests__/pending-edit-visibility.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/pending-edit-visibility.test.ts
@@ -12,6 +12,22 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const readableDocumentIds = vi.fn();
 const singleDocumentReadable = vi.fn();
 const resolveSingleDocumentId = vi.fn();
+const contentKinds = vi.fn();
+const configValue = vi.fn();
+
+// The registry decides whether a row's own scope kind is still the live one, and
+// the localization config decides whether its language can still be read in.
+// Both are container-backed, so a harness that omits them leaves every row
+// undecidable and the whole file green-on-nothing.
+vi.mock("../../../services/lib/registered-content-slugs", () => ({
+  registeredContentKinds: () => contentKinds() as unknown,
+}));
+vi.mock("../../../di/container", () => ({
+  container: {
+    has: () => true,
+    get: () => configValue() as unknown,
+  },
+}));
 
 vi.mock("../../../services/lib/readable-documents", () => ({
   readableDocumentIds: (...args: unknown[]) =>
@@ -58,6 +74,21 @@ beforeEach(() => {
   );
   singleDocumentReadable.mockResolvedValue(true);
   resolveSingleDocumentId.mockResolvedValue("single-live");
+  contentKinds.mockResolvedValue(
+    new Map([
+      ["posts", "collection"],
+      ["site-settings", "single"],
+    ])
+  );
+  configValue.mockReturnValue({
+    localization: {
+      locales: [
+        { code: "en" },
+        { code: "de" },
+        ...Array.from({ length: 8 }, (_, index) => ({ code: `l${index}` })),
+      ],
+    },
+  });
 });
 
 describe("collection rows", () => {
@@ -107,6 +138,36 @@ describe("collection rows", () => {
     expect(visible.map(r => r.locale)).toEqual(["en"]);
   });
 
+  it("issues reads CONCURRENTLY, within a bound", async () => {
+    // 🔴 Each unit enters the full collection read path, so awaiting them one
+    // after another turns a page spanning many collections or languages into
+    // that many sequential round trips -- enough to time a dashboard out while
+    // the connection pool sits idle. Bounded, not unbounded: the first group is
+    // deliberately one, so a cold per-user permission cache is filled once
+    // rather than missed by everything in the fan-out.
+    let inFlight = 0;
+    let peak = 0;
+    readableDocumentIds.mockImplementation(async (_slug, ids: string[]) => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise(resolve => setTimeout(resolve, 0));
+      inFlight--;
+      return new Set(ids);
+    });
+
+    await visiblePendingEdits(
+      Array.from({ length: 8 }, (_, index) =>
+        row({ entryId: `e${index}`, locale: `l${index}` })
+      ),
+      caller
+    );
+
+    // More than one at a time proves it is not serial; the bound proves it is
+    // not an unbounded fan-out.
+    expect(peak).toBeGreaterThan(1);
+    expect(peak).toBeLessThanOrEqual(8);
+  });
+
   it("asks ONCE for rows that share a slug and language", async () => {
     // The control on the grouping: per-locale must not become per-row, which
     // would put one read per document in front of every dashboard load.
@@ -125,6 +186,68 @@ describe("collection rows", () => {
       caller,
       "en"
     );
+  });
+});
+
+describe("rows nothing can decide", () => {
+  it("drops a row whose language is no longer configured", async () => {
+    // 🔴 Forwarding an unconfigured locale does NOT authorize it:
+    // `resolveRequestedLocale` substitutes the configured DEFAULT for any code
+    // it does not recognise. A draft written under a language later removed
+    // would be judged by the default language's verdict — a row exposed on a
+    // predicate never evaluated for it, which is the defect the per-locale fix
+    // exists to prevent, wearing a different hat.
+    const visible = await visiblePendingEdits(
+      [row({ entryId: "e1", locale: "fr" })],
+      caller
+    );
+
+    expect(visible).toEqual([]);
+    expect(readableDocumentIds).not.toHaveBeenCalled();
+  });
+
+  it("keeps a configured language beside a removed one", async () => {
+    // The control: dropping unconfigured locales must not drop everything.
+    const visible = await visiblePendingEdits(
+      [
+        row({ entryId: "e1", locale: "fr" }),
+        row({ entryId: "e1", locale: "en" }),
+      ],
+      caller
+    );
+
+    expect(visible.map(r => r.locale)).toEqual(["en"]);
+  });
+
+  it("drops a row whose scope kind no longer matches the registry", async () => {
+    // Deleting a collection leaves its history behind, and a Single may later
+    // take the freed slug. Probing the COLLECTION read path for a slug that now
+    // belongs to a Single asks about a table that is not there — it throws and
+    // breaks both cards rather than dropping one orphaned row.
+    const visible = await visiblePendingEdits(
+      [
+        row({
+          entryId: "e1",
+          scopeKind: "collection",
+          scopeSlug: "site-settings",
+        }),
+      ],
+      caller
+    );
+
+    expect(visible).toEqual([]);
+    expect(readableDocumentIds).not.toHaveBeenCalled();
+    expect(singleDocumentReadable).not.toHaveBeenCalled();
+  });
+
+  it("drops a row whose slug is in neither registry", async () => {
+    const visible = await visiblePendingEdits(
+      [row({ entryId: "e1", scopeSlug: "deleted-collection" })],
+      caller
+    );
+
+    expect(visible).toEqual([]);
+    expect(readableDocumentIds).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/nextly/src/domains/versions/__tests__/pending-edit-visibility.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/pending-edit-visibility.test.ts
@@ -1,0 +1,167 @@
+/**
+ * How pending-edit rows are handed to the read path for a verdict.
+ *
+ * The verdict itself belongs to the collection and Singles read paths and is
+ * driven against a real database elsewhere. What this file pins is the SHAPE of
+ * the question — which rows are asked about, grouped how, and which are never
+ * asked about at all — because that is where this module can be wrong while
+ * every access rule underneath it is right.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const readableDocumentIds = vi.fn();
+const singleDocumentReadable = vi.fn();
+const resolveSingleDocumentId = vi.fn();
+
+vi.mock("../../../services/lib/readable-documents", () => ({
+  readableDocumentIds: (...args: unknown[]) =>
+    readableDocumentIds(...args) as unknown,
+}));
+vi.mock("../../singles/services/single-document-access", () => ({
+  singleDocumentReadable: (...args: unknown[]) =>
+    singleDocumentReadable(...args) as unknown,
+  resolveSingleDocumentId: (...args: unknown[]) =>
+    resolveSingleDocumentId(...args) as unknown,
+}));
+
+import { visiblePendingEdits } from "../pending-edit-visibility";
+
+const caller = { user: { id: "user-1", roles: ["editor"] } };
+
+function row(patch: {
+  entryId: string;
+  locale?: string | null;
+  scopeKind?: string;
+  scopeSlug?: string;
+}) {
+  return {
+    id: `v-${patch.entryId}-${patch.locale ?? "none"}`,
+    scopeKind: patch.scopeKind ?? "collection",
+    scopeSlug: patch.scopeSlug ?? "posts",
+    entryId: patch.entryId,
+    locale: patch.locale ?? null,
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+    versionNo: null,
+    status: "draft",
+    isAutosave: false,
+    label: null,
+    sourceVersionNo: null,
+    createdBy: null,
+    createdAt: new Date("2020-01-01T00:00:00Z"),
+  } as unknown as Parameters<typeof visiblePendingEdits>[0][number];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  readableDocumentIds.mockImplementation((_slug, ids: string[]) =>
+    Promise.resolve(new Set(ids))
+  );
+  singleDocumentReadable.mockResolvedValue(true);
+  resolveSingleDocumentId.mockResolvedValue("single-live");
+});
+
+describe("collection rows", () => {
+  it("asks about each LOCALE separately, carrying the locale into the read", async () => {
+    // 🔴 A stored read rule is a predicate over the collection's own fields, and
+    // a localized field answers differently per language --
+    // `localized-target-predicate.integration.test.ts` pins one row readable in
+    // `en` and denied in `de`. Asking once per slug judges whichever
+    // translation the read defaults to and marks every other language visible
+    // on the strength of it.
+    await visiblePendingEdits(
+      [
+        row({ entryId: "e1", locale: "en" }),
+        row({ entryId: "e1", locale: "de" }),
+      ],
+      caller
+    );
+
+    expect(readableDocumentIds).toHaveBeenCalledTimes(2);
+    expect(readableDocumentIds).toHaveBeenCalledWith(
+      "posts",
+      ["e1"],
+      caller,
+      "en"
+    );
+    expect(readableDocumentIds).toHaveBeenCalledWith(
+      "posts",
+      ["e1"],
+      caller,
+      "de"
+    );
+  });
+
+  it("keeps the language the read allowed and drops the one it refused", async () => {
+    readableDocumentIds.mockImplementation((_slug, ids: string[], _c, locale) =>
+      Promise.resolve(locale === "en" ? new Set(ids) : new Set())
+    );
+
+    const visible = await visiblePendingEdits(
+      [
+        row({ entryId: "e1", locale: "de" }),
+        row({ entryId: "e1", locale: "en" }),
+      ],
+      caller
+    );
+
+    expect(visible.map(r => r.locale)).toEqual(["en"]);
+  });
+
+  it("asks ONCE for rows that share a slug and language", async () => {
+    // The control on the grouping: per-locale must not become per-row, which
+    // would put one read per document in front of every dashboard load.
+    await visiblePendingEdits(
+      [
+        row({ entryId: "e1", locale: "en" }),
+        row({ entryId: "e2", locale: "en" }),
+      ],
+      caller
+    );
+
+    expect(readableDocumentIds).toHaveBeenCalledTimes(1);
+    expect(readableDocumentIds).toHaveBeenCalledWith(
+      "posts",
+      ["e1", "e2"],
+      caller,
+      "en"
+    );
+  });
+});
+
+describe("single rows", () => {
+  const single = (entryId: string, locale?: string | null) =>
+    row({ entryId, locale, scopeKind: "single", scopeSlug: "site-settings" });
+
+  it("resolves the live document id WITHOUT materializing the Single", async () => {
+    // 🔴 The read probe goes through `SingleEntryService.get`, which AUTO-CREATES
+    // a missing Single -- so probing first makes loading a dashboard perform a
+    // write. The id is resolved from the backing row instead, which is what
+    // `resolveSingleDocumentId` exists for.
+    await visiblePendingEdits([single("single-live")], caller);
+
+    expect(resolveSingleDocumentId).toHaveBeenCalledWith("site-settings");
+    expect(singleDocumentReadable).toHaveBeenCalled();
+  });
+
+  it("drops a row belonging to a PREDECESSOR document, without probing at all", async () => {
+    // A version row outlives the document it describes: a Single deleted and
+    // recreated leaves rows naming the old id. Judging those by the
+    // replacement's verdict exposes the predecessor's entry id and edit time.
+    const visible = await visiblePendingEdits(
+      [single("single-deleted")],
+      caller
+    );
+
+    expect(visible).toEqual([]);
+    expect(singleDocumentReadable).not.toHaveBeenCalled();
+  });
+
+  it("drops every row when the Single has never been materialized", async () => {
+    resolveSingleDocumentId.mockResolvedValue(null);
+
+    const visible = await visiblePendingEdits([single("single-live")], caller);
+
+    expect(visible).toEqual([]);
+    expect(singleDocumentReadable).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nextly/src/domains/versions/__tests__/pending-edits-document-rules.integration.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/pending-edits-document-rules.integration.test.ts
@@ -1,0 +1,241 @@
+/**
+ * A stored read rule constrains ROWS, and the pending-edits cards must obey it.
+ *
+ * 🔴 `readableEntities` decides whether a collection is in reach AT ALL, and its
+ * own contract says so -- the per-row rules of whatever query follows decide
+ * which documents come back. A collection carrying a stored `owner-only` read
+ * rule therefore passes that coarse check for every editor, while the ordinary
+ * read path additionally filters to `created_by = caller`. A cross-document read
+ * that stops at the collection name reports one author's documents to another:
+ * the count includes them, and the list hands back their entry ids and the
+ * instants they were edited.
+ *
+ * Written against a real database because the constraint only exists once the
+ * access service has evaluated a STORED rule and the read path has turned it
+ * into SQL; a fake collection cannot produce either.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, defineSingle, text } from "../../../config";
+import {
+  createTestNextly,
+  getConfiguredTestDialects,
+  type TestDialect,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import { VERSIONS_TABLE } from "../../../schemas/versions/types";
+import { executeWidgetQuery } from "../../widgets/execute";
+import { VERSIONS_SOURCE_ID } from "../../widgets/system-source-ids";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+const OWNER = "user-owner";
+const OTHER = "user-other";
+
+/** A working draft for one document, so it counts as a pending edit. */
+function draft(
+  entryId: string,
+  scope: { kind: string; slug: string } = { kind: "collection", slug: "docs" }
+) {
+  return {
+    id: crypto.randomUUID(),
+    scopeKind: scope.kind,
+    scopeSlug: scope.slug,
+    entryId,
+    versionNo: null,
+    status: "draft",
+    isAutosave: false,
+    snapshot: JSON.stringify({ title: "unpublished" }),
+    label: null,
+    locale: null,
+    sourceVersionNo: null,
+    createdBy: null,
+    createdAt: new Date("2020-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+  };
+}
+
+/**
+ * One collection under a stored owner-only read rule, with a pending edit on a
+ * document owned by each of two users.
+ *
+ * The rule is written onto the collection row rather than declared in
+ * `defineCollection`, because the stored shape (`accessRules`) is what the
+ * access service reads; the code-first surface exposes `access` functions, which
+ * return a verdict and never a row constraint.
+ */
+async function boot(
+  dialect: TestDialect
+): Promise<{ ownerEntry: string; otherEntry: string }> {
+  current = await createTestNextly({
+    dialect,
+    collections: [
+      defineCollection({
+        slug: "docs",
+        versions: { drafts: true },
+        // Code-defined access ADMITS the collection, so the coarse entity check
+        // passes for a caller holding no stored grant. Without it `canReadEntity`
+        // denies `docs` outright and every read below answers empty -- which
+        // looks exactly like the row rule working and proves nothing.
+        access: { read: () => true },
+        fields: [text({ name: "title" })],
+      }),
+    ],
+  });
+
+  await current.adapter.update(
+    "dynamic_collections",
+    { access_rules: { read: { type: "owner-only" } } },
+    { and: [{ column: "slug", op: "=", value: "docs" }] }
+  );
+
+  const handler = current.getService("collectionsHandler");
+  const made: Record<string, string> = {};
+  for (const [key, userId] of [
+    ["ownerEntry", OWNER],
+    ["otherEntry", OTHER],
+  ] as const) {
+    const created = await handler.createEntry(
+      { collectionName: "docs", user: { id: userId }, routeAuthorized: true },
+      { title: `${userId} document` }
+    );
+    expect(created.success).toBe(true);
+    made[key] = (created.data as { id: string }).id;
+    await current.adapter.insert(VERSIONS_TABLE, draft(made[key]));
+  }
+  // 🔴 The control, and the reason this file can be believed. It establishes
+  // BOTH halves of the fixture the assertions depend on: the coarse entity
+  // check admits `docs` for this caller (or the ordinary read would be empty
+  // too), and the stored rule genuinely constrains rows (or it would return
+  // both). Without it, a versions read answering nothing is indistinguishable
+  // from a collection the caller cannot reach at all -- which is what the first
+  // draft of this test actually measured.
+  const readable = await handler.listEntries({
+    collectionName: "docs",
+    user: { id: OWNER },
+    routeAuthorized: true,
+  });
+  expect(readable.success).toBe(true);
+  expect((readable.data!.docs as { id: string }[]).map(row => row.id)).toEqual([
+    made.ownerEntry,
+  ]);
+
+  return { ownerEntry: made.ownerEntry!, otherEntry: made.otherEntry! };
+}
+
+const caller = { user: { id: OWNER, roles: ["editor"] } };
+
+describe.each(getConfiguredTestDialects())(
+  "pending edits under a stored read rule (%s)",
+  dialect => {
+    it("counts only the documents this caller may actually read", async () => {
+      await boot(dialect);
+
+      const result = await executeWidgetQuery(
+        { source: VERSIONS_SOURCE_ID, op: "count" },
+        caller
+      );
+
+      // Two documents hold a pending edit; the owner-only rule leaves this
+      // caller able to read exactly one of them.
+      expect(result).toMatchObject({ op: "count", total: 1 });
+    });
+
+    it("counts a document that has NEVER been published", async () => {
+      // 🔴 The card exists to name unpublished work, and the newest of that is a
+      // document nobody has published yet. The readability probe reads through
+      // the ordinary path, which for a lifecycle collection defaults to
+      // PUBLISHED rows -- so a probe that did not ask for every state would
+      // report the caller's own brand-new draft as unreadable and drop it,
+      // hiding exactly the work the reader opened the dashboard to find.
+      current = await createTestNextly({
+        dialect,
+        collections: [
+          defineCollection({
+            slug: "docs",
+            status: true,
+            versions: { drafts: true },
+            access: { read: () => true },
+            fields: [text({ name: "title" })],
+          }),
+        ],
+      });
+
+      const handler = current.getService("collectionsHandler");
+      const created = await handler.createEntry(
+        { collectionName: "docs", user: { id: OWNER }, routeAuthorized: true },
+        { title: "never published", status: "draft" }
+      );
+      expect(created.success).toBe(true);
+      const entryId = (created.data as { id: string }).id;
+      await current.adapter.insert(VERSIONS_TABLE, draft(entryId));
+
+      const result = await executeWidgetQuery(
+        { source: VERSIONS_SOURCE_ID, op: "count" },
+        caller
+      );
+
+      expect(result).toMatchObject({ op: "count", total: 1 });
+    });
+
+    it("counts a SINGLE's pending edit through the Singles read path", async () => {
+      // 🔴 A `single` row is decided by a different path from a collection row —
+      // a Single carries its own stored rules and, when localized, is a
+      // different document per language. Its branch is also where the Singles
+      // read path is reached, and that import is DEFERRED to keep the two
+      // domains out of a module cycle, so a collection-only fixture never
+      // executes it: the code would be loaded for the first time in production.
+      current = await createTestNextly({
+        dialect,
+        singles: [
+          defineSingle({
+            slug: "site-settings",
+            versions: { drafts: true },
+            access: { read: () => true },
+            fields: [text({ name: "title" })],
+          }),
+        ],
+      });
+
+      const singles = current.getService("singleEntryService");
+      const document = await singles.get("site-settings", {
+        overrideAccess: true,
+      });
+      expect(document.success).toBe(true);
+      const entryId = (document.data as { id: string }).id;
+      await current.adapter.insert(
+        VERSIONS_TABLE,
+        draft(entryId, { kind: "single", slug: "site-settings" })
+      );
+
+      const result = await executeWidgetQuery(
+        { source: VERSIONS_SOURCE_ID, op: "count" },
+        caller
+      );
+
+      expect(result).toMatchObject({ op: "count", total: 1 });
+    });
+
+    it("lists no document belonging to another author", async () => {
+      const { ownerEntry, otherEntry } = await boot(dialect);
+
+      const result = await executeWidgetQuery(
+        { source: VERSIONS_SOURCE_ID, op: "list" },
+        caller
+      );
+      const ids = (
+        result as unknown as { items: { entryId: string }[] }
+      ).items.map(item => item.entryId);
+
+      // Asserted by IDENTITY, not by length: a list that dropped the caller's
+      // own document and kept the other author's has the same size.
+      expect(ids).toEqual([ownerEntry]);
+      expect(ids).not.toContain(otherEntry);
+    });
+  }
+);

--- a/packages/nextly/src/domains/versions/__tests__/pending-edits.integration.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/pending-edits.integration.test.ts
@@ -1,10 +1,16 @@
 /**
- * Counting and listing pending edits across collections, against a real database.
+ * Reading pending edits across collections, against a real database.
  *
- * The distinctness is the whole claim and only a database can settle it: a
- * working draft is one row per document per LOCALE, so "14 documents have
- * unpublished changes" counted from rows says 42 for an install translating
- * into three languages.
+ * The SQL distinct-count tests that stood here are gone with the code they
+ * described. Counting documents in the database could not survive
+ * authorization: a stored read rule lives on the collection rather than on the
+ * version row, so the number it produced included documents the caller may not
+ * open, and using it even as a BOUND made one caller's card depend on data they
+ * cannot see. The count is a walk over authorized rows now, covered where that
+ * walk lives.
+ *
+ * What a database still has to settle is here: which rows a scope admits, and
+ * that a document drafted in several languages is one document.
  */
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -65,44 +71,6 @@ function draft(patch: {
 }
 
 describe.each(getConfiguredTestDialects())("pending edits (%s)", dialect => {
-  it("counts DOCUMENTS, not the rows their locales create", async () => {
-    // 🔴 The distinguishing case. One document translated into two languages is
-    // one thing an editor must publish; counting rows reports two, and the
-    // number a dashboard shows would grow with the install's locale count
-    // rather than with its unpublished work.
-    const app = await boot(dialect);
-    const repo = new VersionsRepository(app.adapter);
-
-    for (const row of [
-      draft({ entryId: "e1", locale: "en" }),
-      draft({ entryId: "e1", locale: "fr" }),
-      draft({ entryId: "e2", locale: "en" }),
-    ]) {
-      await app.adapter.insert(VERSIONS_TABLE, row);
-    }
-
-    expect(await repo.countDocumentsWithPendingEdits(["posts"])).toBe(2);
-  });
-
-  it("ignores autosaves, which are not pending edits", async () => {
-    // An autosave is the editor's in-flight buffer, not a change awaiting
-    // publication. Counting it tells a reader to publish something nobody
-    // decided to keep.
-    const app = await boot(dialect);
-    const repo = new VersionsRepository(app.adapter);
-
-    await app.adapter.insert(
-      VERSIONS_TABLE,
-      draft({ entryId: "e1", locale: null })
-    );
-    await app.adapter.insert(
-      VERSIONS_TABLE,
-      draft({ entryId: "e2", locale: null, isAutosave: true })
-    );
-
-    expect(await repo.countDocumentsWithPendingEdits(["posts"])).toBe(1);
-  });
-
   it("counts and lists only the collections the caller may read", async () => {
     const app = await boot(dialect);
     const repo = new VersionsRepository(app.adapter);
@@ -116,9 +84,9 @@ describe.each(getConfiguredTestDialects())("pending edits (%s)", dialect => {
       draft({ entryId: "e2", locale: null, scopeSlug: "secrets" })
     );
 
-    expect(await repo.countDocumentsWithPendingEdits(["posts"])).toBe(1);
     const listed = await repo.findPendingEditRows({
       slugs: ["posts"],
+      order: "recency" as const,
       limit: 10,
     });
     expect(listed.map(row => row.scopeSlug)).toEqual(["posts"]);
@@ -136,10 +104,13 @@ describe.each(getConfiguredTestDialects())("pending edits (%s)", dialect => {
       draft({ entryId: "e1", locale: null })
     );
 
-    expect(await repo.countDocumentsWithPendingEdits([])).toBe(0);
-    expect(await repo.findPendingEditRows({ slugs: [], limit: 10 })).toEqual(
-      []
-    );
+    expect(
+      await repo.findPendingEditRows({
+        slugs: [],
+        limit: 10,
+        order: "recency" as const,
+      })
+    ).toEqual([]);
   });
 
   it("lists one row per DOCUMENT, so locales cannot crowd out other work", async () => {
@@ -179,6 +150,7 @@ describe.each(getConfiguredTestDialects())("pending edits (%s)", dialect => {
     const rows = newestPerDocument(
       await repo.findPendingEditRows({
         slugs: ["posts"],
+        order: "recency" as const,
         limit: 10,
       }),
       2
@@ -215,6 +187,7 @@ describe.each(getConfiguredTestDialects())("pending edits (%s)", dialect => {
 
     const rows = await repo.findPendingEditRows({
       slugs: ["posts"],
+      order: "recency" as const,
       limit: 1000,
     });
     expect(rows).toHaveLength(501);
@@ -246,6 +219,7 @@ describe.each(getConfiguredTestDialects())("pending edits (%s)", dialect => {
 
     const rows = await repo.findPendingEditRows({
       slugs: ["posts"],
+      order: "recency" as const,
       limit: 10,
     });
     expect(rows.map(row => row.entryId)).toEqual(["new", "old"]);

--- a/packages/nextly/src/domains/versions/__tests__/pending-edits.integration.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/pending-edits.integration.test.ts
@@ -16,7 +16,7 @@ import {
   type TestNextly,
 } from "../../../plugins/test-nextly";
 import { VERSIONS_TABLE } from "../../../schemas/versions/types";
-import { VersionsRepository } from "../versions-repository";
+import { newestPerDocument, VersionsRepository } from "../versions-repository";
 
 let current: TestNextly | undefined;
 
@@ -117,12 +117,12 @@ describe.each(getConfiguredTestDialects())("pending edits (%s)", dialect => {
     );
 
     expect(await repo.countDocumentsWithPendingEdits(["posts"])).toBe(1);
-    const listed = await repo.findRecentPendingEdits({
+    const listed = await repo.findPendingEditRows({
       slugs: ["posts"],
       limit: 10,
-      maxPerDocument: 1,
+      offset: 0,
     });
-    expect(listed.map(r => r.scopeSlug)).toEqual(["posts"]);
+    expect(listed.map(row => row.scopeSlug)).toEqual(["posts"]);
   });
 
   it("answers ZERO and an empty list for a caller who may read nothing", async () => {
@@ -139,11 +139,7 @@ describe.each(getConfiguredTestDialects())("pending edits (%s)", dialect => {
 
     expect(await repo.countDocumentsWithPendingEdits([])).toBe(0);
     expect(
-      await repo.findRecentPendingEdits({
-        slugs: [],
-        limit: 10,
-        maxPerDocument: 1,
-      })
+      await repo.findPendingEditRows({ slugs: [], limit: 10, offset: 0 })
     ).toEqual([]);
   });
 
@@ -176,18 +172,26 @@ describe.each(getConfiguredTestDialects())("pending edits (%s)", dialect => {
       await app.adapter.insert(VERSIONS_TABLE, row);
     }
 
-    const rows = await repo.findRecentPendingEdits({
-      slugs: ["posts"],
-      limit: 2,
-      maxPerDocument: 2,
-    });
-    expect(rows.map(r => r.entryId)).toEqual(["translated", "other"]);
+    // The collapse is the CALLER's now, applied after it has authorized what it
+    // may show: a localized Single is authorized per language, so collapsing
+    // inside the read would offer only each document's newest locale and lose a
+    // readable older one. The repository returns rows; this is the same
+    // property, asserted where it now lives.
+    const rows = newestPerDocument(
+      await repo.findPendingEditRows({
+        slugs: ["posts"],
+        limit: 10,
+        offset: 0,
+      }),
+      2
+    );
+    expect(rows.map(row => row.entryId)).toEqual(["translated", "other"]);
     // The row kept is the document's LATEST instant, which is what makes the
     // list agree with the order it claims.
     expect(rows[0]?.locale).toBe("en");
   });
 
-  it("counts every document, past the row ceiling a scan used to carry", async () => {
+  it("returns every row asked for, past the ceiling a scan used to carry", async () => {
     // 🔴 The regression this file exists to hold. The row fetch used to take
     // `Math.min` against a ceiling declared beside it, and that ceiling did not
     // know what the caller had asked for: a request for a thousand documents
@@ -195,6 +199,12 @@ describe.each(getConfiguredTestDialects())("pending edits (%s)", dialect => {
     // under-reported while every feasibility check it had made said its answer
     // was exact. 501 is one past that old ceiling, which is the smallest input
     // that separates the two implementations.
+    //
+    // The bound is the caller's alone now, and the caller pages until it has the
+    // DOCUMENTS it wants -- so no number taken from configuration stands between
+    // the request and the rows. Drafts written under a locale since removed from
+    // the config are still rows, and a bound derived from the live locale count
+    // cannot see them.
     const app = await boot(dialect);
     const repo = new VersionsRepository(app.adapter);
 
@@ -205,15 +215,15 @@ describe.each(getConfiguredTestDialects())("pending edits (%s)", dialect => {
       );
     }
 
-    const rows = await repo.findRecentPendingEdits({
+    const rows = await repo.findPendingEditRows({
       slugs: ["posts"],
       limit: 1000,
-      maxPerDocument: 1,
+      offset: 0,
     });
     expect(rows).toHaveLength(501);
     // Asserted on IDENTITY too: a scan that returned 501 of the wrong rows, or
     // 501 with a duplicate, has the same length.
-    expect(new Set(rows.map(r => r.entryId)).size).toBe(501);
+    expect(new Set(rows.map(row => row.entryId)).size).toBe(501);
   });
 
   it("lists the most recently touched first, and never the snapshot", async () => {
@@ -237,14 +247,14 @@ describe.each(getConfiguredTestDialects())("pending edits (%s)", dialect => {
       })
     );
 
-    const rows = await repo.findRecentPendingEdits({
+    const rows = await repo.findPendingEditRows({
       slugs: ["posts"],
       limit: 10,
-      maxPerDocument: 1,
+      offset: 0,
     });
-    expect(rows.map(r => r.entryId)).toEqual(["new", "old"]);
+    expect(rows.map(row => row.entryId)).toEqual(["new", "old"]);
     // The snapshot is the document's unpublished content and the largest column
     // in the table; a card listing titles has no use for it.
-    expect(rows.every(r => !("snapshot" in r))).toBe(true);
+    expect(rows.every(row => !("snapshot" in row))).toBe(true);
   });
 });

--- a/packages/nextly/src/domains/versions/__tests__/pending-edits.integration.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/pending-edits.integration.test.ts
@@ -187,6 +187,35 @@ describe.each(getConfiguredTestDialects())("pending edits (%s)", dialect => {
     expect(rows[0]?.locale).toBe("en");
   });
 
+  it("counts every document, past the row ceiling a scan used to carry", async () => {
+    // 🔴 The regression this file exists to hold. The row fetch used to take
+    // `Math.min` against a ceiling declared beside it, and that ceiling did not
+    // know what the caller had asked for: a request for a thousand documents
+    // read five hundred rows and returned five hundred documents, so the caller
+    // under-reported while every feasibility check it had made said its answer
+    // was exact. 501 is one past that old ceiling, which is the smallest input
+    // that separates the two implementations.
+    const app = await boot(dialect);
+    const repo = new VersionsRepository(app.adapter);
+
+    for (let index = 0; index < 501; index++) {
+      await app.adapter.insert(
+        VERSIONS_TABLE,
+        draft({ entryId: `e${index}`, locale: null })
+      );
+    }
+
+    const rows = await repo.findRecentPendingEdits({
+      slugs: ["posts"],
+      limit: 1000,
+      maxPerDocument: 1,
+    });
+    expect(rows).toHaveLength(501);
+    // Asserted on IDENTITY too: a scan that returned 501 of the wrong rows, or
+    // 501 with a duplicate, has the same length.
+    expect(new Set(rows.map(r => r.entryId)).size).toBe(501);
+  });
+
   it("lists the most recently touched first, and never the snapshot", async () => {
     const app = await boot(dialect);
     const repo = new VersionsRepository(app.adapter);

--- a/packages/nextly/src/domains/versions/__tests__/pending-edits.integration.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/pending-edits.integration.test.ts
@@ -120,7 +120,6 @@ describe.each(getConfiguredTestDialects())("pending edits (%s)", dialect => {
     const listed = await repo.findPendingEditRows({
       slugs: ["posts"],
       limit: 10,
-      offset: 0,
     });
     expect(listed.map(row => row.scopeSlug)).toEqual(["posts"]);
   });
@@ -138,9 +137,9 @@ describe.each(getConfiguredTestDialects())("pending edits (%s)", dialect => {
     );
 
     expect(await repo.countDocumentsWithPendingEdits([])).toBe(0);
-    expect(
-      await repo.findPendingEditRows({ slugs: [], limit: 10, offset: 0 })
-    ).toEqual([]);
+    expect(await repo.findPendingEditRows({ slugs: [], limit: 10 })).toEqual(
+      []
+    );
   });
 
   it("lists one row per DOCUMENT, so locales cannot crowd out other work", async () => {
@@ -181,7 +180,6 @@ describe.each(getConfiguredTestDialects())("pending edits (%s)", dialect => {
       await repo.findPendingEditRows({
         slugs: ["posts"],
         limit: 10,
-        offset: 0,
       }),
       2
     );
@@ -218,7 +216,6 @@ describe.each(getConfiguredTestDialects())("pending edits (%s)", dialect => {
     const rows = await repo.findPendingEditRows({
       slugs: ["posts"],
       limit: 1000,
-      offset: 0,
     });
     expect(rows).toHaveLength(501);
     // Asserted on IDENTITY too: a scan that returned 501 of the wrong rows, or
@@ -250,7 +247,6 @@ describe.each(getConfiguredTestDialects())("pending edits (%s)", dialect => {
     const rows = await repo.findPendingEditRows({
       slugs: ["posts"],
       limit: 10,
-      offset: 0,
     });
     expect(rows.map(row => row.entryId)).toEqual(["new", "old"]);
     // The snapshot is the document's unpublished content and the largest column

--- a/packages/nextly/src/domains/versions/__tests__/versions-widget-source.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/versions-widget-source.test.ts
@@ -173,12 +173,43 @@ describe("who the numbers are for", () => {
       ...row,
       entryId: `e${index}`,
     }));
-    // One full page, then the remainder, then the end of the table.
-    pendingEditRows
-      .mockResolvedValueOnce(many.slice(0, 100))
-      .mockResolvedValueOnce(many.slice(100))
-      .mockResolvedValue([]);
+    // Pages of exactly ROW_PAGE, as production reads them -- a mocked page
+    // larger than the real one would never reach the round boundary this test
+    // exists for.
+    let served = 0;
+    pendingEditRows.mockImplementation(() => {
+      const page = many.slice(served, served + 100);
+      served += page.length;
+      return Promise.resolve(page);
+    });
     visible.mockImplementation((rows: unknown) => Promise.resolve(rows));
+
+    await expect(
+      executeWidgetQuery({ source: VERSIONS_SOURCE_ID, op: "count" }, caller)
+    ).resolves.toEqual({ op: "count", total: 1000 });
+  });
+
+  it("ANSWERS when every candidate has been met, even at the last round", async () => {
+    // 🔴 The row-round boundary, which the document-quota fix did not reach.
+    // 1,000 readable documents drafted in six languages are 6,000 ROWS, and at
+    // the production page size that is exactly the permitted rounds — so the
+    // walk met every candidate on its final round and still fell out with
+    // `exhausted: false`, refusing an answer it held exactly. Meeting the
+    // candidate total IS exhaustion: there is nothing another page could add.
+    countPendingEdits.mockResolvedValue(1000);
+    const rows = Array.from({ length: 6000 }, (_, index) => ({
+      ...row,
+      entryId: `e${index % 1000}`,
+      locale: `l${Math.floor(index / 1000)}`,
+      id: `v${index}`,
+    }));
+    let served = 0;
+    pendingEditRows.mockImplementation(() => {
+      const page = rows.slice(served, served + 100);
+      served += page.length;
+      return Promise.resolve(page);
+    });
+    visible.mockImplementation((page: unknown) => Promise.resolve(page));
 
     await expect(
       executeWidgetQuery({ source: VERSIONS_SOURCE_ID, op: "count" }, caller)
@@ -241,9 +272,12 @@ describe("who the numbers are for", () => {
     );
 
     expect(pendingEditRows).toHaveBeenCalledTimes(2);
-    // The second read continues where the first ended rather than repeating it.
+    // The second read continues from the LAST ROW of the first rather than from
+    // a count of rows already seen, so a row that moved cannot shift the window.
     expect(pendingEditRows).toHaveBeenLastCalledWith(
-      expect.objectContaining({ offset: 100 })
+      expect.objectContaining({
+        after: { updatedAt: row.updatedAt, id: row.id },
+      })
     );
   });
 

--- a/packages/nextly/src/domains/versions/__tests__/versions-widget-source.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/versions-widget-source.test.ts
@@ -188,6 +188,41 @@ describe("who the numbers are for", () => {
     ).resolves.toMatchObject({ op: "count" });
   });
 
+  it("escalates to the full scan when the small budget cannot fill the card", async () => {
+    // A list takes a modest budget first, so the ordinary dashboard load does
+    // not pay the count's price for rows it discards. When row rules remove
+    // enough that the card cannot be filled AND that budget was exhausted, the
+    // short answer is retried rather than returned.
+    recentPendingEdits.mockResolvedValue(Array.from({ length: 60 }, () => row));
+    visible.mockResolvedValue([]);
+
+    await executeWidgetQuery(
+      { source: VERSIONS_SOURCE_ID, op: "list", limit: 5 },
+      caller
+    );
+
+    expect(recentPendingEdits).toHaveBeenCalledTimes(2);
+    expect(recentPendingEdits).toHaveBeenLastCalledWith(
+      expect.objectContaining({ limit: 1000 })
+    );
+  });
+
+  it("does NOT escalate when the small budget already saw every candidate", async () => {
+    // 🔴 The control that makes the test above mean something. A budget that
+    // was not exhausted has already seen every candidate there is, so a short
+    // answer from it is the true one -- escalating would re-read the same rows
+    // and make every under-filled card cost two scans forever.
+    recentPendingEdits.mockResolvedValue([row]);
+    visible.mockResolvedValue([]);
+
+    await executeWidgetQuery(
+      { source: VERSIONS_SOURCE_ID, op: "list", limit: 5 },
+      caller
+    );
+
+    expect(recentPendingEdits).toHaveBeenCalledTimes(1);
+  });
+
   it("asks the access layer ONCE per query", async () => {
     // Two resolutions of one caller's permissions are two chances to disagree,
     // and each is a round of database reads.

--- a/packages/nextly/src/domains/versions/__tests__/versions-widget-source.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/versions-widget-source.test.ts
@@ -3,7 +3,6 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const countPendingEdits = vi.fn();
 const pendingEditRows = vi.fn();
 const has = vi.fn();
 const readable = vi.fn();
@@ -13,7 +12,7 @@ const visible = vi.fn();
 vi.mock("../../../di/container", () => ({
   container: {
     has: (name: string) => has(name) as boolean,
-    get: () => ({ countPendingEdits, pendingEditRows }),
+    get: () => ({ pendingEditRows }),
   },
 }));
 // `readAccessCaller` is kept REAL and only the decision is replaced, so what
@@ -72,7 +71,6 @@ const row = {
 beforeEach(() => {
   vi.clearAllMocks();
   has.mockReturnValue(true);
-  countPendingEdits.mockResolvedValue(14);
   pendingEditRows.mockResolvedValue([row]);
   readable.mockResolvedValue(new Set(["posts"]));
   registeredSlugs.mockResolvedValue(["posts", "secrets"]);
@@ -97,7 +95,9 @@ describe("who the numbers are for", () => {
       ["posts", "secrets"],
       expect.objectContaining({ userId: "user-1" })
     );
-    expect(countPendingEdits).toHaveBeenCalledWith(["posts"]);
+    expect(pendingEditRows).toHaveBeenCalledWith(
+      expect.objectContaining({ readableSlugs: ["posts"] })
+    );
   });
 
   it("bounds the LIST the same way", async () => {
@@ -145,7 +145,9 @@ describe("who the numbers are for", () => {
       caller
     );
 
-    expect(countPendingEdits).toHaveBeenCalledWith([]);
+    expect(pendingEditRows).toHaveBeenCalledWith(
+      expect.objectContaining({ readableSlugs: [] })
+    );
   });
 
   it("hands every candidate row, and the caller, to the document filter", async () => {
@@ -162,50 +164,33 @@ describe("who the numbers are for", () => {
     expect(visible).toHaveBeenCalledWith([row], caller);
   });
 
-  it("ANSWERS a count of exactly the bound, rather than refusing at it", async () => {
-    // 🔴 The boundary the bound documents as answerable. Stopping the walk at a
-    // document quota cannot tell "exactly this many" from "more than this
-    // many", so a set of exactly CANDIDATE_SCAN readable documents came back
-    // unexhausted and was refused -- at the one size the aggregate admits. The
-    // walk runs to exhaustion now; the aggregate is what bounds it.
-    countPendingEdits.mockResolvedValue(1000);
-    const many = Array.from({ length: 1000 }, (_, index) => ({
+  /*
+   * Three tests stood here, and the behaviour they described is GONE.
+   *
+   * They required an exact count at a document quota, an exact count once every
+   * candidate had been met, and a refusal past the bound. All three belonged to
+   * a design that promised an exact number over a set the database cannot
+   * filter — and every mechanism that tried to keep that promise past a bound
+   * produced a wrong answer instead: a quota could not tell "exactly this many"
+   * from "more than this many", and a shortcut on documents already met
+   * conflated SEEING a document with DECIDING it, since authorization is per
+   * language. The count says `atLeast` now, so there is no quota to sit on and
+   * no refusal to provoke.
+   */
+
+  it("counts every visible document when the rows run out", async () => {
+    // Exhaustion is the ROWS running out and nothing else. The count walks by
+    // identity, which is stable: a working-draft update rewrites the snapshot
+    // and the instant, never the id, so the enumeration cannot be outrun by the
+    // rows it is enumerating.
+    const many = Array.from({ length: 250 }, (_, index) => ({
       ...row,
       entryId: `e${index}`,
-    }));
-    // Pages of exactly ROW_PAGE, as production reads them -- a mocked page
-    // larger than the real one would never reach the round boundary this test
-    // exists for.
-    let served = 0;
-    pendingEditRows.mockImplementation(() => {
-      const page = many.slice(served, served + 100);
-      served += page.length;
-      return Promise.resolve(page);
-    });
-    visible.mockImplementation((rows: unknown) => Promise.resolve(rows));
-
-    await expect(
-      executeWidgetQuery({ source: VERSIONS_SOURCE_ID, op: "count" }, caller)
-    ).resolves.toEqual({ op: "count", total: 1000 });
-  });
-
-  it("ANSWERS when every candidate has been met, even at the last round", async () => {
-    // 🔴 The row-round boundary, which the document-quota fix did not reach.
-    // 1,000 readable documents drafted in six languages are 6,000 ROWS, and at
-    // the production page size that is exactly the permitted rounds — so the
-    // walk met every candidate on its final round and still fell out with
-    // `exhausted: false`, refusing an answer it held exactly. Meeting the
-    // candidate total IS exhaustion: there is nothing another page could add.
-    countPendingEdits.mockResolvedValue(1000);
-    const rows = Array.from({ length: 6000 }, (_, index) => ({
-      ...row,
-      entryId: `e${index % 1000}`,
-      locale: `l${Math.floor(index / 1000)}`,
       id: `v${index}`,
     }));
     let served = 0;
-    pendingEditRows.mockImplementation(() => {
-      const page = rows.slice(served, served + 100);
+    pendingEditRows.mockImplementation(({ limit }: { limit: number }) => {
+      const page = many.slice(served, served + limit);
       served += page.length;
       return Promise.resolve(page);
     });
@@ -213,22 +198,56 @@ describe("who the numbers are for", () => {
 
     await expect(
       executeWidgetQuery({ source: VERSIONS_SOURCE_ID, op: "count" }, caller)
-    ).resolves.toEqual({ op: "count", total: 1000 });
+    ).resolves.toEqual({ op: "count", total: 250 });
   });
 
-  it("refuses a COUNT it cannot answer exactly, rather than reporting a floor", async () => {
-    // 🔴 Row rules cannot be applied in SQL -- the rule lives on the collection,
-    // the candidates live in the version table, and the port has no join -- so
-    // an exact count means materialising candidates, which is bounded work. Past
-    // the bound the honest answers are "refuse" or "report a number that is
-    // quietly too small", and a metric that under-reports is the defect this
-    // module was repaired for.
-    countPendingEdits.mockResolvedValue(1001);
+  it("counts by IDENTITY, not by recency", async () => {
+    // 🔴 A count enumerates; it does not rank. `updatedAt` advances every time
+    // somebody types, so a draft not yet read can move AHEAD of a recency cursor
+    // and be excluded from every later page — a guaranteed miss for the rest of
+    // the walk, which makes the total silently too small.
+    await executeWidgetQuery(
+      { source: VERSIONS_SOURCE_ID, op: "count" },
+      caller
+    );
 
-    await expect(
-      executeWidgetQuery({ source: VERSIONS_SOURCE_ID, op: "count" }, caller)
-    ).rejects.toThrow();
-    expect(pendingEditRows).not.toHaveBeenCalled();
+    expect(pendingEditRows).toHaveBeenCalledWith(
+      expect.objectContaining({ order: "identity" })
+    );
+  });
+
+  it("says AT LEAST when the row budget binds, rather than refusing", async () => {
+    let issued = 0;
+    pendingEditRows.mockImplementation(({ limit }: { limit: number }) =>
+      Promise.resolve(
+        Array.from({ length: limit }, () => ({
+          ...row,
+          entryId: `e${issued++}`,
+          id: `v${issued}`,
+        }))
+      )
+    );
+    visible.mockImplementation((page: unknown) => Promise.resolve(page));
+
+    const result = await executeWidgetQuery(
+      { source: VERSIONS_SOURCE_ID, op: "count" },
+      caller
+    );
+
+    expect(result).toMatchObject({ op: "count", atLeast: true });
+    // The floor is what the walk actually saw.
+    expect((result as { total: number }).total).toBe(2000);
+  });
+
+  it("does not mark a whole count as a floor", async () => {
+    // The control: `atLeast` must be absent when the rows ran out, or every
+    // card renders `N+` forever and the flag stops meaning anything.
+    const result = await executeWidgetQuery(
+      { source: VERSIONS_SOURCE_ID, op: "count" },
+      caller
+    );
+
+    expect(result).not.toHaveProperty("atLeast");
   });
 
   it("authorizes each LOCALE row, then keeps the newest one that survives", async () => {

--- a/packages/nextly/src/domains/versions/__tests__/versions-widget-source.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/versions-widget-source.test.ts
@@ -162,6 +162,29 @@ describe("who the numbers are for", () => {
     expect(visible).toHaveBeenCalledWith([row], caller);
   });
 
+  it("ANSWERS a count of exactly the bound, rather than refusing at it", async () => {
+    // 🔴 The boundary the bound documents as answerable. Stopping the walk at a
+    // document quota cannot tell "exactly this many" from "more than this
+    // many", so a set of exactly CANDIDATE_SCAN readable documents came back
+    // unexhausted and was refused -- at the one size the aggregate admits. The
+    // walk runs to exhaustion now; the aggregate is what bounds it.
+    countPendingEdits.mockResolvedValue(1000);
+    const many = Array.from({ length: 1000 }, (_, index) => ({
+      ...row,
+      entryId: `e${index}`,
+    }));
+    // One full page, then the remainder, then the end of the table.
+    pendingEditRows
+      .mockResolvedValueOnce(many.slice(0, 100))
+      .mockResolvedValueOnce(many.slice(100))
+      .mockResolvedValue([]);
+    visible.mockImplementation((rows: unknown) => Promise.resolve(rows));
+
+    await expect(
+      executeWidgetQuery({ source: VERSIONS_SOURCE_ID, op: "count" }, caller)
+    ).resolves.toEqual({ op: "count", total: 1000 });
+  });
+
   it("refuses a COUNT it cannot answer exactly, rather than reporting a floor", async () => {
     // 🔴 Row rules cannot be applied in SQL -- the rule lives on the collection,
     // the candidates live in the version table, and the port has no join -- so
@@ -175,17 +198,6 @@ describe("who the numbers are for", () => {
       executeWidgetQuery({ source: VERSIONS_SOURCE_ID, op: "count" }, caller)
     ).rejects.toThrow();
     expect(pendingEditRows).not.toHaveBeenCalled();
-  });
-
-  it("answers a COUNT that sits exactly ON the bound", async () => {
-    // The boundary control. Comparing the FETCHED length instead of the total
-    // cannot tell "exactly at the bound" from "beyond it", and would refuse a
-    // set it could have answered.
-    countPendingEdits.mockResolvedValue(1000);
-
-    await expect(
-      executeWidgetQuery({ source: VERSIONS_SOURCE_ID, op: "count" }, caller)
-    ).resolves.toMatchObject({ op: "count" });
   });
 
   it("authorizes each LOCALE row, then keeps the newest one that survives", async () => {
@@ -208,7 +220,7 @@ describe("who the numbers are for", () => {
 
     // BOTH locale rows must reach the decision -- handing it one is the defect.
     expect(visible).toHaveBeenCalledWith([newer, older], caller);
-    const items = (result as { items: { locale: string }[] }).items;
+    const items = (result as unknown as { items: { locale: string }[] }).items;
     expect(items).toHaveLength(1);
     expect(items[0]?.locale).toBe("en");
   });

--- a/packages/nextly/src/domains/versions/__tests__/versions-widget-source.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/versions-widget-source.test.ts
@@ -4,7 +4,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const countPendingEdits = vi.fn();
-const recentPendingEdits = vi.fn();
+const pendingEditRows = vi.fn();
 const has = vi.fn();
 const readable = vi.fn();
 const registeredSlugs = vi.fn();
@@ -13,7 +13,7 @@ const visible = vi.fn();
 vi.mock("../../../di/container", () => ({
   container: {
     has: (name: string) => has(name) as boolean,
-    get: () => ({ countPendingEdits, recentPendingEdits }),
+    get: () => ({ countPendingEdits, pendingEditRows }),
   },
 }));
 // `readAccessCaller` is kept REAL and only the decision is replaced, so what
@@ -73,7 +73,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   has.mockReturnValue(true);
   countPendingEdits.mockResolvedValue(14);
-  recentPendingEdits.mockResolvedValue([row]);
+  pendingEditRows.mockResolvedValue([row]);
   readable.mockResolvedValue(new Set(["posts"]));
   registeredSlugs.mockResolvedValue(["posts", "secrets"]);
   visible.mockImplementation((rows: unknown) => Promise.resolve(rows));
@@ -106,7 +106,7 @@ describe("who the numbers are for", () => {
       caller
     );
 
-    expect(recentPendingEdits).toHaveBeenCalledWith(
+    expect(pendingEditRows).toHaveBeenCalledWith(
       expect.objectContaining({ readableSlugs: ["posts"] })
     );
   });
@@ -174,7 +174,7 @@ describe("who the numbers are for", () => {
     await expect(
       executeWidgetQuery({ source: VERSIONS_SOURCE_ID, op: "count" }, caller)
     ).rejects.toThrow();
-    expect(recentPendingEdits).not.toHaveBeenCalled();
+    expect(pendingEditRows).not.toHaveBeenCalled();
   });
 
   it("answers a COUNT that sits exactly ON the bound", async () => {
@@ -188,31 +188,59 @@ describe("who the numbers are for", () => {
     ).resolves.toMatchObject({ op: "count" });
   });
 
-  it("escalates to the full scan when the small budget cannot fill the card", async () => {
-    // A list takes a modest budget first, so the ordinary dashboard load does
-    // not pay the count's price for rows it discards. When row rules remove
-    // enough that the card cannot be filled AND that budget was exhausted, the
-    // short answer is retried rather than returned.
-    recentPendingEdits.mockResolvedValue(Array.from({ length: 60 }, () => row));
-    visible.mockResolvedValue([]);
+  it("authorizes each LOCALE row, then keeps the newest one that survives", async () => {
+    // 🔴 The ordering property, and the reason the collapse moved out of the
+    // read. A document is one thing to publish across every language it is
+    // drafted in, but a localized Single is authorized PER language -- so
+    // collapsing before the decision offers the filter each document's newest
+    // locale alone. Where that one is denied and an older one is readable, the
+    // document disappears from a card its reader is entitled to see.
+    const newer = { ...row, locale: "fr", updatedAt: new Date("2026-02-01") };
+    const older = { ...row, locale: "en", updatedAt: new Date("2026-01-01") };
+    pendingEditRows.mockResolvedValue([newer, older]);
+    // The newest locale is refused; the older one survives.
+    visible.mockResolvedValue([older]);
+
+    const result = await executeWidgetQuery(
+      { source: VERSIONS_SOURCE_ID, op: "list", limit: 5 },
+      caller
+    );
+
+    // BOTH locale rows must reach the decision -- handing it one is the defect.
+    expect(visible).toHaveBeenCalledWith([newer, older], caller);
+    const items = (result as { items: { locale: string }[] }).items;
+    expect(items).toHaveLength(1);
+    expect(items[0]?.locale).toBe("en");
+  });
+
+  it("reads another page when the first cannot fill the card", async () => {
+    // Rows, not documents, are what a page holds: a document contributes one
+    // row per locale and a row a rule hides contributes nothing, so a page can
+    // yield fewer documents than it has rows. Answering from one page would
+    // report the end of the feed rather than the end of that page.
+    pendingEditRows
+      .mockResolvedValueOnce(Array.from({ length: 100 }, () => row))
+      .mockResolvedValueOnce([row]);
+    visible.mockResolvedValueOnce([]).mockResolvedValueOnce([row]);
 
     await executeWidgetQuery(
       { source: VERSIONS_SOURCE_ID, op: "list", limit: 5 },
       caller
     );
 
-    expect(recentPendingEdits).toHaveBeenCalledTimes(2);
-    expect(recentPendingEdits).toHaveBeenLastCalledWith(
-      expect.objectContaining({ limit: 1000 })
+    expect(pendingEditRows).toHaveBeenCalledTimes(2);
+    // The second read continues where the first ended rather than repeating it.
+    expect(pendingEditRows).toHaveBeenLastCalledWith(
+      expect.objectContaining({ offset: 100 })
     );
   });
 
-  it("does NOT escalate when the small budget already saw every candidate", async () => {
-    // 🔴 The control that makes the test above mean something. A budget that
-    // was not exhausted has already seen every candidate there is, so a short
-    // answer from it is the true one -- escalating would re-read the same rows
-    // and make every under-filled card cost two scans forever.
-    recentPendingEdits.mockResolvedValue([row]);
+  it("stops at the end of the table rather than paging past it", async () => {
+    // 🔴 The control that makes the test above mean something. A SHORT page is
+    // the end of the rows, so a card that could not be filled from it is
+    // genuinely short -- paging on would re-ask an exhausted table on every
+    // dashboard load.
+    pendingEditRows.mockResolvedValue([row]);
     visible.mockResolvedValue([]);
 
     await executeWidgetQuery(
@@ -220,7 +248,7 @@ describe("who the numbers are for", () => {
       caller
     );
 
-    expect(recentPendingEdits).toHaveBeenCalledTimes(1);
+    expect(pendingEditRows).toHaveBeenCalledTimes(1);
   });
 
   it("asks the access layer ONCE per query", async () => {
@@ -294,6 +322,6 @@ describe("what it answers with", () => {
         caller
       )
     ).rejects.toThrow(/unavailable source or unsupported op/);
-    expect(recentPendingEdits).not.toHaveBeenCalled();
+    expect(pendingEditRows).not.toHaveBeenCalled();
   });
 });

--- a/packages/nextly/src/domains/versions/__tests__/versions-widget-source.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/versions-widget-source.test.ts
@@ -8,6 +8,7 @@ const recentPendingEdits = vi.fn();
 const has = vi.fn();
 const readable = vi.fn();
 const registeredSlugs = vi.fn();
+const visible = vi.fn();
 
 vi.mock("../../../di/container", () => ({
   container: {
@@ -28,6 +29,18 @@ vi.mock("../../../auth/entity-read-access", async importOriginal => ({
 }));
 vi.mock("../../../services/lib/registered-content-slugs", () => ({
   registeredContentSlugs: () => registeredSlugs() as unknown,
+}));
+// A PASS-THROUGH, so the assertions below stay about what this module decides:
+// which collections are in reach, and what it answers with. The document-level
+// filter it stands in for reaches the ordinary read path and a stored access
+// rule, neither of which exists in a unit harness --
+// `pending-edits-document-rules.integration.test.ts` drives the real one
+// against a real database and a real owner-only rule. The final test in this
+// block is what keeps the substitution honest: it asserts the rows and the
+// caller actually reach this seam, so deleting the call is not a green.
+vi.mock("../pending-edit-visibility", () => ({
+  visiblePendingEdits: (rows: unknown, caller: unknown) =>
+    visible(rows, caller) as unknown,
 }));
 
 import { executeWidgetQuery } from "../../widgets/execute";
@@ -63,6 +76,7 @@ beforeEach(() => {
   recentPendingEdits.mockResolvedValue([row]);
   readable.mockResolvedValue(new Set(["posts"]));
   registeredSlugs.mockResolvedValue(["posts", "secrets"]);
+  visible.mockImplementation((rows: unknown) => Promise.resolve(rows));
   clearSources();
   clearSystemResolvers();
   registerVersionsWidgetSource();
@@ -132,6 +146,46 @@ describe("who the numbers are for", () => {
     );
 
     expect(countPendingEdits).toHaveBeenCalledWith([]);
+  });
+
+  it("hands every candidate row, and the caller, to the document filter", async () => {
+    // 🔴 Entity access is one axis short: a stored owner-only or custom read
+    // rule narrows which of a collection's documents come back, and a version
+    // read filtered by collection name alone reported another author's entry
+    // ids and edit times. The caller has to reach that decision too -- an id
+    // cannot be judged against a rule written about a key's own scope.
+    await executeWidgetQuery(
+      { source: VERSIONS_SOURCE_ID, op: "list" },
+      caller
+    );
+
+    expect(visible).toHaveBeenCalledWith([row], caller);
+  });
+
+  it("refuses a COUNT it cannot answer exactly, rather than reporting a floor", async () => {
+    // 🔴 Row rules cannot be applied in SQL -- the rule lives on the collection,
+    // the candidates live in the version table, and the port has no join -- so
+    // an exact count means materialising candidates, which is bounded work. Past
+    // the bound the honest answers are "refuse" or "report a number that is
+    // quietly too small", and a metric that under-reports is the defect this
+    // module was repaired for.
+    countPendingEdits.mockResolvedValue(1001);
+
+    await expect(
+      executeWidgetQuery({ source: VERSIONS_SOURCE_ID, op: "count" }, caller)
+    ).rejects.toThrow();
+    expect(recentPendingEdits).not.toHaveBeenCalled();
+  });
+
+  it("answers a COUNT that sits exactly ON the bound", async () => {
+    // The boundary control. Comparing the FETCHED length instead of the total
+    // cannot tell "exactly at the bound" from "beyond it", and would refuse a
+    // set it could have answered.
+    countPendingEdits.mockResolvedValue(1000);
+
+    await expect(
+      executeWidgetQuery({ source: VERSIONS_SOURCE_ID, op: "count" }, caller)
+    ).resolves.toMatchObject({ op: "count" });
   });
 
   it("asks the access layer ONCE per query", async () => {

--- a/packages/nextly/src/domains/versions/db-api.ts
+++ b/packages/nextly/src/domains/versions/db-api.ts
@@ -66,6 +66,17 @@ export interface VersionsSelectOptions {
     nulls?: "first" | "last";
   }[];
   limit?: number;
+  /**
+   * Where the page starts.
+   *
+   * Exposed because a cross-document read cannot size its query in advance: a
+   * document contributes one row per locale, and rows a stored access rule
+   * hides contribute none at all, so how many rows a page of DOCUMENTS costs is
+   * not knowable before reading them. Paging is what lets the caller keep
+   * reading until it has what it asked for, rather than guessing a bound from a
+   * number that does not describe the data. The adapter has always supported it.
+   */
+  offset?: number;
 }
 
 /** The database methods the versions repository depends on. */

--- a/packages/nextly/src/domains/versions/db-api.ts
+++ b/packages/nextly/src/domains/versions/db-api.ts
@@ -106,21 +106,6 @@ export interface VersionsDbApi {
    * by both the adapter and the transaction context, whose wider `where` and
    * extra optional arguments remain assignable to this narrower shape.
    */
-  /**
-   * How many rows match, or how many DISTINCT column combinations do.
-   *
-   * 🔴 OPTIONAL, and that is not timidity about the feature. This port is
-   * satisfied structurally by two different things: the pooled adapter, which
-   * has this, and the transaction context, which does not -- and the releases
-   * and jobs repositories are typed against the same port. A required method
-   * would make every one of them stop satisfying it for a capability none of
-   * them uses. A caller that needs it asks and refuses when absent, which is
-   * the same shape `dialect?` above already takes.
-   */
-  count?(
-    table: string,
-    options?: { where?: VersionsWhere; distinctOn?: string[] }
-  ): Promise<number>;
   delete(table: string, where: VersionsWhere): Promise<number>;
   /**
    * Update rows matching `where`.

--- a/packages/nextly/src/domains/versions/pending-edit-visibility.ts
+++ b/packages/nextly/src/domains/versions/pending-edit-visibility.ts
@@ -10,113 +10,195 @@
  * counted one author's documents for another and listed their entry ids and the
  * instants they were edited.
  *
- * Every decision here is delegated. A stored rule can be owner-only or an
- * arbitrary function, and evaluating either is the read path's job — this asks
- * that path about a known set of documents rather than reproducing what it
- * would say, which is the second access implementation this domain exists to
- * avoid.
+ * Version rows OUTLIVE the things they describe — that is what history is — so a
+ * row reaching here may name a document, a language or an entity that no longer
+ * exists, or a slug some other entity has since taken over. Each of those is
+ * UNDECIDABLE rather than deniable, and every one is dropped: nothing here can
+ * judge them, and admitting what cannot be judged is the inversion this pass
+ * exists to remove.
+ *
+ * Every decision that IS made is delegated. A stored rule can be owner-only or
+ * an arbitrary function, and evaluating either is the read path's job — this
+ * asks that path about a known set of documents rather than reproducing what it
+ * would say.
  *
  * @module domains/versions/pending-edit-visibility
  */
 
+import { authorizationGroups } from "../../auth/entity-read-access";
+import { container } from "../../di/container";
+import type { NextlyServiceConfig } from "../../di/register";
 import type { ReadCaller } from "../../services/dashboard/readable-resources";
 import { readableDocumentIds } from "../../services/lib/readable-documents";
+import { registeredContentKinds } from "../../services/lib/registered-content-slugs";
 
 import type { VersionMeta } from "./versions-repository";
 
-/**
- * Rows grouped by the slug AND locale they belong to, order preserved.
- *
- * 🔴 Locale is part of the key, not a detail. A stored read rule is a predicate
- * over the collection's own fields, and a localized field answers differently
- * per language — `localized-target-predicate.integration.test.ts` pins exactly
- * that, with one row readable in `en` and denied in `de`. Authorizing a slug
- * once therefore judges whichever translation the read defaults to and marks
- * every locale row visible on the strength of it, disclosing the entry id,
- * language and edit time of a translation the rule refuses.
- */
-function byReadUnit(
-  rows: readonly VersionMeta[]
-): Map<string, { slug: string; locale: string | null; rows: VersionMeta[] }> {
-  const grouped = new Map<
-    string,
-    { slug: string; locale: string | null; rows: VersionMeta[] }
-  >();
-  for (const row of rows) {
-    // NUL-joined for the reason the version key is: a slug may contain any
-    // delimiter that reads as safe.
-    const key = `${row.scopeSlug}\u0000${row.locale ?? ""}`;
-    const existing = grouped.get(key);
-    if (existing) existing.rows.push(row);
-    else
-      grouped.set(key, {
-        slug: row.scopeSlug,
-        locale: row.locale,
-        rows: [row],
-      });
-  }
-  return grouped;
+/** What a row must resolve to before any access question can be asked about it. */
+interface Subject {
+  kind: "collection" | "single";
+  slug: string;
+  entryId: string;
+  locale: string | null;
 }
 
-/** The collection rows whose documents survive that collection's read rules. */
-async function visibleCollectionRows(
+/** One read's worth of rows: a slug, in a language, and what it answers for. */
+interface ReadUnit {
+  subject: Subject;
+  rows: VersionMeta[];
+}
+
+/**
+ * The languages a read can actually be performed in, or `null` when the install
+ * configures none.
+ *
+ * 🔴 Needed because forwarding an unconfigured locale does NOT authorize it:
+ * `resolveRequestedLocale` substitutes the configured DEFAULT for any code it
+ * does not recognise. A working draft written under a language later removed
+ * from the configuration would therefore be judged by the default language's
+ * verdict — a row exposed on a predicate never evaluated for it, which is the
+ * same defect as passing no locale at all.
+ */
+function configuredLocales(): Set<string> | null {
+  try {
+    if (!container.has("config")) return null;
+    const localization =
+      container.get<NextlyServiceConfig>("config").localization;
+    if (!localization) return null;
+    return new Set(localization.locales.map(locale => locale.code));
+  } catch {
+    // A container that cannot answer leaves every localized row undecidable,
+    // which `subjectOf` turns into "dropped" rather than "allowed".
+    return null;
+  }
+}
+
+/**
+ * The document a row names, or `null` when nothing here can decide it.
+ *
+ * Three ways a row is undecidable, each of which has cost a real defect:
+ *
+ * - Its scope kind disagrees with the registry. Deleting a collection leaves its
+ *   history behind, and a Single may later take the freed slug — so a
+ *   `collection` row can survive under a name that now belongs to a Single.
+ *   Probing the collection read path for it asks about a table that is not
+ *   there, which throws and breaks both cards rather than dropping one row.
+ * - Its slug is in neither registry, so there is no read path to ask at all.
+ * - Its language is no longer configured, so a read cannot be performed IN that
+ *   language and would silently answer about the default one instead.
+ */
+function subjectOf(
+  row: VersionMeta,
+  kinds: ReadonlyMap<string, "collection" | "single">,
+  locales: Set<string> | null
+): Subject | null {
+  const kind = kinds.get(row.scopeSlug);
+  if (!kind || kind !== row.scopeKind) return null;
+  if (row.locale !== null && !locales?.has(row.locale)) return null;
+  return {
+    kind,
+    slug: row.scopeSlug,
+    entryId: row.entryId,
+    locale: row.locale,
+  };
+}
+
+/** Rows grouped into the units one read can answer for: a slug in a language. */
+function readUnits(
   rows: readonly VersionMeta[],
+  subjects: ReadonlyMap<VersionMeta, Subject>,
+  kind: "collection" | "single"
+): Map<string, ReadUnit> {
+  const units = new Map<string, ReadUnit>();
+  for (const row of rows) {
+    const subject = subjects.get(row);
+    if (!subject || subject.kind !== kind) continue;
+    const key = `${subject.slug} ${subject.locale ?? ""}`;
+    const existing = units.get(key);
+    if (existing) existing.rows.push(row);
+    else units.set(key, { subject, rows: [row] });
+  }
+  return units;
+}
+
+/**
+ * Collection rows whose documents survive that collection's read rules.
+ *
+ * 🔴 Grouped by slug AND language, because a stored rule is a predicate over the
+ * collection's own fields and a localized field answers differently per
+ * language — `localized-target-predicate.integration.test.ts` pins one row
+ * readable in `en` and denied in `de`. One verdict per slug would mark every
+ * other language visible on the strength of whichever the read defaulted to.
+ *
+ * Run with BOUNDED CONCURRENCY rather than one after another. Each unit enters
+ * the full collection read path, so a page spanning many collections or
+ * languages became that many sequential round trips — enough to time a dashboard
+ * out while the connection pool sat idle. `authorizationGroups` is the bound the
+ * entity-level decisions already use, and its first group of one is what lets a
+ * cold per-user permission cache be filled once rather than missed by everything
+ * in the fan-out.
+ */
+async function visibleCollectionRows(
+  units: ReadonlyMap<string, ReadUnit>,
   caller: ReadCaller
 ): Promise<Set<VersionMeta>> {
   const visible = new Set<VersionMeta>();
-  for (const unit of byReadUnit(rows).values()) {
-    const readable = await readableDocumentIds(
-      unit.slug,
-      unit.rows.map(row => row.entryId),
-      caller,
-      unit.locale
+
+  for (const group of authorizationGroups([...units.keys()])) {
+    const settled = await Promise.allSettled(
+      group.map(async key => {
+        const unit = units.get(key) as ReadUnit;
+        const readable = await readableDocumentIds(
+          unit.subject.slug,
+          unit.rows.map(row => row.entryId),
+          caller,
+          unit.subject.locale
+        );
+        return { unit, readable };
+      })
     );
-    for (const row of unit.rows) {
-      if (readable.has(row.entryId)) visible.add(row);
+    for (const outcome of settled) {
+      // A rejected read has told us nothing, and "nothing" must not read as
+      // "visible" -- the fail-closed direction `readableEntities` also takes.
+      if (outcome.status !== "fulfilled") continue;
+      const { unit, readable } = outcome.value;
+      for (const row of unit.rows) {
+        if (readable.has(row.entryId)) visible.add(row);
+      }
     }
   }
   return visible;
 }
 
 /**
- * The single rows whose document this caller may read, asked once per language.
+ * Single rows whose document this caller may read, asked once per language.
  *
- * Per LOCALE, because a localized Single is a different document per language
- * and an owner-only or custom rule can answer differently for each — the same
- * reason `SingleAccessSubject` carries a locale at all.
+ * The live document's id is resolved FIRST, and without materializing anything.
+ * A version row outlives the document it describes, so a Single deleted and
+ * recreated leaves rows naming its predecessor — and the probe reads through
+ * `SingleEntryService`, which auto-creates a missing Single, so asking it first
+ * would make loading a dashboard perform a write.
  *
- * `routeAuthorized: false` states the truth: the widget endpoint authorized a
- * WIDGET, not a read of this Single, so the coarse gate has not run for this
- * operation and must not be skipped. Claiming otherwise would hand a caller
- * holding no read grant the existence and edit time of the document.
+ * `routeAuthorized: false` states the truth: the surface asking this authorized
+ * a widget, not a read of this Single, so the coarse gate has not run for that
+ * operation and must not be skipped.
  */
 async function visibleSingleRows(
-  rows: readonly VersionMeta[],
+  units: ReadonlyMap<string, ReadUnit>,
   caller: ReadCaller
 ): Promise<Set<VersionMeta>> {
   const visible = new Set<VersionMeta>();
-  if (rows.length === 0) return visible;
+  if (units.size === 0) return visible;
 
   // 🔴 Imported HERE rather than at the top of the module, because the static
-  // edge is a cycle: the Singles read path imports this domain (draft overlay,
-  // in-transaction capture, snapshot shaping), so a top-level import back into
-  // it closes the loop. Rollup already reports that shape elsewhere in this
-  // package as producing a circular chunk dependency and a broken execution
-  // order, and the failure would land at boot rather than here. Deferring it
-  // also means an install whose pending edits are all collections never loads
-  // the Singles query service at all.
+  // edge is a cycle: the Singles read path imports this domain, so a top-level
+  // import back into it closes the loop. Rollup already reports that shape
+  // elsewhere in this package as producing a broken execution order, and the
+  // failure would land at boot rather than here.
   const { singleDocumentReadable, resolveSingleDocumentId } = await import(
     "../singles/services/single-document-access"
   );
 
-  // 🔴 Resolved BEFORE the probe, and without materializing anything. A version
-  // row outlives the document it describes, so a Single that was deleted and
-  // recreated leaves rows naming the predecessor -- and judging those by the
-  // replacement's verdict exposes the old entry id and edit time. The probe
-  // itself cannot be asked first either: it reads through `SingleEntryService`,
-  // which AUTO-CREATES a missing Single, so loading a dashboard would perform a
-  // write. `resolveSingleDocumentId` exists for exactly this and reads the
-  // backing row directly; `canReadLiveSingle` compares the id the same way.
   const liveIds = new Map<string, Promise<string | null>>();
   const liveIdOf = (slug: string): Promise<string | null> => {
     let pending = liveIds.get(slug);
@@ -127,52 +209,71 @@ async function visibleSingleRows(
     return pending;
   };
 
-  const verdicts = new Map<string, Promise<boolean>>();
-  for (const row of rows) {
-    // An unmaterialized Single, or a row belonging to a predecessor document.
-    if ((await liveIdOf(row.scopeSlug)) !== row.entryId) continue;
-    const key = `${row.scopeSlug} ${row.locale ?? ""}`;
-    let verdict = verdicts.get(key);
-    if (!verdict) {
-      verdict = singleDocumentReadable(row.scopeSlug, {
-        user: caller.user,
-        ...(caller.authenticatedScope
-          ? { actor: caller.authenticatedScope }
-          : {}),
-        routeAuthorized: false,
-        ...(row.locale === null ? {} : { locale: row.locale }),
-      });
-      verdicts.set(key, verdict);
+  /**
+   * One unit's rows that name the LIVE document, or none.
+   *
+   * 🔴 The probe is skipped entirely when nothing here names it — the Single is
+   * unmaterialized, or every row is a predecessor's. It reads through a path
+   * that AUTO-CREATES a missing Single, so asking about one that is not there
+   * turns a dashboard read into a write; and asking about a live document on
+   * behalf of rows that do not name it spends a read whose verdict cannot admit
+   * any of them.
+   */
+  const liveRowsOf = async (unit: ReadUnit): Promise<VersionMeta[]> => {
+    const liveId = await liveIdOf(unit.subject.slug);
+    if (liveId === null) return [];
+    return unit.rows.filter(row => row.entryId === liveId);
+  };
+
+  for (const group of authorizationGroups([...units.keys()])) {
+    const settled = await Promise.allSettled(
+      group.map(async key => {
+        const unit = units.get(key) as ReadUnit;
+        const live = await liveRowsOf(unit);
+        if (live.length === 0) return [];
+        const allowed = await singleDocumentReadable(unit.subject.slug, {
+          user: caller.user,
+          ...(caller.authenticatedScope
+            ? { actor: caller.authenticatedScope }
+            : {}),
+          routeAuthorized: false,
+          ...(unit.subject.locale === null
+            ? {}
+            : { locale: unit.subject.locale }),
+        });
+        return allowed ? live : [];
+      })
+    );
+    for (const outcome of settled) {
+      // A rejected read has told us nothing, and "nothing" must not read as
+      // "visible" -- the fail-closed direction `readableEntities` also takes.
+      if (outcome.status !== "fulfilled") continue;
+      for (const row of outcome.value) visible.add(row);
     }
-    if (await verdict) visible.add(row);
   }
   return visible;
 }
 
-/**
- * `rows`, in their original order, keeping only what the caller may be told.
- *
- * A row whose `scopeKind` is neither a collection nor a single is DROPPED
- * rather than passed through. Nothing here can decide such a row — there is no
- * read path to ask — and admitting what cannot be judged is the inversion this
- * pass exists to remove. It costs nothing today, since the source's candidate
- * slugs come from the collection and single registries.
- */
+/** `rows`, in their original order, keeping only what the caller may be told. */
 export async function visiblePendingEdits(
   rows: readonly VersionMeta[],
   caller: ReadCaller
 ): Promise<VersionMeta[]> {
   if (rows.length === 0) return [];
 
+  const kinds = await registeredContentKinds();
+  const locales = configuredLocales();
+
+  const subjects = new Map<VersionMeta, Subject>();
+  for (const row of rows) {
+    const subject = subjectOf(row, kinds, locales);
+    if (subject) subjects.set(row, subject);
+  }
+  if (subjects.size === 0) return [];
+
   const [collections, singles] = await Promise.all([
-    visibleCollectionRows(
-      rows.filter(row => row.scopeKind === "collection"),
-      caller
-    ),
-    visibleSingleRows(
-      rows.filter(row => row.scopeKind === "single"),
-      caller
-    ),
+    visibleCollectionRows(readUnits(rows, subjects, "collection"), caller),
+    visibleSingleRows(readUnits(rows, subjects, "single"), caller),
   ]);
 
   return rows.filter(row => collections.has(row) || singles.has(row));

--- a/packages/nextly/src/domains/versions/pending-edit-visibility.ts
+++ b/packages/nextly/src/domains/versions/pending-edit-visibility.ts
@@ -1,0 +1,133 @@
+/**
+ * Which pending-edit rows this caller may actually be told about.
+ *
+ * 🔴 The version table is keyed by (scopeKind, scopeSlug, entryId) and carries
+ * no access rules of its own, so a read of it bounded only by collection name
+ * answers about documents the ordinary read path would refuse. Entity-level
+ * access decides whether a collection is IN REACH; a stored `owner-only` or
+ * `custom` read rule then narrows which of its rows come back, and that second
+ * axis is invisible to a slug filter. Without this pass the dashboard's cards
+ * counted one author's documents for another and listed their entry ids and the
+ * instants they were edited.
+ *
+ * Every decision here is delegated. A stored rule can be owner-only or an
+ * arbitrary function, and evaluating either is the read path's job — this asks
+ * that path about a known set of documents rather than reproducing what it
+ * would say, which is the second access implementation this domain exists to
+ * avoid.
+ *
+ * @module domains/versions/pending-edit-visibility
+ */
+
+import type { ReadCaller } from "../../services/dashboard/readable-resources";
+import { readableDocumentIds } from "../../services/lib/readable-documents";
+
+import type { VersionMeta } from "./versions-repository";
+
+/** Rows grouped by the slug they belong to, preserving their order. */
+function bySlug(rows: readonly VersionMeta[]): Map<string, VersionMeta[]> {
+  const grouped = new Map<string, VersionMeta[]>();
+  for (const row of rows) {
+    const existing = grouped.get(row.scopeSlug);
+    if (existing) existing.push(row);
+    else grouped.set(row.scopeSlug, [row]);
+  }
+  return grouped;
+}
+
+/** The collection rows whose documents survive that collection's read rules. */
+async function visibleCollectionRows(
+  rows: readonly VersionMeta[],
+  caller: ReadCaller
+): Promise<Set<VersionMeta>> {
+  const visible = new Set<VersionMeta>();
+  for (const [slug, slugRows] of bySlug(rows)) {
+    const readable = await readableDocumentIds(
+      slug,
+      slugRows.map(row => row.entryId),
+      caller
+    );
+    for (const row of slugRows) if (readable.has(row.entryId)) visible.add(row);
+  }
+  return visible;
+}
+
+/**
+ * The single rows whose document this caller may read, asked once per language.
+ *
+ * Per LOCALE, because a localized Single is a different document per language
+ * and an owner-only or custom rule can answer differently for each — the same
+ * reason `SingleAccessSubject` carries a locale at all.
+ *
+ * `routeAuthorized: false` states the truth: the widget endpoint authorized a
+ * WIDGET, not a read of this Single, so the coarse gate has not run for this
+ * operation and must not be skipped. Claiming otherwise would hand a caller
+ * holding no read grant the existence and edit time of the document.
+ */
+async function visibleSingleRows(
+  rows: readonly VersionMeta[],
+  caller: ReadCaller
+): Promise<Set<VersionMeta>> {
+  const visible = new Set<VersionMeta>();
+  if (rows.length === 0) return visible;
+
+  // 🔴 Imported HERE rather than at the top of the module, because the static
+  // edge is a cycle: the Singles read path imports this domain (draft overlay,
+  // in-transaction capture, snapshot shaping), so a top-level import back into
+  // it closes the loop. Rollup already reports that shape elsewhere in this
+  // package as producing a circular chunk dependency and a broken execution
+  // order, and the failure would land at boot rather than here. Deferring it
+  // also means an install whose pending edits are all collections never loads
+  // the Singles query service at all.
+  const { singleDocumentReadable } = await import(
+    "../singles/services/single-document-access"
+  );
+
+  const verdicts = new Map<string, Promise<boolean>>();
+  for (const row of rows) {
+    const key = `${row.scopeSlug} ${row.locale ?? ""}`;
+    let verdict = verdicts.get(key);
+    if (!verdict) {
+      verdict = singleDocumentReadable(row.scopeSlug, {
+        user: caller.user,
+        ...(caller.authenticatedScope
+          ? { actor: caller.authenticatedScope }
+          : {}),
+        routeAuthorized: false,
+        ...(row.locale === null ? {} : { locale: row.locale }),
+      });
+      verdicts.set(key, verdict);
+    }
+    if (await verdict) visible.add(row);
+  }
+  return visible;
+}
+
+/**
+ * `rows`, in their original order, keeping only what the caller may be told.
+ *
+ * A row whose `scopeKind` is neither a collection nor a single is DROPPED
+ * rather than passed through. Nothing here can decide such a row — there is no
+ * read path to ask — and admitting what cannot be judged is the inversion this
+ * pass exists to remove. It costs nothing today, since the source's candidate
+ * slugs come from the collection and single registries.
+ */
+export async function visiblePendingEdits(
+  rows: readonly VersionMeta[],
+  caller: ReadCaller
+): Promise<VersionMeta[]> {
+  if (rows.length === 0) return [];
+
+  const [collections, singles] = await Promise.all([
+    visibleCollectionRows(
+      rows.filter(row => row.scopeKind === "collection"),
+      caller
+    ),
+    visibleSingleRows(
+      rows.filter(row => row.scopeKind === "single"),
+      caller
+    ),
+  ]);
+
+  return rows.filter(row => collections.has(row) || singles.has(row));
+}

--- a/packages/nextly/src/domains/versions/pending-edit-visibility.ts
+++ b/packages/nextly/src/domains/versions/pending-edit-visibility.ts
@@ -24,13 +24,36 @@ import { readableDocumentIds } from "../../services/lib/readable-documents";
 
 import type { VersionMeta } from "./versions-repository";
 
-/** Rows grouped by the slug they belong to, preserving their order. */
-function bySlug(rows: readonly VersionMeta[]): Map<string, VersionMeta[]> {
-  const grouped = new Map<string, VersionMeta[]>();
+/**
+ * Rows grouped by the slug AND locale they belong to, order preserved.
+ *
+ * 🔴 Locale is part of the key, not a detail. A stored read rule is a predicate
+ * over the collection's own fields, and a localized field answers differently
+ * per language — `localized-target-predicate.integration.test.ts` pins exactly
+ * that, with one row readable in `en` and denied in `de`. Authorizing a slug
+ * once therefore judges whichever translation the read defaults to and marks
+ * every locale row visible on the strength of it, disclosing the entry id,
+ * language and edit time of a translation the rule refuses.
+ */
+function byReadUnit(
+  rows: readonly VersionMeta[]
+): Map<string, { slug: string; locale: string | null; rows: VersionMeta[] }> {
+  const grouped = new Map<
+    string,
+    { slug: string; locale: string | null; rows: VersionMeta[] }
+  >();
   for (const row of rows) {
-    const existing = grouped.get(row.scopeSlug);
-    if (existing) existing.push(row);
-    else grouped.set(row.scopeSlug, [row]);
+    // NUL-joined for the reason the version key is: a slug may contain any
+    // delimiter that reads as safe.
+    const key = `${row.scopeSlug}\u0000${row.locale ?? ""}`;
+    const existing = grouped.get(key);
+    if (existing) existing.rows.push(row);
+    else
+      grouped.set(key, {
+        slug: row.scopeSlug,
+        locale: row.locale,
+        rows: [row],
+      });
   }
   return grouped;
 }
@@ -41,13 +64,16 @@ async function visibleCollectionRows(
   caller: ReadCaller
 ): Promise<Set<VersionMeta>> {
   const visible = new Set<VersionMeta>();
-  for (const [slug, slugRows] of bySlug(rows)) {
+  for (const unit of byReadUnit(rows).values()) {
     const readable = await readableDocumentIds(
-      slug,
-      slugRows.map(row => row.entryId),
-      caller
+      unit.slug,
+      unit.rows.map(row => row.entryId),
+      caller,
+      unit.locale
     );
-    for (const row of slugRows) if (readable.has(row.entryId)) visible.add(row);
+    for (const row of unit.rows) {
+      if (readable.has(row.entryId)) visible.add(row);
+    }
   }
   return visible;
 }
@@ -79,12 +105,32 @@ async function visibleSingleRows(
   // order, and the failure would land at boot rather than here. Deferring it
   // also means an install whose pending edits are all collections never loads
   // the Singles query service at all.
-  const { singleDocumentReadable } = await import(
+  const { singleDocumentReadable, resolveSingleDocumentId } = await import(
     "../singles/services/single-document-access"
   );
 
+  // 🔴 Resolved BEFORE the probe, and without materializing anything. A version
+  // row outlives the document it describes, so a Single that was deleted and
+  // recreated leaves rows naming the predecessor -- and judging those by the
+  // replacement's verdict exposes the old entry id and edit time. The probe
+  // itself cannot be asked first either: it reads through `SingleEntryService`,
+  // which AUTO-CREATES a missing Single, so loading a dashboard would perform a
+  // write. `resolveSingleDocumentId` exists for exactly this and reads the
+  // backing row directly; `canReadLiveSingle` compares the id the same way.
+  const liveIds = new Map<string, Promise<string | null>>();
+  const liveIdOf = (slug: string): Promise<string | null> => {
+    let pending = liveIds.get(slug);
+    if (!pending) {
+      pending = resolveSingleDocumentId(slug);
+      liveIds.set(slug, pending);
+    }
+    return pending;
+  };
+
   const verdicts = new Map<string, Promise<boolean>>();
   for (const row of rows) {
+    // An unmaterialized Single, or a row belonging to a predecessor document.
+    if ((await liveIdOf(row.scopeSlug)) !== row.entryId) continue;
     const key = `${row.scopeSlug} ${row.locale ?? ""}`;
     let verdict = verdicts.get(key);
     if (!verdict) {

--- a/packages/nextly/src/domains/versions/versions-repository.ts
+++ b/packages/nextly/src/domains/versions/versions-repository.ts
@@ -134,6 +134,22 @@ export interface PendingEditCursor {
 }
 
 /**
+ * How a paged pending-edit read is ordered, and why the choice is the CALLER's.
+ *
+ * - `recency` — newest first, which is what a "recently edited" card means.
+ * - `identity` — by row id, which means nothing to a reader and is STABLE.
+ *
+ * 🔴 A count pages by identity, and that is a correctness decision rather than a
+ * preference. `updatedAt` advances every time somebody types, so a draft not yet
+ * read can move AHEAD of a recency cursor and be excluded from every later page
+ * — not a race window but a guaranteed miss for the rest of the walk, which
+ * makes a total silently too small. A working-draft update rewrites `snapshot`,
+ * `createdBy` and `updatedAt` and never the id, so an identity cursor cannot be
+ * outrun by the rows it is enumerating.
+ */
+export type PendingEditOrder = "recency" | "identity";
+
+/**
  * Strictly after `cursor` in `updatedAt DESC, id DESC` order.
  *
  * 🔴 A cursor rather than an OFFSET, because the rows being paged are the most
@@ -147,7 +163,13 @@ export interface PendingEditCursor {
  * Spelled as the two-branch disjunction rather than a row constructor, because
  * `(a, b) < (x, y)` is not portable across the three dialects this must run on.
  */
-function olderThan(cursor: PendingEditCursor): VersionsWhere {
+function olderThan(
+  cursor: PendingEditCursor,
+  order: PendingEditOrder
+): VersionsWhere {
+  if (order === "identity") {
+    return { and: [{ column: "id", op: "<", value: cursor.id }] };
+  }
   return {
     or: [
       { and: [{ column: "updatedAt", op: "<", value: cursor.updatedAt }] },
@@ -159,6 +181,17 @@ function olderThan(cursor: PendingEditCursor): VersionsWhere {
       },
     ],
   };
+}
+
+/** The ordering clause for `order`, unique in both cases so a cursor is exact. */
+function orderClause(
+  order: PendingEditOrder
+): { column: string; direction: "desc"; nulls?: "last" }[] {
+  if (order === "identity") return [{ column: "id", direction: "desc" }];
+  return [
+    { column: "updatedAt", direction: "desc", nulls: "last" },
+    { column: "id", direction: "desc" },
+  ];
 }
 
 /** Identifies the document a version belongs to. */
@@ -375,38 +408,6 @@ export class VersionsRepository {
     };
   }
 
-  /** The count capability, or a refusal naming why it is absent. */
-  private counter(): NonNullable<VersionsDbApi["count"]> {
-    const count = this.db.count?.bind(this.db);
-    if (!count) {
-      // The pooled adapter has it; a transaction context does not. A read path
-      // reaching here on a tx handle is a wiring mistake, not a caller's.
-      throw NextlyError.internal({
-        logContext: { reason: "versions-count-unsupported" },
-      });
-    }
-    return count;
-  }
-
-  /**
-   * How many DOCUMENTS hold a pending edit, within the given collections.
-   *
-   * 🔴 Documents, not rows. A working draft is one row per document per LOCALE,
-   * so a document edited in three languages is one thing to fix and three rows
-   * -- and "14 documents have unpublished changes" counted from rows says 42.
-   * The distinct combination is the document's identity, which is why the
-   * adapter's `distinctOn` exists rather than a row count here.
-   */
-  async countDocumentsWithPendingEdits(
-    slugs: readonly string[]
-  ): Promise<number> {
-    if (slugs.length === 0) return 0;
-    return this.counter()(TABLE, {
-      where: this.pendingEditWhere(slugs),
-      distinctOn: ["scopeKind", "scopeSlug", "entryId"],
-    });
-  }
-
   /**
    * One PAGE of pending-edit rows, newest first — rows, not documents.
    *
@@ -437,27 +438,23 @@ export class VersionsRepository {
   async findPendingEditRows(input: {
     slugs: readonly string[];
     limit: number;
+    order: PendingEditOrder;
     after?: PendingEditCursor;
   }): Promise<VersionMeta[]> {
     if (input.slugs.length === 0 || input.limit <= 0) return [];
     const scope = this.pendingEditWhere(input.slugs);
     return this.db.select<VersionMeta>(TABLE, {
       columns: [...VERSION_META_COLUMNS],
-      where: input.after ? { and: [scope, olderThan(input.after)] } : scope,
-      // `nulls` is stated for the reason the module's other ordered read states
-      // it: the default differs per dialect, and a limited list must not return
-      // different rows per engine.
-      // 🔴 `id` breaks the ties, and it is what makes OFFSET paging sound. An
-      // order on `updatedAt` alone is not TOTAL -- SQLite stores whole seconds,
-      // so working drafts saved in the same second tie -- and a database may
-      // order tied rows differently between two queries. Paging an unstable
-      // order returns one row twice and SKIPS another, and the skipped document
-      // is simply lost: a caller de-duplicating what it received cannot notice
-      // the one it never saw.
-      orderBy: [
-        { column: "updatedAt", direction: "desc", nulls: "last" },
-        { column: "id", direction: "desc" },
-      ],
+      where: input.after
+        ? { and: [scope, olderThan(input.after, input.order)] }
+        : scope,
+      // Both orderings end in a UNIQUE column, which is what lets a cursor name
+      // a position exactly: `updatedAt` alone is not total -- SQLite stores
+      // whole seconds, so drafts saved together tie -- and a cursor over a
+      // non-unique key cannot say which of the tied rows a page ended on.
+      // `nulls` is stated because the default differs per dialect, and a limited
+      // list must not return different rows per engine.
+      orderBy: orderClause(input.order),
       limit: input.limit,
     });
   }

--- a/packages/nextly/src/domains/versions/versions-repository.ts
+++ b/packages/nextly/src/domains/versions/versions-repository.ts
@@ -121,6 +121,46 @@ export function newestPerDocument(
   return newest;
 }
 
+/**
+ * Where a page of pending edits left off.
+ *
+ * The ordering key in full, which is what a cursor has to be: `updatedAt` alone
+ * is not unique, so a cursor carrying only the instant cannot say WHICH of the
+ * rows sharing it was the last one read.
+ */
+export interface PendingEditCursor {
+  updatedAt: Date;
+  id: string;
+}
+
+/**
+ * Strictly after `cursor` in `updatedAt DESC, id DESC` order.
+ *
+ * 🔴 A cursor rather than an OFFSET, because the rows being paged are the most
+ * MUTABLE in the system: a working draft's `updatedAt` advances every time
+ * somebody types. Under OFFSET, a row updated between two pages moves ahead of
+ * the offset, so the next page repeats a row already seen and SKIPS one that was
+ * never read — and the skipped document is lost silently, since de-duplicating
+ * what arrived cannot reveal what did not. Anchoring to the last row read makes
+ * the pages disjoint whatever moves behind them.
+ *
+ * Spelled as the two-branch disjunction rather than a row constructor, because
+ * `(a, b) < (x, y)` is not portable across the three dialects this must run on.
+ */
+function olderThan(cursor: PendingEditCursor): VersionsWhere {
+  return {
+    or: [
+      { and: [{ column: "updatedAt", op: "<", value: cursor.updatedAt }] },
+      {
+        and: [
+          { column: "updatedAt", op: "=", value: cursor.updatedAt },
+          { column: "id", op: "<", value: cursor.id },
+        ],
+      },
+    ],
+  };
+}
+
 /** Identifies the document a version belongs to. */
 export interface VersionRef {
   scopeKind: VersionScopeKind;
@@ -381,14 +421,15 @@ export class VersionsRepository {
    * {@link newestPerDocument} is exported for the caller to apply on the far
    * side of that decision.
    *
-   * 🔴 Paged rather than bounded by an arithmetic guess. The bound used to be
-   * `limit * maxPerDocument`, where `maxPerDocument` was the install's CURRENT
-   * locale count — which does not bound the data: working drafts written under a
-   * locale since removed from the configuration are still rows, so the read
-   * could return too few rows to yield `limit` documents while the caller's
-   * feasibility check said its answer was exact. A page and an offset make the
-   * caller's real bound — how many DOCUMENTS it wants — the only one, and it
-   * stops when it has them or when the rows run out.
+   * 🔴 Paged by CURSOR rather than bounded by an arithmetic guess. The bound
+   * used to be `limit * maxPerDocument`, where `maxPerDocument` was the
+   * install's CURRENT locale count — which does not bound the data: working
+   * drafts written under a locale since removed from the configuration are still
+   * rows, so the read could return too few rows to yield `limit` documents while
+   * the caller's feasibility check said its answer was exact. Paging makes the
+   * caller's real bound — how many DOCUMENTS it wants — the only one; the cursor
+   * is what keeps the pages disjoint while the rows underneath them move. See
+   * {@link olderThan}.
    *
    * The snapshot is projected away. It is the largest column in the table and a
    * card that lists titles has no use for it.
@@ -396,12 +437,13 @@ export class VersionsRepository {
   async findPendingEditRows(input: {
     slugs: readonly string[];
     limit: number;
-    offset: number;
+    after?: PendingEditCursor;
   }): Promise<VersionMeta[]> {
     if (input.slugs.length === 0 || input.limit <= 0) return [];
+    const scope = this.pendingEditWhere(input.slugs);
     return this.db.select<VersionMeta>(TABLE, {
       columns: [...VERSION_META_COLUMNS],
-      where: this.pendingEditWhere(input.slugs),
+      where: input.after ? { and: [scope, olderThan(input.after)] } : scope,
       // `nulls` is stated for the reason the module's other ordered read states
       // it: the default differs per dialect, and a limited list must not return
       // different rows per engine.
@@ -417,7 +459,6 @@ export class VersionsRepository {
         { column: "id", direction: "desc" },
       ],
       limit: input.limit,
-      offset: input.offset,
     });
   }
 

--- a/packages/nextly/src/domains/versions/versions-repository.ts
+++ b/packages/nextly/src/domains/versions/versions-repository.ts
@@ -74,33 +74,19 @@ const VERSION_META_COLUMNS = [
 ] as const;
 
 /**
- * How many rows to read to be sure of finding `limit` distinct documents.
- *
- * 🔴 Derived from the caller's `limit` and NOTHING else. This used to take
- * `Math.min` against a second ceiling declared here, and the two bounds did not
- * know about each other: a caller asking for a thousand documents got five
- * hundred rows, so it received fewer documents than exist while every
- * feasibility check it had made said the answer was exact. A quiet floor, which
- * is the failure the caller's own bound exists to refuse.
- *
- * One bound, owned by the caller, is what makes that unrepresentable. The row
- * count follows from it, because a document holds at most `maxPerDocument`
- * working drafts -- one per locale -- so that many rows per document is enough
- * and no ceiling here can be right without knowing what the caller promised.
- */
-function scanBound(limit: number, maxPerDocument: number): number {
-  return limit * Math.max(maxPerDocument, 1);
-}
-
-/**
  * A document's identity across locales.
  *
  * NUL-joined rather than concatenated, so a slug ending in the separator cannot
  * spell the same key as a different slug and entry id pair -- the columns are
  * free strings and a delimiter that can occur inside one is a collision waiting
  * for the install that names a collection unusually.
+ *
+ * Exported because the collapse it keys now happens AFTER authorization, in the
+ * caller: a version row's identity belongs to this module, and the decision
+ * about which rows a reader may see belongs to the read path, so the two meet at
+ * the caller rather than one reimplementing the other.
  */
-function documentKey(row: VersionMeta): string {
+export function documentKey(row: VersionMeta): string {
   return [row.scopeKind, row.scopeSlug, row.entryId].join("\u0000");
 }
 
@@ -109,10 +95,17 @@ function documentKey(row: VersionMeta): string {
  *
  * Relies on the caller's `updatedAt DESC` ordering: the first row seen for a
  * document IS its latest instant, so keeping the first and dropping the rest
- * needs no comparison. Stops at `limit`, which is what makes the scan bound
- * above sufficient rather than merely generous.
+ * needs no comparison.
+ *
+ * 🔴 Run this AFTER authorization, never before. The key deliberately excludes
+ * `locale`, because a document is one thing to publish however many languages
+ * it is drafted in -- but a localized Single is authorized PER LANGUAGE, so
+ * collapsing first hands the visibility filter only the newest locale. Where
+ * that one is denied and an older one is readable, the document disappears from
+ * a card its reader is entitled to see, and no test that uses an unlocalized
+ * document can tell.
  */
-function newestPerDocument(
+export function newestPerDocument(
   rows: readonly VersionMeta[],
   limit: number
 ): VersionMeta[] {
@@ -375,46 +368,47 @@ export class VersionsRepository {
   }
 
   /**
-   * The DOCUMENTS most recently left with a pending edit, newest first.
+   * One PAGE of pending-edit rows, newest first — rows, not documents.
    *
-   * 🔴 Documents, not rows, and the difference is visible on the dashboard. A
-   * working draft is one row per document per LOCALE, so a page edited in three
-   * languages is three rows -- and limiting the query alone let one document
-   * take three of a five-row card while other recent work fell off the end. The
-   * count beside it is document-based, so the list also disagreed with the
-   * number it sits under, and because the card's `select` omits `locale` the
-   * extra rows rendered as indistinguishable duplicates rather than as anything
-   * a reader could explain.
+   * 🔴 It returns rows and collapses nothing, and that ordering is the point. A
+   * working draft is one row per document per LOCALE, and a document is one
+   * thing to publish however many languages it is drafted in — so the two views
+   * are both needed and the collapse has to happen AFTER the caller has
+   * authorized what it may see. Collapsing here handed the visibility filter
+   * only each document's newest locale, and a localized Single is authorized per
+   * language: where its newest pending locale is denied and an older one is
+   * readable, the document vanished from a card its reader was entitled to.
+   * {@link newestPerDocument} is exported for the caller to apply on the far
+   * side of that decision.
    *
-   * Over-fetch then collapse, because the data port has no GROUP BY and adding
-   * one for a single card would widen every adapter. The bound is exact rather
-   * than a guess: rows arrive newest-first, so a document's FIRST row is its
-   * latest instant, and every row preceding it belongs to a document at least as
-   * recent. At most `maxPerDocument` rows can come from any one of those, so the
-   * newest `limit` documents are all represented within
-   * `limit * maxPerDocument` rows — see {@link scanBound}, which is derived from
-   * `limit` alone so this cannot return fewer documents than the caller asked
-   * for while the caller believes it asked for few enough.
+   * 🔴 Paged rather than bounded by an arithmetic guess. The bound used to be
+   * `limit * maxPerDocument`, where `maxPerDocument` was the install's CURRENT
+   * locale count — which does not bound the data: working drafts written under a
+   * locale since removed from the configuration are still rows, so the read
+   * could return too few rows to yield `limit` documents while the caller's
+   * feasibility check said its answer was exact. A page and an offset make the
+   * caller's real bound — how many DOCUMENTS it wants — the only one, and it
+   * stops when it has them or when the rows run out.
    *
    * The snapshot is projected away. It is the largest column in the table and a
    * card that lists titles has no use for it.
    */
-  async findRecentPendingEdits(input: {
+  async findPendingEditRows(input: {
     slugs: readonly string[];
     limit: number;
-    maxPerDocument: number;
+    offset: number;
   }): Promise<VersionMeta[]> {
     if (input.slugs.length === 0 || input.limit <= 0) return [];
-    const rows = await this.db.select<VersionMeta>(TABLE, {
+    return this.db.select<VersionMeta>(TABLE, {
       columns: [...VERSION_META_COLUMNS],
       where: this.pendingEditWhere(input.slugs),
       // `nulls` is stated for the reason the module's other ordered read states
       // it: the default differs per dialect, and a limited list must not return
       // different rows per engine.
       orderBy: [{ column: "updatedAt", direction: "desc", nulls: "last" }],
-      limit: scanBound(input.limit, input.maxPerDocument),
+      limit: input.limit,
+      offset: input.offset,
     });
-    return newestPerDocument(rows, input.limit);
   }
 
   /**

--- a/packages/nextly/src/domains/versions/versions-repository.ts
+++ b/packages/nextly/src/domains/versions/versions-repository.ts
@@ -405,7 +405,17 @@ export class VersionsRepository {
       // `nulls` is stated for the reason the module's other ordered read states
       // it: the default differs per dialect, and a limited list must not return
       // different rows per engine.
-      orderBy: [{ column: "updatedAt", direction: "desc", nulls: "last" }],
+      // 🔴 `id` breaks the ties, and it is what makes OFFSET paging sound. An
+      // order on `updatedAt` alone is not TOTAL -- SQLite stores whole seconds,
+      // so working drafts saved in the same second tie -- and a database may
+      // order tied rows differently between two queries. Paging an unstable
+      // order returns one row twice and SKIPS another, and the skipped document
+      // is simply lost: a caller de-duplicating what it received cannot notice
+      // the one it never saw.
+      orderBy: [
+        { column: "updatedAt", direction: "desc", nulls: "last" },
+        { column: "id", direction: "desc" },
+      ],
       limit: input.limit,
       offset: input.offset,
     });

--- a/packages/nextly/src/domains/versions/versions-repository.ts
+++ b/packages/nextly/src/domains/versions/versions-repository.ts
@@ -74,20 +74,22 @@ const VERSION_META_COLUMNS = [
 ] as const;
 
 /**
- * The largest number of rows a recent-edits scan will read.
+ * How many rows to read to be sure of finding `limit` distinct documents.
  *
- * A ceiling on the over-fetch, not on the answer. It only binds when
- * `limit * maxPerDocument` exceeds it -- a 5-row card needs it past 100
- * configured locales -- and when it does the card returns FEWER documents rather
- * than wrong ones. Worth having because `maxPerDocument` is the configured
- * locale count, and rows written under a locale later removed from the config
- * are not bounded by it.
+ * 🔴 Derived from the caller's `limit` and NOTHING else. This used to take
+ * `Math.min` against a second ceiling declared here, and the two bounds did not
+ * know about each other: a caller asking for a thousand documents got five
+ * hundred rows, so it received fewer documents than exist while every
+ * feasibility check it had made said the answer was exact. A quiet floor, which
+ * is the failure the caller's own bound exists to refuse.
+ *
+ * One bound, owned by the caller, is what makes that unrepresentable. The row
+ * count follows from it, because a document holds at most `maxPerDocument`
+ * working drafts -- one per locale -- so that many rows per document is enough
+ * and no ceiling here can be right without knowing what the caller promised.
  */
-const MAX_PENDING_EDIT_SCAN = 500;
-
-/** How many rows to read to be sure of finding `limit` distinct documents. */
 function scanBound(limit: number, maxPerDocument: number): number {
-  return Math.min(limit * Math.max(maxPerDocument, 1), MAX_PENDING_EDIT_SCAN);
+  return limit * Math.max(maxPerDocument, 1);
 }
 
 /**
@@ -390,8 +392,9 @@ export class VersionsRepository {
    * latest instant, and every row preceding it belongs to a document at least as
    * recent. At most `maxPerDocument` rows can come from any one of those, so the
    * newest `limit` documents are all represented within
-   * `limit * maxPerDocument` rows. See {@link scanBound} for the cap and what it
-   * costs.
+   * `limit * maxPerDocument` rows — see {@link scanBound}, which is derived from
+   * `limit` alone so this cannot return fewer documents than the caller asked
+   * for while the caller believes it asked for few enough.
    *
    * The snapshot is projected away. It is the largest column in the table and a
    * card that lists titles has no use for it.

--- a/packages/nextly/src/domains/versions/versions-service.ts
+++ b/packages/nextly/src/domains/versions/versions-service.ts
@@ -23,6 +23,7 @@ import {
   VersionsRepository,
   type AutosaveWriteResult,
   type PendingEditCursor,
+  type PendingEditOrder,
   type VersionMeta,
   type VersionRef,
   type VersionRow,
@@ -48,22 +49,6 @@ export class VersionsService {
   }
 
   /**
-   * How many documents hold a pending edit, within collections the caller reads.
-   *
-   * 🔴 The allowlist is REQUIRED and ENUMERATED — `[]` means exactly nothing,
-   * and there is no value meaning "no filter". This service has no authorization
-   * of its own (unlike `ReleasesService`, none of its methods takes an actor) so
-   * the bound has to arrive from the caller, and an optional parameter would
-   * produce an install-wide number for a reader entitled to part of it the first
-   * time somebody forgot it. The one caller resolves the list through
-   * `readableEntities`, which answers every registered entity for a super admin
-   * rather than a bypass, so nothing here needs a wider case.
-   */
-  async countPendingEdits(readableSlugs: readonly string[]): Promise<number> {
-    return this.repo.countDocumentsWithPendingEdits(readableSlugs);
-  }
-
-  /**
    * One page of pending-edit ROWS, newest first.
    *
    * 🔴 Rows rather than documents, and the caller collapses them itself — after
@@ -77,11 +62,13 @@ export class VersionsService {
   async pendingEditRows(input: {
     readableSlugs: readonly string[];
     limit: number;
+    order: PendingEditOrder;
     after?: PendingEditCursor;
   }): Promise<VersionMeta[]> {
     return this.repo.findPendingEditRows({
       slugs: input.readableSlugs,
       limit: input.limit,
+      order: input.order,
       ...(input.after ? { after: input.after } : {}),
     });
   }

--- a/packages/nextly/src/domains/versions/versions-service.ts
+++ b/packages/nextly/src/domains/versions/versions-service.ts
@@ -22,6 +22,7 @@ import type { VersionsDbApi } from "./db-api";
 import {
   VersionsRepository,
   type AutosaveWriteResult,
+  type PendingEditCursor,
   type VersionMeta,
   type VersionRef,
   type VersionRow,
@@ -76,12 +77,12 @@ export class VersionsService {
   async pendingEditRows(input: {
     readableSlugs: readonly string[];
     limit: number;
-    offset: number;
+    after?: PendingEditCursor;
   }): Promise<VersionMeta[]> {
     return this.repo.findPendingEditRows({
       slugs: input.readableSlugs,
       limit: input.limit,
-      offset: input.offset,
+      ...(input.after ? { after: input.after } : {}),
     });
   }
 

--- a/packages/nextly/src/domains/versions/versions-service.ts
+++ b/packages/nextly/src/domains/versions/versions-service.ts
@@ -39,30 +39,11 @@ export interface VersionListOptions {
   locale?: string;
 }
 
-/** Construction-time facts this service cannot derive from its database handle. */
-export interface VersionsServiceOptions {
-  /**
-   * How many working drafts one document can hold — the install's configured
-   * locale count, since a working draft is one row per document per locale.
-   *
-   * Read by the recent-edits list to bound the rows it must scan to find a full
-   * page of distinct DOCUMENTS. Defaults to 1, which is exactly right for an
-   * install with no localization configured and merely conservative otherwise:
-   * too low returns fewer documents than asked, never wrong ones.
-   */
-  maxWorkingDraftsPerDocument?: number;
-}
-
 export class VersionsService {
   private readonly repo: VersionsRepository;
-  private readonly maxWorkingDraftsPerDocument: number;
 
-  constructor(db: VersionsDbApi, options: VersionsServiceOptions = {}) {
+  constructor(db: VersionsDbApi) {
     this.repo = new VersionsRepository(db);
-    this.maxWorkingDraftsPerDocument = Math.max(
-      Math.trunc(options.maxWorkingDraftsPerDocument ?? 1) || 1,
-      1
-    );
   }
 
   /**
@@ -81,15 +62,26 @@ export class VersionsService {
     return this.repo.countDocumentsWithPendingEdits(readableSlugs);
   }
 
-  /** The documents most recently left with a pending edit, newest first. */
-  async recentPendingEdits(input: {
+  /**
+   * One page of pending-edit ROWS, newest first.
+   *
+   * 🔴 Rows rather than documents, and the caller collapses them itself — after
+   * it has decided which it may show. A working draft is one row per document
+   * per locale, and a localized Single is authorized per language, so collapsing
+   * before that decision offers the newest locale alone and loses a readable
+   * older one. This service used to take the install's locale count to size a
+   * single read; that number does not bound the data, because drafts written
+   * under a locale since removed from the configuration are still rows.
+   */
+  async pendingEditRows(input: {
     readableSlugs: readonly string[];
     limit: number;
+    offset: number;
   }): Promise<VersionMeta[]> {
-    return this.repo.findRecentPendingEdits({
+    return this.repo.findPendingEditRows({
       slugs: input.readableSlugs,
       limit: input.limit,
-      maxPerDocument: this.maxWorkingDraftsPerDocument,
+      offset: input.offset,
     });
   }
 

--- a/packages/nextly/src/domains/versions/versions-widget-source.ts
+++ b/packages/nextly/src/domains/versions/versions-widget-source.ts
@@ -70,6 +70,7 @@ import { visiblePendingEdits } from "./pending-edit-visibility";
 import {
   documentKey,
   newestPerDocument,
+  type PendingEditCursor,
   type VersionMeta,
 } from "./versions-repository";
 import type { VersionsService } from "./versions-service";
@@ -259,44 +260,90 @@ function describe(
  * only be published when it did: otherwise the answer is a floor, and a metric
  * that quietly under-reports is the failure this whole source was repaired for.
  */
+/** What a walk has accumulated so far, across its rounds. */
+interface Gathered {
+  documents: VersionMeta[];
+  /** Documents already kept, so one split across a page cannot appear twice. */
+  seen: Set<string>;
+  /**
+   * Every document the walk has MET, visible or not. The candidate aggregate
+   * counts documents too, so meeting that many means every candidate has been
+   * decided — which is exhaustion, whether or not another page exists.
+   */
+  met: Set<string>;
+}
+
+/**
+ * Fold one page and its authorized rows into `gathered`; true when it is full.
+ *
+ * The collapse runs per round against what is already kept rather than over the
+ * whole walk at the end, so a document drafted in several languages across a
+ * page boundary is still counted once.
+ */
+function absorbPage(
+  gathered: Gathered,
+  rows: readonly VersionMeta[],
+  visible: readonly VersionMeta[],
+  wanted: number
+): boolean {
+  for (const row of rows) gathered.met.add(documentKey(row));
+  for (const row of newestPerDocument(visible, Number.MAX_SAFE_INTEGER)) {
+    const key = documentKey(row);
+    if (gathered.seen.has(key)) continue;
+    gathered.seen.add(key);
+    gathered.documents.push(row);
+    if (gathered.documents.length >= wanted) return true;
+  }
+  return false;
+}
+
 async function gatherVisibleDocuments(
   wanted: number,
   readableSlugs: readonly string[],
-  caller: ReadCaller
+  caller: ReadCaller,
+  candidateTotal?: number
 ): Promise<{ documents: VersionMeta[]; exhausted: boolean }> {
-  const documents: VersionMeta[] = [];
-  const seen = new Set<string>();
-  let offset = 0;
+  const gathered: Gathered = {
+    documents: [],
+    seen: new Set(),
+    met: new Set(),
+  };
+  let after: PendingEditCursor | undefined;
+  // 🔴 Three ways out, and only two of them are exhaustion. Rows running out and
+  // every candidate having been decided both mean nothing further exists; the
+  // ROUNDS running out means the walk stopped early, and a count published from
+  // that would be a floor. Tracked explicitly because collapsing the exits into
+  // one `break` loses exactly that distinction.
+  let exhausted = false;
 
   for (let round = 0; round < MAX_GATHER_ROUNDS; round++) {
     const rows = await service().pendingEditRows({
       readableSlugs,
       limit: ROW_PAGE,
-      offset,
+      ...(after ? { after } : {}),
     });
-    if (rows.length === 0) return { documents, exhausted: true };
-    offset += rows.length;
+    if (rows.length === 0) {
+      exhausted = true;
+      break;
+    }
+    // Anchored to the LAST row of this page, in the order it was read.
+    const last = rows[rows.length - 1];
+    after = { updatedAt: last.updatedAt, id: last.id };
 
-    // Collapsed per ROUND against everything already kept, so a document split
-    // across a page boundary cannot appear twice.
-    for (const row of newestPerDocument(
-      await visiblePendingEdits(rows, caller),
-      Number.MAX_SAFE_INTEGER
-    )) {
-      const key = documentKey(row);
-      if (seen.has(key)) continue;
-      seen.add(key);
-      documents.push(row);
-      if (documents.length >= wanted) {
-        return { documents, exhausted: false };
-      }
+    const visible = await visiblePendingEdits(rows, caller);
+    if (absorbPage(gathered, rows, visible, wanted)) {
+      return { documents: gathered.documents, exhausted: false };
     }
 
-    // A short page is the end of the table, not the end of this round.
-    if (rows.length < ROW_PAGE) return { documents, exhausted: true };
+    const everyCandidateMet =
+      candidateTotal !== undefined && gathered.met.size >= candidateTotal;
+    if (everyCandidateMet || rows.length < ROW_PAGE) {
+      exhausted = true;
+      break;
+    }
   }
 
-  return { documents, exhausted: false };
+  return { documents: gathered.documents, exhausted };
 }
 
 async function resolveVersions(
@@ -330,9 +377,8 @@ async function resolveVersions(
         },
       });
     };
-    if ((await service().countPendingEdits(readableSlugs)) > CANDIDATE_SCAN) {
-      refuse();
-    }
+    const candidateTotal = await service().countPendingEdits(readableSlugs);
+    if (candidateTotal > CANDIDATE_SCAN) refuse();
 
     // 🔴 Asked to run to EXHAUSTION rather than to a document quota. Stopping
     // at a quota cannot tell "there are exactly this many" from "there are more
@@ -343,7 +389,8 @@ async function resolveVersions(
     const { documents, exhausted } = await gatherVisibleDocuments(
       Number.MAX_SAFE_INTEGER,
       readableSlugs,
-      caller
+      caller,
+      candidateTotal
     );
     // The candidate count passing is still not enough on its own. It counts
     // documents, while the walk reads rows, and rows a stored rule hides are

--- a/packages/nextly/src/domains/versions/versions-widget-source.ts
+++ b/packages/nextly/src/domains/versions/versions-widget-source.ts
@@ -121,8 +121,13 @@ const ROW_PAGE = 100;
  * this caller. Reaching it returns FEWER documents than asked for, and the count
  * refuses rather than publishing that as a total — so the failure direction is a
  * thin card or an honest refusal, never a number that is quietly too small.
+ *
+ * Generous because the count runs to exhaustion over a set the aggregate has
+ * already bounded at {@link CANDIDATE_SCAN} DOCUMENTS, while a round reads
+ * ROWS: a document contributes one per locale, so the rows behind that bound are
+ * a multiple of it that nothing here can know in advance.
  */
-const MAX_GATHER_ROUNDS = 20;
+const MAX_GATHER_ROUNDS = 60;
 
 /**
  * The fields this source publishes.
@@ -329,12 +334,18 @@ async function resolveVersions(
       refuse();
     }
 
+    // 🔴 Asked to run to EXHAUSTION rather than to a document quota. Stopping
+    // at a quota cannot tell "there are exactly this many" from "there are more
+    // than this many", so a set of exactly `CANDIDATE_SCAN` readable documents
+    // -- which the aggregate above admits -- came back unexhausted and refused,
+    // at precisely the boundary the bound documents as answerable. The
+    // aggregate is what bounds this walk; the walk's own job is to finish.
     const { documents, exhausted } = await gatherVisibleDocuments(
-      CANDIDATE_SCAN,
+      Number.MAX_SAFE_INTEGER,
       readableSlugs,
       caller
     );
-    // 🔴 The candidate count passing is NOT enough on its own. It counts
+    // The candidate count passing is still not enough on its own. It counts
     // documents, while the walk reads rows, and rows a stored rule hides are
     // read without yielding one -- so a caller who may see little can exhaust
     // the rounds on a set the aggregate said was small. Publishing what the

--- a/packages/nextly/src/domains/versions/versions-widget-source.ts
+++ b/packages/nextly/src/domains/versions/versions-widget-source.ts
@@ -67,6 +67,7 @@ import { VERSIONS_SOURCE_ID } from "../widgets/system-source-ids";
 import { registerSystemSource } from "../widgets/system-sources";
 
 import { visiblePendingEdits } from "./pending-edit-visibility";
+import type { VersionMeta } from "./versions-repository";
 import type { VersionsService } from "./versions-service";
 
 export { VERSIONS_SOURCE_ID };
@@ -84,14 +85,35 @@ const DEFAULT_LIMIT = 5;
  * ask the ordinary read path about them. That is bounded work, and this is the
  * bound.
  *
- * Reaching it means something different for each op, so each says so itself:
- * the LIST needs only enough survivors to fill a handful of slots and is
- * unaffected, while the COUNT would silently report a floor — and a metric that
- * quietly under-reports is the failure this whole change is repairing, so it
- * refuses instead. A thousand documents carrying unpublished edits is already
- * an extreme state for an editorial install.
+ * The COUNT is what it really bounds: past it, an exact answer is not available
+ * and the card refuses rather than reporting a floor — a metric that quietly
+ * under-reports is the failure this whole change is repairing. A LIST rarely
+ * comes near it, taking {@link LIST_CANDIDATES} first and escalating only when
+ * that cannot fill the card.
+ *
+ * 🔴 It is the ONE bound, and the repository derives its row fetch from it
+ * rather than declaring a second. Two independent ceilings is what produced the
+ * defect this constant exists to prevent: a caller asking for a thousand
+ * documents received five hundred, so it under-reported while every check it
+ * had made said the answer was exact.
  */
 const CANDIDATE_SCAN = 1000;
+
+/**
+ * How many candidates a LIST considers before it needs the full scan.
+ *
+ * A list wants a handful of visible rows, not every candidate, and on the
+ * ordinary install — where no collection carries a stored row rule — the first
+ * `limit` candidates are all visible and this is the only read. Scanning to
+ * {@link CANDIDATE_SCAN} for a five-row card would make every dashboard load
+ * pay the count's price for rows it discards.
+ *
+ * It is a budget rather than a cap: when filtering removes enough that the card
+ * cannot be filled AND this budget was actually exhausted, the query escalates
+ * to the full scan. So the short answer this could produce is retried rather
+ * than returned, and only the two conditions together spend the larger read.
+ */
+const LIST_CANDIDATES = 60;
 
 /**
  * The fields this source publishes.
@@ -209,6 +231,42 @@ function describe(
   });
 }
 
+/** The visible candidates within `budget`, and how many were considered. */
+async function visibleWithin(
+  budget: number,
+  readableSlugs: readonly string[],
+  caller: ReadCaller
+): Promise<{ visible: VersionMeta[]; scanned: number }> {
+  const candidates = await service().recentPendingEdits({
+    readableSlugs,
+    limit: budget,
+  });
+  return {
+    visible: await visiblePendingEdits(candidates, caller),
+    scanned: candidates.length,
+  };
+}
+
+/**
+ * Enough visible rows to fill a card of `limit`, escalating only when needed.
+ *
+ * The second read is spent on exactly one shape: the small budget was exhausted
+ * AND too few of its candidates survived. A budget that was not exhausted has
+ * already seen every candidate there is, so a short answer from it is the true
+ * one and re-reading would return the same rows.
+ */
+async function enoughToFill(
+  limit: number,
+  readableSlugs: readonly string[],
+  caller: ReadCaller
+): Promise<VersionMeta[]> {
+  const first = await visibleWithin(LIST_CANDIDATES, readableSlugs, caller);
+  if (first.visible.length >= limit || first.scanned < LIST_CANDIDATES) {
+    return first.visible;
+  }
+  return (await visibleWithin(CANDIDATE_SCAN, readableSlugs, caller)).visible;
+}
+
 async function resolveVersions(
   query: WidgetQuery,
   caller: ReadCaller
@@ -244,19 +302,20 @@ async function resolveVersions(
     }
   }
 
-  const visible = await visiblePendingEdits(
-    await service().recentPendingEdits({
-      readableSlugs,
-      limit: CANDIDATE_SCAN,
-    }),
-    caller
-  );
-
   if (query.op === "count") {
+    const { visible } = await visibleWithin(
+      CANDIDATE_SCAN,
+      readableSlugs,
+      caller
+    );
     return { op: "count", total: visible.length };
   }
 
-  const rows = visible.slice(0, query.limit ?? DEFAULT_LIMIT);
+  const limit = query.limit ?? DEFAULT_LIMIT;
+  const rows = (await enoughToFill(limit, readableSlugs, caller)).slice(
+    0,
+    limit
+  );
   const names = selectedNames(query);
   const fields = query.select?.length ? describe(names) : undefined;
 

--- a/packages/nextly/src/domains/versions/versions-widget-source.ts
+++ b/packages/nextly/src/domains/versions/versions-widget-source.ts
@@ -67,7 +67,11 @@ import { VERSIONS_SOURCE_ID } from "../widgets/system-source-ids";
 import { registerSystemSource } from "../widgets/system-sources";
 
 import { visiblePendingEdits } from "./pending-edit-visibility";
-import type { VersionMeta } from "./versions-repository";
+import {
+  documentKey,
+  newestPerDocument,
+  type VersionMeta,
+} from "./versions-repository";
 import type { VersionsService } from "./versions-service";
 
 export { VERSIONS_SOURCE_ID };
@@ -100,20 +104,25 @@ const DEFAULT_LIMIT = 5;
 const CANDIDATE_SCAN = 1000;
 
 /**
- * How many candidates a LIST considers before it needs the full scan.
+ * Rows read per round while gathering documents.
  *
- * A list wants a handful of visible rows, not every candidate, and on the
- * ordinary install — where no collection carries a stored row rule — the first
- * `limit` candidates are all visible and this is the only read. Scanning to
- * {@link CANDIDATE_SCAN} for a five-row card would make every dashboard load
- * pay the count's price for rows it discards.
- *
- * It is a budget rather than a cap: when filtering removes enough that the card
- * cannot be filled AND this budget was actually exhausted, the query escalates
- * to the full scan. So the short answer this could produce is retried rather
- * than returned, and only the two conditions together spend the larger read.
+ * Rows, not documents: a document contributes one row per locale it is drafted
+ * in, and rows a stored rule hides contribute none at all, so how many rows a
+ * page of documents costs is not knowable in advance. Rounds are what make that
+ * unnecessary — this only has to be large enough that the ordinary install,
+ * where nothing is filtered, finishes in one.
  */
-const LIST_CANDIDATES = 60;
+const ROW_PAGE = 100;
+
+/**
+ * How many rounds a gather runs before answering with what it has.
+ *
+ * The bound on an install whose pending edits are almost entirely unreadable to
+ * this caller. Reaching it returns FEWER documents than asked for, and the count
+ * refuses rather than publishing that as a total — so the failure direction is a
+ * thin card or an honest refusal, never a number that is quietly too small.
+ */
+const MAX_GATHER_ROUNDS = 20;
 
 /**
  * The fields this source publishes.
@@ -231,40 +240,58 @@ function describe(
   });
 }
 
-/** The visible candidates within `budget`, and how many were considered. */
-async function visibleWithin(
-  budget: number,
-  readableSlugs: readonly string[],
-  caller: ReadCaller
-): Promise<{ visible: VersionMeta[]; scanned: number }> {
-  const candidates = await service().recentPendingEdits({
-    readableSlugs,
-    limit: budget,
-  });
-  return {
-    visible: await visiblePendingEdits(candidates, caller),
-    scanned: candidates.length,
-  };
-}
-
 /**
- * Enough visible rows to fill a card of `limit`, escalating only when needed.
+ * Up to `wanted` DOCUMENTS the caller may see, newest first.
  *
- * The second read is spent on exactly one shape: the small budget was exhausted
- * AND too few of its candidates survived. A budget that was not exhausted has
- * already seen every candidate there is, so a short answer from it is the true
- * one and re-reading would return the same rows.
+ * 🔴 The order is the correctness property. Rows are read, then AUTHORIZED, and
+ * only then collapsed to one per document — because a localized Single is
+ * authorized per language while a document is one thing to publish across all of
+ * them. Collapsing first offers the visibility filter each document's newest
+ * locale alone, so a document whose newest pending locale is denied disappears
+ * even when an older locale is readable and the reader is entitled to it.
+ *
+ * `exhausted` says whether the table ran out rather than the rounds. A count may
+ * only be published when it did: otherwise the answer is a floor, and a metric
+ * that quietly under-reports is the failure this whole source was repaired for.
  */
-async function enoughToFill(
-  limit: number,
+async function gatherVisibleDocuments(
+  wanted: number,
   readableSlugs: readonly string[],
   caller: ReadCaller
-): Promise<VersionMeta[]> {
-  const first = await visibleWithin(LIST_CANDIDATES, readableSlugs, caller);
-  if (first.visible.length >= limit || first.scanned < LIST_CANDIDATES) {
-    return first.visible;
+): Promise<{ documents: VersionMeta[]; exhausted: boolean }> {
+  const documents: VersionMeta[] = [];
+  const seen = new Set<string>();
+  let offset = 0;
+
+  for (let round = 0; round < MAX_GATHER_ROUNDS; round++) {
+    const rows = await service().pendingEditRows({
+      readableSlugs,
+      limit: ROW_PAGE,
+      offset,
+    });
+    if (rows.length === 0) return { documents, exhausted: true };
+    offset += rows.length;
+
+    // Collapsed per ROUND against everything already kept, so a document split
+    // across a page boundary cannot appear twice.
+    for (const row of newestPerDocument(
+      await visiblePendingEdits(rows, caller),
+      Number.MAX_SAFE_INTEGER
+    )) {
+      const key = documentKey(row);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      documents.push(row);
+      if (documents.length >= wanted) {
+        return { documents, exhausted: false };
+      }
+    }
+
+    // A short page is the end of the table, not the end of this round.
+    if (rows.length < ROW_PAGE) return { documents, exhausted: true };
   }
-  return (await visibleWithin(CANDIDATE_SCAN, readableSlugs, caller)).visible;
+
+  return { documents, exhausted: false };
 }
 
 async function resolveVersions(
@@ -284,38 +311,41 @@ async function resolveVersions(
   ];
 
   if (query.op === "count") {
-    // Asked BEFORE materialising anything, and it is the one thing SQL can
-    // still answer here: how many documents are candidates at all, before row
-    // rules narrow them. Larger than the scan bound means no honest exact
-    // answer is available, so it refuses rather than reporting a floor -- and
-    // refusing costs one aggregate instead of a thousand-document fetch that
-    // would be discarded. Comparing the fetched LENGTH instead cannot tell
-    // "exactly at the bound" from "beyond it", and would refuse a set it could
-    // have answered exactly.
-    if ((await service().countPendingEdits(readableSlugs)) > CANDIDATE_SCAN) {
+    // Asked BEFORE gathering anything, and it is the one thing SQL can still
+    // answer here: how many documents are candidates at all, before row rules
+    // narrow them. Larger than the bound means no honest exact answer is
+    // available, so it refuses rather than reporting a floor -- and refusing
+    // costs one aggregate rather than a thousand-document walk that would be
+    // discarded.
+    const refuse = (): never => {
       throw NextlyError.internal({
         logContext: {
           reason: "pending-edits-scan-exhausted",
           scanned: CANDIDATE_SCAN,
         },
       });
+    };
+    if ((await service().countPendingEdits(readableSlugs)) > CANDIDATE_SCAN) {
+      refuse();
     }
-  }
 
-  if (query.op === "count") {
-    const { visible } = await visibleWithin(
+    const { documents, exhausted } = await gatherVisibleDocuments(
       CANDIDATE_SCAN,
       readableSlugs,
       caller
     );
-    return { op: "count", total: visible.length };
+    // 🔴 The candidate count passing is NOT enough on its own. It counts
+    // documents, while the walk reads rows, and rows a stored rule hides are
+    // read without yielding one -- so a caller who may see little can exhaust
+    // the rounds on a set the aggregate said was small. Publishing what the
+    // walk found there would be a floor wearing an exactness check.
+    if (!exhausted) refuse();
+    return { op: "count", total: documents.length };
   }
 
   const limit = query.limit ?? DEFAULT_LIMIT;
-  const rows = (await enoughToFill(limit, readableSlugs, caller)).slice(
-    0,
-    limit
-  );
+  const rows = (await gatherVisibleDocuments(limit, readableSlugs, caller))
+    .documents;
   const names = selectedNames(query);
   const fields = query.select?.length ? describe(names) : undefined;
 

--- a/packages/nextly/src/domains/versions/versions-widget-source.ts
+++ b/packages/nextly/src/domains/versions/versions-widget-source.ts
@@ -8,9 +8,14 @@
  * that simply called it would answer an install-wide number to a reader
  * entitled to part of it.
  *
- * The bound is `readableEntities`, asked once per registered entity, and NOT a
- * filter over the caller's permission slugs. The two look equivalent and are
- * not, in both directions:
+ * Authorization here has TWO axes, and each is load-bearing. The first decides
+ * which collections are in reach; the second decides which of their documents
+ * are, and stopping at the first is what made this card disclose one author's
+ * work to another.
+ *
+ * **Which collections.** `readableEntities`, asked once per registered entity,
+ * and NOT a filter over the caller's permission slugs. The two look equivalent
+ * and are not, in both directions:
  *
  * - An API key is judged on its OWN stamped scope. Resolving the owner's
  *   role-derived slugs instead hands a narrowly scoped key everything its
@@ -33,6 +38,17 @@
  * nothing, instead of the three-way `undefined | [] | list` whose collapse hands
  * every document to a caller granted none.
  *
+ * **Which documents.** `readableEntities` is coarse BY CONTRACT — it says
+ * whether an entity is in reach at all, and leaves the per-row rules of the
+ * query that follows to decide what comes back. A collection carrying a stored
+ * `owner-only` or `custom` read rule therefore admits every editor at that
+ * check while the ordinary read path narrows to a subset, and a version query
+ * filtered by collection name alone counted and listed the documents in
+ * between: other authors' entry ids, their languages, and when they last
+ * touched them. `visiblePendingEdits` closes it by asking the ordinary read
+ * path which of the candidate documents survive, rather than reproducing a rule
+ * that may be an arbitrary function.
+ *
  * @module domains/versions/versions-widget-source
  */
 
@@ -50,12 +66,32 @@ import { failUnavailableSourceOrOp } from "../widgets/sources";
 import { VERSIONS_SOURCE_ID } from "../widgets/system-source-ids";
 import { registerSystemSource } from "../widgets/system-sources";
 
+import { visiblePendingEdits } from "./pending-edit-visibility";
 import type { VersionsService } from "./versions-service";
 
 export { VERSIONS_SOURCE_ID };
 
 /** How many rows the list card draws when the query names no limit. */
 const DEFAULT_LIMIT = 5;
+
+/**
+ * How many pending-edit DOCUMENTS one query may consider before answering.
+ *
+ * 🔴 The bound exists because the answer cannot be computed in SQL. A stored
+ * read rule narrows which of a collection's rows a caller may see, that rule
+ * lives on the collection rather than on the version row, and the data port has
+ * no join — so the only way to answer honestly is to take the candidates and
+ * ask the ordinary read path about them. That is bounded work, and this is the
+ * bound.
+ *
+ * Reaching it means something different for each op, so each says so itself:
+ * the LIST needs only enough survivors to fill a handful of slots and is
+ * unaffected, while the COUNT would silently report a floor — and a metric that
+ * quietly under-reports is the failure this whole change is repairing, so it
+ * refuses instead. A thousand documents carrying unpublished edits is already
+ * an extreme state for an editorial install.
+ */
+const CANDIDATE_SCAN = 1000;
 
 /**
  * The fields this source publishes.
@@ -190,16 +226,37 @@ async function resolveVersions(
   ];
 
   if (query.op === "count") {
-    return {
-      op: "count",
-      total: await service().countPendingEdits(readableSlugs),
-    };
+    // Asked BEFORE materialising anything, and it is the one thing SQL can
+    // still answer here: how many documents are candidates at all, before row
+    // rules narrow them. Larger than the scan bound means no honest exact
+    // answer is available, so it refuses rather than reporting a floor -- and
+    // refusing costs one aggregate instead of a thousand-document fetch that
+    // would be discarded. Comparing the fetched LENGTH instead cannot tell
+    // "exactly at the bound" from "beyond it", and would refuse a set it could
+    // have answered exactly.
+    if ((await service().countPendingEdits(readableSlugs)) > CANDIDATE_SCAN) {
+      throw NextlyError.internal({
+        logContext: {
+          reason: "pending-edits-scan-exhausted",
+          scanned: CANDIDATE_SCAN,
+        },
+      });
+    }
   }
 
-  const rows = await service().recentPendingEdits({
-    readableSlugs,
-    limit: query.limit ?? DEFAULT_LIMIT,
-  });
+  const visible = await visiblePendingEdits(
+    await service().recentPendingEdits({
+      readableSlugs,
+      limit: CANDIDATE_SCAN,
+    }),
+    caller
+  );
+
+  if (query.op === "count") {
+    return { op: "count", total: visible.length };
+  }
+
+  const rows = visible.slice(0, query.limit ?? DEFAULT_LIMIT);
   const names = selectedNames(query);
   const fields = query.select?.length ? describe(names) : undefined;
 

--- a/packages/nextly/src/domains/versions/versions-widget-source.ts
+++ b/packages/nextly/src/domains/versions/versions-widget-source.ts
@@ -71,6 +71,7 @@ import {
   documentKey,
   newestPerDocument,
   type PendingEditCursor,
+  type PendingEditOrder,
   type VersionMeta,
 } from "./versions-repository";
 import type { VersionsService } from "./versions-service";
@@ -81,54 +82,42 @@ export { VERSIONS_SOURCE_ID };
 const DEFAULT_LIMIT = 5;
 
 /**
- * How many pending-edit DOCUMENTS one query may consider before answering.
+ * How many ROWS a count may read before it answers with a floor.
  *
- * 🔴 The bound exists because the answer cannot be computed in SQL. A stored
- * read rule narrows which of a collection's rows a caller may see, that rule
- * lives on the collection rather than on the version row, and the data port has
- * no join — so the only way to answer honestly is to take the candidates and
- * ask the ordinary read path about them. That is bounded work, and this is the
- * bound.
+ * 🔴 Rows, not documents, and bounded on the CALLER's own work. The bound used
+ * to be a pre-authorization count of candidate documents, which made one
+ * caller's card depend on data they cannot see: a collection accumulating other
+ * people's drafts past the threshold broke every owner's dashboard, and whether
+ * a caller received a number or a failure disclosed which side of it that unseen
+ * population sat on.
  *
- * The COUNT is what it really bounds: past it, an exact answer is not available
- * and the card refuses rather than reporting a floor — a metric that quietly
- * under-reports is the failure this whole change is repairing. A LIST rarely
- * comes near it, taking {@link LIST_CANDIDATES} first and escalating only when
- * that cannot fill the card.
- *
- * 🔴 It is the ONE bound, and the repository derives its row fetch from it
- * rather than declaring a second. Two independent ceilings is what produced the
- * defect this constant exists to prevent: a caller asking for a thousand
- * documents received five hundred, so it under-reported while every check it
- * had made said the answer was exact.
+ * Reaching it is not a failure. The count says `atLeast` and the card renders
+ * `N+` — a reader learns the scale, and nothing claims to be whole that is not.
+ * Every mechanism that tried to preserve exactness past a bound instead produced
+ * a wrong answer: a document quota could not tell "exactly this many" from "more
+ * than this many", and a shortcut on documents already seen conflated meeting a
+ * document with deciding it, since authorization is per language.
  */
-const CANDIDATE_SCAN = 1000;
+const COUNT_ROW_BUDGET = 2000;
 
 /**
- * Rows read per round while gathering documents.
+ * How many rows a LIST reads before answering with what it has.
  *
- * Rows, not documents: a document contributes one row per locale it is drafted
- * in, and rows a stored rule hides contribute none at all, so how many rows a
- * page of documents costs is not knowable in advance. Rounds are what make that
- * unnecessary — this only has to be large enough that the ordinary install,
- * where nothing is filtered, finishes in one.
+ * Much smaller, because a card wants a handful of rows and the ordinary install
+ * — where nothing is filtered — fills it from the first page. A list that comes
+ * back short under heavy filtering is a thin card, never a wrong one.
+ */
+const LIST_ROW_BUDGET = 400;
+
+/**
+ * Rows read per round.
+ *
+ * A document contributes one row per language, and rows a stored rule hides
+ * contribute none, so how many rows a page of DOCUMENTS costs is not knowable in
+ * advance. Rounds make that unnecessary; this only has to be large enough that
+ * the ordinary install finishes in one.
  */
 const ROW_PAGE = 100;
-
-/**
- * How many rounds a gather runs before answering with what it has.
- *
- * The bound on an install whose pending edits are almost entirely unreadable to
- * this caller. Reaching it returns FEWER documents than asked for, and the count
- * refuses rather than publishing that as a total — so the failure direction is a
- * thin card or an honest refusal, never a number that is quietly too small.
- *
- * Generous because the count runs to exhaustion over a set the aggregate has
- * already bounded at {@link CANDIDATE_SCAN} DOCUMENTS, while a round reads
- * ROWS: a document contributes one per locale, so the rows behind that bound are
- * a multiple of it that nothing here can know in advance.
- */
-const MAX_GATHER_ROUNDS = 60;
 
 /**
  * The fields this source publishes.
@@ -265,16 +254,10 @@ interface Gathered {
   documents: VersionMeta[];
   /** Documents already kept, so one split across a page cannot appear twice. */
   seen: Set<string>;
-  /**
-   * Every document the walk has MET, visible or not. The candidate aggregate
-   * counts documents too, so meeting that many means every candidate has been
-   * decided — which is exhaustion, whether or not another page exists.
-   */
-  met: Set<string>;
 }
 
 /**
- * Fold one page and its authorized rows into `gathered`; true when it is full.
+ * Fold one page's authorized rows into `gathered`; true when it is full.
  *
  * The collapse runs per round against what is already kept rather than over the
  * whole walk at the end, so a document drafted in several languages across a
@@ -282,11 +265,9 @@ interface Gathered {
  */
 function absorbPage(
   gathered: Gathered,
-  rows: readonly VersionMeta[],
   visible: readonly VersionMeta[],
   wanted: number
 ): boolean {
-  for (const row of rows) gathered.met.add(documentKey(row));
   for (const row of newestPerDocument(visible, Number.MAX_SAFE_INTEGER)) {
     const key = documentKey(row);
     if (gathered.seen.has(key)) continue;
@@ -297,53 +278,57 @@ function absorbPage(
   return false;
 }
 
+/**
+ * Walk pending-edit rows, authorizing each page, until `wanted` documents are
+ * found or `rowBudget` rows have been read.
+ *
+ * 🔴 `exhausted` means the ROWS ran out — nothing else. Earlier versions tried
+ * to conclude it sooner, and each shortcut was wrong in its own way: stopping at
+ * a document quota could not tell "exactly this many" from "more than this
+ * many", and stopping once every candidate had been MET conflated seeing a
+ * document with deciding it. Authorization is per LANGUAGE, so a document first
+ * met through a locale it is denied in may still be readable in a locale that
+ * has not been read yet — and a walk that stopped there reported zero for a set
+ * the caller could see entirely.
+ */
 async function gatherVisibleDocuments(
   wanted: number,
+  rowBudget: number,
+  order: PendingEditOrder,
   readableSlugs: readonly string[],
-  caller: ReadCaller,
-  candidateTotal?: number
+  caller: ReadCaller
 ): Promise<{ documents: VersionMeta[]; exhausted: boolean }> {
-  const gathered: Gathered = {
-    documents: [],
-    seen: new Set(),
-    met: new Set(),
-  };
+  const gathered: Gathered = { documents: [], seen: new Set() };
   let after: PendingEditCursor | undefined;
-  // 🔴 Three ways out, and only two of them are exhaustion. Rows running out and
-  // every candidate having been decided both mean nothing further exists; the
-  // ROUNDS running out means the walk stopped early, and a count published from
-  // that would be a floor. Tracked explicitly because collapsing the exits into
-  // one `break` loses exactly that distinction.
-  let exhausted = false;
+  let read = 0;
 
-  for (let round = 0; round < MAX_GATHER_ROUNDS; round++) {
+  while (read < rowBudget) {
+    const want = Math.min(ROW_PAGE, rowBudget - read);
     const rows = await service().pendingEditRows({
       readableSlugs,
-      limit: ROW_PAGE,
+      order,
+      limit: want,
       ...(after ? { after } : {}),
     });
     if (rows.length === 0) {
-      exhausted = true;
-      break;
+      return { documents: gathered.documents, exhausted: true };
     }
+    read += rows.length;
     // Anchored to the LAST row of this page, in the order it was read.
     const last = rows[rows.length - 1];
     after = { updatedAt: last.updatedAt, id: last.id };
 
     const visible = await visiblePendingEdits(rows, caller);
-    if (absorbPage(gathered, rows, visible, wanted)) {
+    if (absorbPage(gathered, visible, wanted)) {
       return { documents: gathered.documents, exhausted: false };
     }
-
-    const everyCandidateMet =
-      candidateTotal !== undefined && gathered.met.size >= candidateTotal;
-    if (everyCandidateMet || rows.length < ROW_PAGE) {
-      exhausted = true;
-      break;
+    // A short page is the end of the rows, not the end of this round.
+    if (rows.length < want) {
+      return { documents: gathered.documents, exhausted: true };
     }
   }
 
-  return { documents: gathered.documents, exhausted };
+  return { documents: gathered.documents, exhausted: false };
 }
 
 async function resolveVersions(
@@ -363,47 +348,46 @@ async function resolveVersions(
   ];
 
   if (query.op === "count") {
-    // Asked BEFORE gathering anything, and it is the one thing SQL can still
-    // answer here: how many documents are candidates at all, before row rules
-    // narrow them. Larger than the bound means no honest exact answer is
-    // available, so it refuses rather than reporting a floor -- and refusing
-    // costs one aggregate rather than a thousand-document walk that would be
-    // discarded.
-    const refuse = (): never => {
-      throw NextlyError.internal({
-        logContext: {
-          reason: "pending-edits-scan-exhausted",
-          scanned: CANDIDATE_SCAN,
-        },
-      });
-    };
-    const candidateTotal = await service().countPendingEdits(readableSlugs);
-    if (candidateTotal > CANDIDATE_SCAN) refuse();
-
-    // 🔴 Asked to run to EXHAUSTION rather than to a document quota. Stopping
-    // at a quota cannot tell "there are exactly this many" from "there are more
-    // than this many", so a set of exactly `CANDIDATE_SCAN` readable documents
-    // -- which the aggregate above admits -- came back unexhausted and refused,
-    // at precisely the boundary the bound documents as answerable. The
-    // aggregate is what bounds this walk; the walk's own job is to finish.
+    // 🔴 No pre-authorization aggregate decides anything here any more. Counting
+    // candidates before the row rules narrow them made the answer depend on data
+    // the caller cannot see: one collection accumulating other people's drafts
+    // past the bound broke every owner's card, and whether a caller got a number
+    // or a failure disclosed which side of the threshold that unseen population
+    // sat on. The walk is bounded by ROWS it reads, which is the caller's own
+    // work and nobody else's.
     const { documents, exhausted } = await gatherVisibleDocuments(
       Number.MAX_SAFE_INTEGER,
+      COUNT_ROW_BUDGET,
+      // By IDENTITY, because a count needs to ENUMERATE rather than to rank, and
+      // an id cannot be outrun by the rows being enumerated.
+      "identity",
       readableSlugs,
-      caller,
-      candidateTotal
+      caller
     );
-    // The candidate count passing is still not enough on its own. It counts
-    // documents, while the walk reads rows, and rows a stored rule hides are
-    // read without yielding one -- so a caller who may see little can exhaust
-    // the rounds on a set the aggregate said was small. Publishing what the
-    // walk found there would be a floor wearing an exactness check.
-    if (!exhausted) refuse();
-    return { op: "count", total: documents.length };
+    return {
+      op: "count",
+      total: documents.length,
+      // Said plainly rather than refused or quietly truncated. A reader learns
+      // the scale, the card renders `N+`, and nothing claims to be whole that
+      // is not.
+      ...(exhausted ? {} : { atLeast: true as const }),
+    };
   }
 
   const limit = query.limit ?? DEFAULT_LIMIT;
-  const rows = (await gatherVisibleDocuments(limit, readableSlugs, caller))
-    .documents;
+  const rows = (
+    await gatherVisibleDocuments(
+      limit,
+      LIST_ROW_BUDGET,
+      // By RECENCY, because "recently edited" is what the card means. A row
+      // saved mid-walk can move ahead of the cursor and be missed, which for a
+      // point-in-time list of the newest few is an ordinary consequence of
+      // reading a moving set -- and is why the COUNT does not order this way.
+      "recency",
+      readableSlugs,
+      caller
+    )
+  ).documents;
   const names = selectedNames(query);
   const fields = query.select?.length ? describe(names) : undefined;
 

--- a/packages/nextly/src/domains/widgets/result.ts
+++ b/packages/nextly/src/domains/widgets/result.ts
@@ -29,7 +29,26 @@ export interface WidgetResultField {
 }
 
 export type WidgetResult =
-  | { op: "count"; total: number }
+  | {
+      op: "count";
+      total: number;
+      /**
+       * Whether `total` is a FLOOR rather than the whole answer.
+       *
+       * 🔴 Present because some counts cannot be computed in the database. Where
+       * a source's rows are filtered by a rule the query cannot express — a
+       * stored `owner-only` or `custom` read rule lives on the collection, not
+       * on the sidecar table being counted — the only honest count walks
+       * candidates and authorizes them, which is bounded work. Past that bound
+       * the choice is to refuse, to publish a number that is quietly too small,
+       * or to say plainly that there are at least this many.
+       *
+       * Saying so is the option that stays true: a reader learns the scale
+       * without being told a wrong figure, and a card renders `1,000+` rather
+       * than failing. Absent means the count is whole.
+       */
+      atLeast?: boolean;
+    }
   | {
       op: "list";
       items: Record<string, unknown>[];

--- a/packages/nextly/src/services/lib/readable-documents.ts
+++ b/packages/nextly/src/services/lib/readable-documents.ts
@@ -1,0 +1,93 @@
+/**
+ * Which of these documents the caller may actually READ, asked of the ordinary
+ * read path.
+ *
+ * 🔴 Entity-level access is one axis short of the question, and its own contract
+ * says so: `readableEntities` decides whether a collection is in reach AT ALL,
+ * leaving the per-row rules of whatever query follows to decide which documents
+ * come back. A collection carrying a stored `owner-only` or `custom` read rule
+ * therefore admits every editor at the coarse check while the read path narrows
+ * to a subset — so a cross-document read keyed by collection name alone reports
+ * one author's documents to another.
+ *
+ * That is not a hypothetical shape: the dashboard's own statistics once counted
+ * rows straight from the physical table and disclosed exactly this, and the
+ * repair was to route the numbers through the access-enforced path rather than
+ * to reproduce the rule. This module is that repair, made reusable — any system
+ * source keyed by collection and document id needs the same intersection.
+ *
+ * The rule is never re-implemented here. A stored rule can be `owner-only` or a
+ * `custom` function, and evaluating either against rows is the read path's job;
+ * this asks it which of a known set of ids survive, which is the same question
+ * a caller opening those documents would get answered.
+ *
+ * @module services/lib/readable-documents
+ */
+
+import { getNextly } from "../../direct-api/nextly";
+import type { ReadCaller } from "../dashboard/readable-resources";
+
+/**
+ * Ids per statement. Each id binds one parameter and SQLite's default
+ * SQLITE_MAX_VARIABLE_NUMBER is 999 — the lowest across supported dialects — so
+ * a set larger than this is asked for in several reads rather than one that the
+ * driver refuses. Matches the chunk the versions repository already deletes in.
+ */
+const ID_CHUNK_SIZE = 500;
+
+/** `ids` split into statement-sized runs. */
+function chunked(ids: readonly string[]): string[][] {
+  const chunks: string[][] = [];
+  for (let index = 0; index < ids.length; index += ID_CHUNK_SIZE) {
+    chunks.push([...ids.slice(index, index + ID_CHUNK_SIZE)]);
+  }
+  return chunks;
+}
+
+/**
+ * The subset of `entryIds` this caller may read from `collection`.
+ *
+ * `overrideAccess: false` with the caller's own identity is what applies the
+ * stored rule, and the API key's stamped scope is forwarded so a key is judged
+ * on its own grant rather than on the roles of whoever minted it.
+ *
+ * `status: "all"` because a document with unpublished edits may never have been
+ * published: filtering to published rows would drop precisely the documents a
+ * pending-edits card exists to name, reporting a caller's own work as
+ * unreadable. Access is unaffected by it — the lifecycle decides visibility of
+ * a row's STATE, the access rule decides visibility of the row.
+ *
+ * Only `id` is selected. The caller needs membership, and a projection wide
+ * enough to answer that is the narrowest thing that also cannot carry field
+ * values into a surface that never asked for them.
+ */
+export async function readableDocumentIds(
+  collection: string,
+  entryIds: readonly string[],
+  caller: ReadCaller
+): Promise<Set<string>> {
+  const readable = new Set<string>();
+  if (entryIds.length === 0) return readable;
+
+  for (const chunk of chunked(entryIds)) {
+    const result = await getNextly().find({
+      collection,
+      where: { id: { in: chunk } },
+      select: { id: true },
+      // The whole chunk can legitimately come back; a smaller page would report
+      // the remainder as unreadable.
+      limit: chunk.length,
+      status: "all",
+      overrideAccess: false,
+      user: caller.user,
+      ...(caller.authenticatedScope
+        ? { actor: caller.authenticatedScope }
+        : {}),
+    });
+    for (const item of result.items ?? []) {
+      const id = (item as { id?: unknown }).id;
+      if (typeof id === "string") readable.add(id);
+    }
+  }
+  return readable;
+}

--- a/packages/nextly/src/services/lib/readable-documents.ts
+++ b/packages/nextly/src/services/lib/readable-documents.ts
@@ -60,11 +60,18 @@ function chunked(ids: readonly string[]): string[][] {
  * Only `id` is selected. The caller needs membership, and a projection wide
  * enough to answer that is the narrowest thing that also cannot carry field
  * values into a surface that never asked for them.
+ *
+ * 🔴 `locale` is part of the QUESTION, not a presentation detail. A stored rule
+ * is a predicate over the collection's fields, and a localized field answers
+ * differently per language, so a read that names no locale judges whichever
+ * translation it defaults to. Asking once per slug and applying that verdict to
+ * every language discloses the rows a rule refuses in the others.
  */
 export async function readableDocumentIds(
   collection: string,
   entryIds: readonly string[],
-  caller: ReadCaller
+  caller: ReadCaller,
+  locale?: string | null
 ): Promise<Set<string>> {
   const readable = new Set<string>();
   if (entryIds.length === 0) return readable;
@@ -78,6 +85,7 @@ export async function readableDocumentIds(
       // the remainder as unreadable.
       limit: chunk.length,
       status: "all",
+      ...(locale === null || locale === undefined ? {} : { locale }),
       overrideAccess: false,
       user: caller.user,
       ...(caller.authenticatedScope

--- a/packages/nextly/src/services/lib/registered-content-slugs.ts
+++ b/packages/nextly/src/services/lib/registered-content-slugs.ts
@@ -61,9 +61,35 @@ async function singleSlugs(): Promise<string[]> {
  * were the whole answer.
  */
 export async function registeredContentSlugs(): Promise<string[]> {
+  return [...(await registeredContentKinds()).keys()];
+}
+
+/**
+ * The same slugs, each paired with the registry that owns it.
+ *
+ * 🔴 The kind is not decoration. A Single is read through its own service, so a
+ * caller that authorizes one as a collection asks about a table that does not
+ * hold the document — and deleting a collection leaves its history behind, so a
+ * freed slug that a Single later takes leaves version rows whose own scope kind
+ * disagrees with the registry. A surface holding only a slug and a recorded kind
+ * needs this to tell a live subject from an orphaned one.
+ *
+ * A name in NEITHER registry is absent rather than defaulted: guessing a kind
+ * for it would send a row to a read path that cannot answer about it.
+ *
+ * Collections are written last, so a slug claimed by both resolves to the
+ * collection. The registries do not permit that overlap; stating the precedence
+ * keeps this total rather than order-dependent if they ever do.
+ */
+export async function registeredContentKinds(): Promise<
+  Map<string, "collection" | "single">
+> {
   const [collections, singles] = await Promise.all([
     collectionSlugs(),
     singleSlugs(),
   ]);
-  return [...collections, ...singles];
+  const kinds = new Map<string, "collection" | "single">();
+  for (const slug of singles) kinds.set(slug, "single");
+  for (const slug of collections) kinds.set(slug, "collection");
+  return kinds;
 }


### PR DESCRIPTION
Follows the open Codex finding on #1528, *Apply document predicates to pending-version reads*. It is real, and it also corrects something I asserted on that PR.

## The defect

Entity-level access answers **whether a collection is in reach**. It does not answer **which of its documents are** — `readableEntities` says exactly that in its own contract, leaving the per-row rules of the query that follows to decide what comes back.

A collection carrying a stored `owner-only` or `custom` read rule admits every editor at that coarse check, while the ordinary read path narrows to a subset. The pending-edit cards filtered version rows by collection name alone, so they reported one author's documents to another — entry ids, languages, and the instants they were last edited.

Measured on a real database rather than argued. One collection with a stored owner-only rule, two documents owned by two users, a pending edit on each, and a control asserting the ordinary read path:

| | result |
| --- | --- |
| ordinary read (control) | **1** document |
| `system:versions` count | **2** |
| `system:versions` list | both entry ids |

**I was wrong about this on #1528.** I replied there that `access.read` is entity-level and "there is no document predicate for this read to apply". I had measured only the *code-defined* surface — `AccessControlFunction` returns a boolean — and never looked at *stored* rules, which are a separate mechanism: `evaluateAccess` returns `{ allowed: true, query: { created_by: { equals: user.id } } }` for an owner-only read. That was a search stopping at the wrong surface, reported as evidence of absence.

## The fix

The cards ask the ordinary read path which of the candidate documents survive, rather than reproducing the rule. A stored rule can be an arbitrary function, so evaluating it here would be the second access implementation this domain exists to avoid — the same repair the dashboard's own statistics already made when they counted rows straight from the physical table.

- **Singles are asked per locale.** A localized Single is a different document per language and a rule can answer differently for each.
- **A row whose scope is neither a collection nor a single is dropped**, not admitted. Nothing here can judge it.
- **The import into the Singles read path is deferred.** That path imports this domain, so a top-level edge closes a module cycle of the shape this package's build already reports as producing a broken execution order. It also means an install whose pending edits are all collections never loads the Singles query service.

## The cost, stated plainly

The answer can no longer be computed in SQL. The rule lives on the collection, the candidates live in the version table, and the data layer has no join — so an exact count means considering candidates in memory. That is bounded, and **past the bound the count refuses rather than reporting a number that is quietly too small**. The aggregate that decides this is asked first, so a set too large to answer costs one query rather than a fetch that would be discarded.

The list does not pay that price. It considers a modest budget first — the only read it makes on an install with no stored row rules — and escalates to the full scan only when filtering leaves the card unfillable **and** that budget was actually exhausted. A budget that was not exhausted has already seen every candidate, so its short answer is the true one.

**The second commit here fixes a defect in the first**, found by re-reading my own diff rather than by any gate. The bound above was stated twice: the source bounded candidate *documents* at 1000, and the repository independently capped its fetch at 500 *rows*. Neither knew about the other, so between those numbers the count silently returned fewer documents than exist — the exact quiet floor the refusal exists to prevent, reintroduced one file away from it. The row count is now derived from the caller's `limit` alone; a second ceiling cannot be right without knowing what the first promised. The regression test counts 501 documents, one past the old ceiling, which is the smallest input separating the two implementations.

If a `500+` affordance on the metric contract would be preferable to a refused card at that volume, say so and I will do it as its own change — it touches the result shape and the admin renderer.

## Evidence

Every claim above was break-verified against a wrong implementation, with a control before and after:

| break | result |
| --- | --- |
| filter admits every candidate | both disclosure tests fail |
| probe uses `overrideAccess: true` | both fail — so the probe genuinely applies the rule, rather than reaching the rows by another route |
| Singles verdict never consulted | the Singles test fails |
| drop `status: "all"` from the probe | the never-published test fails |
| reinstate the second, independent ceiling | the 501-document count returns 500 |
| list never escalates / always escalates | one test each — the pair bounds the condition from both sides |

That last one is worth flagging: on the first pass the break **moved nothing**, which by the standard in this repo means the property had no coverage rather than that the code was fine. It turned out to be load-bearing — without it a document that has never been published reads as unreadable, and the card hides the newest unpublished work, which is what it exists to show. There is now a case for it.

The first fixture also failed for the wrong reason (`0`, not `2`): the coarse check denied the collection outright, so it never reached the row rules. The control asserting the ordinary read returns exactly one document is what separates "row-constrained" from "denied entirely", and it is why this file can be believed.

Gates: full `nextly` unit suite 884 files / 11268 tests, integration green on sqlite (CI covers all three dialects), lint and check-types clean, fallow `pass` with every `*_introduced` at 0.