### PR TITLE
feat(blocks-engine): publish the sibling-run rule and plan a pattern from a selection

### DIFF
--- a/.changeset/a-saved-pattern-is-lifted-out-as-one-run.md
+++ b/.changeset/a-saved-pattern-is-lifted-out-as-one-run.md
@@ -123,3 +123,38 @@ document nothing validated: two nodes may share an id, and the parent a lookup
 answers with is the first one, not necessarily the one the selection was located
 under. Measured on a document with two parents sharing an id, selecting the
 second parent's children saved the first parent's.
+
+A run is identified by the nodes it was found at, not by their ids. An id is not
+an identity on a document nothing validated: two parents may share one, so
+comparing parent ids merged two containers and accepted children that were never
+siblings. Worse, two lookups of one id disagree in a way no reader would
+predict, because locating a node checks every root before descending while
+finding one walks each root and its descendants in turn — so a nested node and a
+later top-level node sharing an id resolve differently, and re-resolving stored
+the wrong one. The run now carries the node and the parent it actually reached,
+which removes the second lookup rather than trying to make the two agree.
+
+A saved run is refused when it could not be a document. Saving lifts the
+selection out of whatever contained it, so the pattern's roots are the selected
+blocks — and a block declaring which parents it may sit in has just lost the only
+one it had. Selecting columns inside a Columns block is the ordinary way to reach
+this, and the planner reported success while the create refused the document. The
+shared nesting rule is consulted before the lift and the refusal names the
+parents the block requires.
+
+A bound link's fallback follows the copy. A bound `href` keeps its literal in
+`bindings.href.fallback`, which is exactly what renders when the source is empty
+or unresolvable — so a fallback left behind produces a link that works until the
+data does not, which is the one case the fallback exists to cover.
+
+The prop scan is bounded by the document rather than by a number. Both earlier
+caps were guesses about how large a legitimate prop tree gets, and a document
+past the guess had its links silently left dangling instead of being refused. How
+large a document may be is already decided once, by the document limits, so all
+that a cap was really buying was termination on a value that refers to itself —
+which a path set gives without capping anything.
+
+`FRAGMENT_REFERENCE_PROPS`, `remapFragmentProps` and `remapFragmentBindings` are
+exported. A rule described as the single source for every copying surface, which
+a consumer cannot import, is a rule they will write again — which is precisely
+how this one came to exist twice.

--- a/.changeset/a-saved-pattern-is-lifted-out-as-one-run.md
+++ b/.changeset/a-saved-pattern-is-lifted-out-as-one-run.md
@@ -79,3 +79,22 @@ stored documents claiming one id leave any index keyed on it unable to say which
 node it describes. Page-scoped settings are not copied: a document background
 and its custom CSS describe the page, not the run, so a pattern carrying them
 would repaint every page it was inserted into.
+
+A copied subtree's fragment links follow it. `cssId` is not referenced only by
+markup: a link's `href` may be `#pricing`, and the renderer passes a bare
+fragment straight through to the DOM, so a copier that mints a new id for the
+target and leaves the link behind stores an anchor resolving to nothing — the
+same silent breakage as a dangling `aria-labelledby`, one prop over. Composition
+had grown this rule; the copier that saves a pattern was written without it, and
+a later insert cannot repair the result because its own map is keyed by the id
+the save already renamed. The rule now lives in one module that both copiers
+use. It stays narrow — only a whole string of `#` followed by an id THIS copy
+minted is rewritten — so `"#1 bestseller"` is content and a fragment addressing
+something outside the copied run belongs to the page and keeps working.
+
+Locating a node tolerates a damaged document. A stored slot holding `null`
+instead of an array, or a list with a hole in it, threw out of the search and
+took down every caller — a multi-block reorder and a saved pattern included —
+for a node neither of them had touched. These primitives are documented as
+reading documents nothing has validated, so a broken entry is skipped and the
+answer is about the nodes that were actually asked for.

--- a/.changeset/a-saved-pattern-is-lifted-out-as-one-run.md
+++ b/.changeset/a-saved-pattern-is-lifted-out-as-one-run.md
@@ -158,3 +158,23 @@ which a path set gives without capping anything.
 exported. A rule described as the single source for every copying surface, which
 a consumer cannot import, is a rule they will write again — which is precisely
 how this one came to exist twice.
+
+The link scan carries its own stack and its own replacement map. Three separate
+bounds had been tried here and each was a guess about how large a valid prop
+tree gets — a depth cap, a visit budget, and then the component-envelope key
+budget applied to opaque prop records the format does not cap at all. Every one
+of them failed in the same direction: a document past the guess had its links
+silently left dangling instead of being refused. Depth and width are properties
+of authored content, and how large a document may be is already decided once by
+the document limits, so the walk now has no limit of its own.
+
+A recursive walk also could not survive its own input: a few thousand nested
+records is tens of kilobytes, inside the byte limit, and exhausted the call
+stack. The walk is iterative for the same reason the forest walker is.
+
+Rebuilding through one replacement per source object is what makes a copied
+graph come out a graph. Guarding a cycle by tracking the path terminates but
+leaves the copy holding an edge back to the ORIGINAL object — still carrying the
+id the pass just rewrote — so one graph ends up with two versions of one node.
+The same map preserves structure shared without a cycle, rather than splitting a
+record reached from two places into two copies that can drift apart.

--- a/.changeset/a-saved-pattern-is-lifted-out-as-one-run.md
+++ b/.changeset/a-saved-pattern-is-lifted-out-as-one-run.md
@@ -1,0 +1,81 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A selection can be saved as a pattern, and whether it is one run of siblings is
+now decided in one place.
+
+`planSaveAsPattern` is the first of the composition planners: it reads a
+document and answers with the library row to create and the ops the page needs,
+writing nothing. Saving a pattern leaves the page exactly as it was — a pattern
+is copied on insert and keeps no link back — so its page ops are empty, and that
+is the whole behavioural difference from converting a selection into a linked
+component. Splitting the decision from the doing is what lets the caller put the
+create and the page edit in one unit of work and roll the create back when the
+edit fails, and it makes a dry run and a real run the same function rather than
+two that agree until one moves.
+
+The rule about what may be saved — a contiguous run of siblings in one parent
+and slot — moves into the engine and is published from it. The builder had a
+private half of it, which was right while the editor was its only caller and
+stopped being right once planners existed: a planner runs inside a plugin's
+server action, where the builder cannot be imported because it peer-depends on
+React, and the dependency direction is builder to engine, so the engine could
+not have imported a builder-side rule back. One of the two would have had to be
+a second implementation of "do these blocks share a list", and the module that
+held the first one says why that ends badly — it would eventually disagree with
+the toolbar and the keyboard, which act through it. The builder's copy is
+deleted and its multi-block reorder now asks the engine.
+
+The refusal reports its CAUSE rather than a sentence. Which remedy to offer
+belongs to the verb — moving, saving as a pattern and converting to a component
+are three different things to be told to do instead — so the engine says what it
+observed and each surface phrases it. An id the document does not hold is
+reported separately from blocks that sit in different containers: one is a
+caller out of step with the document and the other is an author who selected
+across a boundary, and a single refusal would have sent both to whichever
+sentence was written first.
+
+`reidForestWithMap` re-identifies a run of roots as ONE copy. A saved selection
+is several roots, and re-identifying them one at a time is not the same
+operation: each call can only see the subtree it was handed, so a reference that
+crosses from one root to the next finds no entry in that pass's map and is left
+pointing at the element in the page the pattern was saved from. For
+`aria-labelledby` and `aria-describedby` that is a copy that has silently lost
+its accessible name — invisible to everyone not using assistive technology, and
+by the time it is noticed the pattern is on twenty pages. `reidSubtreeWithMap`
+is now this function called with one root, so the singular and the plural cannot
+drift into disagreeing about what a copy is.
+
+A stored pattern gets fresh ids rather than the page's. It would render
+correctly either way, because insert re-identifies too; storing the page's ids
+would still be wrong, because a node id is how everything here addresses a node
+— styles, locale overlays, the class-usage record, editor history — and two
+stored documents claiming one id leave any index keyed on it unable to say which
+node it describes. Page-scoped settings are not copied: a document background
+and its custom CSS describe the page, not the run, so a pattern carrying them
+would repaint every page it was inserted into.

--- a/.changeset/a-saved-pattern-is-lifted-out-as-one-run.md
+++ b/.changeset/a-saved-pattern-is-lifted-out-as-one-run.md
@@ -98,3 +98,28 @@ took down every caller — a multi-block reorder and a saved pattern included �
 for a node neither of them had touched. These primitives are documented as
 reading documents nothing has validated, so a broken entry is skipped and the
 answer is about the nodes that were actually asked for.
+
+Only a field that HOLDS a link target is rewritten, and matching a minted id is
+not enough on its own. `core/heading` declares `text` and `href` as separate
+props, so a heading legitimately reading `#pricing` beside a sibling carrying
+`cssId: "pricing"` was rewritten to `#pricing-<suffix>` — authored content
+changed silently, and then carried into every insertion of the pattern. The
+field name now decides and the value only decides whether there is anything to
+do, with `href` and `url` listed as data the way the id-bearing markup
+attributes already are. A block with a differently-named target leaves a link
+that no longer jumps, which an author can see and repair; the alternative
+changed what a page said without anyone being able to see it.
+
+The scan bounds WORK rather than depth. A rich-text link inside a list item sits
+ten values down a prop tree, past the old depth cap of eight, so an ordinary
+link in a bulleted list was left pointing at an id that had been re-minted. Any
+fixed depth is arbitrary — rich text nests as deeply as an author nests it —
+while a visit budget bounds a wide tree as well as a deep one and still
+terminates on a value that refers to itself.
+
+A saved run reads each selected node by its own id. Resolving the run's parent a
+second time and indexing into its slot is not the same operation on a stored
+document nothing validated: two nodes may share an id, and the parent a lookup
+answers with is the first one, not necessarily the one the selection was located
+under. Measured on a document with two parents sharing an id, selecting the
+second parent's children saved the first parent's.

--- a/packages/blocks-engine/src/composition-planners.test.ts
+++ b/packages/blocks-engine/src/composition-planners.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Planning a saved pattern from a selection.
+ *
+ * The assertion that matters most is the cross-root reference one. A pattern is
+ * a RUN of siblings, so its document has several roots, and the obvious
+ * implementation — re-identify each root in turn — produces a pattern that
+ * renders, validates and looks right, while a button in the second root points
+ * its `aria-describedby` at an element in the page it was saved FROM. Nothing
+ * on screen shows it. The only people who find out are the ones using a screen
+ * reader, and by then the pattern has been inserted on twenty pages.
+ */
+import { describe, expect, it } from "vitest";
+
+import { planSaveAsPattern } from "./composition-planners";
+import { DOCUMENT_FORMAT_VERSION } from "./document";
+import type { BlockDocument, BlockNode } from "./document";
+import { walkNodes } from "./tree";
+
+function node(
+  id: string,
+  extra: Partial<BlockNode> = {},
+  slots?: Record<string, BlockNode[]>
+): BlockNode {
+  return {
+    id,
+    type: "core/box",
+    version: 1,
+    props: {},
+    ...extra,
+    ...(slots === undefined ? {} : { slots }),
+  };
+}
+
+function page(
+  nodes: BlockNode[],
+  settings?: BlockDocument["settings"]
+): BlockDocument {
+  return {
+    formatVersion: DOCUMENT_FORMAT_VERSION,
+    kind: "page",
+    nodes,
+    ...(settings === undefined ? {} : { settings }),
+  };
+}
+
+const target = {
+  collection: "patterns",
+  fields: { title: "Hero", slug: "hero", granularity: "section" },
+};
+
+/** Every id in a forest. */
+function idsIn(nodes: BlockNode[]): string[] {
+  const out: string[] = [];
+  walkNodes(nodes, n => out.push(n.id));
+  return out;
+}
+
+/** The one node in a forest carrying this test's marker prop. */
+function marked(nodes: BlockNode[], mark: string): BlockNode {
+  let found: BlockNode | undefined;
+  walkNodes(nodes, n => {
+    if (n.props?.mark === mark) found = n;
+  });
+  if (found === undefined) throw new Error(`no node marked ${mark}`);
+  return found;
+}
+
+describe("what a saved pattern is", () => {
+  it("creates a pattern document in the collection the caller named", () => {
+    const doc = page([node("a"), node("b"), node("c")]);
+    const plan = planSaveAsPattern(doc, ["a", "b"], target);
+
+    expect(plan.create?.collection).toBe("patterns");
+    expect(plan.create?.document.kind).toBe("pattern");
+    expect(plan.create?.fields).toEqual(target.fields);
+  });
+
+  it("takes exactly the selected run, in document order", () => {
+    const doc = page([
+      node("a", { props: { mark: "a" } }),
+      node("b", { props: { mark: "b" } }),
+      node("c", { props: { mark: "c" } }),
+    ]);
+    // Ids handed over out of order on purpose: the pattern's order is the
+    // document's, not the order blocks happened to be clicked in.
+    const plan = planSaveAsPattern(doc, ["c", "b"], target);
+
+    expect(plan.create?.document.nodes.map(n => n.props?.mark)).toEqual([
+      "b",
+      "c",
+    ]);
+  });
+
+  it("LEAVES THE PAGE ALONE — a pattern is a copy, not a move", () => {
+    const doc = page([node("a"), node("b")]);
+    const plan = planSaveAsPattern(doc, ["a"], target);
+
+    expect(plan.pageOps).toEqual([]);
+  });
+
+  it("does not mutate the document it was given", () => {
+    const doc = page([node("a", { cssId: "pricing" }), node("b")]);
+    const before = JSON.stringify(doc);
+
+    planSaveAsPattern(doc, ["a", "b"], target);
+
+    expect(JSON.stringify(doc)).toBe(before);
+  });
+});
+
+describe("the copy is a document of its own", () => {
+  it("shares no node id with the page it came from", () => {
+    const doc = page([node("a", {}, { body: [node("a-child")] }), node("b")]);
+    const plan = planSaveAsPattern(doc, ["a", "b"], target);
+
+    const stored = idsIn(plan.create?.document.nodes ?? []);
+    expect(stored).toHaveLength(3);
+    for (const id of ["a", "a-child", "b"]) {
+      expect(stored).not.toContain(id);
+    }
+  });
+
+  it("drops page-scoped settings, which describe the page and not the run", () => {
+    const doc = page([node("a")], {
+      styles: { base: { desktop: { backgroundColor: "red" } } },
+      customCss: ".x{}",
+    });
+    const plan = planSaveAsPattern(doc, ["a"], target);
+
+    expect(plan.create?.document.settings).toBeUndefined();
+  });
+});
+
+describe("a reference that crosses from one root to the next", () => {
+  it("points at the COPY's target, not the page's", () => {
+    const doc = page([
+      node("a", { cssId: "pricing", props: { mark: "target" } }),
+      node("b", {
+        props: { mark: "pointer" },
+        attributes: { "aria-describedby": "pricing" },
+      }),
+    ]);
+
+    const stored = planSaveAsPattern(doc, ["a", "b"], target).create?.document
+      .nodes;
+    expect(stored).toBeDefined();
+
+    const copiedTarget = marked(stored ?? [], "target");
+    const copiedPointer = marked(stored ?? [], "pointer");
+
+    // The id moved...
+    expect(copiedTarget.cssId).not.toBe("pricing");
+    // ...and the reference moved with it, ACROSS the root boundary.
+    expect(copiedPointer.attributes?.["aria-describedby"]).toBe(
+      copiedTarget.cssId
+    );
+  });
+});
+
+describe("a run inside a container", () => {
+  it("plans from the parent's slot, not from the roots", () => {
+    const doc = page([
+      node(
+        "card",
+        {},
+        {
+          body: [
+            node("a", { props: { mark: "a" } }),
+            node("b", { props: { mark: "b" } }),
+            node("c", { props: { mark: "c" } }),
+          ],
+        }
+      ),
+    ]);
+    const plan = planSaveAsPattern(doc, ["b", "c"], target);
+
+    expect(plan.create?.document.nodes.map(n => n.props?.mark)).toEqual([
+      "b",
+      "c",
+    ]);
+  });
+});
+
+describe("what it refuses, and why", () => {
+  it("refuses a selection with a block left out of the middle", () => {
+    const doc = page([node("a"), node("b"), node("c")]);
+    const plan = planSaveAsPattern(doc, ["a", "c"], target);
+
+    expect(plan.problem).toBe("gap");
+    expect(plan.create).toBeUndefined();
+  });
+
+  it("refuses blocks that sit in two different containers", () => {
+    const doc = page([
+      node("one", {}, { body: [node("a")] }),
+      node("two", {}, { body: [node("b")] }),
+    ]);
+
+    expect(planSaveAsPattern(doc, ["a", "b"], target).problem).toBe("split");
+  });
+
+  it("refuses an empty selection", () => {
+    expect(planSaveAsPattern(page([node("a")]), [], target).problem).toBe(
+      "empty"
+    );
+  });
+
+  it("refuses an id the document does not hold, as its own cause", () => {
+    expect(
+      planSaveAsPattern(page([node("a")]), ["a", "ghost"], target).problem
+    ).toBe("unknown");
+  });
+});

--- a/packages/blocks-engine/src/composition-planners.test.ts
+++ b/packages/blocks-engine/src/composition-planners.test.ts
@@ -157,6 +157,26 @@ describe("a reference that crosses from one root to the next", () => {
   });
 });
 
