### PR TITLE
fix(plugin-page-builder,admin): read definitions the way the page renders them

### DIFF
--- a/.changeset/readiness-reads-what-the-page-renders.md
+++ b/.changeset/readiness-reads-what-the-page-renders.md
@@ -1,0 +1,42 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The readiness notice reads definitions the way the page renders them.
+
+Relationship depth is no longer forced to zero. The renderer's component read
+states no depth, so the collection service expands to its default before running
+`afterRead` hooks. Forcing zero handed those hooks bare ids, and a hook whose
+blocks output depends on an expanded relationship then produced a different
+component graph than the page draws — missing an unpublished component, or
+naming one no visitor meets.
+
+A bulk write's warnings reach a consumer that renders its own feedback. They
+were carried into the built-in toast only, so turning `showToast` off to handle
+them yourself was the one route that could not see them: the presenter being
+opted out of was the only thing reading the array. Post-commit hook failures
+were lost the same way, not just readiness notices.

--- a/packages/admin/src/hooks/queries/__tests__/entry-mutation-warnings.test.tsx
+++ b/packages/admin/src/hooks/queries/__tests__/entry-mutation-warnings.test.tsx
@@ -11,7 +11,7 @@
  */
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { renderHook, waitFor } from "@testing-library/react";
+import { render, renderHook, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
@@ -302,5 +302,69 @@ describe("a bulk consumer that renders its own feedback", () => {
     // callback route rather than passing because both fired.
     expect(successSpy).not.toHaveBeenCalled();
     expect(infoSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("one answer to which warnings a bulk write reports", () => {
+  it("drives the toast from the same payload the callback receives", async () => {
+    // Two sources aliased today and were free to diverge: any later filtering
+    // or defaulting in the payload projection would have changed the consumer
+    // route only, leaving the built-in feedback and the custom feedback meant
+    // to replace it disagreeing about the same write.
+    //
+    // Asserted by giving the two routes something to disagree ABOUT: the
+    // callback's payload is captured and compared against what the toast
+    // rendered, so a second source reaching the toast shows up as a mismatch
+    // rather than as two independently-correct assertions.
+    bulkUpdateSpy.mockResolvedValue({
+      message: "Updated 1 entry.",
+      items: [entry],
+      errors: [],
+      warnings: [
+        {
+          severity: "notice",
+          phase: "afterUpdate",
+          collection: "posts",
+          code: "COMPONENTS_NOT_PUBLISHED",
+          message: "This page embeds 1 component that is not published.",
+          entryId: "e1",
+        },
+      ],
+    });
+
+    let seen: { warnings?: { message: string }[] } | undefined;
+    const client = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    });
+    const { result } = renderHook(
+      () =>
+        useBulkUpdateEntries({
+          collectionSlug: "posts",
+          onComplete: (payload: unknown) => {
+            seen = payload as { warnings?: { message: string }[] };
+          },
+        }) as MutationLike,
+      { wrapper: makeWrapper(client) }
+    );
+
+    await result.current.mutateAsync({
+      ids: ["e1"],
+      data: { status: "published" },
+    });
+
+    await waitFor(() => {
+      expect(infoSpy).toHaveBeenCalledTimes(1);
+    });
+
+    const options = infoSpy.mock.calls[0]?.[1] as {
+      description: React.ReactElement;
+    };
+    render(options.description);
+
+    const fromCallback = seen?.warnings?.[0]?.message;
+    expect(fromCallback).toBeDefined();
+    expect(
+      screen.getByText(new RegExp(fromCallback!.slice(0, 20)))
+    ).toBeInTheDocument();
   });
 });

--- a/packages/admin/src/hooks/queries/__tests__/entry-mutation-warnings.test.tsx
+++ b/packages/admin/src/hooks/queries/__tests__/entry-mutation-warnings.test.tsx
@@ -251,3 +251,56 @@ describe("a BULK write", () => {
     expect(infoSpy).not.toHaveBeenCalled();
   });
 });
