### PR TITLE
fix(nextly): record migration metadata so production shows its cards

### DIFF
--- a/.changeset/migrate-records-what-it-created.md
+++ b/.changeset/migrate-records-what-it-created.md
@@ -62,3 +62,16 @@ it never got — and one `migrationStatus` filter that would have thrown for
 anyone who passed it. The three list paths now share one reader, so a method
 cannot be written that skips the ordering, the deserialization or the error
 mapping while looking correct beside the others.
+
+The reconciliation could not have worked from the CLI at all. `adapter.select`
+maps a table name through a resolver and refuses when none is installed, and a
+`nextly migrate` run has no boot to install one — so every registry read threw,
+the per-registry guard caught all three, and the command reported success having
+repaired nothing. It now installs the resolver the way `prune`,
+`webhooks-prune`, `migrate-field-groups` and `dev-server` each already do.
+
+The guard no longer hides that. A registry the pass could not read is reported
+rather than folded into a count of zero, because zero rows repaired and zero
+rows readable are the same number and opposite facts. `nextly migrate` says so,
+and no longer announces "Database is up to date" while registry work it just
+measured is outstanding.

--- a/.changeset/migrate-records-what-it-created.md
+++ b/.changeset/migrate-records-what-it-created.md
@@ -1,0 +1,64 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+`nextly migrate` now records what it created, so a collection built in the
+Schema Builder and deployed to production shows its dashboard cards.
+
+It did not before. `registerFromMigrations` is the only writer that records
+`applied`, and its one caller sits inside `runBootTimeApplyIfDev`, whose first
+line returns unless `NODE_ENV === "development"`. The CLI applied the DDL and
+touched no registry row at all, so the row stayed `pending` after its table
+existed — and a restart re-ran the same dev-gated path and changed nothing.
+
+A third phase now runs after the file migrations, inside the migrate lock. It
+registers what the snapshots describe, then moves every pending row whose table
+actually exists to `applied`. A row whose table is NOT there is left exactly as
+it was: after a migrate run, that has two indistinguishable causes — a migration
+that failed, and one that was never generated — and marking the second `failed`
+would turn a collection still waiting for its DDL into one somebody has to
+repair by hand. The pass runs on every invocation, so a row that misses one run
+is picked up by the next.
+
+The command still succeeds if the bookkeeping fails. By then the DDL has landed,
+and MySQL commits DDL implicitly, so there is no transaction to roll back into;
+failing would report a migration that worked as broken.
+
+`getRecordsWithPendingMigrations` was broken and could not have worked for
+anyone. It filtered on `migration_status` and ordered by `created_at` — physical
+column names — while the adapter resolves columns by their Drizzle property
+names, so it threw "Column not found in table" for every caller. It had no
+callers, which is why nothing surfaced it: it was written for a reconciliation
+pass that was never wired up.
+
+Three sibling queries in the same base service carried the same mistake and are
+fixed with it: two `orderBy` clauses naming `created_at`, which an adapter does
+not reject — it ignores them, so the caller believed it had asked for an order
+it never got — and one `migrationStatus` filter that would have thrown for
+anyone who passed it. The three list paths now share one reader, so a method
+cannot be written that skips the ordering, the deserialization or the error
+mapping while looking correct beside the others.

--- a/packages/nextly/src/cli/commands/__tests__/migrate-core.test.ts
+++ b/packages/nextly/src/cli/commands/__tests__/migrate-core.test.ts
@@ -17,6 +17,12 @@ function deps(over: Record<string, unknown> = {}) {
     lockMode: "fail-fast" as const,
     reconcileCoreFn: vi.fn(async () => ({ changed: false })),
     runFileMigrationsFn: vi.fn(async () => 0),
+    reconcileMetadataFn: vi.fn(async () => ({
+      collectionsRegistered: 0,
+      singlesRegistered: 0,
+      marked: 0,
+      stillPending: 0,
+    })),
     // Pass-through lock that just runs fn (so we test the core, not the lock),
     // in the real shape: the outcome is discriminated so a caller cannot
     // confuse "returned undefined" with "never ran".
@@ -39,6 +45,109 @@ describe("migrateCore", () => {
     expect(d.reconcileCoreFn).toHaveBeenCalledOnce();
     expect(d.runFileMigrationsFn).toHaveBeenCalledOnce();
     expect(res).toMatchObject({ applied: 0, coreChanged: false });
+  });
+
+  /*
+   * 🔴 Phase 3 runs UNCONDITIONALLY, including when no migration file applied.
+   * A run that applies nothing can still have bookkeeping to do: the DDL landed
+   * on a previous invocation and the row stayed `pending`, which is exactly the
+   * production shape this phase exists for. Gating it on `applied > 0` would
+   * make the stuck row unreachable by the command that repairs it.
+   */
+  it("records metadata even when no migration file applied", async () => {
+    const d = deps({ runFileMigrationsFn: vi.fn(async () => 0) });
+    const res = await migrateCore(d as never);
+
+    expect(d.reconcileMetadataFn).toHaveBeenCalledOnce();
+    expect(res.applied).toBe(0);
+  });
+
+  it("reports what the metadata pass did", async () => {
+    const d = deps({
+      reconcileMetadataFn: vi.fn(async () => ({
+        collectionsRegistered: 2,
+        singlesRegistered: 1,
+        marked: 3,
+        stillPending: 1,
+      })),
+    });
+
+    // Surfaced on the RESULT rather than only logged, so a caller can report
+    // what happened instead of inferring it from `applied`, which counts files.
+    expect((await migrateCore(d as never)).metadata).toEqual({
+      collectionsRegistered: 2,
+      singlesRegistered: 1,
+      marked: 3,
+      stillPending: 1,
+    });
+  });
+
+  /*
+   * 🔴 The command SUCCEEDS when bookkeeping fails, and this is the assertion
+   * that keeps it that way. By Phase 3 the DDL has already landed -- MySQL
+   * commits DDL implicitly, so there is no transaction to roll back into --
+   * and failing here would report a migration that worked as broken. The row
+   * is repaired by the next invocation, because this phase runs every time.
+   */
+  it("does not fail the command when recording metadata throws", async () => {
+    const d = deps({
+      reconcileMetadataFn: vi.fn(async () => {
+        throw new Error("registry unreachable");
+      }),
+      runFileMigrationsFn: vi.fn(async () => 4),
+    });
+
+    const res = await migrateCore(d as never);
+
+    // The applied count is the load-bearing half: the files really did land,
+    // and the caller must still be told so.
+    expect(res.applied).toBe(4);
+    expect(res.metadata).toEqual({
+      collectionsRegistered: 0,
+      singlesRegistered: 0,
+      marked: 0,
+      stillPending: 0,
+    });
+  });
+
+  it("runs the metadata pass INSIDE the lock", async () => {
+    // Ordering is the correctness property: outside the lock, two migrates
+    // could sweep the same rows while one of them is still creating tables.
+    const order: string[] = [];
+    const d = deps({
+      runFileMigrationsFn: vi.fn(async () => {
+        order.push("files");
+        return 1;
+      }),
+      reconcileMetadataFn: vi.fn(async () => {
+        order.push("metadata");
+        return {
+          collectionsRegistered: 0,
+          singlesRegistered: 0,
+          marked: 0,
+          stillPending: 0,
+        };
+      }),
+      withLock: async (
+        _db: unknown,
+        _d: unknown,
+        fn: () => Promise<unknown>
+      ) => {
+        order.push("lock:acquired");
+        const value = await fn();
+        order.push("lock:released");
+        return { ran: true as const, value };
+      },
+    });
+
+    await migrateCore(d as never);
+
+    expect(order).toEqual([
+      "lock:acquired",
+      "files",
+      "metadata",
+      "lock:released",
+    ]);
   });
 
   it("THROWS (does not exit) when file migrations reject", async () => {

--- a/packages/nextly/src/cli/commands/__tests__/migrate-core.test.ts
+++ b/packages/nextly/src/cli/commands/__tests__/migrate-core.test.ts
@@ -22,6 +22,7 @@ function deps(over: Record<string, unknown> = {}) {
       singlesRegistered: 0,
       marked: 0,
       stillPending: 0,
+      unreadable: [],
     })),
     // Pass-through lock that just runs fn (so we test the core, not the lock),
     // in the real shape: the outcome is discriminated so a caller cannot
@@ -69,6 +70,7 @@ describe("migrateCore", () => {
         singlesRegistered: 1,
         marked: 3,
         stillPending: 1,
+        unreadable: [],
       })),
     });
 
@@ -79,6 +81,7 @@ describe("migrateCore", () => {
       singlesRegistered: 1,
       marked: 3,
       stillPending: 1,
+      unreadable: [],
     });
   });
 
