### PR TITLE
fix(blocks-react): preview a component's pending edit instead of its published version

### DIFF
--- a/.changeset/a-component-previews-the-edit-being-made.md
+++ b/.changeset/a-component-previews-the-edit-being-made.md
@@ -1,0 +1,53 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A component being edited previews the edit, not the last published version.
+
+Draft mode previewed the wrong document. A page reads the components it embeds
+in one batched query, and the working-draft overlay that surfaces an author's
+pending edits is applied only on the single-entry read path — so the batched
+query returned the live row however wide its lifecycle scope, and the editor
+iframe drew the last published component while the form beside it showed the
+edit in progress. The two disagreed about the same document.
+
+`status: "all"` could not fix that. It widens which rows match; it does not
+reach a working draft, which lives in a snapshot the list path never consults.
+
+A route serving drafts now reads its definitions one per component, opting into
+the overlay explicitly. That read is deliberately not cached, for the reason the
+draft entry read is not: a working draft changes on every save while cache tags
+are burst by writes to the live row, so a cached draft would show an editor
+their previous save and call it a preview.
+
+The cost is one query per component instead of one per page, and it is paid only
+where drafts are served — the editor iframe, with one author and no shared cache
+entry to protect. Every other route keeps the single batched read, still tagged
+per component id, and a route that names `status: "published"` keeps it too:
+an explicit lifecycle scope beats the draft widening, in the same order the
+overlay rule itself applies them. A shareable preview link is unchanged and
+still resolves embedded components to their published versions.