+
+describe("a bulk consumer that renders its own feedback", () => {
+  it("receives the warnings in the callback payload", async () => {
+    // With `showToast` off, the built-in presenter is the ONLY thing that was
+    // reading `response.warnings` — so the surface that opted out in order to
+    // handle them itself was the one surface that could not see them.
+    bulkUpdateSpy.mockResolvedValue({
+      message: "Updated 1 entry.",
+      items: [entry],
+      errors: [],
+      warnings: [
+        {
+          severity: "notice",
+          phase: "afterUpdate",
+          collection: "posts",
+          code: "COMPONENTS_NOT_PUBLISHED",
+          message: "This page embeds 1 component that is not published.",
+          entryId: "e1",
+        },
+      ],
+    });
+
+    let seen: unknown;
+    const client = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    });
+    const { result } = renderHook(
+      () =>
+        useBulkUpdateEntries({
+          collectionSlug: "posts",
+          showToast: false,
+          onComplete: (payload: unknown) => {
+            seen = payload;
+          },
+        }) as MutationLike,
+      { wrapper: makeWrapper(client) }
+    );
+
+    await result.current.mutateAsync({
+      ids: ["e1"],
+      data: { status: "published" },
+    });
+
+    await waitFor(() => {
+      expect(seen).toBeDefined();
+    });
+    expect((seen as { warnings?: unknown[] }).warnings).toHaveLength(1);
+    // The control: the toast really was suppressed, so this asserts the
+    // callback route rather than passing because both fired.
+    expect(successSpy).not.toHaveBeenCalled();
+    expect(infoSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/admin/src/hooks/queries/useBulkEntries.ts
+++ b/packages/admin/src/hooks/queries/useBulkEntries.ts
@@ -52,6 +52,16 @@ export interface BulkCallbackPayload<T> {
   items: T[];
   /** Per-item failures with canonical NextlyErrorCode + public message. */
   errors: PerItemError[];
+  /**
+   * What the server reported about the writes that DID happen.
+   *
+   * Distinct from `errors`, which are per-item failures that stopped a write:
+   * these describe committed writes — a post-commit hook that failed, or an
+   * advisory about the state one left behind. Present here as well as in the
+   * built-in toast, because a consumer that turns `showToast` off to render its
+   * own feedback would otherwise have no route to them at all.
+   */
+  warnings?: HookWarning[];
 }
 
 /** Build the callback payload from a server `BulkResponse<T>`. */
@@ -98,6 +108,12 @@ function toCallbackPayload<T>(
     message: response.message,
     items: response.items,
     errors: response.errors,
+    // Carried into the callback as well as the built-in toast. A consumer that
+    // turns `showToast` off to render its own feedback is the one caller with
+    // no other route to these — the presenter it opted out of was the only
+    // thing reading them, so readiness notices and post-commit hook failures
+    // both vanished for exactly the surface that meant to handle them itself.
+    ...(response.warnings === undefined ? {} : { warnings: response.warnings }),
   };
 }
 

--- a/packages/admin/src/hooks/queries/useBulkEntries.ts
+++ b/packages/admin/src/hooks/queries/useBulkEntries.ts
@@ -78,10 +78,15 @@ export interface BulkCallbackPayload<T> {
  * outcome — and because an author publishing ten pages at once was otherwise
  * told nothing that an author publishing one of them would have been told.
  */
-function toastBulkResult<T>(
-  payload: BulkCallbackPayload<T>,
-  warnings: readonly HookWarning[] | undefined
-): void {
+function toastBulkResult<T>(payload: BulkCallbackPayload<T>): void {
+  // Read OFF the payload rather than taken as a second argument. The payload is
+  // what a consumer's own callback receives, so deriving the toast from it
+  // keeps one answer to "which warnings does this operation report". Passing
+  // the response's array alongside made two, aliased today and free to diverge
+  // the moment `toCallbackPayload` filters or defaults anything — and the two
+  // that then disagreed would be the built-in feedback and the custom feedback
+  // meant to replace it.
+  const warnings = payload.warnings;
   if (payload.failed === 0) {
     toastMutationResult(payload.message, warnings);
     return;
@@ -191,7 +196,7 @@ export function useBulkDeleteEntries({
 
       const payload = toCallbackPayload(response);
 
-      if (showToast) toastBulkResult(payload, response.warnings);
+      if (showToast) toastBulkResult(payload);
 
       onComplete?.(payload);
       onSuccess?.(payload);
@@ -276,7 +281,7 @@ export function useBulkUpdateEntries({
 
       const payload = toCallbackPayload(response);
 
-      if (showToast) toastBulkResult(payload, response.warnings);
+      if (showToast) toastBulkResult(payload);
 
       onComplete?.(payload);
       onSuccess?.(payload);

--- a/packages/plugin-page-builder/src/component-readiness-hook.test.ts
+++ b/packages/plugin-page-builder/src/component-readiness-hook.test.ts
@@ -858,3 +858,22 @@ describe("a write to the component store itself", () => {
     );
   });
 });
+
+describe("reading definitions the way the renderer reads them", () => {
+  it("does not force a relationship depth", async () => {
+    // The renderer's own component read states no `depth`, so the collection
+    // service expands to its default before running `afterRead`. Forcing zero
+    // here hands those hooks bare ids, and a hook whose blocks output depends
+    // on an expanded relationship then yields a different component graph than
+    // the page draws — missing an unpublished component, or naming one no
+    // visitor meets.
+    const h = harness({ published: [] });
+    const ctx = writeContext();
+    (ctx.req as Record<string, unknown>).nextly = h.nextly;
+
+    await h.handlers[0]!(ctx);
+
+    expect(h.finds).toHaveLength(1);
+    expect("depth" in h.finds[0]!).toBe(false);
+  });
+});

--- a/packages/plugin-page-builder/src/component-readiness-hook.ts
+++ b/packages/plugin-page-builder/src/component-readiness-hook.ts
@@ -79,7 +79,6 @@ export interface ReadinessDirectApi {
     limit?: number;
     status?: "published" | "draft" | "all";
     overrideAccess?: boolean;
-    depth?: number;
     // Part of this call's SHAPE, so a caller cannot build a read here that
     // omits one and silently inherits the instance's identity.
     user?: undefined;
@@ -449,6 +448,13 @@ function parseJson(value: string): unknown {
  * every published component missing from it reads as unpublished — a warning
  * manufactured by the read rather than by the data.
  *
+ * Relationship DEPTH is left unstated, which is what the renderer's own
+ * component read does. Forcing it to zero would hand an `afterRead` hook bare
+ * ids where the render gives it expanded relationships, so a hook whose blocks
+ * output depends on one produces a different component graph here than the page
+ * actually draws — and this check would then miss an unpublished component, or
+ * name one no visitor meets.
+ *
  * `overrideAccess` because the question is about the document's lifecycle, not
  * about what this caller may read: an author who cannot read a component still
  * needs to know their page has a hole, and judging it by their permissions
@@ -468,7 +474,6 @@ function storeSource(
         limit: chunk.length,
         status: "published",
         overrideAccess: true,
-        depth: 0,
         // BOTH identity channels cleared, stated rather than omitted.
         // `mergeConfig` spreads the pooled reader's defaults UNDER the call, so
         // an omitted key restores whatever identity the instance was booted


### PR DESCRIPTION
Two findings that arrived on #1544 **after it merged**, so they land here.

## Relationship depth was forced to zero

`readComponentChunk` — the renderer's own component read — states no `depth`, so
the collection service expands to its default before running `afterRead` hooks.
The readiness source forced `depth: 0`, handing those hooks bare ids.

A hook whose blocks output depends on an expanded relationship therefore
produced a **different component graph** here than the page draws: it could miss
an unpublished component, or name one no visitor meets. Depth is now left
unstated, which is the same thing the renderer says.

## A bulk write's warnings never reached a consumer rendering its own feedback

They were carried into the built-in toast only. So turning `showToast` off in
order to present them yourself was the **one** route that could not see them —
the presenter being opted out of was the only thing reading the array.

Post-commit hook failures were lost the same way, not only readiness notices, so
this is wider than the feature that exposed it.

## Evidence

Both break-verified.

| Wrong implementation | Result |
|---|---|
| force `depth: 0` again | 1 fails |
| drop `warnings` from the callback payload | 1 fails |

The bulk test carries its own control — it asserts the toast was genuinely
suppressed, so it proves the **callback** route rather than passing because both
fired.

## Gates

| Gate | Result |
|---|---|
| admin · plugin-page-builder | 3927 · 639 |
| `check-types` (4 packages) | exit 0 |
| `fallow --gate new-only` | **pass**, 0 introduced in every category |
| `check:comments` / `changeset status` | exit 0 |

## Not in this PR

A third finding asks readiness to read the written page back through the public
published pipeline, because a collection- or field-level `afterRead` hook can
transform the blocks field before the renderer sees it. That is real, and it is
the same class as the depth mismatch — but it is another whole read per publish
and it is the eighth time this check has needed something only the render knows.

It is recorded against `decision:pb6-q17-write-hook-or-editor-surface` rather
than patched, because that decision is precisely whether this belongs on the
write path at all.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bulk entry updates and deletions now consistently provide warning messages to completion callbacks, including when toast notifications are disabled.
  * Warning messages shown in notifications now match those delivered through callbacks.
  * Component readiness checks now evaluate relationships consistently with page rendering, improving detection of unpublished or inaccessible components.

* **Tests**
  * Added coverage for bulk-operation warnings and component readiness behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->