### PR TITLE
fix(nextly): index the pending-edit reads and resolve the registry once

### DIFF
--- a/.changeset/the-pending-edit-cards-stop-scanning-history.md
+++ b/.changeset/the-pending-edit-cards-stop-scanning-history.md
@@ -1,0 +1,46 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Index the dashboard's pending-edit reads, and resolve the content registry once per query.
+
+`nextly_versions` gains `nextly_versions_pending_edits_idx`, covering the
+predicates that define a working draft plus the collection filter and the
+cursor's ordering. Every existing index on that table leads with `scope_kind`,
+which these queries never constrain, so both dashboard cards answered with a
+full table scan: the count's row budget bounded the rows it received and
+nothing about the work the database did to find them.
+
+The pending-edit walk now resolves the registry and the configured locales ONCE
+per query rather than per page, and derives its candidate collections from the
+same snapshot it judges rows against. A registry that cannot be enumerated is
+reported rather than silently contributing nothing, so the cards refuse instead
+of stating that no document has unpublished edits.
+
+A count that could only establish a floor now renders as one in every archetype
+that draws it; `stats` cells previously formatted the total alone and presented
+a bounded number as exact.

--- a/.changeset/the-pending-edit-cards-stop-scanning-history.md
+++ b/.changeset/the-pending-edit-cards-stop-scanning-history.md
@@ -41,6 +41,16 @@ same snapshot it judges rows against. A registry that cannot be enumerated is
 reported rather than silently contributing nothing, so the cards refuse instead
 of stating that no document has unpublished edits.
 
+Core-schema reconciliation now compares INDEXES, not columns alone. The core
+snapshot omitted them, and the diff skips a table whose index data is absent, so
+an index-only release produced no operations at all and `nextly migrate`
+reported the core schema as up to date: the index reached newly created
+databases and no existing one. Partial indexes stay out of the comparison, since
+the snapshot type has nowhere to record a predicate and claiming one
+unconditionally proposed the same index on every run.
+
 A count that could only establish a floor now renders as one in every archetype
 that draws it; `stats` cells previously formatted the total alone and presented
-a bounded number as exact.
+a bounded number as exact. A linked stats cell also names its count in the
+link's accessible name — an `aria-label` replaces the element's descendants, so
+a screen reader announced the destination with no number at all.

--- a/packages/admin/src/components/features/widgets/__tests__/stats-archetype.test.tsx
+++ b/packages/admin/src/components/features/widgets/__tests__/stats-archetype.test.tsx
@@ -97,17 +97,23 @@ describe("a stats card", () => {
     expect(screen.getByText("14")).toBeInTheDocument();
   });
 
