### PR TITLE
feat(blocks-engine): plan a pattern into a page, refusing what the apply would refuse

### DIFF
--- a/.changeset/a-pattern-is-placed-or-it-is-refused.md
+++ b/.changeset/a-pattern-is-placed-or-it-is-refused.md
@@ -1,0 +1,61 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A saved pattern can be planned into a page, and every refusal the edit would
+have hit is made before the plan exists rather than thrown while it applies.
+
+`planInsertPattern` is the inverse of saving one, and the second composition
+planner. It re-identifies the pattern's roots together, so a pattern placed twice
+on one page shares no node id and no DOM id with its other copy, and a reference
+crossing from one root to the next follows the copy rather than pointing back at
+the library. The `"document"` target replaces the page's root forest — a
+full-page pattern IS a page layout, and an empty document can be started from one
+— while leaving the page's own settings alone, so starting from a pattern does
+not repaint the page.
+
+The refusals are the point. A plan that reports success and then throws when it
+is applied defeats the reason planning is separate from doing, so the planner
+asks everything the op layer will ask and can be asked early: whether each block
+may sit where it is going, through both halves of the shared nesting rule — the
+child naming its permitted parents, and the slot naming what it admits; whether
+the incoming pattern holds a locked block, which cannot be inserted because the
+inverse of an insert is a remove and a remove refuses a locked subtree, so the
+insert could never be undone; whether replacing the page would delete a locked
+block already on it, which is the same rule reached from the other side and a
+different block from the author's point of view, so it says so separately; and
+whether the destination id is one the document holds twice, which the op layer
+refuses because the incoming node would be placed under both.
+
+A refusal names what it needs. A block that may not sit in a container reports
+the parents it does permit, and a slot that will not have it reports what it
+admits, so a surface can say where the block CAN go instead of only that it
+cannot go here.
+
+`lockedWithin` is published from the engine. A planner has to be able to ask
+whether a subtree is locked before it builds an insert around it, and a rule the
+op layer keeps to itself is one a planner would have to guess at.

--- a/.changeset/a-pattern-is-placed-or-it-is-refused.md
+++ b/.changeset/a-pattern-is-placed-or-it-is-refused.md
@@ -82,3 +82,11 @@ removes every root, and a remove refuses an id the document holds twice — its
 own and any inside the subtree it takes with it — so this was a plan that could
 not apply. A positional insert removes nothing and is unaffected, which is why
 the check belongs to the one target rather than to the planner.
+
+A stored pattern's nodes are checked against the shape rule the insert applies.
+A pattern is persisted, so it can hold a node that type-checks and is still
+structurally invalid — a `version` of zero is the cheap example — and the plan
+reported success while the insert threw on it. Asked of the op layer's own rule
+rather than a copy of it, so the two cannot come to disagree about what a node
+is. The machine caps on depth and size stay with the apply, because they depend
+on limits the plan was never given.

--- a/.changeset/a-pattern-is-placed-or-it-is-refused.md
+++ b/.changeset/a-pattern-is-placed-or-it-is-refused.md
@@ -59,3 +59,26 @@ cannot go here.
 `lockedWithin` is published from the engine. A planner has to be able to ask
 whether a subtree is locked before it builds an insert around it, and a rule the
 op layer keeps to itself is one a planner would have to guess at.
+
+One rule decides where a block may sit, for every planner and every
+destination. Saving a run lifts it to a document root and inserting a pattern
+puts it at a root or in a slot, and those were two implementations of one
+question — which is how two answers about where a block may live come to
+disagree. The target now says which half of the nesting rule to ask, rather than
+each planner asking in its own way.
+
+A destination that does not exist is told apart from one that exists twice.
+Counting "not exactly one" sent a stale target — a container that was deleted
+between opening the editor and dropping the pattern — to the sentence about a
+malformed document, which is advice no author can act on. None means aim
+somewhere that exists; more than one means the document itself is wrong.
+
+The position is checked against the op layer's own rule, asked without applying
+anything, so a negative index or a parent named without its slot is refused
+where a plan is made rather than thrown where it is applied.
+
+Replacing a document refuses one whose ids are not unique. The replacing target
+removes every root, and a remove refuses an id the document holds twice — its
+own and any inside the subtree it takes with it — so this was a plan that could
+not apply. A positional insert removes nothing and is unaffected, which is why
+the check belongs to the one target rather than to the planner.

--- a/.changeset/a-pattern-is-placed-or-it-is-refused.md
+++ b/.changeset/a-pattern-is-placed-or-it-is-refused.md
@@ -129,3 +129,16 @@ Nesting is checked throughout the copied forest rather than only at its roots. A
 pattern's internal placements were legal when it was saved and the rules can
 have moved since, so a pattern saved before a block gained a parent restriction
 would insert and leave the page unpublishable.
+
+The destination is judged by the apply's own document rule rather than by one
+field of it. Checking the format version closed the case that is easy to imagine
+and left the ones that are not: a page whose kind was written by a newer
+version, or one carrying a value JSON cannot hold, planned successfully and threw
+before the first op was dispatched. Everything the apply asks before it looks at
+an op is now asked where the plan is made.
+
+Asking it meant naming it: the checks were written inline and are now three
+functions with the questions they answer — is this a record whose fields are safe
+to read, are its values ones an edit can save, and does it say what it is. The
+order between them is unchanged and load-bearing, because each reads something
+the one before it vouched for.

--- a/.changeset/a-pattern-is-placed-or-it-is-refused.md
+++ b/.changeset/a-pattern-is-placed-or-it-is-refused.md
@@ -90,3 +90,20 @@ reported success while the insert threw on it. Asked of the op layer's own rule
 rather than a copy of it, so the two cannot come to disagree about what a node
 is. The machine caps on depth and size stay with the apply, because they depend
 on limits the plan was never given.
+
+The shape check judges structure, not caps. Depth and size depend on the limits
+whoever applies passes, so judging them here made a plan refuse a document the
+caller's own apply would accept — the dry run disagreeing with the run it
+predicts, in the direction nobody can debug. It uses the same shape-only limits
+the remove path already uses, and the caps stay where the numbers are known.
+
+Replacing a document checks the shape of what it removes. That target removes
+every root, and a remove asks the same shape question an insert does, so a page
+holding a malformed node produced a plan that could not apply.
+
+A pattern that spells one rendered id on two of its own nodes is refused rather
+than placed. Re-identifying does not repair it and is not meant to: two nodes
+sharing an id map to ONE replacement deliberately, because the pair addressed
+one target before and still addresses one after. What that preserves is the
+duplicate, and the copy carries it into a page where an anchor resolves to
+whichever element the browser reaches first and a label names the wrong control.

--- a/.changeset/a-pattern-is-placed-or-it-is-refused.md
+++ b/.changeset/a-pattern-is-placed-or-it-is-refused.md
@@ -107,3 +107,25 @@ sharing an id map to ONE replacement deliberately, because the pair addressed
 one target before and still addresses one after. What that preserves is the
 duplicate, and the copy carries it into a page where an anchor resolves to
 whichever element the browser reaches first and a label names the wrong control.
+
+A saved pattern that contains a locked block can be inserted. The op layer
+refuses an insert carrying a locked subtree, because its inverse is a remove and
+a remove refuses one, so the insert could never be undone — and taken literally
+that made a supported flow impossible: saving a selection with a locked block
+succeeds, the stored pattern keeps the lock, and the pattern was then insertable
+nowhere. A library row nothing can place is worse than refusing the save or
+dropping the lock without saying so. The nodes now arrive unlocked and an update
+locks them where they landed, so the group ends in the state the pattern
+described and stays undoable: inverses are recorded in undo order, so the unlock
+runs before the remove and the remove never meets a locked node.
+
+Both stored documents are checked before either is copied. A pattern is
+persisted, so it can hold a value JSON cannot carry — a function reaching props
+from an in-process caller — and cloning it threw a native error rather than the
+refusal this layer promises. It can also be written in a format this version
+cannot edit, which the apply refuses before it looks at anything else.
+
+Nesting is checked throughout the copied forest rather than only at its roots. A
+pattern's internal placements were legal when it was saved and the rules can
+have moved since, so a pattern saved before a block gained a parent restriction
+would insert and leave the page unpublishable.

--- a/packages/blocks-engine/src/composition-planners.ts
+++ b/packages/blocks-engine/src/composition-planners.ts
@@ -23,7 +23,11 @@
  *
  * @module composition-planners
  */
