### PR TITLE
fix(nextly): obey a collection's stored read rule in the activity feed

### DIFF
--- a/.changeset/activity-feed-obeys-document-rules.md
+++ b/.changeset/activity-feed-obeys-document-rules.md
@@ -1,0 +1,59 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The activity feed obeys a collection's stored read rule, and no longer publishes
+a count it cannot authorize.
+
+Its scope was collection-level, and `entryTitle` is stored on the log row at
+write time rather than hydrated through the read path — so nothing between the
+table and the response consulted a document rule. Under a stored `owner-only`
+or `custom` read rule the feed reported other authors' entry titles, entry ids,
+and the names and email addresses attached to their edits. Measured: with the
+ordinary read returning one document for the caller, the feed returned four
+rows spanning both authors.
+
+Each row's document is now authorized as the caller, by the same decision the
+pending-edit cards use — one implementation, so the two surfaces cannot come to
+different conclusions about who may see a document. A stored rule can be an
+arbitrary function and its constraint is expressed over the collection's own
+fields, which an audit row does not carry, so the constraint cannot be pushed
+into this query the way it is pushed into a collection read; asking the read
+path about a known set of ids is the one form that works for every rule.
+
+Rows that name no document keep their existing treatment: a settings mutation
+is filed under a namespace that is neither a collection nor a single, the
+caller's scope already admitted it, and dropping those would remove credential
+rotations from the feed entirely.
+
+`total` is gone from the response. It counted the rows the collection scope
+admitted, so it reported edits to documents the reader may not open — the same
+disclosure the rows carried, in a number — and it cannot be narrowed without
+authorizing every matching row, which is unbounded over a table that only
+grows. `hasMore` carries the pagination instead, observed by authorizing one
+row past the page. The hand-written `COUNT(*)` behind the old field is removed
+with it.

--- a/.changeset/activity-feed-obeys-document-rules.md
+++ b/.changeset/activity-feed-obeys-document-rules.md
@@ -87,3 +87,12 @@ Refill rounds are anchored to the last row read rather than to a running offset,
 and ordered by a unique key as well as the instant: `activity_log` grows while a
 feed is being built, so under OFFSET a row inserted between rounds shifts every
 later position, repeating one row and silently skipping another.
+
+Each activity row now records what it is ABOUT — a collection document, a
+single, or an install-level settings change — rather than leaving the feed to
+infer it from the slug. A resource that already held a now-reserved name may
+keep it, so an upgraded installation can have a real collection sharing a
+settings namespace; registry membership then read a credential rotation as a
+document in that collection, refused it, and stripped the changed-field detail
+the row exists to record. Rows written before the column fall back to the
+registry, which is what they were always judged by.

--- a/.changeset/activity-feed-obeys-document-rules.md
+++ b/.changeset/activity-feed-obeys-document-rules.md
@@ -57,3 +57,33 @@ authorizing every matching row, which is unbounded over a table that only
 grows. `hasMore` carries the pagination instead, observed by authorizing one
 row past the page. The hand-written `COUNT(*)` behind the old field is removed
 with it.
+
+The activity feed now records the LANGUAGE a write was made in and authorizes
+each row in it. A stored `custom` read rule is a predicate over a collection's
+own fields, and a localized field answers differently per translation, so a row
+judged without a locale is judged against the default one — and an edit made in
+a language the rule denies could still show its title. The locale is derived
+from the event resource that already carries it, so a write cannot report one
+language to a webhook subscriber and a different one to the trail. Rows written
+before the column, and writes with no language of their own, leave it NULL and
+are read as the default, which is what they already meant.
+
+Deleting a document no longer erases it from the feed. A collection delete
+removes the row before appending `entry.deleted`, so the document the event
+names can never be found again — and authorizing by readability alone dropped
+the deletion, and every earlier event for that document, for everyone including
+a super admin. Such a row is now kept without its stored title or metadata: the
+rule that decided who could read them died with the document, so a reader learns
+that something was deleted, by whom and when, but not what it was called. A
+document that still exists and was refused stays refused, and a probe that
+cannot answer drops the row rather than publishing it.
+
+The feed also refuses outright when the content registry cannot be enumerated.
+A slug missing from the registry is read as an install-level event and kept
+without asking the read path — correct when the map is whole, and the same rule
+admits every document row unauthorized when it is not.
+
+Refill rounds are anchored to the last row read rather than to a running offset,
+and ordered by a unique key as well as the instant: `activity_log` grows while a
+feed is being built, so under OFFSET a row inserted between rounds shifts every
+later position, repeating one row and silently skipping another.

--- a/packages/admin/src/hooks/queries/useRecentActivity.ts
+++ b/packages/admin/src/hooks/queries/useRecentActivity.ts
@@ -43,7 +43,6 @@ interface ActivityLogEntry {
 
 interface ActivityLogApiResponse {
   activities: ActivityLogEntry[];
-  total: number;
   hasMore: boolean;
 }
 
@@ -116,7 +115,6 @@ export function useRecentActivity(limit = 10) {
       );
       return {
         activities: raw.activities.map(mapEntry),
-        total: raw.total,
         hasMore: raw.hasMore,
       };
     },

