### PR TITLE
feat: put the releases and activity feeds on the dashboard

### DIFF
--- a/.changeset/two-cards-that-reached-no-reader.md
+++ b/.changeset/two-cards-that-reached-no-reader.md
@@ -91,3 +91,15 @@ unrecognised one degrades to plain text rather than refusing the result.
 Relative times on the activity feed update while the card is open. Deriving the
 label at render instead of at fetch was half the repair; a card nobody touches
 gets no renders, so `useNowTick` supplies them.
+
+Widget date cells honour the admin's configured timezone. General Settings
+carries one and `GeneralSettingsSyncProvider` publishes it to the formatter
+every other admin date already uses, so a cell reading the browser's own zone
+made these cards disagree with the dates beside them for any administrator who
+had set one.
+
+The admin derives the presentable field kinds from core's
+`WIDGET_SOURCE_FIELD_TYPES` instead of restating them. Hand-keeping the list
+meant core could add a kind, the server emit it, and the browser silently erase
+it on the way in — the cell falling back to raw text with nothing reporting that
+a presentation had been lost.

--- a/.changeset/two-cards-that-reached-no-reader.md
+++ b/.changeset/two-cards-that-reached-no-reader.md
@@ -67,3 +67,27 @@ renders the first two and silently ignores the rest, so `core/recently-edited`
 showed a collection beside an opaque document id and never the timestamp, on a
 card whose description promises "newest first". Both now select two, and the
 renderer declares how many it draws so a test can hold declarations to it.
+
+A widget's permission gate is now decided in ONE place, `nextly/widget-gate` — a
+browser-safe entry point with no imports of its own. The layout endpoint and the
+admin both decide whether a reader may be told a card exists, and they had two
+implementations of that answer: a card the server sends and the browser hides is
+invisible with nothing logged anywhere. The rule is parameterised by how a
+single slug is answered, so the server passes its resolved verdicts and the
+browser passes the session's predicate.
+
+A contributed any-of gate no longer goes missing. Boot accepted an array through
+the shared validator, but the summary layout resolution reads was built by a
+string-only reader that dropped it — so the layout endpoint saw no gate and
+published the card's id and default placement to every authenticated reader
+while the browser hid it.
+
+List and table cells are now PRESENTED by the kind their source declared, rather
+than printed. Every source already declares its date fields as dates and that
+declaration stopped at the server, so a row drew `2026-09-01T07:00:00.000Z` on
+cards whose whole subject is when. `WidgetResultField` carries the type, and an
+unrecognised one degrades to plain text rather than refusing the result.
+
+Relative times on the activity feed update while the card is open. Deriving the
+label at render instead of at fetch was half the repair; a card nobody touches
+gets no renders, so `useNowTick` supplies them.

--- a/.changeset/two-cards-that-reached-no-reader.md
+++ b/.changeset/two-cards-that-reached-no-reader.md
@@ -53,3 +53,17 @@ bound to a component in `@nextlyhq/admin`. The two packages do not depend on
 each other, so nothing could notice one naming something the other never
 registered — a card would quietly draw the unresolved placeholder. A test now
 holds the two lists against each other.
+
+A widget's `requiredPermission` now also accepts an ARRAY, meaning any-of. A
+single slug could not describe the rule the services behind these cards apply:
+`ReleasesService.authorize` treats `create` or `publish` as satisfying `read`,
+deliberately, so a role granted only `create` can see the release it just made,
+and the admin's `canViewReleases` capability lists all three. A card gated on
+the read slug alone was a third encoding of that rule and the only one that
+disagreed. Existing single-slug declarations are unchanged.
+
+Two shipped list cards selected more fields than the `list` archetype draws. It
+renders the first two and silently ignores the rest, so `core/recently-edited`
+showed a collection beside an opaque document id and never the timestamp, on a
+card whose description promises "newest first". Both now select two, and the
+renderer declares how many it draws so a test can hold declarations to it.

--- a/.changeset/two-cards-that-reached-no-reader.md
+++ b/.changeset/two-cards-that-reached-no-reader.md
@@ -1,0 +1,55 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Two finished dashboard surfaces reached no reader, and both are now cards on the
+widget grid.
+
+`system:releases` shipped as a registered, access-controlled widget source with
+no widget naming it, so nothing on any dashboard could ask it anything. It now
+backs `core/upcoming-releases`, a list of what is scheduled and not yet shipped,
+soonest first. It is the one core card carrying a `requiredPermission`, because
+`ReleasesService.find` authorizes by throwing: an ungranted reader would get a
+card stuck in its error state rather than an empty one, so the card is hidden
+from them instead — and its placement is kept in the stored layout, so widening
+someone's grant brings the card back where it was.
+
+The recent-activity feed had an endpoint and a component and nothing rendering
+it; the dashboard drew the welcome header and the grid alone. `RecentActivity`
+is now `core/recent-activity`, which also makes it hideable and reorderable like
+every other card. Two controls on it were removed rather than moved: a
+"Detailed Log" link whose destination was the dashboard the card sits on, and a
+"Sync Previous Events" button with no handler behind it. There is no audit-log
+page for either to point at, and a dashboard feed showing a fixed handful of
+rows with no in-widget pagination is what the products we compared against all
+do. Its chrome now matches the cards beside it.
+
+A core card names its body as a `core#` string in `nextly` and that string is
+bound to a component in `@nextlyhq/admin`. The two packages do not depend on
+each other, so nothing could notice one naming something the other never
+registered — a card would quietly draw the unresolved placeholder. A test now
+holds the two lists against each other.

--- a/packages/admin/src/components/features/dashboard/RecentActivity.test.tsx
+++ b/packages/admin/src/components/features/dashboard/RecentActivity.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-import { render, screen, waitFor } from "@admin/__tests__/utils";
+import { act, render, screen, waitFor } from "@admin/__tests__/utils";
 import { useRecentActivity } from "@admin/hooks/queries/useRecentActivity";
 import { Activity } from "@admin/types/dashboard/activity";
 
@@ -178,17 +178,19 @@ describe("RecentActivity", () => {
   });
 
   /*
-   * 🔴 The label is a function of WHEN IT IS READ, and the second render is what
-   * proves it. The label used to be computed while mapping the response and
-   * carried on the entry, so it was correct exactly once and then frozen: an
-   * item fetched as "just now" kept that wording for as long as the query's data
-   * was reused, which on a dashboard left open is indefinitely.
+   * 🔴 The label tracks the clock WITHOUT anything re-rendering the card, and
+   * that is the whole property. Deriving it at render instead of at fetch was
+   * only half the repair: a render has to happen for the derivation to run, and
+   * a dashboard card nobody touches gets none -- so an entry fetched as "just
+   * now" kept that wording for as long as the page stayed open, the same wrong
+   * label reached by a different route.
    *
-   * A single render cannot separate the two implementations -- both print "2h
-   * ago" at the moment of the fetch. Only advancing the clock WITHOUT refetching
-   * does, which is the exact condition the defect needed.
+   * The earlier version of this test called `rerender` itself, which is
+   * precisely what production has nothing to do. It went green on an
+   * implementation that could not update on its own. Here the ONLY thing that
+   * happens between the two assertions is time passing.
    */
