### PR TITLE
fix(blocks-react): bound the component read by the next scheduled release

### DIFF
--- a/.changeset/a-release-reaches-the-components-too.md
+++ b/.changeset/a-release-reaches-the-components-too.md
@@ -1,0 +1,32 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A page picks up a component's scheduled changes at the moment the release goes
+live. The page itself was already refreshing on time; the components inside it
+were not, so a page could keep drawing yesterday's version of a component until
+something unrelated happened to change it.

--- a/packages/blocks-react/src/next.components.test.ts
+++ b/packages/blocks-react/src/next.components.test.ts
@@ -32,6 +32,11 @@ vi.mock("nextly/runtime", async importActual => {
         return await reader();
       }
     ),
+    // A scheduled release, so the bound is a number rather than the `false`
+    // an empty container answers. Whether the bound is COMPUTED correctly is
+    // `nextly`'s to test and is tested there; what belongs here is whether
+    // this read asks for one and applies what it gets.
+    releaseBoundedRevalidate: vi.fn(async () => 42),
   };
 });
 
@@ -306,6 +311,17 @@ describe("the definitions a route reads for its page", () => {
     const meta = await route.generateMetadata({ params: { slug: ["about"] } });
 
     expect(meta.title).toBe("Composed title");
+  });
+
+  it("bounds the read by the next scheduled release", async () => {
+    // Without a window the entry is created with `revalidate: false`, so at
+    // the release instant the page read refreshes around a nested lookup that
+    // stays a cache hit — and the page keeps drawing the pre-release component
+    // until some unrelated write busts its id tag.
+    await renderWith({ hero: definition() }, page(["hero"]));
+
+    const options = cached.mock.calls[0]![0] as { revalidate?: number | false };
+    expect(options.revalidate).toBe(42);
   });
 
   it("asks for nothing when the page embeds no component", async () => {

--- a/packages/blocks-react/src/next.ts
+++ b/packages/blocks-react/src/next.ts
@@ -39,6 +39,7 @@ import {
   entryIdTag,
   getNextly,
   nextlyTags,
+  releaseBoundedRevalidate,
   nextlySingleTags,
   slugToStaticParam,
 } from "nextly/runtime";
@@ -904,6 +905,18 @@ async function readComponentChunk(
   }
 ): Promise<{ items: Record<string, unknown>[] }> {
   const { reader, collection, status, locale, cacheScope } = args;
+  // How long this read may live, bounded by the next scheduled release —
+  // asked for the reason `release-cache-window` states about the two callers
+  // it already had: a release member names a scope, and a bound applied to
+  // some cached reads and not others leaves the unwired one serving its
+  // pre-release content. This is a third such read, so it is a third place
+  // that has to ask.
+  //
+  // Without it the entry is created with `revalidate: false`, so at the
+  // release instant the page read around it refreshes while this one stays a
+  // cache hit — and the page keeps drawing the pre-release component until
+  // some unrelated write happens to bust its id tag.
+  const revalidate = await releaseBoundedRevalidate(undefined);
   return await cachedFind(
     async () =>
       await reader.find({
@@ -934,6 +947,7 @@ async function readComponentChunk(
         // order share one entry rather than filling two with one answer.
         ...[...wanted].sort(),
       ],
+      revalidate,
     }
   );
 }

--- a/packages/nextly/src/runtime.ts
+++ b/packages/nextly/src/runtime.ts
@@ -42,6 +42,7 @@ export {
   nextlySingleTags,
   entryIdTag,
   cachedFind,
+  releaseBoundedRevalidate,
   type NextCacheModule,
   type CachedFindOptions,
 } from "./runtime/cache";

--- a/packages/nextly/src/runtime/cache/index.ts
+++ b/packages/nextly/src/runtime/cache/index.ts
@@ -10,4 +10,5 @@ export type { NextCacheModule } from "./next-cache-revalidator";
 export { registerNextCacheRevalidator } from "./register";
 export { entryIdTag, nextlyTags, nextlySingleTags } from "./nextly-tags";
 export { cachedFind } from "./cached-find";
+export { releaseBoundedRevalidate } from "./release-cache-window";
 export type { CachedFindOptions } from "./cached-find";


### PR DESCRIPTION
Takes `task:pb6-t4c-release-bounded-component-cache`, the last of the five deferred from #1529.

## The defect

`readComponentChunk` supplied no `revalidate`, so its cache entry was created with `revalidate: false`. At a release instant the outer page read is refreshed by `releaseBoundedRevalidate` while this nested lookup **stays a cache hit** — so the page keeps drawing the pre-release component until some unrelated write happens to bust its id tag.

## The part worth reading

`release-cache-window` already carries the reason, about the two callers it had before this one:

> Collections and Singles cache through separate `cachedFind` calls, and a release member names either scope. A bound applied to one and not the other is a Single that keeps serving its pre-release document — a failure visible only in production, and only for the half nobody wired.

I added a **third** such read and did not wire it. That is the second time on this seam that a documented hazard recurred through a new door — the first was `derivePageSeo`, whose docblock warns about metadata describing a different page than the HTML, and which then did exactly that because definitions were an input it lacked. Both are the same shape: **a warning attached to the places that existed when it was written does not attach itself to the next one.**

`releaseBoundedRevalidate` is now published from `nextly/runtime`, as `entryIdTag` was, for the same seam and the same reason.

## Testing

The bound is mocked to return a number, and the test asserts the read applies what it gets. Whether the bound is *computed* correctly is `nextly`'s to test and is tested there; what belongs here is whether this read asks at all — which is exactly the defect.

Break-verified: dropping `revalidate` from the options gives `expected undefined to be 42`.

## Gates

`build` 0 · `check-types` 0 · `lint` 0 · `check:comments` 0 · `changeset status` 0, 25 packages · `fallow` `warn` with `duplication_introduced: 1` — the trusted-read posture across two call sites, unchanged from #1529 and non-blocking.

blocks-react 1146 · nextly 11265 across 884 files.

## This closes the #1529 tranche except the draft pair

`pb6-t4c-draft-posture` and `pb6-t4c-working-draft-definitions` remain, and the first needs `ResolvedContext` to carry the resolved draft grant — a `nextly` API change I would rather have ruled on than pick.