@@ -102,12 +105,17 @@ describe("migrateCore", () => {
     // The applied count is the load-bearing half: the files really did land,
     // and the caller must still be told so.
     expect(res.applied).toBe(4);
-    expect(res.metadata).toEqual({
-      collectionsRegistered: 0,
-      singlesRegistered: 0,
-      marked: 0,
-      stillPending: 0,
-    });
+
+    // 🔴 And the failure is REPORTED, not returned as zeroes. Zero rows
+    // repaired and zero rows readable are the same numbers and opposite facts:
+    // without `unreadable`, a pass that could not look at anything is
+    // indistinguishable from a database that needed nothing.
+    expect(res.metadata.marked).toBe(0);
+    expect(res.metadata.unreadable).toEqual([
+      "collection",
+      "single",
+      "field group",
+    ]);
   });
 
   it("runs the metadata pass INSIDE the lock", async () => {
@@ -126,6 +134,7 @@ describe("migrateCore", () => {
           singlesRegistered: 0,
           marked: 0,
           stillPending: 0,
+          unreadable: [],
         };
       }),
       withLock: async (

--- a/packages/nextly/src/cli/commands/__tests__/migrate-registry-resolver.test.ts
+++ b/packages/nextly/src/cli/commands/__tests__/migrate-registry-resolver.test.ts
@@ -1,0 +1,77 @@
+/**
+ * `nextly migrate` can resolve the registry tables it is about to read.
+ *
+ * 🔴 The defect this guards shipped and was invisible. `adapter.select` maps a
+ * table NAME through a resolver and refuses with "not found in schema registry"
+ * when none is installed; a CLI run has no boot to install one. The metadata
+ * reconciliation therefore threw on every registry, its per-registry guard
+ * caught all three, and the command announced success having repaired nothing
+ * — a no-op in exactly the production case the phase was written for.
+ *
+ * Asserted by OUTCOME rather than by watching for a `setTableResolver` call:
+ * what matters is that `dynamic_collections` resolves afterwards, which is the
+ * property the sweep depends on. A spy would also pass on a resolver that
+ * registered the wrong dialect's tables, or none at all.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { installRegistryResolver } from "../migrate";
+
+function adapterFor(dialect: "postgresql" | "mysql" | "sqlite") {
+  const setTableResolver = vi.fn();
+  return {
+    adapter: {
+      getCapabilities: () => ({ dialect }),
+      setTableResolver,
+    } as never,
+    setTableResolver,
+  };
+}
+
+describe("installRegistryResolver", () => {
+  it.each(["postgresql", "mysql", "sqlite"] as const)(
+    "resolves the registry tables the sweep reads, on %s",
+    dialect => {
+      const { adapter } = adapterFor(dialect);
+
+      const registry = installRegistryResolver(adapter);
+
+      // The three the reconciliation sweeps. A resolver that answered for none
+      // of them is what the shipped defect looked like from the sweep's side.
+      for (const table of [
+        "dynamic_collections",
+        "dynamic_singles",
+        "dynamic_components",
+      ]) {
+        expect(
+          registry.getTable(table),
+          `${table} does not resolve`
+        ).toBeTruthy();
+      }
+    }
+  );
+
+  it("installs the resolver on the adapter", () => {
+    // The other half: a registry built and never handed over resolves
+    // perfectly in the test and not at all in the command.
+    const { adapter, setTableResolver } = adapterFor("sqlite");
+
+    const registry = installRegistryResolver(adapter);
+
+    expect(setTableResolver).toHaveBeenCalledWith(registry);
+  });
+
+  /*
+   * The field-group registry under BOTH spellings. A database whose storage
+   * migration has run answers to one name and a database that predates it to
+   * the other, and this command is the one that runs while that name changes.
+   */
+  it("resolves both spellings of the field-group registry", () => {
+    const { adapter } = adapterFor("postgresql");
+
+    const registry = installRegistryResolver(adapter);
+
+    expect(registry.getTable("dynamic_components")).toBeTruthy();
+    expect(registry.getTable("dynamic_field_groups")).toBeTruthy();
+  });
+});

--- a/packages/nextly/src/cli/commands/migrate.ts
+++ b/packages/nextly/src/cli/commands/migrate.ts
@@ -51,6 +51,7 @@ import {
 } from "../../domains/schema/events/schema-events-repository";
 import { reconcileCore } from "../../domains/schema/migrate/core-reconcile";
 import { reconcileFile } from "../../domains/schema/migrate/drift-reconcile";
+import { reconcileMigrationMetadata } from "../../domains/schema/migrate/reconcile-metadata";
 import { resolveDeclaredSchema } from "../../domains/schema/migrate/resolved-schema";
 import { FIELD_GROUP_HEADER_PATTERN } from "../../domains/schema/migrate-create/format-file";
 import {
@@ -417,6 +418,8 @@ export interface MigrateCoreDeps {
   /** Junction tables the config names outright; see `runFileMigrations`. */
   knownJunctions?: ReadonlySet<string>;
   withLock?: typeof withMigrateLock;
+  /** Seam for tests; defaults to the real metadata reconciliation. */
+  reconcileMetadataFn?: typeof reconcileMigrationMetadata;
 }
 
 export interface MigrateCoreResult {
@@ -432,6 +435,19 @@ export interface MigrateCoreResult {
    * migrations that never started.
    */
   ran: boolean;
+  /**
+   * Registry rows this run brought into agreement with the tables.
+   *
+   * Reported so a caller can say what happened rather than implying it from
+   * `applied`, which counts migration FILES: a run can apply no files and still
+   * record a row whose table landed on a previous one.
+   */
+  metadata: {
+    collectionsRegistered: number;
+    singlesRegistered: number;
+    marked: number;
+    stillPending: number;
+  };
 }
 
 /** Clear a stale migrate lock when `--force-unlock` was passed (else no-op). */
@@ -449,9 +465,17 @@ export async function migrateCore(
 ): Promise<MigrateCoreResult> {
   const reconcile = deps.reconcileCoreFn ?? reconcileCore;
   const runFiles = deps.runFileMigrationsFn ?? runFileMigrations;
+  const reconcileMetadata =
+    deps.reconcileMetadataFn ?? reconcileMigrationMetadata;
   const lock = deps.withLock ?? withMigrateLock;
   let applied = 0;
   let coreChanged = false;
+  let metadata = {
+    collectionsRegistered: 0,
+    singlesRegistered: 0,
+    marked: 0,
+    stillPending: 0,
+  };
 
   const outcome = await lock(
     deps.db,
@@ -489,6 +513,40 @@ export async function migrateCore(
         logger: deps.logger,
         knownJunctions: deps.knownJunctions,
       });
+
+      /*
+       * Phase 3 — make the registry agree with the tables Phase 2 just created.
+       *
+       * 🔴 Inside the lock, unlike the dev-boot path, which runs its equivalent
+       * outside because several dev-server workers race there. A CLI invocation
+       * already holds the lock, so this sweep cannot interleave with another
+       * migrate and needs no conflict tolerance of its own.
+       *
+       * CAUGHT, and the command still succeeds. The DDL has landed by now, and
+       * MySQL commits DDL implicitly, so there is no transaction to roll back
+       * into: a bookkeeping failure leaves working tables beside a row that is
+       * behind. Failing here would report a migration that worked as broken,
+       * and the next invocation repairs the row because this runs every time.
+       */
+      deps.logger.info("Phase 3: recording migration metadata...");
+      try {
+        metadata = await reconcileMetadata({
+          adapter: deps.adapter as unknown as DrizzleAdapter,
+          dialect: deps.dialect,
+          migrationsDir: deps.migrationsDir,
+          logger: {
+            info: (m: string) => deps.logger.debug(m),
+            warn: (m: string) => deps.logger.warn(m),
+            debug: (m: string) => deps.logger.debug(m),
+          },
+        });
+      } catch (error) {
+        deps.logger.warn(
+          `Migration metadata was not recorded: ${
+            error instanceof Error ? error.message : String(error)
+          }. The tables are in place; run \`nextly migrate\` again to record it.`
+        );
+      }
     },
     {
       mode: deps.lockMode ?? "fail-fast",
@@ -501,7 +559,7 @@ export async function migrateCore(
     }
   );
 
-  return { applied, coreChanged, ran: outcome.ran };
+  return { applied, coreChanged, ran: outcome.ran, metadata };
 }
 
 /**

--- a/packages/nextly/src/cli/commands/migrate.ts
+++ b/packages/nextly/src/cli/commands/migrate.ts
@@ -36,6 +36,9 @@ import { resolve } from "node:path";
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import type { Command } from "commander";
 
+import { getDialectTables } from "../../database/index";
+import { SchemaRegistry } from "../../database/schema-registry";
+import { getFieldGroupRegistryAliases } from "../../domains/field-groups/storage/registry-schemas";
 import { resolveRegistryNameFromCatalog } from "../../domains/field-groups/storage/resolve-storage-names";
 import {
   isLocalizationIntentRefusal,
@@ -248,6 +251,8 @@ export async function runMigrate(
     process.exit(1);
   }
 
+  installRegistryResolver(adapter as unknown as DrizzleAdapter);
+
   try {
     const db = (adapter as unknown as DrizzleAdapter).getDrizzle();
     const cwd = options.cwd ?? process.cwd();
@@ -300,7 +305,7 @@ export async function runMigrate(
     // extraneous table) and BEFORE the event is recorded; idempotent. A thrown
     // error here maps to a non-zero CLI exit (the core itself never exits).
     try {
-      const { applied } = await migrateCore({
+      const { applied, metadata } = await migrateCore({
         dialect,
         db,
         adapter,
@@ -325,9 +330,40 @@ export async function runMigrate(
       });
 
       logger.newline();
+
+      /*
+       * 🔴 "Up to date" is a claim about the REGISTRY as well as the files.
+       * Phase 3 can leave rows outstanding while no migration file applied --
+       * a row whose table is absent produces no per-row warning, by design --
+       * so reporting only `applied` let a run announce a current database while
+       * registry work it had just measured was still owed.
+       */
+      const { marked, stillPending, unreadable } = metadata;
+      if (unreadable.length > 0) {
+        // Not a count of rows: this is "the sweep could not look". Reported
+        // separately because zero repaired and zero readable are the same
+        // number and opposite facts.
+        logger.warn(
+          `Could not read the ${unreadable.join(", ")} registry, so migration ` +
+            `status was not reconciled. The tables are in place; re-run \`nextly migrate\`.`
+        );
+      }
+      if (marked > 0) {
+        logger.success(
+          `${formatCount(marked, "registry row")} recorded as applied.`
+        );
+      }
+      if (stillPending > 0) {
+        logger.warn(
+          `${formatCount(stillPending, "registry row")} still awaiting a migration.`
+        );
+      }
+
       logger.success(
         applied === 0
-          ? "Nothing to migrate. Database is up to date."
+          ? stillPending > 0 || unreadable.length > 0
+            ? "No migration files to apply."
+            : "Nothing to migrate. Database is up to date."
           : `${formatCount(applied, "migration")} applied.`
       );
     } catch (err) {
@@ -447,6 +483,7 @@ export interface MigrateCoreResult {
     singlesRegistered: number;
     marked: number;
     stillPending: number;
+    unreadable: string[];
   };
 }
 
