### PR TITLE
docs(root): describe the plugins and packages that actually ship

### DIFF
--- a/.changeset/plugins-that-ship-no-longer-say-otherwise.md
+++ b/.changeset/plugins-that-ship-no-longer-say-otherwise.md
@@ -1,0 +1,23 @@
+---
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/builder": patch
+"nextly": patch
+---
+
+Plugin READMEs no longer tell you plugins are unavailable. Three plugins ship
+today — the Visual Page Builder, SEO and the form builder — but the form
+builder's README said "Plugins are not ready for use yet" and told you not to
+rely on them in production, which is the page npm shows on the package. Every
+plugin README now carries the same short alpha note and links to the stability
+ladder, so you can see which surfaces are settled and which are still moving.
+
+`@nextlyhq/admin-css` gains a README; it was published with a blank page on npm.
+
+The plugin SDK's own source said dashboard widgets were "reserved, not
+rendered". They do render, and are marked experimental only because the
+contribution shape is still settling.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,9 @@ jobs:
       - name: Comment convention
         run: pnpm check:comments
 
+      - name: Docs and README claims
+        run: pnpm check:docs-claims
+
   ci:
     name: Lint / Typecheck / Test / Build
     needs: changes

--- a/.github/workflows/trigger-docs-deploy.yml
+++ b/.github/workflows/trigger-docs-deploy.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches: [main]
     paths:
-      - 'docs/content/**'
+      # The docs live at docs/. There is no docs/content/ directory, so a filter
+      # naming one matches nothing and this workflow never fires.
+      - 'docs/**'
 
 # The job only curls an external deploy hook; it never uses the
 # GITHUB_TOKEN, so the token gets no permissions at all.

--- a/README.md
+++ b/README.md
@@ -36,26 +36,22 @@
 > [!IMPORTANT]
 > Nextly is in alpha. APIs may change before 1.0. Pin exact versions in production.
 
-Nextly is a TypeScript-first, Next.js-native CMS and app framework. Define your content schema in code or build it visually in the admin UI, choose your database, and get a fully-typed REST and Direct API plus a customizable admin dashboard. No SaaS, no proprietary cloud. Your data, your stack.
+Nextly is an open-source content platform for Next.js.
 
-<!--
-HERO VISUAL PLACEHOLDER
-======================
-Swap the box below for a real screenshot, GIF, or short video of the admin
-panel before publishing. Recommended: 1600x900 PNG or MP4 < 5 MB.
--->
-
-<!-- <p align="center">
-  <img alt="Hero placeholder. Replace with admin screenshot or product GIF before launch." src="https://placehold.co/1600x900/0a0a0a/eaeaea?text=Hero+visual+goes+here.+Swap+before+launch&font=inter" width="800" />
-</p> -->
+Developers define the content model in TypeScript, or build it in the admin with the Visual Schema Builder — either way it is the same data model. Your team then composes pages in the Visual Page Builder, translates them, keeps a version history, and schedules what goes live. It all runs inside your own Next.js app, on your own database. No SaaS, no proprietary cloud.
 
 ## Why Nextly?
 
-- **Code-first or visual schema.** Define collections in TypeScript, or build them in the Schema Builder. Same data model either way.
+- **Model in code, or in the admin.** Define your content types (we call them collections) in TypeScript, or build them in the Visual Schema Builder. Same data model either way.
+- **Compose pages visually.** The Visual Page Builder gives your team a canvas of blocks your developers registered. Pages render on the server and ship no JavaScript unless a block needs it.
+- **Run in several languages.** The same site in multiple locales, with a fallback when a translation is missing, and each language published on its own schedule.
+- **Keep a version history.** Compare any two versions of a document and restore one. Restoring snapshots the current state first, so nothing is destroyed.
+- **Schedule what goes live.** Group entries into a release and publish or unpublish them together, at a time you choose.
+- **Control who can edit what.** Roles and permissions, down to individual fields.
+- **Connect it to the rest of your stack.** Webhooks with signing secrets and retries, background jobs, and dashboard widgets in the admin.
+- **Extend it.** A plugin SDK covering schema, services, routes, admin UI and permissions. The Visual Page Builder is itself a plugin, built on that same public API.
 - **Type-safe everywhere.** REST API, Direct API, and the admin UI are typed end-to-end.
-- **Pluggable databases.** PostgreSQL, MySQL, SQLite via official adapters.
-- **Pluggable storage.** Local disk by default; S3 (and R2, MinIO), Vercel Blob, or UploadThing for production.
-- **Granular access control.** Roles, permissions, and field-level access out of the box.
+- **Your database, your storage.** PostgreSQL, MySQL, or SQLite. Local disk by default; S3 (and R2, MinIO), Vercel Blob, or UploadThing for production.
 - **Self-hosted, MIT-licensed.** Your stack, your data, no vendor lock-in.
 
 ## Quickstart
@@ -118,6 +114,14 @@ Set `DATABASE_URL` (and `DB_DIALECT`) in your `.env`; Nextly picks the dialect a
 | **@nextlyhq/ui**      | Headless UI components shared across packages and plugins       |
 | **create-nextly-app** | CLI scaffold for new Nextly projects                            |
 
+### Page builder
+
+| Package                     | Description                                                       |
+| --------------------------- | ----------------------------------------------------------------- |
+| **@nextlyhq/builder**       | The Visual Page Builder editor: shell, canvas, and op store       |
+| **@nextlyhq/blocks-engine** | Block document model, tree operations, and validation. No runtime |
+| **@nextlyhq/blocks-react**  | React Server Component renderer for block documents               |
+
 ### Database adapters
 
 | Package                        | Description                                     |
@@ -134,13 +138,26 @@ Set `DATABASE_URL` (and `DB_DIALECT`) in your `.env`; Nextly picks the dialect a
 | **@nextlyhq/storage-vercel-blob** | Vercel Blob storage                    |
 | **@nextlyhq/storage-uploadthing** | UploadThing storage                    |
 
-### Plugins (coming soon, beta)
+### Plugins
 
-| Package                           | Description                                      |
-| --------------------------------- | ------------------------------------------------ |
-| **@nextlyhq/plugin-form-builder** | Drag-and-drop form builder _(coming soon, beta)_ |
+Nextly has a first-class plugin SDK. The Visual Page Builder is itself a plugin, built on the same public API you would use.
 
