### PR TITLE
docs(root): give every published README the same four sections

### DIFF
--- a/.changeset/cli-says-field-group-not-component.md
+++ b/.changeset/cli-says-field-group-not-component.md
@@ -1,5 +1,29 @@
 ---
 "nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
 ---
 
 The CLI now says "field group" where it still said "component". `db:sync` and

--- a/.changeset/destructive-list-names-what-it-omits.md
+++ b/.changeset/destructive-list-names-what-it-omits.md
@@ -1,5 +1,29 @@
 ---
 "nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
 ---
 
 When a schema change needs a terminal it cannot get, the error listing what you

--- a/.changeset/every-package-readme-answers-the-same-questions.md
+++ b/.changeset/every-package-readme-answers-the-same-questions.md
@@ -1,16 +1,32 @@
 ---
-"@nextlyhq/adapter-drizzle": patch
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
 "@nextlyhq/blocks-engine": patch
 "@nextlyhq/blocks-react": patch
-"@nextlyhq/builder": patch
-"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
 "@nextlyhq/plugin-page-builder": patch
-"@nextlyhq/plugin-sdk": patch
 "@nextlyhq/plugin-seo": patch
-"@nextlyhq/admin-css": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
 ---
 
 Every package's npm page now answers the same four questions: what state the
 package is in, how to install it, what it relates to, and its licence. Eight
-packages were missing at least one of those, and `@nextlyhq/adapter-drizzle` was
-a three-line stub that never said you are not meant to install it directly.
+packages were missing at least one of those, and `@nextlyhq/adapter-drizzle`
+was a three-line stub that never said you are not meant to install it directly.

--- a/.changeset/every-package-readme-answers-the-same-questions.md
+++ b/.changeset/every-package-readme-answers-the-same-questions.md
@@ -1,0 +1,16 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/admin-css": patch
+---
+
+Every package's npm page now answers the same four questions: what state the
+package is in, how to install it, what it relates to, and its licence. Eight
+packages were missing at least one of those, and `@nextlyhq/adapter-drizzle` was
+a three-line stub that never said you are not meant to install it directly.

--- a/.changeset/plugins-that-ship-no-longer-say-otherwise.md
+++ b/.changeset/plugins-that-ship-no-longer-say-otherwise.md
@@ -1,12 +1,29 @@
 ---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
 "@nextlyhq/plugin-form-builder": patch
 "@nextlyhq/plugin-page-builder": patch
 "@nextlyhq/plugin-seo": patch
 "@nextlyhq/plugin-sdk": patch
-"@nextlyhq/admin-css": patch
-"@nextlyhq/admin": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
 "@nextlyhq/builder": patch
-"nextly": patch
+"@nextlyhq/module-specifiers": patch
 ---
 
 Plugin READMEs no longer tell you plugins are unavailable. Three plugins ship

--- a/docs/page-builder/index.mdx
+++ b/docs/page-builder/index.mdx
@@ -35,7 +35,8 @@ plugin uses.
 ## Install
 
 ```bash
-pnpm add @nextlyhq/plugin-page-builder @nextlyhq/blocks-react
+pnpm add @nextlyhq/plugin-page-builder @nextlyhq/blocks-react \
+  @nextlyhq/builder @nextlyhq/plugin-sdk react-hook-form
 ```
 
 Add the plugin to your config. It contributes a `pages` collection whose edit screen is

--- a/packages/adapter-drizzle/README.md
+++ b/packages/adapter-drizzle/README.md
@@ -11,7 +11,7 @@ Internal Drizzle ORM utilities for Nextly's database adapters.
 > [!IMPORTANT]
 > Nextly is in alpha. APIs may change before 1.0. Pin exact versions in production.
 
-> This package is part of Nextly's internals. It is installed automatically as a dependency of [`nextly`](../nextly). Choose [`@nextlyhq/adapter-postgres`](../adapter-postgres), [`@nextlyhq/adapter-mysql`](../adapter-mysql), or [`@nextlyhq/adapter-sqlite`](../adapter-sqlite) for your project.
+This package is part of Nextly's internals. It is installed automatically as a dependency of [`nextly`](../nextly). Choose [`@nextlyhq/adapter-postgres`](../adapter-postgres), [`@nextlyhq/adapter-mysql`](../adapter-mysql), or [`@nextlyhq/adapter-sqlite`](../adapter-sqlite) for your project.
 
 ## Install
 

--- a/packages/adapter-drizzle/README.md
+++ b/packages/adapter-drizzle/README.md
@@ -2,7 +2,31 @@
 
 Internal Drizzle ORM utilities for Nextly's database adapters.
 
