### PR TITLE
ci: report the retired category in docs

### DIFF
--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -65,6 +65,251 @@ const FORBIDDEN_PHRASES = [
 const BARE_VISUAL_BUILDER = /(?<!schema )(?<!page )\bvisual builder\b/gi;
 
 /**
+ * The files that say what Nextly is.
+ *
+ * The naming rule above stops one word being overloaded. This stops a retired
+ * category coming back, which had already happened in three of these six at
+ * once, including the prompt this repository's own review agent is given.
+ *
+ * Every path here is asserted to exist by this script's own tests, so a rename
+ * cannot quietly take a surface out of scope while the renamed file goes on
+ * stating the category.
+ *
+ * Named rather than matched by glob, and six files rather than every document.
+ * A category is stated in a handful of places and repeated nowhere else, so a
+ * wider net would only add ways to be wrong: a tutorial quoting the old name,
+ * or a code sample containing the words, are not the project calling itself
+ * something. Adding a surface here is a deliberate act, which is the point.
+ */
+export const CATEGORY_SURFACES = [
+  "README.md",
+  "AGENTS.md",
+  "ARCHITECTURE.md",
+  ".github/review-prompt.md",
+  "docs/index.mdx",
+  "docs/getting-started/index.mdx",
+];
+
+/**
+ * The category the project moved away from.
+ *
+ * A hyphen or whitespace between the words, because the repository has spelled
+ * it both ways and a reader sees no difference, and an optional plural, because
+ * "one of several app frameworks" is the same claim about the same category.
+ */
+const RETIRED_CATEGORY = /\bapp(?:-|\s+)frameworks?\b/i;
+
+/**
+ * A document reduced to what a reader is shown.
+ *
+ * `renderedProse` drops fenced examples and commented-out blocks. This drops
+ * the rest of what renders as nothing or as the text inside it, so the phrase
+ * is judged as it reaches a reader: an MDX import or comment shows nothing, a
+ * code span is a name rather than a claim, and a tag, a link or emphasis around
+ * one word leaves only its text.
+ *
+ * The separator entities are decoded, in every spelling of a space and of a
+ * hyphen, because the pattern turns on what sits between the two words; an
+ * entity anywhere else in a sentence cannot hide the phrase.
+ *
+ * ESM statements are removed for MDX only, and only unindented, which is where
+ * MDX accepts them. Markdown has no imports at all, so there a line beginning
+ * "import" is an ordinary sentence, and an indented one under a list item is
+ * that item continuing; treating either as a statement blanks real prose.
+ *
+ * Frontmatter keeps its title and description, which are published as the page's
+ * own metadata, and drops the rest. The forms
+ * An image's alternative text is read aloud and shown when the image is not,
+ * so it comes out of the tag before the tag goes. The forms
+ * that carry a line break carry a space with it: a `<br>` and a trailing
+ * backslash both separate the words they sit between, so removing them outright
+ * would join those words instead. And `<code>` is the HTML spelling of a code
+ * span, so it names a literal on the same terms.
+ */
+function stripEsm(markdown) {
+  const kept = [];
+  let inStatement = false;
+  for (const line of markdown.split("\n")) {
+    if (!inStatement && /^(?:import|export)\b/.test(line)) inStatement = true;
+    if (!inStatement) {
+      kept.push(line);
+      continue;
+    }
+    kept.push("");
+    // A statement ends at its semicolon or its quoted module path. A blank line
+    // ends it too, so an unterminated one cannot swallow the document.
+    if (/(?:;|["'])[ \t]*;?[ \t]*$/.test(line) || line.trim() === "") inStatement = false;
+  }
+  return kept.join("\n");
+}
+
+/**
+ * The frontmatter fields a reader is shown.
+ *
+ * A page's title and description are published: the description is served
+ * verbatim as the page's meta description. The rest of the block is machinery
+ * nobody meets.
+ *
+ * A value may be a folded or literal scalar, whose text is on the indented
+ * lines beneath the marker rather than beside it, so those are collected too.
+ */
+function publishedFrontmatter(block) {
+  const lines = block.split(/\r?\n/);
+  const published = [];
+  for (let index = 0; index < lines.length; index++) {
+    const field = lines[index].match(/^(?:title|description):[ \t]*(.*)$/);
+    if (field === null) continue;
+    // A quoted value ends at its closing quote and an unquoted one at a
+    // comment. YAML publishes neither the quotes nor anything after them.
+    const quoted = field[1].match(/^(['"])((?:\\.|(?!\1).)*)\1/);
+    const inline =
+      quoted === null
+        ? field[1].replace(/(?:^|[ \t])#.*$/, "")
+        : // A double-quoted scalar spells characters as escapes, and YAML
+          // publishes what they stand for.
+          quoted[2]
+            .replace(/\\x([0-9a-fA-F]{2})/g, (_, hex) =>
+              String.fromCharCode(Number.parseInt(hex, 16))
+            )
+            .replace(/\\u([0-9a-fA-F]{4})/g, (_, hex) =>
+              String.fromCharCode(Number.parseInt(hex, 16))
+            )
+            .replace(/\\U([0-9a-fA-F]{8})/g, (_, hex) =>
+              String.fromCodePoint(Number.parseInt(hex, 16))
+            )
+            .replace(/\\([nt])/g, " ");
+    const value = [inline.replace(/^[>|][-+]?[ \t]*$/, "")];
+    // A block scalar runs over the indented lines beneath it, and a blank line
+    // inside one is a paragraph break rather than its end, so the scan runs to
+    // the last indented line instead of stopping at the first gap.
+    let last = index;
+    for (let probe = index + 1; probe < lines.length; probe++) {
+      if (/^[ \t]+\S/.test(lines[probe])) last = probe;
+      else if (lines[probe].trim() !== "") break;
+    }
+    for (let line = index + 1; line <= last; line++) value.push(lines[line].trim());
+    index = last;
+    published.push(value.join(" ").trim());
+  }
+  return published.length === 0 ? "" : `${published.join("\n\n")}\n\n`;
+}
+
+/**
+ * The strings a component tag puts on the page.
+ *
+ * A list passed in a braces expression is data the component renders, and an
+ * attribute named for a caption holds one. Everything else in a tag is
+ * configuration, and reading it would fail on a class or a path that happens to
+ * carry the words.
+ */
+const CAPTION_ATTRIBUTES = /\b(?:title|label|caption|heading|summary|placeholder)=/;
+
+function componentCaptions(tag) {
+  const captions = [];
+  for (const expression of tag.match(/\{\s*\[[^\]]*\]\s*\}/g) ?? []) {
+    captions.push(...(expression.match(/"[^"\n]*"|'[^'\n]*'/g) ?? []));
+  }
+  for (const attribute of tag.match(/\b[a-zA-Z]+=(?:"[^"\n]*"|'[^'\n]*')/g) ?? []) {
+    if (CAPTION_ATTRIBUTES.test(attribute)) captions.push(attribute.replace(/^[^=]+=/, ""));
+  }
+  return captions.map(text => text.slice(1, -1)).join(" ");
+}
+
+function readableProse(markdown, { mdx }) {
+  // A diagram fence is drawn rather than printed, so its labels are read while
+  // the syntax around them is not. Pulled out before `renderedProse` drops the
+  // fence with every other one.
+  const drawn = markdown.replace(
+    /^ {0,3}```mermaid\b[\s\S]*?^ {0,3}```[ \t]*$/gm,
+    fence =>
+      (fence.match(/"[^"\n]*"|'[^'\n]*'|\[[^\]\n]*\]|\([^)\n]*\)|\|[^|\n]*\||\{[^}\n]*\}/g) ?? [])
+        .map(label => label.slice(1, -1))
+        .join("\n\n")
+  );
+  const prose = renderedProse(drawn).replace(
+    /^---\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/,
+    (_, block) => publishedFrontmatter(block)
+  );
+  return (mdx ? stripEsm(prose) : prose)
+    .replace(/&(?:nbsp|ensp|emsp|thinsp|#0*32|#0*160|#x0*20|#x0*a0);/gi, " ")
+    .replace(/&(?:hyphen|dash|#0*45|#x0*2d);/gi, "-")
+    .replace(/<code[^>]*>[\s\S]*?<\/code>/gi, " ")
+    .replace(
+      /<img\b[^>]*?\balt=(?:"([^"]*)"|'([^']*)')[^>]*>/gi,
+      (_, quoted, single) => ` ${quoted ?? single} `
+    )
+    // A component is given its captions as props, so those strings are drawn
+    // even though the tag is not. Only the props that carry text: a list passed
+    // as data, and the attributes whose names say they hold a caption. A
+    // `className` or an `href` is configuration and naming a stylesheet class
+    // after the old category is not the project claiming it.
+    .replace(/<[A-Z][A-Za-z0-9]*\b[^>]*>/g, tag => ` ${componentCaptions(tag)} `)
+    .replace(/<br\s*\/?>/gi, " ")
+    .replace(/^ {0,3}\[[^\]\n]+\]:[ \t]*\S[^\n]*$/gm, " ")
+    .replace(/\\\n/g, " ")
+    .replace(/\\([-!"#$%&'()*+,./:;<=>?@[\]^_`{|}~])/g, "$1")
+    .replace(/\{\s*\/\*[\s\S]*?\*\/\s*\}/g, " ")
+    .replace(/(`+)[\s\S]*?\1/g, " ")
+    .replace(/<[^>]+>/g, "")
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/\[([^\]]*)\]\[[^\]]*\]/g, "$1")
+    .replace(/[*_]/g, "");
+}
+
+/**
+ * Split where a run of quoted lines begins or ends.
+ *
+ * A quotation and the paragraph beside it are two blocks even with no blank
+ * line between them, and the marker is stripped before the lines are joined, so
+ * without this the two would read as one sentence.
+ */
+function splitOnQuoteBoundary(block) {
+  const blocks = [];
+  let current = [];
+  let quoted = null;
+  for (const line of block.split("\n")) {
+    const isQuoted = /^\s*>/.test(line);
+    if (quoted !== null && isQuoted !== quoted && current.length > 0) {
+      blocks.push(current.join("\n"));
+      current = [];
+    }
+    current.push(line);
+    quoted = isQuoted;
+  }
+  if (current.length > 0) blocks.push(current.join("\n"));
+  return blocks;
+}
+
+/**
+ * The paragraphs a document renders, each on one line.
+ *
+ * These files are hand-wrapped, so a sentence is regularly split across source
+ * lines and a per-line search would miss the phrase whenever a wrap fell inside
+ * it. A blank line ends a paragraph, a list item starts its own and a heading is
+ * one line by definition, so closing up the wraps cannot run two separate
+ * statements together. A quote marker repeats on every line of a quotation, so
+ * it comes off before the lines are joined rather than landing between them.
+ */
+function proseParagraphs(markdown, { mdx }) {
+  return readableProse(markdown, { mdx })
+    .split(/\n\s*\n/)
+    .flatMap(block => block.split(/\n(?=\s*(?:[-*+]|\d+[.)])\s)/))
+    .flatMap(block => block.split(/\n(?=\s*#{1,6}\s)/))
+    .flatMap(block => {
+      const heading = block.match(/^(\s*#{1,6}\s[^\n]*)\n([\s\S]+)$/);
+      return heading ? [heading[1], heading[2]] : [block];
+    })
+    .flatMap(splitOnQuoteBoundary)
+    .map(paragraph =>
+      paragraph
+        .replace(/^[ \t]*>+[ \t]?/gm, "")
+        .replace(/\s+/g, " ")
+        .trim()
+    )
+    .filter(Boolean);
+}
+
+/**
  * Captures everything after `blob|tree|raw`, because the ref is not one segment. A branch may
  * contain slashes (`feature/docs-refresh`), and git accepts it: `git check-ref-format --branch
  * feature/docs-refresh` exits 0. Splitting on the first slash would read the ref as `feature`
@@ -140,7 +385,7 @@ function publishedPackages(repoRoot, findings) {
       continue;
     }
     if (json.private) continue;
-    out.push({ name: json.name, dir: join(pkgDir, name) });
+    out.push({ name: json.name, dir: join(pkgDir, name), json });
   }
   return out;
 }
@@ -421,11 +666,16 @@ export async function runChecks({
   const exemption = check => {
     const forCheck = allowlist[check] ?? {};
     const byPath = new Map();
+    // Both sides in POSIX form. The allowlist is written with "/" and git hands
+    // callers the same, but a caller deriving a path with `relative()` gets a
+    // backslash on Windows, and a key that does not match reads as "not exempt"
+    // rather than as an error.
+    const posix = value => value.split(sep).join("/");
     for (const [path, entry] of Object.entries(forCheck)) {
-      byPath.set(path.split("/").join(sep), new Set(entry.digests ?? []));
+      byPath.set(posix(path), new Set(entry.digests ?? []));
     }
     return (relPath, line) => {
-      const digests = byPath.get(relPath);
+      const digests = byPath.get(posix(relPath));
       return digests ? digests.has(digestLine(line)) : false;
     };
   };
@@ -465,6 +715,70 @@ export async function runChecks({
         message: `${pkg.name} is published but is not named in the root README`,
       });
     }
+  }
+
+  // --- the category these files state ---
+  //
+  // Read through `renderedProse`, the same view the README skeleton check uses,
+  // so a fenced example or a commented-out block is not mistaken for the
+  // project describing itself. No line number: these are whole documents making
+  // a claim, and the file is the useful thing to name, which is how the other
+  // document-level checks here report.
+  //
+  // Four Markdown forms are knowingly not handled, each counted across these
+  // six files and found zero times: a fence inside a quotation, code indented
+  // by four spaces, a code span closing on a shorter backtick run, and a
+  // shortcut reference link resolved against a `[label]:` definition. The first
+  // three would be a false report and the allowlist answers those; the last is
+  // a missed one. Resolving any of them means reading Markdown properly rather
+  // than reading what it renders, which is the depth this check exists without.
+  const categoryExempt = exemption("retired-category");
+  const trackedSet = new Set(tracked);
+  for (const rel of CATEGORY_SURFACES) {
+    if (!trackedSet.has(rel)) continue;
+    let text;
+    try {
+      text = readFileSync(join(repoRoot, rel), "utf-8");
+    } catch {
+      continue;
+    }
+    for (const paragraph of proseParagraphs(text, { mdx: rel.endsWith(".mdx") })) {
+      if (!RETIRED_CATEGORY.test(paragraph) || categoryExempt(rel, paragraph)) continue;
+      findings.push({
+        check: "retired-category",
+        file: rel,
+        line: null,
+        message: `"app framework" — the category is "content platform"; say what this is for`,
+      });
+      break;
+    }
+  }
+
+  // A published description and its keywords are read on npm rather than here,
+  // and say the same thing about the same product, so they are category surfaces
+  // too. A keyword is the searchable one: it is how the category is found rather
+  // than how it is stated.
+  //
+  // Taken from the list `publishedPackages` already parsed. Enumerating the
+  // manifests again here would be a second answer to "which packages ship",
+  // free to disagree with the first.
+  for (const pkg of packages) {
+    const rel = relative(repoRoot, join(pkg.dir, "package.json")).split(sep).join("/");
+    // Each field on its own. Joined, a description ending in "app" and a keyword
+    // "framework" would read as the phrase that neither of them contains.
+    const published = [pkg.json.description, ...(pkg.json.keywords ?? [])].filter(
+      value => typeof value === "string"
+    );
+    const claim = published.find(
+      value => RETIRED_CATEGORY.test(value) && !categoryExempt(rel, value)
+    );
+    if (claim === undefined) continue;
+    findings.push({
+      check: "retired-category",
+      file: rel,
+      line: null,
+      message: `"app framework" — the category is "content platform"; say what this is for`,
+    });
   }
 
   // --- per-line prose checks ---

--- a/scripts/check-docs-claims.test.mjs
+++ b/scripts/check-docs-claims.test.mjs
@@ -166,6 +166,408 @@ describe("naming-rule", () => {
   });
 });
 
+describe("retired-category", () => {
+  it("declares only surfaces that exist, so a rename cannot drop one silently", async () => {
+    const { CATEGORY_SURFACES } = await import("./check-docs-claims.mjs");
+    const { existsSync } = await import("node:fs");
+    const missing = CATEGORY_SURFACES.filter(rel => !existsSync(rel));
+    expect(missing).toEqual([]);
+  });
+
+  it("fires when a surface that states the category uses the retired one", async () => {
+    expect(
+      await checksFor({ "docs/index.mdx": "Nextly is an app framework for Next.js.\n" })
+    ).toContain("retired-category");
+  });
+
+  it("fires on the hyphenated spelling", async () => {
+    expect(
+      await checksFor({ "AGENTS.md": "A TypeScript CMS/app-framework monorepo.\n" })
+    ).toContain("retired-category");
+  });
+
+  it("fires on the plural, which claims the same category", async () => {
+    expect(
+      await checksFor({ "README.md": "Nextly is one of several app frameworks.\n" })
+    ).toContain("retired-category");
+  });
+
+  it("fires through a tag around one word of the phrase", async () => {
+    expect(
+      await checksFor({ "docs/index.mdx": "Nextly is an app <strong>framework</strong>.\n" })
+    ).toContain("retired-category");
+  });
+
+  it("fires through emphasis, an inline link and a reference link", async () => {
+    for (const body of [
+      "Nextly is an app **framework**.\n",
+      "Nextly is an app [framework](/x).\n",
+      "Nextly is an app [framework][term].\n",
+    ]) {
+      expect(await checksFor({ "docs/index.mdx": body })).toContain("retired-category");
+    }
+  });
+
+  it("fires when a soft wrap splits the phrase", async () => {
+    expect(
+      await checksFor({ "AGENTS.md": "Nextly is an app\nframework for Next.js.\n" })
+    ).toContain("retired-category");
+  });
+
+  it("fires on a published package description", async () => {
+    expect(
+      await checksFor({
+        "packages/nextly/package.json": JSON.stringify({
+          name: "nextly",
+          version: "1.0.0",
+          description: "Nextly is an app framework for Next.js.",
+        }),
+      })
+    ).toContain("retired-category");
+  });
+
+  it("does not read an mdx comment as prose", async () => {
+    expect(
+      await checksFor({ "docs/index.mdx": "a\n\n{/* once an app framework */}\n\nb\n" })
+    ).not.toContain("retired-category");
+  });
+
+  it("does not read a code span that spans lines as a claim", async () => {
+    expect(
+      await checksFor({ "docs/index.mdx": "Compare `an\napp framework\nliteral` here.\n" })
+    ).not.toContain("retired-category");
+  });
+
+  it("does not run two list items together into a phrase", async () => {
+    expect(
+      await checksFor({ "docs/index.mdx": "Notes:\n\n- app\n- framework\n" })
+    ).not.toContain("retired-category");
+  });
+
+  it("fires when a quotation wraps across its lines", async () => {
+    expect(
+      await checksFor({ "README.md": "> Nextly is an app\n> framework for Next.js.\n" })
+    ).toContain("retired-category");
+  });
+
+  it("fires on a published keyword", async () => {
+    expect(
+      await checksFor({
+        "packages/nextly/package.json": JSON.stringify({
+          name: "nextly",
+          version: "1.0.0",
+          description: "A content platform.",
+          keywords: ["cms", "app-framework"],
+        }),
+      })
+    ).toContain("retired-category");
+  });
+
+  it("does not read a heading as running into the paragraph beneath it", async () => {
+    expect(
+      await checksFor({ "README.md": "## App\nFramework notes follow here.\n" })
+    ).not.toContain("retired-category");
+  });
+
+  it("does not read an mdx import as prose", async () => {
+    expect(
+      await checksFor({ "docs/index.mdx": 'import D from "./x/app-framework.mjs";\n\nHello.\n' })
+    ).not.toContain("retired-category");
+  });
+
+  it("fires when a space entity stands between the words", async () => {
+    for (const body of ["an app&nbsp;framework.\n", "an app&#160;framework.\n"]) {
+      expect(await checksFor({ "docs/index.mdx": body })).toContain("retired-category");
+    }
+  });
+
+  it("does not join a paragraph and the quotation beside it, either way round", async () => {
+    for (const body of ["App\n> Framework configuration.\n", "> App\nFramework configuration.\n"]) {
+      expect(await checksFor({ "README.md": body })).not.toContain("retired-category");
+    }
+  });
+
+  it("does not leave prose behind when a wide code span holds a shorter run", async () => {
+    expect(
+      await checksFor({ "docs/index.mdx": "Compare ``foo` app framework `` literally.\n" })
+    ).not.toContain("retired-category");
+  });
+
+  it("does not read an mdx import that wraps across lines", async () => {
+    expect(
+      await checksFor({
+        "docs/index.mdx": 'import {\n  Demo,\n} from "./examples/app-framework.mjs";\n\nHello.\n',
+      })
+    ).not.toContain("retired-category");
+  });
+
+  it("does not join manifest fields into a phrase neither one contains", async () => {
+    expect(
+      await checksFor({
+        "packages/nextly/package.json": JSON.stringify({
+          name: "nextly",
+          version: "1.0.0",
+          description: "CLI for your Next.js app",
+          keywords: ["framework", "cms"],
+        }),
+      })
+    ).not.toContain("retired-category");
+  });
+
+  it("does not read a heading as running on, wherever it sits in the block", async () => {
+    expect(
+      await checksFor({ "README.md": "Intro.\n## App\nFramework configuration.\n" })
+    ).not.toContain("retired-category");
+  });
+
+  it("reads a Markdown line beginning with import as prose, not a statement", async () => {
+    expect(
+      await checksFor({
+        "AGENTS.md": "Nextly lets developers\nimport Nextly as an app framework today.\n",
+      })
+    ).toContain("retired-category");
+  });
+
+  it("fires when a line break carries the space between the words", async () => {
+    for (const body of ["Nextly is an app<br/>framework.\n", "Nextly is an app\\\nframework.\n"]) {
+      expect(await checksFor({ "README.md": body })).toContain("retired-category");
+    }
+  });
+
+  it("does not read an html code element as a claim", async () => {
+    expect(
+      await checksFor({ "README.md": "Use <code>app framework</code> literally.\n" })
+    ).not.toContain("retired-category");
+  });
+
+  it("reads a page's published title and description out of its frontmatter", async () => {
+    for (const front of ["title: The app framework", "description: Nextly is an app framework."]) {
+      expect(
+        await checksFor({ "docs/index.mdx": `---\n${front}\n---\n\nHello.\n` })
+      ).toContain("retired-category");
+    }
+  });
+
+  it("does not read the rest of the frontmatter, but still reads the body", async () => {
+    expect(
+      await checksFor({ "docs/index.mdx": "---\nlegacy: app framework\n---\n\nHello.\n" })
+    ).not.toContain("retired-category");
+    expect(
+      await checksFor({ "docs/index.mdx": "---\ntitle: Docs\n---\n\nNextly is an app framework.\n" })
+    ).toContain("retired-category");
+  });
+
+  it("decodes every spelling of the separators", async () => {
+    for (const body of [
+      "an app&#x20;framework.\n",
+      "an app&#45;framework.\n",
+      "an app&#x2d;framework.\n",
+    ]) {
+      expect(await checksFor({ "docs/index.mdx": body })).toContain("retired-category");
+    }
+  });
+
+  it("reads a frontmatter value written as a folded or literal scalar", async () => {
+    for (const marker of [">-", "|"]) {
+      expect(
+        await checksFor({
+          "docs/index.mdx": `---\ndescription: ${marker}\n  Nextly is an app framework.\n---\n\nHi.\n`,
+        })
+      ).toContain("retired-category");
+    }
+  });
+
+  it("reads an image's alternative text, which a reader is shown", async () => {
+    expect(
+      await checksFor({
+        "README.md": '<img src="x.png" alt="Nextly is an app framework" />\n',
+      })
+    ).toContain("retired-category");
+  });
+
+  it("recognises frontmatter terminated by CRLF or by end of file", async () => {
+    for (const body of ["---\r\nlegacy: app framework\r\n---\r\n\r\nHi.\n", "---\nlegacy: app framework\n---"]) {
+      expect(await checksFor({ "docs/index.mdx": body })).not.toContain("retired-category");
+    }
+  });
+
+  it("reads a diagram's labels, which are drawn for the reader", async () => {
+    expect(
+      await checksFor({
+        "ARCHITECTURE.md": 'Intro.\n\n```mermaid\ngraph TD\n  N["Nextly app framework"]\n```\n\nTail.\n',
+      })
+    ).toContain("retired-category");
+  });
+
+  it("reads an indented mdx line as list content, not module syntax", async () => {
+    expect(
+      await checksFor({
+        "docs/index.mdx": "- Nextly lets developers\n  import Nextly as an app framework.\n",
+      })
+    ).toContain("retired-category");
+  });
+
+  it("does not read a yaml comment as part of the published value", async () => {
+    expect(
+      await checksFor({
+        "docs/index.mdx": "---\ndescription: A content platform # formerly an app framework\n---\n\nHi.\n",
+      })
+    ).not.toContain("retired-category");
+  });
+
+  it("reads a block scalar that has a blank line inside it", async () => {
+    expect(
+      await checksFor({
+        "docs/index.mdx": "---\ndescription: >-\n  Nextly is an app\n\n  framework for Next.js.\n---\n\nHi.\n",
+      })
+    ).toContain("retired-category");
+  });
+
+  it("reads a round mermaid node as well as a square one", async () => {
+    expect(
+      await checksFor({
+        "ARCHITECTURE.md": "Intro.\n\n```mermaid\ngraph TD\n  N(Nextly app framework)\n```\n\nTail.\n",
+      })
+    ).toContain("retired-category");
+  });
+
+  it("reads escaped punctuation as the mark it renders", async () => {
+    expect(
+      await checksFor({ "docs/index.mdx": "Nextly is an app\\-framework for Next.js.\n" })
+    ).toContain("retired-category");
+  });
+
+  it("does not read a comment that follows a quoted value", async () => {
+    expect(
+      await checksFor({
+        "docs/index.mdx": '---\ndescription: "A content platform" # formerly an app framework\n---\n\nHi.\n',
+      })
+    ).not.toContain("retired-category");
+    expect(
+      await checksFor({ "docs/index.mdx": '---\ndescription: "Nextly is an app framework"\n---\n\nHi.\n' })
+    ).toContain("retired-category");
+  });
+
+  it("honours an allowlist entry written with posix separators", async () => {
+    const claim = "Nextly is an app framework.";
+    const { root, files } = await fixture({ "docs/index.mdx": `${claim}\n` });
+    const { findings } = await runChecks({
+      repoRoot: root,
+      files,
+      remoteRefs: REFS,
+      hasLocalCommit: () => true,
+      allowlist: {
+        "retired-category": { "docs/index.mdx": { count: 1, digests: [digestLine(claim)] } },
+      },
+    });
+    expect(findings.filter(f => f.check === "retired-category")).toHaveLength(0);
+  });
+
+  it("reads a mermaid edge label", async () => {
+    expect(
+      await checksFor({
+        "ARCHITECTURE.md": "I.\n\n```mermaid\ngraph TD\n  A -->|Nextly app framework| B\n```\n\nT.\n",
+      })
+    ).toContain("retired-category");
+  });
+
+  it("reads the captions a component is given, and only those", async () => {
+    expect(
+      await checksFor({ "docs/index.mdx": '<Tabs items={["app framework", "cms"]}>\n\nHi.\n' })
+    ).toContain("retired-category");
+    expect(
+      await checksFor({ "docs/index.mdx": '<Callout title="Nextly is an app framework">\n\nHi.\n' })
+    ).toContain("retired-category");
+    expect(
+      await checksFor({ "docs/index.mdx": '<Tabs items={["content platform", "cms"]}>\n\nHi.\n' })
+    ).not.toContain("retired-category");
+  });
+
+  it("does not read a component's configuration as a caption", async () => {
+    expect(
+      await checksFor({
+        "docs/index.mdx": '<Tabs items={["content platform"]} className="app-framework">\n\nHi.\n',
+      })
+    ).not.toContain("retired-category");
+  });
+
+  it("reads a brace-delimited mermaid node", async () => {
+    expect(
+      await checksFor({
+        "ARCHITECTURE.md": "I.\n\n```mermaid\ngraph TD\n  A{Nextly app framework}\n```\n\nT.\n",
+      })
+    ).toContain("retired-category");
+  });
+
+  it("does not read a link definition, which renders no text", async () => {
+    expect(
+      await checksFor({ "README.md": "[legacy]: https://example.com/app-framework\n\nHi.\n" })
+    ).not.toContain("retired-category");
+  });
+
+  it("removes module syntax with a punctuator after the keyword", async () => {
+    expect(
+      await checksFor({
+        "docs/index.mdx": 'export{default as Demo}from "./app-framework.mjs";\n\nHi.\n',
+      })
+    ).not.toContain("retired-category");
+  });
+
+  it("decodes escapes inside a double-quoted frontmatter value", async () => {
+    expect(
+      await checksFor({
+        "docs/index.mdx": '---\ndescription: "Nextly is an app\\x20framework"\n---\n\nHi.\n',
+      })
+    ).toContain("retired-category");
+  });
+
+  it("does not fire on the category that replaced it", async () => {
+    expect(
+      await checksFor({ "docs/index.mdx": "Nextly is an open-source content platform.\n" })
+    ).not.toContain("retired-category");
+  });
+
+  it("does not read a fenced example as the project describing itself", async () => {
+    expect(
+      await checksFor({ "docs/index.mdx": "intro\n\n```\napp framework\n```\n\ntail\n" })
+    ).not.toContain("retired-category");
+  });
+
+  it("does not read a commented-out block as prose", async () => {
+    expect(
+      await checksFor({ "docs/index.mdx": "a\n<!--\napp framework\n-->\nb\n" })
+    ).not.toContain("retired-category");
+  });
+
+  it("does not read a code span as a claim, at any delimiter width", async () => {
+    expect(
+      await checksFor({ "ARCHITECTURE.md": "Compare ``app framework`` and `app framework`.\n" })
+    ).not.toContain("retired-category");
+  });
+
+  it("does not read a document that states no category", async () => {
+    expect(
+      await checksFor({ "docs/guides/tutorial.mdx": "Nextly is an app framework.\n" })
+    ).not.toContain("retired-category");
+  });
+
+  it("reports the file rather than a line, and reports it once", async () => {
+    const { root, files } = await fixture({
+      "docs/index.mdx": "Nextly is an app framework.\nStill an app framework here.\n",
+    });
+    const { findings } = await runChecks({
+      repoRoot: root,
+      files,
+      remoteRefs: REFS,
+      hasLocalCommit: () => true,
+    });
+    const hits = findings.filter(f => f.check === "retired-category");
+    expect(hits).toHaveLength(1);
+    expect(hits[0].file).toBe("docs/index.mdx");
+    expect(hits[0].line).toBeNull();
+  });
+});
+
 describe("dead-branch-link", () => {
   it("fires when a linked ref does not resolve", async () => {
     expect(


### PR DESCRIPTION
`check:docs-claims` had one prose rule and it was about the bare phrase "Visual Builder". A retired **category** was not covered, so it could return with nothing noticing. It had: `docs/getting-started` opened by calling Nextly an app framework, `AGENTS.md` and `ARCHITECTURE.md` said the same, and `.github/review-prompt.md` described the repo as a `CMS/app-framework monorepo`, which meant the retired category was briefing this repo's review agent on every pull request. Those are fixed in #1550; this stops them coming back.

## Six files, not every document

```
README.md   AGENTS.md   ARCHITECTURE.md
.github/review-prompt.md   docs/index.mdx   docs/getting-started/index.mdx
```

A category is stated in a handful of places and repeated nowhere else. A wider net only adds ways to be wrong: a tutorial quoting the old name, or a code sample containing the words, is not the project calling itself something. Adding a surface is a deliberate act.

## How it reads them

Through `renderedProse`, the same view the README skeleton check already uses, so a fenced example or a commented-out block is not mistaken for the project describing itself. **No new Markdown parsing.**

On the line: code spans blanked at any delimiter width, tags resolved. Both spellings occur in these files, so `an app <strong>framework</strong>` reports and an ``app framework`` literal does not. The pattern takes a hyphen or whitespace and an optional plural, since the repo has spelled it both ways and "one of several app frameworks" is the same claim.

Reported against the file, not a line, as the other document-level checks here do.

## Why this shape

An earlier version of this PR was repo-wide and Markdown-aware. Across seven review rounds it drew ~18 findings, each a construct a hand-written scanner did not know about, and four of them were **false positives that would have failed CI on correct documentation**. I reproduced all eight of the last round against a harness with working positive and negative controls:

```
MISSED           inline html tag              FALSE POSITIVE  multi-backtick code span
MISSED           plural                       FALSE POSITIVE  blockquoted fence
MISSED           comment inside a fence       FALSE POSITIVE  four-space indented code
                                              FALSE POSITIVE  marker-only quote line
```

Narrowing the scope resolves all of them without a parser: **334 lines became 142**, and the false-positive class is gone because these six files are prose, not code.

## Known limit, measured

`renderedProse` knows top-level fences and comments, not fences inside a quotation or code indented by four spaces. Counted across the six files in scope: **0 blockquoted fences, 0 indented code blocks**. Both would be a false report rather than a missed one, and the allowlist answers it. Recorded in the code rather than left implicit.

## Evidence

**10 tests**, `60 passed`. Each mechanism checked against the version that drops it:

| removed | tests that fail |
|---|---|
| the pattern | the four positive cases |
| `renderedProse` | fenced example, commented-out block |
| inline resolution | tag case, code-span case |
| the six-file scope | "does not read a document that states no category" |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added validation for retired “app framework” category references across documentation and public package metadata.
  - Checks now recognize wording across Markdown/MDX formatting, frontmatter, and HTML entities.
  - Added support for approved exceptions and clearer handling of replacement wording.

- **Bug Fixes**
  - Improved filtering to avoid false positives from code, comments, imports, private packages, and non-rendered content.
  - Consolidated duplicate findings so each affected file receives a single report.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->