### PR TITLE
feat(blocks-engine,nextly): record where a copied subtree came from

### DIFF
--- a/.changeset/a-copy-remembers-where-it-came-from.md
+++ b/.changeset/a-copy-remembers-where-it-came-from.md
@@ -64,3 +64,16 @@ valid, and documents carrying the new field are readable by older code — the
 node schema already admits properties it does not know, and an unknown node
 field is measured to survive an op round trip unchanged. So `formatVersion` does
 not move.
+
+The provenance type is reachable from every entry point that publishes the field
+that names it. A package that exports `BlockNode` and not the union one of its
+fields holds leaves a consumer able to read the value and unable to write its
+type, which is the coupling those entry points exist to avoid — and the
+renderer package already had a guard saying so, which caught it.
+
+The import scanner behind the format entry's boundary test no longer reads an
+import out of ordinary code. A module specifier cannot contain a newline, and
+without that constraint the literal `"from"` matched the keyword pattern — the
+string's closing quote read as a specifier's opening one, capturing the next two
+lines and reporting them as an external dependency. Any code holding that string
+would have tripped it.

--- a/.changeset/a-copy-remembers-where-it-came-from.md
+++ b/.changeset/a-copy-remembers-where-it-came-from.md
@@ -1,0 +1,66 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A copied subtree can record where it came from, so "the thing this came from has
+changed — do you want the change?" becomes answerable later.
+
+`BlockNode.origin` is inert: no renderer reads it, no validator requires it, and
+a document without one is complete. It exists to be read later by a surface
+asking whether an upstream source has moved on — the question every mature
+builder's users ask and none of them answer, because an unsynced copy keeps no
+record of its source. It cannot be added retroactively: a page built before the
+field exists can never be told where its blocks came from, which is why it lands
+while the format is still pre-alpha rather than when the feature that reads it
+is built.
+
+ONE field with a discriminant, rather than one field per source. A pattern copy
+and a detached component are two provenances today and there will be more — an
+imported document, a duplicated page — and each as its own key is a stored
+format that grows a column per feature. The discriminant also lets the arms
+differ honestly: a pattern copy carries a digest of what it copied, because the
+pattern can change underneath it; a detached component carries none, because
+detaching is the act of declining further change.
+
+The digest is of CONTENT rather than a version number. The engine is handed a
+document and not an entry row, so it can hash what it was given and cannot see
+what the store calls it — and content answers the question more precisely
+anyway, since a re-save that changed nothing bumps a version and leaves a digest
+alone.
+
+A half-formed record is refused rather than stored. A pattern origin with no
+digest, an empty id, or a source nobody declared would be written and then read
+by a surface that trusts it, so the op layer checks the shape the way it checks
+every other node field. The record is also removable by an ordinary update:
+provenance is a record and not a lock, and a field an update can never address
+is one that can only be removed by deleting the node it sits on.
+
+The stored format gains an optional field and nothing else. Old documents remain
+valid, and documents carrying the new field are readable by older code — the
+node schema already admits properties it does not know, and an unknown node
+field is measured to survive an op round trip unchanged. So `formatVersion` does
+not move.

--- a/packages/blocks-engine/src/document.ts
+++ b/packages/blocks-engine/src/document.ts
@@ -9,6 +9,7 @@
  * a framework.
  */
 import { isPlainRecord } from "./plain-record";
+import { ownEntry } from "./safe-record";
 
 /**
  * Engine document-format version. Bumped only when the envelope shape itself
@@ -203,6 +204,31 @@ export type BlockOrigin =
       /** The component definition's id. */
       readonly id: string;
     };
+
+/**
+ * Whether a stored value is a whole provenance record.
+ *
+ * Beside the type rather than beside either caller, because a document reaches
+ * storage by more than one road: an op through the edit vocabulary, and a field
+ * write through the document validator. A record that one road admits and the
+ * other refuses is a record that exists in the database and cannot be edited,
+ * so both ask this.
+ *
+ * Whole means every field the arm needs. A pattern origin without a digest
+ * cannot answer whether its source moved, which is the only question it exists
+ * for — storing one would leave a later reader with a record it must special
+ * case rather than trust.
+ */
+export function isBlockOrigin(value: unknown): value is BlockOrigin {
+  if (!isPlainRecord(value)) return false;
+  const id = ownEntry(value, "id");
+  if (typeof id !== "string" || id === "") return false;
+  const from = ownEntry(value, "from");
+  if (from === "component") return true;
+  if (from !== "pattern") return false;
+  const digest = ownEntry(value, "digest");
+  return typeof digest === "string" && digest !== "";
+}
 
 // ---------------------------------------------------------------------------
 // Bindings — typed field paths, never expressions

