### PR TITLE
fix(root): stop publishing the retired category as a keyword

### DIFF
--- a/.changeset/retire-the-app-framework-keyword.md
+++ b/.changeset/retire-the-app-framework-keyword.md
@@ -1,0 +1,38 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Stop publishing the retired category as an npm keyword.
+
+`nextly`, `@nextlyhq/plugin-form-builder` and `@nextlyhq/plugin-seo` each
+listed `app-framework`, so the category the project moved away from was
+searchable on npm, where more people meet it than meet the repository.
+`nextly@0.0.2-alpha.62` carries it today.
+
+The platform keyword becomes `page-builder`, which is the half of the
+descriptor npm had no word for. The two plugins simply drop it: neither is a
+framework, and the keyword was describing the host rather than the plugin.

--- a/packages/nextly/package.json
+++ b/packages/nextly/package.json
@@ -337,7 +337,7 @@
     "cms",
     "nextjs",
     "headless-cms",
-    "app-framework",
+    "page-builder",
     "framework",
     "typescript",
     "react",

--- a/packages/plugin-form-builder/package.json
+++ b/packages/plugin-form-builder/package.json
@@ -77,8 +77,7 @@
     "forms",
     "form-builder",
     "cms",
-    "headless-cms",
-    "app-framework"
+    "headless-cms"
   ],
   "repository": {
     "type": "git",

--- a/packages/plugin-seo/package.json
+++ b/packages/plugin-seo/package.json
@@ -53,8 +53,7 @@
     "sitemap",
     "metadata",
     "cms",
-    "headless-cms",
-    "app-framework"
+    "headless-cms"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
The retired category is published on npm right now.

```
$ npm view nextly@0.0.2-alpha.62 keywords
[ ... 'app-framework', 'framework', ... ]
```

Three packages list it: `nextly`, `@nextlyhq/plugin-form-builder` and `@nextlyhq/plugin-seo`. npm keyword search reaches more people than this repository does, so this is the widest surface the old category was still on, and the one nothing was checking.

Found by review on #1551, which is the guard for exactly this class. Split out because it is a user-facing fix and should not wait on that PR, which has taken nine review rounds.

## What changes

| package | before | after |
|---|---|---|
| `nextly` | `app-framework` | **`page-builder`** |
| `@nextlyhq/plugin-form-builder` | `app-framework` | removed |
| `@nextlyhq/plugin-seo` | `app-framework` | removed |

`page-builder` rather than nothing on the platform package, because the descriptor is "open-source CMS and visual page builder for Next.js" and npm had a word for the CMS half but not the builder half. The plugins simply drop it: neither is a framework, and the keyword was describing the host.

`framework` on its own stays. It is a generic search term rather than a claim about the category.

## Notes

Manifests are edited as text rather than parsed and reserialised, so nothing else in them moves.

Changeset covers all 25 published packages at `patch`, since they version in lockstep. This changes published metadata, so it is not a docs-only PR.

Once this merges, #1551 adds a check so the keyword cannot come back.