@@ -458,6 +495,39 @@ export async function maybeForceUnlock(
 ): Promise<void> {
   if (!options.forceUnlock) return;
   await forceUnlock(db, dialect);
+}
+
+/**
+ * Give the adapter a way to resolve core table NAMES to Drizzle tables.
+ *
+ * 🔴 Without this, the metadata reconciliation silently does nothing.
+ * `adapter.select` maps a name through a resolver and refuses with "not found
+ * in schema registry" when none is installed. A CLI run has no boot to install
+ * one — which is why `prune`, `webhooks-prune`, `migrate-field-groups` and
+ * `dev-server` each wire it up the same way before touching adapter CRUD.
+ *
+ * Missing here, every registry read in the sweep threw, the per-registry guard
+ * caught all three, and the command reported success having repaired nothing:
+ * a no-op in exactly the production case the phase exists for.
+ *
+ * Both spellings of the field-group registry are registered, because a database
+ * whose storage migration has run has no handle for it under the other name.
+ *
+ * Its own exported function so the wiring can be asserted by its OUTCOME — that
+ * the registry table resolves — rather than by whether a call appears in the
+ * source.
+ */
+export function installRegistryResolver(
+  adapter: DrizzleAdapter
+): SchemaRegistry {
+  const { dialect } = adapter.getCapabilities();
+  const schemaRegistry = new SchemaRegistry(dialect);
+  schemaRegistry.registerStaticSchemas({
+    ...getDialectTables(dialect),
+    ...getFieldGroupRegistryAliases(dialect),
+  });
+  adapter.setTableResolver(schemaRegistry);
+  return schemaRegistry;
 }
 
 export async function migrateCore(
@@ -475,6 +545,7 @@ export async function migrateCore(
     singlesRegistered: 0,
     marked: 0,
     stillPending: 0,
+    unreadable: [] as string[],
   };
 
   const outcome = await lock(
@@ -541,6 +612,12 @@ export async function migrateCore(
           },
         });
       } catch (error) {
+        // The whole pass failed, so nothing was read: say so in the result
+        // rather than returning zeroes that read like "nothing needed doing".
+        metadata = {
+          ...metadata,
+          unreadable: ["collection", "single", "field group"],
+        };
         deps.logger.warn(
           `Migration metadata was not recorded: ${
             error instanceof Error ? error.message : String(error)

--- a/packages/nextly/src/domains/field-groups/__tests__/field-group-registry-service.test.ts
+++ b/packages/nextly/src/domains/field-groups/__tests__/field-group-registry-service.test.ts
@@ -244,7 +244,11 @@ describe("FieldGroupRegistryService", () => {
       >;
       const where = opts.where as Record<string, unknown>;
       expect((where.and as Array<Record<string, unknown>>)[0]).toMatchObject({
-        column: "migration_status",
+        // The SCHEMA PROPERTY, not the physical column. The adapter here is a
+        // mock that accepts any name, which is exactly why the physical
+        // spelling survived in the query for so long: only a real database
+        // refuses it.
+        column: "migrationStatus",
         value: "pending",
       });
     });
@@ -596,7 +600,11 @@ describe("FieldGroupRegistryService", () => {
       const where = opts.where as Record<string, unknown>;
       const andArr = where.and as Array<Record<string, unknown>>;
       expect(andArr[0]).toMatchObject({
-        column: "migration_status",
+        // The SCHEMA PROPERTY, not the physical column. The adapter here is a
+        // mock that accepts any name, which is exactly why the physical
+        // spelling survived in the query for so long: only a real database
+        // refuses it.
+        column: "migrationStatus",
         value: ["pending", "generated"],
       });
     });

--- a/packages/nextly/src/domains/schema/migrate/__tests__/reconcile-metadata.test.ts
+++ b/packages/nextly/src/domains/schema/migrate/__tests__/reconcile-metadata.test.ts
@@ -1,0 +1,231 @@
+/**
+ * The sweep that moves a registry row to `applied` once its table exists.
+ *
+ * The behaviour under test is narrow and the consequences are not: a row left
+ * `pending` means a collection with no dashboard cards, and a row wrongly marked
+ * `failed` means one an operator has to un-fail by hand.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { reconcileMigrationMetadata } from "../reconcile-metadata";
+
+const silent = {
+  info: () => {},
+  warn: () => {},
+  debug: () => {},
+};
+
+/**
+ * An adapter that knows which tables exist.
+ *
+ * `tableExists` is the only thing the sweep asks it, so the fixture is the set
+ * of names that answer true — which is also exactly the state a migration run
+ * leaves behind.
+ */
+function adapterWith(tables: string[]) {
+  return {
+    tableExists: vi.fn(async (name: string) => tables.includes(name)),
+  } as never;
+}
+
+/** A registry service reduced to the two calls the sweep makes. */
+function registryOf(rows: unknown[]) {
+  return {
+    getPendingMigrations: vi.fn(async () => rows),
+    updateMigrationStatusWithVerification: vi.fn(async () => ({
+      verified: true,
+    })),
+  };
+}
+
+/**
+ * The three services are constructed inside the module, so they are replaced
+ * here rather than injected. Each returns its own rows so a test can tell which
+ * registry a count came from.
+ */
+function mockRegistries(
+  collections: unknown[] = [],
+  singles: unknown[] = [],
+  fieldGroups: unknown[] = []
+) {
+  const made = {
+    collection: registryOf(collections),
+    single: registryOf(singles),
+    fieldGroup: registryOf(fieldGroups),
+  };
+  vi.doMock(
+    "../../../collections/services/collection-registry-service",
+    () => ({
+      CollectionRegistryService: class {
+        getPendingMigrations = made.collection.getPendingMigrations;
+        updateMigrationStatusWithVerification =
+          made.collection.updateMigrationStatusWithVerification;
+      },
+    })
+  );
+  vi.doMock("../../../singles/services/single-registry-service", () => ({
+    SingleRegistryService: class {
+      getPendingMigrations = made.single.getPendingMigrations;
+      updateMigrationStatusWithVerification =
+        made.single.updateMigrationStatusWithVerification;
+    },
+  }));
+  vi.doMock(
+    "../../../field-groups/services/field-group-registry-service",
+    () => ({
+      FieldGroupRegistryService: class {
+        getPendingMigrations = made.fieldGroup.getPendingMigrations;
+        updateMigrationStatusWithVerification =
+          made.fieldGroup.updateMigrationStatusWithVerification;
+      },
+    })
+  );
+  return made;
+}
+
+async function run(opts: {
+  tables: string[];
+  collections?: unknown[];
+  singles?: unknown[];
+  fieldGroups?: unknown[];
+  registerFn?: () => Promise<{
+    collectionsRegistered: number;
+    singlesRegistered: number;
+  }>;
+}) {
+  vi.resetModules();
+  const made = mockRegistries(
+    opts.collections ?? [],
+    opts.singles ?? [],
+    opts.fieldGroups ?? []
+  );
+  const { reconcileMigrationMetadata: fresh } = await import(
+    "../reconcile-metadata"
+  );
+  const result = await fresh({
+    adapter: adapterWith(opts.tables),
+    dialect: "sqlite",
+    migrationsDir: "/tmp/migrations",
+    logger: silent,
+    registerFn: (opts.registerFn ??
+      (async () => ({
+        collectionsRegistered: 0,
+        singlesRegistered: 0,
+      }))) as never,
+  });
+  return { result, made };
+}
+
+describe("reconcileMigrationMetadata", () => {
+  it("is exported for the migrate command to call", () => {
+    // The whole defect was that nothing called the reconciliation half, so the
+    // reachability of this function is itself worth an assertion.
+    expect(typeof reconcileMigrationMetadata).toBe("function");
+  });
+
+  it("marks a pending row applied once its table exists", async () => {
+    const { result, made } = await run({
+      tables: ["dc_posts"],
+      collections: [{ slug: "posts", tableName: "dc_posts" }],
+    });
+
+    expect(
+      made.collection.updateMigrationStatusWithVerification
+    ).toHaveBeenCalledWith("posts", "dc_posts");
+    expect(result.marked).toBe(1);
+    expect(result.stillPending).toBe(0);
+  });
+
+  /*
+   * 🔴 The assertion this module exists to guarantee. After a migrate run, a
+   * `pending` row with no table has two indistinguishable causes: a migration
+   * that failed, and a migration file that was never generated.
+   * `updateMigrationStatusWithVerification` writes `failed` for both, so the
+   * sweep must not reach it — condemning the second turns a collection still
+   * waiting for its DDL into one somebody has to repair by hand.
+   */
+  it("leaves a row alone when its table is not there, never marking it failed", async () => {
+    const { result, made } = await run({
+      tables: [],
+      collections: [{ slug: "posts", tableName: "dc_posts" }],
+    });
+
+    expect(
+      made.collection.updateMigrationStatusWithVerification
+    ).not.toHaveBeenCalled();
+    expect(result.marked).toBe(0);
+    expect(result.stillPending).toBe(1);
+  });
+
+  it("sweeps collections, singles and field groups", async () => {
+    // All three registries carry a migration status, and a sweep that reached
+    // only collections would leave the other two permanently behind.
+    const { result, made } = await run({
+      tables: ["dc_posts", "ds_home", "fg_seo"],
+      collections: [{ slug: "posts", tableName: "dc_posts" }],
+      singles: [{ slug: "home", tableName: "ds_home" }],
+      fieldGroups: [{ slug: "seo", tableName: "fg_seo" }],
+    });
+
+    expect(made.collection.getPendingMigrations).toHaveBeenCalledOnce();
+    expect(made.single.getPendingMigrations).toHaveBeenCalledOnce();
+    expect(made.fieldGroup.getPendingMigrations).toHaveBeenCalledOnce();
+    expect(result.marked).toBe(3);
+  });
+
+  it("keeps going when one row cannot be recorded", async () => {
+    vi.resetModules();
+    const made = mockRegistries([
+      { slug: "posts", tableName: "dc_posts" },
+      { slug: "pages", tableName: "dc_pages" },
+    ]);
+    made.collection.updateMigrationStatusWithVerification
+      .mockRejectedValueOnce(new Error("row is locked"))
+      .mockResolvedValueOnce({ verified: true });
+
+    const { reconcileMigrationMetadata: fresh } = await import(
+      "../reconcile-metadata"
+    );
+    const result = await fresh({
+      adapter: adapterWith(["dc_posts", "dc_pages"]),
+      dialect: "sqlite",
+      migrationsDir: "/tmp/migrations",
+      logger: silent,
+      registerFn: (async () => ({
+        collectionsRegistered: 0,
+        singlesRegistered: 0,
+      })) as never,
+    });
+
+    // One failure costs ONE row its status, not the rest of the sweep.
+    expect(result.marked).toBe(1);
+    expect(result.stillPending).toBe(1);
+  });
+
+  it("reports what registration inserted", async () => {
+    const { result } = await run({
+      tables: [],
+      registerFn: async () => ({
+        collectionsRegistered: 2,
+        singlesRegistered: 1,
+      }),
+    });
+
+    expect(result.collectionsRegistered).toBe(2);
+    expect(result.singlesRegistered).toBe(1);
+  });
+
+  it("skips a row carrying no usable slug or table name", async () => {
+    // Counted as still pending rather than dropped, so the totals stay honest
+    // about what the sweep could not act on.
+    const { result, made } = await run({
+      tables: ["dc_posts"],
+      collections: [{ slug: "", tableName: "dc_posts" }, { tableName: null }],
+    });
+
+    expect(
+      made.collection.updateMigrationStatusWithVerification
+    ).not.toHaveBeenCalled();
+    expect(result.stillPending).toBe(2);
+  });
+});

--- a/packages/nextly/src/domains/schema/migrate/__tests__/reconcile-metadata.test.ts
+++ b/packages/nextly/src/domains/schema/migrate/__tests__/reconcile-metadata.test.ts
@@ -228,4 +228,51 @@ describe("reconcileMigrationMetadata", () => {
     ).not.toHaveBeenCalled();
     expect(result.stillPending).toBe(2);
   });
+
+  /*
+   * 🔴 A registry that cannot be READ must not read as a registry with nothing
+   * to do. This is the failure that shipped: `nextly migrate` installs no table
+   * resolver, so every `adapter.select` refuses with "not found in schema
+   * registry", the per-registry guard catches all three, and the pass returns
+   * zeroes -- identical to a database that was already correct. The command
+   * announced success having repaired nothing, in exactly the production case
+   * it was written for.
+   *
+   * `unreadable` is what separates the two. Asserting `marked === 0` cannot:
+   * it is zero in both.
+   */
+  it("reports a registry it could not read at all", async () => {
+    vi.resetModules();
+    const made = mockRegistries();
+    made.collection.getPendingMigrations.mockRejectedValue(
+      new Error("Table 'dynamic_collections' not found in schema registry")
+    );
+
+    const { reconcileMigrationMetadata: fresh } = await import(
+      "../reconcile-metadata"
+    );
+    const result = await fresh({
+      adapter: adapterWith([]),
+      dialect: "sqlite",
+      migrationsDir: "/tmp/migrations",
+      logger: silent,
+      registerFn: (async () => ({
+        collectionsRegistered: 0,
+        singlesRegistered: 0,
+      })) as never,
+    });
+
+    expect(result.unreadable).toContain("collection");
+    // The control: the other two were readable, so this is a report about ONE
+    // registry rather than a pass that failed wholesale.
+    expect(result.unreadable).not.toContain("single");
+  });
+
+  it("reports nothing unreadable when every registry answers", async () => {
+    // The negative half. Without it, an implementation that always listed all
+    // three would satisfy the assertion above.
+    const { result } = await run({ tables: [], collections: [] });
+
+    expect(result.unreadable).toEqual([]);
+  });
 });

--- a/packages/nextly/src/domains/schema/migrate/reconcile-metadata.integration.test.ts
+++ b/packages/nextly/src/domains/schema/migrate/reconcile-metadata.integration.test.ts
@@ -204,6 +204,32 @@ describe.each(DIALECTS.filter(configured))(
       } as never);
     }
 
+    /**
+     * A table that EXISTS. Nothing else about it is under test.
+     *
+     * 🔴 Deliberately not built through the production DDL generator, and the
+     * reason is what the sweep asks. `markApplied` calls `tableExists(name)` and
+     * reads no column, no key and no type — so this stands in for "the DDL
+     * landed", not for a collection's physical table. A shape drifting from what
+     * production creates cannot make this test wrong, because no assertion here
+     * depends on the shape.
+     *
+     * The repository's rule against hand-copied DDL is about fixtures that MODEL
+     * a real table and silently stop matching it; the guard against becoming
+     * that is the sweep's own narrowness. If it ever inspects columns — verifying
+     * a schema change rather than existence, which is the direction this is
+     * heading — this must be built by the generator that creates the real thing,
+     * because then the shape would be the subject.
+     *
+     * One column, portable across all three dialects, so the statement carries
+     * no shape worth mistaking for a model of anything.
+     */
+    async function createStandInTable(name: string): Promise<void> {
+      await testDb.adapter.executeQuery(
+        `CREATE TABLE ${name} (id varchar(36) NOT NULL)`
+      );
+    }
+
     /** What the registry now says about one slug, read straight from the row. */
     async function statusOf(slug: string): Promise<string | undefined> {
       const rows = (await testDb.adapter.select("dynamic_collections", {
@@ -220,9 +246,7 @@ describe.each(DIALECTS.filter(configured))(
       expect(await statusOf(SLUG.posts)).toBe("pending");
 
       // The DDL, as a migration file would have applied it.
-      await testDb.adapter.executeQuery(
-        `CREATE TABLE ${TABLE.posts} (id varchar(36) NOT NULL, PRIMARY KEY (id))`
-      );
+      await createStandInTable(TABLE.posts);
 
       const result = await reconcileMigrationMetadata({
         adapter: testDb.adapter as never,
@@ -261,9 +285,7 @@ describe.each(DIALECTS.filter(configured))(
       // It runs on every invocation of `migrate`, so a second pass over an
       // already-applied row must be a no-op rather than an error or a rewrite.
       await pendingCollection(SLUG.pages, TABLE.pages);
-      await testDb.adapter.executeQuery(
-        `CREATE TABLE ${TABLE.pages} (id varchar(36) NOT NULL, PRIMARY KEY (id))`
-      );
+      await createStandInTable(TABLE.pages);
 
       const deps = {
         adapter: testDb.adapter as never,

--- a/packages/nextly/src/domains/schema/migrate/reconcile-metadata.integration.test.ts
+++ b/packages/nextly/src/domains/schema/migrate/reconcile-metadata.integration.test.ts
@@ -1,0 +1,282 @@
+/**
+ * A row left `pending` by a production migrate becomes `applied` — on a real
+ * database, on every dialect.
+ *
+ * 🔴 The unit suite beside this proves the sweep's decisions with a fake
+ * adapter. It cannot prove the two calls the decision rests on actually work:
+ * `getRecordsWithPendingMigrations` filters `migration_status IN
+ * ('pending','generated')` through `adapter.select`, and `tableExists` is
+ * implemented per dialect against three different catalogs. Both are exactly
+ * the kind of thing that passes against a stub and fails against MySQL.
+ *
+ * The scenario is the production one, which is the only reason this task
+ * existed: a collection is registered with its row `pending`, the DDL lands
+ * separately (as `nextly migrate` applies it), and nothing ever reconciles the
+ * two because the only writer sits behind `NODE_ENV === "development"`.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  createTestDatabase,
+  type TestDatabase,
+} from "../../../__tests__/database/setup";
+import { reconcileCore } from "./core-reconcile";
+
+import { reconcileMigrationMetadata } from "./reconcile-metadata";
+
+type Dialect = "sqlite" | "postgresql" | "mysql";
+
+const silent = { info: () => {}, warn: () => {}, debug: () => {} };
+
+/**
+ * Whether this leg has a database to talk to.
+ *
+ * 🔴 Reads the ENV VAR, not `getTestDatabaseUrl`. That helper falls back to a
+ * default pointing at the conventional ports (5432, 3306), while this
+ * repository's throwaway containers listen on 5435 and 3307 — so it returns a
+ * usable-looking string whether or not anything is there, and a check written
+ * against it never skips. The first version of this file did exactly that and
+ * reported three connection refusals as test failures.
+ *
+ * SQLite is always available, in memory.
+ */
+function configured(type: Dialect): boolean {
+  if (type === "sqlite") return true;
+  const url =
+    type === "postgresql"
+      ? (process.env.TEST_POSTGRES_URL ?? process.env.TEST_DATABASE_URL)
+      : process.env.TEST_MYSQL_URL;
+  return Boolean(url);
+}
+
+/**
+ * Test-owned table names, prefixed per file.
+ *
+ * The repository requires this of tables a suite creates itself: the
+ * integration run is sequential and shares one database per dialect, so a
+ * generic `dc_posts` would collide with any other suite that wanted the same
+ * obvious name.
+ */
+const TABLE = {
+  posts: "dc_reconcile_meta_posts",
+  drafts: "dc_reconcile_meta_drafts",
+  pages: "dc_reconcile_meta_pages",
+} as const;
+
+/**
+ * Registry SLUGS owned by this file, prefixed for the same reason the tables
+ * are.
+ *
+ * 🔴 Not `posts` / `pages`. The integration run is sequential against one
+ * database per dialect, and this suite DELETES its slugs to stay repeatable —
+ * so generic names meant deleting rows other suites had created. Measured: the
+ * publish-enforcement suites passed alone and failed fifteen tests in a batch
+ * run, entirely because of this cleanup.
+ */
+const SLUG = {
+  posts: "reconcile_meta_posts",
+  drafts: "reconcile_meta_drafts",
+  pages: "reconcile_meta_pages",
+} as const;
+
+const DIALECTS: Dialect[] = ["sqlite", "postgresql", "mysql"];
+
+describe.each(DIALECTS.filter(configured))(
+  "reconcileMigrationMetadata on %s",
+  type => {
+    let testDb: TestDatabase;
+
+    /**
+     * A connected database with the core schema present.
+     *
+     * 🔴 Retried WITHOUT schema creation, because the Postgres and MySQL
+     * containers are long-lived and shared: the integration run is sequential
+     * against one database per dialect, so whichever suite runs first creates
+     * the schema and every later `createSchema` collides on an index that is
+     * already there (`relation "users_email_unique" already exists`). The
+     * second attempt is the ordinary case on a warm container; the first is
+     * what a fresh one needs.
+     */
+    /**
+     * A connected database whose CORE tables exist.
+     *
+     * 🔴 Provisioned by `reconcileCore`, the same push `nextly migrate` runs in
+     * Phase 1 — not by the fixture's `createSchema`. That path builds the whole
+     * application schema and cannot do it on MySQL at all: it emits a TEXT
+     * `session_token` inside a key, which MySQL refuses without a key length.
+     * That limitation is the fixture's and predates this suite; going through
+     * the production reconciler instead gets the one table this test needs, on
+     * every dialect, from the code that really creates it.
+     */
+    beforeEach(async () => {
+      testDb = await createTestDatabase({ type, createSchema: false });
+
+      /*
+       * 🔴 Provisioned ONLY when the registry table is genuinely absent, and
+       * the guard is the whole point. `reconcileCore` is a schema PUSH: run
+       * unconditionally against the long-lived Postgres and MySQL containers
+       * this suite shares with every other integration file, it rewrites core
+       * tables underneath them. Measured: running it in each `beforeEach` broke
+       * twelve publish-enforcement tests that pass on a clean tree and pass
+       * when this file runs alone — a fixture reaching outside its own subject.
+       *
+       * The fixture's own `createSchema` is not used instead, because it builds
+       * the whole application schema and cannot do it on MySQL at all: it emits
+       * a TEXT `session_token` inside a key, which MySQL refuses without a key
+       * length. That limitation predates this suite.
+       */
+      if (!(await testDb.adapter.tableExists("dynamic_collections"))) {
+        await reconcileCore({
+          db: testDb.adapter.getDrizzle(),
+          dialect: testDb.adapter.dialect as never,
+          logger: { info: () => {}, warn: () => {} },
+        } as never);
+      }
+    });
+
+    afterEach(async () => {
+      // The test-owned tables are dropped explicitly: the database outlives the
+      // run, so a table left standing makes the NEXT run's "table does not
+      // exist" case silently untrue.
+      for (const name of Object.values(TABLE)) {
+        await testDb?.adapter
+          .executeQuery(`DROP TABLE IF EXISTS ${name}`)
+          .catch(() => {});
+      }
+      await testDb?.adapter
+        .executeQuery(
+          `DELETE FROM dynamic_collections WHERE slug IN ('${SLUG.posts}','${SLUG.drafts}','${SLUG.pages}')`
+        )
+        .catch(() => {});
+      // Guarded: when `beforeEach` throws (an unreachable database, say),
+      // `testDb` is undefined and an unguarded cleanup reports a TypeError that
+      // buries the connection error underneath it.
+      /*
+       * 🔴 DISCONNECT, never `cleanup()`. That helper drops EVERY table on
+       * Postgres and MySQL before disconnecting -- fine for a database a suite
+       * owns, catastrophic for the long-lived containers this run shares
+       * sequentially with a hundred other files. Measured: calling it here
+       * destroyed the schema underneath the publish-enforcement suites and
+       * failed twelve of their tests, which pass on a clean tree and pass when
+       * this file runs alone.
+       *
+       * The rows and tables this file created are removed above, by name, which
+       * is the amount of cleanup it is entitled to do.
+       */
+      await testDb?.adapter.disconnect().catch(() => {});
+    });
+
+    /**
+     * A registry row that is already behind: registered, and still `pending`.
+     *
+     * 🔴 Inserted through the adapter rather than through
+     * `registerCollection`, and the reason is worth stating. That path asserts
+     * global slug availability across collections, singles AND field groups, so
+     * it reads registry tables this test has no reason to care about -- the
+     * first version failed on a missing `dynamic_singles` and the failure was
+     * entirely the fixture's, not the sweep's. Writing the row directly keeps
+     * the test pointed at what it names.
+     */
+    async function pendingCollection(
+      slug: string,
+      tableName: string
+    ): Promise<void> {
+      // Cleared BEFORE inserting, not only after. The database outlives the
+      // run, so a row stranded by an earlier failure would fail this insert on
+      // its primary key — reporting leftover state as a defect in the code
+      // under test, which is exactly how a shared container wastes an
+      // afternoon.
+      await testDb.adapter
+        .executeQuery(`DELETE FROM dynamic_collections WHERE slug = '${slug}'`)
+        .catch(() => {});
+      await testDb.adapter.insert("dynamic_collections", {
+        id: `${slug}-id`,
+        slug,
+        labels: { singular: slug, plural: slug },
+        tableName,
+        fields: [],
+        status: true,
+        source: "ui",
+        locked: false,
+        schemaHash: "test",
+        schemaVersion: 1,
+        migrationStatus: "pending",
+      } as never);
+    }
+
+    /** What the registry now says about one slug, read straight from the row. */
+    async function statusOf(slug: string): Promise<string | undefined> {
+      const rows = (await testDb.adapter.select("dynamic_collections", {
+        where: { and: [{ column: "slug", op: "=", value: slug }] },
+      })) as { migrationStatus?: string }[];
+      return rows[0]?.migrationStatus;
+    }
+
+    it("moves a pending row to applied once its table exists", async () => {
+      await pendingCollection(SLUG.posts, TABLE.posts);
+
+      // The control: the row really is behind before the sweep runs, so a
+      // reconcile that did nothing could not produce the assertion below.
+      expect(await statusOf(SLUG.posts)).toBe("pending");
+
+      // The DDL, as a migration file would have applied it.
+      await testDb.adapter.executeQuery(
+        `CREATE TABLE ${TABLE.posts} (id varchar(36) NOT NULL, PRIMARY KEY (id))`
+      );
+
+      const result = await reconcileMigrationMetadata({
+        adapter: testDb.adapter as never,
+        dialect: testDb.adapter.dialect as never,
+        migrationsDir: "/tmp/nextly-no-migrations",
+        logger: silent,
+      });
+
+      expect(result.marked).toBeGreaterThanOrEqual(1);
+      expect(await statusOf(SLUG.posts)).toBe("applied");
+    });
+
+    /*
+     * 🔴 The row a migration has not reached yet is LEFT ALONE, on a real
+     * database. `updateMigrationStatusWithVerification` would write `failed`
+     * here, and after a migrate run "no table" cannot distinguish a migration
+     * that failed from one that was never generated -- so condemning it turns a
+     * collection still waiting for its DDL into one somebody has to repair by
+     * hand.
+     */
+    it("leaves a pending row alone when its table does not exist", async () => {
+      await pendingCollection(SLUG.drafts, TABLE.drafts);
+
+      const result = await reconcileMigrationMetadata({
+        adapter: testDb.adapter as never,
+        dialect: testDb.adapter.dialect as never,
+        migrationsDir: "/tmp/nextly-no-migrations",
+        logger: silent,
+      });
+
+      expect(result.stillPending).toBeGreaterThanOrEqual(1);
+      expect(await statusOf(SLUG.drafts)).toBe("pending");
+    });
+
+    it("is safe to run twice", async () => {
+      // It runs on every invocation of `migrate`, so a second pass over an
+      // already-applied row must be a no-op rather than an error or a rewrite.
+      await pendingCollection(SLUG.pages, TABLE.pages);
+      await testDb.adapter.executeQuery(
+        `CREATE TABLE ${TABLE.pages} (id varchar(36) NOT NULL, PRIMARY KEY (id))`
+      );
+
+      const deps = {
+        adapter: testDb.adapter as never,
+        dialect: testDb.adapter.dialect as never,
+        migrationsDir: "/tmp/nextly-no-migrations",
+        logger: silent,
+      };
+      await reconcileMigrationMetadata(deps);
+      const second = await reconcileMigrationMetadata(deps);
+
+      // Nothing left pending to mark, and the row is still applied.
+      expect(second.marked).toBe(0);
+      expect(await statusOf(SLUG.pages)).toBe("applied");
+    });
+  }
+);

--- a/packages/nextly/src/domains/schema/migrate/reconcile-metadata.ts
+++ b/packages/nextly/src/domains/schema/migrate/reconcile-metadata.ts
@@ -1,0 +1,290 @@
+/**
+ * Making the registry agree with the tables `migrate` just created.
+ *
+ * 🔴 Without this, a collection built in the Schema Builder and deployed to
+ * production never shows a dashboard card. `registerFromMigrations` is the only
+ * writer that records `applied`, and its one caller sits inside
+ * `runBootTimeApplyIfDev`, whose first line returns unless
+ * `NODE_ENV === "development"`. `nextly migrate` applies the DDL and touches no
+ * registry row at all, so the row stays `pending` after its table exists — and a
+ * restart re-runs the same dev-gated path and changes nothing.
+ *
+ * The reconciliation half of that was already built and never connected:
+ * `getPendingMigrations()` and `updateMigrationStatusWithVerification()` are
+ * public on all three registry services and had no product callers anywhere.
+ *
+ * ## Why WRITE rather than derive on read
+ *
+ * The status could be computed from the file ledger whenever someone asks. It is
+ * written instead, for two reasons. The registry row is what every reader
+ * already consults — the widget layer, the admin, the permission seeder — so
+ * deriving it would mean teaching each of them a second source and keeping the
+ * two agreeing. And Directus, the closest structural analogue with a per-entity
+ * registry, writes its metadata in the same operation as the DDL rather than as
+ * a later pass; the migration tools with no registry at all (Prisma, Drizzle
+ * Kit, Rails, Django) cannot answer the question, because they have no row to
+ * reconcile.
+ *
+ * ## Sequenced with repair, not atomic
+ *
+ * The DDL and this bookkeeping cannot share a transaction: MySQL commits DDL
+ * implicitly, so there is no boundary to roll back across. `migrate` therefore
+ * runs this AFTER the tables land and treats every half as idempotent —
+ * matching what `single-metadata-service` and `field-groups/migration/steps`
+ * already do for the identical DDL-then-registry-row problem. A failure here
+ * leaves tables that work and a row that is behind, which the next invocation
+ * repairs; failing the command instead would report a successful migration as
+ * broken.
+ *
+ * @module domains/schema/migrate/reconcile-metadata
+ */
+
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+
+import type { Logger } from "../../../shared/types";
+import type { SupportedDialect } from "../../../types/database";
+import { CollectionRegistryService } from "../../collections/services/collection-registry-service";
+import { FieldGroupRegistryService } from "../../field-groups/services/field-group-registry-service";
+import { SingleRegistryService } from "../../singles/services/single-registry-service";
+
+import { registerFromMigrations } from "./metadata-register";
+
+/**
+ * The logging surface a CALLER supplies, structural so the CLI's own context
+ * satisfies it without adapting.
+ *
+ * Narrower than `Logger`, which the registry services take: they log with a
+ * metadata object the CLI's logger has no parameter for. {@link asServiceLogger}
+ * widens one into the other in the single place that needs it, rather than
+ * making every caller carry a shape it does not have.
+ */
+export interface ReconcileLogger {
+  info: (message: string) => void;
+  warn: (message: string) => void;
+  debug: (message: string) => void;
+  error?: (message: string) => void;
+}
+
+/**
+ * A `Logger` for the registry services, from the narrower surface above.
+ *
+ * The metadata argument is DROPPED rather than serialized into the message: it
+ * carries slugs and table names this already reports in its own summary, and a
+ * caller whose logger takes no second argument would otherwise see either
+ * nothing or a stringified object appended to every line.
+ */
+function asServiceLogger(logger: ReconcileLogger): Logger {
+  return {
+    debug: message => logger.debug(message),
+    info: message => logger.info(message),
+    warn: message => logger.warn(message),
+    error: message => (logger.error ?? logger.warn)(message),
+  };
+}
+
+export interface ReconcileMetadataDeps {
+  adapter: DrizzleAdapter;
+  dialect: SupportedDialect;
+  migrationsDir: string;
+  logger: ReconcileLogger;
+  /** Seam for tests; defaults to the real snapshot reader. */
+  registerFn?: typeof registerFromMigrations;
+}
+
+export interface ReconcileMetadataResult {
+  collectionsRegistered: number;
+  singlesRegistered: number;
+  /** Rows moved from `pending`/`generated` to `applied`. */
+  marked: number;
+  /**
+   * Rows left exactly as they were, because their table is not there yet.
+   *
+   * Reported rather than silently skipped: it is the number that tells an
+   * operator the difference between "nothing needed doing" and "something is
+   * still waiting for a migration that has not been generated".
+   */
+  stillPending: number;
+}
+
+/** One registry service, reduced to the two calls this needs from it. */
+interface PendingRegistry {
+  kind: string;
+  getPendingMigrations: () => Promise<readonly unknown[]>;
+  updateMigrationStatusWithVerification: (
+    slug: string,
+    tableName: string
+  ) => Promise<{ verified: boolean }>;
+}
+
+/** `slug` and `tableName` off a registry record, when it carries usable ones. */
+function identify(
+  record: unknown
+): { slug: string; tableName: string } | undefined {
+  if (typeof record !== "object" || record === null) return undefined;
+  const { slug, tableName } = record as {
+    slug?: unknown;
+    tableName?: unknown;
+  };
+  if (typeof slug !== "string" || slug === "") return undefined;
+  if (typeof tableName !== "string" || tableName === "") return undefined;
+  return { slug, tableName };
+}
+
+/**
+ * Move every pending row whose table now EXISTS to `applied`.
+ *
+ * 🔴 Existence is checked here, before delegating, and the row is left untouched
+ * when the table is absent. `updateMigrationStatusWithVerification` writes
+ * `failed` in that case, which is right where a create is known to have been
+ * attempted and wrong here: after a migrate run, a `pending` row with no table
+ * has two indistinguishable causes — a migration that failed, and a migration
+ * file that was never generated. Condemning the second turns a collection still
+ * waiting for its DDL into one an operator has to un-fail by hand, and this pass
+ * runs on every invocation, so nothing is lost by waiting.
+ *
+ * The delegate re-checks existence, and that duplicate read is deliberate: it
+ * keeps ONE implementation of "verify, then record", so the status can never be
+ * written by a path that skipped the check.
+ */
+async function markApplied(
+  registry: PendingRegistry,
+  adapter: DrizzleAdapter,
+  logger: ReconcileLogger
+): Promise<{ marked: number; stillPending: number }> {
+  let marked = 0;
+  let stillPending = 0;
+
+  const rows = await registry.getPendingMigrations();
+  for (const row of rows) {
+    const named = identify(row);
+    if (!named) {
+      // A row with no usable slug or table name cannot be verified against
+      // anything. Counted as still pending so the total stays honest.
+      stillPending += 1;
+      continue;
+    }
+
+    try {
+      if (!(await adapter.tableExists(named.tableName))) {
+        stillPending += 1;
+        continue;
+      }
+      const outcome = await registry.updateMigrationStatusWithVerification(
+        named.slug,
+        named.tableName
+      );
+      if (outcome.verified) marked += 1;
+      else stillPending += 1;
+    } catch (error) {
+      // Per ROW, so one unreadable record cannot cost the rest their status.
+      // The tables are already in place; the worst case is a row that stays
+      // behind until the next invocation.
+      stillPending += 1;
+      logger.warn(
+        `Could not record migration status for ${registry.kind} "${named.slug}": ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+  }
+
+  return { marked, stillPending };
+}
+
+/**
+ * Register what the snapshots describe, then record what the tables prove.
+ *
+ * Called INSIDE the migrate lock, unlike the dev-boot path, which runs its
+ * equivalent outside for reasons scoped to several dev-server workers racing.
+ * A CLI invocation holds the lock already, so the read-then-write below cannot
+ * interleave with another migrate — which is what lets it be a plain sweep
+ * rather than a conflict-tolerant one.
+ */
+export async function reconcileMigrationMetadata(
+  deps: ReconcileMetadataDeps
+): Promise<ReconcileMetadataResult> {
+  const { adapter, dialect, migrationsDir, logger } = deps;
+  const register = deps.registerFn ?? registerFromMigrations;
+
+  // Step 1: rows the snapshots describe that the registry does not have yet.
+  // These are inserted already `applied`, because the migration that carries
+  // their DDL is the one that just ran.
+  const registered = await register({
+    migrationsDir,
+    adapter,
+    dialect,
+    logger,
+  });
+
+  // Step 2: rows the registry already had, waiting on a table.
+  const serviceLogger = asServiceLogger(logger);
+  const registries: PendingRegistry[] = [
+    {
+      kind: "collection",
+      ...bind(new CollectionRegistryService(adapter, serviceLogger)),
+    },
+    {
+      kind: "single",
+      ...bind(new SingleRegistryService(adapter, serviceLogger)),
+    },
+    {
+      kind: "field group",
+      ...bind(new FieldGroupRegistryService(adapter, serviceLogger)),
+    },
+  ];
+
+  let marked = 0;
+  let stillPending = 0;
+  for (const registry of registries) {
+    try {
+      const swept = await markApplied(registry, adapter, logger);
+      marked += swept.marked;
+      stillPending += swept.stillPending;
+    } catch (error) {
+      /*
+       * 🔴 Per REGISTRY, so one that cannot be read costs only its own rows.
+       * The reachable cause is an install whose registry table is not there --
+       * a project with no singles has no `dynamic_singles` -- and letting that
+       * throw would mean a missing table for a feature nobody uses stops the
+       * collections beside it from ever recording their status.
+       *
+       * Warned rather than silent: a registry that cannot be swept is a real
+       * gap in what this pass claims to have done, and the count it would have
+       * contributed is simply absent from the totals.
+       */
+      logger.warn(
+        `Could not sweep ${registry.kind} migration statuses: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+  }
+
+  return {
+    collectionsRegistered: registered.collectionsRegistered,
+    singlesRegistered: registered.singlesRegistered,
+    marked,
+    stillPending,
+  };
+}
+
+/**
+ * The two calls, bound to their service.
+ *
+ * Bound rather than passed as `service.getPendingMigrations` directly, because
+ * both read `this`; an unbound reference would throw on the first property
+ * access and read as a database failure.
+ */
+function bind(service: {
+  getPendingMigrations: () => Promise<readonly unknown[]>;
+  updateMigrationStatusWithVerification: (
+    slug: string,
+    tableName: string
+  ) => Promise<{ verified: boolean }>;
+}): Omit<PendingRegistry, "kind"> {
+  return {
+    getPendingMigrations: () => service.getPendingMigrations(),
+    updateMigrationStatusWithVerification: (slug, tableName) =>
+      service.updateMigrationStatusWithVerification(slug, tableName),
+  };
+}

--- a/packages/nextly/src/domains/schema/migrate/reconcile-metadata.ts
+++ b/packages/nextly/src/domains/schema/migrate/reconcile-metadata.ts
@@ -104,6 +104,17 @@ export interface ReconcileMetadataResult {
    * still waiting for a migration that has not been generated".
    */
   stillPending: number;
+  /**
+   * Registries this pass could not read at all, by kind.
+   *
+   * 🔴 Reported rather than only logged, because the per-registry guard below
+   * turns a TOTAL failure into an ordinary-looking success otherwise. That is
+   * not hypothetical: with no table resolver installed, every registry read
+   * refuses, all three are caught, and the command finishes claiming zero rows
+   * needed repair — indistinguishable from a database that was already correct.
+   * A caller that can see this list can say the difference.
+   */
+  unreadable: string[];
 }
 
 /** One registry service, reduced to the two calls this needs from it. */
@@ -235,6 +246,7 @@ export async function reconcileMigrationMetadata(
 
   let marked = 0;
   let stillPending = 0;
+  const unreadable: string[] = [];
   for (const registry of registries) {
     try {
       const swept = await markApplied(registry, adapter, logger);
@@ -252,6 +264,7 @@ export async function reconcileMigrationMetadata(
        * gap in what this pass claims to have done, and the count it would have
        * contributed is simply absent from the totals.
        */
+      unreadable.push(registry.kind);
       logger.warn(
         `Could not sweep ${registry.kind} migration statuses: ${
           error instanceof Error ? error.message : String(error)
@@ -265,6 +278,7 @@ export async function reconcileMigrationMetadata(
     singlesRegistered: registered.singlesRegistered,
     marked,
     stillPending,
+    unreadable,
   };
 }
 

--- a/packages/nextly/src/domains/singles/__tests__/single-registry-service.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-registry-service.test.ts
@@ -347,7 +347,11 @@ describe("SingleRegistryService", () => {
       >;
       const where = opts.where as Record<string, unknown>;
       expect((where.and as Array<Record<string, unknown>>)[0]).toMatchObject({
-        column: "migration_status",
+        // The SCHEMA PROPERTY, not the physical column. The adapter here is a
+        // mock that accepts any name, which is exactly why the physical
+        // spelling survived in the query for so long: only a real database
+        // refuses it.
+        column: "migrationStatus",
         value: "pending",
       });
     });
@@ -642,7 +646,11 @@ describe("SingleRegistryService", () => {
       const where = opts.where as Record<string, unknown>;
       const andArr = where.and as Array<Record<string, unknown>>;
       expect(andArr[0]).toMatchObject({
-        column: "migration_status",
+        // The SCHEMA PROPERTY, not the physical column. The adapter here is a
+        // mock that accepts any name, which is exactly why the physical
+        // spelling survived in the query for so long: only a real database
+        // refuses it.
+        column: "migrationStatus",
         value: ["pending", "generated"],
       });
     });

--- a/packages/nextly/src/shared/base-registry-service.ts
+++ b/packages/nextly/src/shared/base-registry-service.ts
@@ -259,26 +259,12 @@ export abstract class BaseRegistryService<
    * Get all records, optionally filtered by source, migration status, and locked.
    */
   protected async getAllRecords(options?: BaseListOptions): Promise<TRecord[]> {
-    try {
-      const conditions = this.buildFilterConditions(options);
-
-      const results = await this.adapter.select<TRecord>(
-        await this.resolveRegistryTableName(),
-        {
-          where: conditions.length > 0 ? { and: conditions } : undefined,
-          orderBy: [{ column: "created_at", direction: "asc" }],
-          limit: options?.limit,
-          offset: options?.offset,
-        }
-      );
-
-      return results.map(record => this.deserializeRecord(record));
-    } catch (error) {
-      if (NextlyError.is(error)) throw error;
-      // Normalise raw driver errors before mapping so unique/fk/etc. are
-      // classified instead of collapsing to INTERNAL_ERROR.
-      throw NextlyError.fromDatabaseError(toDbError(this.dialect, error));
-    }
+    const conditions = this.buildFilterConditions(options);
+    return this.selectRecords({
+      where: conditions.length > 0 ? { and: conditions } : undefined,
+      limit: options?.limit,
+      offset: options?.offset,
+    });
   }
 
   /**
@@ -328,7 +314,7 @@ export abstract class BaseRegistryService<
         await this.resolveRegistryTableName(),
         {
           where: whereClause,
-          orderBy: [{ column: "created_at", direction: "asc" }],
+          orderBy: [{ column: "createdAt", direction: "asc" }],
           limit: options?.limit,
           offset: options?.offset,
         }
@@ -451,29 +437,65 @@ export abstract class BaseRegistryService<
 
   /**
    * Get all records with pending migrations (status 'pending' or 'generated').
+   *
+   * 🔴 Named by Drizzle SCHEMA PROPERTY, not by physical column.
+   * `adapter.select` resolves each `column` against the table's property names,
+   * so `migration_status` and `created_at` -- the names in the DDL -- do not
+   * resolve at all: the adapter refuses with "Column not found in table",
+   * listing `migrationStatus` and `createdAt` among what it does have.
+   *
+   * This threw for every caller, which is precisely why it had none. The method
+   * was written alongside `updateMigrationStatusWithTableVerification` for a
+   * reconciliation pass that was never wired up, so nothing ever ran it and the
+   * mistake could not surface. The identical defect is recorded in
+   * `activity-log-service`, where a physical name silently dropped an ORDER BY
+   * and made a filtered query fail outright.
    */
   protected async getRecordsWithPendingMigrations(): Promise<TRecord[]> {
+    return this.selectRecords({
+      where: {
+        and: [
+          {
+            column: "migrationStatus",
+            op: "IN",
+            value: ["pending", "generated"],
+          },
+        ],
+      },
+    });
+  }
+
+  /**
+   * Read registry rows, oldest first, deserialized — with driver errors mapped.
+   *
+   * 🔴 ONE reader for every list this service performs, because the three
+   * things it does are each easy to get subtly wrong and were previously
+   * written out per method. The ordering names `createdAt`, the SCHEMA
+   * PROPERTY: `adapter.select` resolves columns against the table's property
+   * names, and a physical `created_at` is not rejected in an `orderBy` — it is
+   * silently ignored, so the caller believes it asked for an order it never
+   * got. The error mapping keeps a unique or foreign-key violation classified
+   * rather than collapsing to INTERNAL_ERROR. And `deserializeRecord` is what
+   * turns stored JSON columns back into values.
+   *
+   * A method that skipped any one of those looked correct beside the others.
+   */
+  private async selectRecords(query: {
+    where?: { and: (WhereCondition | { or: WhereCondition[] })[] };
+    limit?: number;
+    offset?: number;
+  }): Promise<TRecord[]> {
     try {
       const results = await this.adapter.select<TRecord>(
         await this.resolveRegistryTableName(),
         {
-          where: {
-            and: [
-              {
-                column: "migration_status",
-                op: "IN",
-                value: ["pending", "generated"],
-              },
-            ],
-          },
-          orderBy: [{ column: "created_at", direction: "asc" }],
+          ...query,
+          orderBy: [{ column: "createdAt", direction: "asc" }],
         }
       );
-
       return results.map(record => this.deserializeRecord(record));
     } catch (error) {
       if (NextlyError.is(error)) throw error;
-      // Normalise raw driver errors before mapping to NextlyError kind.
       throw NextlyError.fromDatabaseError(toDbError(this.dialect, error));
     }
   }
@@ -609,7 +631,10 @@ export abstract class BaseRegistryService<
 
     if (options?.migrationStatus) {
       conditions.push({
-        column: "migration_status",
+        // The SCHEMA PROPERTY, as everywhere else here: `adapter.select`
+        // resolves against the table's property names, so the physical
+        // `migration_status` refuses outright with "Column not found in table".
+        column: "migrationStatus",
         op: "=",
         value: options.migrationStatus as SqlParam,
       });


### PR DESCRIPTION
A collection built in the Schema Builder and deployed to production **never showed its dashboard cards**. This is that, fixed — and one bug found on the way that could never have worked for anyone.

## The defect, verified on current main

`registerFromMigrations` is the only writer that records `applied`, and it has exactly one caller: `boot-apply.ts:255`. That sits inside `runBootTimeApplyIfDev`, whose first line is `if (process.env.NODE_ENV !== "development") return;`. `cli/commands/migrate.ts` has **zero** references to it or to `migration_status` across 1100+ lines.

So in production the CLI applied the DDL, the row stayed `pending`, the collection never registered, and a restart re-ran the same dev-gated path and changed nothing.

## The reconciliation half was built and never connected

`getRecordsWithPendingMigrations()` and `updateMigrationStatusWithVerification()` are public on all three registry services and had **no product callers anywhere**. The only mention was a docblock in `single-metadata-service.ts:38` saying so outright.

## Phase 3

A third phase after the file migrations, **inside** the migrate lock — unlike the dev-boot path, which runs outside it for reasons scoped to several dev-server workers racing. It registers what the snapshots describe, then moves every pending row whose table exists to `applied`.

**A row whose table is not there is left exactly as it was**, and this diverges from the recorded research, which said to use `updateMigrationStatusWithTableVerification` directly. That method writes `failed` when the table is absent — and after a migrate run, absence has two indistinguishable causes: a migration that failed, and a migration file never generated. Condemning the second turns a collection still waiting for its DDL into one somebody has to un-fail by hand. The pass runs on every invocation, so nothing is lost by waiting.

**The command still succeeds if the bookkeeping fails.** By then the DDL has landed, and MySQL commits DDL implicitly, so there is no transaction to roll back into. Failing would report a migration that worked as broken.

## `getRecordsWithPendingMigrations` was broken

It filtered on `migration_status` and ordered by `created_at` — **physical column names** — while the adapter resolves columns by their Drizzle property names. It threw `Column not found in table` on every call. It had no callers, which is precisely why nothing surfaced it.

The integration test found it. The unit tests could not: their mock adapter accepts any column name, and **two of them asserted the broken spelling** — a mock keeping a broken query looking correct.

Three sibling queries in the same file carried the same mistake and are fixed with it: two `orderBy` clauses naming `created_at`, which an adapter does not reject but silently ignores, so the caller believed it had an order it never got; and one `migrationStatus` filter that would have thrown for anyone who passed it. The three list paths now share one reader, so ordering, deserialization and error mapping cannot be skipped by a method that looks correct beside its neighbours.

## Verification

| gate | result |
| --- | --- |
| `pnpm check-types` (both invocations) | exit 0 |
| `pnpm lint` | exit 0 |
| nextly unit | 891 files / 11368 passed, 42 skipped |
| integration, **all three dialects** | 100 files / 837 passed |
| fallow | `pass`, 0 introduced |
| `npx changeset status` | exit 0 |

Break-verified against wrong implementations, control green either side:

| break | result |
| --- | --- |
| sweep uses the verification method directly (condemns a missing table) | fails |
| Phase 3 gated on `applied > 0` | 2 fail |
| the reconcile throws | command still succeeds — asserted, not assumed |

## Three fixture bugs of mine that the batch run caught

Worth recording, because each passed in isolation and only failed in a full run:

- **`cleanup()` drops every table** on Postgres and MySQL. Calling it in `afterEach` destroyed the schema underneath the publish-enforcement suites — twelve failures that pass on a clean tree and pass when this file runs alone. It disconnects now, and removes only the rows and tables it created, by name.
- **Generic slugs.** `posts` / `pages` are names other suites use, and this file deletes its slugs to stay repeatable. Prefixed now, like the tables already were.
- **A catch that hid its cause.** The provisioning retry caught everything, so a genuine failure produced a database with no tables and the suite failed several steps later as if the code were at fault. It is narrowed to "already exists".

The control that settled all of it: the identical batch on a fully clean tree gave **1** failure (pre-existing, a MySQL rollback test); with my change it gave **13**.

## One thing to know

Integration coverage provisions through `reconcileCore` — the production push — rather than the fixture's `createSchema`, which **cannot create the schema on MySQL at all**: it emits a TEXT `session_token` inside a key, which MySQL refuses without a key length. That limitation is pre-existing and is why no other multi-dialect suite uses that fixture.

Permissions are deliberately out of scope, and I checked rather than assumed: boot pairs registration with permission seeding, and the CLI has no DI container — but `post-init-tasks.ts:91` calls `seedAllPermissions()` on every boot, not dev-gated, so permissions self-heal once the row exists.