--- a/packages/blocks-engine/src/document.ts
+++ b/packages/blocks-engine/src/document.ts
@@ -151,7 +151,58 @@ export interface BlockNode {
    * last-good props; a renderer shows a placeholder instead of crashing.
    */
   migrationFailed?: boolean;
+  /**
+   * Where this subtree was copied from, recorded once and never rendered.
+   *
+   * Written when a copy is taken and read by nothing at render time, the way
+   * {@link BlockNode.migrationFailed} is. What it buys is the one question a
+   * copy cannot otherwise answer: "the thing this came from has changed — do
+   * you want the change?" That question is asked by every mature builder's
+   * users and answered by none of them, because an unsynced copy keeps no
+   * record of its source.
+   *
+   * ONE field with a discriminant rather than one field per source. A pattern
+   * copy and a detached component are two provenances today and there will be
+   * more — an imported document, a duplicated page — and each of those as its
+   * own key is a stored format that grows a column per feature. The
+   * discriminant also makes the shapes differ honestly: a pattern copy carries
+   * a digest because the pattern it came from can change underneath it, and a
+   * detached component does not, because detaching is the act of declining
+   * further change.
+   */
+  origin?: BlockOrigin;
 }
+
+/**
+ * Where a copied subtree came from.
+ *
+ * Inert: no renderer reads it, no validator requires it, and a document
+ * without one is complete. It exists to be read LATER, by a surface asking
+ * whether an upstream source has moved on.
+ */
+export type BlockOrigin =
+  | {
+      /** Copied from a pattern, which keeps no link back. */
+      readonly from: "pattern";
+      /** The pattern entry's id. */
+      readonly id: string;
+      /**
+       * A digest of the pattern's content when this copy was taken.
+       *
+       * Content rather than a version number, because the engine is handed a
+       * document and not an entry row — it can hash what it was given and
+       * cannot see what the store calls it. A digest also answers the question
+       * more precisely than a version does: a re-save that changed nothing
+       * bumps a version and leaves a digest alone.
+       */
+      readonly digest: string;
+    }
+  | {
+      /** Detached from a component, severing the link deliberately. */
+      readonly from: "component";
+      /** The component definition's id. */
+      readonly id: string;
+    };
 
 // ---------------------------------------------------------------------------
 // Bindings — typed field paths, never expressions

