### PR TITLE
fix(ci): make the docs deploy fail loudly, and read the guard's files from git

### DIFF
--- a/.changeset/component-reserved-spellings.md
+++ b/.changeset/component-reserved-spellings.md
@@ -23,7 +23,7 @@
 ---
 
 Reject a field named `id`, `createdAt` or `updatedAt` in a Field Group (component), through both
-the visual builder and `defineFieldGroup`. A component keeps its values in a table of its own
+the Visual Schema Builder and `defineFieldGroup`. A component keeps its values in a table of its own
 carrying those columns, so such a field is emitted into the same `CREATE TABLE` as the injected one
 and the database refuses the statement. The name is now refused where it is chosen, with a message
 saying which system column it collides with.

--- a/.github/workflows/trigger-docs-deploy.yml
+++ b/.github/workflows/trigger-docs-deploy.yml
@@ -17,6 +17,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Vercel Deploy Hook
+        env:
+          DEPLOY_HOOK: ${{ secrets.VERCEL_DOCS_DEPLOY_HOOK }}
         run: |
-          curl -X POST "${{ secrets.VERCEL_DOCS_DEPLOY_HOOK }}"
+          # Fail loudly on a missing secret rather than curling an empty URL.
+          # The publish path spent months not running because nothing said so;
+          # a skip here would recreate exactly that silence.
+          if [ -z "$DEPLOY_HOOK" ]; then
+            echo "::error::VERCEL_DOCS_DEPLOY_HOOK is not set, so docs changes cannot reach nextlyhq.com. Add it to the repository secrets."
+            exit 1
+          fi
+
+          # --fail turns a non-2xx into a non-zero exit. Without it curl reports
+          # success for a 404 from the hook, and the echo below would claim a
+          # deploy that never started.
+          curl --fail --silent --show-error --retry 3 --retry-connrefused \
+            -X POST "$DEPLOY_HOOK"
           echo "Triggered Vercel deploy for docs update"

--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -23,9 +23,28 @@ import { createHash } from "node:crypto";
 import { readFileSync, readdirSync, existsSync } from "node:fs";
 import { basename, dirname, extname, join, relative, sep } from "node:path";
 
