### PR TITLE
test(plugin-page-builder): tell nested discovery from a top-level miss

### DIFF
--- a/packages/plugin-page-builder/src/component-readiness-hook.test.ts
+++ b/packages/plugin-page-builder/src/component-readiness-hook.test.ts
@@ -940,8 +940,21 @@ describe("reading definitions the way the renderer reads them", () => {
 
     await handlers[0]!(write);
 
-    // The nested component is not published, so the expanded read finds a hole
-    // the bare read cannot see. Forcing `depth: 0` makes this silent.
+    // WHICH component, not how many. A count alone cannot tell nested discovery
+    // from a top-level miss: had the first lookup failed to return `hero`, the
+    // resolver would report `hero` itself as missing, the same "1 component"
+    // would hold, and the depth assertion would hold too because that lone
+    // request also omits `depth`. So the discriminating fact is that a SECOND
+    // lookup went out for the nested id — which only happens if `hero` came
+    // back, its expanded document was read, and the walk descended into it.
+    const asked = finds.map(
+      find =>
+        ((find.where as { id?: { in?: string[] } }).id?.in ?? []) as string[]
+    );
+    expect(asked[0]).toEqual(["hero"]);
+    expect(asked.some(ids => ids.includes("nested-unpublished"))).toBe(true);
+
+    // And `hero` is NOT the one reported: it came back published.
     expect(recorded).toHaveLength(1);
     expect((recorded[0] as { message: string }).message).toContain(
       "1 component"


### PR DESCRIPTION
A P1 on #1548, which had already merged.

## The test proved less than it claimed

It asserted a **count**. A count cannot distinguish the two things it needed to:
had the first lookup failed to return the outer component, the resolver would
report *that* component as missing, the same `"1 component"` would hold, and the
no-`depth` assertion would hold too — because that lone request also omits
`depth`.

So the test would have passed while proving nothing about the descent it exists
for. It is the same class as the finding it was written to fix: the previous
round moved it from asserting a request to asserting an outcome, and the outcome
turned out not to be discriminating either.

## What it asserts now

**Which ids were requested.** The first lookup asks for the outer component; a
later one asks for the nested id. That second request only happens if the outer
component came back, its expanded document was read, and the walk descended into
it.

## Verified against the confound, not just the fix

Making the store return no outer row — exactly the case in the finding — now
**fails**, on `expected false to be true` for the nested-lookup assertion. Before
this change that same confound passed.

## Gates

| Gate | Result |
|---|---|
| `plugin-page-builder` | 59 files, 639 tests, exit 0 |
| `check-types` | exit 0 |
| `fallow --gate new-only` | **pass**, 0 introduced in every category |
| `check:comments` | exit 0 |

No changeset: test-only, no shipped behaviour changes, and `changeset status`
passes without one.
