### PR TITLE
fix(blocks-engine): free a slot's replacements before composing its siblings

### DIFF
--- a/.changeset/two-regions-fit-in-either-order.md
+++ b/.changeset/two-regions-fit-in-either-order.md
@@ -1,0 +1,34 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Whether a page fits its block limit no longer depends on the order its regions
+were set up in. When a component offers two regions and a page fills one with
+something larger and one with something smaller, the page was accepted or
+refused according to which region the component's author happened to declare
+first — the smaller content hands back the room the larger one needs, and that
+room was only arriving after it had already been asked for.

--- a/packages/blocks-engine/src/resolve-instances.test.ts
+++ b/packages/blocks-engine/src/resolve-instances.test.ts
@@ -1050,6 +1050,141 @@ describe("resolveComponentInstances what an instance carries", () => {
     expect(result.referenced).toEqual(["hero", "empty"]);
   });
 
+  it("does not let the order two slots are declared in decide whether a page fits", () => {
+    // One node exposes two slots. The page fills one with a component that
+    // GROWS — a single instance becoming four nodes — and the other with three
+    // instances of an empty component, which SHRINK to nothing and hand back
+    // the nodes they occupied. The composed document is five nodes and fits.
+    //
+    // Composed in declaration order, the growing slot spends the room before
+    // the shrinking ones release it, and the instance is refused for `budget`
+    // — so whether a page renders depends on the order an author happened to
+    // declare two independent slots in.
+    const definition = component([box("t", [])], {
+      slots: {
+        grow: { label: "Grow", nodeId: "t", slot: "a" },
+        shrink: { label: "Shrink", nodeId: "t", slot: "b" },
+      },
+    });
+    const doc = page([
+      instance(
+        "i1",
+        "hero",
+        {},
+        {
+          slots: {
+            grow: [instance("g", "big")],
+            shrink: [
+              instance("e1", "empty"),
+              instance("e2", "empty"),
+              instance("e3", "empty"),
+            ],
+          },
+        }
+      ),
+    ]);
+
+    const result = resolveComponentInstances(
+      doc,
+      defs({
+        hero: definition,
+        big: component([node("b1"), node("b2"), node("b3"), node("b4")]),
+        empty: component([]),
+      }),
+      { limits: { ...DEFAULT_LIMITS, maxNodes: 6 } }
+    );
+
+    expect(result.unresolved).toEqual([]);
+  });
+
+  it("takes the loan back, so it cannot pay for a LATER instance", () => {
+    // The loan is for the slot content that earns it and for nothing else. Not
+    // repaying leaves the budget permanently inflated, which is invisible on
+    // the instance that borrowed — it spends what it was owed — and shows up
+    // on the NEXT one, which composes on room that was never released.
+    const definition = component([box("t", [])], {
+      slots: { hole: { label: "Hole", nodeId: "t", slot: "a" } },
+    });
+    const doc = page([
+      instance("i1", "hero", {}, { slots: { hole: [instance("e", "empty")] } }),
+      instance("i2", "big"),
+    ]);
+
+    const result = resolveComponentInstances(
+      doc,
+      defs({
+        hero: definition,
+        empty: component([]),
+        // One node more than the room left after the first instance settles.
+        big: component([
+          node("b1"),
+          node("b2"),
+          node("b3"),
+          node("b4"),
+          node("b5"),
+          node("b6"),
+        ]),
+      }),
+      { limits: { ...DEFAULT_LIMITS, maxNodes: 6 } }
+    );
+
+    expect(result.unresolved).toEqual([
+      { instanceId: "i2", componentId: "big", reason: "budget" },
+    ]);
+  });
+
+  it("CONTROL: still refuses a page whose composed tree does not fit", () => {
+    // The loan changes WHEN room is available, never how much. Same shape as
+    // the case above with a definition twice the size, so the three empty
+    // components cannot pay for it however early they are credited — without
+    // this the rule above passes on an implementation that simply hands out
+    // budget, which is the cap gone.
+    const definition = component([box("t", [])], {
+      slots: {
+        grow: { label: "Grow", nodeId: "t", slot: "a" },
+        shrink: { label: "Shrink", nodeId: "t", slot: "b" },
+      },
+    });
+    const doc = page([
+      instance(
+        "i1",
+        "hero",
+        {},
+        {
+          slots: {
+            grow: [instance("g", "big")],
+            shrink: [
+              instance("e1", "empty"),
+              instance("e2", "empty"),
+              instance("e3", "empty"),
+            ],
+          },
+        }
+      ),
+    ]);
+
+    const result = resolveComponentInstances(
+      doc,
+      defs({
+        hero: definition,
+        big: component([
+          node("b1"),
+          node("b2"),
+          node("b3"),
+          node("b4"),
+          node("b5"),
+          node("b6"),
+          node("b7"),
+          node("b8"),
+        ]),
+        empty: component([]),
+      }),
+      { limits: { ...DEFAULT_LIMITS, maxNodes: 6 } }
+    );
+
+    expect(result.unresolved.map(e => e.reason)).toEqual(["budget"]);
+  });
+
   it("does not compose content bound for a default subtree the page replaced", () => {
     // Two exposed slots: one on a container, one on a node sitting inside that
     // container's DEFAULT children. Filling the outer slot replaces those

--- a/packages/blocks-engine/src/resolve-instances.ts
+++ b/packages/blocks-engine/src/resolve-instances.ts
@@ -1572,7 +1572,47 @@ function composePlannedFor(
   ctx: InlineContext
 ): void {
   if (plan?.slots === undefined) return;
+  // Lent before anything is composed, and taken back after. Every instance in
+  // this content is about to be REPLACED, and each replacement hands back the
+  // node it occupied — but that credit arrives as the instance expands, so a
+  // slot composed early spends room a later sibling has not released yet.
+  // Whether a page fits then depends on the order its author happened to
+  // declare two independent slots in, which is not a decision anybody made.
+  //
+  // The loan changes only WHEN room is available, never how much: each
+  // expansion still credits its own node as it goes, and subtracting the same
+  // figure afterwards leaves the budget exactly where crediting alone would
+  // have left it. Content that is never placed earns nothing and repays
+  // nothing, which is the same no-op.
+  const lent = plannedReplacements(plan, ctx.run.maxNodes);
+  ctx.run.budget += lent;
   for (const content of plan.slots.values()) placedContent(content, ctx);
+  ctx.run.budget -= lent;
+}
+
+/**
+ * How many nodes this node's uncomposed planned content will hand back.
+ *
+ * One per component instance in it, because that is what replacing an instance
+ * frees: the node it occupied, already charged to the page by the host survey.
+ * Content that has been composed already is skipped — its credits are spent.
+ *
+ * Bounded like every other walk of stored content, because this is the page's
+ * own tree and nothing here validated it.
+ */
+function plannedReplacements(plan: NodePlan, maxNodes: number): number {
+  let count = 0;
+  let budget = maxNodes;
+  for (const content of plan.slots?.values() ?? []) {
+    if (content.composed) continue;
+    walkForest(content.nodes, entry => {
+      if (budget <= 0) return "stop";
+      budget -= 1;
+      if (componentIdOf(entry.node) !== undefined) count += 1;
+      return "descend";
+    });
+  }
+  return count;
 }
 
 /**


### PR DESCRIPTION
Takes `task:pb6-slot-budget-order-independence`, filed from #1526 where I measured it as **pre-existing rather than a regression** — the parent implementation is refused on the same input, so this is a property of the budget rather than something the deferred-composition work introduced.

## The defect

A node exposing two slots composes them in declaration order, and each planned instance hands back the node it occupied only *as it expands*. So a slot filled with content that GROWS spends room a sibling filled with content that SHRINKS has not released yet.

Measured: one node, two slots, one filled with a component that becomes four nodes and one with three instances of an empty component. The composed document is five nodes and fits at `maxNodes: 6`. Declared grow-then-shrink it is refused for `budget`; declared the other way it composes. **Whether a page renders depended on the order an author happened to declare two independent slots in**, which is not a decision anybody made.

## The fix

Lend the room the replacements are about to free, before any of them compose, and take the loan back after.

It changes **when** room is available and never how much. Each expansion still credits its own node as it goes, so subtracting the same figure afterwards leaves the budget exactly where crediting alone would have left it; content that is never placed earns nothing and repays nothing, which is the same no-op. The final document size is therefore unchanged — only the point at which a refusal triggers moves.

## Both halves are pinned, and the second one was not at first

- Removing the loan restores the ordering dependence — that test failed before the fix and fails on the mutation.
- **Keeping the loan and never repaying it killed nothing.** An unrepaid loan is invisible on the instance that borrowed, because it spends exactly what it is owed; it shows up on the NEXT instance, which composes on room that was never released. There is now a test for that: an instance with slot content followed by a sibling whose definition is one node too large. Repaid it is refused for `budget`; unrepaid it composes.
- A control asserts an oversized page is still refused, so neither rule passes on an implementation that simply hands out budget.

## Gates

`build` 0 · `check-types` 0 · `lint` 0 · `check:comments` 0 · `fallow` **pass**, 0 introduced · `changeset status` 0, 25 packages.

blocks-engine 1902 (+3) · blocks-react 1151.