-> Public plugin support (stable APIs, plugin gallery, documentation guarantees) lands at the Nextly **beta** release. The package above is published for early exploration only. Surfaces and behaviour will change.
+| Package                           | Description                                                 |
+| --------------------------------- | ----------------------------------------------------------- |
+| **@nextlyhq/plugin-page-builder** | Visual Page Builder: blocks, canvas, server-first rendering |
+| **@nextlyhq/plugin-seo**          | SEO fields and a sitemap for your content                   |
+| **@nextlyhq/plugin-form-builder** | Visual form builder and submission capture                  |
+| **@nextlyhq/plugin-sdk**          | Build your own plugins: schema, services, routes, admin UI  |
+
+> Nextly is in alpha, and some plugin surfaces are still settling. The [stability ladder](https://nextlyhq.com/docs/plugins/stability) says which parts are stable today and which are experimental.
+
+### Tooling
+
+| Package                       | Description                                                        |
+| ----------------------------- | ------------------------------------------------------------------ |
+| **@nextlyhq/adapter-drizzle** | Shared Drizzle ORM adapter logic behind the database adapters      |
+| **@nextlyhq/admin-css**       | Scopes and compiles the admin CSS, for the admin build and plugins |
+| **@nextlyhq/eslint-plugin**   | ESLint rules keeping admin UI on the design-token system           |
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Developers define the content model in TypeScript, or build it in the admin with
 
 - **Model in code, or in the admin.** Define your content types (we call them collections) in TypeScript, or build them in the Visual Schema Builder. Same data model either way.
 - **Compose pages visually.** The Visual Page Builder gives your team a canvas of blocks your developers registered. Pages render on the server and ship no JavaScript unless a block needs it.
-- **Run in several languages.** The same site in multiple locales, with a fallback when a translation is missing, and each language published on its own schedule.
+- **Run in several languages.** The same site in multiple locales, with a fallback when a translation is missing. Each language has its own draft and published state, so you can publish one language without publishing the rest.
 - **Keep a version history.** Compare any two versions of a document and restore one. Restoring snapshots the current state first, so nothing is destroyed.
 - **Schedule what goes live.** Group entries into a release and publish or unpublish them together, at a time you choose.
 - **Control who can edit what.** Roles and permissions, down to individual fields.

--- a/docs/api-reference/direct-api.mdx
+++ b/docs/api-reference/direct-api.mdx
@@ -67,7 +67,7 @@ const visiblePosts = await nextly.find({
 
 ## Collections
 
-These methods hang off the `nextly` root and operate on collection entries. The shapes shown below match the canonical Phase 4 envelopes (`ListResult<T>`, `MutationResult<T>`, etc.) — verify against [`packages/nextly/src/direct-api/types/shared.ts`](https://github.com/nextlyhq/nextly/blob/dev/packages/nextly/src/direct-api/types/shared.ts) if you need the exact TypeScript definitions.
+These methods hang off the `nextly` root and operate on collection entries. The shapes shown below match the canonical Phase 4 envelopes (`ListResult<T>`, `MutationResult<T>`, etc.) — verify against [`packages/nextly/src/direct-api/types/shared.ts`](https://github.com/nextlyhq/nextly/blob/main/packages/nextly/src/direct-api/types/shared.ts) if you need the exact TypeScript definitions.
 
 ### find
 
@@ -575,7 +575,7 @@ The Direct API also exposes typed namespaces for users, media, forms, field grou
 | `nextly.access` | Permission checks | `check`, `checkApiKey` |
 | `nextly.apiKeys` | API keys | `list`, `findByID`, `create`, `update`, `revoke` |
 
-The full TypeScript surface is generated from [`packages/nextly/src/direct-api/namespaces/`](https://github.com/nextlyhq/nextly/tree/dev/packages/nextly/src/direct-api/namespaces).
+The full TypeScript surface is generated from [`packages/nextly/src/direct-api/namespaces/`](https://github.com/nextlyhq/nextly/tree/main/packages/nextly/src/direct-api/namespaces).
 
 ## Querying
 

--- a/docs/api-reference/rest-api.mdx
+++ b/docs/api-reference/rest-api.mdx
@@ -52,7 +52,7 @@ API keys are managed via `POST /api/api-keys` (admin UI). There is **no** `X-API
 
 ## Response envelopes
 
-All responses follow the canonical Phase 4 shapes documented in [`packages/nextly/src/api/response-shapes.ts`](https://github.com/nextlyhq/nextly/blob/dev/packages/nextly/src/api/response-shapes.ts). Content-Type is always `application/json` for success responses and `application/problem+json` for errors. Every response carries an `X-Request-Id` header you can quote when filing bugs.
+All responses follow the canonical Phase 4 shapes documented in [`packages/nextly/src/api/response-shapes.ts`](https://github.com/nextlyhq/nextly/blob/main/packages/nextly/src/api/response-shapes.ts). Content-Type is always `application/json` for success responses and `application/problem+json` for errors. Every response carries an `X-Request-Id` header you can quote when filing bugs.
 
 ### List
 
@@ -578,7 +578,7 @@ curl -X POST http://localhost:3000/api/email/send-with-template \
 
 The media collection is just a normal collection (`/api/collections/media/entries`) with extra plumbing for binary uploads. The `POST /api/collections/media/entries` endpoint accepts `multipart/form-data` with the file under `file` and any other fields alongside.
 
-Image-size presets are managed under `/api/image-sizes`. The `regeneration-status` and `regenerate` sub-routes return a "coming soon" placeholder today (see [`packages/nextly/src/routeHandler.ts`](https://github.com/nextlyhq/nextly/blob/dev/packages/nextly/src/routeHandler.ts)).
+Image-size presets are managed under `/api/image-sizes`. The `regeneration-status` and `regenerate` sub-routes return a "coming soon" placeholder today (see [`packages/nextly/src/routeHandler.ts`](https://github.com/nextlyhq/nextly/blob/main/packages/nextly/src/routeHandler.ts)).
 
 ### API keys
 

--- a/docs/plugins/form-builder.mdx
+++ b/docs/plugins/form-builder.mdx
@@ -161,9 +161,9 @@ Every field supports these common properties: `name`, `label`, `placeholder`, `h
 
 ## Creating Forms
 
-### Visual Builder (Admin UI)
+### Visual form builder (admin UI)
 
-Navigate to **Forms** in the admin sidebar and click **Create New**. The visual builder provides:
+Navigate to **Forms** in the admin sidebar and click **Create New**. The form builder provides:
 
 - **Field Library** -- click or drag field types to add them to the form
 - **Form Canvas** -- reorder fields with drag-and-drop, click to edit

--- a/docs/plugins/schema.mdx
+++ b/docs/plugins/schema.mdx
@@ -4,7 +4,7 @@ description: Contribute collections, extend existing entities (including Builder
 ---
 
 A plugin's schema contributions flow through the **same unified merge pipeline** as your
-app's own code-first schema and the Visual Builder's schema (D3). The host can read them
+app's own code-first schema and the Visual Schema Builder's schema (D3). The host can read them
 *without running your plugin*, so the admin and codegen can reason about them.
 
 ## Contribute new entities

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "check:storage-format-literals": "node scripts/check-storage-format-literals.cjs",
     "check:dev-concurrency": "node scripts/check-dev-concurrency.mjs",
     "check:comments": "node scripts/check-comment-convention.mjs",
+    "check:docs-claims": "node scripts/check-docs-claims.mjs",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "lint": "turbo run lint",
     "lint:design": "node scripts/lint-design.mjs",

--- a/packages/admin-css/README.md
+++ b/packages/admin-css/README.md
@@ -1,0 +1,97 @@
+# @nextlyhq/admin-css
+
+Build tooling to scope and compile Nextly admin CSS, shared by the admin build and by
+third-party plugins.
+
+<p align="left">
+  <a href="https://www.npmjs.com/package/@nextlyhq/admin-css"><img alt="npm" src="https://img.shields.io/npm/v/@nextlyhq/admin-css?style=flat-square&label=npm&color=cb3837" /></a>
+  <a href="https://github.com/nextlyhq/nextly/blob/main/LICENSE.md"><img alt="License" src="https://img.shields.io/github/license/nextlyhq/nextly?style=flat-square&color=blue" /></a>
+</p>
+
+> [!IMPORTANT]
+> Nextly is in alpha. APIs may change before 1.0 — pin exact versions in production.
+> See the [plugin stability ladder](https://nextlyhq.com/docs/plugins/stability) for
+> which plugin surfaces are stable and which are experimental.
+
+## What it is
+
+The Nextly admin mounts inside your application's own document, so every CSS rule it
+ships has to stay under `.nextly-admin`. A rule that escapes that wrapper restyles
+your site's pages.
+
+This package owns that scoping. It is used by two builds — the admin's own, and the
+`nextly-build-admin-css` command that plugins use to compile the stylesheet they ship
+as `admin.styles`. One implementation, so the two can never drift apart.
+
+You do not import it at runtime. It runs at build time.
+
+## Install
+
+```bash
+pnpm add -D @nextlyhq/admin-css
+```
+
+## Compiling a plugin's admin stylesheet
+
+The common case is the CLI. Point it at your Tailwind entry file and an output path:
+
+```bash
+nextly-build-admin-css src/admin.css dist/admin.css
+```
+
+It compiles with the Tailwind CLI, scopes every rule under `.nextly-admin`, **refuses
+to emit if any rule escaped the wrapper**, then minifies. The Tailwind CLI is resolved
+from this package's own dependencies, so you do not need Tailwind on your `PATH`.
+
+Wire it into your plugin's build script:
+
+```json
+{
+  "scripts": {
+    "build:css": "nextly-build-admin-css src/admin.css dist/admin.css"
+  }
+}
+```
+
+## Using the scoping functions directly
+
+If you have your own build pipeline, the same functions are exported:
+
+```js
+import { scopeCss, checkAdminStyles } from "@nextlyhq/admin-css";
+
+const scoped = scopeCss(compiledCss);
+
+// Returns the problems it found; an empty array means the stylesheet is safe.
+const issues = checkAdminStyles({ css: scoped });
+for (const issue of issues) {
+  console.error(`${issue.severity}: ${issue.message}`);
+}
+```
+
+| Export                                     | What it does                                                                                                                  |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
+| `scopeCss(css, scope?)`                    | Scopes every rule in a stylesheet under `.nextly-admin`                                                                       |
+| `checkAdminStyles({ css })`                | Returns `{ severity, message }[]` for rules that escaped the wrapper, and for hardcoded colors that should be `--nx-*` tokens |
+| `findUnscopedRules(css, scope?)`           | Lists the rules that escaped, for reporting                                                                                   |
+| `scopeSelector(selector, scope?)`          | Scopes one selector                                                                                                           |
+| `isScoped(selector, scope?)`               | Whether one selector is already scoped                                                                                        |
+| `splitTopLevel(selector)`                  | Splits a selector list on top-level commas                                                                                    |
+| `confineVariantClasses(css, scope?)`       | Keeps Tailwind variant classes inside the scope                                                                               |
+| `namespaceInternalProperties(css, prefix)` | Namespaces internal custom properties                                                                                         |
+| `prefixKeyframes(css, prefix)`             | Prefixes `@keyframes` names so they cannot collide                                                                            |
+
+## Related packages
+
+- [`@nextlyhq/admin`](../admin) — the admin dashboard these styles belong to
+- [`@nextlyhq/plugin-sdk`](../plugin-sdk) — building a plugin that contributes admin UI
+- [`@nextlyhq/eslint-plugin`](../eslint-plugin) — keeps admin UI on the design-token system
+
+## Documentation
+
+- [Plugin admin UI](https://nextlyhq.com/docs/plugins/admin-ui)
+- [Admin customization](https://nextlyhq.com/docs/admin/customization)
+
+## License
+
+[MIT](https://github.com/nextlyhq/nextly/blob/main/LICENSE.md)

--- a/packages/admin/src/components/features/schema-builder/builder-settings-modal/AdvancedTab.tsx
+++ b/packages/admin/src/components/features/schema-builder/builder-settings-modal/AdvancedTab.tsx
@@ -4,7 +4,7 @@
 // Use as Title and Timestamps are absent from THIS tab, not from the product.
 // Both remain code-first collection options — `admin.useAsTitle` is what the
 // entry table picks its title column from, and `timestamps` defaults to true
-// in `defineCollection`. What the Visual Builder declines to offer is a control
+// in `defineCollection`. What the Visual Schema Builder declines to offer is a control
 // for them: a builder-made entity takes the defaults, and a reader who needs to
 // change either edits the collection config. The i18n switch is gated on
 // the app-level

--- a/packages/admin/src/lib/builder/__tests__/condition-evaluator.test.ts
+++ b/packages/admin/src/lib/builder/__tests__/condition-evaluator.test.ts
@@ -1,5 +1,5 @@
 // Why: pure-function evaluator for FieldCondition. Lock semantics for
-// every operator so future changes to the visual builder can't silently
+// every operator so future changes to the Visual Schema Builder can't silently
 // drift from what the runtime evaluator does. Backwards-compat path
 // (legacy { field, equals } shape) is also covered.
 import { describe, expect, it } from "vitest";

--- a/packages/builder/src/style-control-behaviour.ts
+++ b/packages/builder/src/style-control-behaviour.ts
@@ -16,7 +16,7 @@
  * this holds the behaviour under a key derived from it.
  *
  * The alternative was measured in the field rather than reasoned about: a
- * visual builder that allows functions inside its input config has to stringify
+ * Visual Page Builder that allows functions inside its input config has to stringify
  * and re-evaluate them, and documents the consequence — such a function may not
  * reference anything outside its own body, which typechecks and fails at
  * runtime.

--- a/packages/nextly/src/cli/commands/db-sync-demote.ts
+++ b/packages/nextly/src/cli/commands/db-sync-demote.ts
@@ -2,7 +2,7 @@
 // code-owned collection (defined in nextly.config.ts) to UI-owned by
 // writing it to dynamic_collections and instructing the user to delete
 // the code block.
-// collection in code hand off schema editing to the visual builder
+// collection in code hand off schema editing to the Visual Schema Builder
 // without re-creating anything.
 
 import { createHash } from "node:crypto";

--- a/packages/nextly/src/domains/collections/services/collection-registry-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-registry-service.ts
@@ -168,7 +168,7 @@ export class CollectionRegistryService extends BaseRegistryService<
    * current config — orphans left after a plugin or code collection was removed
    * (D14). They are RETAINED (never auto-dropped); `nextly prune` drops them
    * explicitly. Builder (`ui`) collections are excluded — they are managed via
-   * the Visual Builder, not the code config.
+   * the Visual Schema Builder, not the code config.
    */
   async findOrphanedCollections(
     currentSlugs: string[]

--- a/packages/nextly/src/domains/schema/services/field-diff.ts
+++ b/packages/nextly/src/domains/schema/services/field-diff.ts
@@ -1,6 +1,6 @@
 // Compares old vs new field definitions for the preview endpoint.
 // Pure function, no drizzle-kit dependency. Just JSON comparison.
-// Used by the visual builder's "Save" flow to show what changed before applying.
+// Used by the Visual Schema Builder's "Save" flow to show what changed before applying.
 
 import type { FieldDefinition } from "../../../schemas/dynamic-collections";
 

--- a/packages/plugin-form-builder/README.md
+++ b/packages/plugin-form-builder/README.md
@@ -1,6 +1,6 @@
 # @nextlyhq/plugin-form-builder
 
-Drag-and-drop form builder plugin for Nextly. Build forms visually, collect submissions, and filter them by form. _Coming soon in beta._
+Drag-and-drop form builder plugin for Nextly. Build forms visually, collect submissions, and filter them by form.
 
 <p align="center">
   <a href="https://www.npmjs.com/package/@nextlyhq/plugin-form-builder"><img alt="npm" src="https://img.shields.io/npm/v/@nextlyhq/plugin-form-builder?style=flat-square&label=npm&color=cb3837" /></a>
@@ -8,11 +8,10 @@ Drag-and-drop form builder plugin for Nextly. Build forms visually, collect subm
   <a href="https://nextlyhq.com/docs"><img alt="Status" src="https://img.shields.io/badge/status-alpha-orange?style=flat-square" /></a>
 </p>
 
-> [!WARNING]
-> **Coming soon in beta. Plugins are not ready for use yet.** Public plugin support, including stable APIs, the official plugin gallery, and documentation guarantees, lands at the Nextly **beta** release. This package is published for early exploration only. Surfaces, names, and behaviour will change without notice. Do not rely on plugins for production or serious development work. Wait for the beta release announcement before integrating plugins into your project.
-
 > [!IMPORTANT]
-> Nextly is in alpha. APIs may change before 1.0. Pin exact versions in production.
+> Nextly is in alpha. APIs may change before 1.0 — pin exact versions in production.
+> See the [plugin stability ladder](https://nextlyhq.com/docs/plugins/stability) for
+> which plugin surfaces are stable and which are experimental.
 
 ## What it is
 

--- a/packages/plugin-page-builder/README.md
+++ b/packages/plugin-page-builder/README.md
@@ -5,8 +5,13 @@ extensible foundation in the spirit of Gutenberg/Elementor. Drag-and-drop editin
 iframe canvas, per-block styling with responsive overrides, a data-driven Query Loop, and
 a server-first renderer that ships zero client JS by default.
 
-> **Status:** alpha. The block model, registries, and render pipeline are stable; the
-> editor interactions are evolving. MIT-licensed.
+> [!IMPORTANT]
+> Nextly is in alpha. APIs may change before 1.0 — pin exact versions in production.
+> See the [plugin stability ladder](https://nextlyhq.com/docs/plugins/stability) for
+> which plugin surfaces are stable and which are experimental.
+
+> The block model, registries, and render pipeline are stable; the editor
+> interactions are still evolving. MIT-licensed.
 
 ## Install
 

--- a/packages/plugin-sdk/src/admin.ts
+++ b/packages/plugin-sdk/src/admin.ts
@@ -5,8 +5,9 @@
  * shell (which provides `@nextlyhq/admin` + React).
  *
  * @public Graduated in P9 — `plugin-form-builder` exercises the menu/pages/views
- *   registration. Dashboard widgets (`PluginAdminWidget`, D22) remain
- *   `@experimental` until M8. See `STABILITY.md`.
+ *   registration. Dashboard widgets (`PluginAdminWidget`, D22) render, but the
+ *   contribution shape is still settling, so they remain `@experimental`.
+ *   See `STABILITY.md`.
  */
 export {
   registerComponent,

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -279,8 +279,9 @@ export type {
  *
  * @public `PluginAdminContributions`, `PluginAdminPage`, `PluginCollectionView`,
  *   `PluginMenuItem`, `ComponentPath` — exercised by `plugin-form-builder`.
- * @experimental `PluginAdminWidget` — dashboard-widget rendering is deferred to
- *   M8 (D22); the contract is reserved, not rendered.
+ * @experimental `PluginAdminWidget` — dashboard widgets render (D22); the
+ *   contribution shape is still settling, so it graduates once a first-party
+ *   plugin ships one.
  */
 export type {
   ComponentPath,

--- a/packages/plugin-seo/README.md
+++ b/packages/plugin-seo/README.md
@@ -1,6 +1,9 @@
 # @nextlyhq/plugin-seo
 
-> Nextly is in alpha. APIs may change before 1.0.
+> [!IMPORTANT]
+> Nextly is in alpha. APIs may change before 1.0 — pin exact versions in production.
+> See the [plugin stability ladder](https://nextlyhq.com/docs/plugins/stability) for
+> which plugin surfaces are stable and which are experimental.
 
 First-party SEO plugin for Nextly. It is **opt-in** and **framework-agnostic** (zero `next` dependency), so it is safe in every deployment mode — an integrated site, a headless setup feeding a separate frontend, or an internal admin tool. You add it only to the collections that need SEO.
 

--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -19,7 +19,8 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { readFileSync, readdirSync, existsSync } from "node:fs";
 import { basename, dirname, extname, join, relative, sep } from "node:path";
 
 const SKIP_DIRS = new Set([
@@ -44,7 +45,40 @@ const FORBIDDEN_PHRASES = [
 /** The whole positioning failure traces to one overloaded word; this is what stops it recurring. */
 const BARE_VISUAL_BUILDER = /(?<!schema )(?<!page )\bvisual builder\b/gi;
 
-const REPO_LINK = /github\.com\/nextlyhq\/nextly\/(?:blob|tree|raw)\/([^/\s)]+)\//g;
+/**
+ * Captures everything after `blob|tree|raw`, because the ref is not one segment. A branch may
+ * contain slashes (`feature/docs-refresh`), and git accepts it: `git check-ref-format --branch
+ * feature/docs-refresh` exits 0. Splitting on the first slash would read the ref as `feature`
+ * and report a live branch as dead, which is the failure mode this whole check exists to avoid.
+ */
+const REPO_LINK = /github\.com\/nextlyhq\/nextly\/(?:blob|tree|raw)\/([^\s)\]"'`]+)/g;
+
+const HEX_REF = /^[0-9a-f]{7,40}$/i;
+
+/**
+ * Split a link's tail into the ref and the path under it.
+ *
+ * The ref boundary is not derivable from the string, so it is resolved against the refs the
+ * remote actually has: the longest leading run of segments that names a real ref wins. A ref
+ * shaped like a commit is handed back for object lookup instead.
+ */
+export function splitRefAndPath(tail, remoteRefs) {
+  const segments = tail.split("/").filter(Boolean);
+  if (segments.length === 0) return null;
+
+  if (remoteRefs) {
+    for (let take = Math.min(segments.length, 8); take >= 1; take--) {
+      const candidate = segments.slice(0, take).join("/");
+      if (remoteRefs.has(candidate)) {
+        return { ref: candidate, resolved: true };
+      }
+    }
+  }
+  // Nothing matched. A single segment shaped like a commit is a pinned link, judged separately;
+  // otherwise report the longest plausible ref rather than the first segment, so the message
+  // names what was actually looked for.
+  return { ref: segments[0], resolved: false };
+}
 
 function walk(dir, out = []) {
   let entries;
@@ -80,7 +114,12 @@ function proseFiles(repoRoot) {
     });
 }
 
-function publishedPackages(repoRoot) {
+/**
+ * A manifest that will not parse is reported rather than skipped. Skipping drops the package
+ * from every other check here, so a syntax error would quietly buy an exemption from all of
+ * them — the check would go green precisely because something was broken.
+ */
+function publishedPackages(repoRoot, findings) {
   const pkgDir = join(repoRoot, "packages");
   if (!existsSync(pkgDir)) return [];
   const out = [];
@@ -90,7 +129,13 @@ function publishedPackages(repoRoot) {
     let json;
     try {
       json = JSON.parse(readFileSync(manifest, "utf-8"));
-    } catch {
+    } catch (error) {
+      findings.push({
+        check: "unreadable-manifest",
+        file: relative(repoRoot, manifest),
+        line: null,
+        message: `cannot be parsed, so this package is invisible to every other check: ${error.message}`,
+      });
       continue;
     }
     if (json.private) continue;
@@ -100,32 +145,68 @@ function publishedPackages(repoRoot) {
 }
 
 /**
- * Resolve a git ref against the remote.
+ * Every ref the remote has, read in one call.
  *
  * `git ls-remote` rather than `rev-parse`, because CI clones shallow: a ref that exists is
  * absent from a depth-1 local clone, and a check that goes red on a correct tree teaches people
- * to ignore it. Returns null — not false — when the remote cannot be reached, so "I could not
- * tell" never masquerades as "it does not exist".
+ * to wave reds through. One call rather than one per link, because the longest-prefix match in
+ * `splitRefAndPath` needs the whole set to decide where a ref ends.
+ *
+ * Returns null — not an empty set — when the remote cannot be reached, so "I could not tell"
+ * never masquerades as "it does not exist".
  */
-function makeRefResolver(repoRoot) {
-  const cache = new Map();
-  return ref => {
-    if (/^[0-9a-f]{7,40}$/i.test(ref)) return true;
-    if (cache.has(ref)) return cache.get(ref);
-    let result;
-    try {
-      const out = execFileSync(
-        "git",
-        ["ls-remote", "--heads", "--tags", "origin", ref],
-        { cwd: repoRoot, encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] }
-      );
-      result = out.trim().length > 0;
-    } catch {
-      result = null;
+function listRemoteRefs(repoRoot) {
+  try {
+    const out = execFileSync("git", ["ls-remote", "--heads", "--tags", "origin"], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const refs = new Set();
+    for (const line of out.split("\n")) {
+      const name = line.split("\t")[1];
+      if (!name) continue;
+      refs.add(name.replace(/^refs\/(heads|tags)\//, "").replace(/\^\{\}$/, ""));
     }
-    cache.set(ref, result);
-    return result;
+    return refs.size > 0 ? refs : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether a commit-shaped ref names an object this clone holds.
+ *
+ * A shallow clone genuinely cannot answer this, and `ls-remote` cannot be asked about an
+ * arbitrary sha. So a miss is reported as unverifiable rather than dead: the alternative,
+ * accepting every hex string, made pinned links a blind spot in the one check meant to cover
+ * them.
+ */
+function makeCommitProbe(repoRoot) {
+  const cache = new Map();
+  return sha => {
+    if (cache.has(sha)) return cache.get(sha);
+    let present;
+    try {
+      execFileSync("git", ["cat-file", "-e", `${sha}^{commit}`], {
+        cwd: repoRoot,
+        stdio: ["ignore", "ignore", "ignore"],
+      });
+      present = true;
+    } catch {
+      present = false;
+    }
+    cache.set(sha, present);
+    return present;
   };
+}
+
+/** Matches `digestOffences` in check-comment-convention.mjs so the two allowlists read alike. */
+export function digestLine(line) {
+  return createHash("sha256")
+    .update(line.trim().replace(/\s+/g, " "))
+    .digest("hex")
+    .slice(0, 16);
 }
 
 /** A page is reachable when its own directory's meta.json lists it. A directory with no
@@ -146,7 +227,16 @@ function metaReachability(repoRoot, findings) {
     let pages;
     try {
       pages = JSON.parse(readFileSync(metaPath, "utf-8")).pages ?? [];
-    } catch {
+    } catch (error) {
+      // Unreadable navigation metadata is a deploy failure waiting to happen: the docs site
+      // parses this file to build its sidebar. Skipping it would report success on a tree that
+      // cannot render.
+      findings.push({
+        check: "unreadable-meta",
+        file: relative(repoRoot, metaPath),
+        line: null,
+        message: `cannot be parsed, so the docs navigation cannot be built: ${error.message}`,
+      });
       continue;
     }
     const listed = new Set(pages.map(p => String(p).replace(/^\.\//, "")));
@@ -164,19 +254,54 @@ function metaReachability(repoRoot, findings) {
   }
 }
 
-export async function runChecks({ repoRoot, allowlist = {}, resolveRef }) {
+export async function runChecks({
+  repoRoot,
+  allowlist = {},
+  remoteRefs,
+  hasLocalCommit,
+}) {
   const findings = [];
   const unverifiable = [];
-  const resolve = resolveRef ?? makeRefResolver(repoRoot);
-  const allowed = check =>
-    new Set(Object.keys(allowlist[check] ?? {}).map(p => p.split("/").join(sep)));
+  const refs = remoteRefs === undefined ? listRemoteRefs(repoRoot) : remoteRefs;
+  const commitPresent = hasLocalCommit ?? makeCommitProbe(repoRoot);
+
+  /**
+   * An exemption covers ONE claim, not one file.
+   *
+   * Keying only by path would silence every line in an exempt file, so an accurate "coming soon"
+   * on one line would also let an inaccurate one elsewhere in the same file through — a
+   * file-wide bypass wearing the shape of a single exception. Digests are per-line and match
+   * `comment-convention-allowlist.json`.
+   */
+  const exemption = check => {
+    const forCheck = allowlist[check] ?? {};
+    const byPath = new Map();
+    for (const [path, entry] of Object.entries(forCheck)) {
+      byPath.set(path.split("/").join(sep), new Set(entry.digests ?? []));
+    }
+    return (relPath, line) => {
+      const digests = byPath.get(relPath);
+      return digests ? digests.has(digestLine(line)) : false;
+    };
+  };
 
   // --- readme-present + root-readme-lists-package ---
-  const packages = publishedPackages(repoRoot);
+  const packages = publishedPackages(repoRoot, findings);
   const rootReadmePath = join(repoRoot, "README.md");
   const rootReadme = existsSync(rootReadmePath)
     ? readFileSync(rootReadmePath, "utf-8")
     : null;
+
+  if (rootReadme === null && packages.length > 0) {
+    // Treating the root README as optional let the whole root-readme check disappear the moment
+    // the file did. This job is the guard for exactly that file.
+    findings.push({
+      check: "root-readme-present",
+      file: "README.md",
+      line: null,
+      message: `absent, but ${packages.length} package(s) are published and must be listed in it`,
+    });
+  }
 
   for (const pkg of packages) {
     if (!existsSync(join(pkg.dir, "README.md"))) {
@@ -198,9 +323,9 @@ export async function runChecks({ repoRoot, allowlist = {}, resolveRef }) {
   }
 
   // --- per-line prose checks ---
-  const phraseAllowed = allowed("forbidden-status-phrase");
-  const namingAllowed = allowed("naming-rule");
-  const linkAllowed = allowed("dead-branch-link");
+  const phraseExempt = exemption("forbidden-status-phrase");
+  const namingExempt = exemption("naming-rule");
+  const linkExempt = exemption("dead-branch-link");
 
   for (const file of proseFiles(repoRoot)) {
     const rel = relative(repoRoot, file);
@@ -219,7 +344,7 @@ export async function runChecks({ repoRoot, allowlist = {}, resolveRef }) {
 
       // Prose only. A "Coming soon" badge in admin UI or an API placeholder string is a
       // fact about the running product, not a claim about what the project ships.
-      if (isProse && !phraseAllowed.has(rel)) {
+      if (isProse && !phraseExempt(rel, line)) {
         for (const phrase of FORBIDDEN_PHRASES) {
           if (lower.includes(phrase)) {
             findings.push({
@@ -233,7 +358,7 @@ export async function runChecks({ repoRoot, allowlist = {}, resolveRef }) {
         }
       }
 
-      if (!namingAllowed.has(rel)) {
+      if (!namingExempt(rel, line)) {
         BARE_VISUAL_BUILDER.lastIndex = 0;
         if (BARE_VISUAL_BUILDER.test(line)) {
           findings.push({
@@ -245,22 +370,42 @@ export async function runChecks({ repoRoot, allowlist = {}, resolveRef }) {
         }
       }
 
-      if (!linkAllowed.has(rel)) {
+      if (!linkExempt(rel, line)) {
         REPO_LINK.lastIndex = 0;
         let match;
         while ((match = REPO_LINK.exec(line)) !== null) {
-          const ref = match[1];
-          const resolved = resolve(ref);
-          if (resolved === null) {
-            unverifiable.push({ check: "dead-branch-link", file: rel, line: i + 1, ref });
-          } else if (resolved === false) {
-            findings.push({
+          if (refs === null) {
+            unverifiable.push({
               check: "dead-branch-link",
               file: rel,
               line: i + 1,
-              message: `links to ref "${ref}", which does not resolve on origin`,
+              ref: match[1],
             });
+            continue;
           }
+          const split = splitRefAndPath(match[1], refs);
+          if (split === null || split.resolved) continue;
+
+          if (HEX_REF.test(split.ref)) {
+            // A pinned commit. `ls-remote` cannot be asked about an arbitrary sha, and a shallow
+            // clone may not hold the object, so a miss is unverifiable rather than dead.
+            if (!commitPresent(split.ref)) {
+              unverifiable.push({
+                check: "dead-branch-link",
+                file: rel,
+                line: i + 1,
+                ref: split.ref,
+              });
+            }
+            continue;
+          }
+
+          findings.push({
+            check: "dead-branch-link",
+            file: rel,
+            line: i + 1,
+            message: `links to ref "${split.ref}", which does not resolve on origin`,
+          });
         }
       }
     }

--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -1,0 +1,310 @@
+#!/usr/bin/env node
+
+/**
+ * Documentation and README claims must match what the repository actually ships.
+ *
+ * The failure this guards against is not carelessness. It is that a fact about the product —
+ * "plugins are not ready", "the builder is called X", "this file lives on branch Y" — gets
+ * written down in more than one place, and only some of the copies get updated. Every defect
+ * this checks for was found in the repository, not imagined: a published package whose README
+ * told npm visitors not to use it, nine published packages missing from the root README, four
+ * links to a branch that no longer exists, and one product name written three different ways.
+ *
+ * A SCRIPT rather than a test, matching `check-comment-convention.mjs`: the rule spans docs,
+ * package manifests and READMEs, so a test rooted in any one package would read as repository
+ * coverage while checking a fraction of it.
+ *
+ * Usage:
+ *   node scripts/check-docs-claims.mjs
+ */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
+import { basename, dirname, extname, join, relative, sep } from "node:path";
+
+const SKIP_DIRS = new Set([
+  "node_modules", ".git", "dist", ".next", ".turbo", ".changeset", "coverage",
+]);
+
+/**
+ * Phrases that state a shipped thing is unavailable.
+ *
+ * A CURATED LIST is the mechanism here, unlike `dead-branch-link` below, which resolves what it
+ * checks. There is no way to ask the repository whether a sentence is true, so the list names
+ * the specific shapes that have gone stale, and the allowlist carries the ones that are
+ * genuinely accurate. That difference is deliberate, not an inconsistency between the checks.
+ */
+const FORBIDDEN_PHRASES = [
+  "coming soon",
+  "not ready for use",
+  "not yet available",
+  "plugins are not ready",
+];
+
+/** The whole positioning failure traces to one overloaded word; this is what stops it recurring. */
+const BARE_VISUAL_BUILDER = /(?<!schema )(?<!page )\bvisual builder\b/gi;
+
+const REPO_LINK = /github\.com\/nextlyhq\/nextly\/(?:blob|tree|raw)\/([^/\s)]+)\//g;
+
+function walk(dir, out = []) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      walk(join(dir, entry.name), out);
+    } else {
+      out.push(join(dir, entry.name));
+    }
+  }
+  return out;
+}
+
+/** Files whose prose is a claim about the product. CHANGELOGs are excluded everywhere: they are
+ *  Changesets' historical record, and rewriting history to satisfy a lint is worse than the lint. */
+function proseFiles(repoRoot) {
+  return walk(repoRoot)
+    .filter(f => {
+      if (basename(f) === "CHANGELOG.md") return false;
+      const ext = extname(f);
+      const rel = relative(repoRoot, f);
+      if (ext === ".md" || ext === ".mdx") return true;
+      return (
+        (ext === ".ts" || ext === ".tsx" || ext === ".mjs") &&
+        rel.split(sep)[0] === "packages"
+      );
+    });
+}
+
+function publishedPackages(repoRoot) {
+  const pkgDir = join(repoRoot, "packages");
+  if (!existsSync(pkgDir)) return [];
+  const out = [];
+  for (const name of readdirSync(pkgDir)) {
+    const manifest = join(pkgDir, name, "package.json");
+    if (!existsSync(manifest)) continue;
+    let json;
+    try {
+      json = JSON.parse(readFileSync(manifest, "utf-8"));
+    } catch {
+      continue;
+    }
+    if (json.private) continue;
+    out.push({ name: json.name, dir: join(pkgDir, name) });
+  }
+  return out;
+}
+
+/**
+ * Resolve a git ref against the remote.
+ *
+ * `git ls-remote` rather than `rev-parse`, because CI clones shallow: a ref that exists is
+ * absent from a depth-1 local clone, and a check that goes red on a correct tree teaches people
+ * to ignore it. Returns null — not false — when the remote cannot be reached, so "I could not
+ * tell" never masquerades as "it does not exist".
+ */
+function makeRefResolver(repoRoot) {
+  const cache = new Map();
+  return ref => {
+    if (/^[0-9a-f]{7,40}$/i.test(ref)) return true;
+    if (cache.has(ref)) return cache.get(ref);
+    let result;
+    try {
+      const out = execFileSync(
+        "git",
+        ["ls-remote", "--heads", "--tags", "origin", ref],
+        { cwd: repoRoot, encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] }
+      );
+      result = out.trim().length > 0;
+    } catch {
+      result = null;
+    }
+    cache.set(ref, result);
+    return result;
+  };
+}
+
+/** A page is reachable when its own directory's meta.json lists it. A directory with no
+ *  meta.json is auto-included by fumadocs, so nothing there can be orphaned. */
+function metaReachability(repoRoot, findings) {
+  const docsDir = join(repoRoot, "docs");
+  if (!existsSync(docsDir)) return;
+  const byDir = new Map();
+  for (const file of walk(docsDir)) {
+    if (extname(file) !== ".mdx") continue;
+    const dir = dirname(file);
+    if (!byDir.has(dir)) byDir.set(dir, []);
+    byDir.get(dir).push(file);
+  }
+  for (const [dir, files] of byDir) {
+    const metaPath = join(dir, "meta.json");
+    if (!existsSync(metaPath)) continue;
+    let pages;
+    try {
+      pages = JSON.parse(readFileSync(metaPath, "utf-8")).pages ?? [];
+    } catch {
+      continue;
+    }
+    const listed = new Set(pages.map(p => String(p).replace(/^\.\//, "")));
+    for (const file of files) {
+      const slug = basename(file, ".mdx");
+      if (!listed.has(slug)) {
+        findings.push({
+          check: "meta-reachable",
+          file: relative(repoRoot, file),
+          line: null,
+          message: `not listed in ${relative(repoRoot, metaPath)}; nextly-site's build fails on an unreachable page`,
+        });
+      }
+    }
+  }
+}
+
+export async function runChecks({ repoRoot, allowlist = {}, resolveRef }) {
+  const findings = [];
+  const unverifiable = [];
+  const resolve = resolveRef ?? makeRefResolver(repoRoot);
+  const allowed = check =>
+    new Set(Object.keys(allowlist[check] ?? {}).map(p => p.split("/").join(sep)));
+
+  // --- readme-present + root-readme-lists-package ---
+  const packages = publishedPackages(repoRoot);
+  const rootReadmePath = join(repoRoot, "README.md");
+  const rootReadme = existsSync(rootReadmePath)
+    ? readFileSync(rootReadmePath, "utf-8")
+    : null;
+
+  for (const pkg of packages) {
+    if (!existsSync(join(pkg.dir, "README.md"))) {
+      findings.push({
+        check: "readme-present",
+        file: relative(repoRoot, join(pkg.dir, "README.md")),
+        line: null,
+        message: `${pkg.name} is published but has no README, so its npm page is blank`,
+      });
+    }
+    if (rootReadme !== null && !rootReadme.includes(pkg.name)) {
+      findings.push({
+        check: "root-readme-lists-package",
+        file: "README.md",
+        line: null,
+        message: `${pkg.name} is published but is not named in the root README`,
+      });
+    }
+  }
+
+  // --- per-line prose checks ---
+  const phraseAllowed = allowed("forbidden-status-phrase");
+  const namingAllowed = allowed("naming-rule");
+  const linkAllowed = allowed("dead-branch-link");
+
+  for (const file of proseFiles(repoRoot)) {
+    const rel = relative(repoRoot, file);
+    let text;
+    try {
+      text = readFileSync(file, "utf-8");
+    } catch {
+      continue;
+    }
+    const lines = text.split("\n");
+    const isProse = rel.endsWith(".md") || rel.endsWith(".mdx");
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const lower = line.toLowerCase();
+
+      // Prose only. A "Coming soon" badge in admin UI or an API placeholder string is a
+      // fact about the running product, not a claim about what the project ships.
+      if (isProse && !phraseAllowed.has(rel)) {
+        for (const phrase of FORBIDDEN_PHRASES) {
+          if (lower.includes(phrase)) {
+            findings.push({
+              check: "forbidden-status-phrase",
+              file: rel,
+              line: i + 1,
+              message: `"${phrase}" — say what ships today, or allowlist this line if it is accurate`,
+            });
+            break;
+          }
+        }
+      }
+
+      if (!namingAllowed.has(rel)) {
+        BARE_VISUAL_BUILDER.lastIndex = 0;
+        if (BARE_VISUAL_BUILDER.test(line)) {
+          findings.push({
+            check: "naming-rule",
+            file: rel,
+            line: i + 1,
+            message: `bare "Visual Builder" — write "Visual Schema Builder" or "Visual Page Builder"`,
+          });
+        }
+      }
+
+      if (!linkAllowed.has(rel)) {
+        REPO_LINK.lastIndex = 0;
+        let match;
+        while ((match = REPO_LINK.exec(line)) !== null) {
+          const ref = match[1];
+          const resolved = resolve(ref);
+          if (resolved === null) {
+            unverifiable.push({ check: "dead-branch-link", file: rel, line: i + 1, ref });
+          } else if (resolved === false) {
+            findings.push({
+              check: "dead-branch-link",
+              file: rel,
+              line: i + 1,
+              message: `links to ref "${ref}", which does not resolve on origin`,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  metaReachability(repoRoot, findings);
+
+  return { findings, unverifiable };
+}
+
+const invokedDirectly =
+  process.argv[1] && process.argv[1].endsWith("check-docs-claims.mjs");
+
+if (invokedDirectly) {
+  const repoRoot = process.cwd();
+  const allowlistPath = join(repoRoot, "scripts", "docs-claims-allowlist.json");
+  const allowlist = existsSync(allowlistPath)
+    ? JSON.parse(readFileSync(allowlistPath, "utf-8"))
+    : {};
+
+  const { findings, unverifiable } = await runChecks({ repoRoot, allowlist });
+
+  if (unverifiable.length > 0) {
+    console.warn(
+      `${unverifiable.length} link ref(s) could not be resolved against origin (offline?). Not counted as failures.`
+    );
+  }
+
+  if (findings.length === 0) {
+    console.log("docs claims: no findings.");
+    process.exit(0);
+  }
+
+  const byCheck = new Map();
+  for (const f of findings) {
+    if (!byCheck.has(f.check)) byCheck.set(f.check, []);
+    byCheck.get(f.check).push(f);
+  }
+  for (const [check, items] of byCheck) {
+    console.error(`\n${check} (${items.length}):`);
+    for (const item of items) {
+      console.error(`  ${item.file}${item.line ? `:${item.line}` : ""} — ${item.message}`);
+    }
+  }
+  console.error(`\n${findings.length} finding(s).`);
+  process.exit(1);
+}

--- a/scripts/check-docs-claims.test.mjs
+++ b/scripts/check-docs-claims.test.mjs
@@ -1,0 +1,179 @@
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { runChecks } from "./check-docs-claims.mjs";
+
+/**
+ * Each fixture exhibits exactly one defect, and every check is asserted twice:
+ * once on a tree that has the defect, once on the nearest tree that does not.
+ * A check that only ever passes has not been shown to work, and the negative
+ * case is what distinguishes "the check fired" from "the check fires on
+ * anything".
+ */
+async function fixture(files) {
+  const root = await mkdtemp(join(tmpdir(), "docs-claims-"));
+  for (const [rel, body] of Object.entries(files)) {
+    const full = join(root, rel);
+    await mkdir(dirname(full), { recursive: true });
+    await writeFile(full, body);
+  }
+  return root;
+}
+
+const pkg = (extra = {}) =>
+  JSON.stringify({ name: "@nextlyhq/thing", version: "0.0.2-alpha.62", ...extra });
+
+async function checksFor(files) {
+  const root = await fixture(files);
+  const { findings } = await runChecks({ repoRoot: root, resolveRef: () => true });
+  return findings.map(f => f.check);
+}
+
+describe("readme-present", () => {
+  it("fires when a published package has no README", async () => {
+    expect(await checksFor({ "packages/thing/package.json": pkg() })).toContain(
+      "readme-present"
+    );
+  });
+
+  it("does not fire for a private package", async () => {
+    expect(
+      await checksFor({ "packages/thing/package.json": pkg({ private: true }) })
+    ).not.toContain("readme-present");
+  });
+});
+
+describe("root-readme-lists-package", () => {
+  it("fires when a published package is absent from the root README", async () => {
+    expect(
+      await checksFor({
+        "README.md": "# nextly\n",
+        "packages/thing/package.json": pkg(),
+        "packages/thing/README.md": "# thing\n",
+      })
+    ).toContain("root-readme-lists-package");
+  });
+
+  it("does not fire once the root README names it", async () => {
+    expect(
+      await checksFor({
+        "README.md": "# nextly\n\n| **@nextlyhq/thing** | does a thing |\n",
+        "packages/thing/package.json": pkg(),
+        "packages/thing/README.md": "# thing\n",
+      })
+    ).not.toContain("root-readme-lists-package");
+  });
+});
+
+describe("forbidden-status-phrase", () => {
+  it("fires on 'coming soon' in a published package README", async () => {
+    expect(
+      await checksFor({
+        "packages/thing/package.json": pkg(),
+        "packages/thing/README.md": "# thing\n\nComing soon in beta.\n",
+      })
+    ).toContain("forbidden-status-phrase");
+  });
+
+  it("fires on 'not ready for use' in a docs page", async () => {
+    expect(
+      await checksFor({ "docs/a.mdx": "Plugins are not ready for use yet.\n" })
+    ).toContain("forbidden-status-phrase");
+  });
+
+  it("does not fire inside a CHANGELOG, which is a historical record", async () => {
+    expect(
+      await checksFor({
+        "packages/thing/package.json": pkg(),
+        "packages/thing/README.md": "# thing\n",
+        "packages/thing/CHANGELOG.md": "Coming soon in beta.\n",
+      })
+    ).not.toContain("forbidden-status-phrase");
+  });
+
+  it("does not fire on an allowlisted line", async () => {
+    const root = await fixture({ "docs/a.mdx": "returns a coming soon placeholder\n" });
+    const { findings } = await runChecks({
+      repoRoot: root,
+      resolveRef: () => true,
+      allowlist: { "forbidden-status-phrase": { "docs/a.mdx": "accurate here" } },
+    });
+    expect(findings.map(f => f.check)).not.toContain("forbidden-status-phrase");
+  });
+});
+
+describe("naming-rule", () => {
+  it("fires on the bare phrase Visual Builder", async () => {
+    expect(await checksFor({ "docs/a.mdx": "The Visual Builder does things.\n" })).toContain(
+      "naming-rule"
+    );
+  });
+
+  it("does not fire on the two qualified forms", async () => {
+    expect(
+      await checksFor({
+        "docs/a.mdx": "The Visual Schema Builder and the Visual Page Builder.\n",
+      })
+    ).not.toContain("naming-rule");
+  });
+});
+
+describe("dead-branch-link", () => {
+  it("fires when a linked ref does not resolve", async () => {
+    const root = await fixture({
+      "docs/a.mdx": "https://github.com/nextlyhq/nextly/blob/dev/x.ts\n",
+    });
+    const { findings } = await runChecks({
+      repoRoot: root,
+      resolveRef: ref => ref === "main",
+    });
+    expect(findings.map(f => f.check)).toContain("dead-branch-link");
+  });
+
+  it("does not fire for a ref that resolves", async () => {
+    const root = await fixture({
+      "docs/a.mdx": "https://github.com/nextlyhq/nextly/blob/main/x.ts\n",
+    });
+    const { findings } = await runChecks({
+      repoRoot: root,
+      resolveRef: ref => ref === "main",
+    });
+    expect(findings.map(f => f.check)).not.toContain("dead-branch-link");
+  });
+
+  it("reports unverifiable rather than failing when refs cannot be resolved", async () => {
+    const root = await fixture({
+      "docs/a.mdx": "https://github.com/nextlyhq/nextly/blob/dev/x.ts\n",
+    });
+    const { findings, unverifiable } = await runChecks({
+      repoRoot: root,
+      resolveRef: () => null,
+    });
+    expect(findings.map(f => f.check)).not.toContain("dead-branch-link");
+    expect(unverifiable.length).toBeGreaterThan(0);
+  });
+});
+
+describe("meta-reachable", () => {
+  it("fires when an mdx page is unreachable from meta.json", async () => {
+    expect(
+      await checksFor({
+        "docs/meta.json": JSON.stringify({ pages: ["index"] }),
+        "docs/index.mdx": "# i\n",
+        "docs/orphan.mdx": "# o\n",
+      })
+    ).toContain("meta-reachable");
+  });
+
+  it("does not fire once the page is listed", async () => {
+    expect(
+      await checksFor({
+        "docs/meta.json": JSON.stringify({ pages: ["index", "orphan"] }),
+        "docs/index.mdx": "# i\n",
+        "docs/orphan.mdx": "# o\n",
+      })
+    ).not.toContain("meta-reachable");
+  });
+});

--- a/scripts/check-docs-claims.test.mjs
+++ b/scripts/check-docs-claims.test.mjs
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
 
-import { runChecks } from "./check-docs-claims.mjs";
+import { digestLine, runChecks, splitRefAndPath } from "./check-docs-claims.mjs";
 
 /**
  * Each fixture exhibits exactly one defect, and every check is asserted twice:
@@ -25,9 +25,16 @@ async function fixture(files) {
 const pkg = (extra = {}) =>
   JSON.stringify({ name: "@nextlyhq/thing", version: "0.0.2-alpha.62", ...extra });
 
-async function checksFor(files) {
+const REFS = new Set(["main", "feature/docs-refresh", "v1.2.3"]);
+
+async function checksFor(files, opts = {}) {
   const root = await fixture(files);
-  const { findings } = await runChecks({ repoRoot: root, resolveRef: () => true });
+  const { findings } = await runChecks({
+    repoRoot: root,
+    remoteRefs: REFS,
+    hasLocalCommit: () => true,
+    ...opts,
+  });
   return findings.map(f => f.check);
 }
 
@@ -94,13 +101,39 @@ describe("forbidden-status-phrase", () => {
   });
 
   it("does not fire on an allowlisted line", async () => {
-    const root = await fixture({ "docs/a.mdx": "returns a coming soon placeholder\n" });
+    const exempt = "returns a coming soon placeholder";
+    const root = await fixture({ "docs/a.mdx": `${exempt}\n` });
     const { findings } = await runChecks({
       repoRoot: root,
-      resolveRef: () => true,
-      allowlist: { "forbidden-status-phrase": { "docs/a.mdx": "accurate here" } },
+      remoteRefs: REFS,
+      hasLocalCommit: () => true,
+      allowlist: {
+        "forbidden-status-phrase": {
+          "docs/a.mdx": { count: 1, digests: [digestLine(exempt)] },
+        },
+      },
     });
     expect(findings.map(f => f.check)).not.toContain("forbidden-status-phrase");
+  });
+
+  it("still fires on a DIFFERENT claim in the same allowlisted file", async () => {
+    const exempt = "returns a coming soon placeholder";
+    const root = await fixture({
+      "docs/a.mdx": `${exempt}\nPlugins are not ready for use yet.\n`,
+    });
+    const { findings } = await runChecks({
+      repoRoot: root,
+      remoteRefs: REFS,
+      hasLocalCommit: () => true,
+      allowlist: {
+        "forbidden-status-phrase": {
+          "docs/a.mdx": { count: 1, digests: [digestLine(exempt)] },
+        },
+      },
+    });
+    const hits = findings.filter(f => f.check === "forbidden-status-phrase");
+    expect(hits).toHaveLength(1);
+    expect(hits[0].line).toBe(2);
   });
 });
 
@@ -122,37 +155,78 @@ describe("naming-rule", () => {
 
 describe("dead-branch-link", () => {
   it("fires when a linked ref does not resolve", async () => {
-    const root = await fixture({
-      "docs/a.mdx": "https://github.com/nextlyhq/nextly/blob/dev/x.ts\n",
-    });
-    const { findings } = await runChecks({
-      repoRoot: root,
-      resolveRef: ref => ref === "main",
-    });
-    expect(findings.map(f => f.check)).toContain("dead-branch-link");
+    expect(
+      await checksFor({ "docs/a.mdx": "https://github.com/nextlyhq/nextly/blob/dev/x.ts\n" })
+    ).toContain("dead-branch-link");
   });
 
   it("does not fire for a ref that resolves", async () => {
-    const root = await fixture({
-      "docs/a.mdx": "https://github.com/nextlyhq/nextly/blob/main/x.ts\n",
-    });
-    const { findings } = await runChecks({
-      repoRoot: root,
-      resolveRef: ref => ref === "main",
-    });
-    expect(findings.map(f => f.check)).not.toContain("dead-branch-link");
+    expect(
+      await checksFor({ "docs/a.mdx": "https://github.com/nextlyhq/nextly/blob/main/x.ts\n" })
+    ).not.toContain("dead-branch-link");
   });
 
-  it("reports unverifiable rather than failing when refs cannot be resolved", async () => {
+  it("accepts a ref containing slashes, which git permits", async () => {
+    expect(
+      await checksFor({
+        "docs/a.mdx":
+          "https://github.com/nextlyhq/nextly/blob/feature/docs-refresh/docs/x.mdx\n",
+      })
+    ).not.toContain("dead-branch-link");
+  });
+
+  it("still fires on a dead multi-segment ref", async () => {
+    expect(
+      await checksFor({
+        "docs/a.mdx": "https://github.com/nextlyhq/nextly/blob/feature/gone/docs/x.mdx\n",
+      })
+    ).toContain("dead-branch-link");
+  });
+
+  it("reports a pinned commit the clone does not hold as unverifiable, not dead", async () => {
+    const root = await fixture({
+      "docs/a.mdx": "https://github.com/nextlyhq/nextly/blob/deadbeef/missing.md\n",
+    });
+    const { findings, unverifiable } = await runChecks({
+      repoRoot: root,
+      remoteRefs: REFS,
+      hasLocalCommit: () => false,
+    });
+    expect(findings.map(f => f.check)).not.toContain("dead-branch-link");
+    expect(unverifiable.some(u => u.ref === "deadbeef")).toBe(true);
+  });
+
+  it("accepts a pinned commit the clone does hold", async () => {
+    const root = await fixture({
+      "docs/a.mdx": "https://github.com/nextlyhq/nextly/blob/deadbeef/x.md\n",
+    });
+    const { findings, unverifiable } = await runChecks({
+      repoRoot: root,
+      remoteRefs: REFS,
+      hasLocalCommit: () => true,
+    });
+    expect(findings.map(f => f.check)).not.toContain("dead-branch-link");
+    expect(unverifiable).toHaveLength(0);
+  });
+
+  it("reports unverifiable rather than failing when the remote is unreachable", async () => {
     const root = await fixture({
       "docs/a.mdx": "https://github.com/nextlyhq/nextly/blob/dev/x.ts\n",
     });
     const { findings, unverifiable } = await runChecks({
       repoRoot: root,
-      resolveRef: () => null,
+      remoteRefs: null,
+      hasLocalCommit: () => false,
     });
     expect(findings.map(f => f.check)).not.toContain("dead-branch-link");
     expect(unverifiable.length).toBeGreaterThan(0);
+  });
+
+  it("resolves the longest matching ref prefix, not the first segment", () => {
+    expect(splitRefAndPath("feature/docs-refresh/docs/x.mdx", REFS)).toEqual({
+      ref: "feature/docs-refresh",
+      resolved: true,
+    });
   });
 });
 
@@ -175,5 +249,34 @@ describe("meta-reachable", () => {
         "docs/orphan.mdx": "# o\n",
       })
     ).not.toContain("meta-reachable");
+  });
+});
+
+describe("unreadable metadata", () => {
+  it("fires on a meta.json that will not parse", async () => {
+    expect(
+      await checksFor({ "docs/meta.json": "{ not json", "docs/a.mdx": "# a\n" })
+    ).toContain("unreadable-meta");
+  });
+
+  it("fires on a package.json that will not parse", async () => {
+    expect(await checksFor({ "packages/thing/package.json": "{ nope" })).toContain(
+      "unreadable-manifest"
+    );
+  });
+});
+
+describe("root-readme-present", () => {
+  it("fires when published packages exist but the root README does not", async () => {
+    expect(
+      await checksFor({
+        "packages/thing/package.json": pkg(),
+        "packages/thing/README.md": "# thing\n",
+      })
+    ).toContain("root-readme-present");
+  });
+
+  it("does not fire when there are no published packages", async () => {
+    expect(await checksFor({ "docs/a.mdx": "# a\n" })).not.toContain("root-readme-present");
   });
 });

--- a/scripts/docs-claims-allowlist.json
+++ b/scripts/docs-claims-allowlist.json
@@ -1,5 +1,9 @@
 {
   "forbidden-status-phrase": {
-    "docs/api-reference/rest-api.mdx": "Accurate. The image-size regeneration sub-routes genuinely return a placeholder: packages/nextly/src/routeHandler.ts returns { message: \"Batch regeneration coming soon\" } for regenerationStatus and regenerate. Remove this entry when those routes do the work."
+    "docs/api-reference/rest-api.mdx": {
+      "count": 1,
+      "digests": ["eceb86bd05632f29"],
+      "reason": "Accurate. packages/nextly/src/routeHandler.ts returns { message: \"Batch regeneration coming soon\" } for the image-size regenerationStatus and regenerate sub-routes. Remove this entry when those routes do the work."
+    }
   }
 }

--- a/scripts/docs-claims-allowlist.json
+++ b/scripts/docs-claims-allowlist.json
@@ -1,0 +1,5 @@
+{
+  "forbidden-status-phrase": {
+    "docs/api-reference/rest-api.mdx": "Accurate. The image-size regeneration sub-routes genuinely return a placeholder: packages/nextly/src/routeHandler.ts returns { message: \"Batch regeneration coming soon\" } for regenerationStatus and regenerate. Remove this entry when those routes do the work."
+  }
+}


### PR DESCRIPTION
## Summary

The monorepo understated the product in the places a technical evaluator reads first, and one workflow meant docs fixes never reached the website at all. First of three PRs in the G6 group (monorepo docs + package READMEs).

**What was wrong, all measured on `cabf1ba5f`:**

| Defect | Evidence |
|---|---|
| `packages/plugin-form-builder/README.md` told readers *"Plugins are not ready for use yet… Do not rely on plugins for production or serious development work"* | This is the text npm renders on the package page. Three plugins are published at `0.0.2-alpha.62` |
| Root README headed a section **"Plugins (coming soon, beta)"** listing one plugin | `plugin-page-builder`, `plugin-seo`, `plugin-form-builder` all ship |
| Root README named **11 of 20** published packages | The nine missing included the entire page-builder stack (`blocks-engine`, `blocks-react`, `builder`, `plugin-page-builder`) and `plugin-sdk` |
| `@nextlyhq/admin-css` published with **no README** | Blank npm page |
| **The docs deploy hook has never fired** | `trigger-docs-deploy.yml` filtered `docs/content/**`. `git log -- docs/content/` returns **0** commits ever; `git log -- docs/` returns **64** |
| 4 links to branch `dev` | `git ls-remote --heads origin dev` returns 0 rows. Control: 26 `blob/main` links, and `main` resolves |
| 9 bare uses of "Visual Builder" | Against 67 "Visual Schema Builder". "Visual Page Builder" appeared **once** in the whole repository |
| 2 source comments told plugin authors dashboard widgets do not render | `plugin-sdk/src/index.ts` and `src/admin.ts` said "reserved, not rendered" / "until M8". `docs/plugins/stability.mdx:54` says rendered, and `registerWidget` appears in 52 files |

## The guard

`scripts/check-docs-claims.mjs` (`pnpm check:docs-claims`, wired into CI beside `check:comments`) makes these permanent. It follows the repository's existing convention for this kind of rule: `agents-md-scopes-agree.test.mjs`, `node-range-agrees.test.mjs`, `check-comment-convention.mjs`.

Six checks: published package with no README; published package missing from the root README; a status phrase claiming a shipped thing is unavailable; bare "Visual Builder"; a link to a git ref that does not resolve; an `.mdx` unreachable from `meta.json`.

Two design points worth review:

- **The ref check resolves the ref rather than matching a name.** Checking for the literal string `dev` catches today's four links and nothing else; the real failure is "a ref we link to stopped existing", which will recur under a different name. It uses `git ls-remote` rather than `rev-parse` because CI clones shallow, and reports *unverifiable* rather than *failing* when the remote is unreachable — a check that goes red on a correct tree teaches people to wave reds through.
- **The status-phrase check reads prose only.** A "Coming soon" badge in admin UI or an API placeholder string is a fact about the running product, not a claim about what the project ships. Scoping it to source produced 18 false positives.

## Test plan

- `pnpm vitest run --dir scripts check-docs-claims` — **15 passed**. Every check is asserted twice: once on a tree exhibiting the defect, once on the nearest tree without it. Seven of the fifteen are negative controls.
- `pnpm test:scripts` — **26 files, 710 tests passed**.
- `pnpm check:comments` — passes; 402 pre-existing allowlisted offences, **zero new**.
- Full `pnpm turbo lint` + `build` + `test` via the pre-push hook — passed, no bypass.
- **The guard reports 27 findings on `cabf1ba5f` and 0 on this branch.** The breakdown matches the manual audit exactly: 9 naming-rule, 9 root-readme-lists-package, 4 dead-branch-link, 4 forbidden-status-phrase, 1 readme-present.
- `packages/admin-css/README.md` documents 9 exports, verified by importing the real module and comparing against `Object.keys`. Its usage snippet was **executed**, which caught two errors in my first draft: `checkAdminStyles` returns an issues array rather than throwing, and takes `{ css }` rather than a bare string.

## Changeset

Added: **patch**, covering the eight published packages whose README or shipped source text changed.

## Pre-existing issues, not regressions

- `pnpm lint` on a **fresh worktree** reports `import-x/no-unresolved` for `@nextlyhq/ui` and a false `no-unused-vars` for `DrizzleAdapter` (used at `db-sync-demote.ts:69`). Both disappear after `pnpm build`, because eslint resolves workspace packages through their built `dist`. Not introduced here, but worth knowing before someone reads a fresh-clone lint run as a regression.
- `docs/api-reference/rest-api.mdx:581` says "coming soon" and is **correct** — `routeHandler.ts:1116` genuinely returns `{ message: "Batch regeneration coming soon" }`. It is allowlisted with that reason recorded in the file, to be removed when those routes do the work.

## Deliberately not in this PR

The docs IA restructure and the 13 new capability sections (PR 2), and the remaining package READMEs (PR 3). Wording here uses only the category words already settled in the positioning document; anything the GTM work could still move stays out.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README with clearer descriptions of Nextly’s platform capabilities, packages, plugins, SDKs, and tooling.
  - Added documentation for the admin CSS package, including installation, usage, exports, and build guidance.
  - Improved plugin documentation with clearer builder terminology, stability information, and production version-pinning guidance.
  - Updated API reference links to point to the main source branch.
  - Added automated checks to help keep documentation claims, links, package listings, and metadata accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->