-  it("makes each number a link named for where it goes", () => {
-    // The number is the target, and the accessible name says what activating it
-    // does -- "1,204" alone tells a screen-reader user nothing.
+  it("makes each number a link named for the count AND where it goes", () => {
+    // The number is the target, and the accessible name carries both halves.
+    //
+    // 🔴 The count has to be IN the name, not merely inside the link. An
+    // `aria-label` replaces the element's descendants as its accessible name,
+    // so a label naming only the destination announced "Draft posts" with no
+    // number at all -- and, once a count could be a floor, no way to tell
+    // `14` from `14 or more` while the visible card showed the difference.
+    // The destination stays, because "1,204" alone says nothing about what
+    // activating it does.
     renderWith({ total: count(1204), draft: count(14) });
 
-    const drafts = screen.getByRole("link", { name: "Draft posts" });
+    const drafts = screen.getByRole("link", { name: "14, Draft posts" });
     expect(drafts).toHaveAttribute("href", expect.stringContaining("where="));
-    expect(screen.getByRole("link", { name: "All posts" })).toHaveAttribute(
-      "href",
-      "/admin/collections/posts"
-    );
+    expect(
+      screen.getByRole("link", { name: "1,204, All posts" })
+    ).toHaveAttribute("href", "/admin/collections/posts");
   });
 
   it("draws a card whose id contains the separator a composite key would use", () => {

--- a/packages/admin/src/components/features/widgets/archetypes/__tests__/count-floor.test.tsx
+++ b/packages/admin/src/components/features/widgets/archetypes/__tests__/count-floor.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * How a bounded count is drawn — in EVERY archetype that draws one.
+ *
+ * 🔴 Both are asserted in one file, from one table, deliberately. The defect
+ * this covers is not that either renderer was wrong on its own: `metric` handled
+ * `atLeast` correctly from the day the field was added, and `stats` formatted
+ * `total` and ignored it, so the same query rendered `2,000+` on one card and a
+ * confident `2,000` in a cell beside it. A per-archetype test file reproduces
+ * exactly that — whoever adds the next archetype copies the neighbouring file
+ * and its coverage, or does not. A table over the renderers makes the omission
+ * a failing test rather than a missing one.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type {
+  DashboardWidget,
+  WidgetResult,
+} from "@admin/types/dashboard/widgets";
+
+import { metricBody } from "../metric";
+import { statsBody } from "../stats";
+
+const metricWidget = {
+  id: "acme/pending",
+  title: "Pending edits",
+  archetype: "metric",
+  size: "sm",
+  query: { source: "system:versions", op: "count" },
+} as DashboardWidget;
+
+const statsWidget = {
+  id: "acme/health",
+  title: "Content health",
+  archetype: "stats",
+  size: "md",
+  cells: [
+    { key: "pending", label: "Pending", query: { source: "s", op: "count" } },
+  ],
+} as unknown as DashboardWidget;
+
+const count = (total: number, atLeast?: boolean): WidgetResult => ({
+  op: "count",
+  total,
+  ...(atLeast === undefined ? {} : { atLeast }),
+});
+
+/** Each archetype that draws a count, and how to draw one with it. */
+const renderers: [string, (result: WidgetResult) => void][] = [
+  [
+    "metric",
+    result => {
+      const outcome = metricBody(result, metricWidget);
+      if (!outcome.ok) throw new Error(`refused: ${outcome.message}`);
+      render(<>{outcome.node}</>);
+    },
+  ],
+  [
+    "stats",
+    result => {
+      const outcome = statsBody(statsWidget, () => ({ ok: true, result }));
+      if (!outcome.ok) throw new Error(`refused: ${outcome.message}`);
+      render(<>{outcome.node}</>);
+    },
+  ],
+];
+
+describe.each(renderers)("a count drawn by %s", (_name, draw) => {
+  it("marks a FLOOR so the number does not read as the whole figure", () => {
+    draw(count(2000, true));
+
+    // The glyph and the words are asserted separately because they are two
+    // different readings of one claim: `+` is punctuation a screen reader may
+    // not voice, so a card carrying only the glyph tells a sighted reader the
+    // number is bounded and tells everyone else it is exact.
+    expect(screen.getByText("2,000", { exact: false }).textContent).toContain(
+      "+"
+    );
+    expect(screen.getByText("or more")).toBeInTheDocument();
+  });
+
+  it("says nothing extra when the count IS the whole figure", () => {
+    // The control. Without it, a renderer that appended "+ or more" to every
+    // count would satisfy the case above -- and a reader would be told no
+    // number on the dashboard could be trusted.
+    draw(count(2000));
+
+    expect(screen.getByText("2,000")).toBeInTheDocument();
+    expect(screen.queryByText("or more")).not.toBeInTheDocument();
+  });
+});

--- a/packages/admin/src/components/features/widgets/archetypes/__tests__/count-floor.test.tsx
+++ b/packages/admin/src/components/features/widgets/archetypes/__tests__/count-floor.test.tsx
@@ -10,7 +10,7 @@
  * and its coverage, or does not. A table over the renderers makes the omission
  * a failing test rather than a missing one.
  */
-import { render, screen } from "@testing-library/react";
+import { render, screen, type RenderResult } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import type {
@@ -46,13 +46,13 @@ const count = (total: number, atLeast?: boolean): WidgetResult => ({
 });
 
 /** Each archetype that draws a count, and how to draw one with it. */
-const renderers: [string, (result: WidgetResult) => void][] = [
+const renderers: [string, (result: WidgetResult) => RenderResult][] = [
   [
     "metric",
     result => {
       const outcome = metricBody(result, metricWidget);
       if (!outcome.ok) throw new Error(`refused: ${outcome.message}`);
-      render(<>{outcome.node}</>);
+      return render(<>{outcome.node}</>);
     },
   ],
   [
@@ -60,32 +60,75 @@ const renderers: [string, (result: WidgetResult) => void][] = [
     result => {
       const outcome = statsBody(statsWidget, () => ({ ok: true, result }));
       if (!outcome.ok) throw new Error(`refused: ${outcome.message}`);
-      render(<>{outcome.node}</>);
+      return render(<>{outcome.node}</>);
     },
   ],
 ];
 
 describe.each(renderers)("a count drawn by %s", (_name, draw) => {
-  it("marks a FLOOR so the number does not read as the whole figure", () => {
-    draw(count(2000, true));
+  it("marks a FLOOR for both readers, in their own notation", () => {
+    const { container } = draw(count(2000, true));
 
-    // The glyph and the words are asserted separately because they are two
-    // different readings of one claim: `+` is punctuation a screen reader may
-    // not voice, so a card carrying only the glyph tells a sighted reader the
-    // number is bounded and tells everyone else it is exact.
-    expect(screen.getByText("2,000", { exact: false }).textContent).toContain(
+    // Asserted separately because they are two renderings of one claim and
+    // each can be lost on its own: `+` is punctuation a screen reader may not
+    // voice, and the words are invisible.
+    expect(container.textContent).toContain("2,000");
+    expect(container.querySelector('[aria-hidden="true"]')?.textContent).toBe(
       "+"
     );
-    expect(screen.getByText("or more")).toBeInTheDocument();
+    expect(container.querySelector(".sr-only")?.textContent).toBe(" or more");
   });
 
   it("says nothing extra when the count IS the whole figure", () => {
-    // The control. Without it, a renderer that appended "+ or more" to every
-    // count would satisfy the case above -- and a reader would be told no
+    // The control. Without it, a renderer that appended the floor wording to
+    // every count would satisfy the case above, and a reader would be told no
     // number on the dashboard could be trusted.
-    draw(count(2000));
+    const { container } = draw(count(2000));
 
-    expect(screen.getByText("2,000")).toBeInTheDocument();
-    expect(screen.queryByText("or more")).not.toBeInTheDocument();
+    expect(container.textContent).toContain("2,000");
+    expect(container.querySelector(".sr-only")).toBeNull();
+    expect(container.textContent).not.toContain("or more");
+  });
+});
+
+describe("a stats cell that links", () => {
+  /** The generated collection-health cells all declare a link. */
+  const linked = {
+    ...statsWidget,
+    cells: [
+      {
+        key: "pending",
+        label: "Pending",
+        query: { source: "s", op: "count" },
+        link: { href: "/admin/posts?status=draft", label: "Draft posts" },
+      },
+    ],
+  } as unknown as DashboardWidget;
+
+  const drawLinked = (result: WidgetResult) => {
+    const outcome = statsBody(linked, () => ({ ok: true, result }));
+    if (!outcome.ok) throw new Error(`refused: ${outcome.message}`);
+    return render(<>{outcome.node}</>);
+  };
+
+  it("names the count AND the floor, not just the destination", () => {
+    // 🔴 An `aria-label` REPLACES the element's descendants as the accessible
+    // name, so the `sr-only` wording inside the link is not announced at all.
+    // Naming only the destination left a screen-reader user hearing "Draft
+    // posts" with no number and no way to tell a bounded count from a whole
+    // one -- while the visible card showed `2,000+`.
+    drawLinked(count(2000, true));
+
+    expect(
+      screen.getByRole("link", { name: "2,000 or more, Draft posts" })
+    ).toBeInTheDocument();
+  });
+
+  it("names an exact count without the floor wording", () => {
+    drawLinked(count(2000));
+
+    expect(
+      screen.getByRole("link", { name: "2,000, Draft posts" })
+    ).toBeInTheDocument();
   });
 });

--- a/packages/admin/src/components/features/widgets/archetypes/count-value.tsx
+++ b/packages/admin/src/components/features/widgets/archetypes/count-value.tsx
@@ -15,6 +15,31 @@
 import type { JSX } from "react";
 
 /**
+ * The words a floor is said in, for both readers.
+ *
+ * One constant rather than one per renderer: the visible `+` and the spoken
+ * phrase are two notations for the same claim, and a card whose two readers
+ * disagree about whether a number is whole is the defect this module exists to
+ * prevent, one level down.
+ */
+const FLOOR_SUFFIX = " or more";
+
+/**
+ * What assistive technology should HEAR for a count.
+ *
+ * 🔴 Exported because a rendered node is not always what gets announced. A
+ * stats cell that links wraps its number in an `aria-label`, and an
+ * `aria-label` REPLACES the element's descendants as its accessible name — so
+ * everything {@link CountValue} renders, the number included, was dropped from
+ * what a screen reader read out. Composing that name from this keeps one
+ * spoken form wherever a count is announced.
+ */
+export function countLabel(total: number, atLeast?: boolean): string {
+  const formatted = total.toLocaleString();
+  return atLeast === true ? `${formatted}${FLOOR_SUFFIX}` : formatted;
+}
+
+/**
  * `total`, with a trailing `+` when the source could only establish a floor.
  *
  * The marker is punctuation a screen reader may not voice, so the words are
@@ -35,7 +60,7 @@ export function CountValue({
       {atLeast === true ? (
         <>
           <span aria-hidden="true">+</span>
-          <span className="sr-only"> or more</span>
+          <span className="sr-only">{FLOOR_SUFFIX}</span>
         </>
       ) : null}
     </>

--- a/packages/admin/src/components/features/widgets/archetypes/count-value.tsx
+++ b/packages/admin/src/components/features/widgets/archetypes/count-value.tsx
@@ -1,0 +1,43 @@
+/**
+ * How a count is written when it may be a FLOOR rather than a total.
+ *
+ * 🔴 One implementation, used by every archetype that draws a count. `metric`
+ * and `stats` each formatted their own, and when `WidgetResult` gained
+ * `atLeast` only one of them was taught about it — so the same query rendered
+ * `2,000+` on a metric card and `2,000` on a stats cell, the second stating as
+ * exact a number its own source had declined to vouch for. Two renderers of one
+ * value agree on the day they are written; the drift is silent because each
+ * reads correctly on its own.
+ *
+ * @module components/features/widgets/archetypes/count-value
+ */
+
+import type { JSX } from "react";
+
+/**
+ * `total`, with a trailing `+` when the source could only establish a floor.
+ *
+ * The marker is punctuation a screen reader may not voice, so the words are
+ * given separately rather than relying on it: `aria-hidden` on the glyph and an
+ * `sr-only` phrase beside it means both readings carry the same claim, and a
+ * reader using assistive technology is not told a bounded number is a whole one.
+ */
+export function CountValue({
+  total,
+  atLeast,
+}: {
+  total: number;
+  atLeast?: boolean;
+}): JSX.Element {
+  return (
+    <>
+      {total.toLocaleString()}
+      {atLeast === true ? (
+        <>
+          <span aria-hidden="true">+</span>
+          <span className="sr-only"> or more</span>
+        </>
+      ) : null}
+    </>
+  );
+}

--- a/packages/admin/src/components/features/widgets/archetypes/metric.tsx
+++ b/packages/admin/src/components/features/widgets/archetypes/metric.tsx
@@ -12,6 +12,7 @@
  * @module components/features/widgets/archetypes/metric
  */
 
+import { CountValue } from "./count-value";
 import type { ArchetypeAccepts, ArchetypeBody } from "./types";
 
 /**
@@ -58,18 +59,12 @@ export const metricBody: ArchetypeBody = (result, definition) => {
         // core ones reads as a different component, not as a peer.
         className="text-2xl font-bold leading-none tabular-nums tracking-tight text-foreground"
       >
-        {result.total.toLocaleString()}
-        {result.atLeast === true ? (
-          <>
-            {/* A floor, said in the number itself. The card cannot know the
-                whole figure -- the rows behind it are filtered by a rule the
-                database cannot apply -- and a bare number would claim it does.
-                Announced to assistive technology in words, since a trailing
-                "+" is punctuation a screen reader may not voice. */}
-            <span aria-hidden="true">+</span>
-            <span className="sr-only"> or more</span>
-          </>
-        ) : null}
+        {/* A floor is said in the number itself: the card cannot know the whole
+            figure -- the rows behind it are filtered by a rule the database
+            cannot apply -- and a bare number would claim it does. Drawn by the
+            shared renderer so a stats cell showing the same query cannot
+            disagree with this one about whether it is exact. */}
+        <CountValue total={result.total} atLeast={result.atLeast} />
       </p>
     ),
   };

--- a/packages/admin/src/components/features/widgets/archetypes/stats.tsx
+++ b/packages/admin/src/components/features/widgets/archetypes/stats.tsx
@@ -9,9 +9,12 @@
  * @module components/features/widgets/archetypes/stats
  */
 
+import type { ReactNode } from "react";
+
 import { Link } from "@admin/components/ui/link";
 import type { WidgetSlot } from "@admin/types/dashboard/widgets";
 
+import { CountValue } from "./count-value";
 import type { ArchetypeAccepts, CellsBody, CellSlotLookup } from "./types";
 
 /** A stats card is its cells, so a declaration without them draws nothing. */
@@ -33,13 +36,21 @@ export const statsAccepts: ArchetypeAccepts = definition => {
  * query's limit.
  */
 function cellValue(slot: WidgetSlot | undefined): {
-  text: string;
+  text: ReactNode;
   muted: boolean;
 } {
   if (!slot) return { text: "…", muted: true };
   if (!slot.ok) return { text: "—", muted: true };
   if (slot.result.op !== "count") return { text: "—", muted: true };
-  return { text: slot.result.total.toLocaleString(), muted: false };
+  // 🔴 Through the shared renderer, so a cell cannot present as exact a count
+  // its source reported as a floor. Formatting `total` alone here is what let
+  // one query render `2,000+` on a metric card and `2,000` in a stats cell.
+  return {
+    text: (
+      <CountValue total={slot.result.total} atLeast={slot.result.atLeast} />
+    ),
+    muted: false,
+  };
 }
 
 export const statsBody: CellsBody = (definition, slotFor: CellSlotLookup) => {

--- a/packages/admin/src/components/features/widgets/archetypes/stats.tsx
+++ b/packages/admin/src/components/features/widgets/archetypes/stats.tsx
@@ -14,7 +14,7 @@ import type { ReactNode } from "react";
 import { Link } from "@admin/components/ui/link";
 import type { WidgetSlot } from "@admin/types/dashboard/widgets";
 
-import { CountValue } from "./count-value";
+import { CountValue, countLabel } from "./count-value";
 import type { ArchetypeAccepts, CellsBody, CellSlotLookup } from "./types";
 
 /** A stats card is its cells, so a declaration without them draws nothing. */
@@ -38,6 +38,8 @@ export const statsAccepts: ArchetypeAccepts = definition => {
 function cellValue(slot: WidgetSlot | undefined): {
   text: ReactNode;
   muted: boolean;
+  /** The spoken form, present only when there is a real number to speak. */
+  spoken?: string;
 } {
   if (!slot) return { text: "…", muted: true };
   if (!slot.ok) return { text: "—", muted: true };
@@ -50,6 +52,7 @@ function cellValue(slot: WidgetSlot | undefined): {
       <CountValue total={slot.result.total} atLeast={slot.result.atLeast} />
     ),
     muted: false,
+    spoken: countLabel(slot.result.total, slot.result.atLeast),
   };
 }
 
@@ -97,7 +100,7 @@ export const statsBody: CellsBody = (definition, slotFor: CellSlotLookup) => {
         className="grid grid-cols-[repeat(auto-fit,minmax(6.5rem,1fr))] gap-4"
       >
         {cells.map(cell => {
-          const { text, muted } = cellValue(slotFor(cell.key));
+          const { text, muted, spoken } = cellValue(slotFor(cell.key));
           const value = (
             <span
               // `tabular-nums` for the reason `metric` uses it: the grid
@@ -116,10 +119,16 @@ export const statsBody: CellsBody = (definition, slotFor: CellSlotLookup) => {
                 {cell.link ? (
                   <Link
                     href={cell.link.href}
-                    // The number is the target, and the accessible name says
-                    // where it goes -- "1,204" alone tells a screen-reader user
-                    // nothing about what activating it does.
-                    aria-label={cell.link.label}
+                    // 🔴 The NUMBER as well as the destination. An
+                    // `aria-label` replaces the element's descendants as its
+                    // accessible name, so naming only the destination meant a
+                    // screen reader announced "Draft posts" and neither the
+                    // count nor, when the count was a floor, that it was one.
+                    // The label still ends with the destination, because
+                    // "1,204" alone says nothing about what activating it does.
+                    aria-label={
+                      spoken ? `${spoken}, ${cell.link.label}` : cell.link.label
+                    }
                     className="rounded-sm hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                   >
                     {value}

--- a/packages/nextly/src/database/sqlite-core-tables.ts
+++ b/packages/nextly/src/database/sqlite-core-tables.ts
@@ -391,6 +391,12 @@ export function generateSqliteCoreTableStatements(): string[] {
       ON "nextly_versions" ("draft_key")`,
     `CREATE INDEX IF NOT EXISTS "nextly_versions_doc_recent_idx"
       ON "nextly_versions" ("scope_kind", "scope_slug", "entry_id", "created_at")`,
+    // The dashboard's pending-edit cards. Its columns are the WHERE clause of
+    // `findPendingEditRows` followed by that read's own ordering; every index
+    // above leads with "scope_kind", which that query never constrains, so
+    // without this one both cards scan the whole version history.
+    `CREATE INDEX IF NOT EXISTS "nextly_versions_pending_edits_idx"
+      ON "nextly_versions" ("is_autosave", "status", "version_no", "scope_slug", "updated_at", "id")`,
     // Content releases. Columns match schemas/releases/sqlite.ts.
     `CREATE TABLE IF NOT EXISTS "nextly_releases" (
       "id" TEXT PRIMARY KEY NOT NULL,

--- a/packages/nextly/src/domains/schema/migrate/core-index-reconcile.integration.test.ts
+++ b/packages/nextly/src/domains/schema/migrate/core-index-reconcile.integration.test.ts
@@ -1,0 +1,168 @@
+/**
+ * An index added to a core table reaches an EXISTING database.
+ *
+ * 🔴 It did not. `getCoreSchema()` built each core table through
+ * `drizzleTableToTableSpec()`, which omitted indexes, and `diffIndexes` skips
+ * any table whose `indexes` is `undefined` — so an index-only release produced
+ * no operations, `reconcileCore` returned `changed: false` before reaching the
+ * push, and only databases created AFTER the release ever got the index. Every
+ * upgraded installation kept the behaviour the index existed to remove, and
+ * nothing anywhere reported a difference: the declaration was present, the
+ * schema test passed, and `nextly migrate` said the core schema was up to date.
+ *
+ * The drop-and-reconcile shape is the point. Asserting that a fresh database
+ * has the index proves nothing about this, because a fresh database is created
+ * by the push and always had it — the failing case is a database that exists,
+ * is otherwise current, and is missing exactly one index.
+ *
+ * Each dialect gets its own database for the reason the idempotency suite
+ * beside this one gives: the property is about a database nothing else has
+ * touched.
+ */
+import { createPool } from "mysql2";
+import { Pool } from "pg";
+import { describe, expect, it } from "vitest";
+
+import { createAdapter } from "../../../database/factory";
+import { getSchemaEventsDdl } from "../events/schema-events-ddl";
+
+import { reconcileCore } from "./core-reconcile";
+
+const DB_NAME = "nextly_core_index";
+const INDEX = "nextly_versions_pending_edits_idx";
+
+/** The indexes the live database reports on `nextly_versions`. */
+async function liveIndexes(
+  adapter: { executeQuery: (sql: string) => Promise<unknown> },
+  dialect: "postgresql" | "mysql"
+): Promise<string[]> {
+  const sql =
+    dialect === "postgresql"
+      ? `SELECT indexname AS name FROM pg_indexes WHERE tablename = 'nextly_versions'`
+      : `SELECT DISTINCT index_name AS name FROM information_schema.statistics
+         WHERE table_schema = DATABASE() AND table_name = 'nextly_versions'`;
+  const rows = (await adapter.executeQuery(sql)) as unknown;
+  const list = Array.isArray(rows)
+    ? rows
+    : ((rows as { rows?: unknown[] }).rows ?? []);
+  return (Array.isArray(list[0]) ? (list[0] as unknown[]) : list).map(row =>
+    String((row as { name?: string; NAME?: string }).name ?? "")
+  );
+}
+
+/**
+ * Reconcile, remove the index behind the differ's back, reconcile again.
+ *
+ * Returns what the second reconcile reported and whether the index came back,
+ * because both matter and only together: an index restored by a run that
+ * reported `changed: false` would mean something else put it there.
+ */
+async function dropThenReconcile(
+  url: string,
+  dialect: "postgresql" | "mysql"
+): Promise<{ before: boolean; reported: boolean; after: boolean }> {
+  const prevUrl = process.env.DATABASE_URL;
+  const prevDialect = process.env.DB_DIALECT;
+  const restoreEnv = (): void => {
+    if (prevUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = prevUrl;
+    if (prevDialect === undefined) delete process.env.DB_DIALECT;
+    else process.env.DB_DIALECT = prevDialect;
+  };
+
+  let adapter: Awaited<ReturnType<typeof createAdapter>> | undefined;
+  try {
+    process.env.DATABASE_URL = url;
+    process.env.DB_DIALECT = dialect;
+    const connected = await createAdapter({
+      type: dialect,
+      url,
+    } as Parameters<typeof createAdapter>[0]);
+    adapter = connected;
+
+    const ensureLedger = async (): Promise<void> => {
+      if (await connected.tableExists("nextly_schema_events")) return;
+      for (const stmt of getSchemaEventsDdl(dialect)) {
+        await connected.executeQuery(stmt);
+      }
+    };
+    const run = (): Promise<{ changed: boolean }> =>
+      reconcileCore({
+        db: connected.getDrizzle(),
+        dialect,
+        logger: { info: () => {}, warn: () => {} },
+        ensureLedger,
+      });
+
+    await run();
+    // The control: the database this test then breaks must have had the index,
+    // or "it came back" would be a claim about an index that was never there.
+    const before = (await liveIndexes(connected, dialect)).includes(INDEX);
+
+    await connected.executeQuery(
+      dialect === "postgresql"
+        ? `DROP INDEX "${INDEX}"`
+        : `DROP INDEX ${INDEX} ON nextly_versions`
+    );
+
+    const reported = (await run()).changed;
+    const after = (await liveIndexes(connected, dialect)).includes(INDEX);
+    return { before, reported, after };
+  } finally {
+    await adapter?.disconnect?.();
+    restoreEnv();
+  }
+}
+
+describe.skipIf(!process.env.TEST_POSTGRES_URL)(
+  "core index reconciliation (postgresql)",
+  () => {
+    it("restores an index missing from an existing database", async () => {
+      const admin = new Pool({
+        connectionString: process.env.TEST_POSTGRES_URL,
+      });
+      try {
+        await admin.query(`DROP DATABASE IF EXISTS ${DB_NAME}`);
+        await admin.query(`CREATE DATABASE ${DB_NAME}`);
+        const url = new URL(process.env.TEST_POSTGRES_URL as string);
+        url.pathname = `/${DB_NAME}`;
+        const outcome = await dropThenReconcile(url.toString(), "postgresql");
+        expect(outcome).toEqual({
+          before: true,
+          reported: true,
+          after: true,
+        });
+      } finally {
+        await admin.query(`DROP DATABASE IF EXISTS ${DB_NAME}`).catch(() => {});
+        await admin.end();
+      }
+    }, 60_000);
+  }
+);
+
+describe.skipIf(!process.env.TEST_MYSQL_URL)(
+  "core index reconciliation (mysql)",
+  () => {
+    it("restores an index missing from an existing database", async () => {
+      const admin = createPool({
+        uri: process.env.TEST_MYSQL_URL as string,
+        multipleStatements: false,
+      }).promise();
+      try {
+        await admin.query(`DROP DATABASE IF EXISTS ${DB_NAME}`);
+        await admin.query(`CREATE DATABASE ${DB_NAME}`);
+        const url = new URL(process.env.TEST_MYSQL_URL as string);
+        url.pathname = `/${DB_NAME}`;
+        const outcome = await dropThenReconcile(url.toString(), "mysql");
+        expect(outcome).toEqual({
+          before: true,
+          reported: true,
+          after: true,
+        });
+      } finally {
+        await admin.query(`DROP DATABASE IF EXISTS ${DB_NAME}`).catch(() => {});
+        await admin.end();
+      }
+    }, 60_000);
+  }
+);

--- a/packages/nextly/src/domains/versions/__tests__/pending-edit-paging.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/pending-edit-paging.test.ts
@@ -43,8 +43,14 @@ describe("paged pending-edit reads", () => {
     });
 
     expect(selects).toHaveLength(1);
+    // Exact rather than "contains the id column", because the ABSENCE of a
+    // `nulls` placement is load-bearing too: the adapter spells one as a
+    // leading `updated_at IS NULL` sort key, which no index can supply, and
+    // `updated_at` is NOT NULL on all three dialects so it could never have
+    // separated any rows. Asking for it cost an index-ordered read and bought
+    // nothing.
     expect(selects[0]?.orderBy).toEqual([
-      { column: "updatedAt", direction: "desc", nulls: "last" },
+      { column: "updatedAt", direction: "desc" },
       { column: "id", direction: "desc" },
     ]);
   });

--- a/packages/nextly/src/domains/versions/__tests__/pending-edit-query-plan.integration.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/pending-edit-query-plan.integration.test.ts
@@ -1,0 +1,150 @@
+/**
+ * The PLAN the pending-edit read produces — measured, not assumed.
+ *
+ * 🔴 An index that exists and an index the planner chooses are two different
+ * claims, and only the second one is the fix. Before
+ * `nextly_versions_pending_edits_idx`, every index on this table led with
+ * `scope_kind` — a column this query never constrains — so SQLite answered both
+ * dashboard cards with `SCAN nextly_versions`. Proving the count's walk had seen
+ * every pending edit therefore meant reading every version ever captured: the
+ * 2,000-row budget bounded the rows the walk RECEIVED and nothing whatever about
+ * the work the database did to produce them.
+ *
+ * SQLite only, and deliberately so. `EXPLAIN QUERY PLAN` is the one plan format
+ * of the three that is stable enough to assert on, and the property under test —
+ * that the predicates are an index seek rather than a table scan — is a
+ * consequence of the index's column order, which
+ * `schemas/versions/__tests__/pending-edits-index.test.ts` pins for all three
+ * dialects.
+ *
+ * The SQL is CAPTURED from the repository rather than written out here. A
+ * hand-written query would be a second derivation of the same intent, and it
+ * could go on being served by an index after the real one had drifted away from
+ * it — proving something about a statement the product never sends.
+ */
+import { sql as rawSql } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+
+import { createTestNextly } from "../../../plugins/test-nextly";
+import { VersionsRepository, type VersionRef } from "../versions-repository";
+
+/** Drizzle db proxy that records the SQL of every select it is asked to run. */
+function captureSelectSql(adapter: unknown, sink: string[]): void {
+  const host = adapter as { getDrizzle: (...args: unknown[]) => unknown };
+  const original = host.getDrizzle.bind(host);
+  host.getDrizzle = (...args: unknown[]) => {
+    const db = original(...args) as object;
+    const wrapBuilder = (builder: object): object =>
+      new Proxy(builder, {
+        get(target, prop, receiver) {
+          if (prop === "then") {
+            const toSql = (target as { toSQL?: () => { sql: string } }).toSQL;
+            if (typeof toSql === "function") sink.push(toSql.call(target).sql);
+          }
+          const value = Reflect.get(target, prop, receiver) as unknown;
+          if (typeof value !== "function") return value;
+          return (...callArgs: unknown[]) => {
+            const out = (value as (...a: unknown[]) => unknown).apply(
+              target,
+              callArgs
+            );
+            return out && typeof out === "object" && "toSQL" in out
+              ? wrapBuilder(out as object)
+              : out;
+          };
+        },
+      });
+    return new Proxy(db, {
+      get(target, prop, receiver) {
+        const value = Reflect.get(target, prop, receiver) as unknown;
+        if (typeof value !== "function") return value;
+        const bound = (value as (...a: unknown[]) => unknown).bind(target);
+        if (prop !== "select") return bound;
+        return (...callArgs: unknown[]) =>
+          wrapBuilder(bound(...callArgs) as object);
+      },
+    });
+  };
+}
+
+/** `sql` with its placeholders filled, so it can be explained as written. */
+function bind(sql: string, values: readonly string[]): string {
+  let next = 0;
+  return sql.replace(/\?/g, () => values[next++] ?? "NULL");
+}
+
+async function plan(adapter: unknown, statement: string): Promise<string> {
+  const rows = await (
+    adapter as { queryStatement: (s: unknown) => Promise<{ detail: string }[]> }
+  ).queryStatement(rawSql.raw(`EXPLAIN QUERY PLAN ${statement}`));
+  return rows.map(row => row.detail).join(" | ");
+}
+
+describe("pending-edit read plan (sqlite)", () => {
+  it("seeks the pending-edits index instead of scanning the table", async () => {
+    const handle = await createTestNextly();
+    try {
+      if (handle.adapter.getCapabilities().dialect !== "sqlite") return;
+      const repo = new VersionsRepository(handle.adapter);
+
+      // History has to OUTNUMBER the working drafts for the difference to mean
+      // anything: the defect is that proving exhaustion walks the durable rows
+      // too, and a table holding only drafts cannot show it.
+      for (let i = 0; i < 200; i++) {
+        const ref: VersionRef = {
+          scopeKind: "collection",
+          scopeSlug: "posts",
+          entryId: `entry-${i % 40}`,
+        };
+        await repo.insertVersion({
+          ref,
+          versionNo: Math.floor(i / 40) + 1,
+          status: "published",
+          isAutosave: false,
+          snapshot: { title: `v${i}` },
+        });
+      }
+      for (let i = 0; i < 3; i++) {
+        await repo.upsertWorkingDraft({
+          ref: {
+            scopeKind: "collection",
+            scopeSlug: "posts",
+            entryId: `entry-${i}`,
+          },
+          locale: null,
+          snapshot: { title: `draft-${i}` },
+        });
+      }
+
+      const captured: string[] = [];
+      captureSelectSql(handle.adapter, captured);
+
+      for (const order of ["identity", "recency"] as const) {
+        const rows = await repo.findPendingEditRows({
+          slugs: ["posts"],
+          limit: 100,
+          order,
+        });
+        // The control: the query this plan describes is the one that answers.
+        // A plan asserted over a statement returning nothing would be green for
+        // a read that had stopped working.
+        expect(rows).toHaveLength(3);
+      }
+
+      expect(captured).toHaveLength(2);
+      for (const statement of captured) {
+        const detail = await plan(
+          handle.adapter,
+          bind(statement, ["0", "'draft'", "'posts'", "100"])
+        );
+        expect(detail).toContain("nextly_versions_pending_edits_idx");
+        // The claim is the absence of a scan, stated on its own: an index can
+        // be NAMED in a plan that still walks the table through it, which is
+        // exactly what the primary-key autoindex did for the identity order.
+        expect(detail).not.toContain("SCAN");
+      }
+    } finally {
+      await handle.destroy();
+    }
+  });
+});

--- a/packages/nextly/src/domains/versions/__tests__/pending-edit-visibility.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/pending-edit-visibility.test.ts
@@ -12,7 +12,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const readableDocumentIds = vi.fn();
 const singleDocumentReadable = vi.fn();
 const resolveSingleDocumentId = vi.fn();
-const contentKinds = vi.fn();
+const contentSnapshot = vi.fn();
 const configValue = vi.fn();
 
 // The registry decides whether a row's own scope kind is still the live one, and
@@ -20,7 +20,7 @@ const configValue = vi.fn();
 // Both are container-backed, so a harness that omits them leaves every row
 // undecidable and the whole file green-on-nothing.
 vi.mock("../../../services/lib/registered-content-slugs", () => ({
-  registeredContentKinds: () => contentKinds() as unknown,
+  registeredContentSnapshot: () => contentSnapshot() as unknown,
 }));
 vi.mock("../../../di/container", () => ({
   container: {
@@ -40,9 +40,22 @@ vi.mock("../../singles/services/single-document-access", () => ({
     resolveSingleDocumentId(...args) as unknown,
 }));
 
-import { visiblePendingEdits } from "../pending-edit-visibility";
+import {
+  resolvePendingEditScope,
+  visiblePendingEdits,
+  type PendingEditScope,
+} from "../pending-edit-visibility";
 
 const caller = { user: { id: "user-1", roles: ["editor"] } };
+
+/**
+ * The install-wide facts, resolved the way the source resolves them.
+ *
+ * Taken from `resolvePendingEditScope` rather than hand-built, so these cases
+ * exercise the object the product actually passes down. A literal written here
+ * would go on agreeing with itself after the resolver's shape changed.
+ */
+const scopeNow = (): Promise<PendingEditScope> => resolvePendingEditScope();
 
 function row(patch: {
   entryId: string;
@@ -74,12 +87,13 @@ beforeEach(() => {
   );
   singleDocumentReadable.mockResolvedValue(true);
   resolveSingleDocumentId.mockResolvedValue("single-live");
-  contentKinds.mockResolvedValue(
-    new Map([
+  contentSnapshot.mockResolvedValue({
+    kinds: new Map([
       ["posts", "collection"],
       ["site-settings", "single"],
-    ])
-  );
+    ]),
+    degraded: false,
+  });
   configValue.mockReturnValue({
     localization: {
       locales: [
@@ -104,7 +118,8 @@ describe("collection rows", () => {
         row({ entryId: "e1", locale: "en" }),
         row({ entryId: "e1", locale: "de" }),
       ],
-      caller
+      caller,
+      await scopeNow()
     );
 
     expect(readableDocumentIds).toHaveBeenCalledTimes(2);
@@ -132,7 +147,8 @@ describe("collection rows", () => {
         row({ entryId: "e1", locale: "de" }),
         row({ entryId: "e1", locale: "en" }),
       ],
-      caller
+      caller,
+      await scopeNow()
     );
 
     expect(visible.map(r => r.locale)).toEqual(["en"]);
@@ -159,7 +175,8 @@ describe("collection rows", () => {
       Array.from({ length: 8 }, (_, index) =>
         row({ entryId: `e${index}`, locale: `l${index}` })
       ),
-      caller
+      caller,
+      await scopeNow()
     );
 
     // More than one at a time proves it is not serial; the bound proves it is
@@ -176,7 +193,8 @@ describe("collection rows", () => {
         row({ entryId: "e1", locale: "en" }),
         row({ entryId: "e2", locale: "en" }),
       ],
-      caller
+      caller,
+      await scopeNow()
     );
 
     expect(readableDocumentIds).toHaveBeenCalledTimes(1);
@@ -199,7 +217,8 @@ describe("rows nothing can decide", () => {
     // exists to prevent, wearing a different hat.
     const visible = await visiblePendingEdits(
       [row({ entryId: "e1", locale: "fr" })],
-      caller
+      caller,
+      await scopeNow()
     );
 
     expect(visible).toEqual([]);
@@ -213,7 +232,8 @@ describe("rows nothing can decide", () => {
         row({ entryId: "e1", locale: "fr" }),
         row({ entryId: "e1", locale: "en" }),
       ],
-      caller
+      caller,
+      await scopeNow()
     );
 
     expect(visible.map(r => r.locale)).toEqual(["en"]);
@@ -232,7 +252,8 @@ describe("rows nothing can decide", () => {
           scopeSlug: "site-settings",
         }),
       ],
-      caller
+      caller,
+      await scopeNow()
     );
 
     expect(visible).toEqual([]);
@@ -243,7 +264,8 @@ describe("rows nothing can decide", () => {
   it("drops a row whose slug is in neither registry", async () => {
     const visible = await visiblePendingEdits(
       [row({ entryId: "e1", scopeSlug: "deleted-collection" })],
-      caller
+      caller,
+      await scopeNow()
     );
 
     expect(visible).toEqual([]);
@@ -260,7 +282,11 @@ describe("single rows", () => {
     // a missing Single -- so probing first makes loading a dashboard perform a
     // write. The id is resolved from the backing row instead, which is what
     // `resolveSingleDocumentId` exists for.
-    await visiblePendingEdits([single("single-live")], caller);
+    await visiblePendingEdits(
+      [single("single-live")],
+      caller,
+      await scopeNow()
+    );
 
     expect(resolveSingleDocumentId).toHaveBeenCalledWith("site-settings");
     expect(singleDocumentReadable).toHaveBeenCalled();
@@ -272,7 +298,8 @@ describe("single rows", () => {
     // replacement's verdict exposes the predecessor's entry id and edit time.
     const visible = await visiblePendingEdits(
       [single("single-deleted")],
-      caller
+      caller,
+      await scopeNow()
     );
 
     expect(visible).toEqual([]);
@@ -282,9 +309,48 @@ describe("single rows", () => {
   it("drops every row when the Single has never been materialized", async () => {
     resolveSingleDocumentId.mockResolvedValue(null);
 
-    const visible = await visiblePendingEdits([single("single-live")], caller);
+    const visible = await visiblePendingEdits(
+      [single("single-live")],
+      caller,
+      await scopeNow()
+    );
 
     expect(visible).toEqual([]);
     expect(singleDocumentReadable).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolving the scope", () => {
+  it("reads the registry ONCE, however many pages are judged against it", async () => {
+    // 🔴 The registry and the locale config both answer an unreachable
+    // dependency with an EMPTY result, on purpose. Re-read per page, that
+    // safety inverts: a transient failure on one page drops every row that
+    // page holds while its neighbours keep theirs, and the walk goes on to
+    // publish the shortfall as a whole number. One resolution cannot fail
+    // halfway.
+    const scope = await scopeNow();
+    const rows = Array.from({ length: 3 }, (_, index) =>
+      row({ entryId: `e${index}`, locale: "en" })
+    );
+
+    for (const one of rows) await visiblePendingEdits([one], caller, scope);
+
+    expect(contentSnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it("carries the registry's own report that it could not be enumerated", async () => {
+    contentSnapshot.mockResolvedValue({ kinds: new Map(), degraded: true });
+
+    expect((await scopeNow()).degraded).toBe(true);
+  });
+
+  it("is NOT degraded when an install has simply registered nothing", async () => {
+    // The control that keeps `degraded` meaning what it says. An empty
+    // registry and an unreachable one produce the same empty map, and folding
+    // them together would either fail every empty install or excuse the case
+    // this flag exists to report.
+    contentSnapshot.mockResolvedValue({ kinds: new Map(), degraded: false });
+
+    expect((await scopeNow()).degraded).toBe(false);
   });
 });

--- a/packages/nextly/src/domains/versions/__tests__/versions-widget-source.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/versions-widget-source.test.ts
@@ -7,6 +7,7 @@ const pendingEditRows = vi.fn();
 const has = vi.fn();
 const readable = vi.fn();
 const registeredSlugs = vi.fn();
+const scopeDegraded = vi.fn();
 const visible = vi.fn();
 
 vi.mock("../../../di/container", () => ({
@@ -26,9 +27,7 @@ vi.mock("../../../auth/entity-read-access", async importOriginal => ({
   readableEntities: (slugs: readonly string[], caller: unknown) =>
     readable(slugs, caller) as unknown,
 }));
-vi.mock("../../../services/lib/registered-content-slugs", () => ({
-  registeredContentSlugs: () => registeredSlugs() as unknown,
-}));
+
 // A PASS-THROUGH, so the assertions below stay about what this module decides:
 // which collections are in reach, and what it answers with. The document-level
 // filter it stands in for reaches the ordinary read path and a stored access
@@ -37,9 +36,24 @@ vi.mock("../../../services/lib/registered-content-slugs", () => ({
 // against a real database and a real owner-only rule. The final test in this
 // block is what keeps the substitution honest: it asserts the rows and the
 // caller actually reach this seam, so deleting the call is not a green.
-vi.mock("../pending-edit-visibility", () => ({
+//
+// Spread from the real module rather than written as a closed literal: a
+// literal silently drops every export it does not list, so a new one becomes
+// `undefined` at the call site and the failure names the mock rather than the
+// change that introduced it.
+vi.mock("../pending-edit-visibility", async importOriginal => ({
+  ...(await importOriginal<typeof import("../pending-edit-visibility")>()),
   visiblePendingEdits: (rows: unknown, caller: unknown) =>
     visible(rows, caller) as unknown,
+  resolvePendingEditScope: async () => ({
+    // The registry snapshot the source bounds the query with. Its keys ARE the
+    // candidate slugs, which is the property under test in the block below.
+    kinds: new Map(
+      ((await registeredSlugs()) as string[]).map(slug => [slug, "collection"])
+    ),
+    locales: null,
+    degraded: (scopeDegraded() as boolean) ?? false,
+  }),
 }));
 
 import { executeWidgetQuery } from "../../widgets/execute";
@@ -74,6 +88,7 @@ beforeEach(() => {
   pendingEditRows.mockResolvedValue([row]);
   readable.mockResolvedValue(new Set(["posts"]));
   registeredSlugs.mockResolvedValue(["posts", "secrets"]);
+  scopeDegraded.mockReturnValue(false);
   visible.mockImplementation((rows: unknown) => Promise.resolve(rows));
   clearSources();
   clearSystemResolvers();
@@ -177,6 +192,41 @@ describe("who the numbers are for", () => {
    * language. The count says `atLeast` now, so there is no quota to sit on and
    * no refusal to provoke.
    */
+
+  it("REFUSES when the registry could not be enumerated, rather than answering 0", async () => {
+    // 🔴 The registry answers an unreachable dependency with an empty set, which
+    // is the right fail-closed direction for an access decision and the wrong
+    // one for a number: no slug is in reach, so nothing is counted, and the card
+    // states as fact that nobody has unpublished work. A count is a positive
+    // claim about documents this never managed to look for. The grid draws a
+    // failed card per widget, so refusing costs the reader one card and not the
+    // dashboard.
+    scopeDegraded.mockReturnValue(true);
+
+    await expect(
+      executeWidgetQuery({ source: VERSIONS_SOURCE_ID, op: "count" }, caller)
+    ).rejects.toThrow();
+  });
+
+  it("answers 0 for an install that has genuinely registered nothing", async () => {
+    // The control that stops the refusal above swallowing a legitimate empty
+    // install: both produce an empty candidate set, and only one of them is a
+    // failure. Without this, mapping "no slugs" to a refusal would break every
+    // dashboard on a fresh install and read as the same fix.
+    registeredSlugs.mockResolvedValue([]);
+    readable.mockResolvedValue(new Set());
+
+    // Asserted as "answers at all", plus the empty candidate list it answers
+    // FROM. `total` is not the property here: the empty-slug short circuit
+    // lives in the repository, which this harness replaces, so a count taken
+    // from the stub would be measuring the stub.
+    await expect(
+      executeWidgetQuery({ source: VERSIONS_SOURCE_ID, op: "count" }, caller)
+    ).resolves.toMatchObject({ op: "count" });
+    expect(pendingEditRows).toHaveBeenCalledWith(
+      expect.objectContaining({ readableSlugs: [] })
+    );
+  });
 
   it("counts every visible document when the rows run out", async () => {
     // Exhaustion is the ROWS running out and nothing else. The count walks by

--- a/packages/nextly/src/domains/versions/pending-edit-visibility.ts
+++ b/packages/nextly/src/domains/versions/pending-edit-visibility.ts
@@ -30,7 +30,7 @@ import { container } from "../../di/container";
 import type { NextlyServiceConfig } from "../../di/register";
 import type { ReadCaller } from "../../services/dashboard/readable-resources";
 import { readableDocumentIds } from "../../services/lib/readable-documents";
-import { registeredContentKinds } from "../../services/lib/registered-content-slugs";
+import { registeredContentSnapshot } from "../../services/lib/registered-content-slugs";
 
 import type { VersionMeta } from "./versions-repository";
 
@@ -59,7 +59,7 @@ interface ReadUnit {
  * verdict — a row exposed on a predicate never evaluated for it, which is the
  * same defect as passing no locale at all.
  */
-function configuredLocales(): Set<string> | null {
+function configuredLocales(): ReadonlySet<string> | null {
   try {
     if (!container.has("config")) return null;
     const localization =
@@ -90,7 +90,7 @@ function configuredLocales(): Set<string> | null {
 function subjectOf(
   row: VersionMeta,
   kinds: ReadonlyMap<string, "collection" | "single">,
-  locales: Set<string> | null
+  locales: ReadonlySet<string> | null
 ): Subject | null {
   const kind = kinds.get(row.scopeSlug);
   if (!kind || kind !== row.scopeKind) return null;
@@ -254,15 +254,44 @@ async function visibleSingleRows(
   return visible;
 }
 
+/**
+ * The install-wide facts every page of one walk must be judged against.
+ *
+ * 🔴 Resolved ONCE per query and carried, never re-read per page. Both halves
+ * turn a failure into an EMPTY answer on purpose — an unreachable registry
+ * contributes no slugs, an unreadable config no languages — and under a
+ * per-page read that safety became a defect: a transient failure on the seventh
+ * page dropped every row that page held, the pages either side of it kept
+ * theirs, and the walk finished and published the shortfall as a whole number.
+ * A snapshot cannot fail halfway; it is either the basis for the entire answer
+ * or the reason there is not one.
+ */
+export interface PendingEditScope {
+  kinds: ReadonlyMap<string, "collection" | "single">;
+  locales: ReadonlySet<string> | null;
+  /** True when the registry could not be enumerated, so `kinds` is a floor. */
+  degraded: boolean;
+}
+
+/** One resolution of the registry and the configured languages. */
+export async function resolvePendingEditScope(): Promise<PendingEditScope> {
+  const snapshot = await registeredContentSnapshot();
+  return {
+    kinds: snapshot.kinds,
+    locales: configuredLocales(),
+    degraded: snapshot.degraded,
+  };
+}
+
 /** `rows`, in their original order, keeping only what the caller may be told. */
 export async function visiblePendingEdits(
   rows: readonly VersionMeta[],
-  caller: ReadCaller
+  caller: ReadCaller,
+  scope: PendingEditScope
 ): Promise<VersionMeta[]> {
   if (rows.length === 0) return [];
 
-  const kinds = await registeredContentKinds();
-  const locales = configuredLocales();
+  const { kinds, locales } = scope;
 
   const subjects = new Map<VersionMeta, Subject>();
   for (const row of rows) {

--- a/packages/nextly/src/domains/versions/versions-repository.ts
+++ b/packages/nextly/src/domains/versions/versions-repository.ts
@@ -42,8 +42,13 @@ const TABLE = VERSIONS_TABLE;
  * that does not match the documents it points at.
  *
  * Never mutated -- both consumers spread it into a fresh `and` array.
+ *
+ * Exported so `nextly_versions_pending_edits_idx` can be checked against it
+ * rather than against a second list of the same column names: an index that
+ * does not cover every predicate here stops serving the query it exists for,
+ * and a copy of this shape in a test could not notice that.
  */
-const WORKING_DRAFT_SHAPE: readonly VersionsWhereCondition[] = [
+export const WORKING_DRAFT_SHAPE: readonly VersionsWhereCondition[] = [
   { column: "isAutosave", op: "=", value: false },
   { column: "versionNo", op: "IS NULL" },
   { column: "status", op: "=", value: "draft" },
@@ -183,13 +188,24 @@ function olderThan(
   };
 }
 
-/** The ordering clause for `order`, unique in both cases so a cursor is exact. */
+/**
+ * The ordering clause for `order`, unique in both cases so a cursor is exact.
+ *
+ * 🔴 No `nulls` placement, and its absence is deliberate. `updated_at` is
+ * NOT NULL on all three dialects, so no row can sit in either group and the
+ * per-dialect default has nothing to disagree about — but asking for one is not
+ * free: the adapter spells `nulls` as a LEADING `updated_at IS NULL` sort key,
+ * an expression `nextly_versions_pending_edits_idx` cannot supply, so SQLite
+ * sorted the rows in a temp B-tree rather than reading them in index order. It
+ * bought a guarantee the column's own nullability already gives, and paid for
+ * it in the one place this ordering is used.
+ */
 function orderClause(
   order: PendingEditOrder
-): { column: string; direction: "desc"; nulls?: "last" }[] {
+): { column: string; direction: "desc" }[] {
   if (order === "identity") return [{ column: "id", direction: "desc" }];
   return [
-    { column: "updatedAt", direction: "desc", nulls: "last" },
+    { column: "updatedAt", direction: "desc" },
     { column: "id", direction: "desc" },
   ];
 }
@@ -452,8 +468,7 @@ export class VersionsRepository {
       // a position exactly: `updatedAt` alone is not total -- SQLite stores
       // whole seconds, so drafts saved together tie -- and a cursor over a
       // non-unique key cannot say which of the tied rows a page ended on.
-      // `nulls` is stated because the default differs per dialect, and a limited
-      // list must not return different rows per engine.
+      // Neither states a `nulls` placement; `orderClause` says why.
       orderBy: orderClause(input.order),
       limit: input.limit,
     });

--- a/packages/nextly/src/domains/versions/versions-repository.ts
+++ b/packages/nextly/src/domains/versions/versions-repository.ts
@@ -451,6 +451,23 @@ export class VersionsRepository {
    * The snapshot is projected away. It is the largest column in the table and a
    * card that lists titles has no use for it.
    */
+  /**
+   * 🔴 Served by `nextly_versions_pending_edits_idx`, and by nothing else on
+   * this table. Every other index leads with `scope_kind`, which this query
+   * never constrains, so before that index existed SQLite answered the count
+   * with `SCAN nextly_versions USING INDEX sqlite_autoindex_nextly_versions_1`
+   * and the list with `SCAN nextly_versions` plus a temp B-tree, per page.
+   * Proving the count had seen every pending edit therefore meant reading every
+   * version ever captured: the caller's row budget bounded the rows it RECEIVED
+   * and nothing about the work the database did to find them.
+   *
+   * The index columns are this WHERE clause in order, then the cursor's own
+   * ordering. A single-collection install reads it in order and sorts nothing;
+   * with several collections the `IN` list is several ranges no engine here can
+   * merge, and the sort that follows is over working drafts alone rather than
+   * the whole table -- proportional to the number the card reports, not to the
+   * history behind it.
+   */
   async findPendingEditRows(input: {
     slugs: readonly string[];
     limit: number;

--- a/packages/nextly/src/domains/versions/versions-widget-source.ts
+++ b/packages/nextly/src/domains/versions/versions-widget-source.ts
@@ -59,14 +59,17 @@ import {
 import { container } from "../../di/container";
 import { NextlyError } from "../../errors/nextly-error";
 import type { ReadCaller } from "../../services/dashboard/readable-resources";
-import { registeredContentSlugs } from "../../services/lib/registered-content-slugs";
 import type { WidgetQuery } from "../widgets/query";
 import type { WidgetResult } from "../widgets/result";
 import { failUnavailableSourceOrOp } from "../widgets/sources";
 import { VERSIONS_SOURCE_ID } from "../widgets/system-source-ids";
 import { registerSystemSource } from "../widgets/system-sources";
 
-import { visiblePendingEdits } from "./pending-edit-visibility";
+import {
+  resolvePendingEditScope,
+  visiblePendingEdits,
+  type PendingEditScope,
+} from "./pending-edit-visibility";
 import {
   documentKey,
   newestPerDocument,
@@ -97,6 +100,34 @@ const DEFAULT_LIMIT = 5;
  * a wrong answer: a document quota could not tell "exactly this many" from "more
  * than this many", and a shortcut on documents already seen conflated meeting a
  * document with deciding it, since authorization is per language.
+ *
+ * 🔴 A KNOWN, ACCEPTED disclosure lives here, recorded so nobody has to
+ * rediscover it and nobody removes it believing it accidental. `atLeast` is set
+ * when this budget binds, and the budget counts RAW rows — so whether a caller
+ * sees `5` or `5+` depends on how many draft rows exist in the collections they
+ * can reach, their colleagues' included. One bit, about total VOLUME: never
+ * which documents, whose, or when they were touched, which is what the
+ * pre-`visiblePendingEdits` card exposed.
+ *
+ * It is not removable while any bound exists, and that is the whole argument.
+ * The budget is here to bound WORK, work is raw rows, and any flag derived from
+ * a bound on unfiltered data is a fact about unfiltered data. Deriving it from
+ * the visible set instead means having no bound at all, so one dashboard load
+ * on a large install walks the entire pending-edit index — a self-inflicted
+ * denial of service on a page every session opens, traded for one bit.
+ *
+ * Nor does the index make the bound cheap enough to raise out of reach. The
+ * page-level cost is not the row read: each page also asks the ordinary read
+ * path which of its documents survive, once per slug and language, and THOSE
+ * scale with the number of pages. Raising this multiplies the authorization
+ * round trips behind every dashboard, which is the cost the number was chosen
+ * against.
+ *
+ * The general fix is to let the database apply the access rule itself, as
+ * Payload and Directus do — exact, cheap and leak-free. It needs the version
+ * row to carry or join the fields a rule names, and a `custom` rule is an
+ * arbitrary function that cannot be pushed down at all, so it closes the common
+ * case and not this one. Its own piece of work, not a patch here.
  */
 const COUNT_ROW_BUDGET = 2000;
 
@@ -296,7 +327,8 @@ async function gatherVisibleDocuments(
   rowBudget: number,
   order: PendingEditOrder,
   readableSlugs: readonly string[],
-  caller: ReadCaller
+  caller: ReadCaller,
+  scope: PendingEditScope
 ): Promise<{ documents: VersionMeta[]; exhausted: boolean }> {
   const gathered: Gathered = { documents: [], seen: new Set() };
   let after: PendingEditCursor | undefined;
@@ -318,7 +350,7 @@ async function gatherVisibleDocuments(
     const last = rows[rows.length - 1];
     after = { updatedAt: last.updatedAt, id: last.id };
 
-    const visible = await visiblePendingEdits(rows, caller);
+    const visible = await visiblePendingEdits(rows, caller, scope);
     if (absorbPage(gathered, visible, wanted)) {
       return { documents: gathered.documents, exhausted: false };
     }
@@ -340,9 +372,26 @@ async function resolveVersions(
   // Resolved ONCE per query and passed down, rather than each read asking
   // again: the two ops answer about the same set, and two resolutions of one
   // caller's permissions are two chances to disagree.
+  //
+  // 🔴 The candidate slugs come from the SAME snapshot the per-page visibility
+  // pass is judged against, so one query cannot be bounded by one enumeration
+  // of the registry and then filtered by another. Two reads can disagree — a
+  // collection registered between them is in the second and not the first —
+  // and the rows in between would be decided by a set that never bounded them.
+  const scope = await resolvePendingEditScope();
+  if (scope.degraded) {
+    // A registry that could not be enumerated makes every answer here a floor
+    // with nothing to say so. `0` would be a positive claim about documents
+    // this never managed to look for, and reporting a failure is the honest
+    // form of "not known" -- the grid renders one per card, so the rest of the
+    // dashboard still draws.
+    throw NextlyError.internal({
+      logContext: { reason: "content-registry-unreachable" },
+    });
+  }
   const readableSlugs = [
     ...(await readableEntities(
-      await registeredContentSlugs(),
+      [...scope.kinds.keys()],
       readAccessCaller(caller)
     )),
   ];
@@ -362,7 +411,8 @@ async function resolveVersions(
       // an id cannot be outrun by the rows being enumerated.
       "identity",
       readableSlugs,
-      caller
+      caller,
+      scope
     );
     return {
       op: "count",
@@ -385,7 +435,8 @@ async function resolveVersions(
       // reading a moving set -- and is why the COUNT does not order this way.
       "recency",
       readableSlugs,
-      caller
+      caller,
+      scope
     )
   ).documents;
   const names = selectedNames(query);

--- a/packages/nextly/src/schemas/_internal/drizzle-to-tablespec.ts
+++ b/packages/nextly/src/schemas/_internal/drizzle-to-tablespec.ts
@@ -7,31 +7,136 @@
  * differences when the schema is in sync. See build-from-fields.ts for the
  * type-token alignment contract (Phase 5 / 2026-05-01 note).
  *
- * Plan A scope: this utility produces the shape needed by `getCoreSchema()`
- * (table name + columns with name/type/nullable/default). Indexes and
- * constraints are out of scope — the diff engine treats absence as "no
- * structural constraint to compare against." Plan C will extend this if
- * Phase 1 needs richer comparison for core-schema reconciliation.
+ * Produces the shape `getCoreSchema()` needs: table name, columns, and — when
+ * the caller names a dialect — the table's declared INDEXES.
+ *
+ * 🔴 Indexes are why the dialect argument exists. Omitting them does not make
+ * the comparison conservative, it makes it blind: `diffIndexes` skips a table
+ * whose `indexes` is `undefined`, so an index-only release produced no
+ * operations at all, `reconcileCore` returned `changed: false` before reaching
+ * the push, and the index reached fresh databases only. Every upgraded
+ * installation kept the table scan the new index existed to remove, with
+ * nothing anywhere reporting a difference.
+ *
+ * Reading them needs the dialect because the accessor is per dialect —
+ * `getTableConfig` is exported separately by pg-core, mysql-core and
+ * sqlite-core, and a `Table` does not say which one it came from. A caller
+ * with no dialect to give still gets the columns-only spec, which is what
+ * `undefined` has always meant here.
  *
  * @module schemas/_internal/drizzle-to-tablespec
  * @since v0.0.3-alpha (Plan A — schemas consolidation)
  */
 
+import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 import { getColumns, getTableName, type Table } from "drizzle-orm";
+import { getTableConfig as mysqlTableConfig } from "drizzle-orm/mysql-core";
+import { getTableConfig as pgTableConfig } from "drizzle-orm/pg-core";
+import { getTableConfig as sqliteTableConfig } from "drizzle-orm/sqlite-core";
 
 import type {
   ColumnSpec,
+  IndexSpec,
   TableSpec,
 } from "../../domains/schema/pipeline/diff/types";
+
+/**
+ * One declared index, read from whichever dialect described it.
+ *
+ * Narrowed from `unknown` rather than asserted into a shared interface: the
+ * three `getTableConfig` functions each return their OWN `Index` type, and the
+ * column entries differ enough between them that no single assertion satisfies
+ * all three without lying about at least one.
+ */
+function indexSpecOf(candidate: unknown): IndexSpec | undefined {
+  if (typeof candidate !== "object" || candidate === null) return undefined;
+  const config = (candidate as { config?: unknown }).config;
+  if (typeof config !== "object" || config === null) return undefined;
+  const { name, unique, columns, where } = config as {
+    name?: unknown;
+    unique?: unknown;
+    columns?: unknown;
+    where?: unknown;
+  };
+  if (typeof name !== "string") return undefined;
+  // 🔴 PARTIAL indexes are dropped, because `IndexSpec` cannot express one: it
+  // is a name, a column list and a uniqueness flag, with nowhere to put the
+  // predicate. Including one asserts an UNCONDITIONAL index the database does
+  // not have, so the diff proposes adding it, the push writes nothing new, and
+  // the next run proposes it again -- measured on PostgreSQL as four indexes
+  // re-proposed forever, which made `reconcileCore` report a change on every
+  // run against a database it had just written.
+  //
+  // Omitting them is the honest reading rather than a workaround: an index this
+  // type cannot describe is one the diff does not track, which is what leaving
+  // it out has always meant here. Nothing is put at risk -- `diffIndexes` only
+  // drops names it manages (`idx_`/`uq_` prefixes), and no core index is named
+  // that way.
+  if (where !== undefined && where !== null) return undefined;
+  const names = Array.isArray(columns)
+    ? columns.flatMap(column => {
+        const columnName = (column as { name?: unknown } | null)?.name;
+        return typeof columnName === "string" ? [columnName] : [];
+      })
+    : [];
+  return { name, columns: names, unique: unique === true };
+}
+
+/**
+ * The indexes a table declares, as the diff engine spells them.
+ *
+ * A table whose accessor cannot be read contributes NO index data rather than
+ * an empty list: `[]` asserts "this table has none", which would invite
+ * dropping indexes that were merely unreadable, while `undefined` keeps the
+ * pre-existing "not tracked" meaning that makes `diffIndexes` skip the table.
+ */
+function declaredIndexes(
+  table: Table,
+  dialect: SupportedDialect
+): IndexSpec[] | undefined {
+  try {
+    // A switch rather than a lookup, because the three accessors are generic
+    // over their own dialect's table type: as a union they share no callable
+    // signature, and each `case` is one concrete function applied to one handle.
+    const declared: unknown[] | undefined = (() => {
+      switch (dialect) {
+        case "postgresql":
+          return pgTableConfig(table as never).indexes;
+        // No `as never` here, unlike its neighbours: the MySQL accessor takes a
+        // plain `Table`, while the PostgreSQL and SQLite ones are generic over
+        // their own dialect's table type and reject a bare `Table`.
+        case "mysql":
+          return mysqlTableConfig(table).indexes;
+        case "sqlite":
+          return sqliteTableConfig(table as never).indexes;
+        default:
+          return undefined;
+      }
+    })();
+    if (!declared) return undefined;
+    return declared.flatMap(entry => {
+      const spec = indexSpecOf(entry);
+      return spec ? [spec] : [];
+    });
+  } catch {
+    // A handle this accessor cannot read is UNKNOWN, not empty.
+    return undefined;
+  }
+}
 
 /**
  * Convert one Drizzle table to a TableSpec.
  *
  * @param table - a Drizzle table object (pgTable, mysqlTable, or sqliteTable result)
- * @returns TableSpec with `name` and `columns` populated. Indexes and
- *   constraints are intentionally omitted.
+ * @param dialect - which dialect's accessor to read indexes with. Omitted, the
+ *   spec carries columns alone and the diff skips this table's index dimension.
+ * @returns TableSpec with `name` and `columns`, plus `indexes` when a dialect
+ *   was given.
  */
-export function drizzleTableToTableSpec(table: Table): TableSpec {
+export function drizzleTableToTableSpec(
+  table: Table,
+  dialect?: SupportedDialect
+): TableSpec {
   const name = getTableName(table);
   // Drizzle v1 exposes table column metadata through getColumns()
   // (the pre-v1 accessor is deprecated); the TableSpec conversion below is
@@ -51,7 +156,8 @@ export function drizzleTableToTableSpec(table: Table): TableSpec {
     ...(col.primary === true ? { primaryKey: true } : {}),
   }));
 
-  return { name, columns };
+  const indexes = dialect ? declaredIndexes(table, dialect) : undefined;
+  return { name, columns, ...(indexes ? { indexes } : {}) };
 }
 
 /**

--- a/packages/nextly/src/schemas/index.ts
+++ b/packages/nextly/src/schemas/index.ts
@@ -261,7 +261,11 @@ export function getCoreSchema(
   }
 
   return {
-    tables: tables.map(drizzleTableToTableSpec),
+    // 🔴 An arrow, not a bare reference. `map` passes the ARRAY INDEX as the
+    // second argument, which this function now reads as a dialect -- so
+    // `tables.map(drizzleTableToTableSpec)` would hand table 0 the dialect `0`
+    // and silently drop every table's indexes but one.
+    tables: tables.map(table => drizzleTableToTableSpec(table, dialect)),
   };
 }
 

--- a/packages/nextly/src/schemas/versions/__tests__/pending-edits-index.test.ts
+++ b/packages/nextly/src/schemas/versions/__tests__/pending-edits-index.test.ts
@@ -1,0 +1,72 @@
+/**
+ * `nextly_versions_pending_edits_idx` — the index the dashboard cards read on.
+ *
+ * 🔴 Checked against `WORKING_DRAFT_SHAPE` rather than against a second list of
+ * column names. The index earns its place only by covering every predicate that
+ * query applies; a hand-copied expectation would keep passing after a predicate
+ * was added to the shape and not to the index, which is exactly the drift that
+ * silently returns both cards to a full table scan.
+ *
+ * Declared for all three dialects here, and the PLAN it produces is measured on
+ * SQLite in `pending-edit-query-plan.integration.test.ts` — presence and use are
+ * two different claims, and an index nothing chooses is not a fix.
+ */
+import { getTableConfig as mysqlTableConfig } from "drizzle-orm/mysql-core";
+import { getTableConfig as pgTableConfig } from "drizzle-orm/pg-core";
+import { getTableConfig as sqliteTableConfig } from "drizzle-orm/sqlite-core";
+import { describe, expect, it } from "vitest";
+
+import { WORKING_DRAFT_SHAPE } from "../../../domains/versions/versions-repository";
+import { nextlyVersionsMysql } from "../mysql";
+import { nextlyVersionsPg } from "../postgres";
+import { nextlyVersionsSqlite } from "../sqlite";
+
+const INDEX_NAME = "nextly_versions_pending_edits_idx";
+
+/** Drizzle property name → database column name, per the versions table. */
+const COLUMN_OF: Record<string, string> = {
+  isAutosave: "is_autosave",
+  versionNo: "version_no",
+  status: "status",
+};
+
+const dialects = [
+  ["sqlite", () => sqliteTableConfig(nextlyVersionsSqlite)],
+  ["postgresql", () => pgTableConfig(nextlyVersionsPg)],
+  ["mysql", () => mysqlTableConfig(nextlyVersionsMysql)],
+] as const;
+
+function indexColumns(config: {
+  indexes: readonly { config: { name: string; columns: readonly unknown[] } }[];
+}): string[] {
+  const found = config.indexes.find(index => index.config.name === INDEX_NAME);
+  if (!found) return [];
+  return found.config.columns.map(
+    column => (column as { name: string }).name ?? String(column)
+  );
+}
+
+describe.each(dialects)("%s pending-edits index", (_name, read) => {
+  it("covers every predicate that defines a working draft", () => {
+    const columns = indexColumns(read() as never);
+
+    // The predicates lead, so all three are equality probes rather than filters
+    // applied to rows the index already made the engine fetch.
+    const predicates = WORKING_DRAFT_SHAPE.map(
+      condition => COLUMN_OF[condition.column] ?? condition.column
+    );
+    expect(columns.slice(0, predicates.length).sort()).toEqual(
+      [...predicates].sort()
+    );
+  });
+
+  it("then takes the collection filter and the cursor's own ordering", () => {
+    const columns = indexColumns(read() as never);
+
+    expect(columns.slice(WORKING_DRAFT_SHAPE.length)).toEqual([
+      "scope_slug",
+      "updated_at",
+      "id",
+    ]);
+  });
+});

--- a/packages/nextly/src/schemas/versions/mysql.ts
+++ b/packages/nextly/src/schemas/versions/mysql.ts
@@ -89,24 +89,9 @@ export const nextlyVersionsMysql = mysqlTable(
       table.entryId,
       table.createdAt
     ),
-    // The dashboard's pending-edit cards: every working draft in a set of
-    // collections, newest first.
-    //
-    // 🔴 Its columns are the WHERE clause of `findPendingEditRows`, in that
-    // order, because none of the indexes above can serve it — all three lead
-    // with `scope_kind`, which that query never constrains. Without this,
-    // SQLite answered both cards with `SCAN nextly_versions`: proving the walk
-    // had seen every pending edit meant reading every version ever captured,
-    // so the count's row budget bounded the rows it RECEIVED and nothing about
-    // the work the database did to find them.
-    //
-    // The three leading columns are constants for that query, `scope_slug`
-    // takes the readable-collection list, and the trailing pair is the cursor's
-    // own ordering. A single-collection install therefore reads it in order and
-    // sorts nothing; with several collections the `IN` list becomes several
-    // ranges that no index can merge, and the sort that follows is over
-    // working drafts alone rather than over the whole table -- proportional to
-    // the number the card reports, not to the history behind it.
+    // The dashboard's pending-edit cards. Column order is the WHERE clause of
+    // `findPendingEditRows` followed by its cursor; that function's docblock
+    // says why none of the indexes above can serve it.
     index("nextly_versions_pending_edits_idx").on(
       table.isAutosave,
       table.status,

--- a/packages/nextly/src/schemas/versions/mysql.ts
+++ b/packages/nextly/src/schemas/versions/mysql.ts
@@ -89,6 +89,32 @@ export const nextlyVersionsMysql = mysqlTable(
       table.entryId,
       table.createdAt
     ),
+    // The dashboard's pending-edit cards: every working draft in a set of
+    // collections, newest first.
+    //
+    // 🔴 Its columns are the WHERE clause of `findPendingEditRows`, in that
+    // order, because none of the indexes above can serve it — all three lead
+    // with `scope_kind`, which that query never constrains. Without this,
+    // SQLite answered both cards with `SCAN nextly_versions`: proving the walk
+    // had seen every pending edit meant reading every version ever captured,
+    // so the count's row budget bounded the rows it RECEIVED and nothing about
+    // the work the database did to find them.
+    //
+    // The three leading columns are constants for that query, `scope_slug`
+    // takes the readable-collection list, and the trailing pair is the cursor's
+    // own ordering. A single-collection install therefore reads it in order and
+    // sorts nothing; with several collections the `IN` list becomes several
+    // ranges that no index can merge, and the sort that follows is over
+    // working drafts alone rather than over the whole table -- proportional to
+    // the number the card reports, not to the history behind it.
+    index("nextly_versions_pending_edits_idx").on(
+      table.isAutosave,
+      table.status,
+      table.versionNo,
+      table.scopeSlug,
+      table.updatedAt,
+      table.id
+    ),
   ]
 );
 

--- a/packages/nextly/src/schemas/versions/postgres.ts
+++ b/packages/nextly/src/schemas/versions/postgres.ts
@@ -97,24 +97,9 @@ export const nextlyVersionsPg = pgTable(
       table.entryId,
       table.createdAt
     ),
-    // The dashboard's pending-edit cards: every working draft in a set of
-    // collections, newest first.
-    //
-    // 🔴 Its columns are the WHERE clause of `findPendingEditRows`, in that
-    // order, because none of the indexes above can serve it — all three lead
-    // with `scope_kind`, which that query never constrains. Without this,
-    // SQLite answered both cards with `SCAN nextly_versions`: proving the walk
-    // had seen every pending edit meant reading every version ever captured,
-    // so the count's row budget bounded the rows it RECEIVED and nothing about
-    // the work the database did to find them.
-    //
-    // The three leading columns are constants for that query, `scope_slug`
-    // takes the readable-collection list, and the trailing pair is the cursor's
-    // own ordering. A single-collection install therefore reads it in order and
-    // sorts nothing; with several collections the `IN` list becomes several
-    // ranges that no index can merge, and the sort that follows is over
-    // working drafts alone rather than over the whole table -- proportional to
-    // the number the card reports, not to the history behind it.
+    // The dashboard's pending-edit cards. Column order is the WHERE clause of
+    // `findPendingEditRows` followed by its cursor; that function's docblock
+    // says why none of the indexes above can serve it.
     index("nextly_versions_pending_edits_idx").on(
       table.isAutosave,
       table.status,

--- a/packages/nextly/src/schemas/versions/postgres.ts
+++ b/packages/nextly/src/schemas/versions/postgres.ts
@@ -97,6 +97,32 @@ export const nextlyVersionsPg = pgTable(
       table.entryId,
       table.createdAt
     ),
+    // The dashboard's pending-edit cards: every working draft in a set of
+    // collections, newest first.
+    //
+    // 🔴 Its columns are the WHERE clause of `findPendingEditRows`, in that
+    // order, because none of the indexes above can serve it — all three lead
+    // with `scope_kind`, which that query never constrains. Without this,
+    // SQLite answered both cards with `SCAN nextly_versions`: proving the walk
+    // had seen every pending edit meant reading every version ever captured,
+    // so the count's row budget bounded the rows it RECEIVED and nothing about
+    // the work the database did to find them.
+    //
+    // The three leading columns are constants for that query, `scope_slug`
+    // takes the readable-collection list, and the trailing pair is the cursor's
+    // own ordering. A single-collection install therefore reads it in order and
+    // sorts nothing; with several collections the `IN` list becomes several
+    // ranges that no index can merge, and the sort that follows is over
+    // working drafts alone rather than over the whole table -- proportional to
+    // the number the card reports, not to the history behind it.
+    index("nextly_versions_pending_edits_idx").on(
+      table.isAutosave,
+      table.status,
+      table.versionNo,
+      table.scopeSlug,
+      table.updatedAt,
+      table.id
+    ),
   ]
 );
 

--- a/packages/nextly/src/schemas/versions/sqlite.ts
+++ b/packages/nextly/src/schemas/versions/sqlite.ts
@@ -87,6 +87,32 @@ export const nextlyVersionsSqlite = sqliteTable(
       table.entryId,
       table.createdAt
     ),
+    // The dashboard's pending-edit cards: every working draft in a set of
+    // collections, newest first.
+    //
+    // 🔴 Its columns are the WHERE clause of `findPendingEditRows`, in that
+    // order, because none of the indexes above can serve it — all three lead
+    // with `scope_kind`, which that query never constrains. Without this,
+    // SQLite answered both cards with `SCAN nextly_versions`: proving the walk
+    // had seen every pending edit meant reading every version ever captured,
+    // so the count's row budget bounded the rows it RECEIVED and nothing about
+    // the work the database did to find them.
+    //
+    // The three leading columns are constants for that query, `scope_slug`
+    // takes the readable-collection list, and the trailing pair is the cursor's
+    // own ordering. A single-collection install therefore reads it in order and
+    // sorts nothing; with several collections the `IN` list becomes several
+    // ranges that no index can merge, and the sort that follows is over
+    // working drafts alone rather than over the whole table -- proportional to
+    // the number the card reports, not to the history behind it.
+    index("nextly_versions_pending_edits_idx").on(
+      table.isAutosave,
+      table.status,
+      table.versionNo,
+      table.scopeSlug,
+      table.updatedAt,
+      table.id
+    ),
   ]
 );
 

--- a/packages/nextly/src/schemas/versions/sqlite.ts
+++ b/packages/nextly/src/schemas/versions/sqlite.ts
@@ -87,24 +87,9 @@ export const nextlyVersionsSqlite = sqliteTable(
       table.entryId,
       table.createdAt
     ),
-    // The dashboard's pending-edit cards: every working draft in a set of
-    // collections, newest first.
-    //
-    // 🔴 Its columns are the WHERE clause of `findPendingEditRows`, in that
-    // order, because none of the indexes above can serve it — all three lead
-    // with `scope_kind`, which that query never constrains. Without this,
-    // SQLite answered both cards with `SCAN nextly_versions`: proving the walk
-    // had seen every pending edit meant reading every version ever captured,
-    // so the count's row budget bounded the rows it RECEIVED and nothing about
-    // the work the database did to find them.
-    //
-    // The three leading columns are constants for that query, `scope_slug`
-    // takes the readable-collection list, and the trailing pair is the cursor's
-    // own ordering. A single-collection install therefore reads it in order and
-    // sorts nothing; with several collections the `IN` list becomes several
-    // ranges that no index can merge, and the sort that follows is over
-    // working drafts alone rather than over the whole table -- proportional to
-    // the number the card reports, not to the history behind it.
+    // The dashboard's pending-edit cards. Column order is the WHERE clause of
+    // `findPendingEditRows` followed by its cursor; that function's docblock
+    // says why none of the indexes above can serve it.
     index("nextly_versions_pending_edits_idx").on(
       table.isAutosave,
       table.status,

--- a/packages/nextly/src/services/lib/registered-content-slugs.ts
+++ b/packages/nextly/src/services/lib/registered-content-slugs.ts
@@ -22,33 +22,45 @@
 
 import { container } from "../../di/container";
 
+/** A registry's slugs, and whether they are all of them. */
+interface RegistryRead {
+  slugs: string[];
+  reachable: boolean;
+}
+
 /** The registered collection slugs, or none when the registry is unreachable. */
-async function collectionSlugs(): Promise<string[]> {
+async function collectionSlugs(): Promise<RegistryRead> {
   try {
     const collections = await container
       .get<{
         getAllCollections: () => Promise<Array<{ slug: string }>>;
       }>("collectionRegistryService")
       .getAllCollections();
-    return collections.map(collection => String(collection.slug));
+    return {
+      slugs: collections.map(collection => String(collection.slug)),
+      reachable: true,
+    };
   } catch {
     // Unreachable registry: contribute nothing rather than guess.
-    return [];
+    return { slugs: [], reachable: false };
   }
 }
 
 /** The registered single slugs, or none when the registry is unreachable. */
-async function singleSlugs(): Promise<string[]> {
+async function singleSlugs(): Promise<RegistryRead> {
   try {
     const singles = await container
       .get<{
         getAllSingles: () => Promise<Array<{ slug: string }>>;
       }>("singleRegistryService")
       .getAllSingles();
-    return singles.map(single => String(single.slug));
+    return {
+      slugs: singles.map(single => String(single.slug)),
+      reachable: true,
+    };
   } catch {
     // As above.
-    return [];
+    return { slugs: [], reachable: false };
   }
 }
 
@@ -84,12 +96,43 @@ export async function registeredContentSlugs(): Promise<string[]> {
 export async function registeredContentKinds(): Promise<
   Map<string, "collection" | "single">
 > {
+  return (await registeredContentSnapshot()).kinds;
+}
+
+/** What one registry enumeration saw, and whether it saw everything. */
+export interface ContentRegistrySnapshot {
+  kinds: Map<string, "collection" | "single">;
+  /**
+   * True when a registry could not be reached, so `kinds` is a FLOOR.
+   *
+   * 🔴 Reported rather than swallowed, because the two callers of this want
+   * opposite things from the same failure. An access decision wants the
+   * fail-closed empty set: admitting nothing is safe. A COUNT does not — "no
+   * documents have pending edits" is a positive claim, and answering it from a
+   * registry that could not be enumerated states as fact something never
+   * observed. Both readings stay available; neither is imposed here.
+   */
+  degraded: boolean;
+}
+
+/**
+ * One enumeration of both registries, with the kinds and the confidence.
+ *
+ * Resolved ONCE by a caller that makes several decisions from it. Asking again
+ * per page let a transient failure answer differently mid-walk: the pages read
+ * before it kept their rows, the page during it silently dropped every row it
+ * held, and the walk went on to publish the shortfall as a whole number.
+ */
+export async function registeredContentSnapshot(): Promise<ContentRegistrySnapshot> {
   const [collections, singles] = await Promise.all([
     collectionSlugs(),
     singleSlugs(),
   ]);
   const kinds = new Map<string, "collection" | "single">();
-  for (const slug of singles) kinds.set(slug, "single");
-  for (const slug of collections) kinds.set(slug, "collection");
-  return kinds;
+  for (const slug of singles.slugs) kinds.set(slug, "single");
+  for (const slug of collections.slugs) kinds.set(slug, "collection");
+  return {
+    kinds,
+    degraded: !collections.reachable || !singles.reachable,
+  };
 }


### PR DESCRIPTION
Closes the four findings Codex posted on #1532 about ninety seconds before it merged, so they landed on `main` unanswered — plus the two it found on the first head here.

## The measurement

Both pending-edit cards read `nextly_versions` filtered by the working-draft predicates plus a collection list. Every index on that table leads with `scope_kind`, which neither query constrains. Captured from the repository's own emitted SQL and explained on a seeded database:

| walk | plan, before | plan, after |
| --- | --- | --- |
| count (`identity`) | `SCAN nextly_versions USING INDEX sqlite_autoindex_nextly_versions_1` | `SEARCH … USING INDEX nextly_versions_pending_edits_idx` |
| list (`recency`) | `SCAN nextly_versions` + `USE TEMP B-TREE FOR ORDER BY` | `SEARCH … USING INDEX nextly_versions_pending_edits_idx` |

Proving the count had seen every pending edit meant reading every version ever captured: the 2,000-row budget bounded the rows the walk *received* and nothing about the work behind them. The list was worse and the finding did not mention it — a full scan plus a temp sort on **every page**.

Four candidate index shapes were measured against both orderings, with one slug and with a realistic multi-slug `IN` list. With several collections no shape avoids the sort, because an `IN` list is several index ranges no engine here merges in order — so a second index buys nothing and one is correct. The achievable win is `SCAN` → `SEARCH`: the sort that remains is over working drafts alone, proportional to the number the card reports rather than to the history behind it.

## The index would not have reached an existing database

The most serious finding, and it invalidated an assumption I had made without checking. `getCoreSchema()` builds each core table through `drizzleTableToTableSpec()`, which returned `{name, columns}` and no indexes; `diffIndexes` skips any table whose index data is absent; `reconcileCore` returns at `ops.length === 0`. So an index-only release produced no operations and `nextly migrate` reported the core schema as up to date. The index reached freshly created databases and no others — a shipped no-op, on exactly the installations with enough history to need it.

Core reconciliation now compares indexes, read through each dialect's own `getTableConfig`. Ops remain a *decision* rather than the DDL — `applyCore` pushes the whole dialect bundle through drizzle-kit, which already handled indexes — so index drift now reaches the applier that could always fix it.

Two things only measurement settled:

- Turning it on immediately broke the existing idempotency suite on PostgreSQL with four spurious `add_index` ops, all of them **partial** indexes. `IndexSpec` is a name, a column list and a uniqueness flag with nowhere to record a predicate, so claiming one unconditionally re-proposes it on every run. Partial indexes are excluded, and both dialects pass again.
- Drops are impossible here: `isManagedIndexName` matches only `idx_`/`uq_` **prefixes**, and every core index uses an `_idx`/`_uidx` suffix.

`core-index-reconcile.integration.test.ts` drops the index from an existing database and reconciles. Break-verified against the pre-fix spec it reports the finding exactly: `{before: true, reported: false, after: false}` — the control confirming the index was there, then reconcile declaring no change and never restoring it.

## The rest

- **The `nulls` placement is gone** from that ordering. `updated_at` is `NOT NULL` on all three dialects, so it could never have separated any rows, while the adapter spells it as a leading `updated_at IS NULL` sort key no index can supply.
- **One registry snapshot per query**, candidates derived from it rather than a second enumeration. Both helpers answer an unreachable dependency with an empty result — right for an access decision, wrong for a number — and read per page that safety inverted: a transient failure on one page dropped every row it held while its neighbours kept theirs, and the walk published the shortfall as exact. A registry that cannot be enumerated is now reported, and the cards refuse rather than stating that nobody has unpublished work.
- **The count floor is drawn by one renderer**, used by both archetypes. `metric` and `stats` each formatted their own, so when `WidgetResult` gained `atLeast` only one learned about it.
- **A linked stats cell names its count.** An `aria-label` replaces the element's descendants as the accessible name, so the cell announced "Draft posts" with no number at all — floor or not. Now `"14, Draft posts"`.

## The finding accepted rather than fixed

`atLeast` still follows a budget over **raw** rows, so it carries one bit about the total volume of drafts in reachable collections. It is not removable while any bound exists: the budget bounds work, work is raw rows, so a flag derived from it is a fact about unfiltered data. Deriving it from the visible set means no bound, and one dashboard load on a large install then walks the whole pending-edit index.

The index does not make the budget cheap enough to raise out of reach either — the per-page cost is dominated by the authorization probes, one per slug and locale, which scale with pages rather than row cost.

The general fix is to let the database apply the access rule, as Payload and Directus do; it needs the version row to carry or join the fields a rule names, and a `custom` rule is an arbitrary function that cannot be pushed down. Recorded in the source and as `decision:pending-edit-count-volume-bit`, scoped as its own work.

## Verification

- nextly unit **887 files / 11,299 tests**; admin **396 / 3,913**; nextly integration across **all three dialects** — **288 files / 2,221 tests**. All green.
- `lint` and `check-types` clean for both packages, **0 errors**.
- fallow `warn`, 22 changed files against `origin/main`, `duplication_introduced: 4`. Controlled: the same tree with the index removed from the three dialect schema files reports `0 introduced / 10 inherited`. Adding one index to three near-identical per-dialect files re-attributes pre-existing clone groups rather than creating new ones; eliminating it would mean restructuring the dialect schemas.
- Break-verified against wrong implementations rather than mutations: index absent and an index leading with `scope_kind` both fail the plan test; a predicate added to `WORKING_DRAFT_SHAPE` without widening the index fails all six structural cases; the pre-fix core spec fails the reconciliation test; removing the degraded refusal fails, and so does the plausible wrong fix of refusing on an *empty* registry, caught by its own control; reverting `stats` to formatting `total` fails exactly the stats case; naming only the destination in the link fails both accessible-name cases.

**Correction to an earlier revision of this description:** it reported three pre-existing lint errors in `sidebar/index.tsx`, `useRoleForm.ts` and `field-validation.ts` as present on `origin/main`. That was wrong. A root build had left `packages/nextly/dist` with its JavaScript but none of its type declarations while still exiting 0, and admin's type-aware rules then reported on 39 lines across files this branch never touches. The check I used to call them pre-existing ran against that same broken build, so the control shared the defect. After a clean build, admin lints with zero errors.