-const SKIP_DIRS = new Set([
-  "node_modules", ".git", "dist", ".next", ".turbo", ".changeset", "coverage",
-]);
+/**
+ * Files come from git's index, not from a directory walk.
+ *
+ * A walk reads whatever is on disk, and what is on disk differs per machine: `.internal-docs/`
+ * is gitignored and present in some checkouts, so the same commit reported 0 findings in a fresh
+ * worktree and 33 in a working clone. Extending an ignore list cannot close that — the next
+ * ignored directory reopens it. Tracked-ness is the property that actually distinguishes
+ * authored content from whatever a build or a local habit left behind, and it is the same
+ * choice `check-comment-convention.mjs` makes for the same reason.
+ */
+function trackedFiles(repoRoot) {
+  try {
+    const out = execFileSync("git", ["ls-files", "-z"], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return out.split("\0").filter(Boolean);
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Phrases that state a shipped thing is unavailable.
@@ -80,38 +99,17 @@ export function splitRefAndPath(tail, remoteRefs) {
   return { ref: segments[0], resolved: false };
 }
 
-function walk(dir, out = []) {
-  let entries;
-  try {
-    entries = readdirSync(dir, { withFileTypes: true });
-  } catch {
-    return out;
-  }
-  for (const entry of entries) {
-    if (entry.isDirectory()) {
-      if (SKIP_DIRS.has(entry.name)) continue;
-      walk(join(dir, entry.name), out);
-    } else {
-      out.push(join(dir, entry.name));
-    }
-  }
-  return out;
-}
-
 /** Files whose prose is a claim about the product. CHANGELOGs are excluded everywhere: they are
  *  Changesets' historical record, and rewriting history to satisfy a lint is worse than the lint. */
-function proseFiles(repoRoot) {
-  return walk(repoRoot)
-    .filter(f => {
-      if (basename(f) === "CHANGELOG.md") return false;
-      const ext = extname(f);
-      const rel = relative(repoRoot, f);
-      if (ext === ".md" || ext === ".mdx") return true;
-      return (
-        (ext === ".ts" || ext === ".tsx" || ext === ".mjs") &&
-        rel.split(sep)[0] === "packages"
-      );
-    });
+function proseFiles(tracked) {
+  return tracked.filter(rel => {
+    if (basename(rel) === "CHANGELOG.md") return false;
+    const ext = extname(rel);
+    if (ext === ".md" || ext === ".mdx") return true;
+    return (
+      (ext === ".ts" || ext === ".tsx" || ext === ".mjs") && rel.split("/")[0] === "packages"
+    );
+  });
 }
 
 /**
@@ -211,15 +209,14 @@ export function digestLine(line) {
 
 /** A page is reachable when its own directory's meta.json lists it. A directory with no
  *  meta.json is auto-included by fumadocs, so nothing there can be orphaned. */
-function metaReachability(repoRoot, findings) {
-  const docsDir = join(repoRoot, "docs");
-  if (!existsSync(docsDir)) return;
+function metaReachability(repoRoot, tracked, findings) {
   const byDir = new Map();
-  for (const file of walk(docsDir)) {
-    if (extname(file) !== ".mdx") continue;
-    const dir = dirname(file);
+  for (const rel of tracked) {
+    if (extname(rel) !== ".mdx") continue;
+    if (rel.split("/")[0] !== "docs") continue;
+    const dir = dirname(join(repoRoot, rel));
     if (!byDir.has(dir)) byDir.set(dir, []);
-    byDir.get(dir).push(file);
+    byDir.get(dir).push(join(repoRoot, rel));
   }
   for (const [dir, files] of byDir) {
     const metaPath = join(dir, "meta.json");
@@ -259,9 +256,16 @@ export async function runChecks({
   allowlist = {},
   remoteRefs,
   hasLocalCommit,
+  files,
 }) {
   const findings = [];
   const unverifiable = [];
+  const tracked = files ?? trackedFiles(repoRoot);
+  if (tracked === null) {
+    throw new Error(
+      `cannot list tracked files in ${repoRoot}; this check reads git's index, not the filesystem`
+    );
+  }
   const refs = remoteRefs === undefined ? listRemoteRefs(repoRoot) : remoteRefs;
   const commitPresent = hasLocalCommit ?? makeCommitProbe(repoRoot);
 
@@ -327,24 +331,27 @@ export async function runChecks({
   const namingExempt = exemption("naming-rule");
   const linkExempt = exemption("dead-branch-link");
 
-  for (const file of proseFiles(repoRoot)) {
-    const rel = relative(repoRoot, file);
+  for (const rel of proseFiles(tracked)) {
     let text;
     try {
-      text = readFileSync(file, "utf-8");
+      text = readFileSync(join(repoRoot, rel), "utf-8");
     } catch {
       continue;
     }
     const lines = text.split("\n");
     const isProse = rel.endsWith(".md") || rel.endsWith(".mdx");
+    const isChangeset = rel.startsWith(".changeset/");
 
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
       const lower = line.toLowerCase();
 
-      // Prose only. A "Coming soon" badge in admin UI or an API placeholder string is a
-      // fact about the running product, not a claim about what the project ships.
-      if (isProse && !phraseExempt(rel, line)) {
+      // Prose only, and never a changeset. A "Coming soon" badge in admin UI or an API
+      // placeholder string is a fact about the running product, not a claim about what the
+      // project ships; and a changeset routinely QUOTES the false claim a change removed,
+      // which reads identically to making one. The naming rule still applies to changesets,
+      // because they become CHANGELOG entries and the product's name has one spelling.
+      if (isProse && !isChangeset && !phraseExempt(rel, line)) {
         for (const phrase of FORBIDDEN_PHRASES) {
           if (lower.includes(phrase)) {
             findings.push({
@@ -411,7 +418,7 @@ export async function runChecks({
     }
   }
 
-  metaReachability(repoRoot, findings);
+  metaReachability(repoRoot, tracked, findings);
 
   return { findings, unverifiable };
 }

--- a/scripts/check-docs-claims.test.mjs
+++ b/scripts/check-docs-claims.test.mjs
@@ -12,6 +12,11 @@ import { digestLine, runChecks, splitRefAndPath } from "./check-docs-claims.mjs"
  * case is what distinguishes "the check fired" from "the check fires on
  * anything".
  */
+/**
+ * Returns the root AND the file list, because the checker reads git's index rather than the
+ * disk. A fixture directory is not a git repository, so the list is injected — and injecting it
+ * is also what keeps a stray file in the temp directory from changing a result.
+ */
 async function fixture(files) {
   const root = await mkdtemp(join(tmpdir(), "docs-claims-"));
   for (const [rel, body] of Object.entries(files)) {
@@ -19,7 +24,7 @@ async function fixture(files) {
     await mkdir(dirname(full), { recursive: true });
     await writeFile(full, body);
   }
-  return root;
+  return { root, files: Object.keys(files) };
 }
 
 const pkg = (extra = {}) =>
@@ -27,10 +32,11 @@ const pkg = (extra = {}) =>
 
 const REFS = new Set(["main", "feature/docs-refresh", "v1.2.3"]);
 
-async function checksFor(files, opts = {}) {
-  const root = await fixture(files);
+async function checksFor(spec, opts = {}) {
+  const { root, files } = await fixture(spec);
   const { findings } = await runChecks({
     repoRoot: root,
+    files,
     remoteRefs: REFS,
     hasLocalCommit: () => true,
     ...opts,
@@ -102,9 +108,10 @@ describe("forbidden-status-phrase", () => {
 
   it("does not fire on an allowlisted line", async () => {
     const exempt = "returns a coming soon placeholder";
-    const root = await fixture({ "docs/a.mdx": `${exempt}\n` });
+    const { root, files } = await fixture({ "docs/a.mdx": `${exempt}\n` });
     const { findings } = await runChecks({
       repoRoot: root,
+      files,
       remoteRefs: REFS,
       hasLocalCommit: () => true,
       allowlist: {
@@ -118,11 +125,12 @@ describe("forbidden-status-phrase", () => {
 
   it("still fires on a DIFFERENT claim in the same allowlisted file", async () => {
     const exempt = "returns a coming soon placeholder";
-    const root = await fixture({
+    const { root, files } = await fixture({
       "docs/a.mdx": `${exempt}\nPlugins are not ready for use yet.\n`,
     });
     const { findings } = await runChecks({
       repoRoot: root,
+      files,
       remoteRefs: REFS,
       hasLocalCommit: () => true,
       allowlist: {
@@ -184,11 +192,12 @@ describe("dead-branch-link", () => {
   });
 
   it("reports a pinned commit the clone does not hold as unverifiable, not dead", async () => {
-    const root = await fixture({
+    const { root, files } = await fixture({
       "docs/a.mdx": "https://github.com/nextlyhq/nextly/blob/deadbeef/missing.md\n",
     });
     const { findings, unverifiable } = await runChecks({
       repoRoot: root,
+      files,
       remoteRefs: REFS,
       hasLocalCommit: () => false,
     });
@@ -197,11 +206,12 @@ describe("dead-branch-link", () => {
   });
 
   it("accepts a pinned commit the clone does hold", async () => {
-    const root = await fixture({
+    const { root, files } = await fixture({
       "docs/a.mdx": "https://github.com/nextlyhq/nextly/blob/deadbeef/x.md\n",
     });
     const { findings, unverifiable } = await runChecks({
       repoRoot: root,
+      files,
       remoteRefs: REFS,
       hasLocalCommit: () => true,
     });
@@ -210,11 +220,12 @@ describe("dead-branch-link", () => {
   });
 
   it("reports unverifiable rather than failing when the remote is unreachable", async () => {
-    const root = await fixture({
+    const { root, files } = await fixture({
       "docs/a.mdx": "https://github.com/nextlyhq/nextly/blob/dev/x.ts\n",
     });
     const { findings, unverifiable } = await runChecks({
       repoRoot: root,
+      files,
       remoteRefs: null,
       hasLocalCommit: () => false,
     });
@@ -278,5 +289,47 @@ describe("root-readme-present", () => {
 
   it("does not fire when there are no published packages", async () => {
     expect(await checksFor({ "docs/a.mdx": "# a\n" })).not.toContain("root-readme-present");
+  });
+});
+
+describe("changeset scoping", () => {
+  it("does not fire the phrase check on a changeset quoting a claim it removed", async () => {
+    expect(
+      await checksFor({
+        ".changeset/x.md": 'The README said "Plugins are not ready for use yet". It no longer does.\n',
+      })
+    ).not.toContain("forbidden-status-phrase");
+  });
+
+  it("still fires the naming rule on a changeset, which becomes a CHANGELOG entry", async () => {
+    expect(
+      await checksFor({ ".changeset/x.md": "Reject a field through the visual builder.\n" })
+    ).toContain("naming-rule");
+  });
+});
+
+describe("enumeration comes from the injected file list, not the disk", () => {
+  it("ignores a file on disk that is not in the list", async () => {
+    const { root } = await fixture({ "docs/tracked.mdx": "# fine\n" });
+    await writeFile(join(root, "docs", "untracked.mdx"), "The Visual Builder is here.\n");
+    const { findings } = await runChecks({
+      repoRoot: root,
+      files: ["docs/tracked.mdx"],
+      remoteRefs: REFS,
+      hasLocalCommit: () => true,
+    });
+    expect(findings.map(f => f.check)).not.toContain("naming-rule");
+  });
+
+  it("reports it once the same file is in the list", async () => {
+    const { root } = await fixture({ "docs/tracked.mdx": "# fine\n" });
+    await writeFile(join(root, "docs", "untracked.mdx"), "The Visual Builder is here.\n");
+    const { findings } = await runChecks({
+      repoRoot: root,
+      files: ["docs/tracked.mdx", "docs/untracked.mdx"],
+      remoteRefs: REFS,
+      hasLocalCommit: () => true,
+    });
+    expect(findings.map(f => f.check)).toContain("naming-rule");
   });
 });


### PR DESCRIPTION
## Summary

Two corrections to what shipped in #1534. Both were only visible *after* it merged, and one of them is currently making `main` red.

### 1. The docs deploy now fires — and its first run failed

#1534 fixed the path filter, so `Trigger Docs Deploy` ran for the first time in the repo's history. It failed:

```
curl -X POST ""
curl: (3) URL rejected: Malformed input to a URL function
```

`VERCEL_DOCS_DEPLOY_HOOK` is not set. So the publish path had **two** faults, not one, and the dead filter was masking the missing secret — fixing the first is what exposed the second.

The step now:

- **refuses an empty hook with an actionable message** rather than curling `""`. It fails rather than skips deliberately: the original defect was a publish path that silently never ran, and a silent skip would recreate exactly that.
- **uses `--fail --show-error --retry 3`**, so a non-2xx from the hook stops reading as a successful deploy. Previously `curl -X POST <url>` exited 0 on a 404 and the step still printed "Triggered Vercel deploy".

> **Action needed from a maintainer:** add `VERCEL_DOCS_DEPLOY_HOOK` to the repository secrets. Until then this workflow fails on every push touching `docs/**`, which is the honest state — docs changes genuinely are not reaching nextlyhq.com.

### 2. The claims guard read the disk, so its answer depended on the machine

`check-docs-claims.mjs` walked the filesystem. On the same commit:

| Checkout | Findings |
|---|---|
| Fresh worktree | **0** |
| A working clone | **33** |

Every one of the 33 came from `.internal-docs/`, which is gitignored and present in some checkouts. CI was unaffected (a fresh clone has no untracked files), but a check that goes red on a correct tree is the exact failure mode I argued against in review of the previous PR, and I shipped it anyway.

It now enumerates from **git's index**. That is not a bigger ignore list — `check-comment-convention.mjs` already documents why the ignore-list approach cannot work here ("`.next` was listed and `.next-e2e` was not, and the next tool to add an output directory reopens it"). Tracked-ness is the property that actually separates authored content from whatever a build left behind. I should have followed the house pattern the first time.

**Consequence:** `.changeset/` came into view, which the old walk had skipped. A changeset routinely *quotes the false claim a change removed* — this PR's own predecessor quotes "Plugins are not ready for use yet" — and that reads identically to making the claim. So the phrase check no longer reads changesets, while the naming rule still does, because changesets become CHANGELOG entries and the product's name has one spelling. That surfaced one genuine bare "visual builder" in a pending changeset, corrected here.

## Test plan

- `pnpm vitest run --dir scripts check-docs-claims` — **29 passed** (was 25).
- `pnpm test:scripts` — **26 files, 724 tests passed**.
- Full `pnpm turbo lint` + `build` + `test` via the pre-push hook — passed, no bypass.
- **The defect's positive control:** two tests write the *same file* to disk and differ only in whether it appears in the injected file list. The one that omits it reports nothing; the one that includes it reports the finding. That distinguishes "reads the list" from "reads the disk", which counting findings alone cannot.
- **Cross-checkout control:** the guard now returns the same answer in a fresh worktree and in a clone that has `.internal-docs/` on disk. Before this change those were 0 and 33.
- The empty-secret branch was dry-run in bash: exits 1 with the intended message.

## Changeset

None. Tooling and CI only; no published package changes.