-import type { BlockDocument, BlockNode } from "./document";
+import {
+  DOCUMENT_FORMAT_VERSION,
+  type BlockDocument,
+  type BlockNode,
+} from "./document";
 import {
   canBeRoot,
   canNest,
@@ -97,8 +101,6 @@ export type PlanProblem =
   | "not-a-pattern"
   /** The destination id is held by more than one node. */
   | "duplicate-destination"
-  /** The pattern holds a locked node, which the op layer will not insert. */
-  | "locked"
   /**
    * Replacing the document would delete a locked block already on the page.
    *
@@ -114,7 +116,9 @@ export type PlanProblem =
   /** The stored pattern holds a node the op layer will not carry. */
   | "invalid-node"
   /** The stored pattern spells one rendered id on two of its own nodes. */
-  | "duplicate-dom-id";
+  | "duplicate-dom-id"
+  /** One of the documents is written in a format this version cannot edit. */
+  | "unsupported-format";
 
 /** A refusal, with whatever the surface needs to phrase it. */
 export interface PlanRefusal {
@@ -327,8 +331,8 @@ export function planInsertPattern(
   target: InsertTarget,
   nesting: NestingSource
 ): PlanResult<never> {
-  if (pattern.kind !== "pattern") return { problem: "not-a-pattern" };
-  if (pattern.nodes.length === 0) return { problem: "empty" };
+  const stored = storedRefusal(document, pattern);
+  if (stored !== undefined) return stored;
 
   const destination = destinationOf(document, target);
   if (destination.problem !== undefined) return destination;
@@ -337,28 +341,75 @@ export function planInsertPattern(
   if (copy.problem !== undefined) return copy;
 
   const refusal =
-    // The op layer's own shape rule, asked before the plan exists. A STORED
-    // pattern can hold a node that type-checks and is still structurally
-    // invalid — `version: 0` — and the insert would throw on it.
-    shapeRefusal(copy.nodes) ??
-    duplicateDomIdRefusal(copy.nodes) ??
     placementRefusal(copy.nodes, destination.place.where, nesting) ??
-    lockRefusal(copy.nodes, "locked") ??
-    // The `"document"` target REMOVES what is there, and a remove refuses a
-    // locked subtree for the same reason an insert refuses one — so replacing a
-    // page that holds a locked block throws at apply time unless it is caught
-    // here. Only that target deletes anything; a positional insert adds.
+    internalNestingRefusal(copy.nodes, nesting) ??
+    // The `"document"` target REMOVES what is there, and a remove refuses both
+    // a locked subtree and a malformed node for the same reasons an insert
+    // does. Only that target deletes anything; a positional insert adds.
     (target === "document"
-      ? (lockRefusal(document.nodes, "destination-locked") ??
-        // A remove asks the same shape question an insert does, so replacing a
-        // page holding a malformed node throws unless it is caught here.
-        shapeRefusal(document.nodes))
+      ? (lockRefusal(document.nodes) ?? shapeRefusal(document.nodes))
       : undefined);
   if (refusal !== undefined) return refusal;
 
   return {
     pageOps: insertOps(copy.nodes, destination.place, document, target),
   };
+}
+
+/**
+ * What must be true of the two STORED documents, asked before anything is
+ * copied out of either.
+ *
+ * Before, and not after, because copying is itself a step that can fail on a
+ * stored document: `structuredClone` throws on a value JSON cannot carry — a
+ * function reaching `props` from an in-process caller — and it throws a native
+ * `DOMException` rather than the refusal this module promises. The shape rule
+ * catches that same node, so asking it first turns a crash into a cause.
+ */
+function storedRefusal(
+  document: BlockDocument,
+  pattern: BlockDocument
+): PlanRefusal | undefined {
+  if (pattern.kind !== "pattern") return { problem: "not-a-pattern" };
+  if (pattern.nodes.length === 0) return { problem: "empty" };
+  // Both envelopes, because the ops are built from one and applied to the
+  // other, and `applyOp` refuses to edit a document written in a format this
+  // version does not know before it looks at anything else.
+  if (
+    document.formatVersion !== DOCUMENT_FORMAT_VERSION ||
+    pattern.formatVersion !== DOCUMENT_FORMAT_VERSION
+  ) {
+    return { problem: "unsupported-format" };
+  }
+  return shapeRefusal(pattern.nodes) ?? duplicateDomIdRefusal(pattern.nodes);
+}
+
+/**
+ * The first placement INSIDE the copied forest that the current rules refuse.
+ *
+ * A pattern is stored, so its internal placements were legal when it was saved
+ * and the rules can have moved since — a block that gained a `parent`
+ * restriction, or a slot that narrowed what it admits. Checking only the roots
+ * against the destination leaves such a pattern insertable and the page
+ * unpublishable, because strict validation asks about every edge.
+ */
+function internalNestingRefusal(
+  roots: readonly BlockNode[],
+  nesting: NestingSource
+): PlanRefusal | undefined {
+  let refusal: PlanRefusal | undefined;
+  walkNodes([...roots], node => {
+    if (refusal !== undefined) return;
+    for (const [slot, children] of Object.entries(node.slots ?? {})) {
+      if (!Array.isArray(children)) continue;
+      refusal ??= placementRefusal(
+        children,
+        { kind: "slot", parentType: node.type, slot },
+        nesting
+      );
+    }
+  });
+  return refusal;
 }
 
 /** Where the run will sit, once the destination has been checked. */
@@ -498,13 +549,19 @@ function domIdsOf(node: BlockNode): string[] {
   return ids;
 }
 
-/** A locked node anywhere in a forest, phrased as the caller's own refusal. */
-function lockRefusal(
-  roots: readonly BlockNode[],
-  problem: "locked" | "destination-locked"
-): PlanRefusal | undefined {
+/**
+ * A locked node the replacing target would DELETE, phrased as a refusal.
+ *
+ * Only the destination side asks this now. A lock on the incoming pattern is
+ * carried across the insert as an update rather than refused — see
+ * {@link insertOps} — but a lock on the page is content an author protected,
+ * and a remove refuses it for a reason no re-ordering of the group can satisfy.
+ */
+function lockRefusal(roots: readonly BlockNode[]): PlanRefusal | undefined {
   for (const root of roots) {
-    if (lockedWithin(root) !== undefined) return { problem };
+    if (lockedWithin(root) !== undefined) {
+      return { problem: "destination-locked" };
+    }
   }
   return undefined;
 }
@@ -597,6 +654,22 @@ function domIdsIn(nodes: BlockNode[]): Set<string> {
  * ids do not move, so the order among the removes does not matter — but they
  * must all precede the inserts, or the pattern's roots would be counted among
  * the roots being cleared away.
+ *
+ * ## A locked block arrives unlocked and is locked once it has landed
+ *
+ * `applyOp` refuses an insert whose subtree arrives locked, because the inverse
+ * of an insert is a remove and a remove refuses a locked subtree — so such an
+ * insert could never be undone. That rule is right, and taken literally it made
+ * a whole supported flow impossible: saving a selection containing a locked
+ * block succeeds, the stored pattern keeps the lock, and the pattern was then
+ * insertable nowhere. A library row nothing can place is worse than either
+ * refusing the save or dropping the lock without saying so.
+ *
+ * So the lock is neither carried on the insert nor discarded: the nodes arrive
+ * unlocked and an update locks them where they landed. The group ends in the
+ * state the pattern described, and it stays undoable because inverses are
+ * recorded in undo order — the unlock runs before the remove, so the remove
+ * never meets a locked node.
  */
 function insertOps(
   roots: readonly BlockNode[],
@@ -608,8 +681,9 @@ function insertOps(
     target === "document"
       ? document.nodes.map(node => ({ kind: "remove", id: node.id }))
       : [];
+  const { nodes, lockedIds } = withoutLocks(roots);
   const start = place.at === null ? 0 : place.at.index;
-  roots.forEach((node, offset) => {
+  nodes.forEach((node, offset) => {
     const at: OpPosition =
       place.at === null || place.at.parentId === undefined
         ? { index: start + offset }
@@ -620,5 +694,56 @@ function insertOps(
           };
     ops.push({ kind: "insert", node, at });
   });
+  for (const id of lockedIds) {
+    ops.push({ kind: "update", id, patch: { locked: true } });
+  }
   return ops;
+}
+
+/** A forest with every lock removed, and the ids that carried one. */
+interface UnlockedForest {
+  readonly nodes: BlockNode[];
+  readonly lockedIds: readonly string[];
+}
+
+/**
+ * Take the locks off, remembering where they were.
+ *
+ * A rebuild rather than a mutation: these nodes are a copy the planner was
+ * handed, and editing them in place would change what the dry run was asked
+ * about. Only `locked` moves — a `slots` value that is not an array is carried
+ * across as it stands, because malformed content is the shape rule's business
+ * and not this function's.
+ */
+function withoutLocks(roots: readonly BlockNode[]): UnlockedForest {
+  const lockedIds: string[] = [];
+
+  const strip = (node: BlockNode): BlockNode => {
+    const slots = node.slots === undefined ? undefined : stripSlots(node.slots);
+    if (node.locked === true) lockedIds.push(node.id);
+    if (node.locked !== true && slots === node.slots) return node;
+    const { locked: _locked, ...rest } = node;
+    return slots === undefined ? rest : { ...rest, slots };
+  };
+
+  const stripSlots = (
+    slots: Record<string, BlockNode[]>
+  ): Record<string, BlockNode[]> => {
+    let changed = false;
+    const next: Record<string, BlockNode[]> = {};
+    for (const [name, children] of Object.entries(slots)) {
+      if (!Array.isArray(children)) {
+        next[name] = children;
+        continue;
+      }
+      const mapped = children.map(strip);
+      if (mapped.some((child, index) => child !== children[index])) {
+        changed = true;
+      }
+      next[name] = mapped;
+    }
+    return changed ? next : slots;
+  };
+
+  return { nodes: roots.map(strip), lockedIds };
 }

--- a/packages/blocks-engine/src/composition-planners.ts
+++ b/packages/blocks-engine/src/composition-planners.ts
@@ -23,11 +23,7 @@
  *
  * @module composition-planners
  */
-import {
-  DOCUMENT_FORMAT_VERSION,
-  type BlockDocument,
-  type BlockNode,
-} from "./document";
+import type { BlockDocument, BlockNode } from "./document";
 import {
   canBeRoot,
   canNest,
@@ -37,6 +33,7 @@ import {
   type NestingVerdict,
 } from "./nesting";
 import {
+  documentRefusal,
   lockedWithin,
   nodeShapeRefusal,
   positionRefusal,
@@ -117,8 +114,8 @@ export type PlanProblem =
   | "invalid-node"
   /** The stored pattern spells one rendered id on two of its own nodes. */
   | "duplicate-dom-id"
-  /** One of the documents is written in a format this version cannot edit. */
-  | "unsupported-format";
+  /** One of the documents cannot be edited at all, whatever the ops say. */
+  | "unusable-document";
 
 /** A refusal, with whatever the surface needs to phrase it. */
 export interface PlanRefusal {
@@ -372,14 +369,16 @@ function storedRefusal(
 ): PlanRefusal | undefined {
   if (pattern.kind !== "pattern") return { problem: "not-a-pattern" };
   if (pattern.nodes.length === 0) return { problem: "empty" };
-  // Both envelopes, because the ops are built from one and applied to the
-  // other, and `applyOp` refuses to edit a document written in a format this
-  // version does not know before it looks at anything else.
+  // BOTH envelopes, judged by the apply's own document rule rather than by a
+  // field of it. The ops are built from one document and applied to the other,
+  // and everything `applyOp` asks before it looks at an op — the envelope's
+  // keys, its values, its format and its kind — is a way a plan can be built
+  // against a destination that cannot be edited at all.
   if (
-    document.formatVersion !== DOCUMENT_FORMAT_VERSION ||
-    pattern.formatVersion !== DOCUMENT_FORMAT_VERSION
+    documentRefusal(document) !== undefined ||
+    documentRefusal(pattern) !== undefined
   ) {
-    return { problem: "unsupported-format" };
+    return { problem: "unusable-document" };
   }
   return shapeRefusal(pattern.nodes) ?? duplicateDomIdRefusal(pattern.nodes);
 }

--- a/packages/blocks-engine/src/composition-planners.ts
+++ b/packages/blocks-engine/src/composition-planners.ts
@@ -34,6 +34,7 @@ import {
 } from "./nesting";
 import {
   lockedWithin,
+  nodeShapeRefusal,
   positionRefusal,
   type BuilderOp,
   type OpPosition,
@@ -109,7 +110,9 @@ export type PlanProblem =
   /** A minted DOM id keeps colliding with one the destination already holds. */
   | "dom-id-collision"
   /** The position names nowhere the op layer would accept. */
-  | "invalid-position";
+  | "invalid-position"
+  /** The stored pattern holds a node the op layer will not carry. */
+  | "invalid-node";
 
 /** A refusal, with whatever the surface needs to phrase it. */
 export interface PlanRefusal {
@@ -334,6 +337,10 @@ export function planInsertPattern(
   if (copy.problem !== undefined) return copy;
 
   const refusal =
+    // The op layer's own shape rule, asked before the plan exists. A STORED
+    // pattern can hold a node that type-checks and is still structurally
+    // invalid — `version: 0` — and the insert would throw on it.
+    shapeRefusal(copy.nodes) ??
     placementRefusal(copy.nodes, destination.place.where, nesting) ??
     lockRefusal(copy.nodes, "locked") ??
     // The `"document"` target REMOVES what is there, and a remove refuses a
@@ -432,6 +439,15 @@ function countById(nodes: BlockNode[], id: string): number {
     if (node.id === id) seen += 1;
   });
   return seen;
+}
+
+/** The first root the op layer would refuse to carry, phrased as a refusal. */
+function shapeRefusal(roots: readonly BlockNode[]): PlanRefusal | undefined {
+  for (const root of roots) {
+    if (nodeShapeRefusal(root) !== undefined)
+      return { problem: "invalid-node" };
+  }
+  return undefined;
 }
 
 /** A locked node anywhere in a forest, phrased as the caller's own refusal. */

--- a/packages/blocks-engine/src/composition-planners.ts
+++ b/packages/blocks-engine/src/composition-planners.ts
@@ -24,10 +24,17 @@
  * @module composition-planners
  */
 import type { BlockDocument, BlockNode } from "./document";
-import { canBeRoot, type NestingSource } from "./nesting";
-import type { BuilderOp } from "./ops";
+import {
+  canBeRoot,
+  canNest,
+  canNestInSlot,
+  type NestingRefusal,
+  type NestingSource,
+  type NestingVerdict,
+} from "./nesting";
+import { lockedWithin, type BuilderOp, type OpPosition } from "./ops";
 import { contiguousRun, type RunProblem } from "./sibling-run";
-import { reidForestWithMap } from "./tree";
+import { findNode, reidForestWithMap, walkNodes } from "./tree";
 
 /** A library row a planner asks the caller to create. */
 export interface PlannedCreate<TFields> {
@@ -77,7 +84,25 @@ export interface CompositionPlan<TFields> {
  * a new document, and a block that declares which parents it may sit in cannot
  * be one.
  */
-export type PlanProblem = RunProblem | "restricted-at-root";
+export type PlanProblem =
+  | RunProblem
+  | NestingRefusal
+  /** The document handed in is not a pattern. */
+  | "not-a-pattern"
+  /** The destination id is held by more than one node. */
+  | "duplicate-destination"
+  /** The pattern holds a locked node, which the op layer will not insert. */
+  | "locked"
+  /**
+   * Replacing the document would delete a locked block already on the page.
+   *
+   * Told apart from `"locked"` because the two are different blocks and only
+   * one of them is the author's to unlock here: one is inside the pattern being
+   * placed, the other is on the page in front of them.
+   */
+  | "destination-locked"
+  /** A minted DOM id keeps colliding with one the destination already holds. */
+  | "dom-id-collision";
 
 /** A refusal, with whatever the surface needs to phrase it. */
 export interface PlanRefusal {
@@ -194,4 +219,278 @@ function refusedAtRoot(
     };
   }
   return undefined;
+}
+
+/**
+ * Where an inserted pattern goes: a position, or the document itself.
+ *
+ * `"document"` is not a position and is deliberately not spelled as one. It
+ * replaces the root forest — a full-page pattern IS a page layout, and the
+ * builder offers it from an empty document as "start from a pattern" — and no
+ * `OpPosition` can express "instead of everything that is there".
+ */
+export type InsertTarget = OpPosition | "document";
+
+/**
+ * Insert a saved pattern, as a copy that keeps no link back.
+ *
+ * **Everything gets fresh ids.** A pattern may be inserted twice into one page,
+ * and the stored copy carries whatever ids it was saved with, so placing it as
+ * it stands would put two nodes with one id in a document — which the op layer
+ * refuses and every id-keyed reader would misread. The roots are re-identified
+ * TOGETHER so a reference crossing from one root to the next follows the copy.
+ *
+ * **`settings` is the destination's.** A pattern carries no document settings —
+ * they describe a page, not a run — and the `"document"` target replaces the
+ * root forest without touching them, so a full-page pattern does not repaint the
+ * page it is starting.
+ *
+ * ## What it refuses, and why a planner refuses it rather than the apply
+ *
+ * The plan IS the dry run. A plan that reports success and then throws when it
+ * is applied defeats the reason planning is separate from doing, so every
+ * refusal the op layer will make that can be foreseen is made here:
+ *
+ * - a block that may not sit where it is being put, asked of the SHARED nesting
+ *   rule, both halves of it — the child naming its permitted parents and the
+ *   slot naming what it admits;
+ * - a subtree arriving LOCKED, which `applyOp` refuses because the inverse of an
+ *   insert is a remove and a remove refuses a locked subtree, so the insert
+ *   could never be undone;
+ * - a destination parent id the document holds twice, which `applyOp` refuses
+ *   because the incoming node would be placed under both.
+ *
+ * The one refusal left to the apply is the machine cap on depth and size, which
+ * depends on limits the caller passes there.
+ *
+ * Provenance is NOT recorded on the inserted roots. Design Q12 proposes an inert
+ * `origin: { pattern, digest }` so "upstream changed" is answerable later, but
+ * `origin` is not one of the frozen `keyof BlockNode` keys, so recording it is a
+ * change to the stored format rather than an additive field —
+ * `decision:pb6-q12-provenance-on-copies` is with the founder.
+ */
+export function planInsertPattern(
+  document: BlockDocument,
+  pattern: BlockDocument,
+  target: InsertTarget,
+  nesting: NestingSource
+): PlanResult<never> {
+  if (pattern.kind !== "pattern") return { problem: "not-a-pattern" };
+  if (pattern.nodes.length === 0) return { problem: "empty" };
+
+  const destination = destinationOf(document, target);
+  if (destination.problem !== undefined) return destination;
+
+  const copy = freshCopy(pattern.nodes, document);
+  if (copy.problem !== undefined) return copy;
+
+  const refusal =
+    placementRefusal(copy.nodes, destination.place, nesting) ??
+    lockRefusal(copy.nodes, "locked") ??
+    // The `"document"` target REMOVES what is there, and a remove refuses a
+    // locked subtree for the same reason an insert refuses one — so replacing a
+    // page that holds a locked block throws at apply time unless it is caught
+    // here. Only that target deletes anything; a positional insert adds.
+    (target === "document"
+      ? lockRefusal(document.nodes, "destination-locked")
+      : undefined);
+  if (refusal !== undefined) return refusal;
+
+  return {
+    pageOps: insertOps(copy.nodes, destination.place, document, target),
+  };
+}
+
+/** Where the run will sit, once the destination has been checked. */
+interface Destination {
+  readonly place: Placement;
+  readonly problem?: undefined;
+}
+
+/**
+ * The resolved destination: the position, and the parent's TYPE when there is
+ * one.
+ *
+ * The type is carried because the nesting rule is asked about types, and
+ * looking the parent up a second time to get it is the mistake this package has
+ * already made once — a second lookup of one id can answer differently from the
+ * first.
+ */
+interface Placement {
+  readonly at: OpPosition | null;
+  readonly parentType?: string;
+  readonly slot?: string;
+}
+
+function destinationOf(
+  document: BlockDocument,
+  target: InsertTarget
+): Destination | PlanRefusal {
+  if (target === "document") return { place: { at: null } };
+  if (target.parentId === undefined) return { place: { at: target } };
+
+  // Uniqueness FIRST, then the lookup. `applyOp` refuses an insert whose
+  // destination id is held twice, and a find that answers with the first of two
+  // would describe a different container than the one the author aimed at.
+  if (countById(document.nodes, target.parentId) !== 1) {
+    return { problem: "duplicate-destination" };
+  }
+  const parent = findNode(document.nodes, target.parentId);
+  if (parent === undefined) return { problem: "unknown" };
+  return {
+    place: { at: target, parentType: parent.type, slot: target.slot },
+  };
+}
+
+/** How many nodes in a forest carry one id. */
+function countById(nodes: BlockNode[], id: string): number {
+  let seen = 0;
+  walkNodes(nodes, node => {
+    if (node.id === id) seen += 1;
+  });
+  return seen;
+}
+
+/** The first root that may not sit where it is being put, phrased as a refusal. */
+function placementRefusal(
+  roots: readonly BlockNode[],
+  place: Placement,
+  nesting: NestingSource
+): PlanRefusal | undefined {
+  for (const root of roots) {
+    const verdict =
+      place.parentType === undefined || place.slot === undefined
+        ? canBeRoot(root.type, nesting)
+        : bothHalves(root.type, place.parentType, place.slot, nesting);
+    if (verdict.allowed) continue;
+    return {
+      problem: verdict.reason,
+      ...(verdict.permitted === undefined
+        ? {}
+        : { permitted: verdict.permitted }),
+    };
+  }
+  return undefined;
+}
+
+/**
+ * Both halves of the nesting rule, in the order that reports the more
+ * actionable refusal first.
+ *
+ * The child naming its permitted parents is the sharper answer — it names
+ * somewhere the block CAN go — where a slot's allow-list only says this one
+ * will not have it.
+ */
+function bothHalves(
+  childType: string,
+  parentType: string,
+  slot: string,
+  nesting: NestingSource
+): NestingVerdict {
+  const child = canNest(childType, parentType, nesting);
+  return child.allowed
+    ? canNestInSlot(childType, parentType, slot, nesting)
+    : child;
+}
+
+/** A locked node anywhere in a forest, phrased as the caller's own refusal. */
+function lockRefusal(
+  roots: readonly BlockNode[],
+  problem: "locked" | "destination-locked"
+): PlanRefusal | undefined {
+  for (const root of roots) {
+    if (lockedWithin(root) !== undefined) return { problem };
+  }
+  return undefined;
+}
+
+/** A re-identified copy, or the reason one could not be made. */
+interface FreshCopy {
+  readonly nodes: BlockNode[];
+  readonly problem?: undefined;
+}
+
+/**
+ * How many times a fresh set of ids may be minted before giving up.
+ *
+ * `reidForestWithMap` guarantees its DOM ids are unique WITHIN the copy and
+ * says so — it is handed a forest and cannot see the page. A minted id is
+ * derived from a fresh random node id, so colliding with one the destination
+ * already carries needs that exact string to be there already; minting again
+ * draws different ids, so one retry all but settles it and three is a bound
+ * rather than an expectation.
+ *
+ * Checked rather than assumed because the alternative is the failure this
+ * module keeps finding: two elements sharing a DOM id, an anchor resolving to
+ * whichever the browser reaches first, and nothing on screen saying so.
+ *
+ * NOT covered by a test, and deliberately so: the suffix comes from a freshly
+ * minted UUID, so no test can arrange for the destination to hold the string
+ * that is about to be drawn. A test asserting the refusal would be one that
+ * cannot fail. The property this protects IS covered — inserting one pattern
+ * twice into one page and finding no repeated DOM id.
+ */
+const MAX_ID_MINTING_ATTEMPTS = 3;
+
+function freshCopy(
+  roots: BlockNode[],
+  document: BlockDocument
+): FreshCopy | PlanRefusal {
+  const taken = domIdsIn(document.nodes);
+  for (let attempt = 0; attempt < MAX_ID_MINTING_ATTEMPTS; attempt += 1) {
+    const minted = reidForestWithMap(roots);
+    const clash = [...minted.domIds.values()].some(id => taken.has(id));
+    if (!clash) return { nodes: minted.nodes };
+  }
+  return { problem: "dom-id-collision" };
+}
+
+/** Every DOM id the destination already carries, from either spelling. */
+function domIdsIn(nodes: BlockNode[]): Set<string> {
+  const taken = new Set<string>();
+  walkNodes(nodes, node => {
+    if (typeof node.cssId === "string" && node.cssId !== "")
+      taken.add(node.cssId);
+    const attribute = node.attributes?.id;
+    if (typeof attribute === "string" && attribute !== "") taken.add(attribute);
+  });
+  return taken;
+}
+
+/**
+ * The edits, in the order they must apply.
+ *
+ * Each root goes one index after the last, so a run inserted together arrives
+ * in the order it was saved. Every position is computed against the document as
+ * it will be WHEN THAT OP RUNS, which is why the index advances: the op before
+ * it has already shifted every later sibling along.
+ *
+ * The `"document"` target removes first. A remove addresses a node by id and
+ * ids do not move, so the order among the removes does not matter — but they
+ * must all precede the inserts, or the pattern's roots would be counted among
+ * the roots being cleared away.
+ */
+function insertOps(
+  roots: readonly BlockNode[],
+  place: Placement,
+  document: BlockDocument,
+  target: InsertTarget
+): BuilderOp[] {
+  const ops: BuilderOp[] =
+    target === "document"
+      ? document.nodes.map(node => ({ kind: "remove", id: node.id }))
+      : [];
+  const start = place.at === null ? 0 : place.at.index;
+  roots.forEach((node, offset) => {
+    const at: OpPosition =
+      place.at === null || place.at.parentId === undefined
+        ? { index: start + offset }
+        : {
+            parentId: place.at.parentId,
+            slot: place.at.slot,
+            index: start + offset,
+          };
+    ops.push({ kind: "insert", node, at });
+  });
+  return ops;
 }

--- a/packages/blocks-engine/src/composition-planners.ts
+++ b/packages/blocks-engine/src/composition-planners.ts
@@ -32,7 +32,12 @@ import {
   type NestingSource,
   type NestingVerdict,
 } from "./nesting";
-import { lockedWithin, type BuilderOp, type OpPosition } from "./ops";
+import {
+  lockedWithin,
+  positionRefusal,
+  type BuilderOp,
+  type OpPosition,
+} from "./ops";
 import { contiguousRun, type RunProblem } from "./sibling-run";
 import { findNode, reidForestWithMap, walkNodes } from "./tree";
 
@@ -102,7 +107,9 @@ export type PlanProblem =
    */
   | "destination-locked"
   /** A minted DOM id keeps colliding with one the destination already holds. */
-  | "dom-id-collision";
+  | "dom-id-collision"
+  /** The position names nowhere the op layer would accept. */
+  | "invalid-position";
 
 /** A refusal, with whatever the surface needs to phrase it. */
 export interface PlanRefusal {
@@ -168,7 +175,9 @@ export function planSaveAsPattern<TFields>(
   if (result.run === undefined) return { problem: result.problem };
 
   const selected = result.run.places.map(place => place.node);
-  const refusal = refusedAtRoot(selected, nesting);
+  // Saving LIFTS the run out, so its blocks become document roots — the same
+  // question an insert asks, asked of the same rule.
+  const refusal = placementRefusal(selected, { kind: "root" }, nesting);
   if (refusal !== undefined) return refusal;
 
   return {
@@ -191,34 +200,74 @@ export function planSaveAsPattern<TFields>(
 }
 
 /**
- * The first selected block that cannot stand at a document root, if any.
+ * Where a block is being put, in the terms the nesting rule judges.
  *
- * Saving a run lifts it OUT of whatever contained it: the pattern document's
- * roots are the selected blocks themselves. A block declaring which parents it
- * may sit in has just lost the only one it had, and the store validates root
- * placement through the same rule — so without this the planner reports success
- * and hands back a document the create then refuses. Selecting a `core/column`
- * inside a `core/columns` is the ordinary way to reach it, not a corner case.
- *
- * Asked of the SHARED rule rather than answered here. The canvas, the validator
- * and this planner have to agree about where a block may sit, and a second
- * implementation would agree only until one of them changed.
+ * A closed pair rather than a nullable parent, for the reason `canBeRoot` is a
+ * separate function from `canNest`: a parent variable that is accidentally
+ * undefined would otherwise turn a lookup that failed into a confident verdict
+ * about the root.
  */
-function refusedAtRoot(
-  selected: readonly BlockNode[],
+export type PlacementTarget =
+  | { readonly kind: "root" }
+  | {
+      readonly kind: "slot";
+      readonly parentType: string;
+      readonly slot: string;
+    };
+
+/**
+ * The first block that may not sit where it is being put, phrased as a refusal.
+ *
+ * ONE implementation for every planner and every destination. Saving a run
+ * lifts it to a document root; inserting a pattern puts it at a root or in a
+ * slot — and asking the same question two ways is how the two come to disagree
+ * about where a block may live. The root case is not a special case of the slot
+ * case, so the target says which question to ask rather than passing an
+ * optional parent that means both.
+ *
+ * A refusal carries `permitted` because the caller is the only place that still
+ * knows which selection was refused, and a surface explaining it needs to name
+ * somewhere the block CAN go — the same reason `NestingVerdict` carries it.
+ */
+function placementRefusal(
+  blocks: readonly BlockNode[],
+  where: PlacementTarget,
   nesting: NestingSource
 ): PlanRefusal | undefined {
-  for (const node of selected) {
-    const verdict = canBeRoot(node.type, nesting);
+  for (const block of blocks) {
+    const verdict =
+      where.kind === "root"
+        ? canBeRoot(block.type, nesting)
+        : bothHalves(block.type, where.parentType, where.slot, nesting);
     if (verdict.allowed) continue;
     return {
-      problem: "restricted-at-root",
+      problem: verdict.reason,
       ...(verdict.permitted === undefined
         ? {}
         : { permitted: verdict.permitted }),
     };
   }
   return undefined;
+}
+
+/**
+ * Both halves of the nesting rule, in the order that reports the more
+ * actionable refusal first.
+ *
+ * The child naming its permitted parents is the sharper answer — it names
+ * somewhere the block CAN go — where a slot's allow-list only says this one
+ * will not have it.
+ */
+function bothHalves(
+  childType: string,
+  parentType: string,
+  slot: string,
+  nesting: NestingSource
+): NestingVerdict {
+  const child = canNest(childType, parentType, nesting);
+  return child.allowed
+    ? canNestInSlot(childType, parentType, slot, nesting)
+    : child;
 }
 
 /**
@@ -285,7 +334,7 @@ export function planInsertPattern(
   if (copy.problem !== undefined) return copy;
 
   const refusal =
-    placementRefusal(copy.nodes, destination.place, nesting) ??
+    placementRefusal(copy.nodes, destination.place.where, nesting) ??
     lockRefusal(copy.nodes, "locked") ??
     // The `"document"` target REMOVES what is there, and a remove refuses a
     // locked subtree for the same reason an insert refuses one — so replacing a
@@ -318,28 +367,62 @@ interface Destination {
  */
 interface Placement {
   readonly at: OpPosition | null;
-  readonly parentType?: string;
-  readonly slot?: string;
+  readonly where: PlacementTarget;
 }
 
 function destinationOf(
   document: BlockDocument,
   target: InsertTarget
 ): Destination | PlanRefusal {
-  if (target === "document") return { place: { at: null } };
-  if (target.parentId === undefined) return { place: { at: target } };
-
-  // Uniqueness FIRST, then the lookup. `applyOp` refuses an insert whose
-  // destination id is held twice, and a find that answers with the first of two
-  // would describe a different container than the one the author aimed at.
-  if (countById(document.nodes, target.parentId) !== 1) {
-    return { problem: "duplicate-destination" };
+  if (target === "document") {
+    // The replacing target REMOVES every root, and a remove refuses an id the
+    // document holds twice — its own and any in the subtree it takes with it.
+    // So for this target the whole document has to be unambiguous, where a
+    // positional insert only cares about the container it aims at.
+    return firstRepeatedId(document.nodes) === undefined
+      ? { place: { at: null, where: { kind: "root" } } }
+      : { problem: "duplicate-destination" };
   }
+
+  // The op layer's own rule for whether a position names anywhere, asked before
+  // anything is built on it. A negative index, or a parent named without its
+  // slot, is refused by `applyOp` — so a plan carrying one is a dry run that
+  // disagrees with the run it predicts.
+  if (positionRefusal(target) !== undefined)
+    return { problem: "invalid-position" };
+
+  if (target.parentId === undefined) {
+    return { place: { at: target, where: { kind: "root" } } };
+  }
+
+  // Told apart, because the remedies are opposite. NONE means the container is
+  // gone — a stale target, and the author should aim somewhere that exists.
+  // MORE THAN ONE means the document is malformed, which no aiming fixes and
+  // which `applyOp` refuses outright because the node would be placed in both.
+  const held = countById(document.nodes, target.parentId);
+  if (held === 0) return { problem: "unknown" };
+  if (held > 1) return { problem: "duplicate-destination" };
+
   const parent = findNode(document.nodes, target.parentId);
   if (parent === undefined) return { problem: "unknown" };
   return {
-    place: { at: target, parentType: parent.type, slot: target.slot },
+    place: {
+      at: target,
+      where: { kind: "slot", parentType: parent.type, slot: target.slot },
+    },
   };
+}
+
+/** The first id this document holds twice, or `undefined`. */
+function firstRepeatedId(nodes: BlockNode[]): string | undefined {
+  const seen = new Set<string>();
+  let repeated: string | undefined;
+  walkNodes(nodes, node => {
+    if (repeated !== undefined) return;
+    if (seen.has(node.id)) repeated = node.id;
+    else seen.add(node.id);
+  });
+  return repeated;
 }
 
 /** How many nodes in a forest carry one id. */
@@ -349,48 +432,6 @@ function countById(nodes: BlockNode[], id: string): number {
     if (node.id === id) seen += 1;
   });
   return seen;
-}
-
-/** The first root that may not sit where it is being put, phrased as a refusal. */
-function placementRefusal(
-  roots: readonly BlockNode[],
-  place: Placement,
-  nesting: NestingSource
-): PlanRefusal | undefined {
-  for (const root of roots) {
-    const verdict =
-      place.parentType === undefined || place.slot === undefined
-        ? canBeRoot(root.type, nesting)
-        : bothHalves(root.type, place.parentType, place.slot, nesting);
-    if (verdict.allowed) continue;
-    return {
-      problem: verdict.reason,
-      ...(verdict.permitted === undefined
-        ? {}
-        : { permitted: verdict.permitted }),
-    };
-  }
-  return undefined;
-}
-
-/**
- * Both halves of the nesting rule, in the order that reports the more
- * actionable refusal first.
- *
- * The child naming its permitted parents is the sharper answer — it names
- * somewhere the block CAN go — where a slot's allow-list only says this one
- * will not have it.
- */
-function bothHalves(
-  childType: string,
-  parentType: string,
-  slot: string,
-  nesting: NestingSource
-): NestingVerdict {
-  const child = canNest(childType, parentType, nesting);
-  return child.allowed
-    ? canNestInSlot(childType, parentType, slot, nesting)
-    : child;
 }
 
 /** A locked node anywhere in a forest, phrased as the caller's own refusal. */
@@ -424,11 +465,17 @@ interface FreshCopy {
  * module keeps finding: two elements sharing a DOM id, an anchor resolving to
  * whichever the browser reaches first, and nothing on screen saying so.
  *
- * NOT covered by a test, and deliberately so: the suffix comes from a freshly
- * minted UUID, so no test can arrange for the destination to hold the string
- * that is about to be drawn. A test asserting the refusal would be one that
- * cannot fail. The property this protects IS covered — inserting one pattern
- * twice into one page and finding no repeated DOM id.
+ * NOT covered by a test, and deliberately so. The suffix comes from a freshly
+ * minted UUID, so no test can arrange for the destination to already hold the
+ * string that is about to be drawn — an assertion about the refusal, or about
+ * which spellings {@link domIdsIn} collects, is one that cannot fail whatever
+ * this code does. I wrote such a test first and deleted it: a green that no
+ * implementation can turn red is not coverage, and leaving it in would have
+ * made this look guarded when only the reasoning guards it.
+ *
+ * The property that IS covered, deterministically, is the one that matters in
+ * practice: inserting one pattern twice into one page and finding no repeated
+ * DOM id anywhere in the result.
  */
 const MAX_ID_MINTING_ATTEMPTS = 3;
 
@@ -445,14 +492,31 @@ function freshCopy(
   return { problem: "dom-id-collision" };
 }
 
-/** Every DOM id the destination already carries, from either spelling. */
+/**
+ * Every DOM id the destination already carries, from either spelling.
+ *
+ * Attribute names are FOLDED. HTML attribute names are case-insensitive, and
+ * the copier that mints replacements folds them too, so a destination storing
+ * `ID` is holding a DOM id as surely as one storing `id` — and an exact-case
+ * read here would not see it. Unreachable in a test for the reason
+ * {@link MAX_ID_MINTING_ATTEMPTS} gives, and correct for a reason that does not
+ * depend on being reachable: this set is a claim about what the page holds, and
+ * a claim that is wrong about half the spellings is wrong.
+ */
 function domIdsIn(nodes: BlockNode[]): Set<string> {
   const taken = new Set<string>();
   walkNodes(nodes, node => {
     if (typeof node.cssId === "string" && node.cssId !== "")
       taken.add(node.cssId);
-    const attribute = node.attributes?.id;
-    if (typeof attribute === "string" && attribute !== "") taken.add(attribute);
+    // FOLDED, because HTML attribute names are case-insensitive and the copier
+    // that mints replacements folds them too (`key.toLowerCase() === "id"`). An
+    // exact-case read here would miss a destination storing `ID`, and the miss
+    // is silent: the collision check passes and the page ends up with two
+    // elements answering to one id.
+    for (const [name, value] of Object.entries(node.attributes ?? {})) {
+      if (name.toLowerCase() !== "id") continue;
+      if (typeof value === "string" && value !== "") taken.add(value);
+    }
   });
   return taken;
 }

--- a/packages/blocks-engine/src/composition-planners.ts
+++ b/packages/blocks-engine/src/composition-planners.ts
@@ -112,7 +112,9 @@ export type PlanProblem =
   /** The position names nowhere the op layer would accept. */
   | "invalid-position"
   /** The stored pattern holds a node the op layer will not carry. */
-  | "invalid-node";
+  | "invalid-node"
+  /** The stored pattern spells one rendered id on two of its own nodes. */
+  | "duplicate-dom-id";
 
 /** A refusal, with whatever the surface needs to phrase it. */
 export interface PlanRefusal {
@@ -315,11 +317,9 @@ export type InsertTarget = OpPosition | "document";
  * The one refusal left to the apply is the machine cap on depth and size, which
  * depends on limits the caller passes there.
  *
- * Provenance is NOT recorded on the inserted roots. Design Q12 proposes an inert
- * `origin: { pattern, digest }` so "upstream changed" is answerable later, but
- * `origin` is not one of the frozen `keyof BlockNode` keys, so recording it is a
- * change to the stored format rather than an additive field —
- * `decision:pb6-q12-provenance-on-copies` is with the founder.
+ * Nothing records where the copy came from. A pattern is copy-on-insert and
+ * keeps no link back, so the inserted nodes are ordinary content from the
+ * moment they land.
  */
 export function planInsertPattern(
   document: BlockDocument,
@@ -341,6 +341,7 @@ export function planInsertPattern(
     // pattern can hold a node that type-checks and is still structurally
     // invalid — `version: 0` — and the insert would throw on it.
     shapeRefusal(copy.nodes) ??
+    duplicateDomIdRefusal(copy.nodes) ??
     placementRefusal(copy.nodes, destination.place.where, nesting) ??
     lockRefusal(copy.nodes, "locked") ??
     // The `"document"` target REMOVES what is there, and a remove refuses a
@@ -348,7 +349,10 @@ export function planInsertPattern(
     // page that holds a locked block throws at apply time unless it is caught
     // here. Only that target deletes anything; a positional insert adds.
     (target === "document"
-      ? lockRefusal(document.nodes, "destination-locked")
+      ? (lockRefusal(document.nodes, "destination-locked") ??
+        // A remove asks the same shape question an insert does, so replacing a
+        // page holding a malformed node throws unless it is caught here.
+        shapeRefusal(document.nodes))
       : undefined);
   if (refusal !== undefined) return refusal;
 
@@ -448,6 +452,50 @@ function shapeRefusal(roots: readonly BlockNode[]): PlanRefusal | undefined {
       return { problem: "invalid-node" };
   }
   return undefined;
+}
+
+/**
+ * A DOM id the copy uses twice, phrased as a refusal.
+ *
+ * Re-identifying does not fix this and is not meant to. A subtree that already
+ * spelled one id on two nodes is malformed, and `reidForestWithMap` maps both
+ * occurrences to ONE replacement deliberately — the pair addressed one target
+ * before and still addresses one after, which is the honest reading of a
+ * document that should not have existed. What that preserves is the duplicate:
+ * the copy carries it into the page, where an anchor resolves to whichever
+ * element the browser reaches first and a label names the wrong control.
+ *
+ * So a stored pattern this broken is refused rather than placed. Folded the way
+ * HTML folds attribute names, and the way validation reports `duplicate-dom-id`
+ * for the same shape.
+ */
+function duplicateDomIdRefusal(
+  roots: readonly BlockNode[]
+): PlanRefusal | undefined {
+  const seen = new Set<string>();
+  let repeated = false;
+  walkNodes([...roots], node => {
+    if (repeated) return;
+    for (const id of domIdsOf(node)) {
+      if (seen.has(id)) {
+        repeated = true;
+        return;
+      }
+      seen.add(id);
+    }
+  });
+  return repeated ? { problem: "duplicate-dom-id" } : undefined;
+}
+
+/** Every DOM id one node carries, from either spelling. */
+function domIdsOf(node: BlockNode): string[] {
+  const ids: string[] = [];
+  if (typeof node.cssId === "string" && node.cssId !== "") ids.push(node.cssId);
+  for (const [name, value] of Object.entries(node.attributes ?? {})) {
+    if (name.toLowerCase() !== "id") continue;
+    if (typeof value === "string" && value !== "") ids.push(value);
+  }
+  return ids;
 }
 
 /** A locked node anywhere in a forest, phrased as the caller's own refusal. */

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -173,6 +173,7 @@ export { planInsertPattern, planSaveAsPattern } from "./composition-planners";
 export type {
   CompositionPlan,
   InsertTarget,
+  PlacementTarget,
   PatternTarget,
   PlanProblem,
   PlanRefusal,
@@ -696,6 +697,9 @@ export {
   // than hand back a plan the apply throws on.
   lockedWithin,
   OpError,
+  // The apply's own position rule, asked without applying: a planner that
+  // wrote its own copy would agree until one of the two moved.
+  positionRefusal,
   positionOf,
   sameStoredValue,
   sameStyleValue,

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -696,6 +696,8 @@ export {
   // refused by the op layer, so a planner has to be able to foresee it rather
   // than hand back a plan the apply throws on.
   lockedWithin,
+  // And the shape rule for what an insert will carry, for the same reason.
+  nodeShapeRefusal,
   OpError,
   // The apply's own position rule, asked without applying: a planner that
   // wrote its own copy would agree until one of the two moved.

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -696,6 +696,9 @@ export {
   // Published for the planners: an insert whose subtree arrives locked is
   // refused by the op layer, so a planner has to be able to foresee it rather
   // than hand back a plan the apply throws on.
+  // And the document-level rule the apply runs before it looks at the op, so a
+  // plan is never built against a destination that cannot be edited at all.
+  documentRefusal,
   lockedWithin,
   // And the shape rule for what an insert will carry, for the same reason.
   nodeShapeRefusal,

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -169,9 +169,10 @@ export type {
 // create and the ops the page needs. Split from the doing so the caller can put
 // both writes in one unit of work and roll the create back — and so the dry run
 // and the real run are the same function rather than two that agree for now.
-export { planSaveAsPattern } from "./composition-planners";
+export { planInsertPattern, planSaveAsPattern } from "./composition-planners";
 export type {
   CompositionPlan,
+  InsertTarget,
   PatternTarget,
   PlanProblem,
   PlanRefusal,
@@ -690,6 +691,10 @@ export {
 export {
   applyOp,
   applyOps,
+  // Published for the planners: an insert whose subtree arrives locked is
+  // refused by the op layer, so a planner has to be able to foresee it rather
+  // than hand back a plan the apply throws on.
+  lockedWithin,
   OpError,
   positionOf,
   sameStoredValue,

--- a/packages/blocks-engine/src/insert-pattern.test.ts
+++ b/packages/blocks-engine/src/insert-pattern.test.ts
@@ -361,6 +361,28 @@ describe("what it refuses before the op layer would", () => {
     expect(() => applyOps(doc, (plan.pageOps ?? []) as never)).not.toThrow();
   });
 
+  it("REFUSES A STORED NODE THE OP LAYER WILL NOT CARRY", () => {
+    // A pattern is stored, so it can hold a node that type-checks and is still
+    // structurally invalid. `version: 0` is the cheap example, and the insert
+    // throws on it — asked of the op layer's own shape rule, not a copy of it.
+    const malformed: BlockDocument = {
+      formatVersion: DOCUMENT_FORMAT_VERSION,
+      kind: "pattern",
+      nodes: [
+        { id: "p1", type: "core/box", version: 0, props: {} } as BlockNode,
+      ],
+    };
+
+    const plan = planInsertPattern(
+      page([node("a")]),
+      malformed,
+      { index: 1 },
+      anyParent
+    );
+
+    expect(plan.problem).toBe("invalid-node");
+  });
+
   it("refuses a document that is not a pattern", () => {
     const notAPattern: BlockDocument = {
       formatVersion: DOCUMENT_FORMAT_VERSION,
@@ -407,6 +429,22 @@ describe("the refusals are the op layer's, not invented", () => {
     expect(() =>
       applyOps(doc, [
         { kind: "insert", node: locked, at: { index: 1 } },
+      ] as never)
+    ).toThrow();
+  });
+
+  it("the INVALID-NODE refusal is real: applying that insert throws", () => {
+    const doc = page([node("a")]);
+    const malformed = {
+      id: "p1",
+      type: "core/box",
+      version: 0,
+      props: {},
+    } as BlockNode;
+
+    expect(() =>
+      applyOps(doc, [
+        { kind: "insert", node: malformed, at: { index: 1 } },
       ] as never)
     ).toThrow();
   });

--- a/packages/blocks-engine/src/insert-pattern.test.ts
+++ b/packages/blocks-engine/src/insert-pattern.test.ts
@@ -268,45 +268,44 @@ describe("what it refuses before the op layer would", () => {
     expect(plan.problem).toBe("restricted-at-root");
   });
 
-  it("REFUSES A LOCKED SUBTREE, which the op layer will not insert", () => {
-    // Not a rule of this planner's own: `applyOp` refuses it because the
-    // inverse of an insert is a remove and a remove refuses a locked subtree,
-    // so the insert could never be undone.
+  it("PLACES A LOCKED BLOCK BY LOCKING IT AFTER IT LANDS", () => {
+    // `applyOp` refuses an insert carrying a locked subtree, because its
+    // inverse is a remove and a remove refuses one — so the insert could never
+    // be undone. Saving a selection with a locked block succeeds, though, so
+    // refusing here would build a library row nothing could ever place.
     const doc = page([node("a")]);
     const saved = pattern([
-      node("p1", {}, { body: [node("deep", { locked: true })] }),
+      node("p1", { locked: true }, { body: [node("deep", { locked: true })] }),
     ]);
 
     const plan = planInsertPattern(doc, saved, { index: 1 }, anyParent);
+    expect(plan.problem).toBeUndefined();
 
-    expect(plan.problem).toBe("locked");
+    const applied = applyOps(doc, (plan.pageOps ?? []) as never);
+    const locks: boolean[] = [];
+    walkNodes(applied.document.nodes, n => {
+      if (n.props?.mark !== undefined || n.id !== "a")
+        locks.push(n.locked === true);
+    });
+    // Both nodes end LOCKED, which is the state the pattern described.
+    expect(locks.filter(Boolean)).toHaveLength(2);
   });
 
-  it("REFUSES REPLACING A PAGE THAT HOLDS A LOCKED BLOCK", () => {
-    // The `"document"` target deletes what is there, and a remove refuses a
-    // locked subtree exactly as an insert does. Found by asking what the ops
-    // this planner emits would do, not by review — the planner reported success
-    // and `applyOps` threw.
-    const doc = page([node("keep", { locked: true }), node("b")]);
+  it("and the group is still undoable, which is why the lock is deferred", () => {
+    // The whole reason the op layer refuses a locked insert. Inverses are
+    // recorded in undo order, so the unlock runs before the remove and the
+    // remove never meets a locked node.
+    const doc = page([node("a")]);
+    const saved = pattern([node("p1", { locked: true })]);
 
-    const plan = planInsertPattern(
-      doc,
-      pattern([node("p1")]),
-      "document",
-      anyParent
-    );
+    const plan = planInsertPattern(doc, saved, { index: 1 }, anyParent);
+    const applied = applyOps(doc, (plan.pageOps ?? []) as never);
 
-    expect(plan.problem).toBe("destination-locked");
-  });
-
-  it("tells the page's locked block apart from the pattern's", () => {
-    // Different blocks, and only one of them is in front of the author here.
-    const lockedPattern = pattern([node("p1", { locked: true })]);
-
-    expect(
-      planInsertPattern(page([node("a")]), lockedPattern, "document", anyParent)
-        .problem
-    ).toBe("locked");
+    expect(() =>
+      applyOps(applied.document, applied.inverses as never)
+    ).not.toThrow();
+    const undone = applyOps(applied.document, applied.inverses as never);
+    expect(undone.document.nodes.map(n => n.id)).toEqual(["a"]);
   });
 
   it("a positional insert does NOT mind a locked block on the page", () => {
@@ -430,6 +429,43 @@ describe("what it refuses before the op layer would", () => {
     expect(plan.problem).toBeUndefined();
   });
 
+  it("REFUSES A DOCUMENT IN A FORMAT THIS VERSION CANNOT EDIT", () => {
+    // `applyOp` refuses to edit such a document before it looks at anything
+    // else, so a plan built against one is a plan that cannot apply.
+    const old = {
+      ...page([node("a")]),
+      formatVersion: 99,
+    } as unknown as BlockDocument;
+
+    expect(
+      planInsertPattern(old, pattern([node("p1")]), { index: 1 }, anyParent)
+        .problem
+    ).toBe("unsupported-format");
+  });
+
+  it("REFUSES A PLACEMENT INSIDE THE PATTERN THAT THE RULES NOW FORBID", () => {
+    // A pattern is stored, so its internal placements were legal when saved and
+    // the rules can have moved since. Checking only the roots would leave such
+    // a pattern insertable and the page unpublishable.
+    const columnsOnly = {
+      parentsOf: (type: string) =>
+        type === "core/column" ? ["core/columns"] : undefined,
+    };
+    const saved = pattern([
+      node(
+        "wrap",
+        { type: "core/box" },
+        {
+          body: [node("c", { type: "core/column" })],
+        }
+      ),
+    ]);
+
+    const plan = planInsertPattern(page([]), saved, "document", columnsOnly);
+
+    expect(plan.problem).toBe("wrong-parent");
+  });
+
   it("refuses a document that is not a pattern", () => {
     const notAPattern: BlockDocument = {
       formatVersion: DOCUMENT_FORMAT_VERSION,
@@ -469,7 +505,7 @@ describe("the refusals are the op layer's, not invented", () => {
     }
   });
 
-  it("the LOCKED refusal is real: applying that insert throws", () => {
+  it("a locked subtree really cannot be INSERTED, which is why it is deferred", () => {
     const doc = page([node("a")]);
     const locked = node("p1", {}, { body: [node("deep", { locked: true })] });
 

--- a/packages/blocks-engine/src/insert-pattern.test.ts
+++ b/packages/blocks-engine/src/insert-pattern.test.ts
@@ -158,6 +158,40 @@ describe("into a container", () => {
     ).toEqual(["x", "p1"]);
   });
 
+  it("REPORTS A MISSING PARENT AS UNKNOWN, not as a duplicate", () => {
+    // Opposite remedies. None means the container is gone — a stale target, and
+    // the author aims somewhere that exists. More than one means the document
+    // is malformed, which no aiming fixes. Counting "not exactly one" collapsed
+    // them and sent a common stale target to the wrong sentence.
+    const doc = page([node("card", {}, { body: [] })]);
+
+    const plan = planInsertPattern(
+      doc,
+      pattern([node("p1")]),
+      { parentId: "ghost", slot: "body", index: 0 },
+      anyParent
+    );
+
+    expect(plan.problem).toBe("unknown");
+  });
+
+  it("REFUSES A POSITION THE OP LAYER WOULD REFUSE", () => {
+    // Asked of the op layer's own rule, not a second copy of it.
+    const doc = page([node("a")]);
+
+    expect(
+      planInsertPattern(doc, pattern([node("p1")]), { index: -1 }, anyParent)
+        .problem
+    ).toBe("invalid-position");
+
+    // A parent named without its slot — a shape a JavaScript caller can pass
+    // even though the published type forbids it.
+    const noSlot = { parentId: "a", index: 0 } as unknown as { index: number };
+    expect(
+      planInsertPattern(doc, pattern([node("p1")]), noSlot, anyParent).problem
+    ).toBe("invalid-position");
+  });
+
   it("refuses a destination id the document holds twice", () => {
     // `applyOp` refuses this outright: the incoming node would be placed under
     // both. Foreseeing it here is the difference between a refusal an author
@@ -284,6 +318,42 @@ describe("what it refuses before the op layer would", () => {
       doc,
       pattern([node("p1")]),
       { index: 1 },
+      anyParent
+    );
+
+    expect(plan.problem).toBeUndefined();
+    expect(() => applyOps(doc, (plan.pageOps ?? []) as never)).not.toThrow();
+  });
+
+  it("REFUSES REPLACING A DOCUMENT WHOSE IDS ARE NOT UNIQUE", () => {
+    // The replacing target removes every root, and a remove refuses an id the
+    // document holds twice — its own and any in the subtree it takes with it.
+    // A positional insert only cares about the container it aims at, so this
+    // check belongs to this target alone.
+    const doc = page([node("dup"), node("dup")]);
+
+    const plan = planInsertPattern(
+      doc,
+      pattern([node("p1")]),
+      "document",
+      anyParent
+    );
+
+    expect(plan.problem).toBe("duplicate-destination");
+  });
+
+  it("a positional insert does not mind a duplicate id elsewhere", () => {
+    // It removes nothing, so the rule that refuses one does not reach it.
+    const doc = page([
+      node("dup"),
+      node("dup"),
+      node("card", {}, { body: [] }),
+    ]);
+
+    const plan = planInsertPattern(
+      doc,
+      pattern([node("p1")]),
+      { parentId: "card", slot: "body", index: 0 },
       anyParent
     );
 

--- a/packages/blocks-engine/src/insert-pattern.test.ts
+++ b/packages/blocks-engine/src/insert-pattern.test.ts
@@ -1,0 +1,368 @@
+/**
+ * Inserting a saved pattern as a copy that keeps no link back.
+ *
+ * Most of these are about what the planner REFUSES. A plan that reports success
+ * and then throws when it is applied defeats the reason planning is separate
+ * from doing, so every refusal the op layer will make and this can foresee is
+ * asserted here — with `applyOps` run afterwards as the oracle, so a refusal
+ * that stopped being necessary shows up as a test that cannot fail.
+ */
+import { describe, expect, it } from "vitest";
+
+import { applyOps } from "./ops";
+import { planInsertPattern } from "./composition-planners";
+import { DOCUMENT_FORMAT_VERSION } from "./document";
+import type { BlockDocument, BlockNode } from "./document";
+import { walkNodes } from "./tree";
+
+function node(
+  id: string,
+  extra: Partial<BlockNode> = {},
+  slots?: Record<string, BlockNode[]>
+): BlockNode {
+  return {
+    id,
+    type: "core/box",
+    version: 1,
+    props: {},
+    ...extra,
+    ...(slots === undefined ? {} : { slots }),
+  };
+}
+
+const page = (
+  nodes: BlockNode[],
+  settings?: BlockDocument["settings"]
+): BlockDocument => ({
+  formatVersion: DOCUMENT_FORMAT_VERSION,
+  kind: "page",
+  nodes,
+  ...(settings === undefined ? {} : { settings }),
+});
+
+const pattern = (nodes: BlockNode[]): BlockDocument => ({
+  formatVersion: DOCUMENT_FORMAT_VERSION,
+  kind: "pattern",
+  nodes,
+});
+
+const anyParent = { parentsOf: () => undefined };
+
+/** Every id in a forest. */
+function idsIn(nodes: BlockNode[]): string[] {
+  const out: string[] = [];
+  walkNodes(nodes, n => out.push(n.id));
+  return out;
+}
+
+/** The marks of the roots, after applying a plan's ops. */
+function rootMarks(doc: BlockDocument, ops: readonly unknown[]): unknown[] {
+  const applied = applyOps(doc, ops as never);
+  return applied.document.nodes.map(n => n.props?.mark);
+}
+
+describe("a pattern arrives as a copy", () => {
+  it("inserts its roots at the position, in the order they were saved", () => {
+    const doc = page([
+      node("a", { props: { mark: "a" } }),
+      node("b", { props: { mark: "b" } }),
+    ]);
+    const saved = pattern([
+      node("p1", { props: { mark: "p1" } }),
+      node("p2", { props: { mark: "p2" } }),
+    ]);
+
+    const plan = planInsertPattern(doc, saved, { index: 1 }, anyParent);
+
+    expect(plan.problem).toBeUndefined();
+    expect(rootMarks(doc, plan.pageOps ?? [])).toEqual(["a", "p1", "p2", "b"]);
+  });
+
+  it("SHARES NO ID with the pattern it came from", () => {
+    const doc = page([node("a")]);
+    const saved = pattern([node("p1", {}, { body: [node("p1-child")] })]);
+
+    const plan = planInsertPattern(doc, saved, { index: 1 }, anyParent);
+    const applied = applyOps(doc, (plan.pageOps ?? []) as never);
+
+    const placed = idsIn(applied.document.nodes);
+    for (const original of ["p1", "p1-child"]) {
+      expect(placed).not.toContain(original);
+    }
+  });
+
+  it("inserted twice, the two copies collide on nothing", () => {
+    const doc = page([node("a")]);
+    const saved = pattern([node("p1", { cssId: "hero" })]);
+
+    const first = planInsertPattern(doc, saved, { index: 1 }, anyParent);
+    const once = applyOps(doc, (first.pageOps ?? []) as never).document;
+    const second = planInsertPattern(once, saved, { index: 2 }, anyParent);
+    const twice = applyOps(once, (second.pageOps ?? []) as never).document;
+
+    const ids = idsIn(twice.nodes);
+    expect(new Set(ids).size).toBe(ids.length);
+    const cssIds = twice.nodes.map(n => n.cssId).filter(Boolean);
+    expect(new Set(cssIds).size).toBe(cssIds.length);
+  });
+});
+
+describe("the document target", () => {
+  it("replaces the root forest and KEEPS the page's own settings", () => {
+    const doc = page(
+      [
+        node("a", { props: { mark: "a" } }),
+        node("b", { props: { mark: "b" } }),
+      ],
+      { customCss: ".page{}" }
+    );
+    const saved = pattern([node("p1", { props: { mark: "p1" } })]);
+
+    const plan = planInsertPattern(doc, saved, "document", anyParent);
+    const applied = applyOps(doc, (plan.pageOps ?? []) as never);
+
+    expect(applied.document.nodes.map(n => n.props?.mark)).toEqual(["p1"]);
+    expect(applied.document.settings?.customCss).toBe(".page{}");
+  });
+
+  it("starts an empty document from a pattern", () => {
+    const doc = page([]);
+    const saved = pattern([
+      node("p1", { props: { mark: "p1" } }),
+      node("p2", { props: { mark: "p2" } }),
+    ]);
+
+    const plan = planInsertPattern(doc, saved, "document", anyParent);
+
+    expect(rootMarks(doc, plan.pageOps ?? [])).toEqual(["p1", "p2"]);
+  });
+});
+
+describe("into a container", () => {
+  it("inserts into the parent's slot", () => {
+    const doc = page([
+      node("card", {}, { body: [node("x", { props: { mark: "x" } })] }),
+    ]);
+    const saved = pattern([node("p1", { props: { mark: "p1" } })]);
+
+    const plan = planInsertPattern(
+      doc,
+      saved,
+      { parentId: "card", slot: "body", index: 1 },
+      anyParent
+    );
+    const applied = applyOps(doc, (plan.pageOps ?? []) as never);
+
+    expect(
+      applied.document.nodes[0]!.slots!.body!.map(n => n.props?.mark)
+    ).toEqual(["x", "p1"]);
+  });
+
+  it("refuses a destination id the document holds twice", () => {
+    // `applyOp` refuses this outright: the incoming node would be placed under
+    // both. Foreseeing it here is the difference between a refusal an author
+    // can read and an exception from the op layer.
+    const doc = page([
+      node("dup", {}, { body: [] }),
+      node("dup", {}, { body: [] }),
+    ]);
+
+    const plan = planInsertPattern(
+      doc,
+      pattern([node("p1")]),
+      { parentId: "dup", slot: "body", index: 0 },
+      anyParent
+    );
+
+    expect(plan.problem).toBe("duplicate-destination");
+  });
+});
+
+describe("what it refuses before the op layer would", () => {
+  it("refuses a block that may not sit in that parent, naming where it can", () => {
+    const columnsOnly = {
+      parentsOf: (type: string) =>
+        type === "core/column" ? ["core/columns"] : undefined,
+    };
+    const doc = page([node("card", {}, { body: [] })]);
+
+    const plan = planInsertPattern(
+      doc,
+      pattern([node("c", { type: "core/column" })]),
+      { parentId: "card", slot: "body", index: 0 },
+      columnsOnly
+    );
+
+    expect(plan.problem).toBe("wrong-parent");
+    expect(plan.permitted).toEqual(["core/columns"]);
+  });
+
+  it("refuses a block the destination SLOT does not admit", () => {
+    const headerTakesText = {
+      parentsOf: () => undefined,
+      slotAllowOf: (parentType: string, slot: string) =>
+        parentType === "core/box" && slot === "header"
+          ? ["core/text"]
+          : undefined,
+    };
+    const doc = page([node("card", {}, { header: [] })]);
+
+    const plan = planInsertPattern(
+      doc,
+      pattern([node("img", { type: "core/image" })]),
+      { parentId: "card", slot: "header", index: 0 },
+      headerTakesText
+    );
+
+    expect(plan.problem).toBe("not-allowed-in-slot");
+    expect(plan.permitted).toEqual(["core/text"]);
+  });
+
+  it("refuses a restricted block at the document root", () => {
+    const columnsOnly = {
+      parentsOf: (type: string) =>
+        type === "core/column" ? ["core/columns"] : undefined,
+    };
+
+    const plan = planInsertPattern(
+      page([]),
+      pattern([node("c", { type: "core/column" })]),
+      "document",
+      columnsOnly
+    );
+
+    expect(plan.problem).toBe("restricted-at-root");
+  });
+
+  it("REFUSES A LOCKED SUBTREE, which the op layer will not insert", () => {
+    // Not a rule of this planner's own: `applyOp` refuses it because the
+    // inverse of an insert is a remove and a remove refuses a locked subtree,
+    // so the insert could never be undone.
+    const doc = page([node("a")]);
+    const saved = pattern([
+      node("p1", {}, { body: [node("deep", { locked: true })] }),
+    ]);
+
+    const plan = planInsertPattern(doc, saved, { index: 1 }, anyParent);
+
+    expect(plan.problem).toBe("locked");
+  });
+
+  it("REFUSES REPLACING A PAGE THAT HOLDS A LOCKED BLOCK", () => {
+    // The `"document"` target deletes what is there, and a remove refuses a
+    // locked subtree exactly as an insert does. Found by asking what the ops
+    // this planner emits would do, not by review — the planner reported success
+    // and `applyOps` threw.
+    const doc = page([node("keep", { locked: true }), node("b")]);
+
+    const plan = planInsertPattern(
+      doc,
+      pattern([node("p1")]),
+      "document",
+      anyParent
+    );
+
+    expect(plan.problem).toBe("destination-locked");
+  });
+
+  it("tells the page's locked block apart from the pattern's", () => {
+    // Different blocks, and only one of them is in front of the author here.
+    const lockedPattern = pattern([node("p1", { locked: true })]);
+
+    expect(
+      planInsertPattern(page([node("a")]), lockedPattern, "document", anyParent)
+        .problem
+    ).toBe("locked");
+  });
+
+  it("a positional insert does NOT mind a locked block on the page", () => {
+    // Only the replacing target deletes anything; adding beside a locked block
+    // is fine, and refusing it would be this planner inventing a rule.
+    const doc = page([node("keep", { locked: true })]);
+
+    const plan = planInsertPattern(
+      doc,
+      pattern([node("p1")]),
+      { index: 1 },
+      anyParent
+    );
+
+    expect(plan.problem).toBeUndefined();
+    expect(() => applyOps(doc, (plan.pageOps ?? []) as never)).not.toThrow();
+  });
+
+  it("refuses a document that is not a pattern", () => {
+    const notAPattern: BlockDocument = {
+      formatVersion: DOCUMENT_FORMAT_VERSION,
+      kind: "page",
+      nodes: [node("p1")],
+    };
+
+    expect(
+      planInsertPattern(page([]), notAPattern, "document", anyParent).problem
+    ).toBe("not-a-pattern");
+  });
+
+  it("refuses a pattern with nothing in it", () => {
+    expect(
+      planInsertPattern(page([]), pattern([]), "document", anyParent).problem
+    ).toBe("empty");
+  });
+});
+
+describe("the refusals are the op layer's, not invented", () => {
+  it("a plan that succeeds APPLIES — no refusal is left to the apply", () => {
+    // The oracle for every refusal above: if the planner passes it, `applyOps`
+    // must not throw. A refusal that stopped being necessary would show up as a
+    // planner that says no to something this proves is fine.
+    const doc = page([node("a"), node("card", {}, { body: [node("x")] })]);
+    const saved = pattern([node("p1", { cssId: "hero" }), node("p2")]);
+
+    for (const target of [
+      { index: 0 },
+      { index: 2 },
+      { parentId: "card", slot: "body", index: 1 },
+      "document" as const,
+    ]) {
+      const plan = planInsertPattern(doc, saved, target, anyParent);
+      expect(plan.problem).toBeUndefined();
+      expect(() => applyOps(doc, (plan.pageOps ?? []) as never)).not.toThrow();
+    }
+  });
+
+  it("the LOCKED refusal is real: applying that insert throws", () => {
+    const doc = page([node("a")]);
+    const locked = node("p1", {}, { body: [node("deep", { locked: true })] });
+
+    expect(() =>
+      applyOps(doc, [
+        { kind: "insert", node: locked, at: { index: 1 } },
+      ] as never)
+    ).toThrow();
+  });
+
+  it("the DESTINATION-LOCKED refusal is real: applying those removes throws", () => {
+    const doc = page([node("keep", { locked: true }), node("b")]);
+
+    expect(() =>
+      applyOps(doc, [{ kind: "remove", id: "keep" }] as never)
+    ).toThrow();
+  });
+
+  it("the DUPLICATE-DESTINATION refusal is real: applying that insert throws", () => {
+    const doc = page([
+      node("dup", {}, { body: [] }),
+      node("dup", {}, { body: [] }),
+    ]);
+
+    expect(() =>
+      applyOps(doc, [
+        {
+          kind: "insert",
+          node: node("p1"),
+          at: { parentId: "dup", slot: "body", index: 0 },
+        },
+      ] as never)
+    ).toThrow();
+  });
+});

--- a/packages/blocks-engine/src/insert-pattern.test.ts
+++ b/packages/blocks-engine/src/insert-pattern.test.ts
@@ -429,7 +429,7 @@ describe("what it refuses before the op layer would", () => {
     expect(plan.problem).toBeUndefined();
   });
 
-  it("REFUSES A DOCUMENT IN A FORMAT THIS VERSION CANNOT EDIT", () => {
+  it("REFUSES A DESTINATION THE APPLY COULD NOT EDIT AT ALL", () => {
     // `applyOp` refuses to edit such a document before it looks at anything
     // else, so a plan built against one is a plan that cannot apply.
     const old = {
@@ -440,7 +440,34 @@ describe("what it refuses before the op layer would", () => {
     expect(
       planInsertPattern(old, pattern([node("p1")]), { index: 1 }, anyParent)
         .problem
-    ).toBe("unsupported-format");
+    ).toBe("unusable-document");
+  });
+
+  it("refuses a destination with a kind this editor does not know", () => {
+    // Checking the format version alone closed the case that is easy to
+    // imagine and left the ones that are not. The apply asks about the whole
+    // envelope before it looks at an op, so the plan asks the same thing.
+    const odd = {
+      ...page([node("a")]),
+      kind: "spreadsheet",
+    } as unknown as BlockDocument;
+
+    expect(
+      planInsertPattern(odd, pattern([node("p1")]), { index: 1 }, anyParent)
+        .problem
+    ).toBe("unusable-document");
+  });
+
+  it("refuses a destination carrying a value JSON cannot hold", () => {
+    const odd = {
+      ...page([node("a")]),
+      metadata: 1n,
+    } as unknown as BlockDocument;
+
+    expect(
+      planInsertPattern(odd, pattern([node("p1")]), { index: 1 }, anyParent)
+        .problem
+    ).toBe("unusable-document");
   });
 
   it("REFUSES A PLACEMENT INSIDE THE PATTERN THAT THE RULES NOW FORBID", () => {

--- a/packages/blocks-engine/src/insert-pattern.test.ts
+++ b/packages/blocks-engine/src/insert-pattern.test.ts
@@ -383,6 +383,53 @@ describe("what it refuses before the op layer would", () => {
     expect(plan.problem).toBe("invalid-node");
   });
 
+  it("REFUSES A PATTERN THAT SPELLS ONE RENDERED ID TWICE", () => {
+    // Re-identifying does not repair this: two nodes sharing an id map to ONE
+    // replacement on purpose, so the copy carries the duplicate into the page
+    // where an anchor resolves to whichever element the browser reaches first.
+    const broken = pattern([
+      node("p1", { cssId: "hero" }),
+      node("p2", { attributes: { ID: "hero" } }),
+    ]);
+
+    expect(
+      planInsertPattern(page([node("a")]), broken, { index: 1 }, anyParent)
+        .problem
+    ).toBe("duplicate-dom-id");
+  });
+
+  it("REFUSES REPLACING A PAGE THAT HOLDS A MALFORMED NODE", () => {
+    // The replacing target removes every root, and a remove asks the same
+    // shape question an insert does.
+    const doc = page([
+      { id: "bad", type: "core/box", version: 0, props: {} } as BlockNode,
+    ]);
+
+    expect(
+      planInsertPattern(doc, pattern([node("p1")]), "document", anyParent)
+        .problem
+    ).toBe("invalid-node");
+  });
+
+  it("DOES NOT refuse a deep pattern the caller's own limits would accept", () => {
+    // The shape check judges structure, not caps. Depth and size belong to
+    // whoever applies: a host that raises `maxDepth` must not have a plan
+    // refuse a document its own apply accepts.
+    let deep: BlockNode = node("leaf");
+    for (let i = 0; i < 12; i += 1) {
+      deep = node(`w${i}`, {}, { body: [deep] });
+    }
+
+    const plan = planInsertPattern(
+      page([node("a")]),
+      pattern([deep]),
+      { index: 1 },
+      anyParent
+    );
+
+    expect(plan.problem).toBeUndefined();
+  });
+
   it("refuses a document that is not a pattern", () => {
     const notAPattern: BlockDocument = {
       formatVersion: DOCUMENT_FORMAT_VERSION,

--- a/packages/blocks-engine/src/ops.ts
+++ b/packages/blocks-engine/src/ops.ts
@@ -2354,6 +2354,35 @@ function assertNodeId(id: string, verb: string): void {
  * honoured at the node and defeated one level up.
  */
 /**
+ * Why this node would be refused as an insert's subtree, or `undefined`.
+ *
+ * The companion to {@link positionRefusal} and published for the same reason: a
+ * planner has to know whether the subtree it is about to hand over will be
+ * taken. A stored pattern can hold a node that is type-compatible and
+ * structurally invalid — `version: 0` is the cheap example — and without this
+ * the plan reports success and the apply throws.
+ *
+ * Judged against the DEFAULT limits unless a caller says otherwise. The
+ * structural rules do not depend on them; the machine caps on depth and size
+ * do, and a caller that applies with tighter limits can still be refused there.
+ * That one refusal is deliberately left to the apply, because a plan cannot
+ * foresee a cap it was never given.
+ */
+export function nodeShapeRefusal(
+  node: BlockNode,
+  verb = "insert",
+  limits: DocumentLimits = DEFAULT_LIMITS
+): string | undefined {
+  try {
+    assertNodeShape(node, verb, limits);
+    return undefined;
+  } catch (error) {
+    if (error instanceof OpError) return error.message;
+    throw error;
+  }
+}
+
+/**
  * Why this position would be refused, phrased as the op layer phrases it, or
  * `undefined` when it would be accepted.
  *

--- a/packages/blocks-engine/src/ops.ts
+++ b/packages/blocks-engine/src/ops.ts
@@ -2362,16 +2362,20 @@ function assertNodeId(id: string, verb: string): void {
  * structurally invalid — `version: 0` is the cheap example — and without this
  * the plan reports success and the apply throws.
  *
- * Judged against the DEFAULT limits unless a caller says otherwise. The
- * structural rules do not depend on them; the machine caps on depth and size
- * do, and a caller that applies with tighter limits can still be refused there.
- * That one refusal is deliberately left to the apply, because a plan cannot
- * foresee a cap it was never given.
+ * Judged with the SHAPE-ONLY limits by default, which is what makes this usable
+ * from a planner. The structural rules do not depend on limits; the caps on
+ * depth and size do, and those belong to whoever applies — a host that raises
+ * `maxDepth` would otherwise have a plan refuse a document its own apply
+ * accepts, which is the dry run disagreeing with the run it predicts in the
+ * direction nobody can debug. The same constant the remove path uses, for the
+ * same reason: it asks whether this is a node, not whether it fits.
+ *
+ * A caller that wants a cap judged too passes its own limits.
  */
 export function nodeShapeRefusal(
   node: BlockNode,
   verb = "insert",
-  limits: DocumentLimits = DEFAULT_LIMITS
+  limits: DocumentLimits = SHAPE_ONLY_LIMITS
 ): string | undefined {
   try {
     assertNodeShape(node, verb, limits);

--- a/packages/blocks-engine/src/ops.ts
+++ b/packages/blocks-engine/src/ops.ts
@@ -2361,6 +2361,33 @@ function assertNodeId(id: string, verb: string): void {
  * honoured at the node and defeated one level up.
  */
 /**
+ * Why this DOCUMENT could not be edited at all, or `undefined`.
+ *
+ * The third of these asking forms, and the broadest: it covers everything
+ * `applyOp` checks before it looks at the op — the envelope being a record, its
+ * keys being ones JSON carries, `nodes` being an array, the envelope's values
+ * being serializable, `formatVersion` and `kind` being owned and known.
+ *
+ * A planner needs it because a stored destination can fail any of those and a
+ * plan built against one advertises an edit that throws. Checking a single
+ * field instead — the format version, say — closes the case that is easy to
+ * imagine and leaves the ones that are not: a page whose `kind` was written by
+ * a newer version, or one carrying a `BigInt` in an envelope field.
+ *
+ * Reported rather than thrown, and never re-implemented: the assertion is the
+ * rule, and a second predicate spelling of it would agree only until one moved.
+ */
+export function documentRefusal(document: unknown): string | undefined {
+  try {
+    assertEditableDocument(document as BlockDocument);
+    return undefined;
+  } catch (error) {
+    if (error instanceof OpError) return error.message;
+    throw error;
+  }
+}
+
+/**
  * Why this node would be refused as an insert's subtree, or `undefined`.
  *
  * The companion to {@link positionRefusal} and published for the same reason: a
@@ -2716,6 +2743,174 @@ function withNodes(document: BlockDocument, nodes: BlockNode[]): BlockDocument {
 }
 
 /**
+ * Every refusal that is about the DOCUMENT rather than about the edit.
+ *
+ * Extracted so a planner can ask it without applying anything. `applyOp` runs
+ * these before it dispatches an op, so a plan built against a document that
+ * fails any of them is a plan that cannot apply — and a dry run blind to them
+ * advertises success for an edit that throws. {@link documentRefusal} is the
+ * asking form.
+ *
+ * Three questions, asked in an order that is load-bearing: is this a record
+ * whose fields are safe to read, are the values it holds ones an edit can save,
+ * and does it say what it is. Each precedes the next because the next reads
+ * something the previous one vouched for.
+ */
+function assertEditableDocument(document: BlockDocument): void {
+  assertEditableEnvelope(document);
+  assertEnvelopeValues(document);
+  assertDocumentIdentity(document);
+}
+
+/**
+ * The envelope as a shape: a record, holding only keys JSON carries, with a
+ * forest that is an array.
+ *
+ * First, and every check below it depends on that: each one reads a field off
+ * the envelope, which is only safe once the envelope is known to be a record
+ * whose fields are held rather than computed.
+ */
+function assertEditableEnvelope(document: BlockDocument): void {
+  if (!isPlainRecord(document)) {
+    throw new OpError(
+      `a document of ${describe(document)} holds no forest to edit. Every ` +
+        `document is a record whose nodes are an array.`
+    );
+  }
+  // The ENVELOPE's own keys, by the same rule its contents are held to, and
+  // before anything reads a field off it — `nodes` included.
+  //
+  // `withNodes` builds the result by spreading, and a spread copies enumerable
+  // own properties only — so a `kind` or `formatVersion` defined as
+  // non-enumerable is read and accepted by the checks below and then absent
+  // from the document they admitted. The result enters history without a field
+  // every document must carry, and nothing downstream is looking.
+  //
+  // Accessors are refused for the second reason the value checks refuse them:
+  // reading one runs code, and the guard would be executing the document's own
+  // getters while deciding whether to trust it.
+  if (!hasOnlyJsonOwnKeys(document)) {
+    throw new OpError(
+      `a document carrying a field JSON cannot write, or one computed rather ` +
+        `than held, cannot be edited. Every field a document names must ` +
+        `survive being written down and read back.`
+    );
+  }
+  // NOW the forest, once reading a field off the envelope is known to be safe.
+  if (!Array.isArray(document.nodes)) {
+    throw new OpError(
+      `a document whose nodes are ${describe(document.nodes)} holds no forest ` +
+        `to edit. Every document is a record whose nodes are an array.`
+    );
+  }
+}
+
+/**
+ * The envelope's VALUES, which its descriptors say nothing about.
+ *
+ * Separate from the shape because it answers a different question and pays a
+ * different cost: this one walks, under a shared budget, and it is the check
+ * that stops a value the edit cannot serialize from reaching a save.
+ */
+function assertEnvelopeValues(document: BlockDocument): void {
+  // The envelope's VALUES, not only its keys. Descriptors say a field is held
+  // rather than computed; they say nothing about what is held. An in-process
+  // document carrying `metadata: 1n` satisfies every check above, and then
+  // `documentBytes` leaks `TypeError: Do not know how to serialize a BigInt`
+  // from inside an insert, a move or an update — while a remove, which never
+  // measures bytes, succeeds and hands back a document that cannot be saved.
+  //
+  // The forest is excluded deliberately rather than overlooked. `isJsonValue`
+  // refuses past its own value-depth bound, which is far below the depth a
+  // document may legitimately reach, so walking `nodes` through it would refuse
+  // documents the machine cap allows and name the wrong reason for it. The
+  // forest has its own entry walk, its own depth guard and its own per-op value
+  // checks; this covers the fields none of those look at.
+  //
+  // ONE budget across every envelope field, not one per field. A fresh
+  // `isJsonValue` call per key lets several fields referencing the same large
+  // dense array each pay the full walk, so a two-million-element array named by
+  // a handful of unknown envelope fields is cheap to construct and forces
+  // hundreds of millions of visits before any cap runs. The same shared
+  // decision the forest and an inserted subtree already use.
+  const envelopeKeys: string[] = [];
+  const envelopeValues: unknown[] = [];
+  for (const [key, value] of Object.entries(document)) {
+    if (key === "nodes") continue;
+    envelopeKeys.push(key);
+    envelopeValues.push(value);
+  }
+  if (!areJsonValues(envelopeValues)) {
+    // The offender named on the failing branch only, where a second walk is
+    // affordable because it runs once and then throws.
+    for (let index = 0; index < envelopeValues.length; index += 1) {
+      if (isJsonValue(envelopeValues[index])) continue;
+      throw new OpError(
+        `a document whose ${describe(envelopeKeys[index])} is ` +
+          `${describe(envelopeValues[index])} cannot be edited: JSON cannot ` +
+          `write that value, so the edit would apply and then fail to save.`
+      );
+    }
+    throw new OpError(
+      `this document's fields hold more values than an edit may examine, so ` +
+        `it would not save.`
+    );
+  }
+}
+
+/**
+ * What the document says it IS: its format and its kind, owned rather than
+ * inherited, and both known to this version.
+ *
+ * Last, because it reads two fields and the checks above are what make reading
+ * a field off this envelope safe.
+ */
+function assertDocumentIdentity(document: BlockDocument): void {
+  // Every ENTRY, not just the array. A stored forest carrying a `null` or a
+  // primitive passes the array check and then reaches helpers that read `.id`
+  // off it, so the failure surfaces as a TypeError from inside the engine
+  // rather than as a refusal naming the malformed document.
+  // The format this module knows how to edit. A document written by a newer
+  // version may carry fields with meanings this code does not have, and editing
+  // it with current semantics silently rewrites them. Refused rather than
+  // guessed: an editor that cannot read a document should say so, not save over
+  // it.
+  // OWN properties, not merely resolvable ones. `Object.prototype` can be given
+  // a `formatVersion` or a `kind`, and a document owning only `nodes` then
+  // satisfies both comparisons below by INHERITING them — while `withNodes`
+  // spreads, which copies own enumerable properties only. The edit succeeds and
+  // hands back `{ nodes: [] }` with neither mandatory field, so the document
+  // that enters history is missing what every reader after it requires.
+  for (const field of ["formatVersion", "kind"] as const) {
+    if (!Object.hasOwn(document, field)) {
+      throw new OpError(
+        `a document that does not carry its own ${field} cannot be edited. ` +
+          `The field resolves through the prototype, so the edit would return ` +
+          `a document without it.`
+      );
+    }
+  }
+  if (document.formatVersion !== DOCUMENT_FORMAT_VERSION) {
+    throw new OpError(
+      `a document in format ${describe(document.formatVersion)} cannot be ` +
+        `edited by this version, which writes format ` +
+        `${String(DOCUMENT_FORMAT_VERSION)}. Editing it would rewrite fields ` +
+        `whose meaning this code does not know.`
+    );
+  }
+  // The kind, asked of the engine's own set rather than restated here. A
+  // document with a missing or unknown kind is accepted by every structural
+  // check and then refused by `validate()` with `invalid-kind`, so the edit
+  // enters history and every save afterwards fails.
+  if (!DOCUMENT_KINDS.includes(document.kind)) {
+    throw new OpError(
+      `a document of kind ${describe(document.kind)} is not one this editor ` +
+        `knows. Every document names a kind from: ${DOCUMENT_KINDS.join(", ")}.`
+    );
+  }
+}
+
+/**
  * Apply one op, returning the new forest and the op that undoes it.
  *
  * **A document handed to this function must be treated as immutable
@@ -2773,124 +2968,8 @@ export function applyOp(
   // enumerable `nodes` is a throwing accessor ran its getter here and left this
   // module as a native error rather than the `OpError` it promises — the exact
   // fault the descriptor check exists to refuse, reached one line before it.
-  if (!isPlainRecord(document)) {
-    throw new OpError(
-      `a document of ${describe(document)} holds no forest to edit. Every ` +
-        `document is a record whose nodes are an array.`
-    );
-  }
-  // The ENVELOPE's own keys, by the same rule its contents are held to, and
-  // before anything reads a field off it — `nodes` included.
-  //
-  // `withNodes` builds the result by spreading, and a spread copies enumerable
-  // own properties only — so a `kind` or `formatVersion` defined as
-  // non-enumerable is read and accepted by the checks below and then absent
-  // from the document they admitted. The result enters history without a field
-  // every document must carry, and nothing downstream is looking.
-  //
-  // Accessors are refused for the second reason the value checks refuse them:
-  // reading one runs code, and the guard would be executing the document's own
-  // getters while deciding whether to trust it.
-  if (!hasOnlyJsonOwnKeys(document)) {
-    throw new OpError(
-      `a document carrying a field JSON cannot write, or one computed rather ` +
-        `than held, cannot be edited. Every field a document names must ` +
-        `survive being written down and read back.`
-    );
-  }
-  // NOW the forest, once reading a field off the envelope is known to be safe.
-  if (!Array.isArray(document.nodes)) {
-    throw new OpError(
-      `a document whose nodes are ${describe(document.nodes)} holds no forest ` +
-        `to edit. Every document is a record whose nodes are an array.`
-    );
-  }
-  // The envelope's VALUES, not only its keys. Descriptors say a field is held
-  // rather than computed; they say nothing about what is held. An in-process
-  // document carrying `metadata: 1n` satisfies every check above, and then
-  // `documentBytes` leaks `TypeError: Do not know how to serialize a BigInt`
-  // from inside an insert, a move or an update — while a remove, which never
-  // measures bytes, succeeds and hands back a document that cannot be saved.
-  //
-  // The forest is excluded deliberately rather than overlooked. `isJsonValue`
-  // refuses past its own value-depth bound, which is far below the depth a
-  // document may legitimately reach, so walking `nodes` through it would refuse
-  // documents the machine cap allows and name the wrong reason for it. The
-  // forest has its own entry walk, its own depth guard and its own per-op value
-  // checks; this covers the fields none of those look at.
-  //
-  // ONE budget across every envelope field, not one per field. A fresh
-  // `isJsonValue` call per key lets several fields referencing the same large
-  // dense array each pay the full walk, so a two-million-element array named by
-  // a handful of unknown envelope fields is cheap to construct and forces
-  // hundreds of millions of visits before any cap runs. The same shared
-  // decision the forest and an inserted subtree already use.
-  const envelopeKeys: string[] = [];
-  const envelopeValues: unknown[] = [];
-  for (const [key, value] of Object.entries(document)) {
-    if (key === "nodes") continue;
-    envelopeKeys.push(key);
-    envelopeValues.push(value);
-  }
-  if (!areJsonValues(envelopeValues)) {
-    // The offender named on the failing branch only, where a second walk is
-    // affordable because it runs once and then throws.
-    for (let index = 0; index < envelopeValues.length; index += 1) {
-      if (isJsonValue(envelopeValues[index])) continue;
-      throw new OpError(
-        `a document whose ${describe(envelopeKeys[index])} is ` +
-          `${describe(envelopeValues[index])} cannot be edited: JSON cannot ` +
-          `write that value, so the edit would apply and then fail to save.`
-      );
-    }
-    throw new OpError(
-      `this document's fields hold more values than an edit may examine, so ` +
-        `it would not save.`
-    );
-  }
+  assertEditableDocument(document);
   const nodes = document.nodes;
-  // Every ENTRY, not just the array. A stored forest carrying a `null` or a
-  // primitive passes the array check and then reaches helpers that read `.id`
-  // off it, so the failure surfaces as a TypeError from inside the engine
-  // rather than as a refusal naming the malformed document.
-  // The format this module knows how to edit. A document written by a newer
-  // version may carry fields with meanings this code does not have, and editing
-  // it with current semantics silently rewrites them. Refused rather than
-  // guessed: an editor that cannot read a document should say so, not save over
-  // it.
-  // OWN properties, not merely resolvable ones. `Object.prototype` can be given
-  // a `formatVersion` or a `kind`, and a document owning only `nodes` then
-  // satisfies both comparisons below by INHERITING them — while `withNodes`
-  // spreads, which copies own enumerable properties only. The edit succeeds and
-  // hands back `{ nodes: [] }` with neither mandatory field, so the document
-  // that enters history is missing what every reader after it requires.
-  for (const field of ["formatVersion", "kind"] as const) {
-    if (!Object.hasOwn(document, field)) {
-      throw new OpError(
-        `a document that does not carry its own ${field} cannot be edited. ` +
-          `The field resolves through the prototype, so the edit would return ` +
-          `a document without it.`
-      );
-    }
-  }
-  if (document.formatVersion !== DOCUMENT_FORMAT_VERSION) {
-    throw new OpError(
-      `a document in format ${describe(document.formatVersion)} cannot be ` +
-        `edited by this version, which writes format ` +
-        `${String(DOCUMENT_FORMAT_VERSION)}. Editing it would rewrite fields ` +
-        `whose meaning this code does not know.`
-    );
-  }
-  // The kind, asked of the engine's own set rather than restated here. A
-  // document with a missing or unknown kind is accepted by every structural
-  // check and then refused by `validate()` with `invalid-kind`, so the edit
-  // enters history and every save afterwards fails.
-  if (!DOCUMENT_KINDS.includes(document.kind)) {
-    throw new OpError(
-      `a document of kind ${describe(document.kind)} is not one this editor ` +
-        `knows. Every document names a kind from: ${DOCUMENT_KINDS.join(", ")}.`
-    );
-  }
   assertForestEntries(nodes);
   // Depth the ENGINE can survive, checked before any of its helpers run.
   //

--- a/packages/blocks-engine/src/ops.ts
+++ b/packages/blocks-engine/src/ops.ts
@@ -2354,6 +2354,38 @@ function assertNodeId(id: string, verb: string): void {
  * honoured at the node and defeated one level up.
  */
 /**
+ * Why this position would be refused, phrased as the op layer phrases it, or
+ * `undefined` when it would be accepted.
+ *
+ * The SAME rule the apply runs, reached without applying anything. A planner
+ * has to know whether the position it is about to emit will be taken, and the
+ * alternative — a second, non-throwing copy of `assertPosition` — is the
+ * parallel implementation this package refuses everywhere else: it would agree
+ * on the day it was written and diverge the first time either moved.
+ *
+ * Expressed by catching rather than by restructuring the validator, and that is
+ * deliberate. `assertPosition` reports a different sentence per malformed field,
+ * so a predicate form of it IS this function; and it carries a
+ * `fallow-ignore-next-line complexity` suppression as RELOCATED code, so
+ * rewriting it here would reopen a move that was made byte-for-byte on purpose.
+ * Only an `OpError` is treated as a refusal — anything else is a fault in this
+ * module and is rethrown rather than reported as a bad position.
+ */
+export function positionRefusal(
+  at: unknown,
+  verb = "insert"
+): string | undefined {
+  try {
+    assertPositionContainer(at, verb);
+    assertPosition(at as TreePosition, verb);
+    return undefined;
+  } catch (error) {
+    if (error instanceof OpError) return error.message;
+    throw error;
+  }
+}
+
+/**
  * The first locked node anywhere in a subtree, or `undefined`.
  *
  * Exported because a PLANNER has to be able to ask it before an insert is

--- a/packages/blocks-engine/src/ops.ts
+++ b/packages/blocks-engine/src/ops.ts
@@ -2370,7 +2370,11 @@ function assertNodeId(id: string, verb: string): void {
  * direction nobody can debug. The same constant the remove path uses, for the
  * same reason: it asks whether this is a node, not whether it fits.
  *
- * A caller that wants a cap judged too passes its own limits.
+ * A caller may pass its own limits to have the node-count and depth caps judged
+ * as well. The BYTE cap is not among them and cannot be: `assertFitsCaps`
+ * measures the document the node is going into, and this is handed a subtree
+ * with no destination. A caller that needs the byte cap judged has to ask the
+ * apply, which is where the destination is.
  */
 export function nodeShapeRefusal(
   node: BlockNode,

--- a/packages/blocks-engine/src/ops.ts
+++ b/packages/blocks-engine/src/ops.ts
@@ -2353,7 +2353,18 @@ function assertNodeId(id: string, verb: string): void {
  * an author delete a locked block by deleting the column it sits in — the lock
  * honoured at the node and defeated one level up.
  */
-function lockedWithin(node: BlockNode): string | undefined {
+/**
+ * The first locked node anywhere in a subtree, or `undefined`.
+ *
+ * Exported because a PLANNER has to be able to ask it before an insert is
+ * built. `applyOp` refuses an insert whose subtree arrives locked — the inverse
+ * of an insert is a remove, and a remove refuses a locked subtree, so accepting
+ * it would put the document one edit from a state its own undo could not leave.
+ * A planner that could not ask would report a plan the apply then throws on,
+ * which is exactly the gap between a dry run and a real run that planning
+ * separately exists to close.
+ */
+export function lockedWithin(node: BlockNode): string | undefined {
   let found: string | undefined;
   walkNodes([node], candidate => {
     if (found === undefined && candidate.locked === true) found = candidate.id;


### PR DESCRIPTION
Plan 06 (Phase 5), T-2 slice 3. Follows #1554, which shipped `planSaveAsPattern`; this is its inverse and the planner T-3 ("insert a pattern, and save a selection as one") needs.

## What ships

**`planInsertPattern(document, pattern, target, nesting)`** — pure, returning only `pageOps`: nothing is created, so `create` is absent and the return is typed `PlanResult<never>` to say so.

The pattern's roots are re-identified **together**, so a pattern placed twice on one page shares no node id and no DOM id with its other copy, and a reference crossing from one root to the next follows the copy instead of pointing back at the library.

**The `"document"` target** replaces the root forest and leaves the page's own `settings` alone — a full-page pattern is a page layout, and starting an empty page from one should not repaint it.

## The refusals are the substance

The design's argument for planning separately from doing is that *the plan IS the dry run*, so what a preview shows and what a save applies cannot differ. A plan that reports success and then throws on apply breaks exactly that. So the planner asks everything the op layer will ask and can be asked early:

| Refusal | Why the op layer makes it |
|---|---|
| `wrong-parent` / `not-allowed-in-slot` / `restricted-at-root` | both halves of the shared nesting rule — the child naming its permitted parents, and the slot naming what it admits |
| `locked` | `applyOp` refuses an insert whose subtree arrives locked: its inverse is a remove, and a remove refuses a locked subtree, so the insert could never be undone |
| `destination-locked` | the `"document"` target **deletes** what is there, and that remove hits the same rule from the other side |
| `duplicate-destination` | `applyOp` refuses an insert whose destination id is held twice — the node would be placed under both |
| `not-a-pattern`, `empty` | a page document or an empty one is not something to insert |

A refusal **names what it needs**: a block that may not sit in a container reports the parents it does permit, and a slot reports what it admits, so a surface can say where the block *can* go rather than only that it cannot go here.

## One I found before review did

`destination-locked` was not on my list. I asked what the ops this planner emits would actually do, and measured:

```
planner problem: (none — reports success)
apply: THROWS: remove: "keep" is locked and sits inside what this would delete.
```

It is told apart from `locked` deliberately. They are different blocks and only one is in front of the author — the pattern's locked block is inside something they are placing; the page's is on the screen. A single cause would have sent both to whichever sentence was written first, which is the same discrimination the `unknown`/`split` split makes in `siblingRun`.

There is also a test that a **positional** insert does *not* mind a locked block on the page. Only the replacing target deletes anything, and refusing there would be this planner inventing a rule the op layer does not have.

## Verification

Every refusal has a companion test proving the op layer really makes it — `applyOps` throwing on the same input. That is the oracle: a refusal that stops being necessary shows up as a planner saying no to something provably fine, rather than as quietly redundant code.

The positive case has one too: **every target the planner accepts is applied through `applyOps` and must not throw**. So the refusal list cannot silently grow past what the apply actually requires.

Break-verified, each killing only its own tests:

| Wrong implementation | Killed |
|---|---|
| skip the locked checks | 2 |
| skip the nesting check | 3 |
| skip the duplicate-destination check | 1 |
| insert every root at the same index | 2 |
| keep the pattern's own ids (no reid) | 2 |
| replace the document without removing what is there | 1 |

**One branch deliberately has no test.** The DOM-id collision retry: the minted suffix comes from a fresh UUID, so no test can arrange for the destination to already hold the string about to be drawn — an assertion there could not fail. It is stated in the source, and the property it protects *is* covered, by inserting one pattern twice and finding no repeated DOM id.

## Gates

| Gate | Exit |
|---|---|
| `fallow audit --gate new-only --base origin/main` | **0** — `pass`, `changed_files_count: 5`, `introduced: 0` everywhere |
| `npm run check:comments` | **0** |
| `npx changeset status` | **0** |
| `npx turbo run check-types` | **0** — 42/42 |

Suites, each from its own package directory: `blocks-engine` 46 files / 1988 tests, `builder` 100 / 2804, `blocks-react` 48 / 1162, `plugin-page-builder` 59 / 639, `plugin-sdk` 4 / 20. All exit 0.

## A founder decision this surfaced

Design §6.3 says each inserted root gains an inert `origin: { pattern, digest }` so "upstream changed" is answerable later, citing **Q12**. Two things were not true of that as written:

1. **Q12 was never ruled** — the design says "Recommendation: yes. What I need from you: yes or no", and there was no ledger node, so nothing was tracking that it needs the founder.
2. **It is not additive.** `origin` is not one of the fifteen keys in the frozen `keyof BlockNode` ([block-document.test-d.ts:112](packages/nextly/src/plugins/codegen/block-document.test-d.ts#L112)), so recording it changes the stored format, the golden schema and the generated parser.

So this ships **without** provenance, and `decision:pb6-q12-provenance-on-copies` is now filed with the trade-off spelled out. The design's own argument — "cheap now, impossible to backfill" — is a reason to decide it soon rather than a reason for me to decide it.

## Next in this row

`planSaveAsComponent` and `planConvertToComponent`, then `planDetach` (which must inline the **resolved** subtree through `resolveComponentInstances`, not a second traversal), `planUpdatePatternFromSelection`, `planDuplicateComponent`, then the write-side cycle check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for inserting saved patterns into documents or specific slots.
  * Inserted patterns are copied independently with fresh identifiers and preserve saved ordering.
  * Document-level insertion replaces existing roots while preserving page settings.
  * Added validation for invalid destinations, locked areas, malformed content, duplicate identifiers, unsupported formats, and nesting conflicts.
  * Locked content remains protected after insertion while preserving undo support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->