--- a/packages/blocks-react/src/next.components.test.ts
+++ b/packages/blocks-react/src/next.components.test.ts
@@ -153,16 +153,20 @@ describe("the definitions a route reads for its page", () => {
   });
 
   it("reads definitions at the posture the route serves", async () => {
-    // The SAME scope the entry read uses, not a second opinion. A page serving
-    // published content must not inline a draft component, and a route
-    // explicitly serving drafts must.
+    // The SAME scope the entry read uses, not a second opinion: a page serving
+    // published content must not inline a draft component.
     const served = await renderWith({ hero: definition() }, page(["hero"]));
     expect(componentReads(served.calls)[0]!.status).toBe("published");
 
+    // A route explicitly serving drafts must inline the draft, and it cannot do
+    // that through this batched read at any `status` — the overlay lives on the
+    // per-id path. Asserted where that read can be observed, under "a
+    // component's pending edits in draft mode" below; what belongs here is that
+    // the batched query is not the channel it takes.
     const draft = await renderWith({ hero: definition() }, page(["hero"]), {
       draft: true,
     });
-    expect(componentReads(draft.calls)[0]!.status).toBe("all");
+    expect(componentReads(draft.calls)).toEqual([]);
   });
 
   it("clears BOTH identity channels", async () => {
@@ -336,5 +340,217 @@ describe("the definitions a route reads for its page", () => {
 
     expect(componentReads(calls)).toEqual([]);
     expect(props.definitions).toBeUndefined();
+  });
+});
+
+/**
+ * What a draft-mode route hands its renderer when a component has pending edits.
+ *
+ * The store double below reproduces the ONE asymmetry this whole suite turns
+ * on, and it is a property of the service, not an invention: the working-draft
+ * overlay is applied in `collection-query-service.getEntry`, so `findByID` can
+ * surface a pending edit and `find` — the list path, which has no equivalent —
+ * cannot. A double whose `find` answered drafts would certify a batched read
+ * that cannot work against the real reader.
+ */
+function splitStoreReader(
+  published: Record<string, unknown>,
+  drafts: Record<string, unknown>,
+  content: BlockDocument
+) {
+  const calls: FindArgs[] = [];
+  const byId: { id: string; draft?: boolean }[] = [];
+  return {
+    calls,
+    byId,
+    nextly: {
+      find: vi.fn(async (args: FindArgs) => {
+        calls.push(args);
+        if (args.collection === "components") {
+          const wanted = args.where?.id?.in;
+          const ids = Array.isArray(wanted) ? (wanted as string[]) : [];
+          // PUBLISHED only, whatever `status` says. `status: "all"` widens which
+          // ROWS match; it does not reach a working draft, which lives in a
+          // snapshot the list path never consults.
+          return {
+            items: ids
+              .filter(id => Object.hasOwn(published, id))
+              .map(id => ({ id, content: published[id] })),
+            meta: {},
+          };
+        }
+        return { items: [{ id: "p1", slug: "about", content }], meta: {} };
+      }),
+      findByID: vi.fn(
+        async (args: { collection: string; id: string; draft?: boolean }) => {
+          if (args.collection !== "components") return null;
+          byId.push({ id: args.id, draft: args.draft });
+          const row =
+            args.draft === true && Object.hasOwn(drafts, args.id)
+              ? drafts[args.id]
+              : published[args.id];
+          return row === undefined ? null : { id: args.id, content: row };
+        }
+      ),
+      media: { findByID: vi.fn(async () => null) },
+    } as never,
+  };
+}
+
+const headingNode = (text: string) => ({
+  id: "h",
+  type: "core/heading",
+  version: 1,
+  props: { text, level: 1 },
+});
+
+describe("a component's pending edits in draft mode", () => {
+  it("previews the WORKING DRAFT, not the last published definition", async () => {
+    // The defect this row exists for: the editor iframe drew the last published
+    // component while the author was editing it, so the preview disagreed with
+    // the form beside it.
+    const r = splitStoreReader(
+      { hero: definition([headingNode("PUBLISHED")]) },
+      { hero: definition([headingNode("PENDING EDIT")]) },
+      page(["hero"])
+    );
+    const route = createBlocksPage({
+      collections: ["pages"],
+      field: "content",
+      nextly: r.nextly,
+      draft: true,
+    } as Parameters<typeof createBlocksPage>[0]);
+
+    const element = (await route.ContentPage({
+      params: { slug: ["about"] },
+    })) as ReactElement<{ definitions?: Map<string, BlockDocument> }>;
+
+    const hero = element.props.definitions?.get("hero");
+    expect(hero?.nodes[0]?.props).toMatchObject({ text: "PENDING EDIT" });
+  });
+
+  it("draws the pending edit into the page the visitor is shown", async () => {
+    // Asserted through the COMPOSED document rather than the definitions map,
+    // because the map is the fetch's own output: a read that returned the draft
+    // and a composition that dropped it would still satisfy the test above.
+    // `derived.title` is produced by composing the page with its definitions.
+    const r = splitStoreReader(
+      { hero: definition([headingNode("PUBLISHED")]) },
+      { hero: definition([headingNode("PENDING EDIT")]) },
+      page(["hero"])
+    );
+    const route = createBlocksPage({
+      collections: ["pages"],
+      field: "content",
+      nextly: r.nextly,
+      draft: true,
+      blocks: createBlockResolver(coreBlocks),
+      metadata: (
+        _entry: unknown,
+        _context: unknown,
+        derived: { title?: string }
+      ) => ({ title: derived.title ?? "NO TITLE" }),
+    } as Parameters<typeof createBlocksPage>[0]);
+
+    const meta = await route.generateMetadata({ params: { slug: ["about"] } });
+
+    expect(meta.title).toBe("PENDING EDIT");
+  });
+
+  it("does NOT cache the draft read", async () => {
+    // The rule `resolve-content` states for the draft entry read, which this
+    // read sits beside: a working draft changes on every save while cache tags
+    // are burst by writes to the LIVE row, so a cached draft shows an editor
+    // their previous save and calls it a preview. No key fixes that, which is
+    // why the answer is not to cache rather than to key more finely.
+    cached.mockClear();
+    const r = splitStoreReader(
+      { hero: definition() },
+      { hero: definition() },
+      page(["hero"])
+    );
+    const route = createBlocksPage({
+      collections: ["pages"],
+      field: "content",
+      nextly: r.nextly,
+      draft: true,
+    } as Parameters<typeof createBlocksPage>[0]);
+
+    await route.ContentPage({ params: { slug: ["about"] } });
+
+    expect(r.byId).toHaveLength(1);
+    expect(cached).not.toHaveBeenCalled();
+  });
+
+  it("keeps the published route on ONE batched query", async () => {
+    // The per-id read is the price of seeing a draft and is paid in the editor
+    // iframe only. Taken on the published path it would turn one query per page
+    // into one per component, on the path that serves every visitor.
+    const r = splitStoreReader(
+      { hero: definition(), footer: definition() },
+      {},
+      page(["hero", "footer"])
+    );
+    const route = createBlocksPage({
+      collections: ["pages"],
+      field: "content",
+      nextly: r.nextly,
+    } as Parameters<typeof createBlocksPage>[0]);
+
+    await route.ContentPage({ params: { slug: ["about"] } });
+
+    expect(componentReads(r.calls)).toHaveLength(1);
+    expect(r.byId).toEqual([]);
+  });
+
+  it("lets an EXPLICIT published status beat the draft widening", async () => {
+    // The order `resolveDraftOverlay` applies: a route that named `published`
+    // is asking for the live document, and overlaying a pending edit on top of
+    // it answers a question it did not ask. Without this the `draft: true`
+    // half of the gate would decide alone, and a route that had narrowed
+    // itself on purpose would quietly serve drafts.
+    const r = splitStoreReader(
+      { hero: definition([headingNode("PUBLISHED")]) },
+      { hero: definition([headingNode("PENDING EDIT")]) },
+      page(["hero"])
+    );
+    const route = createBlocksPage({
+      collections: ["pages"],
+      field: "content",
+      nextly: r.nextly,
+      draft: true,
+      status: "published",
+    } as Parameters<typeof createBlocksPage>[0]);
+
+    const element = (await route.ContentPage({
+      params: { slug: ["about"] },
+    })) as ReactElement<{ definitions?: Map<string, BlockDocument> }>;
+
+    expect(r.byId).toEqual([]);
+    expect(componentReads(r.calls)[0]!.status).toBe("published");
+    expect(
+      element.props.definitions?.get("hero")?.nodes[0]?.props
+    ).toMatchObject({ text: "PUBLISHED" });
+  });
+
+  it("asks for the draft explicitly rather than relying on a widened status", async () => {
+    // `status: "all"` widens which rows match; it does not reach the working
+    // draft. Without the opt-in the per-id read would return the published row
+    // and the page would be exactly as wrong, through a more expensive route.
+    const r = splitStoreReader(
+      { hero: definition() },
+      { hero: definition() },
+      page(["hero"])
+    );
+    const route = createBlocksPage({
+      collections: ["pages"],
+      field: "content",
+      nextly: r.nextly,
+      draft: true,
+    } as Parameters<typeof createBlocksPage>[0]);
+
+    await route.ContentPage({ params: { slug: ["about"] } });
+
+    expect(r.byId).toEqual([{ id: "hero", draft: true }]);
   });
 });