+describe("a link inside the saved run still reaches its own target", () => {
+  it("stores an href pointing at the pattern's target, not the page's", () => {
+    const doc = page([
+      node("t", { cssId: "pricing", props: { mark: "target" } }),
+      node("l", { props: { mark: "link", href: "#pricing" } }),
+    ]);
+
+    const stored =
+      planSaveAsPattern(doc, ["t", "l"], target).create?.document.nodes ?? [];
+    const copiedTarget = marked(stored, "target");
+    const copiedLink = marked(stored, "link");
+
+    // The id moved, so a stored `#pricing` would address nothing at all — and
+    // insert cannot repair it later, because its own map is keyed by the id
+    // this copy already renamed.
+    expect(copiedTarget.cssId).not.toBe("pricing");
+    expect(copiedLink.props?.href).toBe(`#${copiedTarget.cssId}`);
+  });
+});
+
 describe("a run inside a container", () => {
   it("plans from the parent's slot, not from the roots", () => {
     const doc = page([

--- a/packages/blocks-engine/src/composition-planners.test.ts
+++ b/packages/blocks-engine/src/composition-planners.test.ts
@@ -201,6 +201,49 @@ describe("a run inside a container", () => {
   });
 });
 
+describe("a document whose ids are not unique", () => {
+  it("SAVES THE BLOCKS THE AUTHOR SELECTED, not a namesake parent's", () => {
+    // Two parents share an id. `siblingRun` located the selection under the
+    // SECOND; a lookup by that id answers with the FIRST. Reading the run's
+    // indexes out of the re-resolved parent therefore took the wrong
+    // container's blocks — a pattern saved from content nobody selected, with
+    // nothing reporting it. Each node is now fetched by its own id instead.
+    const doc: BlockDocument = {
+      formatVersion: DOCUMENT_FORMAT_VERSION,
+      kind: "page",
+      nodes: [
+        node(
+          "dup",
+          {},
+          {
+            body: [
+              node("f1", { props: { mark: "first-parent-a" } }),
+              node("f2", { props: { mark: "first-parent-b" } }),
+            ],
+          }
+        ),
+        node(
+          "dup",
+          {},
+          {
+            body: [
+              node("s1", { props: { mark: "wanted-a" } }),
+              node("s2", { props: { mark: "wanted-b" } }),
+            ],
+          }
+        ),
+      ],
+    };
+
+    const plan = planSaveAsPattern(doc, ["s1", "s2"], target);
+
+    expect(plan.create?.document.nodes.map(n => n.props?.mark)).toEqual([
+      "wanted-a",
+      "wanted-b",
+    ]);
+  });
+});
+
 describe("what it refuses, and why", () => {
   it("refuses a selection with a block left out of the middle", () => {
     const doc = page([node("a"), node("b"), node("c")]);

--- a/packages/blocks-engine/src/composition-planners.test.ts
+++ b/packages/blocks-engine/src/composition-planners.test.ts
@@ -43,6 +43,20 @@ function page(
   };
 }
 
+/**
+ * A nesting source that restricts nothing, which is the ordinary case.
+ *
+ * Explicit rather than defaulted, because "no restriction" is a real answer a
+ * registry gives and the planner must be handed one rather than assume it.
+ */
+const anyParent = { parentsOf: () => undefined };
+
+/** The shipped shape of a restricted block: a column belongs inside columns. */
+const columnsOnly = {
+  parentsOf: (type: string) =>
+    type === "core/column" ? ["core/columns"] : undefined,
+};
+
 const target = {
   collection: "patterns",
   fields: { title: "Hero", slug: "hero", granularity: "section" },
@@ -68,7 +82,7 @@ function marked(nodes: BlockNode[], mark: string): BlockNode {
 describe("what a saved pattern is", () => {
   it("creates a pattern document in the collection the caller named", () => {
     const doc = page([node("a"), node("b"), node("c")]);
-    const plan = planSaveAsPattern(doc, ["a", "b"], target);
+    const plan = planSaveAsPattern(doc, ["a", "b"], target, anyParent);
 
     expect(plan.create?.collection).toBe("patterns");
     expect(plan.create?.document.kind).toBe("pattern");
@@ -83,7 +97,7 @@ describe("what a saved pattern is", () => {
     ]);
     // Ids handed over out of order on purpose: the pattern's order is the
     // document's, not the order blocks happened to be clicked in.
-    const plan = planSaveAsPattern(doc, ["c", "b"], target);
+    const plan = planSaveAsPattern(doc, ["c", "b"], target, anyParent);
 
     expect(plan.create?.document.nodes.map(n => n.props?.mark)).toEqual([
       "b",
@@ -93,7 +107,7 @@ describe("what a saved pattern is", () => {
 
   it("LEAVES THE PAGE ALONE — a pattern is a copy, not a move", () => {
     const doc = page([node("a"), node("b")]);
-    const plan = planSaveAsPattern(doc, ["a"], target);
+    const plan = planSaveAsPattern(doc, ["a"], target, anyParent);
 
     expect(plan.pageOps).toEqual([]);
   });
@@ -102,7 +116,7 @@ describe("what a saved pattern is", () => {
     const doc = page([node("a", { cssId: "pricing" }), node("b")]);
     const before = JSON.stringify(doc);
 
-    planSaveAsPattern(doc, ["a", "b"], target);
+    planSaveAsPattern(doc, ["a", "b"], target, anyParent);
 
     expect(JSON.stringify(doc)).toBe(before);
   });
@@ -111,7 +125,7 @@ describe("what a saved pattern is", () => {
 describe("the copy is a document of its own", () => {
   it("shares no node id with the page it came from", () => {
     const doc = page([node("a", {}, { body: [node("a-child")] }), node("b")]);
-    const plan = planSaveAsPattern(doc, ["a", "b"], target);
+    const plan = planSaveAsPattern(doc, ["a", "b"], target, anyParent);
 
     const stored = idsIn(plan.create?.document.nodes ?? []);
     expect(stored).toHaveLength(3);
@@ -125,7 +139,7 @@ describe("the copy is a document of its own", () => {
       styles: { base: { desktop: { backgroundColor: "red" } } },
       customCss: ".x{}",
     });
-    const plan = planSaveAsPattern(doc, ["a"], target);
+    const plan = planSaveAsPattern(doc, ["a"], target, anyParent);
 
     expect(plan.create?.document.settings).toBeUndefined();
   });
@@ -141,8 +155,8 @@ describe("a reference that crosses from one root to the next", () => {
       }),
     ]);
 
-    const stored = planSaveAsPattern(doc, ["a", "b"], target).create?.document
-      .nodes;
+    const stored = planSaveAsPattern(doc, ["a", "b"], target, anyParent).create
+      ?.document.nodes;
     expect(stored).toBeDefined();
 
     const copiedTarget = marked(stored ?? [], "target");
@@ -165,7 +179,8 @@ describe("a link inside the saved run still reaches its own target", () => {
     ]);
 
     const stored =
-      planSaveAsPattern(doc, ["t", "l"], target).create?.document.nodes ?? [];
+      planSaveAsPattern(doc, ["t", "l"], target, anyParent).create?.document
+        .nodes ?? [];
     const copiedTarget = marked(stored, "target");
     const copiedLink = marked(stored, "link");
 
@@ -192,7 +207,7 @@ describe("a run inside a container", () => {
         }
       ),
     ]);
-    const plan = planSaveAsPattern(doc, ["b", "c"], target);
+    const plan = planSaveAsPattern(doc, ["b", "c"], target, anyParent);
 
     expect(plan.create?.document.nodes.map(n => n.props?.mark)).toEqual([
       "b",
@@ -235,7 +250,7 @@ describe("a document whose ids are not unique", () => {
       ],
     };
 
-    const plan = planSaveAsPattern(doc, ["s1", "s2"], target);
+    const plan = planSaveAsPattern(doc, ["s1", "s2"], target, anyParent);
 
     expect(plan.create?.document.nodes.map(n => n.props?.mark)).toEqual([
       "wanted-a",
@@ -244,10 +259,79 @@ describe("a document whose ids are not unique", () => {
   });
 });
 
+describe("a run lifted out of its container", () => {
+  it("REFUSES a block that cannot stand at a root, and says what it needs", () => {
+    // Saving lifts the run OUT: the pattern's roots are the selected blocks.
+    // A `core/column` declares `parent: ["core/columns"]`, so it has just lost
+    // the only container it may sit in — and the store validates root
+    // placement by the same rule, so planning this as a success would hand
+    // back a document the create then refuses.
+    const doc = page([
+      node(
+        "columns",
+        { type: "core/columns" },
+        {
+          children: [
+            node("c1", { type: "core/column" }),
+            node("c2", { type: "core/column" }),
+          ],
+        }
+      ),
+    ]);
+
+    const plan = planSaveAsPattern(doc, ["c1", "c2"], target, columnsOnly);
+
+    expect(plan.problem).toBe("restricted-at-root");
+    expect(plan.permitted).toEqual(["core/columns"]);
+    expect(plan.create).toBeUndefined();
+  });
+
+  it("allows the CONTAINER itself, which is the remedy", () => {
+    const doc = page([
+      node(
+        "columns",
+        { type: "core/columns" },
+        {
+          children: [node("c1", { type: "core/column" })],
+        }
+      ),
+    ]);
+
+    const plan = planSaveAsPattern(doc, ["columns"], target, columnsOnly);
+
+    expect(plan.problem).toBeUndefined();
+    expect(plan.create?.document.nodes).toHaveLength(1);
+  });
+});
+
+describe("an id that names two different nodes", () => {
+  it("saves the node the SELECTION found, not a namesake elsewhere", () => {
+    // The search behind `contiguousRun` checks every root before descending;
+    // a plain find walks each root and its descendants in turn. So a nested
+    // node and a later top-level node sharing an id resolve differently in the
+    // two, and re-looking-up the id stored the wrong one. The run now carries
+    // the node it actually found.
+    const doc = page([
+      node(
+        "holder",
+        {},
+        { body: [node("same", { props: { mark: "nested" } })] }
+      ),
+      node("same", { props: { mark: "top-level" } }),
+    ]);
+
+    const plan = planSaveAsPattern(doc, ["same"], target, anyParent);
+
+    expect(plan.create?.document.nodes.map(n => n.props?.mark)).toEqual([
+      "top-level",
+    ]);
+  });
+});
+
 describe("what it refuses, and why", () => {
   it("refuses a selection with a block left out of the middle", () => {
     const doc = page([node("a"), node("b"), node("c")]);
-    const plan = planSaveAsPattern(doc, ["a", "c"], target);
+    const plan = planSaveAsPattern(doc, ["a", "c"], target, anyParent);
 
     expect(plan.problem).toBe("gap");
     expect(plan.create).toBeUndefined();
@@ -259,18 +343,21 @@ describe("what it refuses, and why", () => {
       node("two", {}, { body: [node("b")] }),
     ]);
 
-    expect(planSaveAsPattern(doc, ["a", "b"], target).problem).toBe("split");
+    expect(planSaveAsPattern(doc, ["a", "b"], target, anyParent).problem).toBe(
+      "split"
+    );
   });
 
   it("refuses an empty selection", () => {
-    expect(planSaveAsPattern(page([node("a")]), [], target).problem).toBe(
-      "empty"
-    );
+    expect(
+      planSaveAsPattern(page([node("a")]), [], target, anyParent).problem
+    ).toBe("empty");
   });
 
   it("refuses an id the document does not hold, as its own cause", () => {
     expect(
-      planSaveAsPattern(page([node("a")]), ["a", "ghost"], target).problem
+      planSaveAsPattern(page([node("a")]), ["a", "ghost"], target, anyParent)
+        .problem
     ).toBe("unknown");
   });
 });

--- a/packages/blocks-engine/src/composition-planners.ts
+++ b/packages/blocks-engine/src/composition-planners.ts
@@ -143,35 +143,33 @@ export function planSaveAsPattern<TFields>(
 /**
  * The selected nodes themselves, in document order.
  *
- * `undefined` when the list the run named cannot be read back — which
- * {@link contiguousRun} having just located every id makes unreachable, so it
- * is reported as `"unknown"` rather than trusted: a planner that indexed into a
- * missing list would build a pattern out of holes.
+ * Each is fetched by ITS OWN id, never by re-resolving the run's parent and
+ * indexing into its slot. That reads like the same thing and is not, on a
+ * stored document nothing validated: two nodes may share an id, and then the
+ * parent `siblingRun` located a child under is not the parent a later lookup by
+ * that id returns — the first one is. The indexes were then read from the wrong
+ * container and the pattern was saved from blocks the author never selected,
+ * with nothing to show it. Measured on a document with two parents called
+ * `"dup"`: selecting the second parent's two children saved the FIRST parent's.
+ *
+ * Asking for each node by name removes the second lookup that could disagree.
+ * `findNode` and the `locateNode` behind `siblingRun` both answer with the
+ * first match in one forest walk, so they cannot resolve one id differently.
+ *
+ * `undefined` when a node cannot be read back at all, which is unreachable
+ * after {@link contiguousRun} has just located every one of them — reported
+ * rather than trusted, because a planner that skipped a hole would build a
+ * pattern quietly missing a block.
  */
 function runNodes(
   nodes: BlockNode[],
   run: SiblingRun
 ): BlockNode[] | undefined {
-  const list = siblingList(nodes, run);
-  if (list === undefined) return undefined;
   const selected: BlockNode[] = [];
   for (const place of run.places) {
-    const node = list[place.index];
+    const node = findNode(nodes, place.id);
     if (node === undefined) return undefined;
     selected.push(node);
   }
   return selected;
-}
-
-/** The sibling list a run sits in: the roots, or a parent's slot. */
-function siblingList(
-  nodes: BlockNode[],
-  run: SiblingRun
-): BlockNode[] | undefined {
-  if (run.parentId === undefined) return nodes;
-  const parent = findNode(nodes, run.parentId);
-  const slot = run.slot;
-  if (parent === undefined || slot === undefined) return undefined;
-  const children = parent.slots?.[slot];
-  return Array.isArray(children) ? children : undefined;
 }

--- a/packages/blocks-engine/src/composition-planners.ts
+++ b/packages/blocks-engine/src/composition-planners.ts
@@ -24,9 +24,10 @@
  * @module composition-planners
  */
 import type { BlockDocument, BlockNode } from "./document";
+import { canBeRoot, type NestingSource } from "./nesting";
 import type { BuilderOp } from "./ops";
-import { contiguousRun, type RunProblem, type SiblingRun } from "./sibling-run";
-import { findNode, reidForestWithMap } from "./tree";
+import { contiguousRun, type RunProblem } from "./sibling-run";
+import { reidForestWithMap } from "./tree";
 
 /** A library row a planner asks the caller to create. */
 export interface PlannedCreate<TFields> {
@@ -57,6 +58,9 @@ export interface CompositionPlan<TFields> {
    */
   readonly pageOps: readonly BuilderOp[];
   readonly problem?: undefined;
+  // Declared on the success member too, so a caller reads either field off the
+  // union without narrowing first and cannot read a refusal's detail off a plan.
+  readonly permitted?: undefined;
 }
 
 /**
@@ -65,13 +69,32 @@ export interface CompositionPlan<TFields> {
  * Carries the cause from {@link contiguousRun} unchanged, so the sentence shown
  * to an author is composed once per surface rather than once per planner.
  */
-export type PlanResult<TFields> =
-  | CompositionPlan<TFields>
-  | {
-      readonly problem: RunProblem;
-      readonly create?: undefined;
-      readonly pageOps?: undefined;
-    };
+/**
+ * Why a composition action cannot be planned.
+ *
+ * The selection causes come from {@link contiguousRun} unchanged. The nesting
+ * one is this layer's own: a run lifted out of a container becomes the ROOTS of
+ * a new document, and a block that declares which parents it may sit in cannot
+ * be one.
+ */
+export type PlanProblem = RunProblem | "restricted-at-root";
+
+/** A refusal, with whatever the surface needs to phrase it. */
+export interface PlanRefusal {
+  readonly problem: PlanProblem;
+  /**
+   * For `"restricted-at-root"`: the parents the refused block requires.
+   *
+   * Carried rather than left to be looked up, because the caller is the only
+   * place that still knows which selection was refused — the same reason
+   * `NestingVerdict` carries it.
+   */
+  readonly permitted?: readonly string[];
+  readonly create?: undefined;
+  readonly pageOps?: undefined;
+}
+
+export type PlanResult<TFields> = CompositionPlan<TFields> | PlanRefusal;
 
 /** Where a saved selection is stored, in the caller's vocabulary. */
 export interface PatternTarget<TFields> {
@@ -113,13 +136,15 @@ export interface PatternTarget<TFields> {
 export function planSaveAsPattern<TFields>(
   document: BlockDocument,
   selectedIds: readonly string[],
-  target: PatternTarget<TFields>
+  target: PatternTarget<TFields>,
+  nesting: NestingSource
 ): PlanResult<TFields> {
   const result = contiguousRun(document.nodes, selectedIds);
   if (result.run === undefined) return { problem: result.problem };
 
-  const selected = runNodes(document.nodes, result.run);
-  if (selected === undefined) return { problem: "unknown" };
+  const selected = result.run.places.map(place => place.node);
+  const refusal = refusedAtRoot(selected, nesting);
+  if (refusal !== undefined) return refusal;
 
   return {
     create: {
@@ -141,35 +166,32 @@ export function planSaveAsPattern<TFields>(
 }
 
 /**
- * The selected nodes themselves, in document order.
+ * The first selected block that cannot stand at a document root, if any.
  *
- * Each is fetched by ITS OWN id, never by re-resolving the run's parent and
- * indexing into its slot. That reads like the same thing and is not, on a
- * stored document nothing validated: two nodes may share an id, and then the
- * parent `siblingRun` located a child under is not the parent a later lookup by
- * that id returns — the first one is. The indexes were then read from the wrong
- * container and the pattern was saved from blocks the author never selected,
- * with nothing to show it. Measured on a document with two parents called
- * `"dup"`: selecting the second parent's two children saved the FIRST parent's.
+ * Saving a run lifts it OUT of whatever contained it: the pattern document's
+ * roots are the selected blocks themselves. A block declaring which parents it
+ * may sit in has just lost the only one it had, and the store validates root
+ * placement through the same rule — so without this the planner reports success
+ * and hands back a document the create then refuses. Selecting a `core/column`
+ * inside a `core/columns` is the ordinary way to reach it, not a corner case.
  *
- * Asking for each node by name removes the second lookup that could disagree.
- * `findNode` and the `locateNode` behind `siblingRun` both answer with the
- * first match in one forest walk, so they cannot resolve one id differently.
- *
- * `undefined` when a node cannot be read back at all, which is unreachable
- * after {@link contiguousRun} has just located every one of them — reported
- * rather than trusted, because a planner that skipped a hole would build a
- * pattern quietly missing a block.
+ * Asked of the SHARED rule rather than answered here. The canvas, the validator
+ * and this planner have to agree about where a block may sit, and a second
+ * implementation would agree only until one of them changed.
  */
-function runNodes(
-  nodes: BlockNode[],
-  run: SiblingRun
-): BlockNode[] | undefined {
-  const selected: BlockNode[] = [];
-  for (const place of run.places) {
-    const node = findNode(nodes, place.id);
-    if (node === undefined) return undefined;
-    selected.push(node);
+function refusedAtRoot(
+  selected: readonly BlockNode[],
+  nesting: NestingSource
+): PlanRefusal | undefined {
+  for (const node of selected) {
+    const verdict = canBeRoot(node.type, nesting);
+    if (verdict.allowed) continue;
+    return {
+      problem: "restricted-at-root",
+      ...(verdict.permitted === undefined
+        ? {}
+        : { permitted: verdict.permitted }),
+    };
   }
-  return selected;
+  return undefined;
 }

--- a/packages/blocks-engine/src/composition-planners.ts
+++ b/packages/blocks-engine/src/composition-planners.ts
@@ -1,0 +1,177 @@
+/**
+ * Turning a selection into a saved, reusable document — planned, not performed.
+ *
+ * Each planner is PURE. It reads a document and answers with two things: the
+ * library row to create, and the ops the page needs. It writes nothing, mints
+ * no request and knows no collection: the caller supplies the slug it stores
+ * under and the metadata fields that collection declares.
+ *
+ * ## Why the plan is split from the doing
+ *
+ * Saving a selection is two writes in two collections, and the failure mode is
+ * documented in the design (Elementor #36049): the library row is created, the
+ * page edit fails, and an author is left with a pattern nothing points at.
+ * Splitting the decision from the execution is what lets the caller wrap both
+ * in one unit of work, roll the create back when the page ops fail, and offer
+ * the same action as a dry run — the plan IS the dry run, so what a preview
+ * shows and what a real save applies cannot differ.
+ *
+ * It is also what lets an editor, a plugin route and an agent share one answer.
+ * A planner takes a document and returns data, so nothing here needs React, a
+ * request or a database, and the editor's "Save as pattern" and the API's are
+ * the same function rather than two implementations that agree until one moves.
+ *
+ * @module composition-planners
+ */
+import type { BlockDocument, BlockNode } from "./document";
+import type { BuilderOp } from "./ops";
+import { contiguousRun, type RunProblem, type SiblingRun } from "./sibling-run";
+import { findNode, reidForestWithMap } from "./tree";
+
+/** A library row a planner asks the caller to create. */
+export interface PlannedCreate<TFields> {
+  /**
+   * The collection slug to create it in.
+   *
+   * Supplied by the caller and echoed back rather than decided here. The three
+   * composition stores are the page-builder plugin's, and a host may not have
+   * installed it — an engine that named `"patterns"` would be asserting a
+   * collection exists that it cannot see.
+   */
+  readonly collection: string;
+  /** The document to store, with its own ids. */
+  readonly document: BlockDocument;
+  /** The collection's own metadata fields, passed through untouched. */
+  readonly fields: TFields;
+}
+
+/** What a composition action would create, and what it would do to the page. */
+export interface CompositionPlan<TFields> {
+  /** The row to create, absent for an action that only edits the page. */
+  readonly create?: PlannedCreate<TFields>;
+  /**
+   * The edits to apply to the page, in order, as one atomic group.
+   *
+   * Empty is a legitimate plan, not a missing one: saving a selection to the
+   * library leaves the page exactly as it was.
+   */
+  readonly pageOps: readonly BuilderOp[];
+  readonly problem?: undefined;
+}
+
+/**
+ * A plan, or the cause there is none.
+ *
+ * Carries the cause from {@link contiguousRun} unchanged, so the sentence shown
+ * to an author is composed once per surface rather than once per planner.
+ */
+export type PlanResult<TFields> =
+  | CompositionPlan<TFields>
+  | {
+      readonly problem: RunProblem;
+      readonly create?: undefined;
+      readonly pageOps?: undefined;
+    };
+
+/** Where a saved selection is stored, in the caller's vocabulary. */
+export interface PatternTarget<TFields> {
+  readonly collection: string;
+  readonly fields: TFields;
+}
+
+/**
+ * Save a contiguous run of blocks as a pattern.
+ *
+ * **The page is not touched.** A pattern is copy-on-insert and keeps no link
+ * back, so saving one takes a copy and leaves the original where it is —
+ * `pageOps` is empty, and that is the whole behavioural difference from
+ * `planConvertToComponent`, which replaces the run with a linked instance.
+ *
+ * **The copy gets fresh ids.** It would render correctly without them, because
+ * insert re-identifies anyway; storing the page's ids would still be wrong. A
+ * node id is how everything in this system addresses a node — styles, locale
+ * overlays, the class-usage record, editor history — so two stored documents
+ * claiming one id makes any index keyed on it unable to say which node it
+ * describes. Re-identifying at SAVE removes the ambiguity where it is created
+ * rather than relying on every later reader to disambiguate.
+ *
+ * The roots are re-identified TOGETHER: see {@link reidForestWithMap} for why
+ * doing them one at a time silently breaks a reference that crosses from one
+ * root to the next.
+ *
+ * **`settings` is not copied.** Document settings are page-scoped by
+ * definition — a background with no owning node, and the document's custom CSS
+ * — so a pattern that carried them would repaint every page it was inserted
+ * into. Node styles live on the nodes and travel with them.
+ *
+ * **`assets` is not synthesised.** The media index describes a whole document,
+ * and which prop of a block holds a media id is a property of that block's
+ * definition, which the engine cannot read — the same boundary that stops the
+ * id remapper reaching into props. A partial index would be worse than none,
+ * since absence is what a reference check reads as "not used".
+ */
+export function planSaveAsPattern<TFields>(
+  document: BlockDocument,
+  selectedIds: readonly string[],
+  target: PatternTarget<TFields>
+): PlanResult<TFields> {
+  const result = contiguousRun(document.nodes, selectedIds);
+  if (result.run === undefined) return { problem: result.problem };
+
+  const selected = runNodes(document.nodes, result.run);
+  if (selected === undefined) return { problem: "unknown" };
+
+  return {
+    create: {
+      collection: target.collection,
+      document: {
+        // The SOURCE document's version, not the current one. These nodes are
+        // written in the format the page holds them in, and a pattern that
+        // claimed the newest version would tell the migrator there is nothing
+        // to do — so an old page's blocks would be stored as if already
+        // migrated and never brought forward.
+        formatVersion: document.formatVersion,
+        kind: "pattern",
+        nodes: reidForestWithMap(selected).nodes,
+      },
+      fields: target.fields,
+    },
+    pageOps: [],
+  };
+}
+
+/**
+ * The selected nodes themselves, in document order.
+ *
+ * `undefined` when the list the run named cannot be read back — which
+ * {@link contiguousRun} having just located every id makes unreachable, so it
+ * is reported as `"unknown"` rather than trusted: a planner that indexed into a
+ * missing list would build a pattern out of holes.
+ */
+function runNodes(
+  nodes: BlockNode[],
+  run: SiblingRun
+): BlockNode[] | undefined {
+  const list = siblingList(nodes, run);
+  if (list === undefined) return undefined;
+  const selected: BlockNode[] = [];
+  for (const place of run.places) {
+    const node = list[place.index];
+    if (node === undefined) return undefined;
+    selected.push(node);
+  }
+  return selected;
+}
+
+/** The sibling list a run sits in: the roots, or a parent's slot. */
+function siblingList(
+  nodes: BlockNode[],
+  run: SiblingRun
+): BlockNode[] | undefined {
+  if (run.parentId === undefined) return nodes;
+  const parent = findNode(nodes, run.parentId);
+  const slot = run.slot;
+  if (parent === undefined || slot === undefined) return undefined;
+  const children = parent.slots?.[slot];
+  return Array.isArray(children) ? children : undefined;
+}

--- a/packages/blocks-engine/src/fragment-refs.test.ts
+++ b/packages/blocks-engine/src/fragment-refs.test.ts
@@ -1,0 +1,133 @@
+/**
+ * The one rule for what happens to a copied node's link targets.
+ *
+ * Tested here as a unit as well as through the copiers, because the walk has
+ * limits of its own and reaching them through `reidForestWithMap` is not
+ * possible: `structuredClone` gives up first, at a shallower depth. Measured on
+ * node 22 — `structuredClone` throws `RangeError` between 1,000 and 2,000
+ * levels of nesting, while a `JSON` round-trip survives past 5,000. That is a
+ * pre-existing ceiling in the copier and not this module's, but it does mean a
+ * depth test written against the copier measures the clone, not the scan.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  FRAGMENT_REFERENCE_PROPS,
+  remapFragmentBindings,
+  remapFragmentProps,
+} from "./fragment-refs";
+
+const domIds = new Map([["pricing", "pricing-abc12345"]]);
+const target = "#pricing-abc12345";
+
+describe("which values are rewritten", () => {
+  it("rewrites a link target and leaves display text holding the same string", () => {
+    const out = remapFragmentProps(
+      { href: "#pricing", text: "#pricing" },
+      domIds
+    ) as Record<string, string>;
+
+    expect(out.href).toBe(target);
+    expect(out.text).toBe("#pricing");
+  });
+
+  it("names both target fields the shipped blocks use", () => {
+    expect([...FRAGMENT_REFERENCE_PROPS].sort()).toEqual(["href", "url"]);
+  });
+
+  it("leaves a fragment addressing something outside the copy alone", () => {
+    const out = remapFragmentProps({ href: "#elsewhere" }, domIds) as Record<
+      string,
+      string
+    >;
+
+    expect(out.href).toBe("#elsewhere");
+  });
+
+  it("returns the very same value when nothing matched", () => {
+    const props = { href: "#elsewhere", text: "plain" };
+
+    expect(remapFragmentProps(props, domIds)).toBe(props);
+  });
+});
+
+describe("the walk has no limit of its own", () => {
+  it("REACHES A LINK DEEPER THAN THE CALL STACK", () => {
+    // Roughly three thousand nested records is tens of kilobytes, inside the
+    // document byte limit, and overflowed the recursive walk with a RangeError.
+    // Depth is a property of authored content, not something this may refuse.
+    let deep: Record<string, unknown> = { href: "#pricing" };
+    for (let i = 0; i < 20_000; i += 1) deep = { nested: deep };
+
+    let walk = remapFragmentProps(deep, domIds) as Record<string, unknown>;
+    while (walk.nested !== undefined) {
+      walk = walk.nested as Record<string, unknown>;
+    }
+
+    expect(walk.href).toBe(target);
+  });
+
+  it("REACHES A LINK IN A RECORD WIDER THAN THE ENVELOPE BUDGET", () => {
+    // The component-envelope key budget was borrowed for opaque prop records,
+    // which the format does not cap. Past it the record came back untouched and
+    // counted as done — a bound that means "refuse this" in one place and
+    // "nothing to do" in the other.
+    const wide: Record<string, unknown> = { href: "#pricing" };
+    for (let i = 0; i < 5_000; i += 1) wide[`filler${i}`] = i;
+
+    const out = remapFragmentProps(wide, domIds) as Record<string, unknown>;
+
+    expect(out.href).toBe(target);
+  });
+});
+
+describe("a graph comes out a graph", () => {
+  it("closes a cycle on the REPLACEMENT, carrying the rewrite with it", () => {
+    const cyclic: Record<string, unknown> = { href: "#pricing" };
+    cyclic.self = cyclic;
+
+    const out = remapFragmentProps(cyclic, domIds) as Record<string, unknown>;
+
+    expect(out.href).toBe(target);
+    expect(out.self).toBe(out);
+    expect((out.self as Record<string, unknown>).href).toBe(target);
+  });
+
+  it("rebuilds a record reached twice exactly once", () => {
+    const shared: Record<string, unknown> = { href: "#pricing" };
+
+    const out = remapFragmentProps({ a: shared, b: shared }, domIds) as Record<
+      string,
+      unknown
+    >;
+
+    expect(out.a).toBe(out.b);
+  });
+
+  it("survives a cycle through an ARRAY as well as a record", () => {
+    const list: unknown[] = [{ href: "#pricing" }];
+    list.push(list);
+
+    const out = remapFragmentProps({ list }, domIds) as { list: unknown[] };
+
+    expect((out.list[0] as Record<string, string>).href).toBe(target);
+    expect(out.list[1]).toBe(out.list);
+  });
+});
+
+describe("bound link targets", () => {
+  it("remaps the fallback of a bound target field", () => {
+    const out = remapFragmentBindings(
+      { href: { $bind: "cta", fallback: "#pricing" } },
+      domIds
+    ) as Record<string, { fallback: string }>;
+
+    expect(out.href!.fallback).toBe(target);
+  });
+
+  it("leaves a bound field that holds no target alone", () => {
+    const bindings = { text: { $bind: "title", fallback: "#pricing" } };
+
+    expect(remapFragmentBindings(bindings, domIds)).toBe(bindings);
+  });
+});

--- a/packages/blocks-engine/src/fragment-refs.ts
+++ b/packages/blocks-engine/src/fragment-refs.ts
@@ -1,0 +1,113 @@
+/**
+ * Pointing a block's `#fragment` PROPS at wherever those ids ended up.
+ *
+ * `cssId` is not referenced only by markup. A link's `href` may be `#pricing`,
+ * and the renderer accepts that — `core/button` passes a bare fragment through
+ * to the DOM. So a copier that mints a fresh `cssId` and stops has moved the
+ * target and left the link behind, and the anchor resolves to nothing: the same
+ * silent breakage as a dangling `aria-labelledby`, one prop over.
+ *
+ * ## Why this is a module and not a private helper
+ *
+ * Two copiers mint DOM ids. Composition inlines a definition into every
+ * instance of it; saving a selection copies a run out of a page. The first grew
+ * this rule and the second was written without it — the id map was returned,
+ * handed back, and dropped — so a saved pattern stored a link to an id that no
+ * longer existed anywhere. A warning written beside the places that existed
+ * when it was written does not attach itself to the next one, and a rule that
+ * only one of two copiers applies is a rule that holds until someone adds a
+ * third.
+ *
+ * ## Why a copier CAN do this, when it cannot rewrite props generally
+ *
+ * Which prop of a block holds a link is a property of that block's definition,
+ * which the format layer cannot read — and that is exactly why this does not
+ * ask. A value is rewritten ONLY when the whole string is `#` followed by an id
+ * THIS copy minted. Nothing else can produce that: `"#1 bestseller"` names no
+ * minted id and is left as written, and so is a fragment addressing something
+ * outside the copied subtree, which belongs to the page and must keep working.
+ * The rule needs no schema because the map is the evidence.
+ *
+ * @module fragment-refs
+ */
+import { MAX_ENVELOPE_ENTRIES } from "./limits";
+import { isPlainRecord } from "./plain-record";
+import { boundedOwnKeys, defineEntry, ownEntry } from "./safe-record";
+
+/**
+ * How deep a prop tree is searched for fragment links.
+ *
+ * A bound on work over values a stored document supplied, generous enough that
+ * no authored prop shape reaches it.
+ */
+const MAX_PROP_SCAN_DEPTH = 8;
+
+/**
+ * Rewrite every whole-string `#id` in a prop tree that names a minted id.
+ *
+ * Returns the SAME value when nothing matched, so a copy of an ordinary block
+ * allocates nothing and a caller can compare by identity to tell whether the
+ * pass changed anything.
+ */
+export function remapFragmentProps(
+  props: unknown,
+  domIds: ReadonlyMap<string, string>
+): unknown {
+  return remapFragments(props, domIds, 0);
+}
+
+function remapFragments(
+  props: unknown,
+  domIds: ReadonlyMap<string, string>,
+  depth: number
+): unknown {
+  if (domIds.size === 0 || depth > MAX_PROP_SCAN_DEPTH) return props;
+  if (typeof props === "string") return remapOneFragment(props, domIds);
+  if (Array.isArray(props)) return remapFragmentList(props, domIds, depth);
+  if (!isPlainRecord(props)) return props;
+  return remapFragmentRecord(props, domIds, depth);
+}
+
+/** The same, for a record-valued prop. */
+function remapFragmentRecord(
+  props: Record<string, unknown>,
+  domIds: ReadonlyMap<string, string>,
+  depth: number
+): unknown {
+  const keys = boundedOwnKeys(props, MAX_ENVELOPE_ENTRIES);
+  if (keys === null) return props;
+  let changed = false;
+  const next: Record<string, unknown> = {};
+  for (const key of keys) {
+    const value = ownEntry(props, key);
+    const mapped = remapFragments(value, domIds, depth + 1);
+    if (mapped !== value) changed = true;
+    defineEntry(next, key, mapped);
+  }
+  return changed ? next : props;
+}
+
+/** The same, for an array-valued prop. */
+function remapFragmentList(
+  items: readonly unknown[],
+  domIds: ReadonlyMap<string, string>,
+  depth: number
+): unknown {
+  let changed = false;
+  const next = items.map(item => {
+    const mapped = remapFragments(item, domIds, depth + 1);
+    if (mapped !== item) changed = true;
+    return mapped;
+  });
+  return changed ? next : items;
+}
+
+/** One string, rewritten only if it is exactly a fragment this run minted. */
+function remapOneFragment(
+  value: string,
+  domIds: ReadonlyMap<string, string>
+): string {
+  if (!value.startsWith("#")) return value;
+  const target = domIds.get(value.slice(1));
+  return target === undefined ? value : `#${target}`;
+}

--- a/packages/blocks-engine/src/fragment-refs.ts
+++ b/packages/blocks-engine/src/fragment-refs.ts
@@ -68,52 +68,106 @@ export const FRAGMENT_REFERENCE_PROPS: readonly string[] = ["href", "url"];
 const FRAGMENT_REFERENCE_SET = new Set(FRAGMENT_REFERENCE_PROPS);
 
 /**
- * How many values one prop tree may be scanned for.
- *
- * A bound on WORK, not on depth. Depth was the wrong quantity and it was set
- * too low to be safe either way: a rich-text link inside a list item sits at
- * `props → content → root → children → item → children → listitem → children →
- * link → url`, which is ten values down, so an ordinary authored link was
- * already past a cap of eight and was silently left dangling. Any fixed depth
- * is arbitrary here, because rich text nests lists as deeply as an author
- * nests them.
- *
- * Counting visits bounds what a wide tree costs as well as a deep one, and it
- * terminates on a value that refers to itself — which stored JSON cannot be,
- * but a structured clone of an in-memory object can.
- */
-const MAX_PROP_SCAN_VISITS = 20_000;
-
-/** A visit budget, spent as the walk reads values. */
-interface ScanBudget {
-  left: number;
-}
-
-/**
  * Rewrite every link target in a prop tree that names an id this copy minted.
  *
  * Returns the SAME value when nothing matched, so an ordinary block allocates
  * nothing and a caller can compare by identity to tell whether anything moved.
+ *
+ * ## Bounded by the input, not by a number
+ *
+ * There was a cap here — first on depth, then on values visited — and both were
+ * wrong the same way: each was a guess about how large a legitimate prop tree
+ * gets, and a document exceeding the guess had its links silently left dangling
+ * rather than being refused. A depth cap of eight could not reach a rich-text
+ * link inside a list item, which is ten values down. A budget of twenty
+ * thousand visits was reachable by a rich-text value of a few hundred kilobytes
+ * — well inside the document size limit — so it was the same silent failure,
+ * moved further away rather than removed.
+ *
+ * A prop tree is part of a document, and how large a document may be is already
+ * decided once, by the document limits. Scanning all of it is therefore bounded
+ * work already, and the only thing a cap was really buying was TERMINATION on a
+ * value that refers to itself. That is what the path set does, exactly as
+ * `mapForest` does it one module over.
  */
 export function remapFragmentProps(
   props: unknown,
   domIds: ReadonlyMap<string, string>
 ): unknown {
   if (domIds.size === 0) return props;
-  return scan(props, domIds, { left: MAX_PROP_SCAN_VISITS });
+  return scan(props, domIds, new Set());
 }
 
-/** One value: descended into, or returned as it stands. */
+/**
+ * Rewrite a bound prop's FALLBACK when that prop holds a link target.
+ *
+ * A bound `href` keeps its literal in `bindings.href.fallback`, and the binding
+ * contract renders exactly that when the source is empty or the path cannot
+ * resolve. A copy that moves the target and rewrites `props.href` while leaving
+ * the fallback behind therefore produces a link that works until the data does
+ * not — the worst shape this failure can take, because it appears only in the
+ * case the fallback exists to cover.
+ */
+export function remapFragmentBindings(
+  bindings: unknown,
+  domIds: ReadonlyMap<string, string>
+): unknown {
+  if (domIds.size === 0 || !isPlainRecord(bindings)) return bindings;
+  const keys = boundedOwnKeys(bindings, MAX_ENVELOPE_ENTRIES);
+  if (keys === null) return bindings;
+  let changed = false;
+  const next: Record<string, unknown> = {};
+  for (const key of keys) {
+    const binding = ownEntry(bindings, key);
+    const mapped = FRAGMENT_REFERENCE_SET.has(key)
+      ? withRemappedFallback(binding, domIds)
+      : binding;
+    if (mapped !== binding) changed = true;
+    defineEntry(next, key, mapped);
+  }
+  return changed ? next : bindings;
+}
+
+/** One binding, with a fragment fallback pointed at the copy's own target. */
+function withRemappedFallback(
+  binding: unknown,
+  domIds: ReadonlyMap<string, string>
+): unknown {
+  if (!isPlainRecord(binding)) return binding;
+  const fallback = ownEntry(binding, "fallback");
+  if (typeof fallback !== "string") return binding;
+  const mapped = remapOneFragment(fallback, domIds);
+  return mapped === fallback ? binding : { ...binding, fallback: mapped };
+}
+
+/**
+ * One value: descended into, or returned as it stands.
+ *
+ * `onPath` holds the objects between here and the root of this walk. A value
+ * re-entered while it is still on the path is a cycle, and returning it
+ * untouched is what makes this terminate — stored JSON cannot hold one, but a
+ * structured clone of an in-memory object can, and these primitives are
+ * documented as running on documents nothing has validated.
+ *
+ * A PATH rather than everything seen, because a prop tree may legitimately
+ * reach one object from two places, and a value that has merely been visited
+ * before still needs rewriting where it appears again.
+ */
 function scan(
   value: unknown,
   domIds: ReadonlyMap<string, string>,
-  budget: ScanBudget
+  onPath: Set<unknown>
 ): unknown {
-  if (budget.left <= 0) return value;
-  budget.left -= 1;
-  if (Array.isArray(value)) return scanList(value, domIds, budget);
-  if (!isPlainRecord(value)) return value;
-  return scanRecord(value, domIds, budget);
+  if (typeof value !== "object" || value === null) return value;
+  if (onPath.has(value)) return value;
+  onPath.add(value);
+  const out = Array.isArray(value)
+    ? scanList(value, domIds, onPath)
+    : isPlainRecord(value)
+      ? scanRecord(value, domIds, onPath)
+      : value;
+  onPath.delete(value);
+  return out;
 }
 
 /**
@@ -121,15 +175,15 @@ function scan(
  * descended into.
  *
  * The name is checked HERE because this is the only place a value is reached
- * with the field that holds it still in hand. A string found inside an array
- * carries no name of its own and is never rewritten on its own account — but
+ * with the field that holds it still in hand. A string inside an array carries
+ * no name of its own and is never rewritten on its own account — but
  * `cta.links[0].href` still is, because that string is reached as the value of
  * `href` on the record inside the array.
  */
 function scanRecord(
   record: Record<string, unknown>,
   domIds: ReadonlyMap<string, string>,
-  budget: ScanBudget
+  onPath: Set<unknown>
 ): unknown {
   const keys = boundedOwnKeys(record, MAX_ENVELOPE_ENTRIES);
   if (keys === null) return record;
@@ -140,7 +194,7 @@ function scanRecord(
     const mapped =
       FRAGMENT_REFERENCE_SET.has(key) && typeof value === "string"
         ? remapOneFragment(value, domIds)
-        : scan(value, domIds, budget);
+        : scan(value, domIds, onPath);
     if (mapped !== value) changed = true;
     defineEntry(next, key, mapped);
   }
@@ -151,11 +205,11 @@ function scanRecord(
 function scanList(
   items: readonly unknown[],
   domIds: ReadonlyMap<string, string>,
-  budget: ScanBudget
+  onPath: Set<unknown>
 ): unknown {
   let changed = false;
   const next = items.map(item => {
-    const mapped = scan(item, domIds, budget);
+    const mapped = scan(item, domIds, onPath);
     if (mapped !== item) changed = true;
     return mapped;
   });

--- a/packages/blocks-engine/src/fragment-refs.ts
+++ b/packages/blocks-engine/src/fragment-refs.ts
@@ -2,10 +2,10 @@
  * Pointing a block's `#fragment` PROPS at wherever those ids ended up.
  *
  * `cssId` is not referenced only by markup. A link's `href` may be `#pricing`,
- * and the renderer accepts that — `core/button` passes a bare fragment through
- * to the DOM. So a copier that mints a fresh `cssId` and stops has moved the
- * target and left the link behind, and the anchor resolves to nothing: the same
- * silent breakage as a dangling `aria-labelledby`, one prop over.
+ * and the renderer passes a bare fragment through to the DOM, so a copier that
+ * mints a fresh `cssId` and stops has moved the target and left the link
+ * behind: the anchor resolves to nothing, which is the same silent breakage as
+ * a dangling `aria-labelledby`, one prop over.
  *
  * ## Why this is a module and not a private helper
  *
@@ -14,19 +14,35 @@
  * this rule and the second was written without it — the id map was returned,
  * handed back, and dropped — so a saved pattern stored a link to an id that no
  * longer existed anywhere. A warning written beside the places that existed
- * when it was written does not attach itself to the next one, and a rule that
- * only one of two copiers applies is a rule that holds until someone adds a
- * third.
+ * when it was written does not attach itself to the next one.
  *
- * ## Why a copier CAN do this, when it cannot rewrite props generally
+ * ## Only a field that HOLDS a target is rewritten
  *
- * Which prop of a block holds a link is a property of that block's definition,
- * which the format layer cannot read — and that is exactly why this does not
- * ask. A value is rewritten ONLY when the whole string is `#` followed by an id
- * THIS copy minted. Nothing else can produce that: `"#1 bestseller"` names no
- * minted id and is left as written, and so is a fragment addressing something
- * outside the copied subtree, which belongs to the page and must keep working.
- * The rule needs no schema because the map is the evidence.
+ * Matching a minted id does not prove a string is a reference. `core/heading`
+ * declares `text` and `href` as separate props, and an author may legitimately
+ * write a heading reading `#pricing` while a sibling in the same run carries
+ * `cssId: "pricing"` — rewriting on the value alone turned that heading into
+ * `#pricing-<suffix>` and silently changed what the page SAYS, which then
+ * travelled into every insertion of the pattern.
+ *
+ * So the field name decides, and the value only decides whether there is
+ * anything to do. {@link FRAGMENT_REFERENCE_PROPS} lists the names, the way
+ * `ID_REFERENCE_ATTRIBUTES` lists them for markup — as data, in one place,
+ * rather than left to each copier to remember. The engine cannot ask a block
+ * what its props MEAN: `PropSchema.type` is an open string, and no registry
+ * reaches the layer that copies a tree.
+ *
+ * The trade-off is deliberate and it is not symmetric. A name this list does
+ * not carry leaves a link that no longer jumps — visible, and an author can
+ * repair it. Rewriting on the value alone corrupts authored content invisibly
+ * and propagates it. Between failing to help and quietly changing meaning, this
+ * fails to help.
+ *
+ * Two further narrowings keep it away from content even within those fields:
+ * only a WHOLE string of `#` followed by an id THIS copy minted is rewritten,
+ * so `"#1 bestseller"` in an `href` is left alone, and so is a fragment
+ * addressing something outside the copied run — that target belongs to the page
+ * and must keep working.
  *
  * @module fragment-refs
  */
@@ -35,74 +51,118 @@ import { isPlainRecord } from "./plain-record";
 import { boundedOwnKeys, defineEntry, ownEntry } from "./safe-record";
 
 /**
- * How deep a prop tree is searched for fragment links.
+ * Prop names whose STRING value is a link target.
  *
- * A bound on work over values a stored document supplied, generous enough that
- * no authored prop shape reaches it.
+ * Published as data for the same reason `ID_REFERENCE_ATTRIBUTES` is: a surface
+ * that copies nodes without going through this helper still has to know which
+ * fields carry a target, and a block adding a differently-named one belongs
+ * here rather than in a second copy of the rule.
+ *
+ * `href` and `url` are the two the shipped blocks use — `href` on the link and
+ * button blocks, `url` on a rich-text link node and on a serialized button.
+ * `src` is deliberately absent: it addresses media, where a bare fragment means
+ * nothing, and so is a form `action`.
  */
-const MAX_PROP_SCAN_DEPTH = 8;
+export const FRAGMENT_REFERENCE_PROPS: readonly string[] = ["href", "url"];
+
+const FRAGMENT_REFERENCE_SET = new Set(FRAGMENT_REFERENCE_PROPS);
 
 /**
- * Rewrite every whole-string `#id` in a prop tree that names a minted id.
+ * How many values one prop tree may be scanned for.
  *
- * Returns the SAME value when nothing matched, so a copy of an ordinary block
- * allocates nothing and a caller can compare by identity to tell whether the
- * pass changed anything.
+ * A bound on WORK, not on depth. Depth was the wrong quantity and it was set
+ * too low to be safe either way: a rich-text link inside a list item sits at
+ * `props → content → root → children → item → children → listitem → children →
+ * link → url`, which is ten values down, so an ordinary authored link was
+ * already past a cap of eight and was silently left dangling. Any fixed depth
+ * is arbitrary here, because rich text nests lists as deeply as an author
+ * nests them.
+ *
+ * Counting visits bounds what a wide tree costs as well as a deep one, and it
+ * terminates on a value that refers to itself — which stored JSON cannot be,
+ * but a structured clone of an in-memory object can.
+ */
+const MAX_PROP_SCAN_VISITS = 20_000;
+
+/** A visit budget, spent as the walk reads values. */
+interface ScanBudget {
+  left: number;
+}
+
+/**
+ * Rewrite every link target in a prop tree that names an id this copy minted.
+ *
+ * Returns the SAME value when nothing matched, so an ordinary block allocates
+ * nothing and a caller can compare by identity to tell whether anything moved.
  */
 export function remapFragmentProps(
   props: unknown,
   domIds: ReadonlyMap<string, string>
 ): unknown {
-  return remapFragments(props, domIds, 0);
+  if (domIds.size === 0) return props;
+  return scan(props, domIds, { left: MAX_PROP_SCAN_VISITS });
 }
 
-function remapFragments(
-  props: unknown,
+/** One value: descended into, or returned as it stands. */
+function scan(
+  value: unknown,
   domIds: ReadonlyMap<string, string>,
-  depth: number
+  budget: ScanBudget
 ): unknown {
-  if (domIds.size === 0 || depth > MAX_PROP_SCAN_DEPTH) return props;
-  if (typeof props === "string") return remapOneFragment(props, domIds);
-  if (Array.isArray(props)) return remapFragmentList(props, domIds, depth);
-  if (!isPlainRecord(props)) return props;
-  return remapFragmentRecord(props, domIds, depth);
+  if (budget.left <= 0) return value;
+  budget.left -= 1;
+  if (Array.isArray(value)) return scanList(value, domIds, budget);
+  if (!isPlainRecord(value)) return value;
+  return scanRecord(value, domIds, budget);
 }
 
-/** The same, for a record-valued prop. */
-function remapFragmentRecord(
-  props: Record<string, unknown>,
+/**
+ * A record, with an allowlisted string field rewritten and everything else
+ * descended into.
+ *
+ * The name is checked HERE because this is the only place a value is reached
+ * with the field that holds it still in hand. A string found inside an array
+ * carries no name of its own and is never rewritten on its own account — but
+ * `cta.links[0].href` still is, because that string is reached as the value of
+ * `href` on the record inside the array.
+ */
+function scanRecord(
+  record: Record<string, unknown>,
   domIds: ReadonlyMap<string, string>,
-  depth: number
+  budget: ScanBudget
 ): unknown {
-  const keys = boundedOwnKeys(props, MAX_ENVELOPE_ENTRIES);
-  if (keys === null) return props;
+  const keys = boundedOwnKeys(record, MAX_ENVELOPE_ENTRIES);
+  if (keys === null) return record;
   let changed = false;
   const next: Record<string, unknown> = {};
   for (const key of keys) {
-    const value = ownEntry(props, key);
-    const mapped = remapFragments(value, domIds, depth + 1);
+    const value = ownEntry(record, key);
+    const mapped =
+      FRAGMENT_REFERENCE_SET.has(key) && typeof value === "string"
+        ? remapOneFragment(value, domIds)
+        : scan(value, domIds, budget);
     if (mapped !== value) changed = true;
     defineEntry(next, key, mapped);
   }
-  return changed ? next : props;
+  return changed ? next : record;
 }
 
-/** The same, for an array-valued prop. */
-function remapFragmentList(
+/** An array, descended into item by item. */
+function scanList(
   items: readonly unknown[],
   domIds: ReadonlyMap<string, string>,
-  depth: number
+  budget: ScanBudget
 ): unknown {
   let changed = false;
   const next = items.map(item => {
-    const mapped = remapFragments(item, domIds, depth + 1);
+    const mapped = scan(item, domIds, budget);
     if (mapped !== item) changed = true;
     return mapped;
   });
   return changed ? next : items;
 }
 
-/** One string, rewritten only if it is exactly a fragment this run minted. */
+/** One target, rewritten only if it is exactly a fragment this run minted. */
 function remapOneFragment(
   value: string,
   domIds: ReadonlyMap<string, string>

--- a/packages/blocks-engine/src/fragment-refs.ts
+++ b/packages/blocks-engine/src/fragment-refs.ts
@@ -46,9 +46,8 @@
  *
  * @module fragment-refs
  */
-import { MAX_ENVELOPE_ENTRIES } from "./limits";
 import { isPlainRecord } from "./plain-record";
-import { boundedOwnKeys, defineEntry, ownEntry } from "./safe-record";
+import { defineEntry, ownEntry, ownKeys } from "./safe-record";
 
 /**
  * Prop names whose STRING value is a link target.
@@ -66,36 +65,63 @@ import { boundedOwnKeys, defineEntry, ownEntry } from "./safe-record";
 export const FRAGMENT_REFERENCE_PROPS: readonly string[] = ["href", "url"];
 
 const FRAGMENT_REFERENCE_SET = new Set(FRAGMENT_REFERENCE_PROPS);
-
 /**
  * Rewrite every link target in a prop tree that names an id this copy minted.
  *
  * Returns the SAME value when nothing matched, so an ordinary block allocates
  * nothing and a caller can compare by identity to tell whether anything moved.
  *
- * ## Bounded by the input, not by a number
+ * ## Bounded by the document, not by a number of its own
  *
- * There was a cap here — first on depth, then on values visited — and both were
- * wrong the same way: each was a guess about how large a legitimate prop tree
- * gets, and a document exceeding the guess had its links silently left dangling
- * rather than being refused. A depth cap of eight could not reach a rich-text
- * link inside a list item, which is ten values down. A budget of twenty
- * thousand visits was reachable by a rich-text value of a few hundred kilobytes
- * — well inside the document size limit — so it was the same silent failure,
- * moved further away rather than removed.
+ * There were two caps here — first on depth, then on values visited — and both
+ * were guesses about how large a legitimate prop tree gets. Each time a valid
+ * document exceeded the guess, its links were silently left dangling rather
+ * than the document being refused, so raising the number only moved the same
+ * failure further away. A third borrowed bound did the same thing sideways: the
+ * component-envelope key budget was applied to opaque prop records, which the
+ * format does not cap at all, so a record of a thousand keys was returned
+ * untouched and counted as done.
  *
- * A prop tree is part of a document, and how large a document may be is already
- * decided once, by the document limits. Scanning all of it is therefore bounded
- * work already, and the only thing a cap was really buying was TERMINATION on a
- * value that refers to itself. That is what the path set does, exactly as
- * `mapForest` does it one module over.
+ * How large a document may be is decided once, by the document limits. A prop
+ * tree is part of one, so walking all of it is bounded work already, and every
+ * bound this module added was solving a problem it did not have.
+ *
+ * ## Iterative, because a valid tree can be deeper than the stack
+ *
+ * Roughly three thousand nested records — tens of kilobytes, well inside the
+ * document byte limit — exhausted the call stack under a recursive walk. Depth
+ * is a property of authored content and not something this module may refuse,
+ * so the walk carries its own stack, the way the forest walker does for exactly
+ * the same reason.
+ *
+ * ## One replacement per source object
+ *
+ * The map is what makes a graph come out a graph. A record reached twice is
+ * rebuilt once and both edges point at that one rebuild — so a cycle closes on
+ * the REPLACEMENT rather than on the original, which is the bug a path-set
+ * guard leaves behind: it terminates, but the copy ends up holding an edge back
+ * to the original object, still carrying the id this pass just rewrote. Shared
+ * structure that is not cyclic is preserved for the same reason, rather than
+ * being duplicated into two divergent copies.
  */
 export function remapFragmentProps(
   props: unknown,
   domIds: ReadonlyMap<string, string>
 ): unknown {
-  if (domIds.size === 0) return props;
-  return scan(props, domIds, new Set());
+  if (domIds.size === 0 || !isTraversable(props)) return props;
+
+  const copy = shellFor(props);
+  const run: Rebuild = {
+    domIds,
+    copies: new Map([[props, copy]]),
+    stack: [frameFor(props, copy)],
+    changed: false,
+  };
+  while (run.stack.length > 0) step(run);
+
+  // Nothing matched, so the copy describes exactly what was already there and
+  // the caller learns "unchanged" from identity rather than from a comparison.
+  return run.changed ? copy : props;
 }
 
 /**
@@ -113,11 +139,9 @@ export function remapFragmentBindings(
   domIds: ReadonlyMap<string, string>
 ): unknown {
   if (domIds.size === 0 || !isPlainRecord(bindings)) return bindings;
-  const keys = boundedOwnKeys(bindings, MAX_ENVELOPE_ENTRIES);
-  if (keys === null) return bindings;
   let changed = false;
   const next: Record<string, unknown> = {};
-  for (const key of keys) {
+  for (const key of ownKeys(bindings)) {
     const binding = ownEntry(bindings, key);
     const mapped = FRAGMENT_REFERENCE_SET.has(key)
       ? withRemappedFallback(binding, domIds)
@@ -140,80 +164,104 @@ function withRemappedFallback(
   return mapped === fallback ? binding : { ...binding, fallback: mapped };
 }
 
-/**
- * One value: descended into, or returned as it stands.
- *
- * `onPath` holds the objects between here and the root of this walk. A value
- * re-entered while it is still on the path is a cycle, and returning it
- * untouched is what makes this terminate — stored JSON cannot hold one, but a
- * structured clone of an in-memory object can, and these primitives are
- * documented as running on documents nothing has validated.
- *
- * A PATH rather than everything seen, because a prop tree may legitimately
- * reach one object from two places, and a value that has merely been visited
- * before still needs rewriting where it appears again.
- */
-function scan(
-  value: unknown,
-  domIds: ReadonlyMap<string, string>,
-  onPath: Set<unknown>
-): unknown {
-  if (typeof value !== "object" || value === null) return value;
-  if (onPath.has(value)) return value;
-  onPath.add(value);
-  const out = Array.isArray(value)
-    ? scanList(value, domIds, onPath)
-    : isPlainRecord(value)
-      ? scanRecord(value, domIds, onPath)
-      : value;
-  onPath.delete(value);
-  return out;
+/** A value this walk descends into: a plain record, or an array. */
+type Traversable = Record<string, unknown> | unknown[];
+
+/** One object being rebuilt, and how far through its entries the walk is. */
+interface Frame {
+  readonly source: Traversable;
+  readonly copy: Traversable;
+  /** The source's own keys, or `null` when it is an array. */
+  readonly keys: string[] | null;
+  index: number;
+}
+
+/** Everything one rebuild carries between steps. */
+interface Rebuild {
+  readonly domIds: ReadonlyMap<string, string>;
+  /** Source object → the single replacement standing in for it. */
+  readonly copies: Map<Traversable, Traversable>;
+  readonly stack: Frame[];
+  changed: boolean;
+}
+
+function isTraversable(value: unknown): value is Traversable {
+  return Array.isArray(value) || isPlainRecord(value);
+}
+
+/** An empty replacement of the same shape, filled in as the walk proceeds. */
+function shellFor(value: Traversable): Traversable {
+  return Array.isArray(value) ? [] : {};
+}
+
+function frameFor(source: Traversable, copy: Traversable): Frame {
+  return {
+    source,
+    copy,
+    keys: Array.isArray(source) ? null : ownKeys(source),
+    index: 0,
+  };
+}
+
+/** How many entries a frame has to get through. */
+function sizeOf(frame: Frame): number {
+  return frame.keys === null
+    ? (frame.source as unknown[]).length
+    : frame.keys.length;
+}
+
+/** One entry of the frame on top of the stack. */
+function step(run: Rebuild): void {
+  const frame = run.stack[run.stack.length - 1];
+  if (frame === undefined) return;
+  if (frame.index >= sizeOf(frame)) {
+    run.stack.pop();
+    return;
+  }
+  const at = frame.index;
+  frame.index += 1;
+  const key = frame.keys === null ? null : (frame.keys[at] ?? null);
+  const value =
+    key === null
+      ? (frame.source as unknown[])[at]
+      : ownEntry(frame.source as Record<string, unknown>, key);
+  const resolved = resolveEntry(run, key, value);
+  if (key === null) (frame.copy as unknown[])[at] = resolved;
+  else defineEntry(frame.copy as Record<string, unknown>, key, resolved);
 }
 
 /**
- * A record, with an allowlisted string field rewritten and everything else
- * descended into.
+ * What one entry becomes in the copy.
  *
- * The name is checked HERE because this is the only place a value is reached
- * with the field that holds it still in hand. A string inside an array carries
- * no name of its own and is never rewritten on its own account — but
+ * The field name is checked HERE because this is the only place a value is
+ * reached with the field that holds it still in hand. A string inside an array
+ * carries no name of its own and is never rewritten on its own account — but
  * `cta.links[0].href` still is, because that string is reached as the value of
  * `href` on the record inside the array.
  */
-function scanRecord(
-  record: Record<string, unknown>,
-  domIds: ReadonlyMap<string, string>,
-  onPath: Set<unknown>
+function resolveEntry(
+  run: Rebuild,
+  key: string | null,
+  value: unknown
 ): unknown {
-  const keys = boundedOwnKeys(record, MAX_ENVELOPE_ENTRIES);
-  if (keys === null) return record;
-  let changed = false;
-  const next: Record<string, unknown> = {};
-  for (const key of keys) {
-    const value = ownEntry(record, key);
-    const mapped =
-      FRAGMENT_REFERENCE_SET.has(key) && typeof value === "string"
-        ? remapOneFragment(value, domIds)
-        : scan(value, domIds, onPath);
-    if (mapped !== value) changed = true;
-    defineEntry(next, key, mapped);
+  if (key !== null && FRAGMENT_REFERENCE_SET.has(key)) {
+    if (typeof value !== "string") return descend(run, value);
+    const mapped = remapOneFragment(value, run.domIds);
+    if (mapped !== value) run.changed = true;
+    return mapped;
   }
-  return changed ? next : record;
+  return descend(run, value);
 }
 
-/** An array, descended into item by item. */
-function scanList(
-  items: readonly unknown[],
-  domIds: ReadonlyMap<string, string>,
-  onPath: Set<unknown>
-): unknown {
-  let changed = false;
-  const next = items.map(item => {
-    const mapped = scan(item, domIds, onPath);
-    if (mapped !== item) changed = true;
-    return mapped;
-  });
-  return changed ? next : items;
+/** A child object's single replacement, queued for filling if it is new. */
+function descend(run: Rebuild, value: unknown): unknown {
+  if (!isTraversable(value)) return value;
+  const existing = run.copies.get(value);
+  if (existing !== undefined) return existing;
+  const copy = shellFor(value);
+  run.copies.set(value, copy);
+  run.stack.push(frameFor(value, copy));
+  return copy;
 }
 
 /** One target, rewritten only if it is exactly a fragment this run minted. */

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -143,6 +143,16 @@ export type {
   TreePosition,
 } from "./tree";
 
+// The one rule for which prop of a copied node holds a link, and what happens
+// to it. Published because the module claims to be the single source for every
+// copying surface, and a rule a consumer cannot import is a rule they will
+// write again — which is exactly how the fragment remap came to exist twice.
+export {
+  FRAGMENT_REFERENCE_PROPS,
+  remapFragmentBindings,
+  remapFragmentProps,
+} from "./fragment-refs";
+
 // Whether a selection is one run of siblings. Published because the editor and
 // every composition planner must agree on it, and they cannot share a
 // builder-side copy: a planner runs inside a plugin's server action, where the
@@ -163,6 +173,8 @@ export { planSaveAsPattern } from "./composition-planners";
 export type {
   CompositionPlan,
   PatternTarget,
+  PlanProblem,
+  PlanRefusal,
   PlanResult,
   PlannedCreate,
 } from "./composition-planners";

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -117,6 +117,10 @@ export {
   moveNode,
   reidSubtree,
   reidSubtreeWithMap,
+  // The forest form, which is the shape a saved selection actually has: a
+  // pattern is a run of siblings, and re-identifying its roots one at a time
+  // leaves a reference that crosses between them pointing at the original.
+  reidForestWithMap,
   // The one rule for what a copied DOM id becomes. Public because two copiers
   // apply it — pattern insert and component composition — and a page may hold
   // the output of both, so a second spelling would put two ids on one target.
@@ -133,10 +137,35 @@ export {
 } from "./tree";
 export type {
   NodeLocation,
+  ReidentifiedForest,
   ReidentifiedSubtree,
   SlotDefaultSource,
   TreePosition,
 } from "./tree";
+
+// Whether a selection is one run of siblings. Published because the editor and
+// every composition planner must agree on it, and they cannot share a
+// builder-side copy: a planner runs inside a plugin's server action, where the
+// builder — which peer-depends on React — has no business being imported.
+export { contiguousRun, siblingRun } from "./sibling-run";
+export type {
+  RunPlace,
+  RunProblem,
+  SiblingRun,
+  SiblingRunResult,
+} from "./sibling-run";
+
+// The composition planners: pure functions from a selection to the row to
+// create and the ops the page needs. Split from the doing so the caller can put
+// both writes in one unit of work and roll the create back — and so the dry run
+// and the real run are the same function rather than two that agree for now.
+export { planSaveAsPattern } from "./composition-planners";
+export type {
+  CompositionPlan,
+  PatternTarget,
+  PlanResult,
+  PlannedCreate,
+} from "./composition-planners";
 
 // The node selection every reader of a stored document shares. Public because
 // the page-builder plugin's class-usage record has to stop exactly where the

--- a/packages/blocks-engine/src/resolve-instances.ts
+++ b/packages/blocks-engine/src/resolve-instances.ts
@@ -55,7 +55,7 @@ import {
   type OverrideValue,
 } from "./document";
 import { walkForest } from "./forest-walk";
-import { remapFragmentProps } from "./fragment-refs";
+import { remapFragmentBindings, remapFragmentProps } from "./fragment-refs";
 import {
   countNodes,
   DEFAULT_LIMITS,
@@ -836,17 +836,25 @@ function withRemappedIdReferences(
         string,
         unknown
       >;
+      // The BOUND form of the same field, for the same reason: a bound `href`
+      // renders `bindings.href.fallback` when its source is empty, so a
+      // fallback left behind points at an id this composition has re-minted.
+      const bindings = remapFragmentBindings(
+        node.bindings,
+        ctx.domIds
+      ) as ResolvedBlockNode["bindings"];
       const slots = isPlainRecord(node.slots)
         ? rewriteSlots(node.slots)
         : node.slots;
       if (
         attributes === node.attributes &&
         slots === node.slots &&
-        props === node.props
+        props === node.props &&
+        bindings === node.bindings
       ) {
         return node;
       }
-      return { ...node, attributes, props, slots };
+      return { ...node, attributes, props, bindings, slots };
     });
   const rewriteSlots = (
     slots: Record<string, ResolvedBlockNode[]>

--- a/packages/blocks-engine/src/resolve-instances.ts
+++ b/packages/blocks-engine/src/resolve-instances.ts
@@ -55,6 +55,7 @@ import {
   type OverrideValue,
 } from "./document";
 import { walkForest } from "./forest-walk";
+import { remapFragmentProps } from "./fragment-refs";
 import {
   countNodes,
   DEFAULT_LIMITS,
@@ -831,7 +832,7 @@ function withRemappedIdReferences(
       const attributes = isPlainRecord(node.attributes)
         ? remapIdReferences(node.attributes, ctx.domIds)
         : node.attributes;
-      const props = remapFragments(node.props, ctx.domIds, 0) as Record<
+      const props = remapFragmentProps(node.props, ctx.domIds) as Record<
         string,
         unknown
       >;
@@ -865,84 +866,6 @@ function withRemappedIdReferences(
     return changed ? (next as Record<string, ResolvedBlockNode[]>) : slots;
   };
   return rewrite(roots);
-}
-
-/**
- * How deep a prop tree is searched for fragment links.
- *
- * A bound on work over values a stored definition supplied, generous enough
- * that no authored prop shape reaches it.
- */
-const MAX_PROP_SCAN_DEPTH = 8;
-
-/**
- * Point a block's `#fragment` props at wherever those ids ended up.
- *
- * `cssId` is not referenced only by markup: a link's `href` may be `#pricing`,
- * and the renderer accepts that — `core/button` passes a bare fragment through
- * to the DOM. Remapping the target without the link leaves every composed
- * instance anchored to an id nothing carries, which is the same silent
- * breakage as a dangling `aria-labelledby`, one prop over.
- *
- * A value is rewritten ONLY when the whole string is `#` followed by an id
- * this composition actually minted, and that is what keeps it away from
- * content: `"#1 bestseller"` names no minted id and is left exactly as
- * written, and so is a fragment addressing something outside the component.
- */
-function remapFragments(
-  props: unknown,
-  domIds: ReadonlyMap<string, string>,
-  depth: number
-): unknown {
-  if (domIds.size === 0 || depth > MAX_PROP_SCAN_DEPTH) return props;
-  if (typeof props === "string") return remapOneFragment(props, domIds);
-  if (Array.isArray(props)) return remapFragmentList(props, domIds, depth);
-  if (!isPlainRecord(props)) return props;
-  return remapFragmentRecord(props, domIds, depth);
-}
-
-/** The same, for a record-valued prop. */
-function remapFragmentRecord(
-  props: Record<string, unknown>,
-  domIds: ReadonlyMap<string, string>,
-  depth: number
-): unknown {
-  const keys = boundedOwnKeys(props, MAX_ENVELOPE_ENTRIES);
-  if (keys === null) return props;
-  let changed = false;
-  const next: Record<string, unknown> = {};
-  for (const key of keys) {
-    const value = ownEntry(props, key);
-    const mapped = remapFragments(value, domIds, depth + 1);
-    if (mapped !== value) changed = true;
-    defineEntry(next, key, mapped);
-  }
-  return changed ? next : props;
-}
-
-/** The same, for an array-valued prop. */
-function remapFragmentList(
-  items: readonly unknown[],
-  domIds: ReadonlyMap<string, string>,
-  depth: number
-): unknown {
-  let changed = false;
-  const next = items.map(item => {
-    const mapped = remapFragments(item, domIds, depth + 1);
-    if (mapped !== item) changed = true;
-    return mapped;
-  });
-  return changed ? next : items;
-}
-
-/** One string, rewritten only if it is exactly a fragment this run minted. */
-function remapOneFragment(
-  value: string,
-  domIds: ReadonlyMap<string, string>
-): string {
-  if (!value.startsWith("#")) return value;
-  const target = domIds.get(value.slice(1));
-  return target === undefined ? value : `#${target}`;
 }
 
 /** Everything one speculative expansion may have to give back. */

--- a/packages/blocks-engine/src/safe-record.ts
+++ b/packages/blocks-engine/src/safe-record.ts
@@ -106,6 +106,35 @@ export function ownEntry<T>(
  * deserve opposite treatment: one is ordinary, the other is a document to
  * refuse.
  */
+/**
+ * The own keys of an untrusted record, however many there are.
+ *
+ * The counterpart to {@link boundedOwnKeys}, and choosing between them is a
+ * question about what the record IS. A budget belongs where the record is a
+ * declared envelope whose size the format decides — a component's exposed
+ * properties, say — because a record past that size is a document to refuse.
+ * It does not belong where the record is opaque content a block defines for
+ * itself, because nothing in the format caps that, and a traversal that gave up
+ * at a borrowed limit would return such a record UNCHANGED and call it done.
+ *
+ * That is not hypothetical: a prop record of a thousand keys walked past the
+ * component-envelope budget and had its link left addressing an id that had
+ * been re-minted, silently, because a bound copied from a neighbouring concern
+ * read as a refusal in one place and as "nothing to do" in the other.
+ *
+ * Enumerated the same way, so the two cannot disagree about what an own key is.
+ */
+export function ownKeys(record: object): string[] {
+  const keys: string[] = [];
+  for (const key in record) {
+    // The record's own keys are stored data, so it may carry a
+    // `hasOwnProperty` of its own and answer the question with it.
+    if (!Object.prototype.hasOwnProperty.call(record, key)) continue;
+    keys.push(key);
+  }
+  return keys;
+}
+
 export function boundedOwnKeys(record: object, limit: number): string[] | null {
   const keys: string[] = [];
   for (const key in record) {

--- a/packages/blocks-engine/src/sibling-run.test.ts
+++ b/packages/blocks-engine/src/sibling-run.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Whether a selection is one run of siblings.
+ *
+ * Two failures are worth more than the rest and most of these assertions exist
+ * for them. A rule that keys the list on the parent ALONE reads a card's header
+ * and its footer as one list, so a reorder swaps a block between two regions it
+ * was never in. And a rule that reports "an id I cannot find" as "these are in
+ * different containers" tells an author to fix their selection when what is
+ * actually wrong is that the caller is out of step with the document.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { BlockNode } from "./document";
+import { contiguousRun, siblingRun } from "./sibling-run";
+
+/** A node, optionally holding named slots of children. */
+function node(id: string, slots?: Record<string, BlockNode[]>): BlockNode {
+  return {
+    id,
+    type: "core/box",
+    version: 1,
+    props: {},
+    ...(slots === undefined ? {} : { slots }),
+  };
+}
+
+/** Three top-level siblings. */
+const flat = (): BlockNode[] => [node("a"), node("b"), node("c")];
+
+describe("a selection that shares one list", () => {
+  it("reports each block's index, at the top level", () => {
+    const found = siblingRun(flat(), ["a", "b"]);
+    expect(found.run).toEqual({
+      places: [
+        { id: "a", index: 0 },
+        { id: "b", index: 1 },
+      ],
+    });
+  });
+
+  it("names the parent and slot when the run is nested", () => {
+    const nodes = [node("card", { body: [node("a"), node("b")] })];
+    const found = siblingRun(nodes, ["a", "b"]);
+    expect(found.run?.parentId).toBe("card");
+    expect(found.run?.slot).toBe("body");
+  });
+
+  it("sorts by index however the ids arrived", () => {
+    const found = siblingRun(flat(), ["c", "a", "b"]);
+    expect(found.run?.places.map(place => place.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("allows a gap, because a reorder does not care about one", () => {
+    const found = siblingRun(flat(), ["a", "c"]);
+    expect(found.run?.places.map(place => place.index)).toEqual([0, 2]);
+  });
+});
+
+describe("a selection that does not share one list", () => {
+  it("refuses blocks in two different parents", () => {
+    const nodes = [
+      node("one", { body: [node("a")] }),
+      node("two", { body: [node("b")] }),
+    ];
+    expect(siblingRun(nodes, ["a", "b"]).problem).toBe("split");
+  });
+
+  it("refuses two SLOTS of one parent, which share a parent id", () => {
+    const nodes = [node("card", { header: [node("a")], footer: [node("b")] })];
+    expect(siblingRun(nodes, ["a", "b"]).problem).toBe("split");
+  });
+
+  it("refuses one parent's slot and one root, which share a slot of nothing", () => {
+    const nodes = [node("a"), node("card", { body: [node("b")] })];
+    expect(siblingRun(nodes, ["a", "b"]).problem).toBe("split");
+  });
+
+  it("tells an unknown id apart from a split", () => {
+    expect(siblingRun(flat(), ["a", "nowhere"]).problem).toBe("unknown");
+  });
+
+  it("refuses an empty selection rather than answering with an empty run", () => {
+    const found = siblingRun(flat(), []);
+    expect(found.problem).toBe("empty");
+    expect(found.run).toBeUndefined();
+  });
+});
+
+describe("contiguity", () => {
+  it("accepts a consecutive run", () => {
+    expect(contiguousRun(flat(), ["a", "b"]).run?.places).toHaveLength(2);
+  });
+
+  it("accepts it whatever order the ids arrived in", () => {
+    expect(contiguousRun(flat(), ["b", "a"]).run?.places).toEqual([
+      { id: "a", index: 0 },
+      { id: "b", index: 1 },
+    ]);
+  });
+
+  it("accepts a single block", () => {
+    expect(contiguousRun(flat(), ["b"]).run?.places).toEqual([
+      { id: "b", index: 1 },
+    ]);
+  });
+
+  it("refuses a run with a block left out of the middle", () => {
+    expect(contiguousRun(flat(), ["a", "c"]).problem).toBe("gap");
+  });
+
+  it("keeps the cause when the selection was not one list at all", () => {
+    const nodes = [node("card", { header: [node("a")], footer: [node("b")] })];
+    // "split", not "gap": the run never got far enough to have indexes to
+    // compare, and an author told to close a gap would be looking for one that
+    // is not there.
+    expect(contiguousRun(nodes, ["a", "b"]).problem).toBe("split");
+  });
+
+  it("accepts a nested run, so the rule is not a top-level one", () => {
+    const nodes = [node("card", { body: [node("a"), node("b"), node("c")] })];
+    expect(contiguousRun(nodes, ["b", "c"]).run?.parentId).toBe("card");
+    expect(contiguousRun(nodes, ["a", "c"]).problem).toBe("gap");
+  });
+});

--- a/packages/blocks-engine/src/sibling-run.test.ts
+++ b/packages/blocks-engine/src/sibling-run.test.ts
@@ -29,13 +29,16 @@ const flat = (): BlockNode[] => [node("a"), node("b"), node("c")];
 
 describe("a selection that shares one list", () => {
   it("reports each block's index, at the top level", () => {
-    const found = siblingRun(flat(), ["a", "b"]);
-    expect(found.run).toEqual({
-      places: [
-        { id: "a", index: 0 },
-        { id: "b", index: 1 },
-      ],
-    });
+    const nodes = flat();
+    const found = siblingRun(nodes, ["a", "b"]);
+    expect(found.run?.parentId).toBeUndefined();
+    expect(found.run?.slot).toBeUndefined();
+    expect(found.run?.places.map(p => [p.id, p.index])).toEqual([
+      ["a", 0],
+      ["b", 1],
+    ]);
+    // The node is carried, and it is the one in THIS forest, not a copy.
+    expect(found.run?.places[0]!.node).toBe(nodes[0]);
   });
 
   it("names the parent and slot when the run is nested", () => {
@@ -93,6 +96,31 @@ describe("a selection that does not share one list", () => {
     expect(contiguousRun(nodes, ["p", "y1"]).problem).toBe("split");
   });
 
+  it("refuses two DIFFERENT parents that share an id and a slot name", () => {
+    // Comparing the parent's id merged them: two distinct containers spelled
+    // the same, so children that were never siblings were accepted as one run
+    // and, with consecutive indexes, passed the contiguity check too. An id is
+    // not an identity on a document nothing validated — the parent OBJECT is.
+    const nodes = [
+      node("dup", { body: [node("a"), node("filler")] }),
+      node("dup", { body: [node("other"), node("b")] }),
+    ];
+
+    expect(siblingRun(nodes, ["a", "b"]).problem).toBe("split");
+    expect(contiguousRun(nodes, ["a", "b"]).problem).toBe("split");
+  });
+
+  it("still accepts a real run under a parent whose id is duplicated", () => {
+    // The guard is about identity, not about refusing duplicated ids: two
+    // genuine siblings under one of those parents are still one run.
+    const nodes = [
+      node("dup", { body: [node("a"), node("b")] }),
+      node("dup", { body: [node("x")] }),
+    ];
+
+    expect(contiguousRun(nodes, ["a", "b"]).run?.places).toHaveLength(2);
+  });
+
   it("tells an unknown id apart from a split", () => {
     expect(siblingRun(flat(), ["a", "nowhere"]).problem).toBe("unknown");
   });
@@ -110,16 +138,18 @@ describe("contiguity", () => {
   });
 
   it("accepts it whatever order the ids arrived in", () => {
-    expect(contiguousRun(flat(), ["b", "a"]).run?.places).toEqual([
-      { id: "a", index: 0 },
-      { id: "b", index: 1 },
+    expect(
+      contiguousRun(flat(), ["b", "a"]).run?.places.map(p => [p.id, p.index])
+    ).toEqual([
+      ["a", 0],
+      ["b", 1],
     ]);
   });
 
   it("accepts a single block", () => {
-    expect(contiguousRun(flat(), ["b"]).run?.places).toEqual([
-      { id: "b", index: 1 },
-    ]);
+    expect(
+      contiguousRun(flat(), ["b"]).run?.places.map(p => [p.id, p.index])
+    ).toEqual([["b", 1]]);
   });
 
   it("refuses a run with a block left out of the middle", () => {

--- a/packages/blocks-engine/src/sibling-run.test.ts
+++ b/packages/blocks-engine/src/sibling-run.test.ts
@@ -75,6 +75,24 @@ describe("a selection that does not share one list", () => {
     expect(siblingRun(nodes, ["a", "b"]).problem).toBe("split");
   });
 
+  it("refuses a pair whose parent and slot JOIN to the same text", () => {
+    // The list was once identified by `parentId + " " + slot`, on the stated
+    // ground that an id cannot contain a space. Validation asks a node id only
+    // to be a non-empty string, and these primitives read stored documents that
+    // nothing validated, so both halves are arbitrary text. Here `"a"` + `"b c"`
+    // and `"a b"` + `"c"` both spell `"a b c"`, and the two containers merged:
+    // the run was accepted, the contiguity check passed, and a pattern saved
+    // from it took the first container's second block instead of the one the
+    // author had actually selected in the second.
+    const nodes = [
+      node("a", { "b c": [node("p"), node("q")] }),
+      node("a b", { c: [node("y0"), node("y1")] }),
+    ];
+
+    expect(siblingRun(nodes, ["p", "y1"]).problem).toBe("split");
+    expect(contiguousRun(nodes, ["p", "y1"]).problem).toBe("split");
+  });
+
   it("tells an unknown id apart from a split", () => {
     expect(siblingRun(flat(), ["a", "nowhere"]).problem).toBe("unknown");
   });

--- a/packages/blocks-engine/src/sibling-run.ts
+++ b/packages/blocks-engine/src/sibling-run.ts
@@ -32,7 +32,7 @@
  * @module sibling-run
  */
 import type { BlockNode } from "./document";
-import { locateNode } from "./tree";
+import { locateNode, type NodeLocation } from "./tree";
 
 /** Why a selection is not one run of siblings. */
 export type RunProblem =
@@ -50,6 +50,19 @@ export interface RunPlace {
   readonly id: string;
   /** Its index in that sibling list. */
   readonly index: number;
+  /**
+   * The node that was FOUND here, carried rather than left to be looked up.
+   *
+   * An id is not an identity on a stored document nothing validated: two nodes
+   * may carry the same one, and two lookups then disagree about which is meant.
+   * They disagree in a way no reader would predict — the search behind this one
+   * checks every root before descending, while a plain find walks each root and
+   * its descendants in turn, so a nested node and a later top-level node
+   * sharing an id resolve to different nodes in the two. Carrying the node the
+   * search actually reached removes the second lookup instead of trying to make
+   * the two agree.
+   */
+  readonly node: BlockNode;
 }
 
 /** A selection that all sits in one sibling list. */
@@ -98,7 +111,7 @@ export function siblingRun(
   if (ids.length === 0) return { problem: "empty" };
 
   const places: RunPlace[] = [];
-  let parentId: string | undefined;
+  let parent: BlockNode | undefined;
   let slot: string | undefined;
   let anchored = false;
 
@@ -111,14 +124,14 @@ export function siblingRun(
     // was written first.
     if (at === undefined) return { problem: "unknown" };
     if (!anchored) {
-      parentId = at.parent?.id;
+      parent = at.parent;
       slot = at.slot;
       anchored = true;
       // A separate flag rather than `parentId === undefined`, because that is
       // what a TOP-LEVEL run legitimately looks like — using it as "not yet
       // seen" would re-anchor on every root and read a whole document as one
       // list.
-    } else if (at.parent?.id !== parentId || at.slot !== slot) {
+    } else if (at.parent !== parent || at.slot !== slot) {
       // Compared FIELD BY FIELD, never as one joined string. Both halves are
       // arbitrary text — validation asks a node id only to be a non-empty
       // string, and these primitives run on stored documents nothing validated
@@ -131,10 +144,16 @@ export function siblingRun(
       // contain the separator.
       return { problem: "split" };
     }
-    places.push({ id, index: at.index });
+    const node = nodeAt(nodes, at);
+    // Unreachable: `locateNode` just read this node out of that very list. It
+    // is checked rather than asserted because the alternative is a run holding
+    // an `undefined` node, which every later step would treat as a block.
+    if (node === undefined) return { problem: "unknown" };
+    places.push({ id, index: at.index, node });
   }
 
   places.sort((left, right) => left.index - right.index);
+  const parentId = parent?.id;
   return {
     run: {
       ...(parentId === undefined ? {} : { parentId }),
@@ -142,6 +161,14 @@ export function siblingRun(
       places,
     },
   };
+}
+
+/** The node a location names, read out of the very list it was found in. */
+function nodeAt(nodes: BlockNode[], at: NodeLocation): BlockNode | undefined {
+  if (at.parent === undefined) return nodes[at.index];
+  const children =
+    at.slot === undefined ? undefined : at.parent.slots?.[at.slot];
+  return Array.isArray(children) ? children[at.index] : undefined;
 }
 
 /**

--- a/packages/blocks-engine/src/sibling-run.ts
+++ b/packages/blocks-engine/src/sibling-run.ts
@@ -80,20 +80,6 @@ export type SiblingRunResult =
   | { readonly problem: RunProblem; readonly run?: undefined };
 
 /**
- * Parent and slot as ONE key.
- *
- * One parent's two slots are two lists, so neither alone identifies the list.
- * The separator is a space, which an id cannot contain, so no pair of distinct
- * containers can collide into a single key.
- */
-function listKey(
-  parentId: string | undefined,
-  slot: string | undefined
-): string {
-  return `${parentId ?? ""} ${slot ?? ""}`;
-}
-
-/**
  * Where each selected node sits, once they all sit in one list.
  *
  * Gaps are ALLOWED here: a reorder steps every selected block one place and
@@ -112,9 +98,9 @@ export function siblingRun(
   if (ids.length === 0) return { problem: "empty" };
 
   const places: RunPlace[] = [];
-  let key: string | undefined;
   let parentId: string | undefined;
   let slot: string | undefined;
+  let anchored = false;
 
   for (const id of ids) {
     const at = locateNode(nodes, id);
@@ -124,12 +110,25 @@ export function siblingRun(
     // is a sentence to show, and a single refusal would send both to whichever
     // was written first.
     if (at === undefined) return { problem: "unknown" };
-    const here = listKey(at.parent?.id, at.slot);
-    if (key === undefined) {
-      key = here;
+    if (!anchored) {
       parentId = at.parent?.id;
       slot = at.slot;
-    } else if (key !== here) {
+      anchored = true;
+      // A separate flag rather than `parentId === undefined`, because that is
+      // what a TOP-LEVEL run legitimately looks like — using it as "not yet
+      // seen" would re-anchor on every root and read a whole document as one
+      // list.
+    } else if (at.parent?.id !== parentId || at.slot !== slot) {
+      // Compared FIELD BY FIELD, never as one joined string. Both halves are
+      // arbitrary text — validation asks a node id only to be a non-empty
+      // string, and these primitives run on stored documents nothing validated
+      // — so any separator can appear inside them, and a joined key merges two
+      // real containers. Measured with `parentId: "a"` / slot `"b c"` against
+      // `parentId: "a b"` / slot `"c"`: both spell `"a b c"`, the selection was
+      // accepted as one contiguous run, and the pattern was saved from the
+      // first container's blocks while the ones the author picked in the second
+      // were dropped. Silently, and only for documents whose ids happen to
+      // contain the separator.
       return { problem: "split" };
     }
     places.push({ id, index: at.index });

--- a/packages/blocks-engine/src/sibling-run.ts
+++ b/packages/blocks-engine/src/sibling-run.ts
@@ -1,0 +1,173 @@
+/**
+ * Whether a set of selected nodes is one run of siblings, and where it sits.
+ *
+ * Asked by two kinds of caller that must not answer it separately. The editor
+ * asks it to reorder a multi-block selection — a step through a list has no
+ * meaning for blocks in different lists. Every composition planner asks it
+ * because a saved pattern, a new component and a converted selection are all
+ * ONE contiguous run lifted out of one place, and inserting one back is the
+ * inverse of taking it out only if that is true.
+ *
+ * ## Why it is published from the engine
+ *
+ * The builder owned a private copy of the first half of this
+ * (`selection-ops.ts:sharedRun`), which was right while the editor was the only
+ * caller. It stopped being right when the planners arrived: a planner runs
+ * inside a plugin's server action as well as in the editor, and the builder
+ * cannot be imported there — it peer-depends on React, and the dependency
+ * direction is builder → engine, so the engine could not import a builder-side
+ * predicate back. One of the two would have had to be a second implementation,
+ * and the module that held the first one says why that ends badly: it would
+ * eventually disagree with the toolbar and the keyboard, which act through it.
+ *
+ * ## What it deliberately does NOT decide
+ *
+ * The sentence an author reads. A refusal is phrased as the REMEDY rather than
+ * the rule — "select blocks that share one container" — and the remedy belongs
+ * to the verb: moving, saving as a pattern and converting to a component are
+ * three different things to be told to do instead. So this reports the CAUSE it
+ * observed, as a closed set, and each surface says what to do about it. That is
+ * the same division the validator uses between an issue and its suggestion.
+ *
+ * @module sibling-run
+ */
+import type { BlockNode } from "./document";
+import { locateNode } from "./tree";
+
+/** Why a selection is not one run of siblings. */
+export type RunProblem =
+  /** Nothing was selected. */
+  | "empty"
+  /** An id names no node in this document. */
+  | "unknown"
+  /** They do not all share one parent and slot. */
+  | "split"
+  /** They share one list, but other blocks sit between them. */
+  | "gap";
+
+/** One selected node's place in the list its siblings share. */
+export interface RunPlace {
+  readonly id: string;
+  /** Its index in that sibling list. */
+  readonly index: number;
+}
+
+/** A selection that all sits in one sibling list. */
+export interface SiblingRun {
+  /**
+   * The node whose slot holds them, or `undefined` at the top level.
+   *
+   * Reported as an id rather than the node, because a caller that wants the
+   * node has the document and a caller that wants to build an op wants the id —
+   * and handing back a node from the document invites mutating it.
+   */
+  readonly parentId?: string;
+  /** The slot within that parent, or `undefined` at the top level. */
+  readonly slot?: string;
+  /** The selected nodes, sorted by their index in that list. */
+  readonly places: readonly RunPlace[];
+}
+
+/**
+ * A run, or the cause there is not one.
+ *
+ * Both members carry the other field as `undefined` so a caller narrows on
+ * `result.run !== undefined` without a type guard, and cannot read a run off a
+ * refusal.
+ */
+export type SiblingRunResult =
+  | { readonly run: SiblingRun; readonly problem?: undefined }
+  | { readonly problem: RunProblem; readonly run?: undefined };
+
+/**
+ * Parent and slot as ONE key.
+ *
+ * One parent's two slots are two lists, so neither alone identifies the list.
+ * The separator is a space, which an id cannot contain, so no pair of distinct
+ * containers can collide into a single key.
+ */
+function listKey(
+  parentId: string | undefined,
+  slot: string | undefined
+): string {
+  return `${parentId ?? ""} ${slot ?? ""}`;
+}
+
+/**
+ * Where each selected node sits, once they all sit in one list.
+ *
+ * Gaps are ALLOWED here: a reorder steps every selected block one place and
+ * does not care whether unselected ones sit between them. Callers that do care
+ * ask {@link contiguousRun}.
+ *
+ * Duplicate ids are not special-cased. `places` reports what it was given, so a
+ * caller that passed one id twice gets it twice — the selection model
+ * de-duplicates before it reaches here, and inventing a second de-duplication
+ * would hide a caller bug rather than fix one.
+ */
+export function siblingRun(
+  nodes: BlockNode[],
+  ids: readonly string[]
+): SiblingRunResult {
+  if (ids.length === 0) return { problem: "empty" };
+
+  const places: RunPlace[] = [];
+  let key: string | undefined;
+  let parentId: string | undefined;
+  let slot: string | undefined;
+
+  for (const id of ids) {
+    const at = locateNode(nodes, id);
+    // Told apart from "split" deliberately. An id the document does not hold is
+    // a caller that is out of step with the document; blocks in two containers
+    // is an author who selected across a boundary. One is a bug and the other
+    // is a sentence to show, and a single refusal would send both to whichever
+    // was written first.
+    if (at === undefined) return { problem: "unknown" };
+    const here = listKey(at.parent?.id, at.slot);
+    if (key === undefined) {
+      key = here;
+      parentId = at.parent?.id;
+      slot = at.slot;
+    } else if (key !== here) {
+      return { problem: "split" };
+    }
+    places.push({ id, index: at.index });
+  }
+
+  places.sort((left, right) => left.index - right.index);
+  return {
+    run: {
+      ...(parentId === undefined ? {} : { parentId }),
+      ...(slot === undefined ? {} : { slot }),
+      places,
+    },
+  };
+}
+
+/**
+ * The same, refusing a run with anything selected out of it.
+ *
+ * What contiguity buys is that the run has a PLACE. A pattern saved from three
+ * sections separated by a fourth has no single index to be re-inserted at, and
+ * converting such a selection to a component would have to remove blocks from
+ * two places and leave the one between them stranded between the halves of
+ * something that is now one node. Requiring a run makes "put it back" the exact
+ * inverse of "take it out", which is what lets insert, convert and detach share
+ * one placement rule instead of three.
+ */
+export function contiguousRun(
+  nodes: BlockNode[],
+  ids: readonly string[]
+): SiblingRunResult {
+  const result = siblingRun(nodes, ids);
+  if (result.run === undefined) return result;
+  return isConsecutive(result.run.places) ? result : { problem: "gap" };
+}
+
+/** Whether sorted places step one index at a time. */
+function isConsecutive(places: readonly RunPlace[]): boolean {
+  const first = places[0];
+  if (first === undefined) return false;
+  return places.every((place, offset) => place.index === first.index + offset);
+}

--- a/packages/blocks-engine/src/tree.reid-with-map.test.ts
+++ b/packages/blocks-engine/src/tree.reid-with-map.test.ts
@@ -291,3 +291,57 @@ describe("a forest is re-identified as one thing", () => {
     expect(domIds.size).toBe(0);
   });
 });
+
+/**
+ * A fragment link lives in PROPS, and the copy has to take it along.
+ *
+ * `cssId` is not referenced only by markup. `core/button` passes a bare `href`
+ * of `#pricing` through to the DOM, so minting a new id for the target and
+ * leaving the link behind produces a copy whose anchor resolves to nothing —
+ * the same silent breakage as a dangling `aria-labelledby`, one prop over. The
+ * rule is deliberately narrow: only a whole string of `#` plus an id THIS copy
+ * minted is rewritten, because nothing else can spell that.
+ */
+describe("a fragment link in props follows the copy", () => {
+  it("repoints an href at the copy's own target", () => {
+    const forest = [
+      node("target", { cssId: "pricing" }),
+      node("link", { props: { href: "#pricing" } } as Partial<BlockNode>),
+    ];
+
+    const { nodes, domIds } = reidForestWithMap(forest);
+
+    expect(nodes[1]!.props.href).toBe(`#${domIds.get("pricing")}`);
+    expect(nodes[1]!.props.href).not.toBe("#pricing");
+  });
+
+  it("reaches a link nested inside an array-valued prop", () => {
+    const forest = [
+      node("target", { cssId: "pricing" }),
+      node("nav", {
+        props: { items: [{ label: "Plans", href: "#pricing" }] },
+      } as Partial<BlockNode>),
+    ];
+
+    const { nodes, domIds } = reidForestWithMap(forest);
+
+    const items = nodes[1]!.props.items as { href: string }[];
+    expect(items[0]!.href).toBe(`#${domIds.get("pricing")}`);
+  });
+
+  it("leaves a string that only LOOKS like a fragment alone", () => {
+    const forest = [
+      node("target", { cssId: "pricing" }),
+      node("copy", {
+        props: { text: "#1 bestseller", href: "#somewhere-else" },
+      } as Partial<BlockNode>),
+    ];
+
+    const { nodes } = reidForestWithMap(forest);
+
+    // Content, not a reference: it names no minted id.
+    expect(nodes[1]!.props.text).toBe("#1 bestseller");
+    // A target OUTSIDE the copied run belongs to the page and still works.
+    expect(nodes[1]!.props.href).toBe("#somewhere-else");
+  });
+});

--- a/packages/blocks-engine/src/tree.reid-with-map.test.ts
+++ b/packages/blocks-engine/src/tree.reid-with-map.test.ts
@@ -432,6 +432,65 @@ describe("the prop scan is bounded by the document, not by a number", () => {
     expect(children[children.length - 1]!.url).toBe(`#${domIds.get("x")}`);
   });
 
+  it("walks a record wider than any envelope budget", () => {
+    // The component-envelope key budget was borrowed for opaque prop records,
+    // which the format does not cap at all — so a record past it was returned
+    // UNCHANGED and counted as done, leaving the link addressing an id that had
+    // just been re-minted. A bound read as "refuse this document" in one place
+    // and as "nothing to do" in the other.
+    const wide: Record<string, unknown> = { href: "#x" };
+    for (let i = 0; i < 1_200; i += 1) wide[`filler${i}`] = `value ${i}`;
+    const forest = [
+      node("target", { cssId: "x" }),
+      node("wide", { props: { blob: wide } } as Partial<BlockNode>),
+    ];
+
+    const { nodes, domIds } = reidForestWithMap(forest);
+
+    const blob = nodes[1]!.props.blob as { href: string };
+    expect(blob.href).toBe(`#${domIds.get("x")}`);
+  });
+
+  it("CLOSES A CYCLE ON THE COPY, not back onto the original", () => {
+    // A path-set guard terminates and still gets this wrong: the cycle-closing
+    // edge returns the ORIGINAL record, so the rebuilt object holds an edge to
+    // an object still carrying the id this pass just rewrote — one graph with
+    // two versions of one node. One replacement per source object is what makes
+    // a graph come out a graph.
+    const cyclic: Record<string, unknown> = { href: "#x" };
+    cyclic.self = cyclic;
+    const forest = [
+      node("target", { cssId: "x" }),
+      node("looped", { props: { nested: cyclic } } as Partial<BlockNode>),
+    ];
+
+    const { nodes, domIds } = reidForestWithMap(forest);
+
+    const copy = nodes[1]!.props.nested as Record<string, unknown>;
+    expect(copy.href).toBe(`#${domIds.get("x")}`);
+    // The edge closes on the rebuild itself...
+    expect(copy.self).toBe(copy);
+    // ...so there is no second version of it still holding the old id.
+    expect((copy.self as Record<string, unknown>).href).toBe(
+      `#${domIds.get("x")}`
+    );
+  });
+
+  it("keeps shared structure shared instead of splitting it in two", () => {
+    // The same map that closes a cycle preserves a diamond: one record reached
+    // from two places is rebuilt once, so the copy has the aliasing the
+    // original had rather than two copies that can drift apart.
+    const shared: Record<string, unknown> = { href: "#x" };
+    const forest = [
+      node("target", { cssId: "x" }),
+      node("both", { props: { a: shared, b: shared } } as Partial<BlockNode>),
+    ];
+
+    const { nodes } = reidForestWithMap(forest);
+
+    expect(nodes[1]!.props.a).toBe(nodes[1]!.props.b);
+  });
+
   it("terminates on a props object that refers to itself", () => {
     // `structuredClone` carries a cycle through, and these primitives are
     // documented as running on documents nothing validated. Before the path

--- a/packages/blocks-engine/src/tree.reid-with-map.test.ts
+++ b/packages/blocks-engine/src/tree.reid-with-map.test.ts
@@ -329,6 +329,60 @@ describe("a fragment link in props follows the copy", () => {
     expect(items[0]!.href).toBe(`#${domIds.get("pricing")}`);
   });
 
+  it("LEAVES DISPLAY TEXT ALONE even when it names a minted id", () => {
+    // The narrowing that stops this rule reaching content. A heading may
+    // legitimately read "#pricing" while a sibling in the same run carries
+    // `cssId: "pricing"` — matching a minted id does not make a string a
+    // reference. Rewriting on the value alone turned the heading into
+    // "#pricing-<suffix>" and changed what the page says, silently, in every
+    // insertion of the pattern afterwards.
+    const forest = [
+      node("target", { cssId: "pricing" }),
+      node("heading", {
+        props: { text: "#pricing", href: "#pricing" },
+      } as Partial<BlockNode>),
+    ];
+
+    const { nodes, domIds } = reidForestWithMap(forest);
+
+    expect(nodes[1]!.props.text).toBe("#pricing");
+    // The field that HOLDS a target still moves, in the same node.
+    expect(nodes[1]!.props.href).toBe(`#${domIds.get("pricing")}`);
+  });
+
+  it("reaches a rich-text link far deeper than any authored nesting", () => {
+    // props → content → root → children → list → children → listitem →
+    // children → link → url. Ten values down, which a depth cap of eight cut
+    // off — so an ordinary link in a bulleted list was left dangling while its
+    // target was re-minted.
+    const link = {
+      type: "link",
+      url: "#pricing",
+      children: [{ type: "text", text: "Plans" }],
+    };
+    const richText = {
+      root: {
+        type: "root",
+        children: [
+          { type: "list", children: [{ type: "listitem", children: [link] }] },
+        ],
+      },
+    };
+    const forest = [
+      node("target", { cssId: "pricing" }),
+      node("body", { props: { content: richText } } as Partial<BlockNode>),
+    ];
+
+    const { nodes, domIds } = reidForestWithMap(forest);
+
+    const content = nodes[1]!.props.content as {
+      root: { children: { children: { children: { url: string }[] }[] }[] };
+    };
+    expect(content.root.children[0]!.children[0]!.children[0]!.url).toBe(
+      `#${domIds.get("pricing")}`
+    );
+  });
+
   it("leaves a string that only LOOKS like a fragment alone", () => {
     const forest = [
       node("target", { cssId: "pricing" }),

--- a/packages/blocks-engine/src/tree.reid-with-map.test.ts
+++ b/packages/blocks-engine/src/tree.reid-with-map.test.ts
@@ -399,3 +399,91 @@ describe("a fragment link in props follows the copy", () => {
     expect(nodes[1]!.props.href).toBe("#somewhere-else");
   });
 });
+
+describe("the prop scan is bounded by the document, not by a number", () => {
+  it("reaches a link past far more content than any cap allowed", () => {
+    // A budget of twenty thousand visits was reachable by a rich-text value of
+    // a few hundred kilobytes — inside the document size limit — so a link
+    // after enough ordinary content was silently left dangling. How large a
+    // document may be is already decided once, by the document limits.
+    const filler = Array.from({ length: 10_000 }, (_, i) => ({
+      type: "text",
+      text: `paragraph ${i}`,
+    }));
+    const forest = [
+      node("target", { cssId: "x" }),
+      node("body", {
+        props: {
+          content: {
+            root: {
+              type: "root",
+              children: [...filler, { type: "link", url: "#x" }],
+            },
+          },
+        },
+      } as Partial<BlockNode>),
+    ];
+
+    const { nodes, domIds } = reidForestWithMap(forest);
+
+    const children = (
+      nodes[1]!.props.content as { root: { children: { url?: string }[] } }
+    ).root.children;
+    expect(children[children.length - 1]!.url).toBe(`#${domIds.get("x")}`);
+  });
+
+  it("terminates on a props object that refers to itself", () => {
+    // `structuredClone` carries a cycle through, and these primitives are
+    // documented as running on documents nothing validated. Before the path
+    // set this recursed until the stack overflowed.
+    const cyclic: Record<string, unknown> = { href: "#x" };
+    cyclic.self = cyclic;
+    const forest = [
+      node("target", { cssId: "x" }),
+      node("looped", { props: { nested: cyclic } } as Partial<BlockNode>),
+    ];
+
+    const { nodes, domIds } = reidForestWithMap(forest);
+
+    const nested = nodes[1]!.props.nested as { href: string };
+    expect(nested.href).toBe(`#${domIds.get("x")}`);
+  });
+});
+
+describe("a bound link's fallback follows the copy", () => {
+  it("remaps the fallback of a bound href", () => {
+    // A bound `href` keeps its literal in `bindings.href.fallback`, and that is
+    // what renders when the source is empty — so a fallback left behind makes
+    // the link work until the data does not.
+    const forest = [
+      node("target", { cssId: "pricing" }),
+      node("cta", {
+        props: { href: "#pricing" },
+        bindings: { href: { $bind: "cta", fallback: "#pricing" } },
+      } as unknown as Partial<BlockNode>),
+    ];
+
+    const { nodes, domIds } = reidForestWithMap(forest);
+
+    const bound = nodes[1]!.bindings as unknown as {
+      href: { fallback: string };
+    };
+    expect(bound.href.fallback).toBe(`#${domIds.get("pricing")}`);
+  });
+
+  it("leaves a bound prop that is NOT a link target alone", () => {
+    const forest = [
+      node("target", { cssId: "pricing" }),
+      node("heading", {
+        bindings: { text: { $bind: "title", fallback: "#pricing" } },
+      } as unknown as Partial<BlockNode>),
+    ];
+
+    const { nodes } = reidForestWithMap(forest);
+
+    const bound = nodes[1]!.bindings as unknown as {
+      text: { fallback: string };
+    };
+    expect(bound.text.fallback).toBe("#pricing");
+  });
+});

--- a/packages/blocks-engine/src/tree.reid-with-map.test.ts
+++ b/packages/blocks-engine/src/tree.reid-with-map.test.ts
@@ -12,7 +12,12 @@
 import { describe, expect, it } from "vitest";
 
 import type { BlockNode } from "./document";
-import { reidSubtree, reidSubtreeWithMap, walkNodes } from "./tree";
+import {
+  reidForestWithMap,
+  reidSubtree,
+  reidSubtreeWithMap,
+  walkNodes,
+} from "./tree";
 
 /** A node with an optional DOM id, and children. */
 function node(
@@ -215,5 +220,74 @@ describe("reidSubtreeWithMap malformed attributes", () => {
     } as unknown as BlockNode;
 
     expect(() => reidSubtreeWithMap(original)).not.toThrow();
+  });
+});
+
+/**
+ * A run of siblings, which is what a saved selection is.
+ *
+ * The singular function cannot answer for this shape. Given one root it builds
+ * its `domIds` from that root's subtree, so a caller looping over N roots hands
+ * each pass a map that knows nothing about the others — and a reference from
+ * the second root to a DOM id in the first is left addressing the ORIGINAL
+ * element. The whole point of the second pass is that no reference is left
+ * behind, and a per-root loop reinstates exactly the gap it closes.
+ */
+describe("a forest is re-identified as one thing", () => {
+  it("gives every node in every root a fresh id", () => {
+    const forest = [node("one", {}, [node("one-child")]), node("two")];
+
+    const { nodes, nodeIds } = reidForestWithMap(forest);
+
+    const fresh = nodes.flatMap(root => allNodes(root)).map(n => n.id);
+    expect(fresh).toHaveLength(3);
+    for (const original of ["one", "one-child", "two"]) {
+      expect(fresh).not.toContain(original);
+      expect(nodeIds.get(original)).toBeDefined();
+    }
+  });
+
+  it("keeps the roots in the order they were given", () => {
+    const forest = [node("first"), node("second")];
+
+    const { nodes, nodeIds } = reidForestWithMap(forest);
+
+    expect(nodes[0]!.id).toBe(nodeIds.get("first"));
+    expect(nodes[1]!.id).toBe(nodeIds.get("second"));
+  });
+
+  it("POINTS A REFERENCE THAT CROSSES ROOTS AT THE COPY", () => {
+    const forest = [
+      node("target", { cssId: "pricing" }),
+      node("pointer", { attributes: { "aria-labelledby": "pricing" } }),
+    ];
+
+    const { nodes, domIds } = reidForestWithMap(forest);
+
+    const copiedId = nodes[0]!.cssId;
+    expect(copiedId).toBe(domIds.get("pricing"));
+    expect(copiedId).not.toBe("pricing");
+    expect(nodes[1]!.attributes!["aria-labelledby"]).toBe(copiedId);
+  });
+
+  it("leaves a token it did not mint alone, so a host page anchor survives", () => {
+    const forest = [
+      node("a", { cssId: "mine" }),
+      node("b", { attributes: { "aria-controls": "mine theirs" } }),
+    ];
+
+    const { nodes, domIds } = reidForestWithMap(forest);
+
+    expect(nodes[1]!.attributes!["aria-controls"]).toBe(
+      `${domIds.get("mine")} theirs`
+    );
+  });
+
+  it("answers an empty forest with an empty forest", () => {
+    const { nodes, nodeIds, domIds } = reidForestWithMap([]);
+
+    expect(nodes).toEqual([]);
+    expect(nodeIds.size).toBe(0);
+    expect(domIds.size).toBe(0);
   });
 });

--- a/packages/blocks-engine/src/tree.test.ts
+++ b/packages/blocks-engine/src/tree.test.ts
@@ -264,6 +264,45 @@ describe("walkNodes / findNode / locateNode", () => {
     expect(nested?.index).toBe(1);
     expect(locateNode(nodes, "missing")).toBeUndefined();
   });
+
+  it("locates past a DAMAGED sibling instead of throwing", () => {
+    // These primitives are documented as running on stored documents nothing
+    // has validated, and one broken slot elsewhere in the forest must not
+    // decide the answer for a selection that has nothing to do with it. Before
+    // the guard this threw a TypeError out of `findIndex`, taking down every
+    // caller — including a multi-block reorder and a saved pattern — for a node
+    // neither of them had touched.
+    const nodes = [
+      {
+        id: "broken",
+        type: "core/box",
+        version: 1,
+        props: {},
+        slots: { body: null },
+      },
+      {
+        id: "holes",
+        type: "core/box",
+        version: 1,
+        props: {},
+        slots: { body: [null] },
+      },
+      {
+        id: "ok",
+        type: "core/box",
+        version: 1,
+        props: {},
+        slots: {
+          body: [{ id: "wanted", type: "core/box", version: 1, props: {} }],
+        },
+      },
+    ] as unknown as BlockNode[];
+
+    const at = locateNode(nodes, "wanted");
+    expect(at?.parent?.id).toBe("ok");
+    expect(at?.slot).toBe("body");
+    expect(at?.index).toBe(0);
+  });
 });
 
 describe("a forest whose slots form a cycle", () => {

--- a/packages/blocks-engine/src/tree.ts
+++ b/packages/blocks-engine/src/tree.ts
@@ -82,7 +82,7 @@ import type { SlotSpec } from "./block";
 import { isBlockType } from "./document";
 import type { BlockNode } from "./document";
 import { walkForest } from "./forest-walk";
-import { remapFragmentProps } from "./fragment-refs";
+import { remapFragmentBindings, remapFragmentProps } from "./fragment-refs";
 import { MAX_DEPTH, MAX_NODES } from "./limits";
 import { canNest, canNestInSlot } from "./nesting";
 import type { NestingSource } from "./nesting";
@@ -1141,10 +1141,24 @@ function relinkOne(
   // for: only a whole string of `#` plus an id THIS copy minted is touched, and
   // nothing but a reference to the copy's own target can spell that.
   const props = remapFragmentProps(copy.props, domIds) as BlockNode["props"];
-  // Both remappers return their input unchanged when nothing matched, so an
+  // And the BOUND form of the same field. A bound `href` keeps its literal in
+  // `bindings.href.fallback`, which is what renders when the source is empty —
+  // so leaving it behind makes the link work until the data does not, which is
+  // the one case the fallback exists for.
+  const bindings = remapFragmentBindings(
+    copy.bindings,
+    domIds
+  ) as BlockNode["bindings"];
+  // Every remapper returns its input unchanged when nothing matched, so an
   // ordinary node is returned as it stands rather than reallocated.
-  if (attributes === copy.attributes && props === copy.props) return copy;
-  return { ...copy, attributes, props };
+  if (
+    attributes === copy.attributes &&
+    props === copy.props &&
+    bindings === copy.bindings
+  ) {
+    return copy;
+  }
+  return { ...copy, attributes, props, bindings };
 }
 
 /**

--- a/packages/blocks-engine/src/tree.ts
+++ b/packages/blocks-engine/src/tree.ts
@@ -82,6 +82,7 @@ import type { SlotSpec } from "./block";
 import { isBlockType } from "./document";
 import type { BlockNode } from "./document";
 import { walkForest } from "./forest-walk";
+import { remapFragmentProps } from "./fragment-refs";
 import { MAX_DEPTH, MAX_NODES } from "./limits";
 import { canNest, canNestInSlot } from "./nesting";
 import type { NestingSource } from "./nesting";
@@ -643,13 +644,20 @@ export function locateNode(
   nodes: BlockNode[],
   id: string
 ): NodeLocation | undefined {
-  const topIndex = nodes.findIndex(node => node.id === id);
+  // Read defensively at every step. This is a stored document and nothing here
+  // has validated it — a slot may hold `null` instead of an array, and a list
+  // may hold a hole — so an entry is asked for its id rather than assumed to
+  // have one. It matters because ONE damaged node anywhere in the forest would
+  // otherwise throw, and the caller looking for a completely unrelated
+  // selection elsewhere in the document gets a crash instead of an answer.
+  const topIndex = nodes.findIndex(node => node?.id === id);
   if (topIndex !== -1) return { index: topIndex };
   let found: NodeLocation | undefined;
   walkNodes(nodes, node => {
     if (found || !node.slots) return;
     for (const [slot, children] of Object.entries(node.slots)) {
-      const index = children.findIndex(child => child.id === id);
+      if (!Array.isArray(children)) continue;
+      const index = children.findIndex(child => child?.id === id);
       if (index !== -1) {
         found = { parent: node, slot, index };
         return;
@@ -1104,16 +1112,39 @@ export function reidForestWithMap(nodes: BlockNode[]): ReidentifiedForest {
   // first had not reached yet. Without it a copied `aria-labelledby` points at
   // the original's id, so the copy loses its accessible name — the same gap
   // composition has, closed the same way.
-  const linked = mapForest(rebuilt, copy =>
-    // `isPlainRecord`, not `!== undefined`. A persisted `attributes: null` is
-    // content the first pass deliberately carries through untouched, and
-    // handing it to the remapper enumerates null and throws — a rebuild that
-    // destroys a node because of a field on a different one.
-    isPlainRecord(copy.attributes)
-      ? { ...copy, attributes: remapIdReferences(copy.attributes, domIds) }
-      : copy
-  );
+  const linked = mapForest(rebuilt, copy => relinkOne(copy, domIds));
   return { nodes: linked, nodeIds, domIds };
+}
+
+/**
+ * One copied node, with every reference to a re-minted id following the copy.
+ *
+ * Both halves matter and only one of them is markup. `aria-labelledby` lives in
+ * `attributes`; a link's target lives in `props` as `href: "#pricing"`, and a
+ * copy that moves the id without the link leaves the anchor resolving to
+ * nothing. Applied HERE rather than left to each caller, because the caller
+ * that forgets does not fail — it stores a document that renders, validates and
+ * quietly points somewhere else.
+ */
+function relinkOne(
+  copy: BlockNode,
+  domIds: ReadonlyMap<string, string>
+): BlockNode {
+  // `isPlainRecord`, not `!== undefined`. A persisted `attributes: null` is
+  // content the first pass deliberately carries through untouched, and handing
+  // it to the remapper enumerates null and throws — a rebuild that destroys a
+  // node because of a field on a different one.
+  const attributes = isPlainRecord(copy.attributes)
+    ? remapIdReferences(copy.attributes, domIds)
+    : copy.attributes;
+  // See `fragment-refs` for why a copier may rewrite a prop it has no schema
+  // for: only a whole string of `#` plus an id THIS copy minted is touched, and
+  // nothing but a reference to the copy's own target can spell that.
+  const props = remapFragmentProps(copy.props, domIds) as BlockNode["props"];
+  // Both remappers return their input unchanged when nothing matched, so an
+  // ordinary node is returned as it stands rather than reallocated.
+  if (attributes === copy.attributes && props === copy.props) return copy;
+  return { ...copy, attributes, props };
 }
 
 /**

--- a/packages/blocks-engine/src/tree.ts
+++ b/packages/blocks-engine/src/tree.ts
@@ -1051,8 +1051,18 @@ export interface ReidentifiedSubtree {
   domIds: ReadonlyMap<string, string>;
 }
 
+/** A re-identified FOREST, and the two maps describing what moved. */
+export interface ReidentifiedForest {
+  /** The rebuilt roots, in the order they were given. */
+  nodes: BlockNode[];
+  /** Every node's old id → its new one, across every root. */
+  nodeIds: ReadonlyMap<string, string>;
+  /** Every DOM id the forest carried → its replacement, across every root. */
+  domIds: ReadonlyMap<string, string>;
+}
+
 /**
- * Deep-clone a subtree with fresh ids, KEEPING its internal references usable.
+ * Deep-clone a FOREST with fresh ids, KEEPING its internal references usable.
  *
  * The same rebuild as {@link reidSubtree}, differing in what happens to a DOM
  * id: dropped there, minted afresh here and recorded. Two copies of one pattern
@@ -1065,23 +1075,36 @@ export interface ReidentifiedSubtree {
  * read and write: it appears in a URL fragment, in a stylesheet and in the
  * attribute panel. A UUID would be unique and unusable.
  *
- * Uniqueness is guaranteed WITHIN the returned subtree, not against the
- * document it is going into — this function is given a subtree and cannot see
- * anything else. A caller inserting into a page it can read should check
- * {@link ReidentifiedSubtree.domIds} against that page.
+ * ## Why a forest, and not one root at a time
+ *
+ * A saved selection is a contiguous RUN of siblings, so the document it becomes
+ * holds several roots, and re-identifying them with one call each is not the
+ * same operation. Each call can only see the subtree it was handed, so its
+ * `domIds` records that subtree's ids and nothing else — and a reference that
+ * crosses from one root to another finds no entry, and is left pointing at the
+ * ORIGINAL element. For `aria-labelledby` and `aria-describedby` that means the
+ * copy silently loses its accessible name, a failure invisible to everyone who
+ * does not use assistive technology. Re-identifying the roots TOGETHER is what
+ * makes the second pass see every id, so the guarantee is a property of this
+ * function rather than of each caller remembering not to loop.
+ *
+ * Uniqueness is guaranteed WITHIN the returned forest, not against the document
+ * it is going into — this function is given a forest and cannot see anything
+ * else. A caller inserting into a page it can read should check
+ * {@link ReidentifiedForest.domIds} against that page.
  */
-export function reidSubtreeWithMap(node: BlockNode): ReidentifiedSubtree {
+export function reidForestWithMap(nodes: BlockNode[]): ReidentifiedForest {
   const nodeIds = new Map<string, string>();
   const domIds = new Map<string, string>();
 
-  const [rebuilt] = mapForest([node], original =>
+  const rebuilt = mapForest(nodes, original =>
     reidOneKeepingReferences(original, nodeIds, domIds)
   );
   // A SECOND pass, because a node may reference an id defined on a node the
   // first had not reached yet. Without it a copied `aria-labelledby` points at
   // the original's id, so the copy loses its accessible name — the same gap
   // composition has, closed the same way.
-  const [linked] = mapForest([rebuilt ?? node], copy =>
+  const linked = mapForest(rebuilt, copy =>
     // `isPlainRecord`, not `!== undefined`. A persisted `attributes: null` is
     // content the first pass deliberately carries through untouched, and
     // handing it to the remapper enumerates null and throws — a rebuild that
@@ -1090,7 +1113,18 @@ export function reidSubtreeWithMap(node: BlockNode): ReidentifiedSubtree {
       ? { ...copy, attributes: remapIdReferences(copy.attributes, domIds) }
       : copy
   );
-  return { node: linked ?? rebuilt ?? node, nodeIds, domIds };
+  return { nodes: linked, nodeIds, domIds };
+}
+
+/**
+ * One subtree, re-identified — {@link reidForestWithMap} for a single root.
+ *
+ * Delegates rather than repeating the two passes, so the singular and the
+ * plural cannot drift into disagreeing about what a copy is.
+ */
+export function reidSubtreeWithMap(node: BlockNode): ReidentifiedSubtree {
+  const { nodes, nodeIds, domIds } = reidForestWithMap([node]);
+  return { node: nodes[0] ?? node, nodeIds, domIds };
 }
 
 /** One node, re-identified, with its DOM id remapped rather than removed. */

--- a/packages/builder/src/selection-ops.ts
+++ b/packages/builder/src/selection-ops.ts
@@ -39,7 +39,7 @@
  */
 
 import {
-  locateNode,
+  siblingRun,
   type BlockDocument,
   type BlockNode,
 } from "@nextlyhq/blocks-engine";
@@ -370,43 +370,6 @@ function moveLockRefusal(
   return null;
 }
 
-/** Where each selected block sits, once they all sit in ONE list. */
-interface SharedRun {
-  /** The selected blocks, sorted by their index in that list. */
-  readonly places: readonly { readonly id: string; readonly index: number }[];
-}
-
-/**
- * The selection as positions in a single sibling list, or `null`.
- *
- * `null` means they do not all share one list — the case a move has no answer
- * for. Two blocks in different containers have no common order to step
- * through, and "one step up" would mean a different distance for each.
- */
-function sharedRun(
-  document: BlockDocument,
-  ids: readonly string[]
-): SharedRun | null {
-  const places: { id: string; index: number }[] = [];
-  let container: string | undefined;
-
-  for (const id of ids) {
-    const at = locateNode(document.nodes, id);
-    if (at === undefined) return null;
-    // Parent and slot together, because one parent's two slots are two lists.
-    // The separator is a space, which an id cannot contain, so no pair of
-    // distinct containers can collide into a single key.
-    const key = `${at.parent?.id ?? ""} ${at.slot ?? ""}`;
-    if (container === undefined) container = key;
-    else if (container !== key) return null;
-    places.push({ id, index: at.index });
-  }
-
-  if (places.length === 0) return null;
-  places.sort((left, right) => left.index - right.index);
-  return { places };
-}
-
 /**
  * Moving every selected block one step, keeping their order and their spacing.
  *
@@ -436,12 +399,23 @@ export function selectionMove(
   const refusal = moveLockRefusal(document, ids);
   if (refusal !== null) return refusal;
 
-  const run = sharedRun(document, ids);
-  if (run === null) return SPLIT_REFUSAL;
+  // The ENGINE's rule, not a copy of it. Every composition planner asks the
+  // same question — a pattern, a component and a converted selection are each
+  // one run lifted out of one place — and a planner runs in a plugin's server
+  // action where this package cannot be imported. Two implementations of "do
+  // these share a list" would disagree the first time either moved.
+  //
+  // `siblingRun` also refuses an empty selection and an id the document does
+  // not hold. Neither reaches here: `normalizeSelection` has already dropped
+  // every absent id and the length guard above has returned. So a split is the
+  // only cause left, and it keeps the sentence it always had.
+  const found = siblingRun(document.nodes, ids);
+  if (found.run === undefined) return SPLIT_REFUSAL;
 
   // Towards the destination first, so each block steps into an index its
   // neighbour has already left.
-  const order = direction === "up" ? run.places : [...run.places].reverse();
+  const places = found.run.places;
+  const order = direction === "up" ? places : [...places].reverse();
 
   const ops: BuilderOp[] = [];
   for (const place of order) {


### PR DESCRIPTION
Plan 06 (Phase 5), T-2 slice 2. Follows #1549, which moved the op vocabulary into the engine — the step that makes an engine-side planner possible at all, since every planner returns `BuilderOp[]`.

## What ships

**`planSaveAsPattern`** — the first composition planner. Pure: it reads a document and returns the library row to create plus the ops the page needs, and writes nothing. Its `pageOps` are **empty**, which is the whole behavioural difference from `planConvertToComponent`: a pattern is copied on insert and keeps no link back, so saving one leaves the page exactly as it was.

Splitting the plan from the doing is what lets the caller put the create and the page edit in one unit of work and roll the create back when the edit fails (the design names Elementor #36049 as the failure mode), and it makes a dry run and a real run the same function rather than two that agree until one moves.

**`siblingRun` / `contiguousRun`** — the rule about what may be saved, published from the engine.

**`reidForestWithMap`** — re-identifying a run of roots as one copy. `reidSubtreeWithMap` now delegates to it.

## Two corrections to the plan documents

**The planner specs are in design §6.3, not §5.** §5 is prior art. Worth recording because the last handoff pointed the wrong way.

**The predicate cannot live in the builder, which the T-2 territory line implies it should.** Measured: `plugin-page-builder` declares `@nextlyhq/builder` only as a *peer* dependency, and the builder peer-depends on `react`, `react-dom`, `plugin-sdk` and `ui`. A planner called from a `contributes.routes` server action — which design §6.3 requires — would therefore pull React into a server route. `blocks-engine` depends only on `css-tree` and `picomatch`, and the direction is builder → engine, so the engine could not import a builder-side predicate back.

So the rule is published from the engine and the builder consumes it. That still changes `packages/builder/src/selection-ops.ts`, so the territory line is satisfied — the file gives up a private copy rather than growing one.

That copy was real: `selection-ops.ts` held a private `sharedRun` doing the parent+slot half of this, used by `selectionMove`. It is deleted. Keeping it would have been the exact thing its own module docblock forbids — *"A second implementation would eventually disagree with the toolbar and the keyboard, which act on one block through those same functions."*

## A refusal reports its cause, not a sentence

`RunProblem` is `"empty" | "unknown" | "split" | "gap"`. The engine says what it observed; each surface phrases the remedy, because the remedy belongs to the verb — moving, saving as a pattern and converting to a component are three different things to be told to do instead. That follows the reasoning already written beside the builder's own refusal: *"Phrased as the remedy rather than the rule."*

`"unknown"` is separated from `"split"` deliberately. An id the document does not hold is a caller out of step with the document; blocks in two containers is an author who selected across a boundary. One is a bug and the other is a sentence to show, and a single refusal would have sent both to whichever was written first.

## The bug this closes before it ships

Design §6.3 says *"Insert = `reidSubtreeWithMap`"*. But a pattern is a **run** of siblings, so its document holds N roots, and `reidSubtreeWithMap` takes one node and builds its `domIds` from that subtree alone. Re-identifying N roots with N calls therefore leaves a reference that crosses from one root to the next — `aria-labelledby`, `aria-describedby`, `for`, `headers` — pointing at the element in the **page the pattern was saved from**.

The result renders, validates and looks correct. The only people who find out are the ones using a screen reader, and by then the pattern is on twenty pages. It is the same gap `reidSubtreeWithMap`'s own second pass exists to close, reinstated by looping.

`reidForestWithMap` re-identifies the roots together so the second pass sees every id, and `reidSubtreeWithMap` is now that function called with one root — so the singular and the plural cannot drift into disagreeing about what a copy is.

## Two decisions written into the planner

**Fresh ids at save, not only at insert.** It would render correctly either way, since insert re-identifies too. Storing the page's ids is still wrong: a node id is how everything here addresses a node — styles, locale overlays, the class-usage record, editor history — so two stored documents claiming one id leave any index keyed on it unable to say which node it describes. Re-identifying at save removes the ambiguity where it is created.

**`settings` is not copied.** `DocumentSettings.styles` is page-scoped by definition ("styles with no owning node") and `customCss` is document-scoped, so a pattern carrying them would repaint every page it was inserted into. Node styles are on the nodes and travel with them.

**`assets` is not synthesised.** Which prop of a block holds a media id is a property of that block's definition, which the engine cannot read — the same boundary that stops the id remapper reaching into props. A partial index is worse than none, since absence is what a reference check reads as "not used".

## Break-verification

Every test was checked against a **wrong implementation**, not a mutation, and each break was confirmed present in the file before the run and the file confirmed byte-identical after restoring.

| Wrong implementation | Killed |
|---|---|
| key the list on the parent only, ignoring the slot | 2 |
| report an unknown id as a split | 1 |
| do not sort — places in the order the ids arrived | 2 |
| contiguity always true (never a gap) | 2 |
| contiguity always false (every run a gap) | 4 |
| an empty selection answers with an empty run | 1 |
| **re-identify each root separately** (the plausible one) | 1 — the cross-root reference test, and only that one |
| keep the page's ids (no reid) | 2 |
| carry the page's settings into the pattern | 1 |
| store it as `kind: "page"` | 1 |
| remove the run from the page as well as copying it | 1 |
| accept a gap by calling `siblingRun` instead of `contiguousRun` | 1 |
| forest reid skips the reference pass | 4, including the **pre-existing** singular test — which is what proves the delegation is real |
| builder computes the run from only the first selected id | 5 builder move tests, including "refuses a selection spread across two containers" |

The first attempt at the `contiguousRun` break failed all 12 tests rather than 1, because the substitute symbol was not imported — a crash, not a behaviour. Redone with the import fixed, it kills exactly the gap test.

**One assertion deliberately not written.** The planner takes the *source* document's `formatVersion` rather than the current constant, so an old page's blocks are not stored as if already migrated. `DocumentFormatVersion` is the literal `1` and only one version exists, so no test can tell the two expressions apart — a test would pass on either. The reasoning is stated in the source instead.

## Gates, from the worktree root

| Gate | Exit |
|---|---|
| `fallow audit --gate new-only --base origin/main` | **0** — verdict `pass`, `changed_files_count: 9`, and `introduced: 0` for complexity, dead code, duplication and styling |
| `npm run check:comments` | **0** |
| `npx changeset status` | **0** |
| `npx turbo run check-types` | **0** — 42/42 tasks |

`changed_files_count: 9` is stated because a fallow run that analyses 0 files passes vacuously.

`check-types` caught a bad fixture in my own test that the green vitest run had not — `NodeStyles` is state → breakpoint → values, and I had written state → values. Fixed and re-run.

## Suites

| Package | Files | Tests |
|---|---|---|
| `blocks-engine` | 44 | 1936 |
| `builder` | 100 | 2804 |
| `blocks-react` | 48 | 1162 |
| `plugin-page-builder` | 59 | 639 |
| `plugin-sdk` | 4 | 20 |

All exit 0, each run from its own package directory.

## Not touched

`SlotSpec.lock`. The T-2 row lists it for removal; `decision:pb6-slotspec-lock-remove-or-implement` is open with the founder and the recommendation is to keep it — it has no reader, but it is exported from `blocks-engine`, re-exported from `blocks-react` and `plugin-sdk`, and pinned by a type assertion in `block-exports.test-d.ts`, while `node.locked` **is** enforced. That makes it the missing half of a working feature, and T-8 Layouts is its natural home.

## Next in this row

`planSaveAsComponent`, `planConvertToComponent`, `planDetach`, `planInsertPattern`, `planUpdatePatternFromSelection`, `planDuplicateComponent`, then the write-side cycle check. `planDetach` must inline the **resolved** subtree through `resolveComponentInstances` rather than walking stored nodes — the resolver is the oracle.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for saving contiguous block selections as reusable patterns in a chosen collection.
  - Preserves selection order and updates internal links, accessibility references, and bound content when creating patterns.
  - Added improved handling for moving selections within the same block group.

- **Bug Fixes**
  - Prevents invalid selections—such as gaps, mixed containers, empty selections, or unknown blocks—from being saved.
  - Prevents blocks from being lifted out of containers when creating patterns.
  - Improved resilience when navigating malformed block structures and handling duplicate block identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->