+<p align="center">
+  <a href="https://www.npmjs.com/package/@nextlyhq/adapter-drizzle"><img alt="npm" src="https://img.shields.io/npm/v/@nextlyhq%2Fadapter-drizzle?style=flat-square&label=npm&color=cb3837" /></a>
+  <a href="https://github.com/nextlyhq/nextly/blob/main/LICENSE.md"><img alt="License" src="https://img.shields.io/github/license/nextlyhq/nextly?style=flat-square&color=blue" /></a>
+  <a href="https://nextlyhq.com/docs"><img alt="Status" src="https://img.shields.io/badge/status-alpha-orange?style=flat-square" /></a>
+</p>
+
+> [!IMPORTANT]
+> Nextly is in alpha. APIs may change before 1.0. Pin exact versions in production.
+
 > This package is part of Nextly's internals. It is installed automatically as a dependency of [`nextly`](../nextly). Choose [`@nextlyhq/adapter-postgres`](../adapter-postgres), [`@nextlyhq/adapter-mysql`](../adapter-mysql), or [`@nextlyhq/adapter-sqlite`](../adapter-sqlite) for your project.
+
+## Install
+
+You do not install this directly. It arrives as a dependency of [`nextly`](../nextly)
+and of each database adapter. Install the adapter for your database instead:
+
+```bash
+pnpm add @nextlyhq/adapter-postgres pg
+```
+
+## Related packages
+
+- [`@nextlyhq/adapter-postgres`](../adapter-postgres) — recommended for production
+- [`@nextlyhq/adapter-mysql`](../adapter-mysql)
+- [`@nextlyhq/adapter-sqlite`](../adapter-sqlite) — local demos
 
 ## License
 

