### PR TITLE
docs: say what Nextly is, in the docs intro and npm description

### DIFF
--- a/.changeset/say-what-nextly-is-in-one-place.md
+++ b/.changeset/say-what-nextly-is-in-one-place.md
@@ -1,0 +1,15 @@
+---
+"nextly": patch
+---
+
+Say what Nextly is, in the words the positioning settles on.
+
+The docs intro described an "app framework" that lets you "define content with
+code or build it visually", which predates the page builder and uses "visually"
+for schema building. That word now means page building, and the collision is the
+messaging bug this release exists to remove.
+
+The intro now opens with the brand category and names both builders explicitly.
+The frontmatter description and the `nextly` package description carry the SEO
+descriptor instead, because a meta description and an npm listing are read in a
+search result rather than on the page.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 
 Nextly is an open-source content platform for Next.js.
 
-Developers define the content model in TypeScript, or build it in the admin with the Visual Schema Builder — either way it is the same data model. Your team then composes pages in the Visual Page Builder, translates them, keeps a version history, and schedules what goes live. It all runs inside your own Next.js app, on your own database. No SaaS, no proprietary cloud.
+Developers define the content model in TypeScript, or build it in the admin with the Visual Schema Builder; either way it is the same data model. Your team then composes pages in the Visual Page Builder, translates them, keeps a version history, and schedules what goes live. It all runs inside your own Next.js app, on your own database. No SaaS, no proprietary cloud.
 
 ## Why Nextly?
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: Nextly Documentation
-description: The open-source, type-safe headless app framework built natively for Next.js. Define content with code or build it visually.
+description: Nextly is an open-source CMS and visual page builder for Next.js. Model content, build pages, localize, version and release from your own stack.
 ---
 
-Nextly is an open-source app framework that runs inside your Next.js application. It gives you two ways to define your content model: write TypeScript config (code-first) or use the Visual Schema Builder in the admin panel. Either way, you get the same type-safe API, the same admin interface, and the same query layer.
+Nextly is an open-source content platform for Next.js. Developers define the content model in TypeScript, or build it in the admin with the Visual Schema Builder; either way it is the same data model, the same type-safe API and the same admin interface. Your team then composes pages in the Visual Page Builder, translates them, keeps a version history, and schedules what goes live. It all runs inside your own Next.js app, on your own database.
 
 ## Why Nextly?
 

--- a/packages/nextly/package.json
+++ b/packages/nextly/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nextly",
   "version": "0.0.2-alpha.62",
-  "description": "Nextly - Core functionality, database, services, and APIs",
+  "description": "Nextly is an open-source CMS and visual page builder for Next.js. Model content, build pages, localize, version and release from your own stack.",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.mjs",


### PR DESCRIPTION
Positioning **Phase 1**, monorepo half.

## The audit changed the scope

Most of this group was already done by G6. Measured rather than assumed:

| Item | State |
|---|---|
| 1.6 README "Plugins (coming soon, beta)" | **already fixed** — the README lists the shipped plugins with no "coming soon" |
| 1.5 npm descriptions | **already current** — and already use the qualified "Visual Page Builder" / "Schema Builder" |
| 1.7 the "Visual Builder" sweep | **nothing to do** — all 21 occurrences are historical `CHANGELOG.md` entries |
| 1.4 docs intro | **outstanding** — this PR |

**On 1.7: I recommend not sweeping the changelogs.** Every remaining occurrence is a released changeset entry at line ~8500, fanned across eight packages. Those are an append-only record of what was said at that release. Rewriting them to say something different from what shipped is revisionism, and it sits badly next to a programme whose whole point is that published claims should be true.

## What changed

The docs intro still described an "app framework" that lets you "define content with code or build it visually" — the wording that predates the page builder and uses "visually" for schema building. That collision is the messaging bug this release exists to remove.

It now follows the doc's two-level category:

- **body opens with the brand category** ("open-source content platform for Next.js") and names both builders explicitly
- **frontmatter description and the `nextly` npm description carry the SEO descriptor**, because those are read in a search result rather than on the page

Also replaced the one em dash in the README, which the house copy rule forbids.

## Verified

- `pnpm check:docs-claims` — no findings (G6's guard)
- Changeset included, `patch` on `nextly`