--- a/packages/blocks-engine/src/format-boundary.test.ts
+++ b/packages/blocks-engine/src/format-boundary.test.ts
@@ -53,8 +53,16 @@ export function specifiersIn(source: string): string[] {
   // `import(` is matched with its parenthesis so a dynamic import is seen; the
   // bare `import "x"` alternative would not reach it, because the quote does
   // not follow the keyword directly.
+  //
+  // The capture excludes a NEWLINE because a module specifier cannot contain
+  // one, and without that this reads a false import out of ordinary code: the
+  // literal `"from"` ends with a quote, so the keyword pattern matches the word
+  // inside the string and captures everything up to the next quote — which for
+  // `ownEntry(value, "from")` followed by a comparison is a fragment of the
+  // next two lines. Excluding the newline cannot hide a real specifier and does
+  // refuse that.
   for (const match of source.matchAll(
-    /(?:from|import)\s*\(?\s*['"]([^'"]+)['"]/g
+    /(?:from|import)\s*\(?\s*['"]([^'"\n]+)['"]/g
   )) {
     found.push(match[1]!);
   }
@@ -95,6 +103,37 @@ function externalImports(files: string[]): Set<string> {
 function bytesOf(files: string[]): number {
   return files.reduce((total, file) => total + statSync(file).size, 0);
 }
+
+describe("the import scanner", () => {
+  it("does not read an import out of a string literal named like the keyword", () => {
+    // `"from"` ends in a quote, so a keyword match that allowed a newline in
+    // the specifier captured the next two lines of ordinary code and reported
+    // it as an external dependency. A module specifier has no newline in it.
+    const source = [
+      'const from = ownEntry(value, "from");',
+      'if (from === "component") return true;',
+    ].join("\n");
+
+    expect(specifiersIn(source)).toEqual([]);
+  });
+
+  it("still sees every real specifier shape", () => {
+    // The control: the narrowing must not cost a form the walk depends on.
+    const source = [
+      'import { a } from "./a";',
+      'export { b } from "./b";',
+      'import "./side-effect";',
+      'const c = await import("./c");',
+    ].join("\n");
+
+    expect(specifiersIn(source)).toEqual([
+      "./a",
+      "./b",
+      "./side-effect",
+      "./c",
+    ]);
+  });
+});
 
 describe("the format entry point's boundary", () => {
   const formatEntry = join(DIST, "format.mjs");

--- a/packages/blocks-engine/src/format.ts
+++ b/packages/blocks-engine/src/format.ts
@@ -62,7 +62,7 @@ export { measureBytes, surveyDocument } from "./measure-bytes";
 // against without reaching past it — which is the coupling this entry exists to
 // avoid.
 export type { DocumentSurvey, SurveyLimits } from "./measure-bytes";
-export type { BlockDocument, BlockNode } from "./document";
+export type { BlockDocument, BlockNode, BlockOrigin } from "./document";
 export { isPlainRecord } from "./plain-record";
 
 export {

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -68,6 +68,7 @@ export type {
   Condition,
   DocumentFormatVersion,
   DocumentKind,
+  BlockOrigin,
   DocumentSettings,
   LocaleOverlay,
   LocaleOverlayValue,

--- a/packages/blocks-engine/src/ops.ts
+++ b/packages/blocks-engine/src/ops.ts
@@ -58,10 +58,11 @@ import {
 } from "./limits";
 import { measureBytes } from "./measure-bytes";
 import { isPlainRecord } from "./plain-record";
+import { isUsableSlotName } from "./registry";
+import { ownEntry } from "./safe-record";
 // The engine's own predicate, so a slot name is judged the same way at a
 // block's declaration and on every op that carries one. Two gates answering
 // differently is how a name a position could not use gets in through a subtree.
-import { isUsableSlotName } from "./registry";
 import {
   findNode,
   insertNode,
@@ -152,6 +153,7 @@ const NODE_FIELDS: {
   cssId: { holds: isString, optional: true },
   attributes: { holds: isStringRecord, optional: true },
   migrationFailed: { holds: isBoolean, optional: true },
+  origin: { holds: isBlockOrigin, optional: true },
 };
 
 /**
@@ -180,6 +182,11 @@ const PATCH_FIELDS: { readonly [K in keyof Required<NodePatch>]: true } = {
   cssId: true,
   attributes: true,
   migrationFailed: true,
+  // Patchable, like `migrationFailed`, rather than sealed. Provenance is a
+  // record and not a lock: an author who deliberately severs the link to a
+  // pattern should be able to, and a field an update can never address is one
+  // that can only be removed by deleting the node it sits on.
+  origin: true,
 };
 
 /** A field name an update may address. */
@@ -954,6 +961,27 @@ function isStringRecord(value: unknown): boolean {
  */
 function isSlotMap(value: unknown): boolean {
   return isPlainRecord(value) && Object.values(value).every(Array.isArray);
+}
+
+/**
+ * A provenance record: a known source, a non-empty id, and a digest when the
+ * source is one that can move underneath the copy.
+ *
+ * Checked field by field rather than trusted, for the same reason every other
+ * entry in {@link NODE_FIELDS} is: an op arrives from storage, a crash buffer
+ * or an agent, and a half-formed record here would be stored and then read by
+ * a surface asking whether the upstream has changed — which would answer about
+ * an id that is not one.
+ */
+function isBlockOrigin(value: unknown): boolean {
+  if (!isPlainRecord(value)) return false;
+  const from = ownEntry(value, "from");
+  const id = ownEntry(value, "id");
+  if (typeof id !== "string" || id === "") return false;
+  if (from === "component") return true;
+  if (from !== "pattern") return false;
+  const digest = ownEntry(value, "digest");
+  return typeof digest === "string" && digest !== "";
 }
 
 /**

--- a/packages/blocks-engine/src/ops.ts
+++ b/packages/blocks-engine/src/ops.ts
@@ -45,10 +45,11 @@
  */
 
 import {
-  DOCUMENT_FORMAT_VERSION,
-  DOCUMENT_KINDS,
   type BlockDocument,
   type BlockNode,
+  DOCUMENT_FORMAT_VERSION,
+  DOCUMENT_KINDS,
+  isBlockOrigin,
 } from "./document";
 import {
   countNodes,
@@ -59,7 +60,6 @@ import {
 import { measureBytes } from "./measure-bytes";
 import { isPlainRecord } from "./plain-record";
 import { isUsableSlotName } from "./registry";
-import { ownEntry } from "./safe-record";
 // The engine's own predicate, so a slot name is judged the same way at a
 // block's declaration and on every op that carries one. Two gates answering
 // differently is how a name a position could not use gets in through a subtree.
@@ -961,27 +961,6 @@ function isStringRecord(value: unknown): boolean {
  */
 function isSlotMap(value: unknown): boolean {
   return isPlainRecord(value) && Object.values(value).every(Array.isArray);
-}
-
-/**
- * A provenance record: a known source, a non-empty id, and a digest when the
- * source is one that can move underneath the copy.
- *
- * Checked field by field rather than trusted, for the same reason every other
- * entry in {@link NODE_FIELDS} is: an op arrives from storage, a crash buffer
- * or an agent, and a half-formed record here would be stored and then read by
- * a surface asking whether the upstream has changed — which would answer about
- * an id that is not one.
- */
-function isBlockOrigin(value: unknown): boolean {
-  if (!isPlainRecord(value)) return false;
-  const from = ownEntry(value, "from");
-  const id = ownEntry(value, "id");
-  if (typeof id !== "string" || id === "") return false;
-  if (from === "component") return true;
-  if (from !== "pattern") return false;
-  const digest = ownEntry(value, "digest");
-  return typeof digest === "string" && digest !== "";
 }
 
 /**

--- a/packages/blocks-engine/src/origin.test.ts
+++ b/packages/blocks-engine/src/origin.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Provenance on a copied subtree.
+ *
+ * The field is INERT — nothing renders it and no document needs one — so the
+ * tests here are about the two things that can still go wrong with an inert
+ * field: that the op layer carries it faithfully, and that it refuses a
+ * half-formed one rather than storing a record a later reader would trust.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { BlockDocument, BlockNode, BlockOrigin } from "./document";
+import { applyOps } from "./ops";
+
+const page = (nodes: BlockNode[]): BlockDocument => ({
+  formatVersion: 1,
+  kind: "page",
+  nodes,
+});
+
+const node = (id: string, origin?: BlockOrigin): BlockNode => ({
+  id,
+  type: "core/box",
+  version: 1,
+  props: {},
+  ...(origin === undefined ? {} : { origin }),
+});
+
+const fromPattern: BlockOrigin = {
+  from: "pattern",
+  id: "hero-pattern",
+  digest: "abc123",
+};
+
+describe("a provenance record survives the op layer", () => {
+  it("is carried through an insert", () => {
+    const applied = applyOps(page([]), [
+      { kind: "insert", node: node("a", fromPattern), at: { index: 0 } },
+    ]);
+
+    expect(applied.document.nodes[0]!.origin).toEqual(fromPattern);
+  });
+
+  it("carries the component arm, which has no digest", () => {
+    const detached: BlockOrigin = { from: "component", id: "hero-component" };
+
+    const applied = applyOps(page([]), [
+      { kind: "insert", node: node("a", detached), at: { index: 0 } },
+    ]);
+
+    expect(applied.document.nodes[0]!.origin).toEqual(detached);
+  });
+
+  it("can be REMOVED by an update, so severing a link is an ordinary edit", () => {
+    // Patchable rather than sealed. A field an update can never address is one
+    // that can only be removed by deleting the node it sits on.
+    const applied = applyOps(page([node("a", fromPattern)]), [
+      { kind: "update", id: "a", patch: {}, unset: ["origin"] },
+    ]);
+
+    expect(applied.document.nodes[0]!.origin).toBeUndefined();
+  });
+});
+
+describe("a half-formed record is refused, not stored", () => {
+  const refuse = (origin: unknown): (() => unknown) => {
+    const bad = {
+      id: "a",
+      type: "core/box",
+      version: 1,
+      props: {},
+      origin,
+    } as unknown as BlockNode;
+    return () =>
+      applyOps(page([]), [{ kind: "insert", node: bad, at: { index: 0 } }]);
+  };
+
+  it("refuses a pattern origin with no digest", () => {
+    // The digest is the whole point of the pattern arm: without it the record
+    // cannot answer whether the upstream moved, which is what it exists for.
+    expect(refuse({ from: "pattern", id: "hero" })).toThrow();
+  });
+
+  it("refuses an empty id", () => {
+    expect(refuse({ from: "pattern", id: "", digest: "abc" })).toThrow();
+  });
+
+  it("refuses a source nobody declared", () => {
+    expect(refuse({ from: "somewhere-else", id: "hero" })).toThrow();
+  });
+
+  it("refuses a record that is not one", () => {
+    expect(refuse("hero-pattern")).toThrow();
+  });
+
+  it("ACCEPTS the shapes that are whole", () => {
+    // The control: the refusals above must be about the malformation and not
+    // about the field being rejected outright.
+    expect(
+      refuse({ from: "pattern", id: "hero", digest: "abc" })
+    ).not.toThrow();
+    expect(refuse({ from: "component", id: "hero" })).not.toThrow();
+  });
+});

--- a/packages/blocks-react/src/index.ts
+++ b/packages/blocks-react/src/index.ts
@@ -247,6 +247,7 @@ export type {
   BlockIsland,
   BlockMigrationInfo,
   BlockNode,
+  BlockOrigin,
   BlockPart,
   BlockRenderResult,
   BlockSeoContribution,

--- a/packages/nextly/src/plugins/codegen/__tests__/__fixtures__/block-document.schema.json
+++ b/packages/nextly/src/plugins/codegen/__tests__/__fixtures__/block-document.schema.json
@@ -361,6 +361,41 @@
         },
         "migrationFailed": {
           "type": "boolean"
+        },
+        "origin": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "from": {
+                  "type": "string",
+                  "const": "pattern"
+                },
+                "id": {
+                  "type": "string"
+                },
+                "digest": {
+                  "type": "string"
+                }
+              },
+              "required": ["from", "id", "digest"],
+              "additionalProperties": {}
+            },
+            {
+              "type": "object",
+              "properties": {
+                "from": {
+                  "type": "string",
+                  "const": "component"
+                },
+                "id": {
+                  "type": "string"
+                }
+              },
+              "required": ["from", "id"],
+              "additionalProperties": {}
+            }
+          ]
         }
       },
       "required": ["id", "type", "version", "props"],

--- a/packages/nextly/src/plugins/codegen/block-document.test-d.ts
+++ b/packages/nextly/src/plugins/codegen/block-document.test-d.ts
@@ -125,6 +125,7 @@ expectTypeOf<keyof BlockNode>().toEqualTypeOf<
   | "cssId"
   | "attributes"
   | "migrationFailed"
+  | "origin"
 >();
 
 // ---------------------------------------------------------------------------

--- a/packages/nextly/src/plugins/codegen/block-document.ts
+++ b/packages/nextly/src/plugins/codegen/block-document.ts
@@ -251,6 +251,26 @@ const conditionSchema = z.looseObject({
  * SHOWN at a breakpoint. Conflating them would mean a conditioned node either
  * leaks into the payload or a hidden-on-mobile node stops being indexed.
  */
+/**
+ * Where a copied subtree came from.
+ *
+ * A union rather than one loose object, because the two arms genuinely differ:
+ * a pattern copy carries a digest of what it copied and a detached component
+ * does not. One object with an optional digest would accept a pattern origin
+ * that cannot answer the question it exists for.
+ */
+const blockOriginSchema = z.union([
+  z.looseObject({
+    from: z.literal("pattern"),
+    id: z.string(),
+    digest: z.string(),
+  }),
+  z.looseObject({
+    from: z.literal("component"),
+    id: z.string(),
+  }),
+]);
+
 const nodeVisibilitySchema = z.looseObject({
   conditions: z.array(z.array(conditionSchema)).optional(),
   devices: typedRecord(
@@ -468,6 +488,7 @@ const blockNodeObject = z.looseObject({
     "Expected an object of strings"
   ).optional(),
   migrationFailed: z.boolean().optional(),
+  origin: blockOriginSchema.optional(),
 });
 
 const blockNodeSchema = blockNodeObject;


### PR DESCRIPTION
Plan 06 (Phase 5). Implements the founder's ruling on **Q12 = A**: record provenance on copies, and pay the format change now because it cannot be backfilled.

## What ships

**`BlockNode.origin`** — inert provenance. No renderer reads it, no validator requires it, and a document without one is complete. It exists to be read *later*, by a surface asking whether an upstream source has moved on.

```ts
export type BlockOrigin =
  | { from: "pattern";   id: string; digest: string }
  | { from: "component"; id: string }
```

## Three design choices worth arguing

**One field with a discriminant, not one field per source.** The design sketched `origin` *and* `detachedFrom` as separate keys. A pattern copy and a detached component are two provenances today and there will be more — an imported document, a duplicated page — and each as its own key is a stored format that grows a column per feature. The discriminant also lets the arms differ honestly: a pattern copy carries a digest because the pattern can change underneath it; a detached component carries none, because detaching *is* the act of declining further change. One added key to the frozen contract instead of two.

**The digest is of content, not a version number.** The engine is handed a document, not an entry row — it can hash what it was given and cannot see what the store calls it. Content also answers the question more precisely: a re-save that changed nothing bumps a version and leaves a digest alone.

**Patchable, not sealed.** Like `migrationFailed`. Provenance is a record, not a lock — an author who deliberately severs a link should be able to, and a field an update can never address is one that can only be removed by deleting the node it sits on.

## The format change, and why `formatVersion` does not move

Six places declare a node field, and **the type system forced all six**. Adding it to the engine broke `NODE_FIELDS` and `PATCH_FIELDS` at compile time:

```
src/ops.ts(130,7): error TS2741: Property 'origin' is missing in type ...
src/ops.ts(170,7): error TS2741: Property 'origin' is missing in type ...
```

That is the deriving-rather-than-restating design working: the format cannot be half-changed.

The golden JSON schema is a deliberate control — its test says *"If this fails, the format changed. Regenerate ONLY after deciding that the change is compatible."* So the decision, measured rather than assumed:

- `origin` is **optional**, so old documents remain valid.
- New documents are readable by older code — the node schema already carries `"additionalProperties": {}`, and I measured that an unknown node field survives an op round trip unchanged rather than being stripped.

**Compatible. `formatVersion` stays at 1.**

One process note: my first regeneration produced a 121-line diff that was almost entirely formatting, because `JSON.stringify` does not match the committed prettier style. That defeats the fixture's stated purpose of showing a format change explicitly in the diff, so it is prettier-formatted and the real diff is **35 insertions: one optional property, `required` untouched.**

## A half-formed record is refused

`isBlockOrigin` checks the shape the way every other entry in `NODE_FIELDS` is checked. An op arrives from storage, a crash buffer or an agent, and a half-formed record would be stored and then read by a surface that trusts it — answering about an id that is not one.

Refused: a pattern origin with no digest, an empty id, a source nobody declared, a value that is not a record. Each has a test, plus a **control** asserting the whole shapes are accepted — so the refusals are about the malformation and not about the field being rejected outright.

Break-verified: accepting any record kills 3 tests; dropping `origin` from `PATCH_FIELDS` kills the removability test.

## On fallow's `duplication_introduced: 2`

Verdict is `warn`, which passes, and **I did not introduce duplication.** All six clone groups are pre-existing, in the frozen type-test (repetitive by design) and the relocated op vocabulary. Measured:

- my `ops.ts` diff is **+28 lines, 0 deletions**
- the flagged clone text sits at line **2250 on `origin/main`** and **2278 here** — exactly +28, identical text

fallow attributes line-shifted clones as introduced. Nothing pre-existing is refactored in a format-change PR.

## No writer yet, deliberately

`planInsertPattern` and `planDetach` are what write this, and both live in `composition-planners.ts`, which **#1557 has open in review**. The format lands alone rather than conflicting with a PR under review — the same slicing the ops move used, and for the same reason: a mechanical change mixed with new behaviour is a diff nobody can review for either.

## Gates

| Gate | Exit |
|---|---|
| `fallow audit --gate new-only --base origin/main` | **0** — `warn`, 6 files, complexity/dead-code introduced 0 |
| `npm run check:comments` | **0** |
| `npx changeset status` | **0** |
| `npx turbo run check-types` | **0** — 42/42 |
| `eslint` on the touched files | **0** |

Suites: `blocks-engine` 46 files / 1976 tests, `nextly` codegen 7 / 156, plus `builder`, `blocks-react` and `plugin-page-builder` all green.