--- a/packages/blocks-react/src/next.components.test.ts
+++ b/packages/blocks-react/src/next.components.test.ts
@@ -40,7 +40,7 @@ vi.mock("nextly/runtime", async importActual => {
   };
 });
 
-const { createBlocksPage } = await import("./next");
+const { createBlocksPage, createSinglePage } = await import("./next");
 const { entryIdTag } = await import("nextly/runtime");
 
 interface FindArgs {
@@ -552,5 +552,99 @@ describe("a component's pending edits in draft mode", () => {
     await route.ContentPage({ params: { slug: ["about"] } });
 
     expect(r.byId).toEqual([{ id: "hero", draft: true }]);
+  });
+});
+
+describe("the lifecycle scope a draft-mode component read stays inside", () => {
+  it("leaves an explicit draft-ONLY scope on the batched read", async () => {
+    // `findByID` takes no `status`, so the per-id read cannot express a
+    // lifecycle scope at all: under `overrideAccess` it is unfiltered and falls
+    // back to the live row when no pending snapshot exists. A route that named
+    // `status: "draft"` would then be handed a PUBLISHED component it excluded.
+    // Which states are public is the workflow's question and it is answered in
+    // the query service, so this path narrows by not taking the per-id route
+    // rather than by re-deciding that rule here.
+    const r = splitStoreReader(
+      { hero: definition([headingNode("PUBLISHED")]) },
+      {},
+      page(["hero"])
+    );
+    const route = createBlocksPage({
+      collections: ["pages"],
+      field: "content",
+      nextly: r.nextly,
+      draft: true,
+      status: "draft",
+    } as Parameters<typeof createBlocksPage>[0]);
+
+    await route.ContentPage({ params: { slug: ["about"] } });
+
+    expect(r.byId).toEqual([]);
+    expect(componentReads(r.calls)[0]!.status).toBe("draft");
+  });
+});
+
+describe("a Single blocks page and the components it embeds", () => {
+  /** A reader serving one Single whose document embeds a component. */
+  function singleStore(published: unknown, drafts: unknown) {
+    const byId: { id: string; draft?: boolean }[] = [];
+    const reader = {
+      findSingle: vi.fn(async () => ({
+        title: "Home",
+        content: page(["hero"]),
+      })),
+      find: vi.fn(async (args: FindArgs) => {
+        if (args.collection === "components") {
+          const wanted = args.where?.id?.in;
+          const ids = Array.isArray(wanted) ? (wanted as string[]) : [];
+          return {
+            items: ids.map(id => ({ id, content: published })),
+            meta: {},
+          };
+        }
+        return { items: [], meta: {} };
+      }),
+      findByID: vi.fn(
+        async (args: { collection: string; id: string; draft?: boolean }) => {
+          if (args.collection !== "components") return null;
+          byId.push({ id: args.id, draft: args.draft });
+          return {
+            id: args.id,
+            content: args.draft === true ? drafts : published,
+          };
+        }
+      ),
+    };
+    return { reader, byId };
+  }
+
+  it("carries a Single's literal draft intent into the component read", async () => {
+    // `blocksSingleConfig` pulls `draft` out before building the shared blocks
+    // route, because the Single's hook has a different shape from the page
+    // route's. The LITERAL is not that hook, and dropping it too left the
+    // Single rendering its own working draft while every component inside it
+    // came from the published batched read — the same stale preview, one level
+    // down.
+    const s = singleStore(
+      definition([headingNode("PUBLISHED")]),
+      definition([headingNode("PENDING EDIT")])
+    );
+    const route = createSinglePage({
+      slug: "homepage",
+      field: "content",
+      nextly: s.reader as never,
+      blocks: createBlockResolver(coreBlocks),
+      draft: true,
+      metadata: (
+        _entry: unknown,
+        _context: unknown,
+        derived: { title?: string }
+      ) => ({ title: derived.title ?? "NO TITLE" }),
+    } as Parameters<typeof createSinglePage>[0]);
+
+    const meta = await route.generateMetadata();
+
+    expect(s.byId).toEqual([{ id: "hero", draft: true }]);
+    expect(meta.title).toBe("PENDING EDIT");
   });
 });