--- a/packages/admin-css/README.md
+++ b/packages/admin-css/README.md
@@ -94,4 +94,4 @@ for (const issue of issues) {
 
 ## License
 
-[MIT](https://github.com/nextlyhq/nextly/blob/main/LICENSE.md)
+[MIT](../../LICENSE.md)

--- a/packages/blocks-engine/README.md
+++ b/packages/blocks-engine/README.md
@@ -3,6 +3,15 @@
 The runtime-free core of the Nextly page builder: the stored document format
 and the pure operations over it.
 
+<p align="center">
+  <a href="https://www.npmjs.com/package/@nextlyhq/blocks-engine"><img alt="npm" src="https://img.shields.io/npm/v/@nextlyhq%2Fblocks-engine?style=flat-square&label=npm&color=cb3837" /></a>
+  <a href="https://github.com/nextlyhq/nextly/blob/main/LICENSE.md"><img alt="License" src="https://img.shields.io/github/license/nextlyhq/nextly?style=flat-square&color=blue" /></a>
+  <a href="https://nextlyhq.com/docs"><img alt="Status" src="https://img.shields.io/badge/status-alpha-orange?style=flat-square" /></a>
+</p>
+
+> [!IMPORTANT]
+> Nextly is in alpha. APIs may change before 1.0. Pin exact versions in production.
+
 ## What lives here
 
 - **The document model** — `BlockDocument` (a `kind`-discriminated envelope
@@ -64,3 +73,24 @@ altogether, and how to override the builder on purpose.
 
 Alpha. The document format carries `formatVersion` and changes to stored
 shapes ship with format migrations once the format is frozen.
+
+## Install
+
+```bash
+pnpm add @nextlyhq/blocks-engine
+```
+
+Most projects get this transitively through
+[`@nextlyhq/plugin-page-builder`](../plugin-page-builder) and do not install it
+directly. Install it when you are writing code against the document model itself —
+a custom block, a migration over stored documents, or your own tooling.
+
+## Related packages
+
+- [`@nextlyhq/blocks-react`](../blocks-react) — renders these documents
+- [`@nextlyhq/plugin-page-builder`](../plugin-page-builder) — the plugin that stores them
+- [`@nextlyhq/builder`](../builder) — the editor that produces them
+
+## License
+
+[MIT](../../LICENSE.md)

--- a/packages/blocks-react/README.md
+++ b/packages/blocks-react/README.md
@@ -2,6 +2,15 @@
 
 The React renderer for Nextly block documents.
 
+<p align="center">
+  <a href="https://www.npmjs.com/package/@nextlyhq/blocks-react"><img alt="npm" src="https://img.shields.io/npm/v/@nextlyhq%2Fblocks-react?style=flat-square&label=npm&color=cb3837" /></a>
+  <a href="https://github.com/nextlyhq/nextly/blob/main/LICENSE.md"><img alt="License" src="https://img.shields.io/github/license/nextlyhq/nextly?style=flat-square&color=blue" /></a>
+  <a href="https://nextlyhq.com/docs"><img alt="Status" src="https://img.shields.io/badge/status-alpha-orange?style=flat-square" /></a>
+</p>
+
+> [!IMPORTANT]
+> Nextly is in alpha. APIs may change before 1.0. Pin exact versions in production.
+
 A block document is plain JSON validated by
 [`@nextlyhq/blocks-engine`](../blocks-engine). This package turns one into a
 React tree, as Server Components, with no client JavaScript unless a block opts
@@ -91,3 +100,22 @@ fixtures. The editor canvas supplies its own. One seam, four consumers.
 Alpha. `PageRenderer`, the core block library and `createBlocksPage` all ship,
 alongside the package boundary, its layering guarantees and the `PageContext`
 contract. The editor surfaces follow.
+
+## Install
+
+```bash
+pnpm add @nextlyhq/blocks-react
+```
+
+Install this in your own app rather than relying on it being present underneath the
+page-builder plugin: your app is what renders the public pages.
+
+## Related packages
+
+- [`@nextlyhq/blocks-engine`](../blocks-engine) — the document model it renders
+- [`@nextlyhq/plugin-page-builder`](../plugin-page-builder) — stores the documents
+- [`@nextlyhq/builder`](../builder) — the editor
+
+## License
+
+[MIT](../../LICENSE.md)

--- a/packages/builder/README.md
+++ b/packages/builder/README.md
@@ -351,9 +351,10 @@ host would hit an unsatisfiable peer one level down.
 pnpm add @nextlyhq/builder
 ```
 
-You are unlikely to install this directly. It arrives with
-[`@nextlyhq/plugin-page-builder`](../plugin-page-builder), which is what an app adds
-to get a page builder.
+You install this alongside [`@nextlyhq/plugin-page-builder`](../plugin-page-builder),
+which is what an app adds to get a page builder. The plugin declares this package as a
+**peer dependency**, so a package manager that does not auto-install peers will not
+supply it and the plugin's admin entry will fail to resolve its imports.
 
 ## Related packages
 

--- a/packages/builder/README.md
+++ b/packages/builder/README.md
@@ -3,7 +3,18 @@
 The visual page-builder editor: the shell, the canvas, and the op store that
 everything in it either produces or reads.
 
-**The editor is landing in slices, and every export is `@experimental`.** What
+<p align="center">
+  <a href="https://www.npmjs.com/package/@nextlyhq/builder"><img alt="npm" src="https://img.shields.io/npm/v/@nextlyhq%2Fbuilder?style=flat-square&label=npm&color=cb3837" /></a>
+  <a href="https://github.com/nextlyhq/nextly/blob/main/LICENSE.md"><img alt="License" src="https://img.shields.io/github/license/nextlyhq/nextly?style=flat-square&color=blue" /></a>
+  <a href="https://nextlyhq.com/docs"><img alt="Status" src="https://img.shields.io/badge/status-alpha-orange?style=flat-square" /></a>
+</p>
+
+> [!IMPORTANT]
+> Nextly is in alpha. APIs may change before 1.0. Pin exact versions in production.
+> **Every export of this package is additionally `@experimental`** and carries no
+> compatibility guarantee even within alpha.
+
+The editor is landing in slices. What
 ships today is the editor SHELL — the rail, the switched left panel, the canvas
 slot, the inspector and the bars around them — the frame geometry that maps
 between the canvas frame and the host page, the op store that every edit is
@@ -333,3 +344,23 @@ than bundled per package.
 React 19, matching the renderer it draws with. `@nextlyhq/blocks-react` requires
 `react: ^19.0.0`, and it is a dependency here rather than a peer, so a React 18
 host would hit an unsatisfiable peer one level down.
+
+## Install
+
+```bash
+pnpm add @nextlyhq/builder
+```
+
+You are unlikely to install this directly. It arrives with
+[`@nextlyhq/plugin-page-builder`](../plugin-page-builder), which is what an app adds
+to get a page builder.
+
+## Related packages
+
+- [`@nextlyhq/plugin-page-builder`](../plugin-page-builder) — the plugin that mounts this editor
+- [`@nextlyhq/blocks-engine`](../blocks-engine) — the document model every edit produces
+- [`@nextlyhq/blocks-react`](../blocks-react) — the renderer the canvas draws through
+
+## License
+
+[MIT](../../LICENSE.md)

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -2,6 +2,15 @@
 
 ESLint rules that keep admin UI on Nextly's design-token system.
 
+<p align="center">
+  <a href="https://www.npmjs.com/package/@nextlyhq/eslint-plugin"><img alt="npm" src="https://img.shields.io/npm/v/@nextlyhq%2Feslint-plugin?style=flat-square&label=npm&color=cb3837" /></a>
+  <a href="https://github.com/nextlyhq/nextly/blob/main/LICENSE.md"><img alt="License" src="https://img.shields.io/github/license/nextlyhq/nextly?style=flat-square&color=blue" /></a>
+  <a href="https://nextlyhq.com/docs"><img alt="Status" src="https://img.shields.io/badge/status-alpha-orange?style=flat-square" /></a>
+</p>
+
+> [!IMPORTANT]
+> Nextly is in alpha. APIs may change before 1.0. Pin exact versions in production.
+
 Nextly's admin is themeable: colours, spacing and radius come from tokens, and
 every surface that consumes them follows a retheme and flips between light and
 dark for free. A surface that reaches past the tokens does not. These rules catch
@@ -140,3 +149,13 @@ the marker is per-line.
 The full token contract — what each token means, the two CSS entry points, and
 how plugin styles inherit the admin's light/dark scope — is in the
 [plugin UI authoring guide](https://nextlyhq.com/docs/plugins).
+
+## Related packages
+
+- [`@nextlyhq/ui`](../ui) — the components these rules keep on-token
+- [`@nextlyhq/admin-css`](../admin-css) — scopes and compiles the admin stylesheet
+- [`@nextlyhq/admin`](../admin) — the admin these tokens theme
+
+## License
+
+[MIT](../../LICENSE.md)

--- a/packages/plugin-page-builder/README.md
+++ b/packages/plugin-page-builder/README.md
@@ -10,8 +10,8 @@ a server-first renderer that ships zero client JS by default.
 > See the [plugin stability ladder](https://nextlyhq.com/docs/plugins/stability) for
 > which plugin surfaces are stable and which are experimental.
 
-> The block model, registries, and render pipeline are stable; the editor
-> interactions are still evolving. MIT-licensed.
+The block model, registries, and render pipeline are stable; the editor interactions
+are still evolving.
 
 ## Install
 

--- a/packages/plugin-page-builder/README.md
+++ b/packages/plugin-page-builder/README.md
@@ -244,3 +244,14 @@ Two steps require a real terminal (not a headless CI sandbox): applying the plug
 table (drizzle push needs a TTY) and the `@nextlyhq/plugin-sdk` default/CJS export used by
 the dev auto-seed. Everything else — build, type-check, unit tests — runs anywhere. See
 the `e2e/` suite for the browser interaction tests (run against a live playground).
+
+## Related packages
+
+- [`@nextlyhq/blocks-engine`](../blocks-engine) — the stored document model
+- [`@nextlyhq/blocks-react`](../blocks-react) — the renderer for public pages
+- [`@nextlyhq/builder`](../builder) — the editor shell and canvas
+- [`@nextlyhq/plugin-sdk`](../plugin-sdk) — the SDK this plugin is built on
+
+## License
+
+[MIT](../../LICENSE.md)

--- a/packages/plugin-page-builder/README.md
+++ b/packages/plugin-page-builder/README.md
@@ -16,8 +16,14 @@ are still evolving.
 ## Install
 
 ```bash
-pnpm add @nextlyhq/plugin-page-builder
+pnpm add @nextlyhq/plugin-page-builder @nextlyhq/builder @nextlyhq/plugin-sdk react-hook-form
 ```
+
+Those three are **peer dependencies** that a scaffolded Nextly app does not already
+have, so install them explicitly rather than relying on your package manager to
+auto-install peers. The plugin's other peers — `@nextlyhq/admin`, `@nextlyhq/ui`,
+`@tanstack/react-query`, `lucide-react`, `nextly`, `next`, `react`, `react-dom` — come
+with the scaffold.
 
 Peers (provided by a Nextly app): `nextly`, `@nextlyhq/admin`, `@nextlyhq/ui`,
 `@nextlyhq/plugin-sdk`, `react`, `react-dom`, `next`, `@tanstack/react-query`,

--- a/packages/plugin-sdk/README.md
+++ b/packages/plugin-sdk/README.md
@@ -2,14 +2,21 @@
 
 The author-facing SDK for building [Nextly](https://nextlyhq.com) plugins.
 
-> **⚠️ Alpha (`0.x`) — pin your versions.**
->
-> The plugin API surface listed in [`STABILITY.md`](./STABILITY.md) is now **stable
-> (`@public`) and semver-protected** (D40): once Nextly reaches `1.0`, breaking it
-> requires a major version bump. Everything still marked `@experimental` carries **no**
-> compatibility guarantee and may change in any release. While we are pre-`1.0`, **pin
-> your `nextly` / `@nextlyhq/plugin-sdk` versions** and read the release notes before
-> upgrading.
+<p align="center">
+  <a href="https://www.npmjs.com/package/@nextlyhq/plugin-sdk"><img alt="npm" src="https://img.shields.io/npm/v/@nextlyhq%2Fplugin-sdk?style=flat-square&label=npm&color=cb3837" /></a>
+  <a href="https://github.com/nextlyhq/nextly/blob/main/LICENSE.md"><img alt="License" src="https://img.shields.io/github/license/nextlyhq/nextly?style=flat-square&color=blue" /></a>
+  <a href="https://nextlyhq.com/docs"><img alt="Status" src="https://img.shields.io/badge/status-alpha-orange?style=flat-square" /></a>
+</p>
+
+> [!IMPORTANT]
+> Nextly is in alpha. APIs may change before 1.0. Pin exact versions in production.
+> See the [stability ladder](https://nextlyhq.com/docs/plugins/stability) for which
+> plugin surfaces are settled and which are still moving.
+
+The surface listed in [`STABILITY.md`](./STABILITY.md) is `@public` and
+semver-protected: once Nextly reaches `1.0`, breaking it requires a major version
+bump. Anything still marked `@experimental` carries no such guarantee and may change
+in any release.
 
 ## What this package is
 
@@ -157,6 +164,13 @@ npm create nextly-app -- --template plugin
 
 which generates the package anatomy plus an embedded `dev/` playground (a minimal
 Nextly app on SQLite with hot-reload) for iterating on your plugin locally.
+
+## Related packages
+
+- [`@nextlyhq/plugin-page-builder`](../plugin-page-builder) — a first-party plugin built on this SDK
+- [`@nextlyhq/plugin-seo`](../plugin-seo) and [`@nextlyhq/plugin-form-builder`](../plugin-form-builder) — the other two
+- [`@nextlyhq/ui`](../ui) — components for admin UI a plugin contributes
+- [`@nextlyhq/admin-css`](../admin-css) — compiles a plugin's `admin.styles`
 
 ## License
 

--- a/packages/plugin-seo/README.md
+++ b/packages/plugin-seo/README.md
@@ -194,6 +194,11 @@ Then reference `https://example.com/sitemap.xml` from `robots.txt` or submit it 
 
 > **Cache or rate-limit the public route.** It is unauthenticated and regenerates the document per request (up to the 50,000-URL / 50 MB caps), and on the `/admin/api` mount Nextly's built-in rate limiter is skipped. Put it behind an edge/CDN cache (sitemaps are crawled infrequently) or a rate limiter at your proxy — or disable it with `sitemap: false` if you don't need it.
 
+## Related packages
+
+- [`nextly`](../nextly) — `buildMetadata` from `nextly/runtime` turns these fields into tags
+- [`@nextlyhq/plugin-sdk`](../plugin-sdk) — the SDK this plugin is built on
+
 ## License
 
 MIT © Nextly

--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -304,6 +304,57 @@ function internalLinks(repoRoot, tracked, findings) {
   }
 }
 
+/**
+ * Every published README carries the same four load-bearing sections.
+ *
+ * These are long-form by decision, which means the same facts are restated in twenty files —
+ * and a restated fact is one that can go stale in nineteen of them. The four checked here are
+ * the ones whose absence is visible on npm and whose presence cannot be inferred: what state
+ * the package is in, how to install it, what it relates to, and its licence. Depth below them
+ * stays a human judgement and is not checked.
+ *
+ * Headings are matched loosely because the house style is not uniform — `Install`,
+ * `Installation`, `Quickstart` and `Usage` all answer the same question, and `See also` is
+ * `Related packages` under another name. Enforcing one spelling would be a rename, not a check.
+ */
+const README_SECTIONS = [
+  { key: "status", label: "an alpha or stability note", test: /in alpha|@?experimental/i },
+  {
+    key: "install",
+    label: "an Install, Installation, Quickstart or Usage section",
+    test: /^##\s+(install|installation|quick\s*start|usage)/im,
+  },
+  {
+    key: "related",
+    label: "a Related packages or See also section",
+    test: /^##\s+(related packages|see also)/im,
+  },
+  { key: "license", label: "a License section", test: /^##\s+licen[sc]e/im },
+];
+
+function readmeSkeleton(repoRoot, packages, findings) {
+  for (const pkg of packages) {
+    const readme = join(pkg.dir, "README.md");
+    if (!existsSync(readme)) continue; // readme-present already reports this
+    let text;
+    try {
+      text = readFileSync(readme, "utf-8");
+    } catch {
+      continue;
+    }
+    for (const section of README_SECTIONS) {
+      if (!section.test.test(text)) {
+        findings.push({
+          check: "readme-skeleton",
+          file: relative(repoRoot, readme),
+          line: null,
+          message: `${pkg.name} is published but its README has no ${section.label}`,
+        });
+      }
+    }
+  }
+}
+
 export async function runChecks({
   repoRoot,
   allowlist = {},
@@ -471,6 +522,7 @@ export async function runChecks({
     }
   }
 
+  readmeSkeleton(repoRoot, packages, findings);
   internalLinks(repoRoot, tracked, findings);
   metaReachability(repoRoot, tracked, findings);
 

--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -354,13 +354,17 @@ const README_SECTIONS = [
 export function renderedProse(markdown) {
   return (
     markdown
-      // Paired fences first, then an unpaired one. An opening fence with no closing
+      // Comments first. A fence marker inside a comment is not a fence, and running
+      // the fence rules first let `<!--\n```\n-->` swallow the rest of the file —
+      // reporting real sections after it as missing, which is a red on a correct
+      // README and the worst direction for this check to fail in.
+      .replace(/<!--[\s\S]*?-->/g, "")
+      // Then paired fences, then an unpaired one. An opening fence with no closing
       // fence renders as code all the way to the end of the file, so stopping at
       // paired blocks would leave that tail in `prose` and let a truncated example
       // satisfy the very sections this is checking for.
       .replace(/^ {0,3}(`{3,}|~{3,})[\s\S]*?^ {0,3}\1[^\n]*$/gm, "")
       .replace(/^ {0,3}(`{3,}|~{3,})[\s\S]*$/m, "")
-      .replace(/<!--[\s\S]*?-->/g, "")
   );
 }
 

--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -325,7 +325,10 @@ const README_SECTIONS = [
     // "in alpha" rejected `## Stability` / "Alpha." — a correct statement several
     // packages already used — and would go on to reject an accurate "Beta" or
     // "Stable" note later, which turns the check into a demand for boilerplate.
-    test: /in alpha|@?experimental|^##\s+(status|stability)/im,
+    // The section alternative requires a NON-EMPTY body: an empty `## Status` answers
+    // nothing, and accepting the heading alone would let the check be satisfied by a
+    // section that exists rather than by a state that is stated.
+    test: /in alpha|@?experimental|^##[ \t]+(status|stability)[ \t]*\r?\n(?:[ \t]*\r?\n)*[ \t]*(?!#)\S/im,
   },
   {
     key: "install",
@@ -349,9 +352,16 @@ const README_SECTIONS = [
  * by the appearance of the thing rather than the thing.
  */
 export function renderedProse(markdown) {
-  return markdown
-    .replace(/^ {0,3}(`{3,}|~{3,})[\s\S]*?^ {0,3}\1[^\n]*$/gm, "")
-    .replace(/<!--[\s\S]*?-->/g, "");
+  return (
+    markdown
+      // Paired fences first, then an unpaired one. An opening fence with no closing
+      // fence renders as code all the way to the end of the file, so stopping at
+      // paired blocks would leave that tail in `prose` and let a truncated example
+      // satisfy the very sections this is checking for.
+      .replace(/^ {0,3}(`{3,}|~{3,})[\s\S]*?^ {0,3}\1[^\n]*$/gm, "")
+      .replace(/^ {0,3}(`{3,}|~{3,})[\s\S]*$/m, "")
+      .replace(/<!--[\s\S]*?-->/g, "")
+  );
 }
 
 function readmeSkeleton(repoRoot, packages, findings) {

--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -318,7 +318,15 @@ function internalLinks(repoRoot, tracked, findings) {
  * `Related packages` under another name. Enforcing one spelling would be a rename, not a check.
  */
 const README_SECTIONS = [
-  { key: "status", label: "an alpha or stability note", test: /in alpha|@?experimental/i },
+  {
+    key: "status",
+    label: "an alpha or stability note, or a Status/Stability section",
+    // Either a note in prose OR a section carrying one. Matching only the phrase
+    // "in alpha" rejected `## Stability` / "Alpha." — a correct statement several
+    // packages already used — and would go on to reject an accurate "Beta" or
+    // "Stable" note later, which turns the check into a demand for boilerplate.
+    test: /in alpha|@?experimental|^##\s+(status|stability)/im,
+  },
   {
     key: "install",
     label: "an Install, Installation, Quickstart or Usage section",
@@ -332,6 +340,20 @@ const README_SECTIONS = [
   { key: "license", label: "a License section", test: /^##\s+licen[sc]e/im },
 ];
 
+/**
+ * Drop what npm will not render as prose before looking for these sections.
+ *
+ * A fenced example showing a README skeleton, or a commented-out block, contains the
+ * very headings this checks for — so testing the raw source would pass a package
+ * whose only `## Install` is inside a code sample. The check would then be satisfied
+ * by the appearance of the thing rather than the thing.
+ */
+export function renderedProse(markdown) {
+  return markdown
+    .replace(/^ {0,3}(`{3,}|~{3,})[\s\S]*?^ {0,3}\1[^\n]*$/gm, "")
+    .replace(/<!--[\s\S]*?-->/g, "");
+}
+
 function readmeSkeleton(repoRoot, packages, findings) {
   for (const pkg of packages) {
     const readme = join(pkg.dir, "README.md");
@@ -342,8 +364,9 @@ function readmeSkeleton(repoRoot, packages, findings) {
     } catch {
       continue;
     }
+    const prose = renderedProse(text);
     for (const section of README_SECTIONS) {
-      if (!section.test.test(text)) {
+      if (!section.test.test(prose)) {
         findings.push({
           check: "readme-skeleton",
           file: relative(repoRoot, readme),

--- a/scripts/check-docs-claims.test.mjs
+++ b/scripts/check-docs-claims.test.mjs
@@ -3,7 +3,12 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
 
-import { digestLine, runChecks, splitRefAndPath } from "./check-docs-claims.mjs";
+import {
+  digestLine,
+  renderedProse,
+  runChecks,
+  splitRefAndPath,
+} from "./check-docs-claims.mjs";
 
 /**
  * Each fixture exhibits exactly one defect, and every check is asserted twice:
@@ -466,5 +471,65 @@ describe("readme-skeleton", () => {
         "packages/thing/README.md": "# t\n",
       })
     ).not.toContain("readme-skeleton");
+  });
+});
+
+describe("readme-skeleton reads only what npm renders", () => {
+  const fenced = [
+    "# @nextlyhq/thing",
+    "",
+    "Does a thing.",
+    "",
+    "Here is the shape every README should have:",
+    "",
+    "````md",
+    "Nextly is in alpha.",
+    "## Install",
+    "## Related packages",
+    "## License",
+    "````",
+    "",
+  ].join("\n");
+
+  it("does not accept sections that exist only inside a code fence", async () => {
+    // Otherwise a README that merely SHOWS the skeleton passes as though it had one.
+    const checks = await checksFor({
+      "README.md": "# nextly\n\n@nextlyhq/thing\n",
+      "packages/thing/package.json": pkg(),
+      "packages/thing/README.md": fenced,
+    });
+    expect(checks).toContain("readme-skeleton");
+  });
+
+  it("does not accept sections that exist only inside an HTML comment", async () => {
+    expect(
+      await checksFor({
+        "README.md": "# nextly\n\n@nextlyhq/thing\n",
+        "packages/thing/package.json": pkg(),
+        "packages/thing/README.md":
+          "# t\n\n<!--\nNextly is in alpha.\n## Install\n## Related packages\n## License\n-->\n",
+      })
+    ).toContain("readme-skeleton");
+  });
+
+  it("accepts a Stability section carrying the state, not just the phrase", async () => {
+    // `## Stability` / `Alpha.` is what blocks-engine used before this work, and it is
+    // a correct statement. Demanding the literal words would be demanding boilerplate.
+    expect(
+      await checksFor({
+        "README.md": "# nextly\n\n@nextlyhq/thing\n",
+        "packages/thing/package.json": pkg(),
+        "packages/thing/README.md":
+          "# t\n\n## Stability\n\nAlpha.\n\n## Install\n\n## Related packages\n\n## License\n",
+      })
+    ).not.toContain("readme-skeleton");
+  });
+
+  it("strips fences and comments but keeps the surrounding prose", () => {
+    const out = renderedProse("before\n\n```\n## Install\n```\n\n<!-- ## License -->\n\nafter\n");
+    expect(out).toContain("before");
+    expect(out).toContain("after");
+    expect(out).not.toContain("## Install");
+    expect(out).not.toContain("## License");
   });
 });

--- a/scripts/check-docs-claims.test.mjs
+++ b/scripts/check-docs-claims.test.mjs
@@ -574,3 +574,35 @@ describe("readme-skeleton reads only what npm renders", () => {
     ).not.toContain("readme-skeleton");
   });
 });
+
+describe("a fence marker inside a comment is not a fence", () => {
+  it("does not let a commented-out fence swallow the rest of the file", () => {
+    // Running the fence rules before comment removal made `<!--\n```\n-->` eat
+    // everything after it, reporting real sections as missing on a correct README.
+    const out = renderedProse("# t\n\n<!--\n```\n-->\n\n## Status\n\nAlpha.\n\n## License\n");
+    expect(out).toContain("## Status");
+    expect(out).toContain("## License");
+  });
+
+  it("passes a README whose comment contains a stray fence marker", async () => {
+    expect(
+      await checksFor({
+        "README.md": "# nextly\n\n@nextlyhq/thing\n",
+        "packages/thing/package.json": pkg(),
+        "packages/thing/README.md":
+          "# t\n\n<!--\n```\n-->\n\n## Status\n\nAlpha.\n\n## Install\n\n## Related packages\n\n## License\n",
+      })
+    ).not.toContain("readme-skeleton");
+  });
+
+  it("still strips a real unclosed fence that is not inside a comment", async () => {
+    expect(
+      await checksFor({
+        "README.md": "# nextly\n\n@nextlyhq/thing\n",
+        "packages/thing/package.json": pkg(),
+        "packages/thing/README.md":
+          "# t\n\n```md\n## Status\n\nAlpha.\n\n## Install\n\n## Related packages\n\n## License\n",
+      })
+    ).toContain("readme-skeleton");
+  });
+});

--- a/scripts/check-docs-claims.test.mjs
+++ b/scripts/check-docs-claims.test.mjs
@@ -403,3 +403,68 @@ describe("internal-docs-link", () => {
     ).not.toContain("internal-docs-link");
   });
 });
+
+describe("readme-skeleton", () => {
+  const full = [
+    "# @nextlyhq/thing",
+    "",
+    "Nextly is in alpha. APIs may change before 1.0.",
+    "",
+    "## Install",
+    "",
+    "## Related packages",
+    "",
+    "## License",
+    "",
+  ].join("\n");
+
+  it("passes a README carrying all four sections", async () => {
+    expect(
+      await checksFor({
+        "README.md": "# nextly\n\n@nextlyhq/thing\n",
+        "packages/thing/package.json": pkg(),
+        "packages/thing/README.md": full,
+      })
+    ).not.toContain("readme-skeleton");
+  });
+
+  it("fires once per missing section, naming which", async () => {
+    const { root, files } = await fixture({
+      "README.md": "# nextly\n\n@nextlyhq/thing\n",
+      "packages/thing/package.json": pkg(),
+      "packages/thing/README.md": "# @nextlyhq/thing\n\nDoes a thing.\n",
+    });
+    const { findings } = await runChecks({
+      repoRoot: root,
+      files,
+      remoteRefs: REFS,
+      hasLocalCommit: () => true,
+    });
+    const skeleton = findings.filter(f => f.check === "readme-skeleton");
+    expect(skeleton).toHaveLength(4);
+    expect(skeleton.map(f => f.message).join(" ")).toContain("alpha or stability note");
+    expect(skeleton.map(f => f.message).join(" ")).toContain("License section");
+  });
+
+  it("accepts the house synonyms rather than one spelling", async () => {
+    // `Quickstart` and `See also` are what several packages already use. A check that
+    // demanded a single heading would be a rename dressed up as a rule.
+    expect(
+      await checksFor({
+        "README.md": "# nextly\n\n@nextlyhq/thing\n",
+        "packages/thing/package.json": pkg(),
+        "packages/thing/README.md":
+          "# t\n\nexperimental\n\n## Quickstart\n\n## See also\n\n## Licence\n",
+      })
+    ).not.toContain("readme-skeleton");
+  });
+
+  it("does not check a private package", async () => {
+    expect(
+      await checksFor({
+        "packages/thing/package.json": pkg({ private: true }),
+        "packages/thing/README.md": "# t\n",
+      })
+    ).not.toContain("readme-skeleton");
+  });
+});

--- a/scripts/check-docs-claims.test.mjs
+++ b/scripts/check-docs-claims.test.mjs
@@ -532,4 +532,45 @@ describe("readme-skeleton reads only what npm renders", () => {
     expect(out).not.toContain("## Install");
     expect(out).not.toContain("## License");
   });
+
+  it("treats an unclosed fence as code through to the end of the file", () => {
+    // Markdown does. Stopping at paired fences would leave the tail in prose, so a
+    // truncated example could satisfy the sections this is looking for.
+    const out = renderedProse("intro\n\n```md\nNextly is in alpha.\n## Install\n");
+    expect(out).toContain("intro");
+    expect(out).not.toContain("## Install");
+    expect(out).not.toContain("in alpha");
+  });
+
+  it("does not accept sections that exist only inside an unclosed fence", async () => {
+    expect(
+      await checksFor({
+        "README.md": "# nextly\n\n@nextlyhq/thing\n",
+        "packages/thing/package.json": pkg(),
+        "packages/thing/README.md":
+          "# t\n\n```md\nNextly is in alpha.\n## Install\n## Related packages\n## License\n",
+      })
+    ).toContain("readme-skeleton");
+  });
+
+  it("rejects an empty Status section, which answers nothing", async () => {
+    const checks = await checksFor({
+      "README.md": "# nextly\n\n@nextlyhq/thing\n",
+      "packages/thing/package.json": pkg(),
+      "packages/thing/README.md":
+        "# t\n\n## Status\n\n## Install\n\n## Related packages\n\n## License\n",
+    });
+    expect(checks).toContain("readme-skeleton");
+  });
+
+  it("accepts a Status section once it carries a value", async () => {
+    expect(
+      await checksFor({
+        "README.md": "# nextly\n\n@nextlyhq/thing\n",
+        "packages/thing/package.json": pkg(),
+        "packages/thing/README.md":
+          "# t\n\n## Status\n\nBeta.\n\n## Install\n\n## Related packages\n\n## License\n",
+      })
+    ).not.toContain("readme-skeleton");
+  });
 });


### PR DESCRIPTION
## Summary

Twenty packages are published, and a README is what npm renders — so each one is a front door for a project about to go public. Eight were missing at least one of the four sections whose absence is visible there: **what state the package is in, how to install it, what it relates to, and its licence.**

`@nextlyhq/adapter-drizzle` was a three-line stub that never said you are not meant to install it directly.

## What this does not do

**Depth is left alone.** Keeping these long-form was a deliberate decision, so this adds the frame around the existing prose rather than rewriting it — `builder` keeps its 335 lines and gains the four sections.

Two packages already stated their status in their own shape: `builder` said every export is `@experimental`, `plugin-sdk` carried its own alpha block. Those were **normalised into the house shape**, not given a second note stacked on top. My first audit scored both as missing a status note, which was the check being too literal rather than the READMEs being wrong.

`adapter-drizzle` gains an Install section that says *you do not install this directly, install the adapter for your database instead*. Padding an internal package to look like a public one would be worse than the stub was.

## The check

`readme-skeleton` in `check-docs-claims.mjs`. This is the mitigation that was promised when we chose long-form READMEs over thin ones: twenty files restating the same facts is nineteen places for a fact to go stale, so the frame is enforced rather than trusted.

It enforces **the frame, not the prose**, and accepts the house synonyms — `Install`, `Installation`, `Quickstart` and `Usage` all answer the same question, and `See also` is `Related packages` under another name. Demanding one spelling would be a rename dressed up as a rule.

## Test plan

- **The check reports 21 findings on `main` and 0 on this branch**, and the breakdown matches what I fixed by hand, package by package.
- `pnpm vitest run --dir scripts check-docs-claims` — **39 passed** (was 35). Four new: a complete README passes; an empty one fires exactly four times and names which sections; the house synonyms are accepted; a private package is not checked.
- `pnpm test:scripts` — **26 files, 734 tests passed**.
- `pnpm check:docs-claims` — clean.
- **87 relative links across all published READMEs checked, 0 broken.** Every `../package-name` and `../../LICENSE.md` resolves to a real path.
- Full lint + build + test via pre-push — passed, no bypass.

One consistency fix beyond the audit: `admin-css` linked its licence by absolute GitHub URL while every other package uses `../../LICENSE.md`. That was mine, from the PR that created it.

## Changeset

One `patch` covering the nine packages whose README changed. READMEs ship inside the npm tarball, so a README-only change is still a published change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded package documentation with installation guidance, stability notices, badges, related-package links, and license information.
  * Added cross-references between related packages and clarified required peer dependencies for Page Builder.
  * Updated Page Builder installation instructions to include required packages.
  * Standardized alpha-status and version-pinning guidance.
  * Corrected a license link to use the repository path.

* **Chores**
  * Added automated checks and test coverage for required README sections and documentation content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->