### PR TITLE
docs: say the current category

### DIFF
--- a/.github/review-prompt.md
+++ b/.github/review-prompt.md
@@ -1,6 +1,6 @@
 # Nextly PR Review Agent (CI)
 
-You are a senior staff-level reviewer for `nextlyhq/nextly`, a TypeScript CMS/app-framework monorepo (Drizzle ORM, Next.js, three SQL dialects, published npm packages). You run inside GitHub Actions. Your job is to find real defects in the PR named in your invocation context and post them as inline review comments, with severity, full context, and a fix hint.
+You are a senior staff-level reviewer for `nextlyhq/nextly`, a TypeScript CMS and page-builder monorepo (Drizzle ORM, Next.js, three SQL dialects, published npm packages). You run inside GitHub Actions. Your job is to find real defects in the PR named in your invocation context and post them as inline review comments, with severity, full context, and a fix hint.
 
 You run once per push, so reviews are rounds: round N must be aware of rounds 1..N-1. An empty round (zero new findings) is the merge signal for this repo, so a false "looks good" is the most expensive mistake you can make, and a fabricated finding is the second most expensive. Honesty in both directions.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # Nextly Monorepo: Agent Guide
 
-Nextly is an open-source, Next.js-native CMS and app framework. Users define
+Nextly is an open-source, Next.js-native content platform: a CMS and a Visual
+Page Builder. Users define
 content schema in TypeScript (code-first) or visually (the Schema Builder), and
 it runs inside their own Next.js app with their own database (Postgres, MySQL,
 or SQLite via Drizzle ORM). This repository is the pnpm + Turborepo monorepo

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7,7 +7,7 @@ conventions, see AGENTS.md and CONTRIBUTING.md. For user-facing docs, see
 
 ## Overview
 
-Nextly is a CMS and app framework that runs INSIDE the user's Next.js app.
+Nextly is a CMS and visual page builder that runs INSIDE the user's Next.js app.
 There is no hosted service: the user's project mounts routes that delegate to
 our packages, and everything (admin panel, REST API, schema management,
 media) executes in their app against their database.

--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -3,7 +3,7 @@ title: Getting Started
 description: Learn what Nextly is, understand its core concepts, and get up and running quickly.
 ---
 
-Nextly is an open-source app framework that embeds directly into your Next.js application. Instead of running a separate server, Nextly lives alongside your frontend code -- same repo, same deployment, same database.
+Nextly is an open-source content platform that embeds directly into your Next.js application. Instead of running a separate server, Nextly lives alongside your frontend code -- same repo, same deployment, same database.
 
 ## Two Ways to Build
 


### PR DESCRIPTION
The docs intro moved to the settled category in #1547, but the **getting-started page still opened by calling Nextly an app framework**, so the first page a reader reaches after the intro contradicted it. It renders publicly at `nextlyhq.com/docs/getting-started`.

`AGENTS.md` and `ARCHITECTURE.md` told anyone, or anything, reading the repo the same thing. And `.github/review-prompt.md` described this as a `CMS/app-framework monorepo`, which meant the retired category was briefing the review agent on every pull request.

Four files, nine lines.

## Scope

This PR originally also added a `retired-category` rule to `check:docs-claims`. That has moved to **#1551**, stacked on this branch.

It was 347 of the 356 changed lines and took 15 review findings across six rounds, all of them about Markdown constructs a line scanner did not know about. The prose fix has been correct and unchallenged since the first round and is the half with user impact, so it should not wait behind a checker. Both are better reviewable apart.

## No changeset

Documentation only, and `AGENTS.md:319` says test-only, CI-only and docs-only PRs carry none. `git diff --name-only origin/main...HEAD | grep -c '^packages/'` returns **0**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated product descriptions to present Nextly as a content platform with CMS and visual page builder capabilities.
  - Refined architecture and getting-started documentation to consistently reflect the platform’s current positioning.
  - Updated review guidance to describe the repository as a TypeScript CMS and page-builder monorepo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->