--- a/packages/blocks-react/src/next.ts
+++ b/packages/blocks-react/src/next.ts
@@ -821,6 +821,18 @@ function componentSource(
   const collection = config.componentCollection ?? COMPONENT_TAG_COLLECTION;
   const field = config.componentField ?? COMPONENT_DOCUMENT_FIELD;
   const status = config.status ?? (config.draft === true ? "all" : "published");
+  // Whether this route may surface a component's PENDING edits.
+  //
+  // Both halves are load-bearing. `draft: true` is the route declaring itself
+  // the editor's, and only the literal is consulted because a per-path `draft`
+  // FUNCTION answers about one entry the visitor asked for and says nothing
+  // about the components inside it — which is also why a shareable preview
+  // link, whose gate is such a function, keeps reading published definitions
+  // (design 6.4, founder Q10). And an explicit `status` beats the widening, in
+  // the same order `resolveDraftOverlay` applies it: a route that asked for
+  // `published` is asking for the live document, so overlaying a draft on top
+  // of it would answer a question it did not ask.
+  const overlayDrafts = config.draft === true && status !== "published";
 
   return async (ids: readonly string[]) => {
     // Dropped before anything is built from them, not repaired. `entryIdTag`
@@ -834,6 +846,15 @@ function componentSource(
     if (wanted.length === 0) return EMPTY_DEFINITIONS;
 
     const found = new Map<string, BlockDocument>();
+    if (overlayDrafts) {
+      return await readDraftDefinitions(wanted, {
+        reader,
+        collection,
+        field,
+        locale,
+        budget,
+      });
+    }
     for (const chunk of chunked(wanted, COMPONENT_BATCH_SIZE)) {
       // One claim per QUERY. A page embedding twenty components spends one
       // read because that is what it costs; charging per definition would
@@ -891,6 +912,72 @@ function chunked<T>(items: readonly T[], size: number): T[][] {
     out.push(items.slice(i, i + size));
   }
   return out;
+}
+
+/**
+ * The definitions a DRAFT-mode route reads, one query per component.
+ *
+ * PER ID because that is the only shape the working draft is reachable in. The
+ * overlay is applied in `collection-query-service.getEntry`; the list path has
+ * no equivalent, so a batched `find` returns the LIVE row however wide its
+ * `status` — `status: "all"` widens which rows match and never reaches a
+ * pending edit. A route previewing an edit would then draw the last published
+ * component, and the form and the picture beside it would disagree about the
+ * document the author is looking at.
+ *
+ * UNCACHED, for the reason `resolve-content` gives for never caching a draft
+ * entry read: a working draft changes on every save while cache tags are burst
+ * by writes to the LIVE row, so a cached draft shows an editor their previous
+ * save and calls it a preview. That also means there is no tag or key to get
+ * right here — the staleness a key could not fix is the whole objection.
+ *
+ * The price is one query per component instead of one per page, and it is paid
+ * ONLY here. Draft mode is the editor iframe: one author, one request, no
+ * shared cache entry to protect. The published path serves every visitor and
+ * keeps its batch, which is what the `overlayDrafts` gate above is for.
+ *
+ * `draft: true` is an opt-in the service still gates on an update-capability
+ * probe, which `overrideAccess` satisfies — the same trust the batched read
+ * already carries, and the same identity channels cleared for the same reason.
+ */
+async function readDraftDefinitions(
+  wanted: readonly string[],
+  args: {
+    reader: NextlyContentReader;
+    collection: string;
+    field: string;
+    locale: string | undefined;
+    budget: QueryBudget;
+  }
+): Promise<Map<string, BlockDocument>> {
+  const { reader, collection, field, locale, budget } = args;
+  const found = new Map<string, BlockDocument>();
+  for (const id of wanted) {
+    // One claim per QUERY, exactly as the batched path charges. Here that is
+    // one per component, which is the honest price of this read rather than a
+    // penalty: a page whose components outrun the allowance stops fetching and
+    // the remainder resolve as missing, with a marker, instead of the route
+    // issuing unbounded reads.
+    if (!budget.take()) break;
+    const row = await reader.findByID({
+      collection,
+      id,
+      draft: true,
+      overrideAccess: true,
+      disableErrors: true,
+      user: undefined,
+      req: undefined,
+      ...(locale ? { locale } : {}),
+    });
+    if (row === null || row === undefined) continue;
+    // Through the SAME reader the batched path uses, so a row is judged
+    // readable by one rule. A second unwrapping here is how the two paths would
+    // come to disagree about which stored value counts as a definition.
+    for (const [foundId, document] of definitionsById([row], field)) {
+      found.set(foundId, document);
+    }
+  }
+  return found;
 }
 
 /** One batched, tagged, posture-carrying read of at most a full chunk. */

--- a/packages/blocks-react/src/next.ts
+++ b/packages/blocks-react/src/next.ts
@@ -823,16 +823,24 @@ function componentSource(
   const status = config.status ?? (config.draft === true ? "all" : "published");
   // Whether this route may surface a component's PENDING edits.
   //
-  // Both halves are load-bearing. `draft: true` is the route declaring itself
-  // the editor's, and only the literal is consulted because a per-path `draft`
-  // FUNCTION answers about one entry the visitor asked for and says nothing
-  // about the components inside it — which is also why a shareable preview
-  // link, whose gate is such a function, keeps reading published definitions
-  // (design 6.4, founder Q10). And an explicit `status` beats the widening, in
-  // the same order `resolveDraftOverlay` applies it: a route that asked for
-  // `published` is asking for the live document, so overlaying a draft on top
-  // of it would answer a question it did not ask.
-  const overlayDrafts = config.draft === true && status !== "published";
+  // Both halves are load-bearing, and both are about what this read can
+  // HONESTLY promise.
+  //
+  // Only the LITERAL `draft` counts. A per-path `draft` function answers about
+  // the one entry a visitor asked for and says nothing about the components
+  // inside it, so a route whose gate is such a function keeps reading published
+  // definitions rather than inheriting a grant that was never about them.
+  //
+  // And the scope must be the unnarrowed one. `findByID` accepts no `status`,
+  // and under `overrideAccess` an absent status is no filter at all, so the
+  // per-id read cannot express a lifecycle scope and falls back to the live row
+  // when no pending snapshot exists. A route that named `status: "draft"` would
+  // then receive a PUBLISHED component it had excluded. Which states are public
+  // is the workflow's question, answered in the query service, so this narrows
+  // by declining the per-id route rather than by re-deciding that rule here —
+  // `status: "all"` is the only scope that excludes nothing and can therefore
+  // be served by an unfiltered read.
+  const overlayDrafts = config.draft === true && status === "all";
 
   return async (ids: readonly string[]) => {
     // Dropped before anything is built from them, not repaired. `entryIdTag`
@@ -1710,7 +1718,19 @@ function blocksSingleConfig(
   } = config;
 
   const routeConfig = blocksRouteConfig(
-    { ...blocksOptions, collections: [slug] },
+    {
+      ...blocksOptions,
+      collections: [slug],
+      // The LITERAL intent, carried; the hook, still not. `draft: true` is a
+      // statement about what this route serves, and the reads it governs here —
+      // the components a page embeds and the media they reference — are the
+      // page's own, not the Single's. Dropped along with the hook, a Single
+      // serving its working draft still drew every embedded component from the
+      // published read, and referenced a never-published image as no picture at
+      // all. A FUNCTION is still withheld: it resolves an entry id this route
+      // has nothing to compare against.
+      ...(config.draft === true ? { draft: true } : {}),
+    },
     isPublic
   );
 


### PR DESCRIPTION
## The defect

Draft mode previewed the wrong document.

A page reads the components it embeds in **one batched query**. The working-draft
overlay — the thing that surfaces an author's pending edits — is applied in
`collection-query-service.getEntry`, the single-entry path. The list path has no
equivalent. So the batched query returned the **live** row however wide its
lifecycle scope, and the editor iframe drew the last published component while
the form beside it showed the edit in progress. The two disagreed about the same
document.

`status: "all"` cannot fix this. It widens which **rows** match; it does not
reach a working draft, which lives in a snapshot the list path never consults.

## Measured, not assumed

- `includeWorkingDraft` appears at lines 2802, 2875, 2893, 3117 and 3204 of
  `collection-query-service.ts` — every one inside `getEntry` (opens at 2665).
  `listEntries` opens at 946 and contains none.
- No new reader surface was needed. `NextlyContentReader` is
  `Pick<Nextly, "find" | "findByID">`, and `findByID` already forwards `draft`
  to `getEntry` as `includeWorkingDraft`.
- The `components` collection qualifies: `status: true` and
  `versions: { drafts: true }`, the authored shorthand config load expands, which
  the existing `draft-split-reach.test.ts` pins. It is not localized, so the
  draft locale is not a constraint.
- `findByID` takes no `status`, and under `overrideAccess: true`
  `resolveStatusFilter` returns `null`. That is *why* the batched path uses
  `find` with an explicit status — so the per-id read is correct on the draft
  path and would be a lifecycle widening on the published one.

## The change

A route serving drafts reads its definitions **one per component**, opting into
the overlay explicitly.

**Uncached**, for the reason `resolve-content` gives for never caching a draft
entry read: a working draft changes on every save while cache tags are burst by
writes to the live row, so a cached draft would show an editor their previous
save and call it a preview. No cache key fixes that, which is why the answer is
not to cache rather than to key more finely.

The per-id cost is paid **only** where drafts are served — the editor iframe,
one author, one request, no shared cache entry to protect. Every other route
keeps the single batched read, still tagged per component id.

Both halves of the gate are load-bearing:

- only the **literal** `draft: true` counts, because a per-path `draft` function
  answers about the one entry a visitor asked for and says nothing about the
  components inside it — which is also why a shareable preview link, whose gate
  is such a function, still resolves components to their **published** versions
  (design §6.4, founder Q10);
- an **explicit** `status` beats the widening, in the same order
  `resolveDraftOverlay` applies it.

## Evidence

The three new behavioural tests fail on `main` with
`expected 'PUBLISHED' to be 'PENDING EDIT'` and no per-id read issued at all.

The store double reproduces the one asymmetry this turns on, and it is a
property of the service rather than an invention: its `find` answers published
rows whatever the `status`, its `findByID` honours the opt-in. A double whose
`find` answered drafts would certify a batched read that cannot work against the
real reader.

One assertion goes through the **composed** document (`derived.title`) rather
than the definitions map, because the map is the fetch's own output: a read that
returned the draft and a composition that dropped it would still satisfy an
assertion on the map.

Break-verified in four directions, each killing only its own test:

| Wrong implementation | Result |
|---|---|
| drop the `draft: true` opt-in | 3 fail |
| `overlayDrafts = true` (widen to every route) | 12 fail |
| drop the explicit-status half of the gate | **survived** → added a test, then it fails |
| wrap the draft read in `cachedFind` | 1 fail |

The third is why the explicit-status test exists: that clause was unguarded
until a break proved it.

## Gates

| Gate | Result |
|---|---|
| `blocks-react` suite | 48 files, 1157 tests, exit 0 |
| `check-types` (incl. `tsconfig.tests.json`) | exit 0 |
| `fallow --gate new-only --base origin/main` | `warn` (passes) |
| `check:comments` | exit 0 |
| `changeset status` | exit 0 |

`fallow` attributes one new duplication clone group: 55 tokens spanning 79
lines, largely docblock prose plus the shared read posture. Left as-is
deliberately — `mediaByQuery` in this same file documents the convention
("kept beside its only caller rather than generalized… a general helper would
put the same decisions somewhere a reader of this resolver cannot see"), and
contradicting that for 55 tokens would cost more legibility than it saves.