--- a/packages/admin/src/types/dashboard/activity.ts
+++ b/packages/admin/src/types/dashboard/activity.ts
@@ -75,8 +75,13 @@ export interface Activity {
 export interface RecentActivityResponse {
   /** Array of activity entries */
   activities: Activity[];
-  /** Total count of activities (for pagination) */
-  total: number;
-  /** Whether there are more activities to load */
+  /**
+   * Whether more activity exists beyond this page.
+   *
+   * There is no total. The server cannot count the feed without authorizing
+   * every matching row against its document's read rule, which is unbounded
+   * over an audit table -- so it publishes what it can observe exactly rather
+   * than a number that would count edits the reader may not see.
+   */
   hasMore: boolean;
 }

--- a/packages/nextly/src/api/__tests__/dashboard-read-scope.test.ts
+++ b/packages/nextly/src/api/__tests__/dashboard-read-scope.test.ts
@@ -103,9 +103,19 @@ beforeEach(() => {
   vi.clearAllMocks();
   rbac = new RBACAccessControlService();
 
-  containerHas.mockImplementation(
-    (name: string) => name === "rbacAccessControlService"
-  );
+  // 🔴 `has` must agree with what `get` resolves. A real container answers both
+  // from one registration map, so a harness reporting `has: false` for a service
+  // its `get` returns is a container that cannot exist -- and code that asks
+  // `has` before `get` (to tell an ABSENT registry from one that failed to
+  // construct) then reads this install as having no content at all.
+  const resolvable = new Set([
+    "rbacAccessControlService",
+    "collectionRegistryService",
+    "singleRegistryService",
+    "dashboardService",
+    "activityLogService",
+  ]);
+  containerHas.mockImplementation((name: string) => resolvable.has(name));
   containerGet.mockImplementation((name: string) => {
     switch (name) {
       case "rbacAccessControlService":

--- a/packages/nextly/src/api/dashboard.test.ts
+++ b/packages/nextly/src/api/dashboard.test.ts
@@ -20,14 +20,26 @@ vi.mock("../init", () => ({
   getCachedNextly: vi.fn().mockResolvedValue(undefined),
 }));
 
-const { containerGet } = vi.hoisted(() => ({ containerGet: vi.fn() }));
+const { containerGet, containerHas } = vi.hoisted(() => ({
+  containerGet: vi.fn(),
+  // 🔴 `has` must agree with what `get` resolves. A real container answers both
+  // from one registration map, so a mock offering only `get` is a container
+  // that cannot exist -- and code asking `has` first (to tell an ABSENT registry
+  // from one that failed to construct) either throws on the missing method or
+  // reads this install as having no content at all.
+  containerHas: vi.fn(),
+}));
 // BOTH specifiers, because they are two module records: the handlers reach the
 // container through the barrel and `registered-content-slugs` through the
 // narrow module, so mocking one leaves the other reading the real container --
 // which answers nothing here and takes the registry read's `catch` branch,
 // reporting an empty candidate list as though the install had no collections.
-vi.mock("../di", () => ({ container: { get: containerGet } }));
-vi.mock("../di/container", () => ({ container: { get: containerGet } }));
+vi.mock("../di", () => ({
+  container: { get: containerGet, has: containerHas },
+}));
+vi.mock("../di/container", () => ({
+  container: { get: containerGet, has: containerHas },
+}));
 
 vi.mock("../services/lib/permissions", () => ({
   // `readCaller` (via `authenticated-read.ts`) resolves this to build the
@@ -113,6 +125,8 @@ function decidingCaller(): Record<string, unknown> {
 beforeEach(() => {
   vi.clearAllMocks();
   serviceStub = {};
+  // Anything the switch below resolves is, by construction, registered.
+  containerHas.mockReturnValue(true);
   containerGet.mockImplementation((name: string) => {
     if (name === "collectionRegistryService") {
       return {
@@ -402,12 +416,10 @@ describe("dashboard activity scope", () => {
   it("scopes the activity feed to the entities the access layer admitted", async () => {
     readableEntities.mockResolvedValue(new Set(["posts"]));
 
-    const getRecentActivity = vi
-      .fn()
-      .mockResolvedValue({
-        activities: [],
-        hasMore: false,
-      } satisfies ActivityLogResult);
+    const getRecentActivity = vi.fn().mockResolvedValue({
+      activities: [],
+      hasMore: false,
+    } satisfies ActivityLogResult);
     serviceStub = { getRecentActivity };
 
     await getDashboardActivity(
@@ -426,12 +438,10 @@ describe("dashboard activity scope", () => {
   it("passes an EMPTY scope through rather than omitting it", async () => {
     readableEntities.mockResolvedValue(new Set());
 
-    const getRecentActivity = vi
-      .fn()
-      .mockResolvedValue({
-        activities: [],
-        hasMore: false,
-      } satisfies ActivityLogResult);
+    const getRecentActivity = vi.fn().mockResolvedValue({
+      activities: [],
+      hasMore: false,
+    } satisfies ActivityLogResult);
     serviceStub = { getRecentActivity };
 
     await getDashboardActivity(
@@ -524,12 +534,10 @@ describe("dashboard read scope for an API-KEY caller", () => {
     authenticateAsApiKey(["read-posts"]);
     readableEntities.mockResolvedValue(new Set(["posts"]));
 
-    const getRecentActivity = vi
-      .fn()
-      .mockResolvedValue({
-        activities: [],
-        hasMore: false,
-      } satisfies ActivityLogResult);
+    const getRecentActivity = vi.fn().mockResolvedValue({
+      activities: [],
+      hasMore: false,
+    } satisfies ActivityLogResult);
     serviceStub = { getRecentActivity };
 
     await getDashboardActivity(

--- a/packages/nextly/src/api/dashboard.test.ts
+++ b/packages/nextly/src/api/dashboard.test.ts
@@ -58,6 +58,7 @@ vi.mock("../auth/entity-read-access", async importOriginal => ({
 import { isErrorResponse, requireAuthentication } from "../auth/middleware";
 import { container } from "../di";
 import { SETTINGS_ACTIVITY_NAMESPACES } from "../domains/audit/settings-activity-namespaces";
+import type { ActivityLogResult } from "../services/dashboard/activity-log-service";
 import { resolveRoleSlugs } from "../services/lib/permissions";
 
 import {
@@ -236,10 +237,17 @@ describe("getDashboardRecentEntries", () => {
 });
 
 describe("getDashboardActivity", () => {
-  it("emits respondData with cursor-shaped { activities, total, hasMore }", async () => {
-    const result = {
-      activities: [{ id: "a1", action: "create", collection: "posts" }],
-      total: 1,
+  it("emits respondData with cursor-shaped { activities, hasMore }", async () => {
+    // 🔴 The stub is typed as `ActivityLogResult` rather than left loose, and
+    // that is the part doing the work. Stubbing a free object let this test go
+    // on asserting a body containing `total` long after the service stopped
+    // producing one — green while pinning the OPPOSITE of the contract, and
+    // unable to notice a reintroduced count. Typed, a stray `total` fails
+    // `check-types` instead of passing silently.
+    const result: ActivityLogResult = {
+      activities: [
+        { id: "a1", action: "create", collection: "posts" },
+      ] as unknown as ActivityLogResult["activities"],
       hasMore: false,
     };
     serviceStub = {
@@ -253,6 +261,10 @@ describe("getDashboardActivity", () => {
     expect(res.status).toBe(200);
     const json = (await res.json()) as Record<string, unknown>;
     expect(json).not.toHaveProperty("data");
+    // Asserted as an absence of its own: `toEqual` against a `total`-free
+    // expectation would still pass if the handler added one back, since the
+    // stub no longer supplies it.
+    expect(json).not.toHaveProperty("total");
     expect(json).toEqual(result);
   });
 });
@@ -392,7 +404,10 @@ describe("dashboard activity scope", () => {
 
     const getRecentActivity = vi
       .fn()
-      .mockResolvedValue({ activities: [], total: 0, hasMore: false });
+      .mockResolvedValue({
+        activities: [],
+        hasMore: false,
+      } satisfies ActivityLogResult);
     serviceStub = { getRecentActivity };
 
     await getDashboardActivity(
@@ -413,7 +428,10 @@ describe("dashboard activity scope", () => {
 
     const getRecentActivity = vi
       .fn()
-      .mockResolvedValue({ activities: [], total: 0, hasMore: false });
+      .mockResolvedValue({
+        activities: [],
+        hasMore: false,
+      } satisfies ActivityLogResult);
     serviceStub = { getRecentActivity };
 
     await getDashboardActivity(
@@ -508,7 +526,10 @@ describe("dashboard read scope for an API-KEY caller", () => {
 
     const getRecentActivity = vi
       .fn()
-      .mockResolvedValue({ activities: [], total: 0, hasMore: false });
+      .mockResolvedValue({
+        activities: [],
+        hasMore: false,
+      } satisfies ActivityLogResult);
     serviceStub = { getRecentActivity };
 
     await getDashboardActivity(

--- a/packages/nextly/src/api/dashboard.ts
+++ b/packages/nextly/src/api/dashboard.ts
@@ -217,10 +217,17 @@ export const getDashboardActivity = withErrorHandler(async (req: Request) => {
     : 5;
 
   const service = await getActivityLogService();
-  const scope = await resolveReadableResources(await readCaller(auth));
-  const result = await service.getRecentActivity({ limit, scope });
+  // The caller WHOLE, and resolved ONCE. Both consumers read it: the scope
+  // decides which collections are in reach, and the feed then authorizes each
+  // row's DOCUMENT as this caller -- a stored owner-only or custom read rule
+  // makes those two different sets, and a feed given only the scope reports one
+  // author's entry titles to another.
+  const caller = await readCaller(auth);
+  const scope = await resolveReadableResources(caller);
+  const result = await service.getRecentActivity({ limit, scope, caller });
 
-  // Cursor-shaped read: keep `hasMore` adjacent to `activities` and `total`.
+  // Cursor-shaped read: `hasMore` sits beside `activities`, with no `total` --
+  // see `ActivityLogResult` for why a count is not published here.
   // Spread into a fresh literal so the response-shape generic accepts the
   // named `ActivityLogResult` interface (no implicit index signature).
   return respondData({ ...result }, { headers: PRIVATE_NO_STORE_HEADERS });

--- a/packages/nextly/src/api/dashboard.ts
+++ b/packages/nextly/src/api/dashboard.ts
@@ -201,10 +201,14 @@ export const getDashboardRecentEntries = withErrorHandler(
  * Query params:
  *   - limit: number (default: 5, max: 50)
  *
- * Body shape: `{ activities, total, hasMore }`. The activity feed is
- * cursor-style (`hasMore` flag, no page/limit/totalPages metadata
- * surfaced to clients), so this uses `respondData` rather than
- * `respondList`.
+ * Body shape: `{ activities, hasMore }`. The activity feed is cursor-style
+ * (`hasMore` flag, no page/limit/totalPages metadata surfaced to clients), so
+ * this uses `respondData` rather than `respondList`.
+ *
+ * No `total`, deliberately: it counted the rows the collection scope admitted,
+ * so it reported edits to documents the reader may not open, and narrowing it
+ * would mean authorizing every matching row — unbounded over a table that only
+ * grows. `ActivityLogResult` carries the same note beside the field's absence.
  */
 export const getDashboardActivity = withErrorHandler(async (req: Request) => {
   const auth = await requireAuthentication(req);

--- a/packages/nextly/src/domains/audit/record-activity.ts
+++ b/packages/nextly/src/domains/audit/record-activity.ts
@@ -28,6 +28,8 @@ import { computeChangedFields } from "../webhooks/envelope";
 
 /** What one mutation records, as the choke point already knows it. */
 export interface RecordMutationActivityInput {
+  /** The language this write was made in; see `RecordMutationEventArgs`. */
+  locale?: string | null;
   action: ActivityLogAction;
   /** Collection slug the entry belongs to. */
   collection: string;
@@ -202,6 +204,7 @@ export async function recordMutationActivity(
     userId: input.actor.id,
     action: input.action,
     collection: input.collection,
+    ...(input.locale === undefined ? {} : { locale: input.locale }),
     ...(input.entryId !== undefined ? { entryId: input.entryId } : {}),
     ...(() => {
       const heading = feedHeading(input.collection, input.data, input.entryId);

--- a/packages/nextly/src/domains/audit/record-activity.ts
+++ b/packages/nextly/src/domains/audit/record-activity.ts
@@ -205,6 +205,9 @@ export async function recordMutationActivity(
     action: input.action,
     collection: input.collection,
     ...(input.locale === undefined ? {} : { locale: input.locale }),
+    // This recorder runs only for collection entries; the caller gates on the
+    // resource kind before reaching it.
+    subjectKind: "collection" as const,
     ...(input.entryId !== undefined ? { entryId: input.entryId } : {}),
     ...(() => {
       const heading = feedHeading(input.collection, input.data, input.entryId);

--- a/packages/nextly/src/domains/audit/record-settings-activity.ts
+++ b/packages/nextly/src/domains/audit/record-settings-activity.ts
@@ -137,6 +137,10 @@ export async function recordSettingsActivity(
     action: input.action,
     collection: input.collection,
     entryId: input.entityId,
+    // Stated rather than left to the registry: an upgraded install may hold a
+    // real collection under this same namespace, and the feed must not treat a
+    // credential rotation as a document in it.
+    subjectKind: "settings",
     entryTitle: input.entityTitle,
     metadata: {
       ...input.metadata,

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -7273,6 +7273,16 @@ export class CollectionMutationService extends BaseService {
                   action: "update",
                   collection: params.collectionName,
                   entryId: params.entryId,
+                  // 🔴 The resolved write locale, exactly as the event-backed
+                  // path above records it. This seam bypasses the outbox --
+                  // a draft save changes no live document -- so omitting it
+                  // filed every localized draft edit as default-locale
+                  // activity, and the feed then authorized the row against the
+                  // default translation while its heading came from the edited
+                  // one.
+                  ...(localizedUpdate
+                    ? { locale: localizedUpdate.writeLocale }
+                    : {}),
                   data: workingDraftDocument ?? updatedDocument,
                   previous: priorWorkingDraftDocument ?? previousDocument,
                   actor: actorForWrite(params.actor, params.user),

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/v1-golden/upgrade-sim-045.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/v1-golden/upgrade-sim-045.integration.test.ts
@@ -329,6 +329,21 @@ const addsActivityLocaleColumn = (stmt: string): boolean => {
   );
 };
 
+/**
+ * The activity log gains what each row is ABOUT.
+ *
+ * The slug alone cannot decide it: a resource that already held a now-reserved
+ * name may keep it, so an upgraded install can have a real collection sharing a
+ * settings namespace, and registry membership then reads a credential rotation
+ * as a document in that collection.
+ */
+const addsActivitySubjectKindColumn = (stmt: string): boolean => {
+  const s = stmt.trim().replace(/;$/, "");
+  return /^ALTER TABLE [`"]?activity_log[`"]? ADD (COLUMN )?[`"]?subject_kind[`"]?[^,]*$/i.test(
+    s
+  );
+};
+
 // Positive guard: the sim must actually create each new table (an empty first
 // pass would otherwise satisfy the additive-only check vacuously).
 const hasCreateTableFor = (stmts: string[], table: string): boolean =>
@@ -440,6 +455,7 @@ describe("existing-user upgrade sim (0.45 DDL → v1)", () => {
               migratesActivityLogActor(s) ||
               addsAuditLogErasureStamp(s) ||
               addsActivityLocaleColumn(s) ||
+              addsActivitySubjectKindColumn(s) ||
               addsPreviewGenerationColumn(s),
             `phantom diff: ${s}`
           ).toBe(true);
@@ -520,6 +536,7 @@ describe("existing-user upgrade sim (0.45 DDL → v1)", () => {
               migratesActivityLogActor(s) ||
               addsAuditLogErasureStamp(s) ||
               addsActivityLocaleColumn(s) ||
+              addsActivitySubjectKindColumn(s) ||
               addsPreviewGenerationColumn(s),
             `unexpected reconcile statement shape: ${s}`
           ).toBe(true);

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/v1-golden/upgrade-sim-045.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/v1-golden/upgrade-sim-045.integration.test.ts
@@ -309,6 +309,26 @@ const addsAuditLogErasureStamp = (stmt: string): boolean => {
   );
 };
 
+/**
+ * The activity log gains the LANGUAGE a mutation was made in.
+ *
+ * The feed authorizes each row's document as the caller, and a stored `custom`
+ * read rule is a predicate over the collection's own fields — which answer
+ * differently per translation. Without the column a row is judged against the
+ * default language, so an edit made in a language the rule denies could still
+ * show its title.
+ *
+ * Pinned to the table AND the column, and required to be the WHOLE statement,
+ * for the reason the erasure stamp above gives: a substring match would admit a
+ * destructive clause riding through beside the additive one.
+ */
+const addsActivityLocaleColumn = (stmt: string): boolean => {
+  const s = stmt.trim().replace(/;$/, "");
+  return /^ALTER TABLE [`"]?activity_log[`"]? ADD (COLUMN )?[`"]?locale[`"]?[^,]*$/i.test(
+    s
+  );
+};
+
 // Positive guard: the sim must actually create each new table (an empty first
 // pass would otherwise satisfy the additive-only check vacuously).
 const hasCreateTableFor = (stmts: string[], table: string): boolean =>
@@ -419,6 +439,7 @@ describe("existing-user upgrade sim (0.45 DDL → v1)", () => {
               addsWebhooksColumn(s) ||
               migratesActivityLogActor(s) ||
               addsAuditLogErasureStamp(s) ||
+              addsActivityLocaleColumn(s) ||
               addsPreviewGenerationColumn(s),
             `phantom diff: ${s}`
           ).toBe(true);
@@ -498,6 +519,7 @@ describe("existing-user upgrade sim (0.45 DDL → v1)", () => {
               addsWebhooksColumn(s) ||
               migratesActivityLogActor(s) ||
               addsAuditLogErasureStamp(s) ||
+              addsActivityLocaleColumn(s) ||
               addsPreviewGenerationColumn(s),
             `unexpected reconcile statement shape: ${s}`
           ).toBe(true);

--- a/packages/nextly/src/domains/users/__tests__/user-delete-audit-erasure.integration.test.ts
+++ b/packages/nextly/src/domains/users/__tests__/user-delete-audit-erasure.integration.test.ts
@@ -472,10 +472,12 @@ describe("deleting a user erases them from the activity log without erasing the 
     const feed = await activity.getRecentActivity({
       userId: String(author.id),
       scope: allResources(),
+      // The feed authorizes each row's document as this caller and answers
+      // empty without one; these rows name no registered content, so the scope
+      // decides them.
+      caller: { user: { id: "reader", roles: [] } },
     });
     expect(feed.activities.map(a => a.entryTitle)).toEqual(["newer", "older"]);
-    // The count query reads the same filter through its own spelling.
-    expect(feed.total).toBe(2);
   });
 
   it("does not rewrite entries the erasure already handled", async () => {

--- a/packages/nextly/src/domains/users/__tests__/user-delete-audit-erasure.integration.test.ts
+++ b/packages/nextly/src/domains/users/__tests__/user-delete-audit-erasure.integration.test.ts
@@ -417,6 +417,11 @@ describe("deleting a user erases them from the activity log without erasing the 
     const live = await activity.getRecentActivity({
       userId: String(author.id),
       scope: allResources(),
+      // The feed authorizes each row's document as this caller and answers
+      // EMPTY without one. These rows name no registered content, so the scope
+      // decides them -- but the caller is still required, because "no caller"
+      // is the fail-closed case rather than a permissive default.
+      caller: { user: { id: "reader", roles: [] } },
     });
     expect(live.activities).toHaveLength(1);
     // The premise: every field the admin renders survives the mapping.
@@ -430,6 +435,11 @@ describe("deleting a user erases them from the activity log without erasing the 
     const erased = await activity.getRecentActivity({
       userId: String(author.id),
       scope: allResources(),
+      // The feed authorizes each row's document as this caller and answers
+      // EMPTY without one. These rows name no registered content, so the scope
+      // decides them -- but the caller is still required, because "no caller"
+      // is the fail-closed case rather than a permissive default.
+      caller: { user: { id: "reader", roles: [] } },
     });
     expect(erased.activities).toHaveLength(1);
     expect(erased.activities[0].userName).toBeNull();

--- a/packages/nextly/src/domains/versions/__tests__/pending-edit-visibility.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/pending-edit-visibility.test.ts
@@ -1,356 +1,89 @@
 /**
- * How pending-edit rows are handed to the read path for a verdict.
+ * What a version row is translated INTO before anyone decides about it.
  *
- * The verdict itself belongs to the collection and Singles read paths and is
- * driven against a real database elsewhere. What this file pins is the SHAPE of
- * the question — which rows are asked about, grouped how, and which are never
- * asked about at all — because that is where this module can be wrong while
- * every access rule underneath it is right.
+ * The decision itself moved to `services/lib/document-visibility`, where the
+ * activity feed asks the same question, and is driven there against a real
+ * database. What is left here is the translation, and it is worth its own file
+ * for one reason: `VersionScopeKind` is WIDER than the two kinds a content read
+ * path can answer for, so this is the seam where a row that nothing can judge
+ * has to be recognised rather than coerced.
  */
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-const readableDocumentIds = vi.fn();
-const singleDocumentReadable = vi.fn();
-const resolveSingleDocumentId = vi.fn();
-const contentSnapshot = vi.fn();
-const configValue = vi.fn();
+const visibleDocuments = vi.fn();
 
-// The registry decides whether a row's own scope kind is still the live one, and
-// the localization config decides whether its language can still be read in.
-// Both are container-backed, so a harness that omits them leaves every row
-// undecidable and the whole file green-on-nothing.
-vi.mock("../../../services/lib/registered-content-slugs", () => ({
-  registeredContentSnapshot: () => contentSnapshot() as unknown,
-}));
-vi.mock("../../../di/container", () => ({
-  container: {
-    has: () => true,
-    get: () => configValue() as unknown,
-  },
+vi.mock("../../../services/lib/document-visibility", async importOriginal => ({
+  ...(await importOriginal<
+    typeof import("../../../services/lib/document-visibility")
+  >()),
+  visibleDocuments: (...args: unknown[]) =>
+    visibleDocuments(...args) as unknown,
 }));
 
-vi.mock("../../../services/lib/readable-documents", () => ({
-  readableDocumentIds: (...args: unknown[]) =>
-    readableDocumentIds(...args) as unknown,
-}));
-vi.mock("../../singles/services/single-document-access", () => ({
-  singleDocumentReadable: (...args: unknown[]) =>
-    singleDocumentReadable(...args) as unknown,
-  resolveSingleDocumentId: (...args: unknown[]) =>
-    resolveSingleDocumentId(...args) as unknown,
-}));
-
+import type { DocumentRef } from "../../../services/lib/document-visibility";
 import {
-  resolvePendingEditScope,
   visiblePendingEdits,
   type PendingEditScope,
 } from "../pending-edit-visibility";
 
 const caller = { user: { id: "user-1", roles: ["editor"] } };
+const scope = {
+  kinds: new Map<string, "collection" | "single">(),
+  locales: null,
+  degraded: false,
+} satisfies PendingEditScope;
 
-/**
- * The install-wide facts, resolved the way the source resolves them.
- *
- * Taken from `resolvePendingEditScope` rather than hand-built, so these cases
- * exercise the object the product actually passes down. A literal written here
- * would go on agreeing with itself after the resolver's shape changed.
- */
-const scopeNow = (): Promise<PendingEditScope> => resolvePendingEditScope();
-
-function row(patch: {
-  entryId: string;
-  locale?: string | null;
-  scopeKind?: string;
-  scopeSlug?: string;
-}) {
+function row(patch: { scopeKind: string; locale?: string | null }) {
   return {
-    id: `v-${patch.entryId}-${patch.locale ?? "none"}`,
-    scopeKind: patch.scopeKind ?? "collection",
-    scopeSlug: patch.scopeSlug ?? "posts",
-    entryId: patch.entryId,
+    id: "v1",
+    scopeKind: patch.scopeKind,
+    scopeSlug: "posts",
+    entryId: "e1",
     locale: patch.locale ?? null,
-    updatedAt: new Date("2026-01-01T00:00:00Z"),
-    versionNo: null,
-    status: "draft",
-    isAutosave: false,
-    label: null,
-    sourceVersionNo: null,
-    createdBy: null,
-    createdAt: new Date("2020-01-01T00:00:00Z"),
   } as unknown as Parameters<typeof visiblePendingEdits>[0][number];
 }
 
-beforeEach(() => {
-  vi.clearAllMocks();
-  readableDocumentIds.mockImplementation((_slug, ids: string[]) =>
-    Promise.resolve(new Set(ids))
-  );
-  singleDocumentReadable.mockResolvedValue(true);
-  resolveSingleDocumentId.mockResolvedValue("single-live");
-  contentSnapshot.mockResolvedValue({
-    kinds: new Map([
-      ["posts", "collection"],
-      ["site-settings", "single"],
-    ]),
-    degraded: false,
-  });
-  configValue.mockReturnValue({
-    localization: {
-      locales: [
-        { code: "en" },
-        { code: "de" },
-        ...Array.from({ length: 8 }, (_, index) => ({ code: `l${index}` })),
-      ],
-    },
-  });
-});
+/** The ref the translation produced for `input`, as the decision would see it. */
+async function refFor(
+  input: ReturnType<typeof row>
+): Promise<DocumentRef | null> {
+  visibleDocuments.mockResolvedValue([]);
+  await visiblePendingEdits([input], caller, scope);
+  const [, ref] = visibleDocuments.mock.calls[0] as [
+    unknown,
+    (item: unknown) => DocumentRef | null,
+  ];
+  return ref(input);
+}
 
-describe("collection rows", () => {
-  it("asks about each LOCALE separately, carrying the locale into the read", async () => {
-    // 🔴 A stored read rule is a predicate over the collection's own fields, and
-    // a localized field answers differently per language --
-    // `localized-target-predicate.integration.test.ts` pins one row readable in
-    // `en` and denied in `de`. Asking once per slug judges whichever
-    // translation the read defaults to and marks every other language visible
-    // on the strength of it.
-    await visiblePendingEdits(
-      [
-        row({ entryId: "e1", locale: "en" }),
-        row({ entryId: "e1", locale: "de" }),
-      ],
-      caller,
-      await scopeNow()
-    );
-
-    expect(readableDocumentIds).toHaveBeenCalledTimes(2);
-    expect(readableDocumentIds).toHaveBeenCalledWith(
-      "posts",
-      ["e1"],
-      caller,
-      "en"
-    );
-    expect(readableDocumentIds).toHaveBeenCalledWith(
-      "posts",
-      ["e1"],
-      caller,
-      "de"
-    );
-  });
-
-  it("keeps the language the read allowed and drops the one it refused", async () => {
-    readableDocumentIds.mockImplementation((_slug, ids: string[], _c, locale) =>
-      Promise.resolve(locale === "en" ? new Set(ids) : new Set())
-    );
-
-    const visible = await visiblePendingEdits(
-      [
-        row({ entryId: "e1", locale: "de" }),
-        row({ entryId: "e1", locale: "en" }),
-      ],
-      caller,
-      await scopeNow()
-    );
-
-    expect(visible.map(r => r.locale)).toEqual(["en"]);
-  });
-
-  it("issues reads CONCURRENTLY, within a bound", async () => {
-    // 🔴 Each unit enters the full collection read path, so awaiting them one
-    // after another turns a page spanning many collections or languages into
-    // that many sequential round trips -- enough to time a dashboard out while
-    // the connection pool sits idle. Bounded, not unbounded: the first group is
-    // deliberately one, so a cold per-user permission cache is filled once
-    // rather than missed by everything in the fan-out.
-    let inFlight = 0;
-    let peak = 0;
-    readableDocumentIds.mockImplementation(async (_slug, ids: string[]) => {
-      inFlight++;
-      peak = Math.max(peak, inFlight);
-      await new Promise(resolve => setTimeout(resolve, 0));
-      inFlight--;
-      return new Set(ids);
+describe("translating a version row", () => {
+  it("names the document a collection row belongs to, language included", async () => {
+    expect(
+      await refFor(row({ scopeKind: "collection", locale: "de" }))
+    ).toEqual({
+      kind: "collection",
+      slug: "posts",
+      entryId: "e1",
+      locale: "de",
     });
-
-    await visiblePendingEdits(
-      Array.from({ length: 8 }, (_, index) =>
-        row({ entryId: `e${index}`, locale: `l${index}` })
-      ),
-      caller,
-      await scopeNow()
-    );
-
-    // More than one at a time proves it is not serial; the bound proves it is
-    // not an unbounded fan-out.
-    expect(peak).toBeGreaterThan(1);
-    expect(peak).toBeLessThanOrEqual(8);
   });
 
-  it("asks ONCE for rows that share a slug and language", async () => {
-    // The control on the grouping: per-locale must not become per-row, which
-    // would put one read per document in front of every dashboard load.
-    await visiblePendingEdits(
-      [
-        row({ entryId: "e1", locale: "en" }),
-        row({ entryId: "e2", locale: "en" }),
-      ],
-      caller,
-      await scopeNow()
-    );
-
-    expect(readableDocumentIds).toHaveBeenCalledTimes(1);
-    expect(readableDocumentIds).toHaveBeenCalledWith(
-      "posts",
-      ["e1", "e2"],
-      caller,
-      "en"
-    );
-  });
-});
-
-describe("rows nothing can decide", () => {
-  it("drops a row whose language is no longer configured", async () => {
-    // 🔴 Forwarding an unconfigured locale does NOT authorize it:
-    // `resolveRequestedLocale` substitutes the configured DEFAULT for any code
-    // it does not recognise. A draft written under a language later removed
-    // would be judged by the default language's verdict — a row exposed on a
-    // predicate never evaluated for it, which is the defect the per-locale fix
-    // exists to prevent, wearing a different hat.
-    const visible = await visiblePendingEdits(
-      [row({ entryId: "e1", locale: "fr" })],
-      caller,
-      await scopeNow()
-    );
-
-    expect(visible).toEqual([]);
-    expect(readableDocumentIds).not.toHaveBeenCalled();
+  it("names a single row the same way", async () => {
+    expect(await refFor(row({ scopeKind: "single" }))).toEqual({
+      kind: "single",
+      slug: "posts",
+      entryId: "e1",
+      locale: null,
+    });
   });
 
-  it("keeps a configured language beside a removed one", async () => {
-    // The control: dropping unconfigured locales must not drop everything.
-    const visible = await visiblePendingEdits(
-      [
-        row({ entryId: "e1", locale: "fr" }),
-        row({ entryId: "e1", locale: "en" }),
-      ],
-      caller,
-      await scopeNow()
-    );
-
-    expect(visible.map(r => r.locale)).toEqual(["en"]);
-  });
-
-  it("drops a row whose scope kind no longer matches the registry", async () => {
-    // Deleting a collection leaves its history behind, and a Single may later
-    // take the freed slug. Probing the COLLECTION read path for a slug that now
-    // belongs to a Single asks about a table that is not there — it throws and
-    // breaks both cards rather than dropping one orphaned row.
-    const visible = await visiblePendingEdits(
-      [
-        row({
-          entryId: "e1",
-          scopeKind: "collection",
-          scopeSlug: "site-settings",
-        }),
-      ],
-      caller,
-      await scopeNow()
-    );
-
-    expect(visible).toEqual([]);
-    expect(readableDocumentIds).not.toHaveBeenCalled();
-    expect(singleDocumentReadable).not.toHaveBeenCalled();
-  });
-
-  it("drops a row whose slug is in neither registry", async () => {
-    const visible = await visiblePendingEdits(
-      [row({ entryId: "e1", scopeSlug: "deleted-collection" })],
-      caller,
-      await scopeNow()
-    );
-
-    expect(visible).toEqual([]);
-    expect(readableDocumentIds).not.toHaveBeenCalled();
-  });
-});
-
-describe("single rows", () => {
-  const single = (entryId: string, locale?: string | null) =>
-    row({ entryId, locale, scopeKind: "single", scopeSlug: "site-settings" });
-
-  it("resolves the live document id WITHOUT materializing the Single", async () => {
-    // 🔴 The read probe goes through `SingleEntryService.get`, which AUTO-CREATES
-    // a missing Single -- so probing first makes loading a dashboard perform a
-    // write. The id is resolved from the backing row instead, which is what
-    // `resolveSingleDocumentId` exists for.
-    await visiblePendingEdits(
-      [single("single-live")],
-      caller,
-      await scopeNow()
-    );
-
-    expect(resolveSingleDocumentId).toHaveBeenCalledWith("site-settings");
-    expect(singleDocumentReadable).toHaveBeenCalled();
-  });
-
-  it("drops a row belonging to a PREDECESSOR document, without probing at all", async () => {
-    // A version row outlives the document it describes: a Single deleted and
-    // recreated leaves rows naming the old id. Judging those by the
-    // replacement's verdict exposes the predecessor's entry id and edit time.
-    const visible = await visiblePendingEdits(
-      [single("single-deleted")],
-      caller,
-      await scopeNow()
-    );
-
-    expect(visible).toEqual([]);
-    expect(singleDocumentReadable).not.toHaveBeenCalled();
-  });
-
-  it("drops every row when the Single has never been materialized", async () => {
-    resolveSingleDocumentId.mockResolvedValue(null);
-
-    const visible = await visiblePendingEdits(
-      [single("single-live")],
-      caller,
-      await scopeNow()
-    );
-
-    expect(visible).toEqual([]);
-    expect(singleDocumentReadable).not.toHaveBeenCalled();
-  });
-});
-
-describe("resolving the scope", () => {
-  it("reads the registry ONCE, however many pages are judged against it", async () => {
-    // 🔴 The registry and the locale config both answer an unreachable
-    // dependency with an EMPTY result, on purpose. Re-read per page, that
-    // safety inverts: a transient failure on one page drops every row that
-    // page holds while its neighbours keep theirs, and the walk goes on to
-    // publish the shortfall as a whole number. One resolution cannot fail
-    // halfway.
-    const scope = await scopeNow();
-    const rows = Array.from({ length: 3 }, (_, index) =>
-      row({ entryId: `e${index}`, locale: "en" })
-    );
-
-    for (const one of rows) await visiblePendingEdits([one], caller, scope);
-
-    expect(contentSnapshot).toHaveBeenCalledTimes(1);
-  });
-
-  it("carries the registry's own report that it could not be enumerated", async () => {
-    contentSnapshot.mockResolvedValue({ kinds: new Map(), degraded: true });
-
-    expect((await scopeNow()).degraded).toBe(true);
-  });
-
-  it("is NOT degraded when an install has simply registered nothing", async () => {
-    // The control that keeps `degraded` meaning what it says. An empty
-    // registry and an unreachable one produce the same empty map, and folding
-    // them together would either fail every empty install or excuse the case
-    // this flag exists to report.
-    contentSnapshot.mockResolvedValue({ kinds: new Map(), degraded: false });
-
-    expect((await scopeNow()).degraded).toBe(false);
+  it("refuses to name a PAGE row, which no content read path can answer for", async () => {
+    // 🔴 `VersionScopeKind` also admits `page`, which the page builder captures
+    // versions under. There is no collection or single read path holding that
+    // document, so coercing it to either sends the row to a service that cannot
+    // answer about it — and a service that answers "no such document" reads as
+    // a denial, which is the inversion this pass exists to remove. `null` is
+    // the honest translation, and the decision drops it.
+    expect(await refFor(row({ scopeKind: "page" }))).toBeNull();
   });
 });

--- a/packages/nextly/src/domains/versions/pending-edit-visibility.ts
+++ b/packages/nextly/src/domains/versions/pending-edit-visibility.ts
@@ -10,278 +10,47 @@
  * counted one author's documents for another and listed their entry ids and the
  * instants they were edited.
  *
+ * The decision itself belongs to {@link visibleDocuments}, which the activity
+ * feed asks the same question of. This module is the TRANSLATION from a version
+ * row to the document it names, and nothing more — so the two surfaces cannot
+ * come to different conclusions about who may see a document.
+ *
+ * That split is not tidiness. Both surfaces once carried their own copy, and
+ * the copies did not stay equal: per-locale grouping, the registry-kind check,
+ * the stale-locale drop, bounded concurrency and resolving a Single's live id
+ * before probing it were each present on one side and absent from the other,
+ * every one of them a defect on the side that lacked it.
+ *
  * Version rows OUTLIVE the things they describe — that is what history is — so a
  * row reaching here may name a document, a language or an entity that no longer
  * exists, or a slug some other entity has since taken over. Each of those is
- * UNDECIDABLE rather than deniable, and every one is dropped: nothing here can
- * judge them, and admitting what cannot be judged is the inversion this pass
- * exists to remove.
- *
- * Every decision that IS made is delegated. A stored rule can be owner-only or
- * an arbitrary function, and evaluating either is the read path's job — this
- * asks that path about a known set of documents rather than reproducing what it
- * would say.
+ * UNDECIDABLE rather than deniable, and `visibleDocuments` drops every one:
+ * nothing can judge them, and admitting what cannot be judged is the inversion
+ * this pass exists to remove.
  *
  * @module domains/versions/pending-edit-visibility
  */
 
-import { authorizationGroups } from "../../auth/entity-read-access";
-import { container } from "../../di/container";
-import type { NextlyServiceConfig } from "../../di/register";
 import type { ReadCaller } from "../../services/dashboard/readable-resources";
-import { readableDocumentIds } from "../../services/lib/readable-documents";
-import { registeredContentSnapshot } from "../../services/lib/registered-content-slugs";
+import {
+  resolveDocumentVisibilityScope,
+  visibleDocuments,
+  type DocumentVisibilityScope,
+} from "../../services/lib/document-visibility";
 
 import type { VersionMeta } from "./versions-repository";
 
-/** What a row must resolve to before any access question can be asked about it. */
-interface Subject {
-  kind: "collection" | "single";
-  slug: string;
-  entryId: string;
-  locale: string | null;
-}
-
-/** One read's worth of rows: a slug, in a language, and what it answers for. */
-interface ReadUnit {
-  subject: Subject;
-  rows: VersionMeta[];
-}
-
 /**
- * The languages a read can actually be performed in, or `null` when the install
- * configures none.
+ * The install-wide facts one query's pages are all judged against.
  *
- * 🔴 Needed because forwarding an unconfigured locale does NOT authorize it:
- * `resolveRequestedLocale` substitutes the configured DEFAULT for any code it
- * does not recognise. A working draft written under a language later removed
- * from the configuration would therefore be judged by the default language's
- * verdict — a row exposed on a predicate never evaluated for it, which is the
- * same defect as passing no locale at all.
+ * Re-exported under this domain's own name rather than making callers reach
+ * into the shared module: the versions source resolves it once per query and
+ * threads it down, and the name says what it scopes.
  */
-function configuredLocales(): ReadonlySet<string> | null {
-  try {
-    if (!container.has("config")) return null;
-    const localization =
-      container.get<NextlyServiceConfig>("config").localization;
-    if (!localization) return null;
-    return new Set(localization.locales.map(locale => locale.code));
-  } catch {
-    // A container that cannot answer leaves every localized row undecidable,
-    // which `subjectOf` turns into "dropped" rather than "allowed".
-    return null;
-  }
-}
-
-/**
- * The document a row names, or `null` when nothing here can decide it.
- *
- * Three ways a row is undecidable, each of which has cost a real defect:
- *
- * - Its scope kind disagrees with the registry. Deleting a collection leaves its
- *   history behind, and a Single may later take the freed slug — so a
- *   `collection` row can survive under a name that now belongs to a Single.
- *   Probing the collection read path for it asks about a table that is not
- *   there, which throws and breaks both cards rather than dropping one row.
- * - Its slug is in neither registry, so there is no read path to ask at all.
- * - Its language is no longer configured, so a read cannot be performed IN that
- *   language and would silently answer about the default one instead.
- */
-function subjectOf(
-  row: VersionMeta,
-  kinds: ReadonlyMap<string, "collection" | "single">,
-  locales: ReadonlySet<string> | null
-): Subject | null {
-  const kind = kinds.get(row.scopeSlug);
-  if (!kind || kind !== row.scopeKind) return null;
-  if (row.locale !== null && !locales?.has(row.locale)) return null;
-  return {
-    kind,
-    slug: row.scopeSlug,
-    entryId: row.entryId,
-    locale: row.locale,
-  };
-}
-
-/** Rows grouped into the units one read can answer for: a slug in a language. */
-function readUnits(
-  rows: readonly VersionMeta[],
-  subjects: ReadonlyMap<VersionMeta, Subject>,
-  kind: "collection" | "single"
-): Map<string, ReadUnit> {
-  const units = new Map<string, ReadUnit>();
-  for (const row of rows) {
-    const subject = subjects.get(row);
-    if (!subject || subject.kind !== kind) continue;
-    const key = `${subject.slug} ${subject.locale ?? ""}`;
-    const existing = units.get(key);
-    if (existing) existing.rows.push(row);
-    else units.set(key, { subject, rows: [row] });
-  }
-  return units;
-}
-
-/**
- * Collection rows whose documents survive that collection's read rules.
- *
- * 🔴 Grouped by slug AND language, because a stored rule is a predicate over the
- * collection's own fields and a localized field answers differently per
- * language — `localized-target-predicate.integration.test.ts` pins one row
- * readable in `en` and denied in `de`. One verdict per slug would mark every
- * other language visible on the strength of whichever the read defaulted to.
- *
- * Run with BOUNDED CONCURRENCY rather than one after another. Each unit enters
- * the full collection read path, so a page spanning many collections or
- * languages became that many sequential round trips — enough to time a dashboard
- * out while the connection pool sat idle. `authorizationGroups` is the bound the
- * entity-level decisions already use, and its first group of one is what lets a
- * cold per-user permission cache be filled once rather than missed by everything
- * in the fan-out.
- */
-async function visibleCollectionRows(
-  units: ReadonlyMap<string, ReadUnit>,
-  caller: ReadCaller
-): Promise<Set<VersionMeta>> {
-  const visible = new Set<VersionMeta>();
-
-  for (const group of authorizationGroups([...units.keys()])) {
-    const settled = await Promise.allSettled(
-      group.map(async key => {
-        const unit = units.get(key) as ReadUnit;
-        const readable = await readableDocumentIds(
-          unit.subject.slug,
-          unit.rows.map(row => row.entryId),
-          caller,
-          unit.subject.locale
-        );
-        return { unit, readable };
-      })
-    );
-    for (const outcome of settled) {
-      // A rejected read has told us nothing, and "nothing" must not read as
-      // "visible" -- the fail-closed direction `readableEntities` also takes.
-      if (outcome.status !== "fulfilled") continue;
-      const { unit, readable } = outcome.value;
-      for (const row of unit.rows) {
-        if (readable.has(row.entryId)) visible.add(row);
-      }
-    }
-  }
-  return visible;
-}
-
-/**
- * Single rows whose document this caller may read, asked once per language.
- *
- * The live document's id is resolved FIRST, and without materializing anything.
- * A version row outlives the document it describes, so a Single deleted and
- * recreated leaves rows naming its predecessor — and the probe reads through
- * `SingleEntryService`, which auto-creates a missing Single, so asking it first
- * would make loading a dashboard perform a write.
- *
- * `routeAuthorized: false` states the truth: the surface asking this authorized
- * a widget, not a read of this Single, so the coarse gate has not run for that
- * operation and must not be skipped.
- */
-async function visibleSingleRows(
-  units: ReadonlyMap<string, ReadUnit>,
-  caller: ReadCaller
-): Promise<Set<VersionMeta>> {
-  const visible = new Set<VersionMeta>();
-  if (units.size === 0) return visible;
-
-  // 🔴 Imported HERE rather than at the top of the module, because the static
-  // edge is a cycle: the Singles read path imports this domain, so a top-level
-  // import back into it closes the loop. Rollup already reports that shape
-  // elsewhere in this package as producing a broken execution order, and the
-  // failure would land at boot rather than here.
-  const { singleDocumentReadable, resolveSingleDocumentId } = await import(
-    "../singles/services/single-document-access"
-  );
-
-  const liveIds = new Map<string, Promise<string | null>>();
-  const liveIdOf = (slug: string): Promise<string | null> => {
-    let pending = liveIds.get(slug);
-    if (!pending) {
-      pending = resolveSingleDocumentId(slug);
-      liveIds.set(slug, pending);
-    }
-    return pending;
-  };
-
-  /**
-   * One unit's rows that name the LIVE document, or none.
-   *
-   * 🔴 The probe is skipped entirely when nothing here names it — the Single is
-   * unmaterialized, or every row is a predecessor's. It reads through a path
-   * that AUTO-CREATES a missing Single, so asking about one that is not there
-   * turns a dashboard read into a write; and asking about a live document on
-   * behalf of rows that do not name it spends a read whose verdict cannot admit
-   * any of them.
-   */
-  const liveRowsOf = async (unit: ReadUnit): Promise<VersionMeta[]> => {
-    const liveId = await liveIdOf(unit.subject.slug);
-    if (liveId === null) return [];
-    return unit.rows.filter(row => row.entryId === liveId);
-  };
-
-  for (const group of authorizationGroups([...units.keys()])) {
-    const settled = await Promise.allSettled(
-      group.map(async key => {
-        const unit = units.get(key) as ReadUnit;
-        const live = await liveRowsOf(unit);
-        if (live.length === 0) return [];
-        const allowed = await singleDocumentReadable(unit.subject.slug, {
-          user: caller.user,
-          ...(caller.authenticatedScope
-            ? { actor: caller.authenticatedScope }
-            : {}),
-          routeAuthorized: false,
-          ...(unit.subject.locale === null
-            ? {}
-            : { locale: unit.subject.locale }),
-        });
-        return allowed ? live : [];
-      })
-    );
-    for (const outcome of settled) {
-      // A rejected read has told us nothing, and "nothing" must not read as
-      // "visible" -- the fail-closed direction `readableEntities` also takes.
-      if (outcome.status !== "fulfilled") continue;
-      for (const row of outcome.value) visible.add(row);
-    }
-  }
-  return visible;
-}
-
-/**
- * The install-wide facts every page of one walk must be judged against.
- *
- * 🔴 Resolved ONCE per query and carried, never re-read per page. Both halves
- * turn a failure into an EMPTY answer on purpose — an unreachable registry
- * contributes no slugs, an unreadable config no languages — and under a
- * per-page read that safety became a defect: a transient failure on the seventh
- * page dropped every row that page held, the pages either side of it kept
- * theirs, and the walk finished and published the shortfall as a whole number.
- * A snapshot cannot fail halfway; it is either the basis for the entire answer
- * or the reason there is not one.
- */
-export interface PendingEditScope {
-  kinds: ReadonlyMap<string, "collection" | "single">;
-  locales: ReadonlySet<string> | null;
-  /** True when the registry could not be enumerated, so `kinds` is a floor. */
-  degraded: boolean;
-}
+export type PendingEditScope = DocumentVisibilityScope;
 
 /** One resolution of the registry and the configured languages. */
-export async function resolvePendingEditScope(): Promise<PendingEditScope> {
-  const snapshot = await registeredContentSnapshot();
-  return {
-    kinds: snapshot.kinds,
-    locales: configuredLocales(),
-    degraded: snapshot.degraded,
-  };
-}
+export const resolvePendingEditScope = resolveDocumentVisibilityScope;
 
 /** `rows`, in their original order, keeping only what the caller may be told. */
 export async function visiblePendingEdits(
@@ -289,21 +58,27 @@ export async function visiblePendingEdits(
   caller: ReadCaller,
   scope: PendingEditScope
 ): Promise<VersionMeta[]> {
-  if (rows.length === 0) return [];
-
-  const { kinds, locales } = scope;
-
-  const subjects = new Map<VersionMeta, Subject>();
-  for (const row of rows) {
-    const subject = subjectOf(row, kinds, locales);
-    if (subject) subjects.set(row, subject);
-  }
-  if (subjects.size === 0) return [];
-
-  const [collections, singles] = await Promise.all([
-    visibleCollectionRows(readUnits(rows, subjects, "collection"), caller),
-    visibleSingleRows(readUnits(rows, subjects, "single"), caller),
-  ]);
-
-  return rows.filter(row => collections.has(row) || singles.has(row));
+  return visibleDocuments(
+    rows,
+    // The whole translation: a version row already records the kind, the slug,
+    // the document and the language it was drafted in. Whether those still name
+    // anything readable is `visibleDocuments`'s question, not this one's.
+    //
+    // 🔴 `VersionScopeKind` is wider than the two kinds a content read path can
+    // answer for -- it also admits `page`, which the page builder captures
+    // versions under. Such a row resolves to `null` and is DROPPED, because
+    // there is no collection or single read path to ask about it; coercing it
+    // to either would send it to a service that does not hold the document.
+    row =>
+      row.scopeKind === "collection" || row.scopeKind === "single"
+        ? {
+            kind: row.scopeKind,
+            slug: row.scopeSlug,
+            entryId: row.entryId,
+            locale: row.locale,
+          }
+        : null,
+    caller,
+    scope
+  );
 }

--- a/packages/nextly/src/domains/webhooks/record-mutation-event.ts
+++ b/packages/nextly/src/domains/webhooks/record-mutation-event.ts
@@ -183,6 +183,16 @@ async function recordActivity(
     action,
     collection: args.resource.collection,
     ...(args.resource.id !== undefined ? { entryId: args.resource.id } : {}),
+    // 🔴 DERIVED from the resource the event already carries, not passed
+    // separately. The write sites that know a language already record it there
+    // for receivers to route on, so taking it from one place means a site
+    // cannot report a locale to a subscriber and a different one — or none — to
+    // the activity trail. A resource without a locale leaves the column NULL,
+    // which the feed reads as the default language: exactly what an unlocalized
+    // write, and every row predating the column, already meant.
+    ...(args.resource.locale !== undefined
+      ? { locale: args.resource.locale }
+      : {}),
     data: args.data,
     previous: args.previous ?? null,
     actor: args.actor ?? null,

--- a/packages/nextly/src/schemas/audit/mysql.ts
+++ b/packages/nextly/src/schemas/audit/mysql.ts
@@ -102,6 +102,8 @@ export const activityLog = mysqlTable(
     collection: varchar("collection", { length: 255 }).notNull(),
     entryId: varchar("entry_id", { length: 191 }),
     entryTitle: text("entry_title"),
+    /** The language this mutation was made in; see `documentRefOf`. */
+    locale: varchar("locale", { length: 32 }),
     metadata: text("metadata"), // JSON string for additional context
     createdAt: timestamp("created_at").defaultNow().notNull(),
     // `datetime`, not `timestamp`: a nullable MySQL TIMESTAMP is subject to

--- a/packages/nextly/src/schemas/audit/mysql.ts
+++ b/packages/nextly/src/schemas/audit/mysql.ts
@@ -104,6 +104,8 @@ export const activityLog = mysqlTable(
     entryTitle: text("entry_title"),
     /** The language this mutation was made in; see `documentRefOf`. */
     locale: varchar("locale", { length: 32 }),
+    /** What the row is ABOUT; see `documentRefOf`. NULL on legacy rows. */
+    subjectKind: varchar("subject_kind", { length: 16 }),
     metadata: text("metadata"), // JSON string for additional context
     createdAt: timestamp("created_at").defaultNow().notNull(),
     // `datetime`, not `timestamp`: a nullable MySQL TIMESTAMP is subject to

--- a/packages/nextly/src/schemas/audit/postgres.ts
+++ b/packages/nextly/src/schemas/audit/postgres.ts
@@ -116,6 +116,8 @@ export const activityLog = pgTable(
     entryTitle: text("entry_title"),
     /** The language this mutation was made in; see `documentRefOf`. */
     locale: text("locale"),
+    /** What the row is ABOUT; see `documentRefOf`. NULL on legacy rows. */
+    subjectKind: text("subject_kind"),
     metadata: text("metadata"), // JSON string for additional context
     createdAt: timestamp("created_at", { withTimezone: false })
       .defaultNow()

--- a/packages/nextly/src/schemas/audit/postgres.ts
+++ b/packages/nextly/src/schemas/audit/postgres.ts
@@ -114,6 +114,8 @@ export const activityLog = pgTable(
     collection: varchar("collection", { length: 255 }).notNull(),
     entryId: text("entry_id"),
     entryTitle: text("entry_title"),
+    /** The language this mutation was made in; see `documentRefOf`. */
+    locale: text("locale"),
     metadata: text("metadata"), // JSON string for additional context
     createdAt: timestamp("created_at", { withTimezone: false })
       .defaultNow()

--- a/packages/nextly/src/schemas/audit/sqlite.ts
+++ b/packages/nextly/src/schemas/audit/sqlite.ts
@@ -72,6 +72,8 @@ export const activityLog = sqliteTable(
     entryTitle: text("entry_title"),
     /** The language this mutation was made in; see `documentRefOf`. */
     locale: text("locale"),
+    /** What the row is ABOUT; see `documentRefOf`. NULL on legacy rows. */
+    subjectKind: text("subject_kind"),
     metadata: text("metadata"), // JSON string for additional context
     createdAt: integer("created_at", { mode: "timestamp" })
       .notNull()

--- a/packages/nextly/src/schemas/audit/sqlite.ts
+++ b/packages/nextly/src/schemas/audit/sqlite.ts
@@ -70,6 +70,8 @@ export const activityLog = sqliteTable(
     collection: text("collection").notNull(),
     entryId: text("entry_id"),
     entryTitle: text("entry_title"),
+    /** The language this mutation was made in; see `documentRefOf`. */
+    locale: text("locale"),
     metadata: text("metadata"), // JSON string for additional context
     createdAt: integer("created_at", { mode: "timestamp" })
       .notNull()

--- a/packages/nextly/src/services/dashboard/__tests__/activity-document-rules.integration.test.ts
+++ b/packages/nextly/src/services/dashboard/__tests__/activity-document-rules.integration.test.ts
@@ -25,8 +25,6 @@ import {
 } from "../../../plugins/test-nextly";
 import { someResources } from "../readable-resources";
 
-import type { ActivityLogService } from "../activity-log-service";
-
 let current: TestNextly | undefined;
 
 afterEach(async () => {
@@ -131,8 +129,11 @@ describe.each(getConfiguredTestDialects())(
         })
       );
 
-      const activity =
-        current.getService<ActivityLogService>("activityLogService");
+      // No explicit type argument: `getService` is keyed on `ServiceMap`, which
+      // already maps this name to `ActivityLogService`. Naming the type again
+      // does not narrow anything -- it supplies a type where a KEY is expected,
+      // and the resulting `unknown` cascades into every use below.
+      const activity = current.getService("activityLogService");
       const feed = await activity.getRecentActivity({
         scope: someResources(["docs"]),
         caller: { user: { id: OWNER, roles: [] } },

--- a/packages/nextly/src/services/dashboard/__tests__/activity-document-rules.integration.test.ts
+++ b/packages/nextly/src/services/dashboard/__tests__/activity-document-rules.integration.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Whether the activity feed obeys a collection's stored read rule.
+ *
+ * 🔴 The feed's scope is COLLECTION-level (`ReadableResources`), and its rows
+ * carry `entryTitle` denormalised at write time rather than hydrated through the
+ * read path — so nothing between the log table and the response consults a
+ * document rule. A collection carrying a stored `owner-only` read rule admits
+ * every editor at the coarse check while the ordinary read path narrows to a
+ * subset, which is the same second axis the pending-edit cards were repaired
+ * for.
+ *
+ * This file settles that by measurement rather than by reading the query,
+ * because "there is no filter here" is exactly the kind of claim that is true
+ * of the code you looked at and false of the system. It failed when written,
+ * returning the other author's title, and is kept as the regression.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../../../config";
+import {
+  createTestNextly,
+  getConfiguredTestDialects,
+  type TestDialect,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import { someResources } from "../readable-resources";
+
+import type { ActivityLogService } from "../activity-log-service";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+const OWNER = "user-owner";
+const OTHER = "user-other";
+
+/** One logged edit, as the audit writer stores it. */
+function activityRow(patch: {
+  userId: string;
+  entryId: string;
+  entryTitle: string;
+}) {
+  return {
+    id: crypto.randomUUID(),
+    userId: patch.userId,
+    userName: patch.userId,
+    userEmail: `${patch.userId}@example.test`,
+    action: "update",
+    collection: "docs",
+    entryId: patch.entryId,
+    entryTitle: patch.entryTitle,
+    metadata: null,
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    identityErasedAt: null,
+  };
+}
+
+describe.each(getConfiguredTestDialects())(
+  "activity feed under a stored read rule (%s)",
+  dialect => {
+    it("does not report entry titles for documents the caller cannot read", async () => {
+      current = await createTestNextly({
+        dialect,
+        collections: [
+          defineCollection({
+            slug: "docs",
+            // Code-defined access ADMITS the collection, so the coarse check
+            // passes for a caller holding no stored grant — without it the feed
+            // is empty for a reason that has nothing to do with document rules.
+            access: { read: () => true },
+            fields: [text({ name: "title" })],
+          }),
+        ],
+      });
+
+      await current.adapter.update(
+        "dynamic_collections",
+        { access_rules: { read: { type: "owner-only" } } },
+        { and: [{ column: "slug", op: "=", value: "docs" }] }
+      );
+
+      const handler = current.getService("collectionsHandler");
+      const made: Record<string, string> = {};
+      for (const [key, userId] of [
+        ["owner", OWNER],
+        ["other", OTHER],
+      ] as const) {
+        const created = await handler.createEntry(
+          {
+            collectionName: "docs",
+            user: { id: userId },
+            routeAuthorized: true,
+          },
+          { title: `${userId} document` }
+        );
+        expect(created.success).toBe(true);
+        made[key] = (created.data as { id: string }).id;
+      }
+
+      // 🔴 The control. It establishes both halves the assertion depends on:
+      // the coarse check admits `docs` for this caller, and the stored rule
+      // genuinely narrows rows. Without it, an empty feed and a correctly
+      // filtered feed look identical.
+      const readable = await handler.listEntries({
+        collectionName: "docs",
+        user: { id: OWNER },
+        routeAuthorized: true,
+      });
+      expect(readable.success).toBe(true);
+      expect((readable.data!.docs as { id: string }[]).map(r => r.id)).toEqual([
+        made.owner,
+      ]);
+
+      await current.adapter.insert(
+        "activity_log",
+        activityRow({
+          userId: OWNER,
+          entryId: made.owner!,
+          entryTitle: "owner document",
+        })
+      );
+      await current.adapter.insert(
+        "activity_log",
+        activityRow({
+          userId: OTHER,
+          entryId: made.other!,
+          entryTitle: "SECRET other-author document",
+        })
+      );
+
+      const activity =
+        current.getService<ActivityLogService>("activityLogService");
+      const feed = await activity.getRecentActivity({
+        scope: someResources(["docs"]),
+        caller: { user: { id: OWNER, roles: [] } },
+      });
+
+      const titles = feed.activities.map(row => row.entryTitle).sort();
+      // Both of the other author's rows must be absent, not just the one this
+      // test inserted: creating an entry logs its own activity row, so the
+      // ordinary product path produces a second disclosure of the same title.
+      expect(titles).not.toContain("SECRET other-author document");
+      expect(titles).not.toContain("user-other document");
+      // Asserted as the WHOLE list rather than by absence: a feed that returned
+      // nothing at all would satisfy both refusals above and prove nothing.
+      expect(titles).toEqual(["owner document", "user-owner document"]);
+    });
+  }
+);

--- a/packages/nextly/src/services/dashboard/__tests__/activity-scope.integration.test.ts
+++ b/packages/nextly/src/services/dashboard/__tests__/activity-scope.integration.test.ts
@@ -1,6 +1,6 @@
 /**
  * The activity feed's permission scope must exclude BOTH sides of a read: the
- * rows a caller may not see, and the total that counts them.
+ * rows a caller may not see.
  *
  * `activity-scope.test.ts` covers this against a mocked adapter, which proves
  * the arguments `getRecentActivity` builds but never executes the SQL
@@ -25,7 +25,7 @@ afterEach(async () => {
 });
 
 describe("activity feed scope (sqlite integration)", () => {
-  it("excludes an unscoped collection from both the activities list and the total", async () => {
+  it("excludes an unscoped collection from the activities list", async () => {
     current = await createTestNextly({ dialect: "sqlite" });
 
     // The write path decides identity by checking whether the account still
@@ -55,16 +55,21 @@ describe("activity feed scope (sqlite integration)", () => {
 
     const result = await activityLog.getRecentActivity({
       scope: someResources(["posts"]),
+      // Required now: the feed authorizes each row's DOCUMENT as this caller,
+      // and answers empty without one. These rows name no entry, so the scope
+      // is the whole decision for them.
+      caller: { user: { id: actorId, roles: [] } },
     });
 
     expect(result.activities.map(a => a.entryTitle)).toEqual(["Visible Post"]);
     expect(result.activities.some(a => a.entryTitle === "Hidden Page")).toBe(
       false
     );
-    // `total` is what exercises countActivities' own IN-clause SQL end to
-    // end. A placeholder/params mismatch there would leave `activities`
-    // correct (a different code path, `adapter.select`) and only this number
-    // silently wrong -- exactly the failure mode I-1 describes.
-    expect(result.total).toBe(1);
+    // There is no `total` to assert any more. It was a `COUNT(*)` over the
+    // rows the COLLECTION scope admitted, so it counted edits to documents the
+    // reader may not open, and it cannot be narrowed without authorizing every
+    // matching row -- unbounded over an audit table. The count and the
+    // hand-written SQL behind it were removed rather than corrected.
+    expect(result.hasMore).toBe(false);
   });
 });

--- a/packages/nextly/src/services/dashboard/__tests__/activity-scope.test.ts
+++ b/packages/nextly/src/services/dashboard/__tests__/activity-scope.test.ts
@@ -307,3 +307,67 @@ describe("history of a document that no longer exists", () => {
     expect(result.activities).toEqual([]);
   });
 });
+
+describe("a settings row under a slug a collection also owns", () => {
+  /**
+   * 🔴 `assertGlobalResourceSlugAvailable` lets a resource that already held a
+   * now-reserved name keep it, so an upgraded install can have a real
+   * collection called `email-providers`. Registry membership then classifies
+   * the settings namespace of the same name as a collection document — its id
+   * is not in that collection, the read path refuses it, and the row is treated
+   * as history for a deleted document: stripped of the changed-field detail a
+   * credential rotation exists to record.
+   */
+  const settingsRow = {
+    id: "s1",
+    action: "update",
+    collection: "email-providers",
+    entryId: "provider-1",
+    entryTitle: "SMTP (primary)",
+    metadata: '{"changed":["host","port"]}',
+    subjectKind: "settings",
+    createdAt: new Date(2026, 0, 1),
+  };
+
+  const drawFeed = async (row: Record<string, unknown>) => {
+    const { service, adapter } = makeService();
+    // The collision: a real collection owns the settings namespace.
+    registeredKinds.mockReturnValue(
+      new Map<string, "collection" | "single">([
+        ["email-providers", "collection"],
+      ])
+    );
+    (adapter.select as ReturnType<typeof vi.fn>).mockResolvedValueOnce([row]);
+    return service.getRecentActivity({
+      limit: 5,
+      scope: someResources(["email-providers"]),
+      caller: { user: { id: "u1", roles: ["editor"] } },
+    });
+  };
+
+  it("keeps the settings row WHOLE, because the row says what it is about", async () => {
+    const result = await drawFeed(settingsRow);
+
+    expect(result.activities).toHaveLength(1);
+    expect(result.activities[0]?.entryTitle).toBe("SMTP (primary)");
+    expect(result.activities[0]?.metadata).toEqual({
+      changed: ["host", "port"],
+    });
+  });
+
+  it("still authorizes a real DOCUMENT under that same slug", async () => {
+    // The control, and the one that stops the clause above becoming a way in:
+    // a row that does not claim to be settings is judged as a document, so a
+    // colliding collection cannot be read by filing activity under its name.
+    //
+    // The document EXISTS here, so the refusal is a refusal rather than the
+    // deleted-history case -- which would keep the row, redacted, and is a
+    // different behaviour with its own tests above.
+    existingIds.mockResolvedValue(new Set(["doc-1"]));
+    const { subjectKind: _dropped, ...documentRow } = settingsRow;
+
+    const result = await drawFeed({ ...documentRow, entryId: "doc-1" });
+
+    expect(result.activities).toEqual([]);
+  });
+});

--- a/packages/nextly/src/services/dashboard/__tests__/activity-scope.test.ts
+++ b/packages/nextly/src/services/dashboard/__tests__/activity-scope.test.ts
@@ -4,13 +4,11 @@ import { ActivityLogService } from "../activity-log-service";
 import { someResources } from "../readable-resources";
 
 /**
- * `dialect` defaults to sqlite. The earlier version of this mock exposed a
- * `getDialect` method that nothing in `ActivityLogService` calls -- the real
- * getter reads `this.adapter.getCapabilities().dialect` -- so every access to
- * `this.dialect` threw, was swallowed by `countActivities`' own `catch`, and
- * silently returned 0. That masked exactly the SQL-emission defect this file
- * now tests for directly: `getCapabilities` is what has to be mocked for
- * `filterClause`'s dialect branches to run at all.
+ * `dialect` defaults to sqlite, and `getCapabilities` is what has to be mocked
+ * for it: the real getter reads `this.adapter.getCapabilities().dialect`, so a
+ * mock exposing a `getDialect` method nothing calls makes every access to
+ * `this.dialect` throw. The count that used to branch on dialect is gone, but
+ * the write path still reads it.
  */
 function makeService(dialect: "postgresql" | "sqlite" = "sqlite") {
   const adapter = {
@@ -36,10 +34,28 @@ describe("activity feed scope", () => {
       scope: someResources([]),
     });
 
-    expect(result).toEqual({ activities: [], total: 0, hasMore: false });
+    expect(result).toEqual({ activities: [], hasMore: false });
     // An empty IN list is a syntax error on some dialects, so the short-circuit
     // must happen BEFORE the query is built, not inside it.
     expect(adapter.select).not.toHaveBeenCalled();
+  });
+
+  it("answers NOTHING when no caller is given, whatever the scope admits", async () => {
+    // 🔴 Fail-closed on the second axis, the same direction an omitted scope
+    // takes on the first. This feed carries entry titles, and without a caller
+    // no row's document can be authorized -- so a caller that forgets to pass
+    // one must get nothing rather than everything its collection scope admits.
+    const { service, adapter } = makeService();
+    (adapter.select as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { id: "a", collection: "posts", entryId: "e1", entryTitle: "Secret" },
+    ]);
+
+    const result = await service.getRecentActivity({
+      limit: 5,
+      scope: someResources(["posts"]),
+    });
+
+    expect(result.activities).toEqual([]);
   });
 
   it("queries with an IN filter over exactly the scope's resources", async () => {
@@ -48,6 +64,9 @@ describe("activity feed scope", () => {
     await service.getRecentActivity({
       limit: 5,
       scope: someResources(["posts", "email-providers"]),
+      // Without one the read never happens at all, so there would be no call to
+      // inspect -- which is the fail-closed behaviour the test above pins.
+      caller: { user: { id: "reader", roles: [] } },
     });
 
     const call = (adapter.select as ReturnType<typeof vi.fn>).mock.calls[0];
@@ -67,74 +86,15 @@ describe("activity feed scope", () => {
   });
 });
 
-describe("countActivities SQL emission", () => {
-  // `countActivities` is private; its emitted SQL and params are observable
-  // only through what it hands `adapter.executeQuery`. Nothing previously
-  // inspected either -- the mock's `executeQuery` return value was read, but
-  // its call arguments never were -- so a placeholder/params mismatch here
-  // (I-1) would produce a wrong `total`, or a silent 0 through the blanket
-  // catch, with a green suite either way.
-  //
-  // One case per dialect, and one filter of each kind (`=` then `IN`) so the
-  // placeholder numbering is proven across a boundary: if it were derived from
-  // the filter's array index rather than from `params.length` as each value is
-  // pushed, the `IN` filter's own placeholders would be right but everything
-  // would still line up here, because index 1 and `params.length` after one
-  // push agree. What catches the regression is that a WRONG numbering scheme
-  // also has to survive the exact params array asserted below, in the exact
-  // order `filterClause` pushes them.
-  it.each([
-    {
-      dialect: "postgresql" as const,
-      expectedSql:
-        'SELECT COUNT(*) as count FROM activity_log WHERE "user_id" = $1 AND "collection" IN ($2, $3)',
-    },
-    {
-      dialect: "sqlite" as const,
-      expectedSql:
-        "SELECT COUNT(*) as count FROM activity_log WHERE `user_id` = ? AND `collection` IN (?, ?)",
-    },
-  ])(
-    "emits the full parameterised SQL and params, on $dialect",
-    async ({ dialect, expectedSql }) => {
-      const { service, adapter } = makeService(dialect);
-
-      await service.getRecentActivity({
-        userId: "u1",
-        scope: someResources(["posts", "email-providers"]),
-      });
-
-      // Full string and full array, not a substring or a `toContain`: either
-      // of those would pass a query missing a clause, carrying an extra one,
-      // or binding its params out of order.
-      expect(adapter.executeQuery).toHaveBeenCalledWith(expectedSql, [
-        "u1",
-        "posts",
-        "email-providers",
-      ]);
-    }
-  );
-
-  it("logs and returns 0, rather than throwing or reporting silently, when the count query fails", async () => {
-    const { service, adapter, logger } = makeService();
-    (adapter.executeQuery as ReturnType<typeof vi.fn>).mockRejectedValue(
-      new Error("connection reset")
-    );
-
-    const result = await service.getRecentActivity({
-      userId: "u1",
-      scope: someResources(["posts"]),
-    });
-
-    // The rows still come back (a different adapter call, `select`, which
-    // this rejection does not touch) -- only `total` degrades.
-    expect(result.total).toBe(0);
-    // The property M-3 fixes: a bare `catch { return 0 }` here made a
-    // placeholder/params mismatch indistinguishable from a legitimate empty
-    // count, with nothing in the logs to tell them apart.
-    expect(logger.error).toHaveBeenCalledWith(
-      "Failed to count activities",
-      expect.objectContaining({ error: "connection reset" })
-    );
-  });
-});
+/**
+ * The `countActivities` SQL-emission suite that stood here is GONE, and so is
+ * the code it observed.
+ *
+ * It watched a hand-written `SELECT COUNT(*)` for a placeholder/params mismatch
+ * across dialects — a real hazard while the feed published a `total`. That
+ * count was removed rather than corrected: it counted rows the COLLECTION scope
+ * admitted, so it reported edits to documents the reader may not open, and an
+ * authorized total would mean authorizing every matching row, which is
+ * unbounded over an audit table. With no count there is no emitted SQL to
+ * observe, and no behaviour left for those tests to describe.
+ */

--- a/packages/nextly/src/services/dashboard/__tests__/activity-scope.test.ts
+++ b/packages/nextly/src/services/dashboard/__tests__/activity-scope.test.ts
@@ -1,7 +1,39 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const scopeDegraded = vi.fn();
+const registeredKinds = vi.fn();
+
+// 🔴 The scope is container-backed, and a unit harness has no registries — so
+// the REAL resolver reports `degraded`, which the service now refuses on. Left
+// unmocked, every case in this file would exercise that refusal instead of what
+// it is named for. `visibleDocuments` stays REAL: these tests are about which
+// rows reach the decision, and substituting the decision as well would let the
+// service hand it anything and still satisfy them.
+const existingIds = vi.fn();
+
+vi.mock("../../lib/readable-documents", async importOriginal => ({
+  ...(await importOriginal<typeof import("../../lib/readable-documents")>()),
+  readableDocumentIds: () => Promise.resolve(new Set<string>()),
+  existingDocumentIds: (...args: unknown[]) => existingIds(...args) as unknown,
+}));
+vi.mock("../../lib/document-visibility", async importOriginal => ({
+  ...(await importOriginal<typeof import("../../lib/document-visibility")>()),
+  resolveDocumentVisibilityScope: () =>
+    Promise.resolve({
+      kinds: registeredKinds() as Map<string, "collection" | "single">,
+      locales: null,
+      degraded: scopeDegraded() as boolean,
+    }),
+}));
 
 import { ActivityLogService } from "../activity-log-service";
 import { someResources } from "../readable-resources";
+
+beforeEach(() => {
+  scopeDegraded.mockReturnValue(false);
+  registeredKinds.mockReturnValue(new Map());
+  existingIds.mockResolvedValue(new Set<string>());
+});
 
 /**
  * `dialect` defaults to sqlite, and `getCapabilities` is what has to be mocked
@@ -98,3 +130,180 @@ describe("activity feed scope", () => {
  * unbounded over an audit table. With no count there is no emitted SQL to
  * observe, and no behaviour left for those tests to describe.
  */
+
+describe("a registry that could not be enumerated", () => {
+  it("REFUSES rather than answering with unauthorized rows", async () => {
+    // 🔴 The failure inverts the safety it is built on. A slug missing from
+    // `kinds` is read as an install-level event and KEPT without asking the
+    // read path -- correct when the map is whole, because settings namespaces
+    // are neither a collection nor a single. When the registry could not be
+    // enumerated, the very same rule admits every document row unauthorized,
+    // so a transient dependency failure turns the feed back into the disclosure
+    // this service was repaired for, and does it silently.
+    const { service, adapter } = makeService();
+    (adapter.select as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { id: "a", collection: "posts", entryId: "e1", entryTitle: "Secret" },
+    ]);
+    scopeDegraded.mockReturnValue(true);
+
+    await expect(
+      service.getRecentActivity({
+        limit: 5,
+        scope: someResources(["posts"]),
+        caller: { user: { id: "u1", roles: ["editor"] } },
+      })
+    ).rejects.toThrow();
+  });
+
+  it("still answers for an install that has registered NOTHING", async () => {
+    // The control that keeps `degraded` meaning what it says: an empty registry
+    // and an unreachable one produce the same empty map, and folding them
+    // together would break every fresh install while reading as the same fix.
+    const { service } = makeService();
+
+    await expect(
+      service.getRecentActivity({
+        limit: 5,
+        scope: someResources(["posts"]),
+        caller: { user: { id: "u1", roles: ["editor"] } },
+      })
+    ).resolves.toMatchObject({ hasMore: false });
+  });
+});
+
+describe("refilling a page whose rows are mostly unreadable", () => {
+  /** Rows the scope admits but no document rule will, forcing another round. */
+  const unreadable = (n: number, from: number) =>
+    Array.from({ length: n }, (_, i) => ({
+      id: `a${from + i}`,
+      collection: "posts",
+      entryId: `e${from + i}`,
+      entryTitle: "hidden",
+      createdAt: new Date(2026, 0, 1, 0, 0, from + i),
+    }));
+
+  it("anchors each round to the LAST ROW READ, never to a running offset", async () => {
+    // 🔴 `activity_log` grows while the feed is being built -- every create,
+    // update and delete appends to it -- so under OFFSET a row inserted between
+    // two rounds shifts every later position by one: the next round repeats a
+    // row already seen and SKIPS one that was never read. The skipped row is
+    // lost silently, because de-duplicating what arrived cannot reveal what did
+    // not, and the feed reports the wrong `hasMore` about it too.
+    const { service, adapter } = makeService();
+    registeredKinds.mockReturnValue(
+      new Map<string, "collection" | "single">([["posts", "collection"]])
+    );
+    // The documents still EXIST, so a refused row is genuinely dropped rather
+    // than kept as redacted deletion history -- otherwise the page fills in one
+    // round and the second round this asserts about never happens.
+    existingIds.mockImplementation((_slug: string, ids: string[]) =>
+      Promise.resolve(new Set(ids))
+    );
+    const select = adapter.select as ReturnType<typeof vi.fn>;
+    // A FULL page (ACTIVITY_PAGE_SIZE), or the loop reads the short page as the
+    // end of the table and never performs the second round this asserts about.
+    select.mockResolvedValueOnce(unreadable(100, 0)).mockResolvedValue([]);
+
+    await service.getRecentActivity({
+      limit: 5,
+      scope: someResources(["posts"]),
+      caller: { user: { id: "u1", roles: ["editor"] } },
+    });
+
+    expect(select.mock.calls.length).toBeGreaterThan(1);
+    const second = select.mock.calls[1]?.[1] as {
+      offset?: number;
+      where?: unknown;
+    };
+    // No offset at all on a later round, and a cursor in its place.
+    expect(second.offset).toBeUndefined();
+    expect(JSON.stringify(second.where)).toContain("createdAt");
+  });
+
+  it("orders by a UNIQUE key as well as the instant", async () => {
+    // `createdAt` alone is not total -- MySQL stores these at second precision,
+    // so a burst of writes ties -- and a cursor over a non-unique key cannot say
+    // which of the tied rows a page ended on.
+    const { service, adapter } = makeService();
+    await service.getRecentActivity({
+      limit: 5,
+      scope: someResources(["posts"]),
+      caller: { user: { id: "u1", roles: ["editor"] } },
+    });
+
+    const first = (adapter.select as ReturnType<typeof vi.fn>).mock
+      .calls[0]?.[1] as { orderBy?: { column: string; direction: string }[] };
+    expect(first.orderBy).toEqual([
+      { column: "createdAt", direction: "desc" },
+      { column: "id", direction: "desc" },
+    ]);
+  });
+});
+
+describe("history of a document that no longer exists", () => {
+  const deletionRow = {
+    id: "a1",
+    action: "delete",
+    collection: "posts",
+    entryId: "gone-1",
+    entryTitle: "Q4 revenue plan",
+    metadata: '{"changed":["title"]}',
+    userName: "Dana",
+    createdAt: new Date(2026, 0, 1),
+  };
+
+  const feed = async () => {
+    const { service, adapter } = makeService();
+    registeredKinds.mockReturnValue(
+      new Map<string, "collection" | "single">([["posts", "collection"]])
+    );
+    (adapter.select as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      deletionRow,
+    ]);
+    return service.getRecentActivity({
+      limit: 5,
+      scope: someResources(["posts"]),
+      caller: { user: { id: "u1", roles: ["editor"] } },
+    });
+  };
+
+  it("KEEPS the event when the document is gone, without its title", async () => {
+    // 🔴 A collection delete removes the row and only then appends
+    // `entry.deleted`, so the document the event names can never be found
+    // again. Judged by readability alone the deletion -- and every earlier
+    // event for that document -- vanishes from the feed for everyone, a super
+    // admin included, which loses precisely the events the trail exists for.
+    existingIds.mockResolvedValue(new Set<string>());
+
+    const result = await feed();
+
+    expect(result.activities).toHaveLength(1);
+    expect(result.activities[0]?.entryTitle).toBeNull();
+    // The event survives; what it was called does not. The rule that decided
+    // who could read this title died with the document, so nothing can
+    // evaluate it now.
+    expect(result.activities[0]?.userName).toBe("Dana");
+  });
+
+  it("DROPS the event when the document exists and was refused", async () => {
+    // The control, and the one that keeps the clause above from becoming a way
+    // in: a document that is merely denied must stay denied. Without it,
+    // "keep what the read path refused" would republish every hidden row.
+    existingIds.mockResolvedValue(new Set(["gone-1"]));
+
+    const result = await feed();
+
+    expect(result.activities).toEqual([]);
+  });
+
+  it("DROPS the event when the probe cannot answer", async () => {
+    // A probe that failed has told us nothing, and nothing must not read as
+    // "deleted" -- that direction publishes a refused row on a dependency
+    // failure, which is the inversion this whole pass removes.
+    existingIds.mockRejectedValue(new Error("probe unavailable"));
+
+    const result = await feed();
+
+    expect(result.activities).toEqual([]);
+  });
+});

--- a/packages/nextly/src/services/dashboard/__tests__/activity-scope.test.ts
+++ b/packages/nextly/src/services/dashboard/__tests__/activity-scope.test.ts
@@ -526,3 +526,121 @@ describe("existence probes for refused rows", () => {
     expect(peak).toBeLessThanOrEqual(8);
   });
 });
+
+describe("rows written before the subject-kind column", () => {
+  /**
+   * 🔴 The column is nullable and NOT backfilled, so every upgraded install
+   * keeps these indefinitely — this classification is the only one they ever
+   * get. Reading "slug not in the registry" as install-level returned a
+   * document's raw title, metadata and actor with no rule applied, which an
+   * HMR removal between the scope query and this pass makes ordinary.
+   */
+  const legacyRow = (collection: string) => ({
+    id: "l1",
+    action: "update",
+    collection,
+    entryId: "e1",
+    entryTitle: "SECRET",
+    metadata: '{"changed":["host"]}',
+    createdAt: new Date(2026, 0, 1),
+  });
+
+  const drawFeed = async (
+    row: Record<string, unknown>,
+    registry: [string, "collection" | "single"][]
+  ) => {
+    const { service, adapter } = makeService();
+    registeredKinds.mockReturnValue(
+      new Map<string, "collection" | "single">(registry)
+    );
+    existingIds.mockImplementation((_s: string, ids: string[]) =>
+      Promise.resolve(new Set(ids))
+    );
+    (adapter.select as ReturnType<typeof vi.fn>).mockResolvedValueOnce([row]);
+    return service.getRecentActivity({
+      limit: 5,
+      scope: someResources([String(row.collection)]),
+      caller: { user: { id: "u1", roles: ["editor"] } },
+    });
+  };
+
+  it("KEEPS one under a known settings namespace", async () => {
+    // Named explicitly rather than inferred from a registry miss. These rows
+    // are credential rotations and their kin, and dropping them would empty
+    // that half of the trail on every upgraded install.
+    const result = await drawFeed(legacyRow("email-providers"), []);
+
+    expect(result.activities).toHaveLength(1);
+    expect(result.activities[0]?.entryTitle).toBe("SECRET");
+  });
+
+  it("DROPS one under a slug the registry does not know", async () => {
+    // The case the old rule got wrong: unknown stops meaning safe.
+    const result = await drawFeed(legacyRow("vanished"), []);
+
+    expect(result.activities).toEqual([]);
+  });
+
+  it("DROPS one when the slug is BOTH a namespace and a collection", async () => {
+    // Irreducibly ambiguous: a legacy row carries nothing saying which it was,
+    // and guessing "settings" would return a real document's row unauthorized.
+    // Fail closed. Rows written from here on state their kind.
+    const result = await drawFeed(legacyRow("email-providers"), [
+      ["email-providers", "collection"],
+    ]);
+
+    expect(result.activities).toEqual([]);
+  });
+
+  it("still authorizes one under an ordinary registered collection", async () => {
+    // The control: legacy rows naming a live collection are documents, and go
+    // through the read path exactly as before.
+    const result = await drawFeed(legacyRow("posts"), [
+      ["posts", "collection"],
+    ]);
+
+    expect(result.activities).toEqual([]);
+    expect(existingIds).toHaveBeenCalled();
+  });
+});
+
+describe("what a redacted deletion still carries", () => {
+  it("drops the document's IDENTIFIER along with its title", async () => {
+    // 🔴 Keeping `entryId` returns the denied document's id to every caller
+    // with collection access — the same thing the authorization pass exists to
+    // withhold, minus the words. The event survives; which document it happened
+    // to does not.
+    const { service, adapter } = makeService();
+    registeredKinds.mockReturnValue(
+      new Map<string, "collection" | "single">([["posts", "collection"]])
+    );
+    existingIds.mockResolvedValue(new Set<string>());
+    (adapter.select as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      {
+        id: "a1",
+        action: "delete",
+        collection: "posts",
+        entryId: "denied-doc",
+        entryTitle: "Q4 plan",
+        subjectKind: "collection",
+        userName: "Dana",
+        userEmail: "dana@example.com",
+        createdAt: new Date(2026, 0, 1),
+      },
+    ]);
+
+    const result = await service.getRecentActivity({
+      limit: 5,
+      scope: someResources(["posts"]),
+      caller: { user: { id: "u1", roles: ["editor"] } },
+    });
+
+    expect(result.activities).toHaveLength(1);
+    expect(result.activities[0]?.entryId).toBeNull();
+    expect(result.activities[0]?.entryTitle).toBeNull();
+    // The actor STAYS, deliberately: an audit trail that cannot say who
+    // deleted something is not one, and that is the trade this redaction was
+    // chosen to make.
+    expect(result.activities[0]?.userName).toBe("Dana");
+  });
+});

--- a/packages/nextly/src/services/dashboard/__tests__/activity-scope.test.ts
+++ b/packages/nextly/src/services/dashboard/__tests__/activity-scope.test.ts
@@ -30,6 +30,11 @@ import { ActivityLogService } from "../activity-log-service";
 import { someResources } from "../readable-resources";
 
 beforeEach(() => {
+  // 🔴 Call history does not reset itself between cases in one file. Without
+  // this, any assertion on how many times a collaborator was CALLED counts
+  // every earlier test's calls too -- and reads as a real defect in whichever
+  // case happens to assert first.
+  vi.clearAllMocks();
   scopeDegraded.mockReturnValue(false);
   registeredKinds.mockReturnValue(new Map());
   existingIds.mockResolvedValue(new Set<string>());
@@ -369,5 +374,155 @@ describe("a settings row under a slug a collection also owns", () => {
     const result = await drawFeed({ ...documentRow, entryId: "doc-1" });
 
     expect(result.activities).toEqual([]);
+  });
+});
+
+describe("a row naming a document nothing can currently decide", () => {
+  /**
+   * 🔴 A registry reload between the scope query and the visibility pass makes
+   * this ordinary: the collection is still in the SQL scope and already gone
+   * from `kinds`. Folding "cannot decide" into "install-level" returned the
+   * row's raw title and metadata with no document rule applied at all.
+   */
+  const statedRow = {
+    id: "d1",
+    action: "update",
+    collection: "vanished",
+    entryId: "e1",
+    entryTitle: "SECRET draft",
+    subjectKind: "collection",
+    createdAt: new Date(2026, 0, 1),
+  };
+
+  const drawFeed = async (row: Record<string, unknown>) => {
+    const { service, adapter } = makeService();
+    // The registry does not know this slug.
+    registeredKinds.mockReturnValue(new Map());
+    (adapter.select as ReturnType<typeof vi.fn>).mockResolvedValueOnce([row]);
+    return service.getRecentActivity({
+      limit: 5,
+      scope: someResources(["vanished"]),
+      caller: { user: { id: "u1", roles: ["editor"] } },
+    });
+  };
+
+  it("DROPS a row that states a document kind", async () => {
+    const result = await drawFeed(statedRow);
+
+    expect(result.activities).toEqual([]);
+  });
+
+  it("still keeps an install-level row under an unknown namespace", async () => {
+    // The control. Settings mutations are filed under namespaces that are in
+    // neither registry, and dropping those would remove credential rotations
+    // from the feed entirely -- so "unknown slug" alone must not mean "drop".
+    const { subjectKind: _k, ...unstated } = statedRow;
+
+    const result = await drawFeed({ ...unstated, subjectKind: "settings" });
+
+    expect(result.activities).toHaveLength(1);
+  });
+});
+
+describe("a refill that runs out of ROUNDS", () => {
+  it("does not report the feed as ended", async () => {
+    // 🔴 Reaching the round limit and reaching the end of the table produce the
+    // same short page, and they are opposite answers to "is there more?". Only
+    // one of them is a fact about the data; reporting it when the scan simply
+    // stopped tells the reader there is no further activity to see.
+    const { service, adapter } = makeService();
+    registeredKinds.mockReturnValue(
+      new Map<string, "collection" | "single">([["posts", "collection"]])
+    );
+    existingIds.mockImplementation((_s: string, ids: string[]) =>
+      Promise.resolve(new Set(ids))
+    );
+    // Every round returns a FULL page of rows no document rule admits, so the
+    // loop keeps going until the round cap stops it.
+    (adapter.select as ReturnType<typeof vi.fn>).mockResolvedValue(
+      Array.from({ length: 100 }, (_, i) => ({
+        id: `a${i}`,
+        collection: "posts",
+        entryId: `e${i}`,
+        entryTitle: "hidden",
+        subjectKind: "collection",
+        createdAt: new Date(2026, 0, 1, 0, 0, i),
+      }))
+    );
+
+    const result = await service.getRecentActivity({
+      limit: 5,
+      scope: someResources(["posts"]),
+      caller: { user: { id: "u1", roles: ["editor"] } },
+    });
+
+    expect(result.activities).toEqual([]);
+    expect(result.hasMore).toBe(true);
+  });
+
+  it("DOES report the end when the table actually runs out", async () => {
+    // The control: without it, `hasMore: true` unconditionally would satisfy
+    // the case above, and the feed would promise another page forever.
+    const { service, adapter } = makeService();
+    (adapter.select as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+    const result = await service.getRecentActivity({
+      limit: 5,
+      scope: someResources(["posts"]),
+      caller: { user: { id: "u1", roles: ["editor"] } },
+    });
+
+    expect(result.hasMore).toBe(false);
+  });
+});
+
+describe("existence probes for refused rows", () => {
+  it("issues them CONCURRENTLY, within a bound", async () => {
+    // 🔴 Each probe is a full collection read, and a page can hold refused rows
+    // across as many collection/language pairs as it has rows -- so awaiting
+    // them one after another put a hundred serial reads after an authorization
+    // pass that is already bounded, and ten refill rounds could make that a
+    // thousand for one dashboard request. Bounded, not unbounded: the first
+    // group is deliberately one, so a cold per-user permission cache is filled
+    // once rather than missed by everything in the fan-out.
+    const { service, adapter } = makeService();
+    const slugs = Array.from({ length: 8 }, (_, i) => `c${i}`);
+    registeredKinds.mockReturnValue(
+      new Map<string, "collection" | "single">(
+        slugs.map(s => [s, "collection"] as const)
+      )
+    );
+    (adapter.select as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      slugs.map((slug, i) => ({
+        id: `a${i}`,
+        collection: slug,
+        entryId: `e${i}`,
+        entryTitle: "hidden",
+        subjectKind: "collection",
+        createdAt: new Date(2026, 0, 1, 0, 0, i),
+      }))
+    );
+
+    let inFlight = 0;
+    let peak = 0;
+    existingIds.mockImplementation(async (_slug: string, ids: string[]) => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise(resolve => setTimeout(resolve, 0));
+      inFlight--;
+      return new Set(ids);
+    });
+
+    await service.getRecentActivity({
+      limit: 5,
+      scope: someResources(slugs),
+      caller: { user: { id: "u1", roles: ["editor"] } },
+    });
+
+    expect(existingIds.mock.calls.length).toBe(8);
+    // More than one at a time proves it is not serial; the bound proves it is
+    // not an unbounded fan-out.
+    expect(peak).toBeGreaterThan(1);
+    expect(peak).toBeLessThanOrEqual(8);
   });
 });

--- a/packages/nextly/src/services/dashboard/activity-log-service.ts
+++ b/packages/nextly/src/services/dashboard/activity-log-service.ts
@@ -94,6 +94,12 @@ export interface LogActivityInput {
   entryTitle?: string;
   /** The language this write was made in; NULL means the default one. */
   locale?: string | null;
+  /**
+   * What this row is ABOUT: a collection document, a single, or an
+   * install-level settings change. Omitted means "not stated", which the feed
+   * falls back to inferring from the registry — see `documentRefOf`.
+   */
+  subjectKind?: ActivitySubjectKind | null;
   metadata?: Record<string, unknown>;
 }
 
@@ -164,6 +170,29 @@ const ACTIVITY_PAGE_SIZE = 100;
 const MAX_REFILL_ROUNDS = 10;
 
 /**
+ * Which read path can answer for a row, or `null` when none can.
+ *
+ * The RECORDED kind wins over the registry: a row that says it is a settings
+ * change names no document, whatever a collection of the same name suggests. A
+ * row that states nothing is one written before the column existed, and falls
+ * back to the registry — which is what those rows were always judged by.
+ *
+ * A stated kind is still checked against the registry, so a slug that no longer
+ * names anything readable stays undecidable rather than being probed against a
+ * read path that cannot answer about it.
+ */
+function subjectKindOf(
+  stated: unknown,
+  kinds: ReadonlyMap<string, "collection" | "single">,
+  slug: string
+): "collection" | "single" | null {
+  if (stated === "settings") return null;
+  if (!kinds.has(slug)) return null;
+  if (stated === "collection" || stated === "single") return stated;
+  return kinds.get(slug) ?? null;
+}
+
+/**
  * The document an activity row is about, or `null` when it is about no document.
  *
  * The row's `collection` is a FREE STRING whose namespace is deliberately wider
@@ -179,7 +208,7 @@ function documentRefOf(
   const slug = typeof row.collection === "string" ? row.collection : undefined;
   const entryId = typeof row.entryId === "string" ? row.entryId : undefined;
   if (!slug || !entryId) return null;
-  const kind = kinds.get(slug);
+  const kind = subjectKindOf(row.subjectKind, kinds, slug);
   if (!kind) return null;
   // 🔴 The language the write was made IN, so the read rule is evaluated for
   // that translation. A localized field answers differently per language, so a
@@ -283,6 +312,20 @@ type ActivityFilter =
   | (ActivityFilterBase & { op: "="; value: string })
   | (ActivityFilterBase & { op: "IN"; value: string[] });
 
+/**
+ * What an activity row is about.
+ *
+ * 🔴 RECORDED rather than inferred from the slug, because the slug cannot always
+ * decide it. `assertGlobalResourceSlugAvailable` lets a resource that already
+ * held a now-reserved name keep it, so an upgraded install can have a real
+ * collection called `email-providers` — and registry membership then classifies
+ * the settings namespace of the same name as a collection document. Its id is
+ * not in that collection, so the read path refuses it and the row is treated as
+ * history for a deleted document: stripped of the very changed-field detail a
+ * credential rotation exists to record.
+ */
+export type ActivitySubjectKind = "collection" | "single" | "settings";
+
 /** A position in the feed's `(createdAt desc, id desc)` order. */
 interface ActivityCursor {
   createdAt: Date;
@@ -372,6 +415,7 @@ export class ActivityLogService extends BaseService {
       entryId: input.entryId ?? null,
       entryTitle: input.entryTitle ?? null,
       locale: input.locale ?? null,
+      subjectKind: input.subjectKind ?? null,
       metadata: input.metadata ? JSON.stringify(input.metadata) : null,
       createdAt,
     };

--- a/packages/nextly/src/services/dashboard/activity-log-service.ts
+++ b/packages/nextly/src/services/dashboard/activity-log-service.ts
@@ -13,7 +13,7 @@
 import { randomUUID } from "crypto";
 
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
-import type { SqlParam } from "@nextlyhq/adapter-drizzle/types";
+import type { SqlParam, WhereClause } from "@nextlyhq/adapter-drizzle/types";
 import { type Column, type Table } from "drizzle-orm";
 
 import { toDbError } from "../../database/errors";
@@ -24,9 +24,15 @@ import { toDbError } from "../../database/errors";
 import { insertErasureAware } from "../../domains/audit/erasure-aware-insert";
 import { NextlyError } from "../../errors";
 import { BaseService } from "../base-service";
+import { visibleDocuments, type DocumentRef } from "../lib/readable-documents";
+import { registeredContentKinds } from "../lib/registered-content-slugs";
 import type { Logger } from "../shared";
 
-import { someResources, type ReadableResources } from "./readable-resources";
+import {
+  someResources,
+  type ReadableResources,
+  type ReadCaller,
+} from "./readable-resources";
 
 /** The three mutation actions tracked in the activity log. */
 export type ActivityLogAction = "create" | "update" | "delete";
@@ -84,10 +90,23 @@ export interface LogActivityInput {
   metadata?: Record<string, unknown>;
 }
 
-/** Paginated activity log response. */
+/**
+ * A page of activity, and whether more of it exists.
+ *
+ * 🔴 There is deliberately no `total`. It used to be a `COUNT(*)` over the rows
+ * a caller's COLLECTION scope admitted, which counted edits to documents the
+ * caller may not read — the same disclosure the rows themselves carried, in a
+ * number. It cannot simply be narrowed either: a document rule can be an
+ * arbitrary function, so an authorized total means authorizing every matching
+ * row, which is unbounded over an audit table that grows forever.
+ *
+ * Publishing a number that cannot be made correct is worse than publishing
+ * none, so `hasMore` carries the pagination instead — the cursor-shaped answer
+ * this endpoint was already moving toward, and the one that does not put an
+ * unbounded aggregate on a growing table in front of every dashboard load.
+ */
 export interface ActivityLogResult {
   activities: ActivityLogEntry[];
-  total: number;
   hasMore: boolean;
 }
 
@@ -103,9 +122,60 @@ export interface ActivityLogQueryOptions {
    * scope it must get nothing rather than everything.
    */
   scope?: ReadableResources;
+  /**
+   * WHO is reading, so each row's document can be authorized.
+   *
+   * 🔴 Required in practice for the same reason `scope` is, and omitted the
+   * same way: no caller means no document can be authorized, so a feed asked
+   * without one answers empty rather than answering about everything the scope
+   * admits. The scope decides which collections are in reach; only the caller
+   * decides which of their documents are, and a stored `owner-only` or `custom`
+   * read rule makes those different sets.
+   */
+  caller?: ReadCaller;
 }
 
 const TABLE = "activity_log";
+
+/**
+ * Rows read per refill round.
+ *
+ * Larger than a dashboard page on purpose: a card asks for five, and reading
+ * five at a time would spend a round trip per unreadable row. Small enough that
+ * a round is a cheap read on a table that only grows.
+ */
+const ACTIVITY_PAGE_SIZE = 100;
+
+/**
+ * How many rounds a page will refill before answering short.
+ *
+ * The bound on an install whose recent activity is almost entirely unreadable
+ * to this caller. Reaching it returns FEWER rows than asked for, never rows the
+ * caller may not see, so the failure direction is a thin feed rather than a
+ * disclosure.
+ */
+const MAX_REFILL_ROUNDS = 10;
+
+/**
+ * The document an activity row is about, or `null` when it is about no document.
+ *
+ * The row's `collection` is a FREE STRING whose namespace is deliberately wider
+ * than the registries — settings mutations are filed under names that are
+ * neither a collection nor a single — so the registry lookup is what separates
+ * a content event from an install-level one. Guessing a kind instead would send
+ * a settings row to a content read path that cannot answer about it.
+ */
+function documentRefOf(
+  row: Record<string, unknown>,
+  kinds: ReadonlyMap<string, "collection" | "single">
+): DocumentRef | null {
+  const slug = typeof row.collection === "string" ? row.collection : undefined;
+  const entryId = typeof row.entryId === "string" ? row.entryId : undefined;
+  if (!slug || !entryId) return null;
+  const kind = kinds.get(slug);
+  if (!kind) return null;
+  return { kind, slug, entryId };
+}
 
 /**
  * The Drizzle surface an activity write needs.
@@ -318,6 +388,7 @@ export class ActivityLogService extends BaseService {
     // exposes entry titles across every collection, so a caller that forgets
     // to pass one gets nothing rather than everything.
     const scope = options?.scope ?? someResources([]);
+    const caller = options?.caller;
 
     try {
       // Each filter carries BOTH spellings because its two consumers disagree
@@ -351,7 +422,7 @@ export class ActivityLogService extends BaseService {
         // dialects, and the short-circuit must happen BEFORE the query is
         // built rather than let the driver reject it.
         if (scope.resources.size === 0) {
-          return { activities: [], total: 0, hasMore: false };
+          return { activities: [], hasMore: false };
         }
         filters.push({
           property: "collection",
@@ -372,19 +443,20 @@ export class ActivityLogService extends BaseService {
             }
           : undefined;
 
-      const rows = await this.adapter.select<Record<string, unknown>>(TABLE, {
+      // One past the page, so `hasMore` is an observation rather than a guess:
+      // the extra row is fetched, AUTHORIZED, and then dropped. Counting
+      // candidates instead would promise another page that document rules may
+      // empty.
+      const visible = await this.visibleActivity(
         where,
-        orderBy: [{ column: "createdAt", direction: "desc" }],
-        limit: limit + 1,
+        limit + 1,
         offset,
-      });
-
-      const hasMore = rows.length > limit;
-      const entries = (hasMore ? rows.slice(0, limit) : rows).map(this.mapRow);
-
-      const total = await this.countActivities(filters);
-
-      return { activities: entries, total, hasMore };
+        caller
+      );
+      return {
+        activities: visible.slice(0, limit).map(this.mapRow),
+        hasMore: visible.length > limit,
+      };
     } catch (error) {
       this.logger.error("Failed to query activity log", {
         error: error instanceof Error ? error.message : String(error),
@@ -399,36 +471,92 @@ export class ActivityLogService extends BaseService {
     }
   }
 
-  private async countActivities(filters: ActivityFilter[]): Promise<number> {
-    try {
-      let sql = `SELECT COUNT(*) as count FROM ${TABLE}`;
-      const params: SqlParam[] = [];
+  /**
+   * Up to `want` activity rows the caller may actually be told about.
+   *
+   * 🔴 Authorization happens AFTER the read and cannot be pushed into it. A
+   * stored read rule is a constraint over the COLLECTION's own fields, and
+   * `activity_log` carries none of them — only a free-text collection name, an
+   * entry id and a denormalised title — so there is no predicate to add here.
+   * Filtering afterwards is what makes the page short, which is why it refills.
+   *
+   * Refilling rather than filtering one page: a page whose rows are mostly
+   * unreadable would otherwise answer with two rows and `hasMore: false`, and
+   * the reader would take that as the end of the feed rather than as the end of
+   * what this page happened to contain.
+   */
+  private async visibleActivity(
+    where: WhereClause | undefined,
+    want: number,
+    offset: number,
+    caller?: ReadCaller
+  ): Promise<Record<string, unknown>[]> {
+    // No caller means no document can be authorized, and this feed carries
+    // entry titles -- so it answers nothing rather than everything the scope
+    // admits. Same fail-closed direction as an omitted scope.
+    if (!caller) return [];
 
-      if (filters.length > 0) {
-        // Placeholder numbering derives from `params.length` as each value is
-        // pushed, not from the filter's own index: an `IN` filter contributes
-        // several parameters, so `$${i + 1}` -- correct only while every
-        // filter carried exactly one value -- would bind the wrong values
-        // for every filter after the first `IN`.
-        const clauses = filters.map(f => this.filterClause(f, params));
-        sql += ` WHERE ${clauses.join(" AND ")}`;
-      }
+    const kinds = await registeredContentKinds();
+    const visible: Record<string, unknown>[] = [];
+    let cursor = offset;
 
-      const result = await this.adapter.executeQuery<{
-        count: number | string;
-      }>(sql, params);
-
-      return Number(result[0]?.count ?? 0);
-    } catch (error) {
-      // Matches the sibling catch in `getRecentActivity`: a placeholder/params
-      // mismatch or a dialect failure here would otherwise surface as a silent
-      // 0 with nothing in the logs to explain it -- the `total` field would be
-      // wrong and nothing would say why.
-      this.logger.error("Failed to count activities", {
-        error: error instanceof Error ? error.message : String(error),
+    // Bounded so an install whose recent activity is almost entirely
+    // unreadable cannot walk the whole table for one card. Reaching it returns
+    // a SHORT page, never a wrong one.
+    for (let round = 0; round < MAX_REFILL_ROUNDS; round++) {
+      const page = await this.adapter.select<Record<string, unknown>>(TABLE, {
+        where,
+        orderBy: [{ column: "createdAt", direction: "desc" }],
+        limit: ACTIVITY_PAGE_SIZE,
+        offset: cursor,
       });
-      return 0;
+      if (page.length === 0) break;
+      cursor += page.length;
+
+      visible.push(...(await this.authorizedRows(page, kinds, caller)));
+      if (visible.length >= want) break;
+      // A short page is the end of the table, not the end of this round.
+      if (page.length < ACTIVITY_PAGE_SIZE) break;
     }
+
+    return visible.slice(0, want);
+  }
+
+  /**
+   * The rows of `page` whose subject this caller may read.
+   *
+   * Three kinds of row, and only one of them names a document:
+   *
+   * - A row with NO entry id is an install-level event -- a settings mutation
+   *   filed under a namespace that is neither a collection nor a single. There
+   *   is no document to authorize, and the caller's scope already admitted the
+   *   namespace, so it is kept. Dropping these would remove SMTP-credential
+   *   rotations and their kin from the feed entirely.
+   * - A row naming a slug in NEITHER registry is the same case wearing an entry
+   *   id, and is kept for the same reason: the scope admitted the namespace and
+   *   there is no content read path that could answer about it. It is not a way
+   *   in -- the scope is built from the registries plus those namespaces, so a
+   *   slug outside both never reaches this method.
+   * - A row naming a registered collection or single is authorized as the
+   *   document it names, by the same decision the pending-edit cards use.
+   */
+  private async authorizedRows(
+    page: readonly Record<string, unknown>[],
+    kinds: ReadonlyMap<string, "collection" | "single">,
+    caller: ReadCaller
+  ): Promise<Record<string, unknown>[]> {
+    const documentRows = page.filter(row => documentRefOf(row, kinds) !== null);
+    const readable = new Set(
+      await visibleDocuments(
+        documentRows,
+        // Non-null by construction: the filter above kept only rows this resolves.
+        row => documentRefOf(row, kinds) as DocumentRef,
+        caller
+      )
+    );
+    return page.filter(
+      row => documentRefOf(row, kinds) === null || readable.has(row)
+    );
   }
 
   /**

--- a/packages/nextly/src/services/dashboard/activity-log-service.ts
+++ b/packages/nextly/src/services/dashboard/activity-log-service.ts
@@ -23,6 +23,7 @@ import { toDbError } from "../../database/errors";
 // the underlying DbError is preserved as `cause` and rich DB context
 // (kind, dialect, code) flows into logContext automatically.
 import { insertErasureAware } from "../../domains/audit/erasure-aware-insert";
+import { SETTINGS_ACTIVITY_NAMESPACES } from "../../domains/audit/settings-activity-namespaces";
 import { NextlyError } from "../../errors";
 import { BaseService } from "../base-service";
 import {
@@ -185,40 +186,68 @@ function statedKindOf(
     : undefined;
 }
 
-/**
- * Which read path can answer for a row, or `null` when none can.
- *
- * The RECORDED kind wins over the registry: a row that says it is a settings
- * change names no document, whatever a collection of the same name suggests. A
- * row that states nothing is one written before the column existed, and falls
- * back to the registry — which is what those rows were always judged by.
- *
- * A stated kind is still checked against the registry, so a slug that no longer
- * names anything readable stays undecidable rather than being probed against a
- * read path that cannot answer about it.
- */
-function subjectKindOf(
-  stated: ActivitySubjectKind | undefined,
-  kinds: ReadonlyMap<string, "collection" | "single">,
-  slug: string
-): "collection" | "single" | null {
-  if (stated === "collection" || stated === "single") {
-    // A stated kind still has to be answerable: the registry is what supplies
-    // the read path, so a slug it no longer knows leaves the row undecidable
-    // rather than decided. The CALLER separates that from "not a document".
-    return kinds.has(slug) ? stated : null;
-  }
-  return kinds.get(slug) ?? null;
+/** True when `slug` names one of the install-level settings namespaces. */
+function isSettingsNamespace(slug: string): boolean {
+  return (SETTINGS_ACTIVITY_NAMESPACES as readonly string[]).includes(slug);
+}
+
+/** A decided document subject, with the language the write was made in. */
+function documentSubject(
+  kind: "collection" | "single",
+  slug: string,
+  entryId: string,
+  row: Record<string, unknown>
+): ActivitySubject {
+  // 🔴 The language the write was made IN, so the read rule is evaluated for
+  // that translation. A localized field answers differently per language, so a
+  // row judged without one is judged against the default — and an edit made in
+  // a language the rule denies would still show its title.
+  return {
+    kind: "document",
+    ref: { kind, slug, entryId, locale: stringOr(row.locale) ?? null },
+  };
 }
 
 /**
- * The document an activity row is about, or `null` when it is about no document.
+ * What to do with a row that states no kind — one written before the column.
+ *
+ * 🔴 The column is nullable and NOT backfilled, so every upgraded installation
+ * keeps rows like these indefinitely and this is the only classification they
+ * ever get. The settings namespaces are therefore named EXPLICITLY rather than
+ * inferred from a registry miss: reading "not in the registry" as install-level
+ * returns a document whose collection has just been removed with its raw title,
+ * metadata and actor and no rule applied, which an HMR reload between the scope
+ * query and this pass makes ordinary.
+ *
+ * The COLLISION is the case that cannot be resolved, and it is resolved the only
+ * safe way. A resource that already held a now-reserved name may keep it, so a
+ * slug can be both a settings namespace and a registered collection — and a
+ * legacy row carries nothing saying which it was. Guessing "settings" would
+ * return a real document's row unauthorized, so it is dropped. Rows written from
+ * here on state their kind and are never ambiguous; what is lost is legacy
+ * settings detail, on colliding installations only.
+ */
+function legacySubject(
+  row: Record<string, unknown>,
+  slug: string,
+  entryId: string,
+  kinds: ReadonlyMap<string, "collection" | "single">
+): ActivitySubject {
+  const registered = kinds.get(slug);
+  if (isSettingsNamespace(slug)) {
+    return registered ? { kind: "undecidable" } : { kind: "install-level" };
+  }
+  if (!registered) return { kind: "undecidable" };
+  return documentSubject(registered, slug, entryId, row);
+}
+
+/**
+ * What a feed row is, once the registry has been consulted.
  *
  * The row's `collection` is a FREE STRING whose namespace is deliberately wider
  * than the registries — settings mutations are filed under names that are
- * neither a collection nor a single — so the registry lookup is what separates
- * a content event from an install-level one. Guessing a kind instead would send
- * a settings row to a content read path that cannot answer about it.
+ * neither a collection nor a single — so what the row STATES, and failing that
+ * the registry, is what separates a content event from an install-level one.
  */
 function subjectOf(
   row: Record<string, unknown>,
@@ -234,26 +263,16 @@ function subjectOf(
     return { kind: "install-level" };
   }
 
-  const kind = subjectKindOf(stated, kinds, slug);
-  if (!kind) {
-    // 🔴 UNDECIDABLE, and it must not collapse into "install-level". A row whose
-    // slug is in neither registry may be a settings namespace this build does
-    // not list — or a document whose collection has just gone, which a registry
-    // reload between the scope query and this pass makes ordinary. The two are
-    // told apart by what the ROW says: one that states a document kind IS a
-    // document, and a document nothing can decide is dropped. Folding it into
-    // "install-level" returns its raw title with no rule applied at all.
-    return stated ? { kind: "undecidable" } : { kind: "install-level" };
+  // A row that STATES a document kind is a document — but only a registered
+  // slug supplies a read path to ask, so one whose collection has gone is
+  // undecidable rather than install-level.
+  if (stated) {
+    return kinds.has(slug)
+      ? documentSubject(stated, slug, entryId, row)
+      : { kind: "undecidable" };
   }
 
-  return {
-    kind: "document",
-    // 🔴 The language the write was made IN, so the read rule is evaluated for
-    // that translation. A localized field answers differently per language, so
-    // a row judged without one is judged against the default — and an edit made
-    // in a language the rule denies would still show its title.
-    ref: { kind, slug, entryId, locale: stringOr(row.locale) ?? null },
-  };
+  return legacySubject(row, slug, entryId, kinds);
 }
 
 /** One existence probe's worth of refused rows: a collection, in a language. */
@@ -919,8 +938,18 @@ export class ActivityLogService extends BaseService {
         const { unit, existing } = outcome.value;
         for (const entry of unit.entries) {
           if (existing.has(entry.entryId)) continue;
+          // 🔴 The IDENTIFIER goes with the title. Keeping `entryId` returns
+          // the denied document's id to every caller with collection access —
+          // the same thing the authorization pass exists to withhold, minus
+          // the words. What is left says an event happened, not which document
+          // it happened to.
+          //
+          // `userName` and `userEmail` stay, deliberately: an audit trail that
+          // cannot say WHO deleted something is not one, and that is the
+          // trade this redaction was chosen to make.
           kept.set(entry.row, {
             ...entry.row,
+            entryId: null,
             entryTitle: null,
             metadata: null,
           });

--- a/packages/nextly/src/services/dashboard/activity-log-service.ts
+++ b/packages/nextly/src/services/dashboard/activity-log-service.ts
@@ -13,7 +13,7 @@
 import { randomUUID } from "crypto";
 
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
-import type { SqlParam, WhereClause } from "@nextlyhq/adapter-drizzle/types";
+import type { WhereClause } from "@nextlyhq/adapter-drizzle/types";
 import { type Column, type Table } from "drizzle-orm";
 
 import { toDbError } from "../../database/errors";
@@ -30,6 +30,7 @@ import {
   type DocumentRef,
   type DocumentVisibilityScope,
 } from "../lib/document-visibility";
+import { existingDocumentIds } from "../lib/readable-documents";
 import type { Logger } from "../shared";
 
 import {
@@ -91,6 +92,8 @@ export interface LogActivityInput {
   collection: string;
   entryId?: string;
   entryTitle?: string;
+  /** The language this write was made in; NULL means the default one. */
+  locale?: string | null;
   metadata?: Record<string, unknown>;
 }
 
@@ -178,7 +181,51 @@ function documentRefOf(
   if (!slug || !entryId) return null;
   const kind = kinds.get(slug);
   if (!kind) return null;
-  return { kind, slug, entryId };
+  // 🔴 The language the write was made IN, so the read rule is evaluated for
+  // that translation. A localized field answers differently per language, so a
+  // row judged without one is judged against the default — and an edit made in
+  // a language the rule denies would still show its title. NULL on unlocalized
+  // documents and on rows written before the column existed; both mean "the
+  // default language", which is exactly what those rows always meant.
+  const locale = typeof row.locale === "string" ? row.locale : null;
+  return { kind, slug, entryId, locale };
+}
+
+/** One existence probe's worth of refused rows: a collection, in a language. */
+interface ProbeUnit {
+  slug: string;
+  locale: string | null;
+  entries: { row: Record<string, unknown>; entryId: string }[];
+}
+
+/**
+ * `refused` grouped into the units one existence probe can answer for.
+ *
+ * Per collection AND language, matching how the read path is asked: a localized
+ * document is a different row per translation, so one probe per slug would ask
+ * about whichever language the read defaulted to.
+ *
+ * Singles are excluded, and their absence is deliberate rather than an omission.
+ * A Single's document is REPLACED rather than removed, so
+ * `resolveSingleDocumentId` still answers and the read path can decide — there
+ * is no "gone" case here for a probe to find.
+ */
+function probeUnits(
+  refused: readonly Record<string, unknown>[],
+  scope: DocumentVisibilityScope
+): ProbeUnit[] {
+  const units = new Map<string, ProbeUnit>();
+  for (const row of refused) {
+    const ref = documentRefOf(row, scope.kinds);
+    if (!ref || ref.kind !== "collection") continue;
+    const locale = ref.locale ?? null;
+    const key = `${ref.slug} ${locale ?? ""}`;
+    const entry = { row, entryId: ref.entryId };
+    const unit = units.get(key);
+    if (unit) unit.entries.push(entry);
+    else units.set(key, { slug: ref.slug, locale, entries: [entry] });
+  }
+  return [...units.values()];
 }
 
 /**
@@ -215,29 +262,79 @@ interface ActivityWriteTables {
 }
 
 /**
- * One query filter, in both the spellings its two consumers need.
+ * One query filter, in the single spelling its only consumer needs.
  *
- * `adapter.select` resolves a name against the Drizzle table and therefore
- * wants the schema property; the count query writes SQL and wants the physical
- * column. They are carried together so a filter cannot be added in one
- * spelling and used in the other.
+ * `adapter.select` resolves a name against the Drizzle table, so the schema
+ * property is what a filter carries. It used to carry the physical column
+ * beside it for a hand-written count query; that query is gone, and with it the
+ * only reason this type knew two names for one thing.
  *
  * A discriminated union rather than `op: "=" | "IN"` paired with
- * `value: SqlParam | SqlParam[]`: those two fields varying independently let
- * `{ op: "=", value: ["a", "b"] }` type-check, a state `filterClause` cannot
- * handle. Tying `op` to `value`'s shape makes that state unrepresentable and
- * lets `filterClause` narrow on `op` without a cast.
+ * `value: string | string[]`: those two fields varying independently let
+ * `{ op: "=", value: ["a", "b"] }` type-check, which is a filter no consumer
+ * can honour. Tying `op` to `value`'s shape makes that state unrepresentable.
  */
 interface ActivityFilterBase {
   /** The Drizzle schema property, for `adapter.select`. */
   property: string;
-  /** The physical column, for the count query's SQL. */
-  column: string;
 }
 
 type ActivityFilter =
-  | (ActivityFilterBase & { op: "="; value: SqlParam })
-  | (ActivityFilterBase & { op: "IN"; value: SqlParam[] });
+  | (ActivityFilterBase & { op: "="; value: string })
+  | (ActivityFilterBase & { op: "IN"; value: string[] });
+
+/** A position in the feed's `(createdAt desc, id desc)` order. */
+interface ActivityCursor {
+  createdAt: Date;
+  id: string;
+}
+
+/** `row` as a cursor, or undefined when it cannot name a position exactly. */
+function cursorOf(
+  row: Record<string, unknown> | undefined
+): ActivityCursor | undefined {
+  if (!row) return undefined;
+  const { createdAt, id } = row;
+  if (typeof id !== "string") return undefined;
+  // Drivers disagree about whether a timestamp arrives decoded: the adapter's
+  // Drizzle path returns a Date, and a raw string is still a valid instant.
+  const at =
+    createdAt instanceof Date
+      ? createdAt
+      : typeof createdAt === "string"
+        ? new Date(createdAt)
+        : undefined;
+  if (!at || Number.isNaN(at.getTime())) return undefined;
+  return { createdAt: at, id };
+}
+
+/**
+ * Strictly after `cursor` in `createdAt DESC, id DESC` order.
+ *
+ * Spelled as the two-branch disjunction rather than a row constructor, because
+ * `(a, b) < (x, y)` is not portable across the three dialects this runs on.
+ */
+function olderThan(cursor: ActivityCursor): WhereClause {
+  return {
+    or: [
+      { and: [{ column: "createdAt", op: "<", value: cursor.createdAt }] },
+      {
+        and: [
+          { column: "createdAt", op: "=", value: cursor.createdAt },
+          { column: "id", op: "<", value: cursor.id },
+        ],
+      },
+    ],
+  };
+}
+
+/** `where`, narrowed to rows strictly after `cursor`. */
+function withCursor(
+  where: WhereClause | undefined,
+  cursor: ActivityCursor
+): WhereClause {
+  return where ? { and: [where, olderThan(cursor)] } : olderThan(cursor);
+}
 
 /**
  * Safely convert an unknown driver-returned value to a nullable string.
@@ -274,6 +371,7 @@ export class ActivityLogService extends BaseService {
       collection: input.collection,
       entryId: input.entryId ?? null,
       entryTitle: input.entryTitle ?? null,
+      locale: input.locale ?? null,
       metadata: input.metadata ? JSON.stringify(input.metadata) : null,
       createdAt,
     };
@@ -395,18 +493,14 @@ export class ActivityLogService extends BaseService {
     const caller = options?.caller;
 
     try {
-      // Each filter carries BOTH spellings because its two consumers disagree
-      // by nature: `adapter.select` resolves names against the Drizzle table,
-      // so it needs the schema property, while the count below writes SQL and
-      // needs the physical column. Deriving both from one entry is what stops
-      // them drifting apart — naming the column for the select silently
-      // dropped the ordering and made a filtered query fail outright.
+      // Named by Drizzle SCHEMA PROPERTY, which is what `adapter.select`
+      // resolves against the table. Naming the physical column here instead
+      // silently dropped the ordering and made a filtered query fail outright.
       const filters: ActivityFilter[] = [];
 
       if (options?.collection) {
         filters.push({
           property: "collection",
-          column: "collection",
           op: "=",
           value: options.collection,
         });
@@ -414,7 +508,6 @@ export class ActivityLogService extends BaseService {
       if (options?.userId) {
         filters.push({
           property: "userId",
-          column: "user_id",
           op: "=",
           value: options.userId,
         });
@@ -430,7 +523,6 @@ export class ActivityLogService extends BaseService {
         }
         filters.push({
           property: "collection",
-          column: "collection",
           op: "IN",
           value: [...scope.resources],
         });
@@ -506,26 +598,79 @@ export class ActivityLogService extends BaseService {
     // its neighbours keep theirs -- and the paging then reports a short feed as
     // though it were the whole answer.
     const scope = await resolveDocumentVisibilityScope();
+    if (scope.degraded) {
+      // 🔴 REFUSE rather than answer, and this direction is the whole point of
+      // the pass. `authorizedRows` reads a slug missing from `scope.kinds` as an
+      // install-level event and keeps it WITHOUT asking the read path — correct
+      // when the map is complete, because settings namespaces are neither a
+      // collection nor a single. When the registry could not be enumerated the
+      // same rule admits every document row unauthorized, so a transient
+      // dependency failure would turn the feed back into exactly the disclosure
+      // this service was repaired for, and turn it on silently.
+      //
+      // The empty-map case is not this one: an install that has registered
+      // nothing has no document rows to admit, and `degraded` is what tells the
+      // two apart.
+      throw NextlyError.internal({
+        logContext: { reason: "content-registry-unreachable" },
+      });
+    }
+    return this.refill(where, want, offset, caller, scope);
+  }
+
+  /**
+   * Read pages until `want` readable rows are found or the rounds run out.
+   *
+   * Separate from the checks that precede it so each reads as one decision: the
+   * caller and the scope decide WHETHER to answer, and this decides how much to
+   * read to do it.
+   */
+  private async refill(
+    where: WhereClause | undefined,
+    want: number,
+    offset: number,
+    caller: ReadCaller,
+    scope: DocumentVisibilityScope
+  ): Promise<Record<string, unknown>[]> {
     const visible: Record<string, unknown>[] = [];
-    let cursor = offset;
+    let after: ActivityCursor | undefined;
 
     // Bounded so an install whose recent activity is almost entirely
     // unreadable cannot walk the whole table for one card. Reaching it returns
     // a SHORT page, never a wrong one.
     for (let round = 0; round < MAX_REFILL_ROUNDS; round++) {
       const page = await this.adapter.select<Record<string, unknown>>(TABLE, {
-        where,
-        orderBy: [{ column: "createdAt", direction: "desc" }],
+        // 🔴 Rounds after the first are anchored to the LAST ROW READ, not to a
+        // running offset. `activity_log` grows while the feed is being built —
+        // every create, update and delete appends to it — and under OFFSET a row
+        // inserted between two rounds shifts every later position by one, so the
+        // next round repeats a row already seen and SKIPS one that was never
+        // read. The skipped row is lost silently: de-duplicating what arrived
+        // cannot reveal what did not, and the feed then reports the wrong
+        // `hasMore` about it too. The caller's own `offset` still positions the
+        // FIRST round, which is the only place it means what it says.
+        where: after ? withCursor(where, after) : where,
+        // Ending in a UNIQUE column is what lets that anchor name a position
+        // exactly. `createdAt` alone is not total -- MySQL stores these at
+        // second precision, so a burst of writes ties -- and a cursor over a
+        // non-unique key cannot say which of the tied rows a page ended on.
+        orderBy: [
+          { column: "createdAt", direction: "desc" },
+          { column: "id", direction: "desc" },
+        ],
         limit: ACTIVITY_PAGE_SIZE,
-        offset: cursor,
+        ...(after ? {} : { offset }),
       });
       if (page.length === 0) break;
-      cursor += page.length;
+      after = cursorOf(page[page.length - 1]) ?? after;
 
       visible.push(...(await this.authorizedRows(page, scope, caller)));
       if (visible.length >= want) break;
       // A short page is the end of the table, not the end of this round.
       if (page.length < ACTIVITY_PAGE_SIZE) break;
+      // A page whose last row cannot be read as a cursor would make the next
+      // round repeat it forever; stop rather than loop on an unknown position.
+      if (!after) break;
     }
 
     return visible.slice(0, want);
@@ -565,46 +710,69 @@ export class ActivityLogService extends BaseService {
         scope
       )
     );
-    return page.filter(
-      row => documentRefOf(row, scope.kinds) === null || readable.has(row)
+    const redacted = await this.historyOfRemovedDocuments(
+      documentRows.filter(row => !readable.has(row)),
+      scope
     );
+    return page.flatMap(row => {
+      if (documentRefOf(row, scope.kinds) === null) return [row];
+      if (readable.has(row)) return [row];
+      const kept = redacted.get(row);
+      return kept ? [kept] : [];
+    });
   }
 
   /**
-   * Render one filter as a parameterised SQL clause, pushing its value(s)
-   * onto `params` as it goes.
+   * The refused rows that describe documents which no longer EXIST, redacted.
    *
-   * Placeholder numbering derives from `params.length` at the moment each
-   * value is pushed, never from the filter's position in the array: an `IN`
-   * filter contributes several parameters, so a caller numbering from the
-   * filter index (`$${i + 1}`) -- correct only while every filter carried
-   * exactly one value -- would bind the wrong values for every filter that
-   * follows the first `IN`.
+   * 🔴 Without this, every deletion disappears from the feed. A collection
+   * delete removes the row and only then appends `entry.deleted`, so the
+   * document the event names can never be found again — and a filter that keeps
+   * only readable documents therefore drops the deletion, and all earlier
+   * history for that document, for everyone including a super admin. The most
+   * consequential events in the trail were the ones it silently lost.
+   *
+   * Refused and GONE are the same absence to a read that enforces access, so
+   * they are told apart by a privileged existence probe — asked only about rows
+   * already refused, and used only to decide whether anything remains to
+   * authorize.
+   *
+   * What survives is the event, not the document: the stored title and metadata
+   * are dropped, because the rule that would have decided who may read them died
+   * with the document and nothing can evaluate it now. A reader learns that
+   * something was deleted, by whom and when; they do not learn what it was
+   * called.
    */
-  private filterClause(filter: ActivityFilter, params: SqlParam[]): string {
-    const quoted =
-      this.dialect === "postgresql"
-        ? `"${filter.column}"`
-        : `\`${filter.column}\``;
+  private async historyOfRemovedDocuments(
+    refused: readonly Record<string, unknown>[],
+    scope: DocumentVisibilityScope
+  ): Promise<Map<Record<string, unknown>, Record<string, unknown>>> {
+    const kept = new Map<Record<string, unknown>, Record<string, unknown>>();
+    if (refused.length === 0) return kept;
 
-    // The discriminated union on `filter.op` narrows `filter.value` to
-    // `SqlParam[]` in this branch and `SqlParam` below without a cast --
-    // the type itself rules out an `IN` filter carrying a scalar or a `=`
-    // filter carrying an array.
-    if (filter.op === "IN") {
-      const placeholders = filter.value
-        .map(v => {
-          params.push(v);
-          return this.dialect === "postgresql" ? `$${params.length}` : "?";
-        })
-        .join(", ");
-      return `${quoted} IN (${placeholders})`;
+    for (const unit of probeUnits(refused, scope)) {
+      let existing: Set<string>;
+      try {
+        existing = await existingDocumentIds(
+          unit.slug,
+          unit.entries.map(entry => entry.entryId),
+          unit.locale
+        );
+      } catch {
+        // A probe that could not answer has told us nothing, and nothing must
+        // not read as "deleted" -- that would publish a refused row.
+        continue;
+      }
+      for (const entry of unit.entries) {
+        if (existing.has(entry.entryId)) continue;
+        kept.set(entry.row, {
+          ...entry.row,
+          entryTitle: null,
+          metadata: null,
+        });
+      }
     }
-
-    params.push(filter.value);
-    return this.dialect === "postgresql"
-      ? `${quoted} = $${params.length}`
-      : `${quoted} = ?`;
+    return kept;
   }
 
   private mapRow = (row: Record<string, unknown>): ActivityLogEntry => {

--- a/packages/nextly/src/services/dashboard/activity-log-service.ts
+++ b/packages/nextly/src/services/dashboard/activity-log-service.ts
@@ -16,6 +16,7 @@ import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import type { WhereClause } from "@nextlyhq/adapter-drizzle/types";
 import { type Column, type Table } from "drizzle-orm";
 
+import { authorizationGroups } from "../../auth/entity-read-access";
 import { toDbError } from "../../database/errors";
 // PR 4 migration: switched from ServiceError.fromDatabaseError to
 // NextlyError.fromDatabaseError. Public message stays generic per §13.8;
@@ -97,7 +98,7 @@ export interface LogActivityInput {
   /**
    * What this row is ABOUT: a collection document, a single, or an
    * install-level settings change. Omitted means "not stated", which the feed
-   * falls back to inferring from the registry — see `documentRefOf`.
+   * falls back to inferring from the registry — see `subjectOf`.
    */
   subjectKind?: ActivitySubjectKind | null;
   metadata?: Record<string, unknown>;
@@ -169,6 +170,21 @@ const ACTIVITY_PAGE_SIZE = 100;
  */
 const MAX_REFILL_ROUNDS = 10;
 
+/** `value` when it is a string, so a driver's `null` or number cannot pass. */
+function stringOr(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+/** The kind the ROW states, or undefined on a row written before the column. */
+function statedKindOf(
+  row: Record<string, unknown>
+): ActivitySubjectKind | undefined {
+  const stated = row.subjectKind;
+  return stated === "collection" || stated === "single" || stated === "settings"
+    ? stated
+    : undefined;
+}
+
 /**
  * Which read path can answer for a row, or `null` when none can.
  *
@@ -182,13 +198,16 @@ const MAX_REFILL_ROUNDS = 10;
  * read path that cannot answer about it.
  */
 function subjectKindOf(
-  stated: unknown,
+  stated: ActivitySubjectKind | undefined,
   kinds: ReadonlyMap<string, "collection" | "single">,
   slug: string
 ): "collection" | "single" | null {
-  if (stated === "settings") return null;
-  if (!kinds.has(slug)) return null;
-  if (stated === "collection" || stated === "single") return stated;
+  if (stated === "collection" || stated === "single") {
+    // A stated kind still has to be answerable: the registry is what supplies
+    // the read path, so a slug it no longer knows leaves the row undecidable
+    // rather than decided. The CALLER separates that from "not a document".
+    return kinds.has(slug) ? stated : null;
+  }
   return kinds.get(slug) ?? null;
 }
 
@@ -201,23 +220,40 @@ function subjectKindOf(
  * a content event from an install-level one. Guessing a kind instead would send
  * a settings row to a content read path that cannot answer about it.
  */
-function documentRefOf(
+function subjectOf(
   row: Record<string, unknown>,
   kinds: ReadonlyMap<string, "collection" | "single">
-): DocumentRef | null {
-  const slug = typeof row.collection === "string" ? row.collection : undefined;
-  const entryId = typeof row.entryId === "string" ? row.entryId : undefined;
-  if (!slug || !entryId) return null;
-  const kind = subjectKindOf(row.subjectKind, kinds, slug);
-  if (!kind) return null;
-  // 🔴 The language the write was made IN, so the read rule is evaluated for
-  // that translation. A localized field answers differently per language, so a
-  // row judged without one is judged against the default — and an edit made in
-  // a language the rule denies would still show its title. NULL on unlocalized
-  // documents and on rows written before the column existed; both mean "the
-  // default language", which is exactly what those rows always meant.
-  const locale = typeof row.locale === "string" ? row.locale : null;
-  return { kind, slug, entryId, locale };
+): ActivitySubject {
+  const slug = stringOr(row.collection);
+  const entryId = stringOr(row.entryId);
+  const stated = statedKindOf(row);
+
+  // No entry id, or a row that says it is a settings change: an install-level
+  // event with no document to authorize.
+  if (!slug || !entryId || stated === "settings") {
+    return { kind: "install-level" };
+  }
+
+  const kind = subjectKindOf(stated, kinds, slug);
+  if (!kind) {
+    // 🔴 UNDECIDABLE, and it must not collapse into "install-level". A row whose
+    // slug is in neither registry may be a settings namespace this build does
+    // not list — or a document whose collection has just gone, which a registry
+    // reload between the scope query and this pass makes ordinary. The two are
+    // told apart by what the ROW says: one that states a document kind IS a
+    // document, and a document nothing can decide is dropped. Folding it into
+    // "install-level" returns its raw title with no rule applied at all.
+    return stated ? { kind: "undecidable" } : { kind: "install-level" };
+  }
+
+  return {
+    kind: "document",
+    // 🔴 The language the write was made IN, so the read rule is evaluated for
+    // that translation. A localized field answers differently per language, so
+    // a row judged without one is judged against the default — and an edit made
+    // in a language the rule denies would still show its title.
+    ref: { kind, slug, entryId, locale: stringOr(row.locale) ?? null },
+  };
 }
 
 /** One existence probe's worth of refused rows: a collection, in a language. */
@@ -245,8 +281,11 @@ function probeUnits(
 ): ProbeUnit[] {
   const units = new Map<string, ProbeUnit>();
   for (const row of refused) {
-    const ref = documentRefOf(row, scope.kinds);
-    if (!ref || ref.kind !== "collection") continue;
+    const subject = subjectOf(row, scope.kinds);
+    if (subject.kind !== "document" || subject.ref.kind !== "collection") {
+      continue;
+    }
+    const ref = subject.ref;
     const locale = ref.locale ?? null;
     const key = `${ref.slug} ${locale ?? ""}`;
     const entry = { row, entryId: ref.entryId };
@@ -325,6 +364,34 @@ type ActivityFilter =
  * credential rotation exists to record.
  */
 export type ActivitySubjectKind = "collection" | "single" | "settings";
+
+/**
+ * A refill's rows, and whether the TABLE ended or the rounds did.
+ *
+ * `end` is the distinction `hasMore` rests on. Reaching `MAX_REFILL_ROUNDS`
+ * with a short page looks identical to running out of activity, and reporting
+ * the second when the first happened tells a reader there is nothing further
+ * to see because the scan hit its own work bound.
+ */
+interface RefilledActivity {
+  rows: Record<string, unknown>[];
+  end: boolean;
+}
+
+/**
+ * What a feed row is, once the registry has been consulted.
+ *
+ * 🔴 THREE states, because two of them were one and the collapse was a hole. An
+ * install-level event has no document to authorize and is kept on the strength
+ * of the caller's scope; a document is authorized through the read path; and a
+ * row that NAMES a document nothing can currently decide is neither — it is
+ * dropped. Returning `null` for both the first and the third handed every
+ * undecidable row's raw title and metadata straight to the reader.
+ */
+type ActivitySubject =
+  | { kind: "install-level" }
+  | { kind: "undecidable" }
+  | { kind: "document"; ref: DocumentRef };
 
 /** A position in the feed's `(createdAt desc, id desc)` order. */
 interface ActivityCursor {
@@ -594,8 +661,13 @@ export class ActivityLogService extends BaseService {
         caller
       );
       return {
-        activities: visible.slice(0, limit).map(this.mapRow),
-        hasMore: visible.length > limit,
+        activities: visible.rows.slice(0, limit).map(this.mapRow),
+        // 🔴 `end` as well as the count, because a page can come back short for
+        // two opposite reasons. The extra row is the ordinary signal; a refill
+        // that stopped at its round limit found fewer than that and has said
+        // nothing about what lies beyond it, so reporting `false` there tells
+        // the reader the feed has ended when only the scan did.
+        hasMore: visible.rows.length > limit || !visible.end,
       };
     } catch (error) {
       this.logger.error("Failed to query activity log", {
@@ -630,11 +702,12 @@ export class ActivityLogService extends BaseService {
     want: number,
     offset: number,
     caller?: ReadCaller
-  ): Promise<Record<string, unknown>[]> {
+  ): Promise<RefilledActivity> {
     // No caller means no document can be authorized, and this feed carries
     // entry titles -- so it answers nothing rather than everything the scope
-    // admits. Same fail-closed direction as an omitted scope.
-    if (!caller) return [];
+    // admits. Same fail-closed direction as an omitted scope. The table is not
+    // what ended, but there is nothing further to offer either.
+    if (!caller) return { rows: [], end: true };
 
     // 🔴 Resolved ONCE for the whole refill, not per page. The registry and the
     // locale config both answer an unreachable dependency with an empty result,
@@ -675,7 +748,7 @@ export class ActivityLogService extends BaseService {
     offset: number,
     caller: ReadCaller,
     scope: DocumentVisibilityScope
-  ): Promise<Record<string, unknown>[]> {
+  ): Promise<RefilledActivity> {
     const visible: Record<string, unknown>[] = [];
     let after: ActivityCursor | undefined;
 
@@ -705,19 +778,30 @@ export class ActivityLogService extends BaseService {
         limit: ACTIVITY_PAGE_SIZE,
         ...(after ? {} : { offset }),
       });
-      if (page.length === 0) break;
+      if (page.length === 0) return { rows: visible.slice(0, want), end: true };
       after = cursorOf(page[page.length - 1]) ?? after;
 
       visible.push(...(await this.authorizedRows(page, scope, caller)));
-      if (visible.length >= want) break;
+      // Enough rows found: the table has not ended, and the caller wants to
+      // know that so `hasMore` stays true.
+      if (visible.length >= want)
+        return { rows: visible.slice(0, want), end: false };
       // A short page is the end of the table, not the end of this round.
-      if (page.length < ACTIVITY_PAGE_SIZE) break;
+      if (page.length < ACTIVITY_PAGE_SIZE) {
+        return { rows: visible.slice(0, want), end: true };
+      }
       // A page whose last row cannot be read as a cursor would make the next
       // round repeat it forever; stop rather than loop on an unknown position.
-      if (!after) break;
+      // Not an END: rows remain, this simply cannot reach them.
+      if (!after) return { rows: visible.slice(0, want), end: false };
     }
 
-    return visible.slice(0, want);
+    // 🔴 The ROUNDS ran out, not the table. Reported as such, because the two
+    // are opposite answers to "is there more?" and only one of them is a fact
+    // about the data: a feed whose first thousand rows are unreadable would
+    // otherwise tell the reader there is no further activity, when the scan
+    // simply stopped working.
+    return { rows: visible.slice(0, want), end: false };
   }
 
   /**
@@ -743,13 +827,19 @@ export class ActivityLogService extends BaseService {
     scope: DocumentVisibilityScope,
     caller: ReadCaller
   ): Promise<Record<string, unknown>[]> {
+    const subjects = new Map(
+      page.map(row => [row, subjectOf(row, scope.kinds)] as const)
+    );
     const documentRows = page.filter(
-      row => documentRefOf(row, scope.kinds) !== null
+      row => subjects.get(row)?.kind === "document"
     );
     const readable = new Set(
       await visibleDocuments(
         documentRows,
-        row => documentRefOf(row, scope.kinds),
+        row => {
+          const subject = subjects.get(row);
+          return subject?.kind === "document" ? subject.ref : null;
+        },
         caller,
         scope
       )
@@ -759,7 +849,13 @@ export class ActivityLogService extends BaseService {
       scope
     );
     return page.flatMap(row => {
-      if (documentRefOf(row, scope.kinds) === null) return [row];
+      const subject = subjects.get(row);
+      // An install-level event has no document to authorize, and the caller's
+      // scope already admitted its namespace.
+      if (subject?.kind === "install-level") return [row];
+      // Nothing here can judge it, and admitting what cannot be judged is the
+      // inversion this pass exists to remove.
+      if (subject?.kind !== "document") return [];
       if (readable.has(row)) return [row];
       const kept = redacted.get(row);
       return kept ? [kept] : [];
@@ -794,26 +890,41 @@ export class ActivityLogService extends BaseService {
     const kept = new Map<Record<string, unknown>, Record<string, unknown>>();
     if (refused.length === 0) return kept;
 
-    for (const unit of probeUnits(refused, scope)) {
-      let existing: Set<string>;
-      try {
-        existing = await existingDocumentIds(
-          unit.slug,
-          unit.entries.map(entry => entry.entryId),
-          unit.locale
-        );
-      } catch {
+    // 🔴 BOUNDED CONCURRENCY, not a sequential loop. Each unit is a full
+    // collection read, and a page can hold refused rows across as many
+    // collection/language pairs as it has rows — so one page could issue a
+    // hundred serial reads AFTER the authorization pass that is already bounded,
+    // and ten refill rounds could make that a thousand for one dashboard
+    // request. `authorizationGroups` is the same bound the authorization pass
+    // uses, and its first group of one keeps a cold per-user permission cache
+    // filled once rather than missed by everything behind it.
+    const units = probeUnits(refused, scope);
+    const byKey = new Map(units.map((unit, index) => [String(index), unit]));
+    for (const group of authorizationGroups([...byKey.keys()])) {
+      const settled = await Promise.allSettled(
+        group.map(async key => {
+          const unit = byKey.get(key) as ProbeUnit;
+          const existing = await existingDocumentIds(
+            unit.slug,
+            unit.entries.map(entry => entry.entryId),
+            unit.locale
+          );
+          return { unit, existing };
+        })
+      );
+      for (const outcome of settled) {
         // A probe that could not answer has told us nothing, and nothing must
         // not read as "deleted" -- that would publish a refused row.
-        continue;
-      }
-      for (const entry of unit.entries) {
-        if (existing.has(entry.entryId)) continue;
-        kept.set(entry.row, {
-          ...entry.row,
-          entryTitle: null,
-          metadata: null,
-        });
+        if (outcome.status !== "fulfilled") continue;
+        const { unit, existing } = outcome.value;
+        for (const entry of unit.entries) {
+          if (existing.has(entry.entryId)) continue;
+          kept.set(entry.row, {
+            ...entry.row,
+            entryTitle: null,
+            metadata: null,
+          });
+        }
       }
     }
     return kept;

--- a/packages/nextly/src/services/dashboard/activity-log-service.ts
+++ b/packages/nextly/src/services/dashboard/activity-log-service.ts
@@ -24,8 +24,12 @@ import { toDbError } from "../../database/errors";
 import { insertErasureAware } from "../../domains/audit/erasure-aware-insert";
 import { NextlyError } from "../../errors";
 import { BaseService } from "../base-service";
-import { visibleDocuments, type DocumentRef } from "../lib/readable-documents";
-import { registeredContentKinds } from "../lib/registered-content-slugs";
+import {
+  resolveDocumentVisibilityScope,
+  visibleDocuments,
+  type DocumentRef,
+  type DocumentVisibilityScope,
+} from "../lib/document-visibility";
 import type { Logger } from "../shared";
 
 import {
@@ -496,7 +500,12 @@ export class ActivityLogService extends BaseService {
     // admits. Same fail-closed direction as an omitted scope.
     if (!caller) return [];
 
-    const kinds = await registeredContentKinds();
+    // 🔴 Resolved ONCE for the whole refill, not per page. The registry and the
+    // locale config both answer an unreachable dependency with an empty result,
+    // so a read per page lets a transient failure drop one page's rows while
+    // its neighbours keep theirs -- and the paging then reports a short feed as
+    // though it were the whole answer.
+    const scope = await resolveDocumentVisibilityScope();
     const visible: Record<string, unknown>[] = [];
     let cursor = offset;
 
@@ -513,7 +522,7 @@ export class ActivityLogService extends BaseService {
       if (page.length === 0) break;
       cursor += page.length;
 
-      visible.push(...(await this.authorizedRows(page, kinds, caller)));
+      visible.push(...(await this.authorizedRows(page, scope, caller)));
       if (visible.length >= want) break;
       // A short page is the end of the table, not the end of this round.
       if (page.length < ACTIVITY_PAGE_SIZE) break;
@@ -542,20 +551,22 @@ export class ActivityLogService extends BaseService {
    */
   private async authorizedRows(
     page: readonly Record<string, unknown>[],
-    kinds: ReadonlyMap<string, "collection" | "single">,
+    scope: DocumentVisibilityScope,
     caller: ReadCaller
   ): Promise<Record<string, unknown>[]> {
-    const documentRows = page.filter(row => documentRefOf(row, kinds) !== null);
+    const documentRows = page.filter(
+      row => documentRefOf(row, scope.kinds) !== null
+    );
     const readable = new Set(
       await visibleDocuments(
         documentRows,
-        // Non-null by construction: the filter above kept only rows this resolves.
-        row => documentRefOf(row, kinds) as DocumentRef,
-        caller
+        row => documentRefOf(row, scope.kinds),
+        caller,
+        scope
       )
     );
     return page.filter(
-      row => documentRefOf(row, kinds) === null || readable.has(row)
+      row => documentRefOf(row, scope.kinds) === null || readable.has(row)
     );
   }
 

--- a/packages/nextly/src/services/lib/__tests__/registered-content-snapshot.test.ts
+++ b/packages/nextly/src/services/lib/__tests__/registered-content-snapshot.test.ts
@@ -1,0 +1,89 @@
+/**
+ * "There is no such registry" and "the registry could not answer" are different
+ * facts, and this file exists because they look identical.
+ *
+ * 🔴 Both produce an empty slug set, and callers treat them oppositely: a
+ * COMPLETE empty answer is an install with no content of that kind, while a
+ * FLOOR means a dependency failed and anything counted or authorized against it
+ * is a shortfall. The activity feed refuses on the second and must not refuse on
+ * the first, or an ordinary install never renders a feed at all.
+ *
+ * Told apart by which operation failed. An earlier version discriminated on
+ * `container.has`, which a container may answer differently from `get` — that
+ * emptied the candidate set for every caller, not just the one asking about
+ * degradation, and took the dashboard's whole read scope with it.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const containerGet = vi.fn();
+const containerHas = vi.fn();
+
+vi.mock("../../../di/container", () => ({
+  container: {
+    get: (name: string) => containerGet(name) as unknown,
+    has: (name: string) => containerHas(name) as boolean,
+  },
+}));
+
+import { registeredContentSnapshot } from "../registered-content-slugs";
+
+const collections = { getAllCollections: vi.fn() };
+const singles = { getAllSingles: vi.fn() };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  collections.getAllCollections.mockResolvedValue([{ slug: "posts" }]);
+  singles.getAllSingles.mockResolvedValue([{ slug: "site-settings" }]);
+  containerHas.mockReturnValue(true);
+  containerGet.mockImplementation((name: string) => {
+    if (name === "collectionRegistryService") return collections;
+    if (name === "singleRegistryService") return singles;
+    throw new Error(`unexpected container.get("${name}")`);
+  });
+});
+
+describe("enumerating the content registries", () => {
+  it("reports both kinds, with the registry that owns each slug", async () => {
+    const snapshot = await registeredContentSnapshot();
+
+    expect(snapshot.kinds.get("posts")).toBe("collection");
+    expect(snapshot.kinds.get("site-settings")).toBe("single");
+    expect(snapshot.degraded).toBe(false);
+  });
+
+  it("is NOT degraded when a registry is simply not registered", async () => {
+    // An install with no singles has no singles, and that is a whole answer.
+    // Marking it a floor makes every caller that refuses on one refuse forever.
+    containerGet.mockImplementation((name: string) => {
+      if (name === "collectionRegistryService") return collections;
+      throw new Error("no such service");
+    });
+
+    const snapshot = await registeredContentSnapshot();
+
+    expect(snapshot.degraded).toBe(false);
+    expect(snapshot.kinds.get("posts")).toBe("collection");
+  });
+
+  it("IS degraded when a registry is present and cannot answer", async () => {
+    // The case the flag exists for: a registered registry that throws has said
+    // nothing about how much it holds, so its empty result is a floor.
+    collections.getAllCollections.mockRejectedValue(new Error("pool timeout"));
+
+    const snapshot = await registeredContentSnapshot();
+
+    expect(snapshot.degraded).toBe(true);
+  });
+
+  it("does not read `container.has` to decide either one", async () => {
+    // The control on the discriminator itself. A container may answer `has` and
+    // `get` differently, and taking `has` as the tell emptied the candidate set
+    // for every caller -- silently, because an empty registry is a legal state.
+    containerHas.mockReturnValue(false);
+
+    const snapshot = await registeredContentSnapshot();
+
+    expect(snapshot.kinds.get("posts")).toBe("collection");
+    expect(snapshot.degraded).toBe(false);
+  });
+});

--- a/packages/nextly/src/services/lib/__tests__/registered-content-snapshot.test.ts
+++ b/packages/nextly/src/services/lib/__tests__/registered-content-snapshot.test.ts
@@ -54,10 +54,9 @@ describe("enumerating the content registries", () => {
   it("is NOT degraded when a registry is simply not registered", async () => {
     // An install with no singles has no singles, and that is a whole answer.
     // Marking it a floor makes every caller that refuses on one refuse forever.
-    containerGet.mockImplementation((name: string) => {
-      if (name === "collectionRegistryService") return collections;
-      throw new Error("no such service");
-    });
+    containerHas.mockImplementation(
+      (name: string) => name === "collectionRegistryService"
+    );
 
     const snapshot = await registeredContentSnapshot();
 
@@ -65,7 +64,7 @@ describe("enumerating the content registries", () => {
     expect(snapshot.kinds.get("posts")).toBe("collection");
   });
 
-  it("IS degraded when a registry is present and cannot answer", async () => {
+  it("IS degraded when a registered registry cannot answer", async () => {
     // The case the flag exists for: a registered registry that throws has said
     // nothing about how much it holds, so its empty result is a floor.
     collections.getAllCollections.mockRejectedValue(new Error("pool timeout"));
@@ -75,15 +74,20 @@ describe("enumerating the content registries", () => {
     expect(snapshot.degraded).toBe(true);
   });
 
-  it("does not read `container.has` to decide either one", async () => {
-    // The control on the discriminator itself. A container may answer `has` and
-    // `get` differently, and taking `has` as the tell emptied the candidate set
-    // for every caller -- silently, because an empty registry is a legal state.
-    containerHas.mockReturnValue(false);
+  it("IS degraded when a registered service FAILS TO CONSTRUCT", async () => {
+    // 🔴 `Container.get` invokes the factory, so a lazy singleton whose
+    // construction throws propagates from `get` exactly as an unregistered name
+    // does -- while `has` is true. Catching around `get` and calling that
+    // "absent" reports a failed dependency as an intentionally empty install,
+    // which is the direction that lets a caller treat missing kinds as
+    // install-level events and admit them unauthorized.
+    containerGet.mockImplementation((name: string) => {
+      if (name === "singleRegistryService") return singles;
+      throw new Error("factory blew up during initialization");
+    });
 
     const snapshot = await registeredContentSnapshot();
 
-    expect(snapshot.kinds.get("posts")).toBe("collection");
-    expect(snapshot.degraded).toBe(false);
+    expect(snapshot.degraded).toBe(true);
   });
 });

--- a/packages/nextly/src/services/lib/__tests__/visible-documents.test.ts
+++ b/packages/nextly/src/services/lib/__tests__/visible-documents.test.ts
@@ -1,0 +1,377 @@
+/**
+ * How pending-edit rows are handed to the read path for a verdict.
+ *
+ * The verdict itself belongs to the collection and Singles read paths and is
+ * driven against a real database elsewhere. What this file pins is the SHAPE of
+ * the question — which rows are asked about, grouped how, and which are never
+ * asked about at all — because that is where this module can be wrong while
+ * every access rule underneath it is right.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const readableDocumentIds = vi.fn();
+const singleDocumentReadable = vi.fn();
+const resolveSingleDocumentId = vi.fn();
+const contentSnapshot = vi.fn();
+const configValue = vi.fn();
+
+// The registry decides whether a row's own scope kind is still the live one, and
+// the localization config decides whether its language can still be read in.
+// Both are container-backed, so a harness that omits them leaves every row
+// undecidable and the whole file green-on-nothing.
+vi.mock("../registered-content-slugs", () => ({
+  registeredContentSnapshot: () => contentSnapshot() as unknown,
+}));
+vi.mock("../readable-documents", () => ({
+  readableDocumentIds: (...args: unknown[]) =>
+    readableDocumentIds(...args) as unknown,
+}));
+vi.mock("../../../di/container", () => ({
+  container: {
+    has: () => true,
+    get: () => configValue() as unknown,
+  },
+}));
+
+vi.mock("../../../domains/singles/services/single-document-access", () => ({
+  singleDocumentReadable: (...args: unknown[]) =>
+    singleDocumentReadable(...args) as unknown,
+  resolveSingleDocumentId: (...args: unknown[]) =>
+    resolveSingleDocumentId(...args) as unknown,
+}));
+
+import {
+  resolveDocumentVisibilityScope,
+  visibleDocuments,
+  type DocumentVisibilityScope,
+} from "../document-visibility";
+
+const caller = { user: { id: "user-1", roles: ["editor"] } };
+
+/**
+ * The install-wide facts, resolved the way the source resolves them.
+ *
+ * Taken from `resolveDocumentVisibilityScope` rather than hand-built, so these cases
+ * exercise the object the product actually passes down. A literal written here
+ * would go on agreeing with itself after the resolver's shape changed.
+ */
+const scopeNow = (): Promise<DocumentVisibilityScope> =>
+  resolveDocumentVisibilityScope();
+
+/**
+ * The version-row shape these cases are written in, handed to the shared
+ * decision through the same translation `visiblePendingEdits` uses.
+ */
+const asDocuments = (
+  rows: ReturnType<typeof row>[],
+  who: typeof caller,
+  scope: DocumentVisibilityScope
+) =>
+  visibleDocuments(
+    rows,
+    r =>
+      r.scopeKind === "collection" || r.scopeKind === "single"
+        ? {
+            kind: r.scopeKind,
+            slug: r.scopeSlug,
+            entryId: r.entryId,
+            locale: r.locale,
+          }
+        : null,
+    who,
+    scope
+  );
+
+function row(patch: {
+  entryId: string;
+  locale?: string | null;
+  scopeKind?: string;
+  scopeSlug?: string;
+}) {
+  return {
+    id: `v-${patch.entryId}-${patch.locale ?? "none"}`,
+    scopeKind: patch.scopeKind ?? "collection",
+    scopeSlug: patch.scopeSlug ?? "posts",
+    entryId: patch.entryId,
+    locale: patch.locale ?? null,
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+    versionNo: null,
+    status: "draft",
+    isAutosave: false,
+    label: null,
+    sourceVersionNo: null,
+    createdBy: null,
+    createdAt: new Date("2020-01-01T00:00:00Z"),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  readableDocumentIds.mockImplementation((_slug, ids: string[]) =>
+    Promise.resolve(new Set(ids))
+  );
+  singleDocumentReadable.mockResolvedValue(true);
+  resolveSingleDocumentId.mockResolvedValue("single-live");
+  contentSnapshot.mockResolvedValue({
+    kinds: new Map([
+      ["posts", "collection"],
+      ["site-settings", "single"],
+    ]),
+    degraded: false,
+  });
+  configValue.mockReturnValue({
+    localization: {
+      locales: [
+        { code: "en" },
+        { code: "de" },
+        ...Array.from({ length: 8 }, (_, index) => ({ code: `l${index}` })),
+      ],
+    },
+  });
+});
+
+describe("collection rows", () => {
+  it("asks about each LOCALE separately, carrying the locale into the read", async () => {
+    // 🔴 A stored read rule is a predicate over the collection's own fields, and
+    // a localized field answers differently per language --
+    // `localized-target-predicate.integration.test.ts` pins one row readable in
+    // `en` and denied in `de`. Asking once per slug judges whichever
+    // translation the read defaults to and marks every other language visible
+    // on the strength of it.
+    await asDocuments(
+      [
+        row({ entryId: "e1", locale: "en" }),
+        row({ entryId: "e1", locale: "de" }),
+      ],
+      caller,
+      await scopeNow()
+    );
+
+    expect(readableDocumentIds).toHaveBeenCalledTimes(2);
+    expect(readableDocumentIds).toHaveBeenCalledWith(
+      "posts",
+      ["e1"],
+      caller,
+      "en"
+    );
+    expect(readableDocumentIds).toHaveBeenCalledWith(
+      "posts",
+      ["e1"],
+      caller,
+      "de"
+    );
+  });
+
+  it("keeps the language the read allowed and drops the one it refused", async () => {
+    readableDocumentIds.mockImplementation((_slug, ids: string[], _c, locale) =>
+      Promise.resolve(locale === "en" ? new Set(ids) : new Set())
+    );
+
+    const visible = await asDocuments(
+      [
+        row({ entryId: "e1", locale: "de" }),
+        row({ entryId: "e1", locale: "en" }),
+      ],
+      caller,
+      await scopeNow()
+    );
+
+    expect(visible.map(r => r.locale)).toEqual(["en"]);
+  });
+
+  it("issues reads CONCURRENTLY, within a bound", async () => {
+    // 🔴 Each unit enters the full collection read path, so awaiting them one
+    // after another turns a page spanning many collections or languages into
+    // that many sequential round trips -- enough to time a dashboard out while
+    // the connection pool sits idle. Bounded, not unbounded: the first group is
+    // deliberately one, so a cold per-user permission cache is filled once
+    // rather than missed by everything in the fan-out.
+    let inFlight = 0;
+    let peak = 0;
+    readableDocumentIds.mockImplementation(async (_slug, ids: string[]) => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise(resolve => setTimeout(resolve, 0));
+      inFlight--;
+      return new Set(ids);
+    });
+
+    await asDocuments(
+      Array.from({ length: 8 }, (_, index) =>
+        row({ entryId: `e${index}`, locale: `l${index}` })
+      ),
+      caller,
+      await scopeNow()
+    );
+
+    // More than one at a time proves it is not serial; the bound proves it is
+    // not an unbounded fan-out.
+    expect(peak).toBeGreaterThan(1);
+    expect(peak).toBeLessThanOrEqual(8);
+  });
+
+  it("asks ONCE for rows that share a slug and language", async () => {
+    // The control on the grouping: per-locale must not become per-row, which
+    // would put one read per document in front of every dashboard load.
+    await asDocuments(
+      [
+        row({ entryId: "e1", locale: "en" }),
+        row({ entryId: "e2", locale: "en" }),
+      ],
+      caller,
+      await scopeNow()
+    );
+
+    expect(readableDocumentIds).toHaveBeenCalledTimes(1);
+    expect(readableDocumentIds).toHaveBeenCalledWith(
+      "posts",
+      ["e1", "e2"],
+      caller,
+      "en"
+    );
+  });
+});
+
+describe("rows nothing can decide", () => {
+  it("drops a row whose language is no longer configured", async () => {
+    // 🔴 Forwarding an unconfigured locale does NOT authorize it:
+    // `resolveRequestedLocale` substitutes the configured DEFAULT for any code
+    // it does not recognise. A draft written under a language later removed
+    // would be judged by the default language's verdict — a row exposed on a
+    // predicate never evaluated for it, which is the defect the per-locale fix
+    // exists to prevent, wearing a different hat.
+    const visible = await asDocuments(
+      [row({ entryId: "e1", locale: "fr" })],
+      caller,
+      await scopeNow()
+    );
+
+    expect(visible).toEqual([]);
+    expect(readableDocumentIds).not.toHaveBeenCalled();
+  });
+
+  it("keeps a configured language beside a removed one", async () => {
+    // The control: dropping unconfigured locales must not drop everything.
+    const visible = await asDocuments(
+      [
+        row({ entryId: "e1", locale: "fr" }),
+        row({ entryId: "e1", locale: "en" }),
+      ],
+      caller,
+      await scopeNow()
+    );
+
+    expect(visible.map(r => r.locale)).toEqual(["en"]);
+  });
+
+  it("drops a row whose scope kind no longer matches the registry", async () => {
+    // Deleting a collection leaves its history behind, and a Single may later
+    // take the freed slug. Probing the COLLECTION read path for a slug that now
+    // belongs to a Single asks about a table that is not there — it throws and
+    // breaks both cards rather than dropping one orphaned row.
+    const visible = await asDocuments(
+      [
+        row({
+          entryId: "e1",
+          scopeKind: "collection",
+          scopeSlug: "site-settings",
+        }),
+      ],
+      caller,
+      await scopeNow()
+    );
+
+    expect(visible).toEqual([]);
+    expect(readableDocumentIds).not.toHaveBeenCalled();
+    expect(singleDocumentReadable).not.toHaveBeenCalled();
+  });
+
+  it("drops a row whose slug is in neither registry", async () => {
+    const visible = await asDocuments(
+      [row({ entryId: "e1", scopeSlug: "deleted-collection" })],
+      caller,
+      await scopeNow()
+    );
+
+    expect(visible).toEqual([]);
+    expect(readableDocumentIds).not.toHaveBeenCalled();
+  });
+});
+
+describe("single rows", () => {
+  const single = (entryId: string, locale?: string | null) =>
+    row({ entryId, locale, scopeKind: "single", scopeSlug: "site-settings" });
+
+  it("resolves the live document id WITHOUT materializing the Single", async () => {
+    // 🔴 The read probe goes through `SingleEntryService.get`, which AUTO-CREATES
+    // a missing Single -- so probing first makes loading a dashboard perform a
+    // write. The id is resolved from the backing row instead, which is what
+    // `resolveSingleDocumentId` exists for.
+    await asDocuments([single("single-live")], caller, await scopeNow());
+
+    expect(resolveSingleDocumentId).toHaveBeenCalledWith("site-settings");
+    expect(singleDocumentReadable).toHaveBeenCalled();
+  });
+
+  it("drops a row belonging to a PREDECESSOR document, without probing at all", async () => {
+    // A version row outlives the document it describes: a Single deleted and
+    // recreated leaves rows naming the old id. Judging those by the
+    // replacement's verdict exposes the predecessor's entry id and edit time.
+    const visible = await asDocuments(
+      [single("single-deleted")],
+      caller,
+      await scopeNow()
+    );
+
+    expect(visible).toEqual([]);
+    expect(singleDocumentReadable).not.toHaveBeenCalled();
+  });
+
+  it("drops every row when the Single has never been materialized", async () => {
+    resolveSingleDocumentId.mockResolvedValue(null);
+
+    const visible = await asDocuments(
+      [single("single-live")],
+      caller,
+      await scopeNow()
+    );
+
+    expect(visible).toEqual([]);
+    expect(singleDocumentReadable).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolving the scope", () => {
+  it("reads the registry ONCE, however many pages are judged against it", async () => {
+    // 🔴 The registry and the locale config both answer an unreachable
+    // dependency with an EMPTY result, on purpose. Re-read per page, that
+    // safety inverts: a transient failure on one page drops every row that
+    // page holds while its neighbours keep theirs, and the walk goes on to
+    // publish the shortfall as a whole number. One resolution cannot fail
+    // halfway.
+    const scope = await scopeNow();
+    const rows = Array.from({ length: 3 }, (_, index) =>
+      row({ entryId: `e${index}`, locale: "en" })
+    );
+
+    for (const one of rows) await asDocuments([one], caller, scope);
+
+    expect(contentSnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it("carries the registry's own report that it could not be enumerated", async () => {
+    contentSnapshot.mockResolvedValue({ kinds: new Map(), degraded: true });
+
+    expect((await scopeNow()).degraded).toBe(true);
+  });
+
+  it("is NOT degraded when an install has simply registered nothing", async () => {
+    // The control that keeps `degraded` meaning what it says. An empty
+    // registry and an unreachable one produce the same empty map, and folding
+    // them together would either fail every empty install or excuse the case
+    // this flag exists to report.
+    contentSnapshot.mockResolvedValue({ kinds: new Map(), degraded: false });
+
+    expect((await scopeNow()).degraded).toBe(false);
+  });
+});

--- a/packages/nextly/src/services/lib/document-visibility.ts
+++ b/packages/nextly/src/services/lib/document-visibility.ts
@@ -1,0 +1,343 @@
+/**
+ * Which of a batch of content-keyed rows the caller may be told about.
+ *
+ * 🔴 ONE implementation of that question, for every surface keyed by collection
+ * and document id. The pending-edit cards and the activity feed each carried
+ * their own, and two implementations of one access decision do not stay equal:
+ * per-locale grouping, the registry-kind check, the stale-locale drop, bounded
+ * concurrency and resolving a Single's live id before probing it were each
+ * present on one side and absent from the other, every one of them a defect on
+ * the side that lacked it.
+ *
+ * Separate from `readable-documents.ts` because the two answer different
+ * questions and only one of them is mockable from the other's tests: that
+ * module asks the read path which ids of ONE collection survive, and this one
+ * decides which collections and languages to ask about at all.
+ *
+ * The rule is never re-implemented here. A stored rule can be `owner-only` or a
+ * `custom` function, and both return a query constraint over the COLLECTION's
+ * own fields — which is why it cannot be pushed into a sidecar table's query:
+ * `activity_log` and `nextly_versions` do not carry the columns a rule names.
+ * Asking the read path which of a known set of ids survive is the one form that
+ * works for every rule, including the ones nobody can predict.
+ *
+ * @module services/lib/document-visibility
+ */
+
+import { authorizationGroups } from "../../auth/entity-read-access";
+import { container } from "../../di/container";
+import type { NextlyServiceConfig } from "../../di/register";
+import type { ReadCaller } from "../dashboard/readable-resources";
+
+import { readableDocumentIds } from "./readable-documents";
+import { registeredContentSnapshot } from "./registered-content-slugs";
+
+/** What a row keyed by content has to name for its document to be authorized. */
+export interface DocumentRef {
+  /**
+   * Which registry owns the slug. A Single is read through its own service, so
+   * a row that mislabels one as a collection is not merely slower — it asks a
+   * question about a table that does not hold the document.
+   */
+  kind: "collection" | "single";
+  slug: string;
+  entryId: string;
+  /**
+   * Which translation, for a localized document. A localized Single is a
+   * different document per language and a rule can answer differently for each,
+   * so the verdict is per locale rather than per slug.
+   */
+  locale?: string | null;
+}
+
+/**
+ * The install-wide facts every batch must be judged against.
+ *
+ * 🔴 Resolved ONCE by the caller and carried, never re-read per page. Both
+ * halves turn a failure into an EMPTY answer on purpose — an unreachable
+ * registry contributes no slugs, an unreadable config no languages — and under
+ * a per-page read that safety became a defect: a transient failure on one page
+ * dropped every row that page held, the pages either side of it kept theirs,
+ * and the walk could finish and publish the shortfall as a whole number. A
+ * snapshot cannot fail halfway; it is either the basis for the entire answer or
+ * the reason there is not one.
+ */
+export interface DocumentVisibilityScope {
+  kinds: ReadonlyMap<string, "collection" | "single">;
+  locales: ReadonlySet<string> | null;
+  /** True when a registry could not be enumerated, so `kinds` is a floor. */
+  degraded: boolean;
+}
+
+/**
+ * The languages a read can actually be performed in, or `null` when the install
+ * configures none.
+ *
+ * 🔴 Needed because forwarding an unconfigured locale does NOT authorize it:
+ * `resolveRequestedLocale` substitutes the configured DEFAULT for any code it
+ * does not recognise. A row written under a language later removed from the
+ * configuration would be judged by the default language's verdict — a row
+ * exposed on a predicate never evaluated for it, which is the same defect as
+ * passing no locale at all.
+ */
+function configuredLocales(): ReadonlySet<string> | null {
+  try {
+    if (!container.has("config")) return null;
+    const localization =
+      container.get<NextlyServiceConfig>("config").localization;
+    if (!localization) return null;
+    return new Set(localization.locales.map(locale => locale.code));
+  } catch {
+    // A container that cannot answer leaves every localized row undecidable,
+    // which `subjectOf` turns into "dropped" rather than "allowed".
+    return null;
+  }
+}
+
+/** One resolution of the registry and the configured languages. */
+export async function resolveDocumentVisibilityScope(): Promise<DocumentVisibilityScope> {
+  const snapshot = await registeredContentSnapshot();
+  return {
+    kinds: snapshot.kinds,
+    locales: configuredLocales(),
+    degraded: snapshot.degraded,
+  };
+}
+
+/** A ref that survived every check nothing here can decide. */
+interface Subject {
+  kind: "collection" | "single";
+  slug: string;
+  entryId: string;
+  locale: string | null;
+}
+
+/**
+ * The document a ref names, or `null` when nothing here can decide it.
+ *
+ * Three ways a ref is undecidable, each of which has cost a real defect:
+ *
+ * - Its recorded kind disagrees with the registry. Deleting a collection leaves
+ *   its history and its activity behind, and a Single may later take the freed
+ *   slug — so a `collection` row can survive under a name that now belongs to a
+ *   Single. Probing the collection read path for it asks about a table that is
+ *   not there, which throws and breaks the whole surface rather than dropping
+ *   one row.
+ * - Its slug is in neither registry, so there is no read path to ask at all.
+ *   The activity log makes that ordinary rather than exotic: it files settings
+ *   mutations under namespaces that are neither a collection nor a single.
+ * - Its language is no longer configured, so a read cannot be performed IN that
+ *   language and would silently answer about the default one instead.
+ *
+ * Every one is DROPPED. Nothing here can judge them, and admitting what cannot
+ * be judged is the inversion this module exists to remove.
+ */
+function subjectOf(
+  ref: DocumentRef,
+  scope: DocumentVisibilityScope
+): Subject | null {
+  const kind = scope.kinds.get(ref.slug);
+  if (!kind || kind !== ref.kind) return null;
+  const locale = ref.locale ?? null;
+  if (locale !== null && !scope.locales?.has(locale)) return null;
+  return { kind, slug: ref.slug, entryId: ref.entryId, locale };
+}
+
+/** One read's worth of items: a slug, in a language, and what it answers for. */
+interface ReadUnit<T> {
+  subject: Subject;
+  entries: { item: T; entryId: string }[];
+}
+
+/** Items grouped into the units one read can answer for: a slug in a language. */
+function readUnits<T>(
+  items: readonly T[],
+  subjects: ReadonlyMap<T, Subject>,
+  kind: "collection" | "single"
+): Map<string, ReadUnit<T>> {
+  const units = new Map<string, ReadUnit<T>>();
+  for (const item of items) {
+    const subject = subjects.get(item);
+    if (!subject || subject.kind !== kind) continue;
+    const key = `${subject.slug} ${subject.locale ?? ""}`;
+    const entry = { item, entryId: subject.entryId };
+    const existing = units.get(key);
+    if (existing) existing.entries.push(entry);
+    else units.set(key, { subject, entries: [entry] });
+  }
+  return units;
+}
+
+/**
+ * Run `decide` over every unit with BOUNDED CONCURRENCY, keeping what it admits.
+ *
+ * 🔴 One implementation of the fail-closed rule, because both kinds need it and
+ * a copy of it would be a second place for "the read failed" to start meaning
+ * "the caller may see this". A rejected decision has told us nothing, and
+ * nothing must not read as visible — the direction `readableEntities` also
+ * takes.
+ *
+ * Bounded rather than unbounded: each unit enters a full read path, so a batch
+ * spanning many collections or languages became that many sequential round
+ * trips one way and an unbounded fan-out the other. `authorizationGroups` is
+ * the bound the entity-level decisions already use, and its first group of one
+ * is what lets a cold per-user permission cache be filled once rather than
+ * missed by everything behind it.
+ */
+async function admittedPerUnit<T>(
+  units: ReadonlyMap<string, ReadUnit<T>>,
+  decide: (unit: ReadUnit<T>) => Promise<readonly T[]>
+): Promise<Set<T>> {
+  const visible = new Set<T>();
+  for (const group of authorizationGroups([...units.keys()])) {
+    const settled = await Promise.allSettled(
+      group.map(key => decide(units.get(key) as ReadUnit<T>))
+    );
+    for (const outcome of settled) {
+      if (outcome.status !== "fulfilled") continue;
+      for (const item of outcome.value) visible.add(item);
+    }
+  }
+  return visible;
+}
+
+/**
+ * Collection items whose documents survive that collection's read rules.
+ *
+ * 🔴 Grouped by slug AND language, because a stored rule is a predicate over the
+ * collection's own fields and a localized field answers differently per
+ * language — `localized-target-predicate.integration.test.ts` pins one row
+ * readable in `en` and denied in `de`. One verdict per slug would mark every
+ * other language visible on the strength of whichever the read defaulted to.
+ *
+ * Run with BOUNDED CONCURRENCY rather than one after another. Each unit enters
+ * the full collection read path, so a batch spanning many collections or
+ * languages became that many sequential round trips — enough to time a dashboard
+ * out while the connection pool sat idle. `authorizationGroups` is the bound the
+ * entity-level decisions already use, and its first group of one is what lets a
+ * cold per-user permission cache be filled once rather than missed by everything
+ * in the fan-out.
+ */
+async function visibleCollectionItems<T>(
+  units: ReadonlyMap<string, ReadUnit<T>>,
+  caller: ReadCaller
+): Promise<Set<T>> {
+  return admittedPerUnit(units, async unit => {
+    const readable = await readableDocumentIds(
+      unit.subject.slug,
+      unit.entries.map(entry => entry.entryId),
+      caller,
+      unit.subject.locale
+    );
+    return unit.entries
+      .filter(entry => readable.has(entry.entryId))
+      .map(entry => entry.item);
+  });
+}
+
+/**
+ * Single items whose document this caller may read, asked once per language.
+ *
+ * The live document's id is resolved FIRST, and without materializing anything.
+ * A row can outlive the document it describes, so a Single deleted and recreated
+ * leaves rows naming its predecessor — and the probe reads through
+ * `SingleEntryService`, which AUTO-CREATES a missing Single, so asking it first
+ * would make loading a dashboard perform a write.
+ *
+ * `routeAuthorized: false` states the truth: the surface asking this authorized
+ * a dashboard read, not a read of this Single, so the coarse gate has not run
+ * for that operation and must not be skipped.
+ */
+async function visibleSingleItems<T>(
+  units: ReadonlyMap<string, ReadUnit<T>>,
+  caller: ReadCaller
+): Promise<Set<T>> {
+  if (units.size === 0) return new Set<T>();
+
+  // 🔴 Imported HERE rather than at the top of the module, because the static
+  // edge is a cycle: the Singles read path imports the versions domain, which
+  // is one of this module's callers. Rollup already reports that shape
+  // elsewhere in this package as producing a broken execution order, and the
+  // failure would land at boot rather than here. Deferring it also means a
+  // caller whose rows are all collections never loads the Singles service.
+  const { singleDocumentReadable, resolveSingleDocumentId } = await import(
+    "../../domains/singles/services/single-document-access"
+  );
+
+  const liveIds = new Map<string, Promise<string | null>>();
+  const liveIdOf = (slug: string): Promise<string | null> => {
+    let pending = liveIds.get(slug);
+    if (!pending) {
+      pending = resolveSingleDocumentId(slug);
+      liveIds.set(slug, pending);
+    }
+    return pending;
+  };
+
+  return admittedPerUnit(units, async unit => {
+    // 🔴 The live id is resolved FIRST, and the probe skipped entirely when no
+    // entry names it. A row outlives the document it describes, so a Single
+    // deleted and recreated leaves rows naming its predecessor — and the probe
+    // reads through `SingleEntryService`, which AUTO-CREATES a missing Single,
+    // so asking it first would make loading a dashboard perform a write.
+    const liveId = await liveIdOf(unit.subject.slug);
+    if (liveId === null) return [];
+    const live = unit.entries.filter(entry => entry.entryId === liveId);
+    if (live.length === 0) return [];
+
+    // `routeAuthorized: false` states the truth: the surface asking this
+    // authorized a dashboard read, not a read of this Single, so the coarse
+    // gate has not run for that operation and must not be skipped.
+    const allowed = await singleDocumentReadable(unit.subject.slug, {
+      user: caller.user,
+      ...(caller.authenticatedScope
+        ? { actor: caller.authenticatedScope }
+        : {}),
+      routeAuthorized: false,
+      ...(unit.subject.locale === null ? {} : { locale: unit.subject.locale }),
+    });
+    return allowed ? live.map(entry => entry.item) : [];
+  });
+}
+
+/**
+ * `items`, in their original order, keeping only those whose document the
+ * caller may be told about.
+ *
+ * 🔴 ONE implementation of that question, for every surface keyed by collection
+ * and document id. The pending-edit cards and the activity feed each had their
+ * own, and two implementations of one access decision do not stay equal: the
+ * per-locale grouping, the registry-kind check, the stale-locale drop and the
+ * live-Single resolution were all found on one side while the other went on
+ * answering without them.
+ *
+ * The two kinds are decided by different paths because they are different
+ * questions: a collection document is one row among many and is asked for by
+ * id, while a Single is one document per language read through its own service.
+ * A caller that collapsed them would ask about a table that does not hold the
+ * document and read the refusal as a denial.
+ */
+export async function visibleDocuments<T>(
+  items: readonly T[],
+  ref: (item: T) => DocumentRef | null,
+  caller: ReadCaller,
+  scope: DocumentVisibilityScope
+): Promise<T[]> {
+  if (items.length === 0) return [];
+
+  const subjects = new Map<T, Subject>();
+  for (const item of items) {
+    const named = ref(item);
+    if (!named) continue;
+    const subject = subjectOf(named, scope);
+    if (subject) subjects.set(item, subject);
+  }
+  if (subjects.size === 0) return [];
+
+  const [collections, singles] = await Promise.all([
+    visibleCollectionItems(readUnits(items, subjects, "collection"), caller),
+    visibleSingleItems(readUnits(items, subjects, "single"), caller),
+  ]);
+
+  return items.filter(item => collections.has(item) || singles.has(item));
+}

--- a/packages/nextly/src/services/lib/readable-documents.ts
+++ b/packages/nextly/src/services/lib/readable-documents.ts
@@ -15,7 +15,10 @@
  * repair was to route the numbers through the access-enforced path rather than
  * to reproduce the rule. This module is that repair, made reusable — the
  * pending-edit cards and the activity feed are two surfaces of it, and any later
- * system source keyed by collection and document id is a third.
+ * system source keyed by collection and document id is a third. Those surfaces
+ * reach it through {@link ./document-visibility}, which decides WHICH documents
+ * a batch of rows names; this module answers the narrower question it is built
+ * from — which ids of ONE collection, in ONE language, survive its read rules.
  *
  * The rule is never re-implemented here. A stored rule can be `owner-only` or a
  * `custom` function, and both return a query constraint expressed over the
@@ -38,24 +41,6 @@ import type { ReadCaller } from "../dashboard/readable-resources";
  * driver refuses. Matches the chunk the versions repository already deletes in.
  */
 const ID_CHUNK_SIZE = 500;
-
-/** What a row keyed by content has to name for its document to be authorized. */
-export interface DocumentRef {
-  /**
-   * Which registry owns the slug. A Single is read through its own service, so
-   * a row that mislabels one as a collection is not merely slower — it asks a
-   * question about a table that does not hold the document.
-   */
-  kind: "collection" | "single";
-  slug: string;
-  entryId: string;
-  /**
-   * Which translation, for a localized Single. A localized Single is a different
-   * document per language and a rule can answer differently for each, so the
-   * verdict is per locale rather than per slug.
-   */
-  locale?: string | null;
-}
 
 /** `ids` split into statement-sized runs. */
 function chunked(ids: readonly string[]): string[][] {
@@ -120,120 +105,4 @@ export async function readableDocumentIds(
     }
   }
   return readable;
-}
-
-/** Items grouped by the slug their document belongs to, order preserved. */
-function bySlug<T>(
-  items: readonly T[],
-  ref: (item: T) => DocumentRef
-): Map<string, T[]> {
-  const grouped = new Map<string, T[]>();
-  for (const item of items) {
-    const slug = ref(item).slug;
-    const existing = grouped.get(slug);
-    if (existing) existing.push(item);
-    else grouped.set(slug, [item]);
-  }
-  return grouped;
-}
-
-/** The collection items whose documents survive that collection's read rules. */
-async function visibleCollectionItems<T>(
-  items: readonly T[],
-  ref: (item: T) => DocumentRef,
-  caller: ReadCaller
-): Promise<Set<T>> {
-  const visible = new Set<T>();
-  for (const [slug, slugItems] of bySlug(items, ref)) {
-    const readable = await readableDocumentIds(
-      slug,
-      slugItems.map(item => ref(item).entryId),
-      caller
-    );
-    for (const item of slugItems) {
-      if (readable.has(ref(item).entryId)) visible.add(item);
-    }
-  }
-  return visible;
-}
-
-/**
- * The single items whose document this caller may read, asked once per language.
- *
- * `routeAuthorized: false` states the truth: the surface asking this authorized
- * a dashboard read, not a read of this Single, so the coarse gate has not run
- * for that operation and must not be skipped. Claiming otherwise would hand a
- * caller holding no read grant the existence and edit time of the document.
- */
-async function visibleSingleItems<T>(
-  items: readonly T[],
-  ref: (item: T) => DocumentRef,
-  caller: ReadCaller
-): Promise<Set<T>> {
-  const visible = new Set<T>();
-  if (items.length === 0) return visible;
-
-  // 🔴 Imported HERE rather than at the top of the module, because the static
-  // edge is a cycle: the Singles read path imports the versions domain, which
-  // is one of this module's callers. Rollup already reports that shape
-  // elsewhere in this package as producing a circular chunk dependency and a
-  // broken execution order, and the failure would land at boot rather than
-  // here. Deferring it also means a caller whose rows are all collections never
-  // loads the Singles query service at all.
-  const { singleDocumentReadable } = await import(
-    "../../domains/singles/services/single-document-access"
-  );
-
-  const verdicts = new Map<string, Promise<boolean>>();
-  for (const item of items) {
-    const { slug, locale } = ref(item);
-    const key = `${slug} ${locale ?? ""}`;
-    let verdict = verdicts.get(key);
-    if (!verdict) {
-      verdict = singleDocumentReadable(slug, {
-        user: caller.user,
-        ...(caller.authenticatedScope
-          ? { actor: caller.authenticatedScope }
-          : {}),
-        routeAuthorized: false,
-        ...(locale === null || locale === undefined ? {} : { locale }),
-      });
-      verdicts.set(key, verdict);
-    }
-    if (await verdict) visible.add(item);
-  }
-  return visible;
-}
-
-/**
- * `items`, in their original order, keeping only those whose document the
- * caller may be told about.
- *
- * The two kinds are decided by different paths because they are different
- * questions: a collection document is one row among many and is asked for by
- * id, while a Single is one document per language read through its own service.
- * A caller that collapsed them would ask about a table that does not hold the
- * document and read the refusal as a denial.
- */
-export async function visibleDocuments<T>(
-  items: readonly T[],
-  ref: (item: T) => DocumentRef,
-  caller: ReadCaller
-): Promise<T[]> {
-  if (items.length === 0) return [];
-
-  const [collections, singles] = await Promise.all([
-    visibleCollectionItems(
-      items.filter(item => ref(item).kind === "collection"),
-      ref,
-      caller
-    ),
-    visibleSingleItems(
-      items.filter(item => ref(item).kind === "single"),
-      ref,
-      caller
-    ),
-  ]);
-
-  return items.filter(item => collections.has(item) || singles.has(item));
 }

--- a/packages/nextly/src/services/lib/readable-documents.ts
+++ b/packages/nextly/src/services/lib/readable-documents.ts
@@ -74,35 +74,109 @@ function chunked(ids: readonly string[]): string[][] {
  * translation it defaults to. Asking once per slug and applying that verdict to
  * every language discloses the rows a rule refuses in the others.
  */
-export async function readableDocumentIds(
+/**
+ * Who the read runs as, and in which language.
+ *
+ * Separated so the two questions this module asks differ in ONE visible place.
+ * Each key is omitted rather than passed as `undefined`, because the read path
+ * distinguishes an absent option from an explicit one — a forwarded
+ * `locale: undefined` is not the same request as no locale at all.
+ */
+function identityOptions(
+  locale: string | null | undefined,
+  access: { overrideAccess: boolean; caller?: ReadCaller }
+): Record<string, unknown> {
+  const caller = access.caller;
+  return {
+    ...(locale === null || locale === undefined ? {} : { locale }),
+    overrideAccess: access.overrideAccess,
+    ...(caller ? { user: caller.user } : {}),
+    ...(caller?.authenticatedScope ? { actor: caller.authenticatedScope } : {}),
+  };
+}
+
+/**
+ * The ids among `entryIds` that `collection` returns for the given read.
+ *
+ * 🔴 One loop for both questions this module asks, because they differ ONLY in
+ * whether access is enforced — and the parts they share are each load-bearing:
+ * the chunking keeps a large set inside the lowest per-statement parameter limit
+ * of the three dialects, `limit: chunk.length` stops a default page reporting
+ * the remainder as missing, and `status: "all"` keeps a draft from reading as
+ * absent. Written twice, those are three chances for the two answers to stop
+ * being comparable — and the whole point is to subtract one from the other.
+ */
+async function idsReturnedBy(
   collection: string,
   entryIds: readonly string[],
-  caller: ReadCaller,
-  locale?: string | null
+  locale: string | null | undefined,
+  access: { overrideAccess: boolean; caller?: ReadCaller }
 ): Promise<Set<string>> {
-  const readable = new Set<string>();
-  if (entryIds.length === 0) return readable;
+  const found = new Set<string>();
+  if (entryIds.length === 0) return found;
 
+  // Built once: nothing here varies per chunk, and assembling it inside the
+  // loop put the identity and locale decisions on every iteration.
+  const scoped = identityOptions(locale, access);
   for (const chunk of chunked(entryIds)) {
     const result = await getNextly().find({
       collection,
       where: { id: { in: chunk } },
       select: { id: true },
       // The whole chunk can legitimately come back; a smaller page would report
-      // the remainder as unreadable.
+      // the remainder as absent.
       limit: chunk.length,
       status: "all",
-      ...(locale === null || locale === undefined ? {} : { locale }),
-      overrideAccess: false,
-      user: caller.user,
-      ...(caller.authenticatedScope
-        ? { actor: caller.authenticatedScope }
-        : {}),
+      ...scoped,
     });
     for (const item of result.items ?? []) {
       const id = (item as { id?: unknown }).id;
-      if (typeof id === "string") readable.add(id);
+      if (typeof id === "string") found.add(id);
     }
   }
-  return readable;
+  return found;
+}
+
+/**
+ * Which of `entryIds` this caller may READ, asked of the ordinary read path.
+ *
+ * `overrideAccess: false`, so a stored `owner-only` or `custom` rule narrows the
+ * answer exactly as it would for a normal read — which is the point: the rule is
+ * evaluated by the path that owns it rather than reproduced here.
+ */
+export async function readableDocumentIds(
+  collection: string,
+  entryIds: readonly string[],
+  caller: ReadCaller,
+  locale?: string | null
+): Promise<Set<string>> {
+  return idsReturnedBy(collection, entryIds, locale, {
+    overrideAccess: false,
+    caller,
+  });
+}
+
+/**
+ * Which of `entryIds` still EXIST in `collection`, regardless of who is asking.
+ *
+ * 🔴 `overrideAccess: true`, and the distinction it buys is the only reason this
+ * exists. A document a caller may not read and a document that is GONE are the
+ * same absence to {@link readableDocumentIds} — both are simply missing from
+ * what comes back — and the activity feed has to tell them apart, because a
+ * delete removes the row BEFORE the `entry.deleted` event is appended. Judged by
+ * readability alone, every deletion and all history for the removed document
+ * vanish from the feed for everyone, super admins included.
+ *
+ * Its answer never reaches a reader on its own. The caller uses it only to
+ * decide whether a row it has already been REFUSED describes something that no
+ * longer exists, and such a row is kept with its identifying detail removed — so
+ * what a privileged read establishes here is "there is nothing left to
+ * authorize", never a fact about a document the caller may not see.
+ */
+export async function existingDocumentIds(
+  collection: string,
+  entryIds: readonly string[],
+  locale?: string | null
+): Promise<Set<string>> {
+  return idsReturnedBy(collection, entryIds, locale, { overrideAccess: true });
 }

--- a/packages/nextly/src/services/lib/readable-documents.ts
+++ b/packages/nextly/src/services/lib/readable-documents.ts
@@ -7,19 +7,23 @@
  * leaving the per-row rules of whatever query follows to decide which documents
  * come back. A collection carrying a stored `owner-only` or `custom` read rule
  * therefore admits every editor at the coarse check while the read path narrows
- * to a subset — so a cross-document read keyed by collection name alone reports
- * one author's documents to another.
+ * to a subset — so any surface keyed by collection name alone reports one
+ * author's documents to another.
  *
  * That is not a hypothetical shape: the dashboard's own statistics once counted
  * rows straight from the physical table and disclosed exactly this, and the
  * repair was to route the numbers through the access-enforced path rather than
- * to reproduce the rule. This module is that repair, made reusable — any system
- * source keyed by collection and document id needs the same intersection.
+ * to reproduce the rule. This module is that repair, made reusable — the
+ * pending-edit cards and the activity feed are two surfaces of it, and any later
+ * system source keyed by collection and document id is a third.
  *
  * The rule is never re-implemented here. A stored rule can be `owner-only` or a
- * `custom` function, and evaluating either against rows is the read path's job;
- * this asks it which of a known set of ids survive, which is the same question
- * a caller opening those documents would get answered.
+ * `custom` function, and both return a query constraint expressed over the
+ * COLLECTION's own fields — which is why the constraint cannot simply be pushed
+ * into a sidecar table's query the way Payload pushes one into its versions
+ * collection: `activity_log` and `nextly_versions` do not carry the columns a
+ * rule names. Asking the read path which of a known set of ids survive is the
+ * one form that works for every rule, including the ones nobody can predict.
  *
  * @module services/lib/readable-documents
  */
@@ -34,6 +38,24 @@ import type { ReadCaller } from "../dashboard/readable-resources";
  * driver refuses. Matches the chunk the versions repository already deletes in.
  */
 const ID_CHUNK_SIZE = 500;
+
+/** What a row keyed by content has to name for its document to be authorized. */
+export interface DocumentRef {
+  /**
+   * Which registry owns the slug. A Single is read through its own service, so
+   * a row that mislabels one as a collection is not merely slower — it asks a
+   * question about a table that does not hold the document.
+   */
+  kind: "collection" | "single";
+  slug: string;
+  entryId: string;
+  /**
+   * Which translation, for a localized Single. A localized Single is a different
+   * document per language and a rule can answer differently for each, so the
+   * verdict is per locale rather than per slug.
+   */
+  locale?: string | null;
+}
 
 /** `ids` split into statement-sized runs. */
 function chunked(ids: readonly string[]): string[][] {
@@ -98,4 +120,120 @@ export async function readableDocumentIds(
     }
   }
   return readable;
+}
+
+/** Items grouped by the slug their document belongs to, order preserved. */
+function bySlug<T>(
+  items: readonly T[],
+  ref: (item: T) => DocumentRef
+): Map<string, T[]> {
+  const grouped = new Map<string, T[]>();
+  for (const item of items) {
+    const slug = ref(item).slug;
+    const existing = grouped.get(slug);
+    if (existing) existing.push(item);
+    else grouped.set(slug, [item]);
+  }
+  return grouped;
+}
+
+/** The collection items whose documents survive that collection's read rules. */
+async function visibleCollectionItems<T>(
+  items: readonly T[],
+  ref: (item: T) => DocumentRef,
+  caller: ReadCaller
+): Promise<Set<T>> {
+  const visible = new Set<T>();
+  for (const [slug, slugItems] of bySlug(items, ref)) {
+    const readable = await readableDocumentIds(
+      slug,
+      slugItems.map(item => ref(item).entryId),
+      caller
+    );
+    for (const item of slugItems) {
+      if (readable.has(ref(item).entryId)) visible.add(item);
+    }
+  }
+  return visible;
+}
+
+/**
+ * The single items whose document this caller may read, asked once per language.
+ *
+ * `routeAuthorized: false` states the truth: the surface asking this authorized
+ * a dashboard read, not a read of this Single, so the coarse gate has not run
+ * for that operation and must not be skipped. Claiming otherwise would hand a
+ * caller holding no read grant the existence and edit time of the document.
+ */
+async function visibleSingleItems<T>(
+  items: readonly T[],
+  ref: (item: T) => DocumentRef,
+  caller: ReadCaller
+): Promise<Set<T>> {
+  const visible = new Set<T>();
+  if (items.length === 0) return visible;
+
+  // 🔴 Imported HERE rather than at the top of the module, because the static
+  // edge is a cycle: the Singles read path imports the versions domain, which
+  // is one of this module's callers. Rollup already reports that shape
+  // elsewhere in this package as producing a circular chunk dependency and a
+  // broken execution order, and the failure would land at boot rather than
+  // here. Deferring it also means a caller whose rows are all collections never
+  // loads the Singles query service at all.
+  const { singleDocumentReadable } = await import(
+    "../../domains/singles/services/single-document-access"
+  );
+
+  const verdicts = new Map<string, Promise<boolean>>();
+  for (const item of items) {
+    const { slug, locale } = ref(item);
+    const key = `${slug} ${locale ?? ""}`;
+    let verdict = verdicts.get(key);
+    if (!verdict) {
+      verdict = singleDocumentReadable(slug, {
+        user: caller.user,
+        ...(caller.authenticatedScope
+          ? { actor: caller.authenticatedScope }
+          : {}),
+        routeAuthorized: false,
+        ...(locale === null || locale === undefined ? {} : { locale }),
+      });
+      verdicts.set(key, verdict);
+    }
+    if (await verdict) visible.add(item);
+  }
+  return visible;
+}
+
+/**
+ * `items`, in their original order, keeping only those whose document the
+ * caller may be told about.
+ *
+ * The two kinds are decided by different paths because they are different
+ * questions: a collection document is one row among many and is asked for by
+ * id, while a Single is one document per language read through its own service.
+ * A caller that collapsed them would ask about a table that does not hold the
+ * document and read the refusal as a denial.
+ */
+export async function visibleDocuments<T>(
+  items: readonly T[],
+  ref: (item: T) => DocumentRef,
+  caller: ReadCaller
+): Promise<T[]> {
+  if (items.length === 0) return [];
+
+  const [collections, singles] = await Promise.all([
+    visibleCollectionItems(
+      items.filter(item => ref(item).kind === "collection"),
+      ref,
+      caller
+    ),
+    visibleSingleItems(
+      items.filter(item => ref(item).kind === "single"),
+      ref,
+      caller
+    ),
+  ]);
+
+  return items.filter(item => collections.has(item) || singles.has(item));
 }

--- a/packages/nextly/src/services/lib/registered-content-slugs.ts
+++ b/packages/nextly/src/services/lib/registered-content-slugs.ts
@@ -87,7 +87,11 @@ export async function registeredContentSlugs(): Promise<string[]> {
  * needs this to tell a live subject from an orphaned one.
  *
  * A name in NEITHER registry is absent rather than defaulted: guessing a kind
- * for it would send a row to a read path that cannot answer about it.
+ * for it would send a row to a read path that cannot answer about it. The
+ * activity log makes that concrete — it files settings mutations under
+ * namespaces that are neither a collection nor a single, and its scope column
+ * is free text, so a map that defaulted them would hand a settings row to a
+ * content read path with nothing to say about it.
  *
  * Collections are written last, so a slug claimed by both resolves to the
  * collection. The registries do not permit that overlap; stating the precedence

--- a/packages/nextly/src/services/lib/registered-content-slugs.ts
+++ b/packages/nextly/src/services/lib/registered-content-slugs.ts
@@ -28,40 +28,57 @@ interface RegistryRead {
   reachable: boolean;
 }
 
-/** The registered collection slugs, or none when the registry is unreachable. */
-async function collectionSlugs(): Promise<RegistryRead> {
+/**
+ * One registry's slugs, separating "there is no such registry" from "it could
+ * not answer".
+ *
+ * 🔴 Two failures that look identical and mean opposite things, and the split is
+ * why they are attempted separately. A registry that is NOT REGISTERED describes
+ * an install with none of that kind of content: contributing nothing is the
+ * COMPLETE answer, and a caller that refuses on a floor must not refuse here or
+ * it refuses forever. A registry that is registered and then THROWS has told us
+ * nothing about how much it holds, so its empty result is a floor — and a
+ * caller counting or authorizing against it would otherwise treat a transient
+ * dependency failure as "there is nothing here".
+ *
+ * Told apart by which operation failed, not by `container.has`: a container may
+ * answer `has` and `get` differently, and taking the presence check as the
+ * discriminator emptied the candidate set for every caller rather than only the
+ * one asking about degradation.
+ */
+async function registryRead<T>(
+  service: string,
+  enumerate: (registry: T) => Promise<Array<{ slug: string }>>
+): Promise<RegistryRead> {
+  let registry: T;
   try {
-    const collections = await container
-      .get<{
-        getAllCollections: () => Promise<Array<{ slug: string }>>;
-      }>("collectionRegistryService")
-      .getAllCollections();
-    return {
-      slugs: collections.map(collection => String(collection.slug)),
-      reachable: true,
-    };
+    registry = container.get<T>(service);
   } catch {
-    // Unreachable registry: contribute nothing rather than guess.
+    // Absent: this install registers no content of that kind, and that is a
+    // whole answer rather than a shortfall.
+    return { slugs: [], reachable: true };
+  }
+  try {
+    const entries = await enumerate(registry);
+    return { slugs: entries.map(entry => String(entry.slug)), reachable: true };
+  } catch {
+    // Present but unreadable: contribute nothing, and SAY that it is a floor.
     return { slugs: [], reachable: false };
   }
 }
 
+/** The registered collection slugs, or none when the registry is unreachable. */
+function collectionSlugs(): Promise<RegistryRead> {
+  return registryRead<{
+    getAllCollections: () => Promise<Array<{ slug: string }>>;
+  }>("collectionRegistryService", registry => registry.getAllCollections());
+}
+
 /** The registered single slugs, or none when the registry is unreachable. */
-async function singleSlugs(): Promise<RegistryRead> {
-  try {
-    const singles = await container
-      .get<{
-        getAllSingles: () => Promise<Array<{ slug: string }>>;
-      }>("singleRegistryService")
-      .getAllSingles();
-    return {
-      slugs: singles.map(single => String(single.slug)),
-      reachable: true,
-    };
-  } catch {
-    // As above.
-    return { slugs: [], reachable: false };
-  }
+function singleSlugs(): Promise<RegistryRead> {
+  return registryRead<{
+    getAllSingles: () => Promise<Array<{ slug: string }>>;
+  }>("singleRegistryService", registry => registry.getAllSingles());
 }
 
 /**

--- a/packages/nextly/src/services/lib/registered-content-slugs.ts
+++ b/packages/nextly/src/services/lib/registered-content-slugs.ts
@@ -32,37 +32,39 @@ interface RegistryRead {
  * One registry's slugs, separating "there is no such registry" from "it could
  * not answer".
  *
- * 🔴 Two failures that look identical and mean opposite things, and the split is
- * why they are attempted separately. A registry that is NOT REGISTERED describes
- * an install with none of that kind of content: contributing nothing is the
- * COMPLETE answer, and a caller that refuses on a floor must not refuse here or
- * it refuses forever. A registry that is registered and then THROWS has told us
- * nothing about how much it holds, so its empty result is a floor — and a
- * caller counting or authorizing against it would otherwise treat a transient
- * dependency failure as "there is nothing here".
+ * 🔴 Two failures that look identical and mean opposite things. A registry that
+ * is NOT REGISTERED describes an install with none of that kind of content:
+ * contributing nothing is the COMPLETE answer, and a caller that refuses on a
+ * floor must not refuse here or it refuses forever. A registry that is
+ * registered and then FAILS has told us nothing about how much it holds, so its
+ * empty result is a floor — and a caller counting or authorizing against it
+ * would otherwise treat a transient dependency failure as "there is nothing
+ * here", which is the direction that admits unauthorized rows.
  *
- * Told apart by which operation failed, not by `container.has`: a container may
- * answer `has` and `get` differently, and taking the presence check as the
- * discriminator emptied the candidate set for every caller rather than only the
- * one asking about degradation.
+ * 🔴 `has` decides absence, and a throw from a REGISTERED service is a floor —
+ * both halves matter, and each was wrong on its own first. `Container.get`
+ * invokes the factory, so a lazy singleton whose construction throws propagates
+ * from `get` exactly as an unregistered name does, while `has` is true: catching
+ * around `get` alone reports a failed dependency as an intentionally absent one.
+ * Reading `has` alone is no better — it answered before the factory ever ran, so
+ * a container that resolves a name it does not report emptied the candidate set
+ * for every caller rather than only the one asking about degradation. Ask `has`
+ * for absence, then let anything after it count as failure.
  */
 async function registryRead<T>(
   service: string,
   enumerate: (registry: T) => Promise<Array<{ slug: string }>>
 ): Promise<RegistryRead> {
-  let registry: T;
+  // Absent: this install registers no content of that kind, and that is a whole
+  // answer rather than a shortfall.
+  if (!container.has(service)) return { slugs: [], reachable: true };
   try {
-    registry = container.get<T>(service);
-  } catch {
-    // Absent: this install registers no content of that kind, and that is a
-    // whole answer rather than a shortfall.
-    return { slugs: [], reachable: true };
-  }
-  try {
+    const registry = container.get<T>(service);
     const entries = await enumerate(registry);
     return { slugs: entries.map(entry => String(entry.slug)), reachable: true };
   } catch {
-    // Present but unreadable: contribute nothing, and SAY that it is a floor.
+    // Registered and unable to answer -- a construction failure inside the
+    // factory included. Contribute nothing, and SAY that it is a floor.
     return { slugs: [], reachable: false };
   }
 }


### PR DESCRIPTION
The dashboard's activity feed discloses other authors' work under a stored `owner-only` or `custom` read rule. Measured on `main` before the fix:

```
control (ordinary read, as the owner) → 1 document
GET /api/dashboard/activity            → the other author's title, plus 3 more rows
```

The feed scopes by collection only, and `entryTitle` is stored denormalised on the log row at write time rather than hydrated through the read path — so nothing between the table and the response consults a document rule. It discloses other authors' entry titles and ids, and the names and emails attached to their edits. The create path logs activity automatically, so this is the ordinary product path, not an exotic one.

## One decision, two surfaces

The pending-edit cards (#1532, #1543) already answer exactly this question, and the obvious repair — give the feed its own copy — is what this change deliberately avoids. Two implementations of one access decision do not stay equal, and these had already diverged: **per-locale grouping, the registry-kind check, the stale-locale drop, bounded concurrency, and resolving a Single's live id before probing it** were all present on the pending-edit side and absent from the feed's. Each is a defect on the side that lacks it, and the last is the sharpest — probing a Single reads through `SingleEntryService`, which **auto-creates a missing Single**, so loading a dashboard would perform a write.

So `services/lib/document-visibility.ts` is now the single decision and both surfaces are translations into it:

- **`pending-edit-visibility.ts`** keeps only what it alone knows: `VersionScopeKind` is wider than the two kinds a content read path can answer for, so a `page`-scoped row (the page builder captures versions under it) resolves to nothing and is dropped rather than sent to a service that does not hold the document.
- **`activity-log-service.ts`** keeps its own three-way split — install-level rows with no entry id, rows under settings namespaces in neither registry, and rows naming a real document — because only the third is a document to authorize. Dropping the first two would remove SMTP-credential rotations and their kin from the feed entirely.

It is separate from `readable-documents.ts` because the two answer different questions: that module asks the read path which ids of **one** collection, in **one** language, survive its rules; this one decides which collections and languages to ask about at all. Keeping them apart also keeps the lower one mockable from the upper one's tests, which is why the split happened when the tests moved.

The **fail-closed rule is written once**: a rejected read has told us nothing, and nothing must not read as visible. Both kinds needed it separately, and a second copy is a second place for that direction to drift.

## Also removed: `total`

The response no longer carries it. It counted rows the collection scope admitted, so it reported edits to documents the reader may not open — the same disclosure the rows carried, in a number — and it cannot be narrowed without authorizing every matching row, which is unbounded over a table that only grows. `hasMore` carries the pagination instead, observed by authorizing one row past the page. The hand-written `COUNT(*)` behind it goes too, and with it the last raw SQL string in that service.

The registry and locale snapshot is resolved **once per refill** rather than per page, for the reason the pending-edit walk does: both helpers answer an unreachable dependency with an empty result, so a per-page read lets a transient failure drop one page's rows while its neighbours keep theirs, and the paging then reports a short feed as though it were whole.

## Verification

- nextly unit **888 files / 11,307 tests**; admin **396 / 3,913**. Integration for the touched areas across **all three dialects**: 22 files / 109 tests. All green.
- `lint` and `check-types` clean for both packages, 0 errors.
- fallow **`pass`** — 15 changed files against `origin/main`, `0` introduced findings of any kind.
- **Break-verified against the live behaviour, not a mutation.** Restoring the shipped feed (scope by collection, no document rules) fails the new integration test on both dialects with `expected [...] to not include 'SECRET other-author document'`. Removing per-locale grouping from the now-shared decision fails three cases at once — which is the point of sharing it: the same break would previously have gone unnoticed on the feed's side.

The 14 behavioural cases that pinned the pending-edit decision moved to `visible-documents.test.ts`, where the behaviour now lives, rather than being duplicated or dropped. What stayed behind is a three-case test for the translation `pending-edit-visibility` still owns.