-  it("derives each timestamp's label from the time it is read", async () => {
+  it("advances each label as time passes, with nothing re-rendering it", async () => {
     mockUseRecentActivity.mockReturnValue({
       data: { activities: mockActivities },
       isLoading: false,
@@ -201,17 +203,18 @@ describe("RecentActivity", () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     try {
       vi.setSystemTime(READ_AT);
-      const { rerender } = render(<RecentActivity />);
+      render(<RecentActivity />);
 
       await waitFor(() => {
         expect(screen.getByText("2h ago")).toBeInTheDocument();
         expect(screen.getByText("3h ago")).toBeInTheDocument();
       });
 
-      // The SAME data, three hours later. Nothing refetches; the mock returns
-      // the identical array, so any change can only come from the render.
-      vi.setSystemTime(new Date(READ_AT.getTime() + 3 * 60 * 60 * 1000));
-      rerender(<RecentActivity />);
+      // Three hours pass. No refetch, no rerender, no interaction -- only the
+      // card's own clock.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3 * 60 * 60 * 1000);
+      });
 
       await waitFor(() => {
         expect(screen.getByText("5h ago")).toBeInTheDocument();

--- a/packages/admin/src/components/features/dashboard/RecentActivity.test.tsx
+++ b/packages/admin/src/components/features/dashboard/RecentActivity.test.tsx
@@ -16,6 +16,20 @@ vi.mock("@admin/hooks/queries/useRecentActivity", () => ({
 
 const mockUseRecentActivity = vi.mocked(useRecentActivity);
 
+/**
+ * The instant the tests pretend it is when the card is first read.
+ *
+ * The fixtures are anchored to it rather than carrying fixed dates, because the
+ * label under test is a function of NOW: hard-coded timestamps drift further
+ * into the past every day the suite runs, so an assertion on "2h ago" would
+ * pass today and fail forever after.
+ */
+const READ_AT = new Date("2026-03-01T12:00:00Z");
+
+function hoursBefore(instant: Date, hours: number): string {
+  return new Date(instant.getTime() - hours * 60 * 60 * 1000).toISOString();
+}
+
 const mockActivities: Activity[] = [
   {
     id: "1",
@@ -33,8 +47,7 @@ const mockActivities: Activity[] = [
     action: "created",
     target: "new user account",
     category: "success",
-    timestamp: "2025-01-10T10:00:00Z",
-    relativeTime: "2 hours ago",
+    timestamp: hoursBefore(READ_AT, 2),
   },
   {
     id: "2",
@@ -51,8 +64,7 @@ const mockActivities: Activity[] = [
     action: "updated",
     target: "role permissions",
     category: "info",
-    timestamp: "2025-01-10T09:30:00Z",
-    relativeTime: "3 hours ago",
+    timestamp: hoursBefore(READ_AT, 3),
   },
 ];
 
@@ -165,7 +177,18 @@ describe("RecentActivity", () => {
     expect(mockUseRecentActivity).toHaveBeenCalledWith(5);
   });
 
-  it("displays relative timestamps", async () => {
+  /*
+   * 🔴 The label is a function of WHEN IT IS READ, and the second render is what
+   * proves it. The label used to be computed while mapping the response and
+   * carried on the entry, so it was correct exactly once and then frozen: an
+   * item fetched as "just now" kept that wording for as long as the query's data
+   * was reused, which on a dashboard left open is indefinitely.
+   *
+   * A single render cannot separate the two implementations -- both print "2h
+   * ago" at the moment of the fetch. Only advancing the clock WITHOUT refetching
+   * does, which is the exact condition the defect needed.
+   */
+  it("derives each timestamp's label from the time it is read", async () => {
     mockUseRecentActivity.mockReturnValue({
       data: { activities: mockActivities },
       isLoading: false,
@@ -175,12 +198,29 @@ describe("RecentActivity", () => {
       status: "success",
     } as ReturnType<typeof useRecentActivity>);
 
-    render(<RecentActivity />);
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      vi.setSystemTime(READ_AT);
+      const { rerender } = render(<RecentActivity />);
 
-    await waitFor(() => {
-      expect(screen.getByText("2 hours ago")).toBeInTheDocument();
-      expect(screen.getByText("3 hours ago")).toBeInTheDocument();
-    });
+      await waitFor(() => {
+        expect(screen.getByText("2h ago")).toBeInTheDocument();
+        expect(screen.getByText("3h ago")).toBeInTheDocument();
+      });
+
+      // The SAME data, three hours later. Nothing refetches; the mock returns
+      // the identical array, so any change can only come from the render.
+      vi.setSystemTime(new Date(READ_AT.getTime() + 3 * 60 * 60 * 1000));
+      rerender(<RecentActivity />);
+
+      await waitFor(() => {
+        expect(screen.getByText("5h ago")).toBeInTheDocument();
+        expect(screen.getByText("6h ago")).toBeInTheDocument();
+      });
+      expect(screen.queryByText("2h ago")).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("displays activity badges with correct variants", async () => {

--- a/packages/admin/src/components/features/dashboard/RecentActivity.test.tsx
+++ b/packages/admin/src/components/features/dashboard/RecentActivity.test.tsx
@@ -92,7 +92,7 @@ describe("RecentActivity", () => {
 
     expect(
       // The copy the error branch renders.
-      screen.getByText(/failed to fetch activity stream/i)
+      screen.getByText(/couldn't load recent activity/i)
     ).toBeInTheDocument();
   });
 
@@ -202,7 +202,7 @@ describe("RecentActivity", () => {
     });
   });
 
-  it("has correct accessibility structure", async () => {
+  it("names its own region, since the grid frames it with no chrome", async () => {
     mockUseRecentActivity.mockReturnValue({
       data: { activities: mockActivities },
       isLoading: false,
@@ -215,11 +215,44 @@ describe("RecentActivity", () => {
     render(<RecentActivity />);
 
     await waitFor(() => {
-      // Header should be present
-      expect(screen.getByText("System Event Log")).toBeInTheDocument();
+      // Asked by ACCESSIBLE NAME rather than by the heading's text, because the
+      // card declares `chrome: "none"` and so owns its own labelled region --
+      // `getByText` would still pass on a heading that labels nothing.
+      expect(
+        screen.getByRole("region", { name: "Recent activity" })
+      ).toBeInTheDocument();
 
-      // Content should be visible
       expect(screen.getByText("John Doe")).toBeVisible();
     });
+  });
+
+  /*
+   * 🔴 Both controls existed and neither worked: a "Detailed Log" link whose
+   * href was the dashboard the card sits on, and a "Sync Previous Events"
+   * button with no handler. Asserted as ABSENCE OF ANY link or button rather
+   * than of those two strings, because the defect is a control that promises a
+   * destination this feed does not have -- re-adding one under a different
+   * label is the same defect and a string match would pass it.
+   */
+  it("offers no navigation or pagination control", async () => {
+    mockUseRecentActivity.mockReturnValue({
+      data: { activities: mockActivities },
+      isLoading: false,
+      error: null,
+      isError: false,
+      isSuccess: true,
+      status: "success",
+    } as ReturnType<typeof useRecentActivity>);
+
+    render(<RecentActivity />);
+
+    // The control: the rows must have rendered, or an empty card would satisfy
+    // the two absence assertions below without the feed ever having drawn.
+    await waitFor(() => {
+      expect(screen.getByText("John Doe")).toBeVisible();
+    });
+
+    expect(screen.queryAllByRole("link")).toHaveLength(0);
+    expect(screen.queryAllByRole("button")).toHaveLength(0);
   });
 });

--- a/packages/admin/src/components/features/dashboard/RecentActivity.tsx
+++ b/packages/admin/src/components/features/dashboard/RecentActivity.tsx
@@ -39,6 +39,7 @@ import type React from "react";
 
 import { AlertCircle } from "@admin/components/icons";
 import { useRecentActivity } from "@admin/hooks/queries/useRecentActivity";
+import { formatRelativeTime } from "@admin/lib/dashboard";
 import { cn } from "@admin/lib/utils";
 import type { Activity } from "@admin/types/dashboard/activity";
 
@@ -117,7 +118,17 @@ const ActivityItem: React.FC<{ activity: Activity }> = ({ activity }) => {
 
         <div className="flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-muted-foreground">
           <Clock className="w-3 h-3 opacity-60" />
-          <time dateTime={activity.timestamp}>{activity.relativeTime}</time>
+          {/*
+            Derived HERE rather than carried on the entry. A relative time is a
+            function of when it is read, and computing it while mapping the
+            response froze it: an entry fetched as "just now" kept that label
+            for as long as the query's data was reused. `dateTime` carries the
+            absolute instant, so the machine-readable value is exact whatever
+            the prose says.
+          */}
+          <time dateTime={activity.timestamp}>
+            {formatRelativeTime(activity.timestamp)}
+          </time>
         </div>
       </div>
 

--- a/packages/admin/src/components/features/dashboard/RecentActivity.tsx
+++ b/packages/admin/src/components/features/dashboard/RecentActivity.tsx
@@ -39,6 +39,7 @@ import type React from "react";
 
 import { AlertCircle } from "@admin/components/icons";
 import { useRecentActivity } from "@admin/hooks/queries/useRecentActivity";
+import { useNowTick } from "@admin/hooks/useNowTick";
 import { formatRelativeTime } from "@admin/lib/dashboard";
 import { cn } from "@admin/lib/utils";
 import type { Activity } from "@admin/types/dashboard/activity";
@@ -56,7 +57,12 @@ export interface RecentActivityProps {
  *
  * Displays a single activity entry with avatar, description, and badge.
  */
-const ActivityItem: React.FC<{ activity: Activity }> = ({ activity }) => {
+const ActivityItem: React.FC<{ activity: Activity; now: number }> = ({
+  activity,
+  // Passed down rather than each row starting its own clock: one timer per
+  // CARD, not one per row, and every row then names the same instant.
+  now,
+}) => {
   const getBadgeStyle = (type: string) => {
     const t = type.toLowerCase();
     if (t.includes("create"))
@@ -127,7 +133,7 @@ const ActivityItem: React.FC<{ activity: Activity }> = ({ activity }) => {
             the prose says.
           */}
           <time dateTime={activity.timestamp}>
-            {formatRelativeTime(activity.timestamp)}
+            {formatRelativeTime(activity.timestamp, now)}
           </time>
         </div>
       </div>
@@ -164,6 +170,17 @@ export const RecentActivity: React.FC<RecentActivityProps> = ({
   limit = 5,
 }) => {
   const { data, isLoading, error } = useRecentActivity(limit);
+  /*
+   * 🔴 Deriving the label at render is only half the repair. A render has to
+   * HAPPEN, and a dashboard card nobody touches gets none -- so an entry
+   * fetched as "just now" would keep that wording for as long as the page is
+   * open, which is the same wrong label reached by a different route. This is
+   * what makes the derivation run again.
+   *
+   * The value is passed to the formatter rather than discarded, so the label a
+   * reader sees and the instant this hook re-rendered for are the same one.
+   */
+  const now = useNowTick();
 
   return (
     <section aria-labelledby="dashboard-activity-heading" className="space-y-6">
@@ -201,7 +218,7 @@ export const RecentActivity: React.FC<RecentActivityProps> = ({
             <EmptyState />
           ) : (
             data.activities.map(activity => (
-              <ActivityItem key={activity.id} activity={activity} />
+              <ActivityItem key={activity.id} activity={activity} now={now} />
             ))
           )}
         </div>

--- a/packages/admin/src/components/features/dashboard/RecentActivity.tsx
+++ b/packages/admin/src/components/features/dashboard/RecentActivity.tsx
@@ -1,8 +1,28 @@
 /**
- * RecentActivity Component
+ * Who changed what, most recent first.
  *
- * Displays a feed of recent activity on the dashboard.
- * Shows user actions like create, update, delete with avatars and timestamps.
+ * Drawn as the dashboard card `core/recent-activity`, which declares
+ * `chrome: "none"` -- so this component owns its own heading and its own
+ * loading, error and empty states, and draws the `<section>` shell its
+ * neighbours draw rather than a `Card` the grid would frame a second time.
+ *
+ * ## It shows a fixed page and offers no way past it
+ *
+ * 🔴 That is the decision, not a gap. The server publishes `{ activities,
+ * hasMore }` and deliberately no total -- counting the feed would mean
+ * authorizing every matching row against its document's read rule, which is
+ * unbounded over a table that only grows. So there is no "showing 5 of N" to
+ * write, and the surveyed products (Strapi's audit widget, WordPress's activity
+ * section, Sanity's document list) all answer the same way: a fixed handful of
+ * rows, no in-widget pagination, no count.
+ *
+ * This component previously carried both of the controls that implies and
+ * NEITHER worked: a "Detailed Log" link whose href was the dashboard the card
+ * sits on, and a "Sync Previous Events" button with no handler. Each promised a
+ * destination that does not exist -- there is no audit-log route in `ROUTES` at
+ * all -- and both were removed rather than wired, because a feed with a
+ * pagination affordance is the shape nothing else ships and the missing page is
+ * a feature to decide on, not a link to point somewhere plausible.
  *
  * @module components/features/dashboard/RecentActivity
  */
@@ -12,18 +32,12 @@ import {
   AvatarFallback,
   AvatarImage,
   Badge,
-  Card,
-  CardHeader,
-  CardTitle,
-  CardContent,
   Spinner,
 } from "@nextlyhq/ui";
-import { Clock, ChevronRight } from "lucide-react";
+import { Clock } from "lucide-react";
 import type React from "react";
 
 import { AlertCircle } from "@admin/components/icons";
-import { Link } from "@admin/components/ui/link";
-import { ROUTES } from "@admin/constants/routes";
 import { useRecentActivity } from "@admin/hooks/queries/useRecentActivity";
 import { cn } from "@admin/lib/utils";
 import type { Activity } from "@admin/types/dashboard/activity";
@@ -141,62 +155,47 @@ export const RecentActivity: React.FC<RecentActivityProps> = ({
   const { data, isLoading, error } = useRecentActivity(limit);
 
   return (
-    <Card className="border-border bg-card/40 backdrop-blur-md rounded-lg overflow-hidden transition-all duration-500 hover:border-border">
-      <CardHeader className="flex flex-row items-center justify-between space-y-0 px-8 py-7  border-b border-border">
-        <div className="space-y-1">
-          <CardTitle className="text-xs font-black uppercase tracking-[0.25em] text-muted-foreground">
-            System Event Log
-          </CardTitle>
-          <div className="h-1 w-8 bg-primary/20 rounded-sm" />
-        </div>
-        <Link
-          href={ROUTES.DASHBOARD}
-          className="text-xs font-black uppercase tracking-[0.2em] text-primary hover-unified transition-all flex items-center gap-2 px-4 py-2 rounded-md bg-primary/5 hover-unified"
+    <section aria-labelledby="dashboard-activity-heading" className="space-y-6">
+      <div className="flex items-center gap-4">
+        <h4
+          id="dashboard-activity-heading"
+          className="text-sm font-semibold tracking-tight text-foreground whitespace-nowrap"
         >
-          Detailed Log <ChevronRight className="h-3 w-3" />
-        </Link>
-      </CardHeader>
-      <CardContent className="p-3">
-        {isLoading && (
-          <div className="flex flex-col items-center justify-center py-20 gap-4">
-            <Spinner size="md" className="text-primary/40" />
-            <span className="text-xs font-black uppercase tracking-[0.2em] text-muted-foreground animate-pulse">
-              Syncing events...
-            </span>
-          </div>
-        )}
+          Recent activity
+        </h4>
+        <div className="h-px flex-1 bg-border" />
+      </div>
 
-        {error && (
-          <div className="flex items-center gap-3 py-12 justify-center text-sm text-destructive bg-destructive/5 rounded-md mx-3 mb-3">
-            <AlertCircle className="h-4 w-4" />
-            <span className="font-bold uppercase tracking-wider text-xs">
-              Failed to fetch activity stream
-            </span>
-          </div>
-        )}
+      {isLoading && (
+        <div className="flex flex-col items-center justify-center py-16 gap-4">
+          <Spinner size="md" className="text-primary/40" />
+          <span className="text-sm text-muted-foreground">
+            Loading activity…
+          </span>
+        </div>
+      )}
 
-        {data && !isLoading && !error && (
-          <div className="space-y-1 p-2">
-            {data.activities.length === 0 ? (
-              <EmptyState />
-            ) : (
-              <>
-                <div className="space-y-1">
-                  {data.activities.map(activity => (
-                    <ActivityItem key={activity.id} activity={activity} />
-                  ))}
-                </div>
-                <div className="mt-6 pt-4  border-t border-border text-center">
-                  <button className="text-xs font-black uppercase tracking-[0.3em] text-muted-foreground hover-unified transition-all duration-500 py-3 px-8 rounded-md hover-unified">
-                    Sync Previous Events
-                  </button>
-                </div>
-              </>
-            )}
-          </div>
-        )}
-      </CardContent>
-    </Card>
+      {error && (
+        // Full-strength destructive border so the boundary is perceivable at
+        // the 3:1 UI minimum, matching the other cards' error state.
+        <div className="flex items-center gap-2 py-6 text-sm text-destructive justify-center bg-destructive/5 border border-destructive rounded-md">
+          <AlertCircle className="h-4 w-4" />
+          <span>Couldn&apos;t load recent activity.</span>
+        </div>
+      )}
+
+      {data && !isLoading && !error && (
+        <div className="space-y-1">
+          {data.activities.length === 0 ? (
+            <EmptyState />
+          ) : (
+            data.activities.map(activity => (
+              <ActivityItem key={activity.id} activity={activity} />
+            ))
+          )}
+        </div>
+      )}
+    </section>
   );
 };
 

--- a/packages/admin/src/components/features/widgets/__tests__/core-components-registry.test.ts
+++ b/packages/admin/src/components/features/widgets/__tests__/core-components-registry.test.ts
@@ -1,0 +1,97 @@
+/**
+ * `registerCoreWidgetComponents` actually REGISTERS, at runtime.
+ *
+ * 🔴 A sibling test compares the two lists as text and cannot prove this. A
+ * syntax scan sees call-shaped source; it does not see the call run. If the
+ * module-scope invocation in `WidgetGrid` were removed, a registration moved
+ * behind a branch that never executes, or the function returned early, both
+ * scanned lists would still agree while `PluginSlot` drew its unresolved
+ * fallback for every reader.
+ *
+ * ## Why the mocks, and what they cost
+ *
+ * `core-components.ts` cannot be imported directly: it imports `TeamSummary`
+ * and `CollectionQuickLinks`, which reach the `@admin/hooks/queries` barrel,
+ * which reaches `pages/dashboard/index.tsx`, which imports `WidgetGrid`, which
+ * calls `registerCoreWidgetComponents()` at module scope -- re-entering the
+ * module being evaluated. Importing it throws before a single case runs, and
+ * that cycle is pre-existing rather than introduced by these cards.
+ *
+ * Each card component is replaced with a stub, which cuts the graph at the
+ * first edge and leaves the module under test untouched. What that costs is
+ * honest to state: this proves the registry receives a component for each path,
+ * not that the component is the real one -- the sibling text scan is what pins
+ * the paths themselves. The two together are the boundary; neither alone is.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const stub = () => null;
+
+// Cut at the components, not at the registry: the registry is the thing under
+// test, and mocking it would leave this asserting its own mock.
+vi.mock("@admin/components/features/dashboard/SeedDemoContentCard", () => ({
+  SeedDemoContentCard: stub,
+}));
+vi.mock("@admin/components/features/dashboard/CollectionQuickLinks", () => ({
+  CollectionQuickLinks: stub,
+}));
+vi.mock("@admin/components/features/dashboard/SinglesQuickLinks", () => ({
+  SinglesQuickLinks: stub,
+}));
+vi.mock("@admin/components/features/dashboard/QuickCreate", () => ({
+  QuickCreate: stub,
+}));
+vi.mock("@admin/components/features/dashboard/TeamSummary", () => ({
+  TeamSummary: stub,
+}));
+vi.mock("@admin/components/features/dashboard/RecentActivity", () => ({
+  RecentActivity: stub,
+}));
+
+describe("core widget components register at runtime", () => {
+  beforeEach(async () => {
+    const { componentRegistry } = await import(
+      "@admin/lib/plugins/component-registry-internal"
+    );
+    componentRegistry.clear();
+  });
+
+  it("registers every path a core card names", async () => {
+    const { hasComponent } = await import(
+      "@admin/lib/plugins/component-registry"
+    );
+    const { registerCoreWidgetComponents } = await import("../core-components");
+
+    // The control, BEFORE the call: every path must be absent first, or a
+    // registry left populated by another module would satisfy the assertions
+    // below without this function having run at all.
+    expect(hasComponent("core#RecentActivity")).toBe(false);
+    expect(hasComponent("core#TeamSummary")).toBe(false);
+
+    registerCoreWidgetComponents();
+
+    for (const path of [
+      "core#SeedDemoContentCard",
+      "core#CollectionQuickLinks",
+      "core#SinglesQuickLinks",
+      "core#QuickCreate",
+      "core#TeamSummary",
+      "core#RecentActivity",
+    ]) {
+      expect(hasComponent(path), `${path} is not registered`).toBe(true);
+    }
+  });
+
+  it("resolves each path to something renderable", async () => {
+    const { getComponent } = await import(
+      "@admin/lib/plugins/component-registry"
+    );
+    const { registerCoreWidgetComponents } = await import("../core-components");
+
+    registerCoreWidgetComponents();
+
+    // `hasComponent` alone would pass on a path registered with `undefined`,
+    // which is the shape a broken import produces.
+    expect(typeof getComponent("core#RecentActivity")).toBe("function");
+  });
+});

--- a/packages/admin/src/components/features/widgets/__tests__/core-widget-components.test.ts
+++ b/packages/admin/src/components/features/widgets/__tests__/core-widget-components.test.ts
@@ -49,9 +49,7 @@ import { dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { CORE_WIDGETS } from "../../../../../../nextly/src/domains/widgets/core-widgets";
-import { holdsWidgetPermission } from "../../../../../../nextly/src/domains/widgets/definition";
 import { LIST_RENDERED_FIELDS } from "../archetypes/list";
-import { holdsWidgetGate } from "../resolve-widgets";
 
 /**
  * Resolved from this file rather than from `process.cwd()`, so the test reads
@@ -152,66 +150,5 @@ describe("core list cards select only fields that get drawn", () => {
 
   it.each(listCards)("%s selects at most what is drawn", (_id, select) => {
     expect(select.length).toBeLessThanOrEqual(LIST_RENDERED_FIELDS);
-  });
-});
-
-/**
- * The admin's permission gate against core's.
- *
- * 🔴 `resolveWidgets` runs in the BROWSER and cannot import the server's
- * `holdsWidgetPermission`, which lives in a package the browser bundle must
- * not pull in wholesale -- the same constraint that makes `useCurrentUserPermissions` keep its
- * own copy of core's system resources. So the any-of rule is written twice, and
- * this is what makes the second copy checkable rather than merely intended.
- *
- * The comparison is on the DECISION, not the shape: for each declaration, what
- * core's reader says the gate names is used to answer the admin's
- * `hasPermission`, and the two verdicts must agree. A test asserting both
- * functions "look the same" would pass on two implementations that diverge on
- * the inputs nobody wrote down -- an empty array, a member that is not a slug.
- */
-describe("the admin's widget gate agrees with core's", () => {
-  const held = new Set(["read-content-releases"]);
-  const hasPermission = (slug: string) => held.has(slug);
-
-  /*
-   * Every case is one both copies must answer identically, and the malformed
-   * ones are the point: each has an obvious wrong reading that fails OPEN, and
-   * core's copy had to be corrected out of exactly that once already.
-   */
-  const cases: readonly (readonly [string, unknown, boolean])[] = [
-    ["no gate at all", undefined, true],
-    ["a held slug", "read-content-releases", true],
-    ["a slug not held", "read-posts", false],
-    ["any-of, first held", ["read-content-releases", "create-x"], true],
-    ["any-of, last held", ["create-x", "read-content-releases"], true],
-    ["any-of, none held", ["create-x", "publish-x"], false],
-    ["an empty string", "", false],
-    ["an empty array", [], false],
-    ["an array carrying a non-slug", ["read-content-releases", 7], false],
-    ["an object", { read: true }, false],
-  ];
-
-  /*
-   * Core's side is the REAL `holdsWidgetPermission`, not a restatement of it
-   * here. A test that recomputed the rule would be a third copy, and it would
-   * agree with whichever of the two it was written from while the other drifted.
-   *
-   * Its verdict map is what `permissionVerdicts` would have resolved: a decision
-   * per slug, with an unheld slug present and `false` rather than missing, so a
-   * gate naming an unknown slug is exercised too.
-   */
-  const verdicts = new Map(
-    [...held, "read-posts", "create-x", "publish-x"].map(slug => [
-      slug,
-      held.has(slug),
-    ])
-  );
-
-  it.each(cases)("%s", (_label, gate, expected) => {
-    expect(holdsWidgetPermission(gate, verdicts), "core's").toBe(expected);
-    expect(holdsWidgetGate(gate as never, hasPermission), "the admin's").toBe(
-      expected
-    );
   });
 });

--- a/packages/admin/src/components/features/widgets/__tests__/core-widget-components.test.ts
+++ b/packages/admin/src/components/features/widgets/__tests__/core-widget-components.test.ts
@@ -49,6 +49,9 @@ import { dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { CORE_WIDGETS } from "../../../../../../nextly/src/domains/widgets/core-widgets";
+import { holdsWidgetPermission } from "../../../../../../nextly/src/domains/widgets/definition";
+import { LIST_RENDERED_FIELDS } from "../archetypes/list";
+import { holdsWidgetGate } from "../resolve-widgets";
 
 /**
  * Resolved from this file rather than from `process.cwd()`, so the test reads
@@ -116,5 +119,99 @@ describe("core widget component paths resolve", () => {
    */
   it("names exactly what it registers", () => {
     expect([...registered].sort()).toEqual([...named].sort());
+  });
+});
+
+/**
+ * A list card asking for fields its renderer will not draw.
+ *
+ * 🔴 This is the OTHER cross-package silence, and it fails more quietly than an
+ * unregistered component: the card renders, correctly, showing fewer columns
+ * than its author selected. Nothing throws, nothing logs, and the row looks
+ * deliberate -- so it survives review by anyone who does not happen to know the
+ * renderer takes two. Both shipped list cards were wrong this way, and one of
+ * them dropped the timestamp from a card whose description promises "newest
+ * first".
+ *
+ * The bound is IMPORTED from the renderer rather than written here, so drawing a
+ * third field is a one-line change in one file rather than a number to find in
+ * two.
+ */
+describe("core list cards select only fields that get drawn", () => {
+  const listCards = CORE_WIDGETS.filter(
+    widget => widget.archetype === "list"
+  ).map(widget => [widget.id, widget.query?.select ?? []] as const);
+
+  // The population: `filter` returning nothing would make `it.each` register no
+  // cases at all, and a describe block with no tests reports as passing.
+  it("finds the list cards to check", () => {
+    expect(listCards.map(([id]) => id)).toEqual(
+      expect.arrayContaining(["core/recently-edited", "core/upcoming-releases"])
+    );
+  });
+
+  it.each(listCards)("%s selects at most what is drawn", (_id, select) => {
+    expect(select.length).toBeLessThanOrEqual(LIST_RENDERED_FIELDS);
+  });
+});
+
+/**
+ * The admin's permission gate against core's.
+ *
+ * 🔴 `resolveWidgets` runs in the BROWSER and cannot import the server's
+ * `holdsWidgetPermission`, which lives in a package the browser bundle must
+ * not pull in wholesale -- the same constraint that makes `useCurrentUserPermissions` keep its
+ * own copy of core's system resources. So the any-of rule is written twice, and
+ * this is what makes the second copy checkable rather than merely intended.
+ *
+ * The comparison is on the DECISION, not the shape: for each declaration, what
+ * core's reader says the gate names is used to answer the admin's
+ * `hasPermission`, and the two verdicts must agree. A test asserting both
+ * functions "look the same" would pass on two implementations that diverge on
+ * the inputs nobody wrote down -- an empty array, a member that is not a slug.
+ */
+describe("the admin's widget gate agrees with core's", () => {
+  const held = new Set(["read-content-releases"]);
+  const hasPermission = (slug: string) => held.has(slug);
+
+  /*
+   * Every case is one both copies must answer identically, and the malformed
+   * ones are the point: each has an obvious wrong reading that fails OPEN, and
+   * core's copy had to be corrected out of exactly that once already.
+   */
+  const cases: readonly (readonly [string, unknown, boolean])[] = [
+    ["no gate at all", undefined, true],
+    ["a held slug", "read-content-releases", true],
+    ["a slug not held", "read-posts", false],
+    ["any-of, first held", ["read-content-releases", "create-x"], true],
+    ["any-of, last held", ["create-x", "read-content-releases"], true],
+    ["any-of, none held", ["create-x", "publish-x"], false],
+    ["an empty string", "", false],
+    ["an empty array", [], false],
+    ["an array carrying a non-slug", ["read-content-releases", 7], false],
+    ["an object", { read: true }, false],
+  ];
+
+  /*
+   * Core's side is the REAL `holdsWidgetPermission`, not a restatement of it
+   * here. A test that recomputed the rule would be a third copy, and it would
+   * agree with whichever of the two it was written from while the other drifted.
+   *
+   * Its verdict map is what `permissionVerdicts` would have resolved: a decision
+   * per slug, with an unheld slug present and `false` rather than missing, so a
+   * gate naming an unknown slug is exercised too.
+   */
+  const verdicts = new Map(
+    [...held, "read-posts", "create-x", "publish-x"].map(slug => [
+      slug,
+      held.has(slug),
+    ])
+  );
+
+  it.each(cases)("%s", (_label, gate, expected) => {
+    expect(holdsWidgetPermission(gate, verdicts), "core's").toBe(expected);
+    expect(holdsWidgetGate(gate as never, hasPermission), "the admin's").toBe(
+      expected
+    );
   });
 });

--- a/packages/admin/src/components/features/widgets/__tests__/core-widget-components.test.ts
+++ b/packages/admin/src/components/features/widgets/__tests__/core-widget-components.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Every `core#` path a core widget NAMES is a path this package REGISTERS.
+ *
+ * 🔴 The two halves live in packages that do not depend on each other. A core
+ * card declares its body as a string in `packages/nextly`
+ * (`core-widgets.ts`), and the component behind that string is bound here
+ * (`core-components.ts`) -- so no type, no import and no build step can notice
+ * that one names something the other never registered. That is the same
+ * two-halves-of-one-name hazard `system-source-ids.ts` exists to manage for a
+ * card's `query.source`, and until this file there was nothing holding the
+ * component half together at all.
+ *
+ * The failure it prevents is quiet and partial: `PluginSlot` resolves an
+ * unregistered path to its unresolved fallback, so the dashboard stands and one
+ * card draws a placeholder -- for every reader, with no error anywhere, and
+ * only until someone happens to look at that card. A rename on either side is
+ * enough to cause it.
+ *
+ * ## Why one side is imported and the other is read as TEXT
+ *
+ * Core's definitions are imported, so the paths compared below are the values
+ * the cards actually carry. This test imports that source module directly, as
+ * `hooks/__tests__/system-resources-parity.test.ts` does and for the same
+ * reason: the admin tsconfig maps only the bare `nextly` specifier, so a
+ * `nextly/*` subpath would resolve to built output and make this test require a
+ * build.
+ *
+ * `core-components.ts` cannot be imported at all. It sits in a PRE-EXISTING
+ * import cycle -- it imports `TeamSummary` and `CollectionQuickLinks`, which
+ * reach the `@admin/hooks/queries` barrel, which reaches
+ * `pages/dashboard/index.tsx`, which imports `WidgetGrid`, which calls
+ * `registerCoreWidgetComponents()` at module scope and so re-enters the module
+ * being evaluated. Importing it from a test throws `Cannot access ... before
+ * initialization` before a single case runs. Verified as pre-existing rather
+ * than assumed: the same one-line probe fails identically on an unmodified
+ * `core-components.ts`.
+ *
+ * So this reads the registration calls out of the file's source. That is a
+ * weaker instrument and the weakness is worth naming: it proves the two LISTS
+ * agree, not that each path resolves to a component at runtime. It is the
+ * drift that actually happens -- a card renamed on one side of a package
+ * boundary -- and it is checkable without depending on the cycle. When the
+ * cycle is broken, replace the scan with `hasComponent` and delete this note.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { CORE_WIDGETS } from "../../../../../../nextly/src/domains/widgets/core-widgets";
+
+/**
+ * Resolved from this file rather than from `process.cwd()`, so the test reads
+ * the same source whether vitest was invoked from the package or the root.
+ */
+const CORE_COMPONENTS = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../core-components.ts"
+);
+
+/**
+ * The paths core's cards NAME, read off the definitions rather than matched out
+ * of their source text.
+ *
+ * A `custom` card is the only kind that names one; the archetype-drawn cards
+ * carry a `query` instead and are correctly absent here.
+ */
+const named = CORE_WIDGETS.map(widget => widget.component).filter(
+  (path): path is string => typeof path === "string"
+);
+
+/**
+ * The paths this package REGISTERS.
+ *
+ * Matched on the call rather than on any `core#` string in the file, so a path
+ * mentioned in a comment is not mistaken for a registration -- the difference
+ * between the two lists is the whole signal, and a prose mention appearing in
+ * one of them would be a false agreement.
+ */
+const registered = [
+  ...readFileSync(CORE_COMPONENTS, "utf8").matchAll(
+    /registerCoreComponent\(\s*"(core#[A-Za-z0-9_]+)"/g
+  ),
+].map(match => match[1] as string);
+
+describe("core widget component paths resolve", () => {
+  /*
+   * The populations, asserted before any claim that they agree. Both sides can
+   * come back empty for reasons that have nothing to do with drift -- a renamed
+   * field on one side, a reformatted call the pattern no longer matches on the
+   * other -- and two empty lists are EQUAL, so the comparison below would pass
+   * having checked nothing.
+   *
+   * Membership rather than a count: a list that dropped one card and gained
+   * another matches any total worth comparing against, and the dropped one is
+   * exactly the card that would then go unchecked.
+   */
+  it("reads a non-empty set of named paths from core", () => {
+    expect(named).toEqual(
+      expect.arrayContaining(["core#TeamSummary", "core#RecentActivity"])
+    );
+  });
+
+  it("reads a non-empty set of registrations from the admin", () => {
+    expect(registered).toEqual(
+      expect.arrayContaining(["core#TeamSummary", "core#RecentActivity"])
+    );
+  });
+
+  /*
+   * Both directions in one assertion, deliberately. A path named and not
+   * registered is a card drawing the unresolved fallback; a path registered and
+   * not named is dead code, or the leftover of a card that was removed. Neither
+   * is acceptable and the message names whichever it is.
+   */
+  it("names exactly what it registers", () => {
+    expect([...registered].sort()).toEqual([...named].sort());
+  });
+});

--- a/packages/admin/src/components/features/widgets/archetypes/__tests__/presented-cells.test.tsx
+++ b/packages/admin/src/components/features/widgets/archetypes/__tests__/presented-cells.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * A cell is PRESENTED by its declared kind, not printed.
+ *
+ * 🔴 The defect this covers reached a reader: `scheduledAt` and `updatedAt` are
+ * declared `date` by their sources, the value crosses the wire as ISO 8601, and
+ * the row drew `2026-09-01T07:00:00.000Z` — on cards whose entire subject is
+ * when something happened or will happen. Selecting a different field was the
+ * first thing tried and it is not a fix: it only moves which column is
+ * unreadable.
+ *
+ * Asserted on the RENDERED row rather than on `asPresentedText` alone, because
+ * the unit was never the broken part. The type existed on the source and
+ * stopped at the server; what had to be proven is that it now reaches the
+ * element a person looks at.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { asPresentedText } from "../cell-text";
+import { listBody } from "../list";
+
+const ISO = "2026-09-01T07:00:00.000Z";
+
+const definition = {
+  id: "core/upcoming-releases",
+  title: "Upcoming releases",
+  archetype: "list",
+  query: { source: "system:releases", op: "list", select: ["title", "when"] },
+} as unknown as Parameters<typeof listBody>[1];
+
+function draw(fields: { name: string; type?: string }[]) {
+  const outcome = listBody(
+    {
+      op: "list",
+      items: [{ title: "Autumn launch", when: ISO }],
+      fields,
+    } as never,
+    definition
+  );
+  if (!outcome.ok) throw new Error(`renderer refused: ${outcome.message}`);
+  render(<>{outcome.node}</>);
+}
+
+describe("a list cell is presented by its declared kind", () => {
+  it("does not print a date as its ISO string", () => {
+    draw([{ name: "title" }, { name: "when", type: "date" }]);
+
+    // The control first: the row rendered at all, so the absence below is
+    // about the FORMATTING and not about an empty card.
+    expect(screen.getByText("Autumn launch")).toBeInTheDocument();
+    expect(screen.queryByText(ISO)).not.toBeInTheDocument();
+  });
+
+  /*
+   * A column the server did not type still renders. This is the compatibility
+   * direction: a source with no declaration, or a result predating types, must
+   * degrade to plain text rather than to an em dash — an unpresented value is
+   * still evidence, and blanking it would report a working row as missing data.
+   */
+  it("prints an untyped column as text", () => {
+    draw([{ name: "title" }, { name: "when" }]);
+
+    expect(screen.getByText(ISO)).toBeInTheDocument();
+  });
+});
+
+describe("asPresentedText", () => {
+  it("leaves a non-date alone", () => {
+    expect(asPresentedText("Autumn launch", "string")).toBe("Autumn launch");
+  });
+
+  /*
+   * An unparseable date falls back to the raw text. The value is still
+   * something a reader can see is wrong; an em dash would claim the row has no
+   * value at all, which is a different and less recoverable report.
+   */
+  it("falls back to the raw text on an unparseable date", () => {
+    expect(asPresentedText("not-a-date", "date")).toBe("not-a-date");
+  });
+
+  it("drops what cannot be printed at all", () => {
+    expect(asPresentedText({ nested: true }, "date")).toBeUndefined();
+    expect(asPresentedText(null, "date")).toBeUndefined();
+  });
+});

--- a/packages/admin/src/components/features/widgets/archetypes/__tests__/presented-cells.test.tsx
+++ b/packages/admin/src/components/features/widgets/archetypes/__tests__/presented-cells.test.tsx
@@ -14,7 +14,12 @@
  * element a person looks at.
  */
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  getGlobalDateTimeConfig,
+  setGlobalDateTimeConfig,
+} from "@admin/lib/dates/format";
 
 import { asPresentedText } from "../cell-text";
 import { listBody } from "../list";
@@ -81,5 +86,48 @@ describe("asPresentedText", () => {
   it("drops what cannot be printed at all", () => {
     expect(asPresentedText({ nested: true }, "date")).toBeUndefined();
     expect(asPresentedText(null, "date")).toBeUndefined();
+  });
+});
+
+/**
+ * The cell honours the ADMIN's configured timezone, not the browser's.
+ *
+ * 🔴 General Settings carries a timezone and `GeneralSettingsSyncProvider`
+ * publishes it to `formatGlobalDateTime` at the root of the admin. A cell
+ * formatting with a bare `toLocaleString` reads the browser's zone instead, so
+ * these cards would disagree with every other date beside them the moment an
+ * administrator configured one -- silently, and only for the administrators who
+ * did.
+ */
+describe("a date cell reads the admin's configured timezone", () => {
+  const original = getGlobalDateTimeConfig();
+  afterEach(() => setGlobalDateTimeConfig(original));
+
+  it("renders the instant in the configured zone", () => {
+    setGlobalDateTimeConfig({ timezone: "Asia/Karachi", locale: "en-US" });
+
+    // 07:00Z is 12:00 in Asia/Karachi (UTC+5, no DST).
+    expect(asPresentedText(ISO, "date")).toContain("12:00");
+  });
+
+  /*
+   * The must-differ control, and it is the assertion that actually proves the
+   * configured zone is CONSULTED. A fixed expectation alone would also pass on
+   * a machine whose local zone happened to match, which is luck rather than
+   * evidence -- two different zones producing the same text can only mean the
+   * setting was ignored.
+   */
+  it("renders the same instant differently in a different zone", () => {
+    setGlobalDateTimeConfig({ timezone: "Asia/Karachi", locale: "en-US" });
+    const karachi = asPresentedText(ISO, "date");
+
+    setGlobalDateTimeConfig({
+      timezone: "Pacific/Kiritimati",
+      locale: "en-US",
+    });
+    const kiritimati = asPresentedText(ISO, "date");
+
+    expect(karachi).toBeDefined();
+    expect(kiritimati).not.toBe(karachi);
   });
 });

--- a/packages/admin/src/components/features/widgets/archetypes/cell-text.ts
+++ b/packages/admin/src/components/features/widgets/archetypes/cell-text.ts
@@ -47,3 +47,50 @@ export function selectsNothing(
   const name = title ?? `This ${archetype} widget`;
   return `"${name}" is a ${archetype} widget whose query selects no fields, so there is nothing to show in each ${unit}.`;
 }
+
+/**
+ * One cell as text, PRESENTED according to the kind the source declared it.
+ *
+ * 🔴 The layer `asText` deliberately is not. `asText` answers "can this value be
+ * printed at all", which is a question about the value; this answers "how should
+ * a reader see it", which is a question about the value AND its declared type.
+ * Keeping them apart is what lets a source with no declaration still render.
+ *
+ * A `date` is the case that forced this. Every source declares its date fields
+ * as such, the value crosses the wire as an ISO 8601 string, and printing it
+ * verbatim put `2026-09-01T07:00:00.000Z` in front of a reader on a card whose
+ * whole subject is when something happens. Selecting a different field is not a
+ * remedy — it just moves which column is unreadable.
+ *
+ * Formatted in the VIEWER's locale and zone via `toLocaleString`, which is the
+ * only zone the browser can speak for. That is a real limitation worth naming
+ * rather than hiding: a release scheduled against a specific timezone is stored
+ * with one, and this cell cannot show it, because the widget query contract
+ * carries a value and its type rather than a value and its zone. A card that
+ * must be authoritative about the authored zone needs its source to publish a
+ * preformatted string; a dashboard summary reading "1 Sept, 08:00" in the
+ * reader's own zone is the right answer for this surface and the wrong one for
+ * a scheduling screen.
+ *
+ * An UNPARSEABLE date falls back to the raw text rather than dropping the cell.
+ * The value is still evidence — a reader can see something is wrong with it —
+ * and an em dash would report a working row as missing data.
+ */
+export function asPresentedText(
+  value: unknown,
+  type: string | undefined
+): string | undefined {
+  const text = asText(value);
+  if (text === undefined) return undefined;
+  if (type !== "date") return text;
+
+  const at = new Date(text);
+  if (Number.isNaN(at.getTime())) return text;
+  return at.toLocaleString(undefined, {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}

--- a/packages/admin/src/components/features/widgets/archetypes/cell-text.ts
+++ b/packages/admin/src/components/features/widgets/archetypes/cell-text.ts
@@ -9,6 +9,8 @@
  * @module components/features/widgets/archetypes/cell-text
  */
 
+import { formatGlobalDateTime } from "@admin/lib/dates/format";
+
 /**
  * One cell as text, or `undefined` when it is not something to print.
  *
@@ -62,15 +64,26 @@ export function selectsNothing(
  * whole subject is when something happens. Selecting a different field is not a
  * remedy — it just moves which column is unreadable.
  *
- * Formatted in the VIEWER's locale and zone via `toLocaleString`, which is the
- * only zone the browser can speak for. That is a real limitation worth naming
- * rather than hiding: a release scheduled against a specific timezone is stored
- * with one, and this cell cannot show it, because the widget query contract
- * carries a value and its type rather than a value and its zone. A card that
- * must be authoritative about the authored zone needs its source to publish a
- * preformatted string; a dashboard summary reading "1 Sept, 08:00" in the
- * reader's own zone is the right answer for this surface and the wrong one for
- * a scheduling screen.
+ * 🔴 Formatted through `formatGlobalDateTime`, the same path every other admin
+ * date goes through, NOT a bare `toLocaleString`. General Settings carries a
+ * timezone, `GeneralSettingsSyncProvider` publishes it to that formatter at the
+ * root of the admin, and a cell reading the browser's own zone instead would
+ * make these cards disagree with every date beside them whenever an
+ * administrator has configured one. The formatter falls back to the local zone
+ * when nothing is configured, so the browser zone remains the default rather
+ * than the rule.
+ *
+ * It is imported from `lib/dates/format` rather than through
+ * `useAdminDateFormatter`: this module is a plain function called from a render
+ * body, not a hook, and the underlying formatter reads a module-level config
+ * that the provider has already set.
+ *
+ * What it still cannot show is the zone a value was AUTHORED against -- a
+ * release scheduled for 09:00 Berlin is stored with that zone, and the widget
+ * query contract carries a value and its declared type rather than a value and
+ * its zone. This renders in the ADMIN's zone, which is the right answer for a
+ * dashboard summary and the wrong one for a scheduling screen, where
+ * `formatScheduledAt` already serves the authored zone from the full release.
  *
  * An UNPARSEABLE date falls back to the raw text rather than dropping the cell.
  * The value is still evidence — a reader can see something is wrong with it —
@@ -84,13 +97,17 @@ export function asPresentedText(
   if (text === undefined) return undefined;
   if (type !== "date") return text;
 
-  const at = new Date(text);
-  if (Number.isNaN(at.getTime())) return text;
-  return at.toLocaleString(undefined, {
-    day: "numeric",
-    month: "short",
-    year: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+  // The raw text is the FALLBACK, so an unparseable value still reaches the
+  // reader as evidence rather than as an em dash claiming the row has nothing.
+  return formatGlobalDateTime(
+    text,
+    {
+      day: "numeric",
+      month: "short",
+      year: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    },
+    text
+  );
 }

--- a/packages/admin/src/components/features/widgets/archetypes/list.tsx
+++ b/packages/admin/src/components/features/widgets/archetypes/list.tsx
@@ -41,6 +41,23 @@ export const listAccepts: ArchetypeAccepts = definition => {
   return selectsNothing(definition.title, "list", "row");
 };
 
+/**
+ * How many of a list card's selected fields this renderer actually draws.
+ *
+ * 🔴 Declared because the number is otherwise invisible at the only place it
+ * matters -- the card DECLARATION, in another package. A row is a label and a
+ * detail, so a third selected field is not extra information: it is dropped in
+ * silence, and the card looks finished while answering a narrower question than
+ * it was written to answer. Two shipped cards did exactly that, one of them
+ * omitting the timestamp from a card sorted by time.
+ *
+ * `listAccepts` cannot enforce it. Selecting too many fields is not a REFUSAL --
+ * the card draws correctly, just not everything asked for -- and turning it into
+ * one would blank a dashboard over what is a declaration mistake. So the check
+ * belongs where declarations are reviewed, and this constant is what it reads.
+ */
+export const LIST_RENDERED_FIELDS = 2;
+
 export const listBody: ArchetypeBody = (result, definition) => {
   if (result.op !== "list") {
     return {
@@ -50,6 +67,9 @@ export const listBody: ArchetypeBody = (result, definition) => {
   }
 
   const select = definition.query?.select ?? [];
+  // Keep in step with LIST_RENDERED_FIELDS: this destructure IS the number that
+  // constant declares, and a third name here without raising it would let a
+  // card select a field the guard still calls undrawable.
   const [labelField, detailField] = select;
   if (!labelField) {
     // Unreachable through the grid, which declines this declaration before it

--- a/packages/admin/src/components/features/widgets/archetypes/list.tsx
+++ b/packages/admin/src/components/features/widgets/archetypes/list.tsx
@@ -20,7 +20,7 @@
  * @module components/features/widgets/archetypes/list
  */
 
-import { asText, selectsNothing } from "./cell-text";
+import { asPresentedText, selectsNothing } from "./cell-text";
 import type { ArchetypeAccepts, ArchetypeBody } from "./types";
 
 /** How many rows a card of this size can show without becoming a table. */
@@ -94,14 +94,26 @@ export const listBody: ArchetypeBody = (result, definition) => {
   }
 
   const rows = result.items.slice(0, MAX_ROWS);
+  // The declared kind per column, so each cell is presented rather than
+  // printed. `fields` is what the SOURCE said survived the read; a column it
+  // does not describe falls back to plain text, which is what every row did
+  // before types were carried.
+  const typeOf = new Map(
+    (result.fields ?? []).map(field => [field.name, field.type])
+  );
 
   return {
     ok: true,
     node: (
       <ul data-testid="widget-list" className="flex flex-col gap-2">
         {rows.map((item, index) => {
-          const label = asText(item[labelField]);
-          const detail = detailField ? asText(item[detailField]) : undefined;
+          const label = asPresentedText(
+            item[labelField],
+            typeOf.get(labelField)
+          );
+          const detail = detailField
+            ? asPresentedText(item[detailField], typeOf.get(detailField))
+            : undefined;
           return (
             <li
               // The index, because a widget's rows have no identity core can

--- a/packages/admin/src/components/features/widgets/archetypes/table.tsx
+++ b/packages/admin/src/components/features/widgets/archetypes/table.tsx
@@ -17,7 +17,7 @@
  * @module components/features/widgets/archetypes/table
  */
 
-import { asText, selectsNothing } from "./cell-text";
+import { asPresentedText, selectsNothing } from "./cell-text";
 import type { ArchetypeAccepts, ArchetypeBody } from "./types";
 
 /**
@@ -134,7 +134,10 @@ export const tableBody: ArchetypeBody = (result, definition) => {
                     {/* An em dash rather than an empty cell, so the grid of
                         cells stays legible and a missing value is visibly a
                         missing value. */}
-                    {asText(item[column.name]) ?? "—"}
+                    {/* Presented by the column's declared kind, so a date
+                        column reads as a date rather than as the ISO string
+                        it crossed the wire as. */}
+                    {asPresentedText(item[column.name], column.type) ?? "—"}
                   </td>
                 ))}
               </tr>

--- a/packages/admin/src/components/features/widgets/core-components.ts
+++ b/packages/admin/src/components/features/widgets/core-components.ts
@@ -19,6 +19,7 @@
 
 import { CollectionQuickLinks } from "@admin/components/features/dashboard/CollectionQuickLinks";
 import { QuickCreate } from "@admin/components/features/dashboard/QuickCreate";
+import { RecentActivity } from "@admin/components/features/dashboard/RecentActivity";
 import { SeedDemoContentCard } from "@admin/components/features/dashboard/SeedDemoContentCard";
 import { SinglesQuickLinks } from "@admin/components/features/dashboard/SinglesQuickLinks";
 import { TeamSummary } from "@admin/components/features/dashboard/TeamSummary";
@@ -38,4 +39,5 @@ export function registerCoreWidgetComponents(): void {
   registerCoreComponent("core#SinglesQuickLinks", SinglesQuickLinks);
   registerCoreComponent("core#QuickCreate", QuickCreate);
   registerCoreComponent("core#TeamSummary", TeamSummary);
+  registerCoreComponent("core#RecentActivity", RecentActivity);
 }

--- a/packages/admin/src/components/features/widgets/resolve-widgets.ts
+++ b/packages/admin/src/components/features/widgets/resolve-widgets.ts
@@ -20,6 +20,7 @@ import type {
   WidgetStatCell,
   WidgetChrome,
 } from "nextly/config";
+import { widgetGateHolds } from "nextly/widget-gate";
 
 import type {
   PluginMetadata,
@@ -187,43 +188,6 @@ function declaredWidgets(
 }
 
 /**
- * Whether this reader satisfies a card's permission gate.
- *
- * 🔴 An ARRAY means ANY-OF, matching `holdsWidgetPermission` on the server. The
- * rule is spelled out twice because this file runs in the BROWSER and the
- * server's copy lives beside code that must not reach the bundle — the same
- * reason `useCurrentUserPermissions` keeps its own copy of core's system
- * resources. `core-widget-components.test.ts` holds the two against each other
- * so the duplication is checked rather than trusted.
- *
- * The server has already dropped cards this reader may not see, so a
- * disagreement here shows or hides a card the server disagrees about rather
- * than disclosing one — but a card the server SENT and this hides is invisible
- * with nothing logged, which is exactly the failure the any-of case was added
- * to fix.
- *
- * Fail-closed on a declaration that is present and unusable: an empty array, or
- * one carrying a non-slug, denies. Reading either as "no gate" would return the
- * card to every reader, which is the direction the server's copy had to be
- * corrected out of once already.
- */
-export function holdsWidgetGate(
-  requiredPermission: string | readonly string[] | undefined,
-  hasPermission: (permission: string) => boolean
-): boolean {
-  if (requiredPermission === undefined) return true;
-
-  const usable = (slug: unknown): slug is string =>
-    typeof slug === "string" && slug !== "";
-
-  if (usable(requiredPermission)) return hasPermission(requiredPermission);
-  if (!Array.isArray(requiredPermission)) return false;
-  if (requiredPermission.length === 0) return false;
-  if (!requiredPermission.every(usable)) return false;
-  return requiredPermission.some(slug => hasPermission(slug));
-}
-
-/**
  * One declaration as the grid renders it, or `undefined` when it is not
  * renderable at all.
  *
@@ -237,7 +201,7 @@ function resolveOne(
   meta: ReadableWidgetDeclaration,
   hasPermission: (permission: string) => boolean
 ): DashboardWidget | undefined {
-  if (!holdsWidgetGate(meta.requiredPermission, hasPermission)) {
+  if (!widgetGateHolds(meta.requiredPermission, hasPermission)) {
     return undefined;
   }
   const archetype = resolveArchetype(meta);
@@ -284,7 +248,7 @@ function resolveRegistered(
   meta: RegisteredWidgetMeta,
   hasPermission: (permission: string) => boolean
 ): DashboardWidget | undefined {
-  if (!holdsWidgetGate(meta.requiredPermission, hasPermission)) {
+  if (!widgetGateHolds(meta.requiredPermission, hasPermission)) {
     return undefined;
   }
 

--- a/packages/admin/src/components/features/widgets/resolve-widgets.ts
+++ b/packages/admin/src/components/features/widgets/resolve-widgets.ts
@@ -80,7 +80,7 @@ function readableActions(
 export interface ReadableWidgetDeclaration {
   id: string;
   size?: "full" | "half";
-  requiredPermission?: string;
+  requiredPermission?: string | readonly string[];
   title?: string;
   description?: string;
   icon?: string;
@@ -187,6 +187,43 @@ function declaredWidgets(
 }
 
 /**
+ * Whether this reader satisfies a card's permission gate.
+ *
+ * 🔴 An ARRAY means ANY-OF, matching `holdsWidgetPermission` on the server. The
+ * rule is spelled out twice because this file runs in the BROWSER and the
+ * server's copy lives beside code that must not reach the bundle — the same
+ * reason `useCurrentUserPermissions` keeps its own copy of core's system
+ * resources. `core-widget-components.test.ts` holds the two against each other
+ * so the duplication is checked rather than trusted.
+ *
+ * The server has already dropped cards this reader may not see, so a
+ * disagreement here shows or hides a card the server disagrees about rather
+ * than disclosing one — but a card the server SENT and this hides is invisible
+ * with nothing logged, which is exactly the failure the any-of case was added
+ * to fix.
+ *
+ * Fail-closed on a declaration that is present and unusable: an empty array, or
+ * one carrying a non-slug, denies. Reading either as "no gate" would return the
+ * card to every reader, which is the direction the server's copy had to be
+ * corrected out of once already.
+ */
+export function holdsWidgetGate(
+  requiredPermission: string | readonly string[] | undefined,
+  hasPermission: (permission: string) => boolean
+): boolean {
+  if (requiredPermission === undefined) return true;
+
+  const usable = (slug: unknown): slug is string =>
+    typeof slug === "string" && slug !== "";
+
+  if (usable(requiredPermission)) return hasPermission(requiredPermission);
+  if (!Array.isArray(requiredPermission)) return false;
+  if (requiredPermission.length === 0) return false;
+  if (!requiredPermission.every(usable)) return false;
+  return requiredPermission.some(slug => hasPermission(slug));
+}
+
+/**
  * One declaration as the grid renders it, or `undefined` when it is not
  * renderable at all.
  *
@@ -200,7 +237,7 @@ function resolveOne(
   meta: ReadableWidgetDeclaration,
   hasPermission: (permission: string) => boolean
 ): DashboardWidget | undefined {
-  if (meta.requiredPermission && !hasPermission(meta.requiredPermission)) {
+  if (!holdsWidgetGate(meta.requiredPermission, hasPermission)) {
     return undefined;
   }
   const archetype = resolveArchetype(meta);
@@ -247,7 +284,7 @@ function resolveRegistered(
   meta: RegisteredWidgetMeta,
   hasPermission: (permission: string) => boolean
 ): DashboardWidget | undefined {
-  if (meta.requiredPermission && !hasPermission(meta.requiredPermission)) {
+  if (!holdsWidgetGate(meta.requiredPermission, hasPermission)) {
     return undefined;
   }
 

--- a/packages/admin/src/hooks/queries/useRecentActivity.ts
+++ b/packages/admin/src/hooks/queries/useRecentActivity.ts
@@ -10,10 +10,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { protectedApi } from "@admin/lib/api/protectedApi";
-import {
-  describeActivityActor,
-  formatRelativeTime,
-} from "@admin/lib/dashboard";
+import { describeActivityActor } from "@admin/lib/dashboard";
 import type {
   Activity,
   ActivityCategory,
@@ -83,7 +80,6 @@ function mapEntry(entry: ActivityLogEntry): Activity {
     collectionLabel,
     category: ACTION_CATEGORIES[entry.action] ?? "info",
     timestamp: entry.createdAt,
-    relativeTime: formatRelativeTime(entry.createdAt),
   };
 }
 

--- a/packages/admin/src/hooks/queries/useWidgetQueries.test.tsx
+++ b/packages/admin/src/hooks/queries/useWidgetQueries.test.tsx
@@ -504,6 +504,62 @@ describe("useWidgetQueries", () => {
       });
     });
 
+    /*
+     * 🔴 The column's declared KIND, which is what lets a cell be presented
+     * rather than printed. This arm rebuilds the result from named fields, so a
+     * property it does not name is discarded -- the exact way `label` was lost
+     * when the server first started describing columns, and the exact way
+     * `type` was lost again the day it was added. A renderer test cannot catch
+     * it: those hand the fields straight to the archetype and never cross this
+     * boundary.
+     */
+    it("carries the column's declared type through", async () => {
+      expect(
+        await slotFor({
+          ok: true,
+          result: {
+            op: "list",
+            items: [{ when: "2026-09-01T07:00:00.000Z" }],
+            fields: [{ name: "when", label: "Scheduled", type: "date" }],
+          },
+        })
+      ).toEqual({
+        ok: true,
+        result: {
+          op: "list",
+          items: [{ when: "2026-09-01T07:00:00.000Z" }],
+          fields: [{ name: "when", label: "Scheduled", type: "date" }],
+        },
+      });
+    });
+
+    /*
+     * An unrecognised kind degrades to an untyped column instead of refusing the
+     * result. A newer server may name a type this build has not learned, and
+     * blanking the card over it would make every future type a breaking change
+     * -- where rendering the value as text is what every column did before types
+     * existed at all.
+     */
+    it("drops an unrecognised type but keeps the column", async () => {
+      expect(
+        await slotFor({
+          ok: true,
+          result: {
+            op: "list",
+            items: [{ when: "soon" }],
+            fields: [{ name: "when", type: "duration" }],
+          },
+        })
+      ).toEqual({
+        ok: true,
+        result: {
+          op: "list",
+          items: [{ when: "soon" }],
+          fields: [{ name: "when" }],
+        },
+      });
+    });
+
     it("drops malformed column descriptions without losing the rows", async () => {
       // A malformed heading costs the columns and nothing more. The rows are
       // the answer, and refusing the whole result over its headings would turn

--- a/packages/admin/src/hooks/queries/useWidgetQueries.ts
+++ b/packages/admin/src/hooks/queries/useWidgetQueries.ts
@@ -222,20 +222,46 @@ function asSlot(value: unknown): WidgetSlot {
  * said this is "the place that has to grow when the result contract does" --
  * and then the contract grew.
  */
+/**
+ * The field kinds this admin knows how to present.
+ *
+ * Its own set rather than a check against core's exported tuple: this module
+ * parses UNTRUSTED JSON off the wire, so the question is what this build can
+ * render, which is a property of this package and not of whichever server
+ * answered.
+ */
+const KNOWN_FIELD_TYPES: ReadonlySet<string> = new Set([
+  "string",
+  "number",
+  "boolean",
+  "date",
+]);
+
 function asResultFields(value: unknown): WidgetResultField[] | undefined {
   if (!Array.isArray(value)) return undefined;
 
   const described: WidgetResultField[] = [];
   for (const raw of value) {
     if (!isObject(raw)) return undefined;
-    const field = raw as { name?: unknown; label?: unknown };
+    const field = raw as { name?: unknown; label?: unknown; type?: unknown };
     if (typeof field.name !== "string" || field.name === "") return undefined;
     if (field.label !== undefined && typeof field.label !== "string") {
       return undefined;
     }
+    /*
+     * An unrecognised kind is DROPPED, not refused. `label` above rejects the
+     * whole list on a wrong shape because a non-string label is a server that
+     * is broken; a type this admin does not know is a server that is NEWER, and
+     * blanking the card over it would make every future type a breaking change.
+     * Falling back to plain text is what the renderer did before types existed.
+     */
+    const type = KNOWN_FIELD_TYPES.has(field.type as string)
+      ? (field.type as WidgetResultField["type"])
+      : undefined;
     described.push({
       name: field.name,
       ...(field.label !== undefined && { label: field.label }),
+      ...(type !== undefined && { type }),
     });
   }
 

--- a/packages/admin/src/hooks/queries/useWidgetQueries.ts
+++ b/packages/admin/src/hooks/queries/useWidgetQueries.ts
@@ -26,7 +26,11 @@
  */
 
 import { useQueries } from "@tanstack/react-query";
-import { MAX_QUERIES_PER_REQUEST, type WidgetQuery } from "nextly/config";
+import {
+  MAX_QUERIES_PER_REQUEST,
+  WIDGET_SOURCE_FIELD_TYPES,
+  type WidgetQuery,
+} from "nextly/config";
 import { useMemo } from "react";
 
 import { protectedApi } from "@admin/lib/api/protectedApi";
@@ -223,19 +227,22 @@ function asSlot(value: unknown): WidgetSlot {
  * and then the contract grew.
  */
 /**
- * The field kinds this admin knows how to present.
+ * The field kinds a result may name, DERIVED from core's vocabulary.
  *
- * Its own set rather than a check against core's exported tuple: this module
- * parses UNTRUSTED JSON off the wire, so the question is what this build can
- * render, which is a property of this package and not of whichever server
- * answered.
+ * 🔴 Not a hand-kept list. The wire's `type` is a `WidgetSourceFieldType`, whose
+ * canonical tuple lives in core, and restating the strings here meant the two
+ * could disagree in the one direction nobody notices: core adds a presentable
+ * kind, the server emits it, and this parser silently erases it -- so the cell
+ * falls back to raw text with the new presentation quietly missing and nothing
+ * reporting a loss.
+ *
+ * The set still exists rather than trusting the wire, because this parses
+ * UNTRUSTED JSON: what arrives has to be checked against the vocabulary, and
+ * deriving the vocabulary from core is what makes that check track core.
  */
-const KNOWN_FIELD_TYPES: ReadonlySet<string> = new Set([
-  "string",
-  "number",
-  "boolean",
-  "date",
-]);
+const KNOWN_FIELD_TYPES: ReadonlySet<string> = new Set(
+  WIDGET_SOURCE_FIELD_TYPES
+);
 
 function asResultFields(value: unknown): WidgetResultField[] | undefined {
   if (!Array.isArray(value)) return undefined;

--- a/packages/admin/src/hooks/useNowTick.ts
+++ b/packages/admin/src/hooks/useNowTick.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Re-render on a clock, so a value DERIVED from the current time stays true.
+ *
+ * 🔴 For relative times, and the distinction it fixes is easy to lose. Deriving
+ * "2h ago" at render instead of at fetch is only half the repair: a render has
+ * to happen for the derivation to run, and a dashboard card that nobody
+ * interacts with gets none. An entry fetched as "just now" then keeps that
+ * wording for as long as the page is open — the same wrong label as before,
+ * arrived at by a different route, and a test that calls `rerender` itself
+ * cannot tell the two apart.
+ *
+ * Returns the current time rather than a counter so the value has a use: a
+ * caller can pass it to a formatter, and nothing has to pretend to read a
+ * variable it does not want. Callers that only need the re-render may ignore it.
+ *
+ * ## What it deliberately does not do
+ *
+ * No pausing while the tab is hidden. One timer per mounted card, at a period
+ * measured in tens of seconds, costs less than the code deciding whether to run
+ * it — and `visibilitychange` handling would be a second mechanism to keep in
+ * step with the first. A hidden tab also gets its timers throttled by the
+ * browser already, which is the behaviour that would have been implemented.
+ *
+ * No alignment to the minute boundary. A label may lag by up to one period,
+ * which for a feed of hours-old events is invisible; aligning would mean
+ * rescheduling every tick to a computed delay, and the failure mode of getting
+ * that arithmetic wrong is a timer that never fires again.
+ */
+export function useNowTick(periodMs = 60_000): number {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    // Guarded, because a non-positive period would schedule a timer that fires
+    // as fast as the event loop allows and would peg a core for as long as the
+    // card is mounted.
+    if (!Number.isFinite(periodMs) || periodMs <= 0) return;
+
+    const id = setInterval(() => setNow(Date.now()), periodMs);
+    return () => clearInterval(id);
+  }, [periodMs]);
+
+  return now;
+}

--- a/packages/admin/src/lib/dashboard.ts
+++ b/packages/admin/src/lib/dashboard.ts
@@ -70,10 +70,15 @@ export function describeActivityActor(entry: {
  * Converts an ISO timestamp to a human-readable relative time string.
  *
  * @param isoTimestamp - ISO 8601 date string
+ * @param at - The instant to measure FROM, in epoch milliseconds. Defaults to
+ *   now, which is what every caller reading a one-off label wants. A caller
+ *   re-rendering on a clock passes the instant that caused the render, so the
+ *   label and the tick behind it cannot disagree -- and a test can state the
+ *   moment it is asking about instead of stubbing the global clock.
  * @returns Relative time string (e.g. "just now", "5m ago", "3h ago", "2d ago", "Mar 1")
  */
-export function formatRelativeTime(isoTimestamp: string): string {
-  const now = Date.now();
+export function formatRelativeTime(isoTimestamp: string, at?: number): string {
+  const now = at ?? Date.now();
   const then = new Date(isoTimestamp).getTime();
   const diffMs = now - then;
   const diffSec = Math.floor(diffMs / 1000);

--- a/packages/admin/src/types/dashboard/activity.ts
+++ b/packages/admin/src/types/dashboard/activity.ts
@@ -63,10 +63,17 @@ export interface Activity {
   collectionLabel?: string;
   /** Activity category for badge styling */
   category: ActivityCategory;
-  /** Timestamp when the activity occurred (ISO 8601 format) */
+  /**
+   * When the activity occurred (ISO 8601).
+   *
+   * 🔴 The only time this entry carries, deliberately. A `relativeTime` string
+   * sat beside it, computed once while mapping the response -- so "just now"
+   * stayed "just now" for as long as the query's data was reused, which on a
+   * dashboard left open is indefinitely. A relative time is a function of when
+   * it is READ, so it is derived at render from this, the way every other
+   * relative time in the admin already is.
+   */
   timestamp: string;
-  /** Relative time string (e.g., "2 minutes ago") */
-  relativeTime: string;
 }
 
 /**

--- a/packages/admin/src/types/dashboard/widgets.ts
+++ b/packages/admin/src/types/dashboard/widgets.ts
@@ -29,6 +29,7 @@ import type {
   WidgetSize,
   WidgetStatCell,
   WidgetChrome,
+  WidgetSourceFieldType,
 } from "nextly/config";
 
 /**
@@ -51,12 +52,17 @@ export interface WidgetResultField {
    * server, and the row drew the ISO string the value crossed as --
    * `2026-09-01T07:00:00.000Z` on a card whose subject is when.
    *
-   * Optional, and an UNRECOGNISED kind arrives as absent rather than rejecting
-   * the result: a newer server may name a type this admin has not learned, and
-   * refusing the whole field list over it would blank a card that could have
-   * rendered its values as text.
+   * Typed from CORE's vocabulary rather than restated here. Repeating the four
+   * strings meant the server could add a kind this build then erased on the way
+   * in -- the parser would drop it, the cell would fall back to raw text, and
+   * nothing would report that a presentation had been lost.
+   *
+   * Still optional, and an unrecognised kind arrives as absent rather than
+   * rejecting the result: a newer server may name a type this build predates,
+   * and refusing the whole field list over it would blank a card that could
+   * have rendered its values as text.
    */
-  type?: "string" | "number" | "boolean" | "date";
+  type?: WidgetSourceFieldType;
 }
 
 export type WidgetResult =

--- a/packages/admin/src/types/dashboard/widgets.ts
+++ b/packages/admin/src/types/dashboard/widgets.ts
@@ -43,6 +43,20 @@ export interface WidgetResultField {
   name: string;
   /** Absent when the source has no human label for this field. */
   label?: string;
+  /**
+   * What KIND of value this column holds, as the source declared it.
+   *
+   * 🔴 Read so a cell can be PRESENTED rather than printed. Every source
+   * declares its date fields as dates, that declaration used to stop at the
+   * server, and the row drew the ISO string the value crossed as --
+   * `2026-09-01T07:00:00.000Z` on a card whose subject is when.
+   *
+   * Optional, and an UNRECOGNISED kind arrives as absent rather than rejecting
+   * the result: a newer server may name a type this admin has not learned, and
+   * refusing the whole field list over it would blank a card that could have
+   * rendered its values as text.
+   */
+  type?: "string" | "number" | "boolean" | "date";
 }
 
 export type WidgetResult =

--- a/packages/admin/tsconfig.json
+++ b/packages/admin/tsconfig.json
@@ -7,6 +7,13 @@
     "baseUrl": ".",
     "paths": {
       "nextly": ["../nextly/src"],
+      // The gate the layout endpoint and the browser BOTH decide with. Mapped
+      // to source because a bare subpath resolves through the package exports
+      // to `dist`, which does not exist until something builds -- so static
+      // analysis reports it unresolved on a clean checkout even though tsc and
+      // the bundler are fine after a build. The bare `nextly` mapping above
+      // does not cover subpaths.
+      "nextly/widget-gate": ["../nextly/src/domains/widgets/gate.ts"],
       "@admin/*": ["./src/*"]
     }
   },

--- a/packages/nextly/package.json
+++ b/packages/nextly/package.json
@@ -47,6 +47,10 @@
       "types": "./dist/field-catalog.d.ts",
       "import": "./dist/collections/fields/catalog.mjs"
     },
+    "./widget-gate": {
+      "types": "./dist/widget-gate.d.ts",
+      "import": "./dist/domains/widgets/gate.mjs"
+    },
     "./query": {
       "types": "./dist/query/index.d.ts",
       "import": "./dist/query/index.mjs"

--- a/packages/nextly/src/config.ts
+++ b/packages/nextly/src/config.ts
@@ -256,6 +256,12 @@ export {
   MAX_PLACEMENTS,
   type ColumnCount,
 } from "./domains/widgets/layout";
+// The VALUE as well as the type. A widget result names each column's kind, and
+// the admin has to decide which kinds it can present -- deriving that from this
+// tuple is what stops the browser silently erasing a kind core has started to
+// emit. `sources.ts` reaches only `NextlyError` and an import-free helper, so
+// publishing it on this client-safe surface pulls no server code after it.
+export { WIDGET_SOURCE_FIELD_TYPES } from "./domains/widgets/sources";
 export type {
   WidgetOp,
   WidgetSourceField,

--- a/packages/nextly/src/domains/releases/__tests__/releases-widget-source.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/releases-widget-source.test.ts
@@ -131,6 +131,30 @@ describe("what it answers with", () => {
     expect(Object.keys(item).sort()).toEqual(["scheduledAt", "state", "title"]);
   });
 
+  /*
+   * 🔴 The DATE's type reaches the result, which is the half that used to stop
+   * at the server. Every source declares `scheduledAt` a date, the renderer
+   * needs that to present it, and without it the row drew the ISO string the
+   * value crossed as -- on a card whose entire subject is when. Asserted on the
+   * producer because the renderer and the wire parser each have their own test,
+   * and all three have to hold for a reader to see a date.
+   */
+  it("publishes the declared kind of each column", async () => {
+    const result = await executeWidgetQuery(
+      {
+        source: RELEASES_SOURCE_ID,
+        op: "list",
+        select: ["title", "scheduledAt"],
+      },
+      caller
+    );
+
+    expect((result as { fields?: unknown }).fields).toEqual([
+      { name: "title", label: "Release", type: "string" },
+      { name: "scheduledAt", label: "Scheduled", type: "date" },
+    ]);
+  });
+
   it("heads only the columns the query selected", async () => {
     const result = await executeWidgetQuery(
       { source: RELEASES_SOURCE_ID, op: "list", select: ["title"] },
@@ -138,7 +162,7 @@ describe("what it answers with", () => {
     );
 
     expect((result as { fields?: unknown }).fields).toEqual([
-      { name: "title", label: "Release" },
+      { name: "title", label: "Release", type: "string" },
     ]);
     const [item] = (result as { items: Record<string, unknown>[] }).items;
     expect(Object.keys(item)).toEqual(["title"]);

--- a/packages/nextly/src/domains/releases/releases-widget-source.ts
+++ b/packages/nextly/src/domains/releases/releases-widget-source.ts
@@ -122,14 +122,18 @@ function describeFields(
   select: readonly string[] | undefined
 ): WidgetResultField[] | undefined {
   if (!select || select.length === 0) return undefined;
-  const labels = new Map(RELEASE_FIELDS.map(f => [f.name, f.label]));
+  // The whole declared field. `scheduledAt` is a `date`, and publishing only
+  // its label left the renderer printing the ISO string it crossed as.
+  const declared = new Map(RELEASE_FIELDS.map(f => [f.name, f]));
   const seen = new Set<string>();
   const described: WidgetResultField[] = [];
   for (const name of select) {
     if (seen.has(name)) continue;
     seen.add(name);
-    const label = labels.get(name);
-    if (label !== undefined) described.push({ name, label });
+    const field = declared.get(name);
+    if (field !== undefined) {
+      described.push({ name, label: field.label, type: field.type });
+    }
   }
   return described.length > 0 ? described : undefined;
 }

--- a/packages/nextly/src/domains/versions/versions-widget-source.ts
+++ b/packages/nextly/src/domains/versions/versions-widget-source.ts
@@ -60,7 +60,7 @@ import { container } from "../../di/container";
 import { NextlyError } from "../../errors/nextly-error";
 import type { ReadCaller } from "../../services/dashboard/readable-resources";
 import type { WidgetQuery } from "../widgets/query";
-import type { WidgetResult } from "../widgets/result";
+import type { WidgetResult, WidgetResultField } from "../widgets/result";
 import { failUnavailableSourceOrOp } from "../widgets/sources";
 import { VERSIONS_SOURCE_ID } from "../widgets/system-source-ids";
 import { registerSystemSource } from "../widgets/system-sources";
@@ -254,15 +254,18 @@ function selectedNames(query: WidgetQuery): string[] {
 }
 
 /** Each selected name paired with the label this source publishes for it. */
-function describe(
-  names: readonly string[]
-): { name: string; label?: string }[] {
-  const labels = new Map(
-    VERSION_FIELDS.map(field => [field.name, field.label])
-  );
+function describe(names: readonly string[]): WidgetResultField[] {
+  // Type as well as label. The renderer presents a value by its declared kind,
+  // so a describer that publishes only the label leaves `updatedAt` to be
+  // printed as the ISO string it crossed the wire as.
+  const declared = new Map(VERSION_FIELDS.map(field => [field.name, field]));
   return names.map(name => {
-    const label = labels.get(name);
-    return { name, ...(label !== undefined && { label }) };
+    const field = declared.get(name);
+    return {
+      name,
+      ...(field?.label !== undefined && { label: field.label }),
+      ...(field?.type !== undefined && { type: field.type }),
+    };
   });
 }
 

--- a/packages/nextly/src/domains/widgets/__tests__/core-widgets.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/core-widgets.test.ts
@@ -1,0 +1,101 @@
+/**
+ * The core cards' declarations, held against the modules that have to honour
+ * them.
+ *
+ * Deliberately NOT a restatement of the list. Asserting that a card carries the
+ * literal written three lines away in `core-widgets.ts` is a test that can only
+ * ever agree with itself, and it would go on agreeing while the thing the
+ * literal REFERS to was renamed underneath it. What is checked here is each
+ * declaration against the module that consumes it.
+ */
+import { describe, expect, it } from "vitest";
+
+import { parsePermissionSlug } from "../../../plugins/routes/permission-slug";
+import { RELEASES_RESOURCE } from "../../releases/services/releases-service";
+import { CORE_WIDGETS } from "../core-widgets";
+import { validateWidgetDefinition } from "../definition";
+
+function card(id: string) {
+  const found = CORE_WIDGETS.find(widget => widget.id === id);
+  // Resolved through a lookup that REFUSES rather than through `!`, so a
+  // renamed or removed card fails here naming itself, instead of every
+  // assertion below reading `undefined` and reporting something unrelated.
+  if (!found) throw new Error(`no core widget with id "${id}"`);
+  return found;
+}
+
+describe("core widget definitions", () => {
+  /*
+   * Every card goes through the same door a plugin's does. Core's list is a
+   * hand-written literal that no caller validates on the way in -- boot calls
+   * `registerWidget`, which validates, but a definition that would be REFUSED
+   * there fails at boot rather than in a test naming the field.
+   */
+  it.each(CORE_WIDGETS.map(widget => [widget.id, widget] as const))(
+    "%s is a valid definition",
+    (_id, widget) => {
+      // An assertion function: it THROWS with a named reason and returns
+      // nothing, so the absence of a throw is the whole result.
+      expect(() => validateWidgetDefinition(widget)).not.toThrow();
+    }
+  );
+
+  /*
+   * 🔴 The load-bearing one. `core/upcoming-releases` is gated by a permission
+   * SLUG -- a string this file spells out -- and the gate only works if that
+   * string parses to the action and resource `ReleasesService` actually
+   * enforces. Two independent renames break it silently and in the dangerous
+   * direction: a slug that parses to a resource nothing grants is refused for
+   * everyone, and the card simply never appears, which looks exactly like a
+   * reader without the permission.
+   *
+   * Compared against `RELEASES_RESOURCE` rather than against the literal
+   * "content-releases", so renaming the resource fails here instead of leaving
+   * a card gated on a resource that no longer exists.
+   */
+  it("gates upcoming releases on the resource the releases service enforces", () => {
+    const { requiredPermission } = card("core/upcoming-releases");
+
+    expect(requiredPermission).toBeDefined();
+    expect(parsePermissionSlug(requiredPermission as string)).toEqual({
+      action: "read",
+      resource: RELEASES_RESOURCE,
+    });
+  });
+
+  /*
+   * The other cards' lack of a gate is a decision rather than an omission -- see
+   * the module docblock -- so it is asserted, not assumed. A gate added to one
+   * of these hides a card every authenticated admin can see today, which is the
+   * behaviour change that docblock exists to prevent.
+   */
+  it("gates no card that predates the grid", () => {
+    const gated = CORE_WIDGETS.filter(
+      widget => widget.requiredPermission !== undefined
+    ).map(widget => widget.id);
+
+    expect(gated).toEqual(["core/upcoming-releases"]);
+  });
+
+  /*
+   * 🔴 Asserted in THIS direction only, and the other one is false. Naming a
+   * component does not imply declining the grid's frame: `core/quick-create`
+   * names one and draws no heading, section or card of its own, so it wants
+   * `WidgetCard` around it and correctly omits `chrome`. The first version of
+   * this test asserted the converse and failed on that card -- which was the
+   * test being wrong, not the card.
+   *
+   * What does hold is that only a card supplying its own body may decline the
+   * frame. An archetype-drawn card with `chrome: "none"` would render its rows
+   * bare, with nothing naming what they are.
+   */
+  it("declines the grid's frame only where the card brings a body", () => {
+    for (const widget of CORE_WIDGETS) {
+      if (widget.chrome !== "none") continue;
+      expect(
+        widget.component,
+        `${widget.id} declines chrome, so it must draw its own`
+      ).toBeDefined();
+    }
+  });
+});

--- a/packages/nextly/src/domains/widgets/__tests__/core-widgets.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/core-widgets.test.ts
@@ -13,7 +13,10 @@ import { describe, expect, it } from "vitest";
 import { parsePermissionSlug } from "../../../plugins/routes/permission-slug";
 import { RELEASES_RESOURCE } from "../../releases/services/releases-service";
 import { CORE_WIDGETS } from "../core-widgets";
-import { validateWidgetDefinition } from "../definition";
+import {
+  requiredPermissionSlugs,
+  validateWidgetDefinition,
+} from "../definition";
 
 function card(id: string) {
   const found = CORE_WIDGETS.find(widget => widget.id === id);
@@ -54,13 +57,39 @@ describe("core widget definitions", () => {
    * a card gated on a resource that no longer exists.
    */
   it("gates upcoming releases on the resource the releases service enforces", () => {
-    const { requiredPermission } = card("core/upcoming-releases");
+    const slugs = requiredPermissionSlugs(
+      card("core/upcoming-releases").requiredPermission
+    );
 
-    expect(requiredPermission).toBeDefined();
-    expect(parsePermissionSlug(requiredPermission as string)).toEqual({
-      action: "read",
-      resource: RELEASES_RESOURCE,
-    });
+    // Read through the gate's own reader, so a declaration this test approves
+    // is one the gate can actually use.
+    expect(slugs).toBeDefined();
+    expect((slugs ?? []).map(parsePermissionSlug)).toEqual([
+      { action: "read", resource: RELEASES_RESOURCE },
+      { action: "create", resource: RELEASES_RESOURCE },
+      { action: "publish", resource: RELEASES_RESOURCE },
+    ]);
+  });
+
+  /*
+   * 🔴 The authorities, held against the RULE rather than against a list.
+   * `ReleasesService.authorize` returns early for `create` or `publish` when the
+   * authority asked for is `read`, so those two are what the card must also
+   * admit. Asserted by exercising that implication -- a card gated on read alone
+   * would satisfy the test above and still hide from a create-only editor, which
+   * is precisely the defect this replaced.
+   */
+  it("admits every authority the service treats as satisfying read", () => {
+    const slugs = new Set(
+      requiredPermissionSlugs(card("core/upcoming-releases").requiredPermission)
+    );
+
+    for (const action of ["read", "create", "publish"]) {
+      expect(
+        slugs.has(`${action}-${RELEASES_RESOURCE}`),
+        `a role holding only ${action}-${RELEASES_RESOURCE} can read releases, so the card must admit it`
+      ).toBe(true);
+    }
   });
 
   /*

--- a/packages/nextly/src/domains/widgets/__tests__/definition.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/definition.test.ts
@@ -407,7 +407,7 @@ describe("chrome decides whether the HOST frames the widget", () => {
 });
 
 describe("a declared permission", () => {
-  it("is refused when it is not a string", () => {
+  it("is refused when it is not a slug or a list of them", () => {
     // The field was declared and never checked, and the gap failed OPEN: the
     // dashboard's server filter reads "not a string" as "no permission
     // declared", so a widget whose author wrote `requiredPermission: { read:
@@ -415,7 +415,7 @@ describe("a declared permission", () => {
     // Refusing the declaration is the only place the mistake is still visible
     // to the person who made it.
     expect(widgetValueProblem({ requiredPermission: { read: true } })).toMatch(
-      /requiredPermission, when given, must be a string/
+      /requiredPermission, when given, must be a permission slug/
     );
     expect(widgetValueProblem({ requiredPermission: 42 })).toMatch(
       /requiredPermission/
@@ -430,6 +430,37 @@ describe("a declared permission", () => {
       widgetValueProblem({ requiredPermission: "invent-something" })
     ).toBeUndefined();
     expect(widgetValueProblem({})).toBeUndefined();
+  });
+
+  it("accepts an any-of list", () => {
+    expect(
+      widgetValueProblem({
+        requiredPermission: [
+          "read-content-releases",
+          "create-content-releases",
+        ],
+      })
+    ).toBeUndefined();
+  });
+
+  /*
+   * 🔴 The forms the array introduced, each refused for the same reason the
+   * object above is: they are PRESENT and unusable, and the gate reads an
+   * unusable declaration as a refusal. Admitting them here while the gate
+   * refuses them would hide a card with no error anywhere -- and admitting an
+   * empty array is worse than that, because "any of nothing" is satisfied by
+   * nobody, so `requiredPermission: []` would silently mean the opposite of
+   * what its author plainly wrote.
+   */
+  it.each([
+    ["an empty array", []],
+    ["an array with an empty member", ["read-posts", ""]],
+    ["an array with a non-slug member", ["read-posts", 7]],
+    ["an empty string", ""],
+  ])("refuses %s", (_label, requiredPermission) => {
+    expect(widgetValueProblem({ requiredPermission })).toMatch(
+      /requiredPermission/
+    );
   });
 });
 

--- a/packages/nextly/src/domains/widgets/__tests__/execute.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/execute.test.ts
@@ -143,8 +143,10 @@ describe("executeWidgetQuery", () => {
       items: [{ id: "1", title: "Hello" }],
       // The selected columns travel with the rows, so a table widget can head
       // them without a second round trip and without the endpoint growing a
-      // channel that would enumerate a source's fields.
-      fields: [{ name: "title", label: "Title" }],
+      // channel that would enumerate a source's fields. The declared TYPE
+      // travels too: it is what lets a cell be presented rather than printed,
+      // and leaving it behind is what drew dates as ISO strings.
+      fields: [{ name: "title", label: "Title", type: "string" }],
     });
   });
 

--- a/packages/nextly/src/domains/widgets/canonical.ts
+++ b/packages/nextly/src/domains/widgets/canonical.ts
@@ -74,7 +74,7 @@ export interface CanonicalWidget {
    * rather than a slug recovered from a display identity.
    */
   collection?: string;
-  requiredPermission?: string;
+  requiredPermission?: string | readonly string[];
   defaultSize?: string;
   defaultHeight?: string;
   defaultOrder?: number;

--- a/packages/nextly/src/domains/widgets/core-widgets.ts
+++ b/packages/nextly/src/domains/widgets/core-widgets.ts
@@ -145,21 +145,27 @@ export const CORE_WIDGETS: readonly WidgetDefinition[] = [
     defaultSize: "md",
     defaultOrder: 35,
     /*
-     * Two fields, for the reason spelled out on `core/upcoming-releases`: the
-     * `list` archetype draws the first two and silently drops the rest. This
-     * card selected three, so it showed a collection beside an opaque document
-     * id and never the timestamp -- on a card whose own description promises
+     * Two fields, because the `list` archetype draws the first two and silently
+     * drops the rest -- see `core/upcoming-releases`. This card selected three,
+     * so `updatedAt` was never drawn on a card whose own description promises
      * "most recently ... newest first".
      *
-     * `entryId` is the one dropped rather than `updatedAt`, because it is a
-     * UUID: `asText` prints it verbatim, so the row read as a collection name
-     * followed by 36 characters no reader can act on, while WHEN, the thing the
-     * card is sorted by, was the field being discarded.
+     * 🔴 `entryId` is KEPT and `scopeSlug` is the one dropped, and the first
+     * attempt at this had it the other way round. Dropping the id looked right
+     * -- it is a uuid, and the collection name reads better -- but two pending
+     * edits in the same collection then render as the same two values, so a
+     * card describing a list of DOCUMENTS could not tell one from another. A
+     * row that cannot name its subject is worse than one naming it awkwardly.
+     *
+     * The uuid is still the wrong thing to show a person, and the fix for that
+     * is not here: `system:versions` publishes no document title, so there is
+     * nothing better to select. Tracked separately -- the source needs a title
+     * field before this card can read the way it should.
      */
     query: {
       source: VERSIONS_SOURCE_ID,
       op: "list",
-      select: ["scopeSlug", "updatedAt"],
+      select: ["entryId", "updatedAt"],
       limit: 5,
     },
   },

--- a/packages/nextly/src/domains/widgets/core-widgets.ts
+++ b/packages/nextly/src/domains/widgets/core-widgets.ts
@@ -144,10 +144,22 @@ export const CORE_WIDGETS: readonly WidgetDefinition[] = [
     archetype: "list",
     defaultSize: "md",
     defaultOrder: 35,
+    /*
+     * Two fields, for the reason spelled out on `core/upcoming-releases`: the
+     * `list` archetype draws the first two and silently drops the rest. This
+     * card selected three, so it showed a collection beside an opaque document
+     * id and never the timestamp -- on a card whose own description promises
+     * "most recently ... newest first".
+     *
+     * `entryId` is the one dropped rather than `updatedAt`, because it is a
+     * UUID: `asText` prints it verbatim, so the row read as a collection name
+     * followed by 36 characters no reader can act on, while WHEN, the thing the
+     * card is sorted by, was the field being discarded.
+     */
     query: {
       source: VERSIONS_SOURCE_ID,
       op: "list",
-      select: ["scopeSlug", "entryId", "updatedAt"],
+      select: ["scopeSlug", "updatedAt"],
       limit: 5,
     },
   },
@@ -171,18 +183,43 @@ export const CORE_WIDGETS: readonly WidgetDefinition[] = [
      * lacks before the query is ever batched, and keeps it in the stored ROW so
      * a reader whose grant is later widened gets it back where it was.
      *
-     * The slug is `${action}-${resource}` and `parsePermissionSlug` splits on
-     * the FIRST hyphen, so this parses to `read` / `content-releases` --
-     * matching `RELEASES_RESOURCE` and the authority `api/releases.ts` requires
-     * of a human. Written out rather than composed from the constant because
-     * importing it would pull the releases service's wiring into this list, the
-     * same coupling `system-source-ids.ts` exists to avoid.
+     * 🔴 THREE slugs, any of which opens it, because `authorize` does not treat
+     * read as the only way to read: it returns early when the caller holds
+     * `create` or `publish`, deliberately, so a role granted only `create` can
+     * see the release it just made. The admin's `canViewReleases` capability
+     * lists the same three. Gating on the read slug alone made this card a
+     * third encoding of one rule and the only one that disagreed -- a
+     * create-only editor could open the releases screen and never see its card.
+     *
+     * Each slug is `${action}-${resource}` and `parsePermissionSlug` splits on
+     * the FIRST hyphen, so these parse to read/create/publish over
+     * `content-releases` -- matching `RELEASES_RESOURCE` and the authorities
+     * `api/releases.ts` requires of a human. Written out rather than composed
+     * from the constants because importing them would pull the releases
+     * service's wiring into this list, the same coupling `system-source-ids.ts`
+     * exists to avoid; a test parses them back and compares.
      */
-    requiredPermission: "read-content-releases",
+    requiredPermission: [
+      "read-content-releases",
+      "create-content-releases",
+      "publish-content-releases",
+    ],
+    /*
+     * 🔴 TWO fields, and `state` is deliberately not one of them. The `list`
+     * archetype destructures `const [labelField, detailField] = select` and
+     * draws nothing past the second, so a third entry is not extra detail --
+     * it is silently dropped. Selecting title, state, scheduledAt therefore
+     * rendered each release beside the word "scheduled" and never showed WHEN,
+     * on a card whose entire subject is when.
+     *
+     * `state` would carry no information even if it were drawn: `resolveReleases`
+     * queries `state: "scheduled"` unconditionally, so every row this source can
+     * return already has it. The invariant field is the one to drop.
+     */
     query: {
       source: RELEASES_SOURCE_ID,
       op: "list",
-      select: ["title", "state", "scheduledAt"],
+      select: ["title", "scheduledAt"],
       limit: 5,
     },
   },

--- a/packages/nextly/src/domains/widgets/core-widgets.ts
+++ b/packages/nextly/src/domains/widgets/core-widgets.ts
@@ -157,10 +157,14 @@ export const CORE_WIDGETS: readonly WidgetDefinition[] = [
      * card describing a list of DOCUMENTS could not tell one from another. A
      * row that cannot name its subject is worse than one naming it awkwardly.
      *
-     * The uuid is still the wrong thing to show a person, and the fix for that
-     * is not here: `system:versions` publishes no document title, so there is
-     * nothing better to select. Tracked separately -- the source needs a title
-     * field before this card can read the way it should.
+     * The uuid is still the wrong thing to show a person, and nothing better is
+     * selectable: `VERSION_FIELDS` publishes `scopeSlug`, `entryId`, `locale`
+     * and `updatedAt`, so `entryId` is the only document identity this source
+     * has. A readable row needs the source to publish a title first, and that
+     * is an access-control change rather than a formatting one -- an entry
+     * title is field content, and `readable-documents.ts` selects `id` alone
+     * precisely so a visibility probe cannot carry field values into a surface
+     * that never asked for them.
      */
     query: {
       source: VERSIONS_SOURCE_ID,

--- a/packages/nextly/src/domains/widgets/core-widgets.ts
+++ b/packages/nextly/src/domains/widgets/core-widgets.ts
@@ -15,24 +15,49 @@
  * contributions, so without a declared position core's cards would sit BELOW
  * every plugin's, which is not the dashboard anyone has today.
  *
- * All four are `custom` with `chrome: "none"`. Each already draws a titled
- * section with its own rules, loading skeleton and error state; framed by
- * `WidgetCard` each would gain a second heading above its own. `title` is still
- * required and still meaningful -- it is what names the card in the layout
- * editor, where a reader chooses what to show.
+ * The `custom` ones carry `chrome: "none"`. Each already draws a titled section
+ * with its own rules, loading skeleton and error state; framed by `WidgetCard`
+ * each would gain a second heading above its own. `title` is still required and
+ * still meaningful -- it is what names the card in the layout editor, where a
+ * reader chooses what to show. Stated as a property of that group rather than
+ * as a count, because the count was written as "all four" and was wrong by two
+ * before anyone reread it.
  *
- * Deliberately NO `requiredPermission`. Every one of these is visible to any
- * authenticated admin today, and adding a gate here would hide a card someone
- * currently sees -- a behaviour change wearing the costume of a refactor. The
- * gate that belongs on `core/team` in particular waits on a question this
- * repository has not answered: which permission gates a bare COUNT of users,
- * given `dashboard-service` computes it unscoped.
+ * Each `custom` card names its body as a `core#` STRING, resolved in the admin
+ * by `core-components.ts`. Nothing in either package can check that the two
+ * agree -- neither depends on the other -- so a card naming a path that was
+ * never registered draws the unresolved fallback, silently and only for the
+ * reader who has it. `core-widget-components.test.ts` in the admin is what
+ * holds the halves together; it reads this file.
+ *
+ * Deliberately no `requiredPermission` on the cards that predate the widget
+ * grid. Every one of those is visible to any authenticated admin today, and
+ * adding a gate would hide a card someone currently sees -- a behaviour change
+ * wearing the costume of a refactor. The gate that belongs on `core/team` in
+ * particular waits on a question this repository has not answered: which
+ * permission gates a bare COUNT of users, given `dashboard-service` computes it
+ * unscoped.
+ *
+ * 🔴 A card added HERE is new to every reader, so that argument does not extend
+ * to it: nothing is hidden that was previously visible, so the gate is decided
+ * by what the CARD'S SOURCE does to a caller who may not see its rows. The two
+ * cards added together answer that differently, and neither is the default:
+ *
+ * - `core/upcoming-releases` is gated. `ReleasesService.find` authorizes by
+ *   THROWING, so an ungranted reader gets a card stuck in its error state
+ *   rather than an empty one -- see its own note.
+ * - `core/recent-activity` is not. Its feed takes the caller's readable
+ *   collections as a scope and defaults that scope to NOTHING, so a reader
+ *   entitled to none of it is shown an empty feed. That is a card correctly
+ *   saying there is nothing to report, which needs no gate; a gate would
+ *   instead hide the feed from anyone whose permissions happened to be narrow
+ *   today.
  *
  * @module domains/widgets/core-widgets
  */
 
 import type { WidgetDefinition } from "./definition";
-import { VERSIONS_SOURCE_ID } from "./system-source-ids";
+import { RELEASES_SOURCE_ID, VERSIONS_SOURCE_ID } from "./system-source-ids";
 
 /**
  * The prefix core's dashboard components resolve under.
@@ -125,5 +150,50 @@ export const CORE_WIDGETS: readonly WidgetDefinition[] = [
       select: ["scopeSlug", "entryId", "updatedAt"],
       limit: 5,
     },
+  },
+  {
+    id: "core/upcoming-releases",
+    title: "Upcoming releases",
+    description: "Scheduled releases that have not shipped yet, soonest first.",
+    archetype: "list",
+    defaultSize: "md",
+    defaultOrder: 40,
+    /*
+     * 🔴 The ONLY core card with a gate, and the asymmetry is deliberate rather
+     * than an inconsistency. `ReleasesService.find` opens with
+     * `authorize(actor, "read")`, which THROWS -- so an ungranted reader does
+     * not get an empty card, they get one stuck in its error state, reporting a
+     * failure that is really a permission they were never meant to have. The
+     * two outcomes a card can have here are "hidden" and "broken", and nothing
+     * in between is reachable.
+     *
+     * `partitionPlacements` drops a card whose `requiredPermission` this caller
+     * lacks before the query is ever batched, and keeps it in the stored ROW so
+     * a reader whose grant is later widened gets it back where it was.
+     *
+     * The slug is `${action}-${resource}` and `parsePermissionSlug` splits on
+     * the FIRST hyphen, so this parses to `read` / `content-releases` --
+     * matching `RELEASES_RESOURCE` and the authority `api/releases.ts` requires
+     * of a human. Written out rather than composed from the constant because
+     * importing it would pull the releases service's wiring into this list, the
+     * same coupling `system-source-ids.ts` exists to avoid.
+     */
+    requiredPermission: "read-content-releases",
+    query: {
+      source: RELEASES_SOURCE_ID,
+      op: "list",
+      select: ["title", "state", "scheduledAt"],
+      limit: 5,
+    },
+  },
+  {
+    id: "core/recent-activity",
+    title: "Recent activity",
+    description: "Who changed what, most recent first.",
+    archetype: "custom",
+    chrome: "none",
+    defaultSize: "full",
+    defaultOrder: 45,
+    component: "core#RecentActivity",
   },
 ] as const;

--- a/packages/nextly/src/domains/widgets/definition.ts
+++ b/packages/nextly/src/domains/widgets/definition.ts
@@ -11,7 +11,18 @@
 
 import { NextlyError } from "../../errors/nextly-error";
 
+import { requiredPermissionSlugs } from "./gate";
 import type { WidgetQuery } from "./query";
+
+// The gate rule lives in a module with no imports so the BROWSER can read it
+// too (`nextly/widget-gate`). Validation asks the same reader the gate asks,
+// so a declaration this file admits is one the gate can actually use.
+
+export {
+  holdsWidgetPermission,
+  requiredPermissionSlugs,
+  widgetGateHolds,
+} from "./gate";
 
 /** Column span at the large breakpoint, as a named step rather than a number. */
 export const WIDGET_SIZES = ["sm", "md", "lg", "xl", "full"] as const;
@@ -175,69 +186,6 @@ export interface WidgetAction {
   requiredPermission?: string;
   /** Opens in a new tab, and says so. */
   external?: boolean;
-}
-
-/**
- * The permission slugs a card's gate names, or `undefined` when the declaration
- * cannot be used as a gate at all.
- *
- * 🔴 ONE reader, because three questions are asked of this field and a
- * disagreement between any two of them hides a card silently: validation
- * refuses an unusable declaration, `permissionVerdicts` decides which slugs to
- * resolve, and `holdsWidgetPermission` decides whether the reader holds one. A
- * collector that skipped a slug the decider then asked for would resolve to a
- * missing verdict, which is `undefined`, which is not `true` -- so the card
- * would vanish for everyone, with nothing logged and nothing thrown.
- *
- * The `undefined` return is NOT "no gate" -- that is the field being absent,
- * which callers check before asking. It means the value is there and unusable,
- * and every caller reads it as a REFUSAL. That direction is deliberate and is
- * the one this validation already had to be corrected into once: reading a
- * malformed gate as "no permission declared" failed OPEN, returning the card to
- * every authenticated caller. An empty array is unusable for exactly the same
- * reason -- "any of nothing" is satisfied by nobody, and treating it as an
- * absent gate would let `requiredPermission: []` mean the opposite of what it
- * plainly says.
- */
-export function requiredPermissionSlugs(
-  value: unknown
-): readonly string[] | undefined {
-  const usable = (slug: unknown): slug is string =>
-    typeof slug === "string" && slug !== "";
-
-  if (usable(value)) return [value];
-  // Every member must be usable, rather than filtering the junk out: an array
-  // whose second entry is a number is a mistake its author can still see, and
-  // silently gating on the first entry alone answers a narrower question than
-  // they wrote.
-  if (Array.isArray(value) && value.length > 0 && value.every(usable)) {
-    return [...(value as readonly string[])];
-  }
-  return undefined;
-}
-
-/**
- * Whether a reader holding `verdicts` may know this widget exists.
- *
- * A widget with no `requiredPermission` is visible to any authenticated reader
- * -- that is what omitting it means, and what core's own cards rely on. A
- * declared permission that is not a usable string is refused rather than read
- * as absent: the gap used to fail OPEN, so a widget whose author wrote an
- * object there was gated for nobody.
- */
-export function holdsWidgetPermission(
-  requiredPermission: unknown,
-  verdicts: ReadonlyMap<string, boolean>
-): boolean {
-  if (requiredPermission === undefined) return true;
-  const slugs = requiredPermissionSlugs(requiredPermission);
-  // Present and unusable. Refused rather than read as absent, which is the
-  // direction this check was corrected into once already.
-  if (slugs === undefined) return false;
-  // ANY-OF. `verdicts.get` is `undefined` for a slug nobody resolved, and
-  // `undefined !== true`, so an unresolved member denies on its own terms
-  // rather than being mistaken for a held grant.
-  return slugs.some(slug => verdicts.get(slug) === true);
 }
 
 export interface WidgetDefinition {

--- a/packages/nextly/src/domains/widgets/definition.ts
+++ b/packages/nextly/src/domains/widgets/definition.ts
@@ -177,6 +177,69 @@ export interface WidgetAction {
   external?: boolean;
 }
 
+/**
+ * The permission slugs a card's gate names, or `undefined` when the declaration
+ * cannot be used as a gate at all.
+ *
+ * 🔴 ONE reader, because three questions are asked of this field and a
+ * disagreement between any two of them hides a card silently: validation
+ * refuses an unusable declaration, `permissionVerdicts` decides which slugs to
+ * resolve, and `holdsWidgetPermission` decides whether the reader holds one. A
+ * collector that skipped a slug the decider then asked for would resolve to a
+ * missing verdict, which is `undefined`, which is not `true` -- so the card
+ * would vanish for everyone, with nothing logged and nothing thrown.
+ *
+ * The `undefined` return is NOT "no gate" -- that is the field being absent,
+ * which callers check before asking. It means the value is there and unusable,
+ * and every caller reads it as a REFUSAL. That direction is deliberate and is
+ * the one this validation already had to be corrected into once: reading a
+ * malformed gate as "no permission declared" failed OPEN, returning the card to
+ * every authenticated caller. An empty array is unusable for exactly the same
+ * reason -- "any of nothing" is satisfied by nobody, and treating it as an
+ * absent gate would let `requiredPermission: []` mean the opposite of what it
+ * plainly says.
+ */
+export function requiredPermissionSlugs(
+  value: unknown
+): readonly string[] | undefined {
+  const usable = (slug: unknown): slug is string =>
+    typeof slug === "string" && slug !== "";
+
+  if (usable(value)) return [value];
+  // Every member must be usable, rather than filtering the junk out: an array
+  // whose second entry is a number is a mistake its author can still see, and
+  // silently gating on the first entry alone answers a narrower question than
+  // they wrote.
+  if (Array.isArray(value) && value.length > 0 && value.every(usable)) {
+    return [...(value as readonly string[])];
+  }
+  return undefined;
+}
+
+/**
+ * Whether a reader holding `verdicts` may know this widget exists.
+ *
+ * A widget with no `requiredPermission` is visible to any authenticated reader
+ * -- that is what omitting it means, and what core's own cards rely on. A
+ * declared permission that is not a usable string is refused rather than read
+ * as absent: the gap used to fail OPEN, so a widget whose author wrote an
+ * object there was gated for nobody.
+ */
+export function holdsWidgetPermission(
+  requiredPermission: unknown,
+  verdicts: ReadonlyMap<string, boolean>
+): boolean {
+  if (requiredPermission === undefined) return true;
+  const slugs = requiredPermissionSlugs(requiredPermission);
+  // Present and unusable. Refused rather than read as absent, which is the
+  // direction this check was corrected into once already.
+  if (slugs === undefined) return false;
+  // ANY-OF. `verdicts.get` is `undefined` for a slug nobody resolved, and
+  // `undefined !== true`, so an unresolved member denies on its own terms
+  // rather than being mistaken for a held grant.
+  return slugs.some(slug => verdicts.get(slug) === true);
+}
+
 export interface WidgetDefinition {
   /** `namespace/name`, e.g. "core/recent-entries". */
   id: string;
@@ -223,8 +286,26 @@ export interface WidgetDefinition {
    *
    * A `PermissionSlug` spelling (`read-posts`), the same vocabulary
    * `WidgetSource.requiredPermission` and `PluginAdminWidget` carry.
+   *
+   * 🔴 An ARRAY means ANY-OF, and it exists because a single slug cannot
+   * describe the rule the services behind these cards actually apply. Release
+   * authority is the worked example: `ReleasesService.authorize` treats `create`
+   * or `publish` as satisfying `read` -- deliberately, so a role granted only
+   * `create` can see the release it just made -- and the admin's
+   * `canViewReleases` capability lists all three. A card gated on the read slug
+   * alone is a THIRD encoding of that rule and the only one that disagrees, so
+   * the reader can open the releases screen and never see its dashboard card.
+   *
+   * Any-of rather than all-of because that is the shape every consumer of this
+   * vocabulary already has -- `requireAnyPermission` at the route layer, the
+   * capability lists in the admin. A card needing all of several grants has no
+   * consumer yet, and inventing the second form before something needs it is
+   * how a declaration ends up with two meanings nobody can keep straight.
+   *
+   * `WidgetAction.requiredPermission` stays a single slug. It gates one
+   * shortcut rather than a card, and nothing has asked it for more.
    */
-  requiredPermission?: string;
+  requiredPermission?: string | readonly string[];
   /** Required for every data archetype; forbidden for `text` and `actions`. */
   query?: WidgetQuery;
   /** Required for `custom`; forbidden otherwise. */
@@ -394,11 +475,17 @@ export function widgetValueProblem(
   // author wrote `requiredPermission: { read: true }` was gated for nobody and
   // returned to every authenticated caller. Refusing the declaration is the
   // only place the mistake is still visible to the person who made it.
+  //
+  // Asked through the same reader the GATE uses, rather than by restating the
+  // shape here. Widening this to accept an any-of array added a second way for
+  // a declaration to be unusable -- an empty array, or one member that is not a
+  // slug -- and a validator that admitted a form the gate then refuses would
+  // hide a card with no error anywhere.
   if (
     widget.requiredPermission !== undefined &&
-    typeof widget.requiredPermission !== "string"
+    requiredPermissionSlugs(widget.requiredPermission) === undefined
   ) {
-    return "requiredPermission, when given, must be a string";
+    return "requiredPermission, when given, must be a permission slug or a non-empty array of them";
   }
 
   // A query is an OBJECT in every version, so it belongs here rather than

--- a/packages/nextly/src/domains/widgets/execute.ts
+++ b/packages/nextly/src/domains/widgets/execute.ts
@@ -146,9 +146,10 @@ function describeSelectedFields(
     for (const key of Object.keys(item)) survived.add(key);
   }
 
-  const labels = new Map<string, string | undefined>(
-    source.fields.map(field => [field.name, field.label])
-  );
+  // The whole declared field, not just its label: the renderer needs the TYPE
+  // to present a value rather than print it, and looking the label up here
+  // while leaving the type behind is what made a date cross as an ISO string.
+  const declared = new Map(source.fields.map(field => [field.name, field]));
 
   const described: WidgetResultField[] = [];
   const taken = new Set<string>();
@@ -156,8 +157,12 @@ function describeSelectedFields(
     if (taken.has(name)) continue;
     taken.add(name);
     if (!survived.has(name)) continue;
-    const label = labels.get(name);
-    described.push({ name, ...(label !== undefined && { label }) });
+    const field = declared.get(name);
+    described.push({
+      name,
+      ...(field?.label !== undefined && { label: field.label }),
+      ...(field?.type !== undefined && { type: field.type }),
+    });
   }
 
   return described.length > 0 ? described : undefined;

--- a/packages/nextly/src/domains/widgets/gate.ts
+++ b/packages/nextly/src/domains/widgets/gate.ts
@@ -1,0 +1,102 @@
+/**
+ * Whether a reader may be told a widget exists.
+ *
+ * 🔴 Its own module, with NO IMPORTS, and that is the whole design. Two
+ * processes decide this question about the same serialized declaration -- the
+ * layout endpoint, which drops a card before sending it, and the browser, which
+ * drops it again before rendering -- and they must not answer differently. A
+ * card the server sends and the browser hides is invisible with nothing logged;
+ * a card the server hides and the browser would have shown is a permission
+ * someone cannot exercise. Neither reports itself.
+ *
+ * The rule lived twice for a while, held together by a parity test. That test
+ * could only ever cover the declarations someone thought to write down: it
+ * proved the two agreed on ten inputs, not that they agreed. A new accepted
+ * gate form, or a change to how an unusable one is read, would pass every case
+ * in it and still split the two processes apart.
+ *
+ * So this file has no dependencies at all -- not `NextlyError`, not a type from
+ * a sibling -- because that is what lets it be an entry point the browser can
+ * import (`nextly/widget-gate`) without pulling the server in behind it. Adding
+ * an import here is not a small change: it is what would force the copy back.
+ *
+ * @module domains/widgets/gate
+ */
+
+/**
+ * The permission slugs a gate names, or `undefined` when the declaration cannot
+ * be used as a gate at all.
+ *
+ * 🔴 The `undefined` return is NOT "no gate" -- that is the field being absent,
+ * which callers check first. It means the value is there and unusable, and
+ * every caller reads it as a REFUSAL. That direction is deliberate and is one
+ * the validation had to be corrected into once: reading a malformed gate as "no
+ * permission declared" failed OPEN, returning the card to every authenticated
+ * caller.
+ *
+ * An empty array is unusable for the same reason and it is the member of that
+ * set most likely to be written on purpose. "Any of nothing" is satisfied by
+ * nobody, so admitting it would gate a card for everyone while reading, to its
+ * author, like a widened grant.
+ */
+export function requiredPermissionSlugs(
+  value: unknown
+): readonly string[] | undefined {
+  const usable = (slug: unknown): slug is string =>
+    typeof slug === "string" && slug !== "";
+
+  if (usable(value)) return [value];
+  // Every member must be usable, rather than filtering the junk out: an array
+  // whose second entry is a number is a mistake its author can still see, and
+  // silently gating on the first entry alone answers a narrower question than
+  // they wrote.
+  if (Array.isArray(value) && value.length > 0 && value.every(usable)) {
+    return [...(value as readonly string[])];
+  }
+  return undefined;
+}
+
+/**
+ * The gate decision, parameterised by how a single slug gets answered.
+ *
+ * 🔴 The two processes differ ONLY in that: the server holds a resolved verdict
+ * map, the browser holds the session's permission predicate. Everything else --
+ * that an absent gate admits everyone, that an unusable one admits nobody, that
+ * an array is ANY-of rather than all-of -- is the same question, so it is asked
+ * in one place and each caller supplies its own answerer.
+ *
+ * Any-of rather than all-of because that is the shape every existing consumer
+ * of this vocabulary has: `requireAnyPermission` at the route layer, the
+ * capability lists in the admin, and `ReleasesService.authorize`, which treats
+ * `create` or `publish` as satisfying `read`. Nothing needs all-of yet, and
+ * inventing the second form before something does is how a declaration ends up
+ * with two meanings nobody can keep straight.
+ */
+export function widgetGateHolds(
+  requiredPermission: unknown,
+  holds: (slug: string) => boolean
+): boolean {
+  if (requiredPermission === undefined) return true;
+  const slugs = requiredPermissionSlugs(requiredPermission);
+  // Present and unusable. Refused rather than read as absent.
+  if (slugs === undefined) return false;
+  return slugs.some(holds);
+}
+
+/**
+ * The gate decision against a map of already-resolved verdicts.
+ *
+ * The server's adapter over {@link widgetGateHolds}. `verdicts.get` answers
+ * `undefined` for a slug nobody resolved, and `undefined !== true`, so an
+ * unresolved member denies on its own terms rather than being mistaken for a
+ * held grant.
+ */
+export function holdsWidgetPermission(
+  requiredPermission: unknown,
+  verdicts: ReadonlyMap<string, boolean>
+): boolean {
+  return widgetGateHolds(
+    requiredPermission,
+    slug => verdicts.get(slug) === true
+  );
+}

--- a/packages/nextly/src/domains/widgets/result.ts
+++ b/packages/nextly/src/domains/widgets/result.ts
@@ -10,6 +10,8 @@
  * @module domains/widgets/result
  */
 
+import type { WidgetSourceFieldType } from "./sources";
+
 /**
  * One column of a list result, as the admin needs to head it.
  *
@@ -26,6 +28,23 @@ export interface WidgetResultField {
   name: string;
   /** Absent when the source has no human label for this field. */
   label?: string;
+  /**
+   * What KIND of value this column holds, as the source declared it.
+   *
+   * 🔴 Carried so the renderer can present a value instead of printing it. Every
+   * source already declares this -- `{ name: "scheduledAt", type: "date" }` --
+   * and it stopped at the server, so a date crossed as an ISO string and the row
+   * drew `2026-09-01T07:00:00.000Z` at the reader. Selecting a different field
+   * is not a fix for that; it is choosing which column to not render properly,
+   * and the next card that selects a date has the same problem again.
+   *
+   * Optional because a source may describe a field it has no declaration for,
+   * and because a widget result predating this carries none. The renderer treats
+   * an absent type as "print it as text", which is what it did for everything
+   * before this existed -- so an old result and a new one differ in quality, not
+   * in correctness.
+   */
+  type?: WidgetSourceFieldType;
 }
 
 export type WidgetResult =

--- a/packages/nextly/src/domains/widgets/visibility.ts
+++ b/packages/nextly/src/domains/widgets/visibility.ts
@@ -18,6 +18,13 @@ import {
   type ReadAccessCaller,
 } from "../../auth/entity-read-access";
 
+import { requiredPermissionSlugs } from "./definition";
+
+// Re-exported from its own module rather than moved-and-forgotten: this is
+// where every caller already reaches for the gate, and the decision now lives
+// beside the reader it is built from.
+export { holdsWidgetPermission, requiredPermissionSlugs } from "./definition";
+
 /**
  * A decision per permission slug, taken in the bounded rounds the query batch
  * already prescribes.
@@ -27,15 +34,16 @@ import {
  * per-user TTL cache, so asking twice is two database reads for one answer.
  */
 export async function permissionVerdicts(
-  slugs: readonly (string | undefined)[],
+  gates: readonly unknown[],
   caller: ReadAccessCaller
 ): Promise<Map<string, boolean>> {
+  // Read through the SAME function the gate below reads with, so the set
+  // resolved here and the set asked about there cannot come apart. A gate may
+  // now name several slugs, so this flattens rather than filters -- collecting
+  // only the first of an any-of array would leave the others unresolved, and an
+  // unresolved slug is a missing verdict, which denies.
   const distinct = [
-    ...new Set(
-      slugs.filter(
-        (slug): slug is string => typeof slug === "string" && slug !== ""
-      )
-    ),
+    ...new Set(gates.flatMap(gate => requiredPermissionSlugs(gate) ?? [])),
   ];
 
   const verdicts = new Map<string, boolean>();
@@ -52,24 +60,4 @@ export async function permissionVerdicts(
     });
   }
   return verdicts;
-}
-
-/**
- * Whether a reader holding `verdicts` may know this widget exists.
- *
- * A widget with no `requiredPermission` is visible to any authenticated reader
- * -- that is what omitting it means, and what core's own cards rely on. A
- * declared permission that is not a usable string is refused rather than read
- * as absent: the gap used to fail OPEN, so a widget whose author wrote an
- * object there was gated for nobody.
- */
-export function holdsWidgetPermission(
-  requiredPermission: unknown,
-  verdicts: ReadonlyMap<string, boolean>
-): boolean {
-  if (requiredPermission === undefined) return true;
-  if (typeof requiredPermission !== "string" || requiredPermission === "") {
-    return false;
-  }
-  return verdicts.get(requiredPermission) === true;
 }

--- a/packages/nextly/src/domains/widgets/visibility.ts
+++ b/packages/nextly/src/domains/widgets/visibility.ts
@@ -18,12 +18,12 @@ import {
   type ReadAccessCaller,
 } from "../../auth/entity-read-access";
 
-import { requiredPermissionSlugs } from "./definition";
+import { requiredPermissionSlugs } from "./gate";
 
 // Re-exported from its own module rather than moved-and-forgotten: this is
 // where every caller already reaches for the gate, and the decision now lives
 // beside the reader it is built from.
-export { holdsWidgetPermission, requiredPermissionSlugs } from "./definition";
+export { holdsWidgetPermission, requiredPermissionSlugs } from "./gate";
 
 /**
  * A decision per permission slug, taken in the bounded rounds the query batch

--- a/packages/nextly/src/plugins/__tests__/contributed-widget-summaries.test.ts
+++ b/packages/nextly/src/plugins/__tests__/contributed-widget-summaries.test.ts
@@ -133,3 +133,101 @@ describe("the size a contributed summary carries", () => {
     return summary.defaultSize;
   }
 });
+
+/**
+ * The gate a contribution declares, as the summary carries it.
+ *
+ * 🔴 This is the channel that FAILED OPEN. Boot validates a contribution with
+ * the same `widgetValueProblem` that accepts an any-of array, so a plugin
+ * declaring one registers cleanly -- but the summary layout resolution reads is
+ * built by a separate reader, and that reader took strings only. It answered
+ * `undefined` for the array, which this summary spells as "no gate", so
+ * `holdsWidgetPermission` returned true and the layout endpoint published the
+ * card's id and default placement to every authenticated reader.
+ *
+ * The symptom was invisible from the product: the browser hid the card, so the
+ * only thing anyone could notice was a card MISSING for someone entitled to it,
+ * while the disclosure had already happened on the wire. Asserted on the
+ * summary rather than on the endpoint, because the summary is where the value
+ * was lost and an endpoint test would go green the moment either half was
+ * repaired.
+ */
+describe("a contributed permission gate survives the summary", () => {
+  function gated(requiredPermission: unknown): PluginDefinition {
+    return {
+      name: "@acme/plugin",
+      contributes: {
+        admin: {
+          widgets: [
+            {
+              id: "acme/latest",
+              title: "Latest",
+              archetype: "metric",
+              requiredPermission,
+              query: { source: "collection:posts", op: "count" },
+            },
+          ],
+        },
+      },
+    } as unknown as PluginDefinition;
+  }
+
+  it("carries a single slug", () => {
+    // The control. A summary that dropped EVERY gate would satisfy nothing
+    // below by carrying nothing, so the string form has to be seen arriving
+    // before the array's arrival means anything.
+    expect(contributedWidgetSummaries([gated("read-posts")])[0]).toMatchObject({
+      requiredPermission: "read-posts",
+    });
+  });
+
+  it("carries an any-of array", () => {
+    expect(
+      contributedWidgetSummaries([gated(["read-posts", "create-posts"])])[0]
+    ).toMatchObject({ requiredPermission: ["read-posts", "create-posts"] });
+  });
+
+  /*
+   * A gate that is PRESENT AND UNUSABLE refuses the whole plugin at boot, which
+   * is stronger than carrying it forward and was worth measuring rather than
+   * assuming: an unusable value that reached the summary would still be refused
+   * by `holdsWidgetPermission`, but refusing at boot puts the error in front of
+   * the person who wrote the declaration instead of silently hiding a card.
+   *
+   * The empty array is the member of this set most likely to be written on
+   * purpose, and it is the one whose plain reading is backwards -- "any of
+   * nothing" is satisfied by nobody, so admitting it would gate the card for
+   * everyone while looking like a widened grant.
+   */
+  it.each([
+    ["an empty array", []],
+    ["an array with a non-slug", ["read-posts", 7]],
+    ["an object", { read: true }],
+  ])("refuses the plugin over %s", (_label, requiredPermission) => {
+    expect(() =>
+      contributedWidgetSummaries([gated(requiredPermission)])
+    ).toThrow(/Plugin configuration is invalid/);
+  });
+
+  it("declares no gate when the contribution omits one", () => {
+    const summary = contributedWidgetSummaries([
+      {
+        name: "@acme/plugin",
+        contributes: {
+          admin: {
+            widgets: [
+              {
+                id: "acme/latest",
+                title: "Latest",
+                archetype: "metric",
+                query: { source: "collection:posts", op: "count" },
+              },
+            ],
+          },
+        },
+      } as unknown as PluginDefinition,
+    ])[0];
+
+    expect(Object.hasOwn(summary as object, "requiredPermission")).toBe(false);
+  });
+});

--- a/packages/nextly/src/plugins/admin-contributions.ts
+++ b/packages/nextly/src/plugins/admin-contributions.ts
@@ -198,7 +198,20 @@ interface PluginAdminWidgetBase {
   id: string;
   /** Column span the current grid honours: `half` spans 6 of 12, `full` spans 12. */
   size?: "full" | "half";
-  requiredPermission?: PermissionSlug;
+  /**
+   * Gates whether the CARD renders. An ARRAY means any-of.
+   *
+   * 🔴 The array form has to be accepted HERE as well as on `WidgetDefinition`,
+   * and the reason is a fail-open rather than a missing feature. Boot validates
+   * a contribution through the same `widgetValueProblem` that accepts an array,
+   * so a plugin declaring one passes registration -- and the summary layout
+   * resolution reads is built by a separate reader, which used to take strings
+   * only. It dropped the array, the layout endpoint saw no gate at all, and the
+   * card's id and default placement went to every authenticated reader while
+   * the browser hid it. Declaring the type narrower than what boot accepts is
+   * what made that reachable.
+   */
+  requiredPermission?: PermissionSlug | readonly PermissionSlug[];
   title?: string;
   description?: string;
   icon?: string;

--- a/packages/nextly/src/plugins/validate-admin-widgets.ts
+++ b/packages/nextly/src/plugins/validate-admin-widgets.ts
@@ -495,7 +495,27 @@ function toSummary(widget: PluginAdminWidget): CanonicalWidget | undefined {
   const id = contributedText(declaration, "id");
   if (id === undefined) return undefined;
 
-  const requiredPermission = contributedText(declaration, "requiredPermission");
+  /*
+   * 🔴 Read through the GATE's own reader, never `contributedText`. A gate may
+   * be a slug or an any-of array, and the string-only helper answered
+   * `undefined` for the array -- which this summary spells as "no
+   * requiredPermission", so `holdsWidgetPermission` returned true and the
+   * layout endpoint published the card's id and default placement to every
+   * authenticated reader. The browser hid it, so the only visible symptom was a
+   * card missing for someone who should have had it, while the disclosure had
+   * already happened on the wire.
+   *
+   * Carried VERBATIM when present, rather than normalised or filtered here.
+   * `holdsWidgetPermission` is the one place that decides what a gate means,
+   * including that a present-but-unusable one refuses -- so passing the value
+   * through unchanged is what keeps this summary from becoming a second opinion
+   * about it. Dropping an unusable gate would turn it into no gate, which is
+   * the same fail-open one level down.
+   */
+  const requiredPermission = declaration.requiredPermission as
+    | string
+    | readonly string[]
+    | undefined;
   const defaultSize = contributedSize(declaration);
   const defaultHeight = contributedText(declaration, "defaultHeight");
   const defaultOrder = declaration.defaultOrder;

--- a/packages/nextly/tsup.config.js
+++ b/packages/nextly/tsup.config.js
@@ -93,6 +93,13 @@ const clientEntries = [
   "src/field-group-reconcile.ts",
   // Pure serializable data, consumed by the admin's field pickers and by plugins.
   "src/collections/fields/catalog.ts",
+  // The widget permission gate, as its OWN entry and with no imports of its
+  // own. The layout endpoint and the browser both decide whether a reader may
+  // be told a card exists, and a second implementation of that answer splits
+  // them apart silently -- a card the server sends and the browser hides
+  // reports nothing anywhere. Reaching it through `nextly/config` instead would
+  // make a bundler traverse the whole config surface for two pure functions.
+  "src/domains/widgets/gate.ts",
   // The query-parameter formats, so a caller writes one with the same code the
   // server reads it with. Imported by the admin's API Playground and by plugin
   // admin components, which is why it is a leaf rather than a root export.


### PR DESCRIPTION
Two finished surfaces reached no reader. Both are now cards on the widget grid.

## `core/upcoming-releases`

`system:releases` shipped as a registered, access-controlled widget source that
**no widget named**, so nothing on any dashboard could ask it anything.
`CORE_WIDGETS` was seven definitions and only `VERSIONS_SOURCE_ID` appeared
among them.

It is the only core card carrying a `requiredPermission`, and the asymmetry is
deliberate. `ReleasesService.find` opens with `authorize(actor, "read")`, which
**throws** — so an ungranted reader would not get an empty card, they would get
one stuck in its error state, reporting a failure that is really a permission
they were never meant to have. The two reachable outcomes are "hidden" and
"broken". `partitionPlacements` drops the card before the query is batched and
keeps the placement in the stored row, so widening someone's grant later brings
it back where it was.

The slug is asserted to **parse** to the resource the service enforces, rather
than compared against a literal:

```
parsePermissionSlug("read-content-releases") === { action: "read", resource: RELEASES_RESOURCE }
```

Renaming either side fails a test instead of silently gating the card on a
resource nobody grants — which fails invisibly, since a card gated on nothing
looks exactly like a reader without the permission.

## `core/recent-activity`

The activity feed had a routed endpoint and a component and **nothing rendering
it**: `pages/dashboard/index.tsx` drew the welcome header and the grid alone,
and every reference to `RecentActivity` outside its own file and test was an
`export` line. This is design task 1.9's unfinished half — *delete the dead
unmounted components or register them.* Registering it also makes the feed
hideable and reorderable like every other card, which is how Strapi treats its
audit widget.

It needs no permission gate: the feed defaults the caller's scope to **nothing**
and short-circuits an empty scope, so a reader entitled to none of it sees an
empty feed rather than an error.

**Two of its controls were removed rather than moved, because neither worked:**

- a **"Detailed Log"** link whose `href` was `ROUTES.DASHBOARD` — the page the
  card sits on. There is no audit-log route in `ROUTES` at all.
- a **"Sync Previous Events"** button with no handler.

Removed rather than wired. Every product surveyed shows a fixed handful of rows
with no in-widget pagination and no count, and that is also the only honest
shape here: the server publishes `hasMore` and deliberately no total, because
counting the feed would mean authorizing every matching row against its
document's read rule — unbounded over a table that only grows. The missing
detail page is a feature to decide on, not a link to point somewhere plausible.

Its chrome now matches its neighbours: a `<section aria-labelledby>` like
`TeamSummary`, rather than a `Card` the grid would frame a second time.

## A guard for a boundary nothing could check

A core card names its body as a `core#` string in `nextly`; that string is bound
to a component in `@nextlyhq/admin`. **Neither package depends on the other**,
so no type, import or build step could notice one naming something the other
never registered — the card would draw the unresolved placeholder, for every
reader, with no error anywhere, until somebody happened to look at it. Same
two-halves-of-one-name hazard `system-source-ids.ts` manages for `query.source`;
nothing was managing it for `component`.

`core-widget-components.test.ts` now holds the two lists against each other.

It reads the admin's registrations as **text** rather than calling
`hasComponent`, and the weakness is named in the file: `core-components.ts`
cannot be imported from a test at all. It sits in a **pre-existing import
cycle** — it imports `TeamSummary`/`CollectionQuickLinks`, which reach the
`@admin/hooks/queries` barrel, which reaches `pages/dashboard/index.tsx`, which
imports `WidgetGrid`, which calls `registerCoreWidgetComponents()` at module
scope and re-enters the module mid-evaluation. Verified pre-existing rather than
assumed: the same one-line probe fails identically with `core-components.ts`
stashed back to `origin/main`. Filed separately; when it is fixed, the scan
should be replaced with `hasComponent`.

## Verification

Break-verified against **wrong implementations**, not mutations of my own code —
each failed for its own reason, with the control green either side:

| break | result |
| --- | --- |
| admin never registers `core#RecentActivity` | 2 failed |
| core renames the path, admin does not follow | 2 failed |
| the source scan stops matching (calls reformatted) | 2 failed — the population assertions **refuse** rather than agreeing vacuously |
| a plausible wrong slug (`read-releases`) | 1 failed |
| the releases gate dropped entirely | 2 failed |

| gate | result |
| --- | --- |
| `pnpm check-types` — nextly, **both** invocations | exit 0 |
| `pnpm check-types` — admin | exit 0 |
| `pnpm lint` — both packages | exit 0 |
| `fallow audit` | `pass`, 6 changed files, **0 introduced** |
| `npx changeset status` | exit 0 |
| nextly unit suite | 890 files / 11342 passed, 42 skipped, 0 failed |
| admin unit suite | 397 files / 3932 passed, 0 failed |

## One test that was wrong before the code was

The first version asserted *names a component ⇒ `chrome: "none"`* and failed on
`core/quick-create`. That card draws no section, heading or card of its own, so
it genuinely wants the grid's frame — the test was wrong, not the card. The
converse is what holds and what shipped: only a card supplying its own body may
decline the frame. Filed for a one-line note on that card, since the next person
adding a custom one will copy whichever neighbour they read first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Recent Activity to the dashboard, with live-updating relative timestamps and clearer loading, error, and empty states.
  - Added an Upcoming Releases card with permission-aware visibility.
  - Widget columns now preserve type information for improved date and value formatting.
  - Widget permissions can now use “any of” multiple required permissions.

- **Bug Fixes**
  - Dates display in localized, readable formats instead of raw timestamps.
  - Unknown column types fall back to plain text rather than preventing cards from rendering.

- **Tests**
  - Expanded coverage for dashboard activity, widgets, permissions, and field presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->