### PR TITLE
test(plugin-page-builder): assert the readiness outcome, not the request shape

### DIFF
--- a/packages/plugin-page-builder/src/component-readiness-hook.test.ts
+++ b/packages/plugin-page-builder/src/component-readiness-hook.test.ts
@@ -860,20 +860,92 @@ describe("a write to the component store itself", () => {
 });
 
 describe("reading definitions the way the renderer reads them", () => {
-  it("does not force a relationship depth", async () => {
-    // The renderer's own component read states no `depth`, so the collection
-    // service expands to its default before running `afterRead`. Forcing zero
-    // here hands those hooks bare ids, and a hook whose blocks output depends
-    // on an expanded relationship then yields a different component graph than
-    // the page draws — missing an unpublished component, or naming one no
-    // visitor meets.
-    const h = harness({ published: [] });
-    const ctx = writeContext();
-    (ctx.req as Record<string, unknown>).nextly = h.nextly;
+  it("finds a nested component only an EXPANDED read reveals", async () => {
+    // Asserted on the OUTCOME, not on the request. "`depth` is absent from the
+    // arguments" restates what the code says about itself: it holds just as
+    // well if the service default were zero anyway, or if `afterRead` ran
+    // before expansion, and neither of those is the behaviour being protected.
+    //
+    // So the store below answers DIFFERENTLY for the two reads, modelling what
+    // the collection service documents: an unstated depth expands to the
+    // default before `afterRead` runs, and a hook whose blocks output depends
+    // on an expanded relationship can only emit the nested instance then. The
+    // readiness result therefore changes with the depth, and the assertion is
+    // about a component a visitor would or would not meet.
+    //
+    // What this cannot do is prove the SERVICE behaves that way — the double
+    // replaces it, so the modelled behaviour is the documented contract rather
+    // than a measurement of it. Only an integration test against a real adapter
+    // could close that, and this is the strongest statement available at the
+    // level the hook lives.
+    const finds: Record<string, unknown>[] = [];
+    const handlers: ((c: unknown) => unknown)[] = [];
+    const ctx = {
+      hooks: {
+        on: (_t: string, _c: string, h: (c: unknown) => unknown) => {
+          handlers.push(h);
+        },
+      },
+      services: {
+        collections: {
+          getCollection: async () => ({
+            status: true,
+            localized: false,
+            fields: [{ name: "content", type: "blocks" }],
+          }),
+        },
+      },
+    };
+    registerComponentReadinessNotice({
+      ctx: ctx as never,
+      componentCollection: COMPONENTS,
+      componentField: "content",
+      limits: () => LIMITS,
+    });
+    const write = writeContext();
+    (write.req as Record<string, unknown>).nextly = {
+      find: async (args: Record<string, unknown>) => {
+        finds.push(args);
+        const wanted =
+          ((args.where as { id?: { in?: string[] } })?.id?.in as string[]) ??
+          [];
+        if (!wanted.includes("hero")) return { items: [] };
+        // `hero` is published either way. What differs is whether its own
+        // document mentions the nested component — which a hook can only
+        // produce from an expanded relationship.
+        const expanded = args.depth !== 0;
+        return {
+          items: [
+            {
+              id: "hero",
+              content: {
+                formatVersion: DOCUMENT_FORMAT_VERSION,
+                kind: "component",
+                nodes: expanded
+                  ? [
+                      {
+                        id: "n",
+                        type: COMPONENT_INSTANCE_TYPE,
+                        version: 1,
+                        props: { componentId: "nested-unpublished" },
+                      },
+                    ]
+                  : [],
+              },
+            },
+          ],
+        };
+      },
+    };
 
-    await h.handlers[0]!(ctx);
+    await handlers[0]!(write);
 
-    expect(h.finds).toHaveLength(1);
-    expect("depth" in h.finds[0]!).toBe(false);
+    // The nested component is not published, so the expanded read finds a hole
+    // the bare read cannot see. Forcing `depth: 0` makes this silent.
+    expect(recorded).toHaveLength(1);
+    expect((recorded[0] as { message: string }).message).toContain(
+      "1 component"
+    );
+    expect(finds.every(find => !("depth" in find))).toBe(true);
   });
 });


### PR DESCRIPTION
A review finding on #1546, which had already merged.

## The test proved less than it looked like it did

It asserted `depth` was absent from the read's arguments. That restates what the
code says about itself: it holds just as well if the collection service's
default were zero anyway, or if `afterRead` ran *before* expansion — and neither
of those is the behaviour being protected. A regression into either would have
kept it green.

## What it asserts now

The store answers **differently** for an expanded and a bare read, modelling
what the collection service documents: an unstated depth expands to the default
before `afterRead` runs, so a hook whose blocks output depends on an expanded
relationship can only emit the nested instance then.

The readiness **result** therefore changes with the depth — the nested
unpublished component is reachable one way and invisible the other. Forcing
`depth: 0` now makes the notice **disappear** (`expected [] to have a length of
1`) rather than merely changing an argument list.

## What it still cannot do, stated in the test

It cannot prove the *service* behaves that way. The double replaces the service,
so the modelled behaviour is the documented contract rather than a measurement
of it. Only an integration test against a real adapter could close that. That
limit is written where the test lives rather than left implied, so nobody reads
this as stronger evidence than it is.

## Gates

| Gate | Result |
|---|---|
| `plugin-page-builder` | 59 files, 639 tests, exit 0 |
| `check-types` | exit 0 |
| `fallow --gate new-only` | **pass**, 0 introduced in every category |
| `check:comments` | exit 0 |

No changeset: this changes no shipped behaviour, and `changeset status` passes
without one. A changeset here would announce nothing to a consumer.
