### PR TITLE
feat(blocks-engine): record which pattern an inserted copy came from

### DIFF
--- a/.changeset/a-pasted-pattern-knows-its-source.md
+++ b/.changeset/a-pasted-pattern-knows-its-source.md
@@ -67,3 +67,14 @@ dropped rather than kept, a malformed entry passed through, a malformed slot
 preserved — and each was learned here. A planner that wrote its own walk
 inherited none of them; the two that had are now expressed through the shared
 one.
+
+The digest describes what a copy would CARRY, so a root's own provenance is
+excluded from it. Inserting overwrites that field, and hashing it would make
+clearing an inert record nothing copies report every existing copy as stale. A
+record deeper than a root is hashed, because that one is copied as it stands.
+The exclusion lives inside the digest rather than at the call site, so a later
+staleness check cannot hash different content from the copy it is judging.
+
+A pattern handed over without an identity is refused rather than given a record
+the op layer rejects. Every non-empty string is a legal id and only the empty
+one is not, which a type cannot say.

--- a/.changeset/a-pasted-pattern-knows-its-source.md
+++ b/.changeset/a-pasted-pattern-knows-its-source.md
@@ -78,3 +78,16 @@ staleness check cannot hash different content from the copy it is judging.
 A pattern handed over without an identity is refused rather than given a record
 the op layer rejects. Every non-empty string is a legal id and only the empty
 one is not, which a type cannot say.
+
+Node ids are excluded from the digest too, for the same reason a root's own
+provenance is: inserting mints every id fresh at every depth, so no stored id
+reaches a copy. Hashing them made an identity-only rewrite of a pattern report
+every existing copy as stale at once.
+
+The rule inside the digest is now one question asked of each field — does a copy
+carry this, or does inserting regenerate it? A field the copy derives FROM stays
+in: renaming a `cssId` from `pricing` to `plans` changes what every copy renders,
+because the minted replacement is built from the stored value. The walk is
+structure-aware rather than a serializer replacer keyed on the name `id`, which
+would have dropped a prop an author named `id` and an `attributes.id` the copy
+does carry.

--- a/.changeset/a-pasted-pattern-knows-its-source.md
+++ b/.changeset/a-pasted-pattern-knows-its-source.md
@@ -106,3 +106,15 @@ setter instead of creating an own property — so the attribute would have been
 absent from what is hashed while the copier carries it, and editing it would
 have produced the same digest and no upstream-change notice. Written through the
 package's prototype-safe record writer, which exists for exactly this.
+
+The rules these copiers share are reachable from the package entry. A module's
+`export` keyword makes a symbol importable within the package; a consumer gets
+only what the entry re-exports, and two of these had the first without the
+second — so a surface holding `BlockOrigin` had no way to check one, and a
+surface copying nodes had no way to tokenise an id reference the way the copier
+does. Both are the defect the rules were centralised to prevent: a caller who
+cannot import the answer writes a second one.
+
+A test now asserts that every function `document.ts` and `tree.ts` export is
+reachable from the entry, asked of the module object rather than of the index
+source, so a re-export that does not resolve cannot pass it.

--- a/.changeset/a-pasted-pattern-knows-its-source.md
+++ b/.changeset/a-pasted-pattern-knows-its-source.md
@@ -91,3 +91,11 @@ because the minted replacement is built from the stored value. The walk is
 structure-aware rather than a serializer replacer keyed on the name `id`, which
 would have dropped a prop an author named `id` and an `attributes.id` the copy
 does carry.
+
+An id reference is hashed as its tokens, because that is how the copier writes
+it back: `"hero   label"` and `"hero label"` name the same two references and
+every copy carries the second, so hashing the spacing reported a change no copy
+can show. Through the copier's own rule, now published, rather than a second
+split that would agree until one of them moved — and only for the
+reference-valued attributes, since whitespace inside an ordinary one is content
+a copy carries exactly.

--- a/.changeset/a-pasted-pattern-knows-its-source.md
+++ b/.changeset/a-pasted-pattern-knows-its-source.md
@@ -99,3 +99,10 @@ can show. Through the copier's own rule, now published, rather than a second
 split that would agree until one of them moved — and only for the
 reference-valued attributes, since whitespace inside an ordinary one is content
 a copy carries exactly.
+
+An attribute stored under `__proto__` is hashed like any other. Attribute names
+come from persisted JSON, and assigning to that one runs the legacy prototype
+setter instead of creating an own property — so the attribute would have been
+absent from what is hashed while the copier carries it, and editing it would
+have produced the same digest and no upstream-change notice. Written through the
+package's prototype-safe record writer, which exists for exactly this.

--- a/.changeset/a-pasted-pattern-knows-its-source.md
+++ b/.changeset/a-pasted-pattern-knows-its-source.md
@@ -1,0 +1,69 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+An inserted pattern records which pattern it came from, and what that pattern
+looked like at the time.
+
+Each inserted root carries `origin: { from: "pattern", id, digest }`, so "the
+pattern this section came from has changed — do you want the change?" becomes
+answerable later. It could not be added retroactively: a page built before this
+can never be told where its blocks came from.
+
+The ROOTS only. The run is what was inserted; a descendant did not come from the
+pattern separately, and marking every node would make an author detaching one
+child look like a second insertion.
+
+It is OVERWRITTEN, never filled in only where absent. A root can arrive already
+carrying a record from an earlier copy, and leaving that in place would
+attribute the insertion to a pattern it has nothing to do with — worse than no
+record, because a staleness check would then compare against the wrong source
+and answer confidently.
+
+For the same reason, saving a selection STRIPS any provenance it was already
+carrying, at every depth. A stored pattern's nodes came from the page, not from
+wherever the page's nodes came from, so a pattern saved out of already-inserted
+content would otherwise claim a source it never had.
+
+The digest is of content rather than a version. The engine is handed a document
+and never an entry row — it can hash what it was given and cannot see what the
+store calls it — and content answers the question more precisely anyway, since a
+re-save that changed nothing bumps a version and leaves a digest alone. It is a
+change hint and not a security boundary: a collision costs one missed notice,
+which is why it is a short hash rather than a cryptographic one.
+
+Inserting takes the pattern's identity alongside its document, as one value.
+Two arguments could be supplied out of step, and an id belonging to a different
+pattern than the nodes writes provenance that reads as authoritative and is
+wrong.
+
+The engine's forest rewrite is published. Three of its behaviours are ones a
+caller changing a single field across a stored tree gets wrong — a cycle entry
+dropped rather than kept, a malformed entry passed through, a malformed slot
+preserved — and each was learned here. A planner that wrote its own walk
+inherited none of them; the two that had are now expressed through the shared
+one.

--- a/packages/blocks-engine/src/composition-planners.ts
+++ b/packages/blocks-engine/src/composition-planners.ts
@@ -23,7 +23,7 @@
  *
  * @module composition-planners
  */
-import type { BlockDocument, BlockNode } from "./document";
+import type { BlockDocument, BlockNode, BlockOrigin } from "./document";
 import {
   canBeRoot,
   canNest,
@@ -40,8 +40,9 @@ import {
   type BuilderOp,
   type OpPosition,
 } from "./ops";
+import { patternDigest } from "./pattern-digest";
 import { contiguousRun, type RunProblem } from "./sibling-run";
-import { findNode, reidForestWithMap, walkNodes } from "./tree";
+import { findNode, mapForest, reidForestWithMap, walkNodes } from "./tree";
 
 /** A library row a planner asks the caller to create. */
 export interface PlannedCreate<TFields> {
@@ -197,7 +198,10 @@ export function planSaveAsPattern<TFields>(
         // migrated and never brought forward.
         formatVersion: document.formatVersion,
         kind: "pattern",
-        nodes: reidForestWithMap(selected).nodes,
+        // Re-identified, then stripped of any provenance the selection
+        // inherited: these nodes came from the page, not from wherever the
+        // page's nodes came from.
+        nodes: withoutOrigin(reidForestWithMap(selected).nodes),
       },
       fields: target.fields,
     },
@@ -277,6 +281,22 @@ function bothHalves(
 }
 
 /**
+ * A pattern as it is STORED: the document, and the identity the store gave it.
+ *
+ * Both, because inserting one records where the copy came from and a document
+ * cannot say what row it is. Passed together rather than as two arguments so
+ * they cannot be supplied out of step — an id belonging to a different pattern
+ * than the nodes would write provenance that is worse than none, since it reads
+ * as authoritative.
+ */
+export interface StoredPattern {
+  /** The pattern entry's id. */
+  readonly id: string;
+  /** Its stored document. */
+  readonly document: BlockDocument;
+}
+
+/**
  * Where an inserted pattern goes: a position, or the document itself.
  *
  * `"document"` is not a position and is deliberately not spelled as one. It
@@ -324,22 +344,32 @@ export type InsertTarget = OpPosition | "document";
  */
 export function planInsertPattern(
   document: BlockDocument,
-  pattern: BlockDocument,
+  pattern: StoredPattern,
   target: InsertTarget,
   nesting: NestingSource
 ): PlanResult<never> {
-  const stored = storedRefusal(document, pattern);
+  const stored = storedRefusal(document, pattern.document);
   if (stored !== undefined) return stored;
 
   const destination = destinationOf(document, target);
   if (destination.problem !== undefined) return destination;
 
-  const copy = freshCopy(pattern.nodes, document);
+  const copy = freshCopy(pattern.document.nodes, document);
   if (copy.problem !== undefined) return copy;
 
+  // Recorded on the way in, and OVERWRITTEN rather than filled in where absent:
+  // a root can arrive carrying a record from an earlier copy. The digest is
+  // taken from the pattern as it stands now, so a later reader can tell whether
+  // the source has moved on since this copy was made.
+  const marked = withOrigin(copy.nodes, {
+    from: "pattern",
+    id: pattern.id,
+    digest: patternDigest(pattern.document.nodes),
+  });
+
   const refusal =
-    placementRefusal(copy.nodes, destination.place.where, nesting) ??
-    internalNestingRefusal(copy.nodes, nesting) ??
+    placementRefusal(marked, destination.place.where, nesting) ??
+    internalNestingRefusal(marked, nesting) ??
     // The `"document"` target REMOVES what is there, and a remove refuses both
     // a locked subtree and a malformed node for the same reasons an insert
     // does. Only that target deletes anything; a positional insert adds.
@@ -349,7 +379,7 @@ export function planInsertPattern(
   if (refusal !== undefined) return refusal;
 
   return {
-    pageOps: insertOps(copy.nodes, destination.place, document, target),
+    pageOps: insertOps(marked, destination.place, document, target),
   };
 }
 
@@ -708,41 +738,54 @@ interface UnlockedForest {
 /**
  * Take the locks off, remembering where they were.
  *
- * A rebuild rather than a mutation: these nodes are a copy the planner was
- * handed, and editing them in place would change what the dry run was asked
- * about. Only `locked` moves — a `slots` value that is not an array is carried
- * across as it stands, because malformed content is the shape rule's business
- * and not this function's.
+ * Through the shared forest rewrite rather than a walk of its own: a
+ * hand-rolled traversal has to re-learn what that one already knows about a
+ * cycle entry, a malformed entry and a malformed slot value, and a planner
+ * editing one field has no business deciding any of them.
+ *
+ * Only `locked` moves; every other field is carried across untouched.
  */
 function withoutLocks(roots: readonly BlockNode[]): UnlockedForest {
   const lockedIds: string[] = [];
-
-  const strip = (node: BlockNode): BlockNode => {
-    const slots = node.slots === undefined ? undefined : stripSlots(node.slots);
-    if (node.locked === true) lockedIds.push(node.id);
-    if (node.locked !== true && slots === node.slots) return node;
+  const nodes = mapForest([...roots], node => {
+    if (node.locked !== true) return node;
+    lockedIds.push(node.id);
     const { locked: _locked, ...rest } = node;
-    return slots === undefined ? rest : { ...rest, slots };
-  };
+    return rest;
+  });
+  return { nodes, lockedIds };
+}
 
-  const stripSlots = (
-    slots: Record<string, BlockNode[]>
-  ): Record<string, BlockNode[]> => {
-    let changed = false;
-    const next: Record<string, BlockNode[]> = {};
-    for (const [name, children] of Object.entries(slots)) {
-      if (!Array.isArray(children)) {
-        next[name] = children;
-        continue;
-      }
-      const mapped = children.map(strip);
-      if (mapped.some((child, index) => child !== children[index])) {
-        changed = true;
-      }
-      next[name] = mapped;
-    }
-    return changed ? next : slots;
-  };
+/**
+ * The forest with every provenance record removed.
+ *
+ * A stored pattern's nodes came from the PAGE, not from wherever the page's
+ * nodes came from. Carrying an inherited `origin` across would make a pattern
+ * saved out of already-inserted content claim a source it never had — and a
+ * later "has the upstream changed" check would then compare against the wrong
+ * pattern and answer confidently, which is worse than having no record at all.
+ */
+function withoutOrigin(roots: readonly BlockNode[]): BlockNode[] {
+  return mapForest([...roots], node => {
+    if (node.origin === undefined) return node;
+    const { origin: _origin, ...rest } = node;
+    return rest;
+  });
+}
 
-  return { nodes: roots.map(strip), lockedIds };
+/**
+ * The inserted roots, each recording the pattern it came from.
+ *
+ * OVERWRITTEN, never filled in only where absent: a root can arrive carrying a
+ * record from an earlier copy, and leaving that in place would attribute this
+ * insertion to a pattern it has nothing to do with. Only the ROOTS are marked,
+ * because the run is what was inserted — a descendant did not come from the
+ * pattern separately, and marking every node would make an author detaching one
+ * child look like a second insertion.
+ */
+function withOrigin(
+  roots: readonly BlockNode[],
+  origin: BlockOrigin
+): BlockNode[] {
+  return roots.map(root => ({ ...root, origin }));
 }

--- a/packages/blocks-engine/src/composition-planners.ts
+++ b/packages/blocks-engine/src/composition-planners.ts
@@ -354,11 +354,14 @@ export function planInsertPattern(
   target: InsertTarget,
   nesting: NestingSource
 ): PlanResult<never> {
-  // The identity BEFORE anything is built on it. An empty id produces a record
-  // `isBlockOrigin` refuses, so the plan would succeed and the insert throw —
-  // and the type cannot say this, because every non-empty string is legal and
-  // only the empty one is not.
-  if (pattern.id === "") return { problem: "invalid-source" };
+  // The identity BEFORE anything is built on it. A record whose id is not a
+  // non-empty string is one `isBlockOrigin` refuses, so the plan would succeed
+  // and the insert throw. Checked at RUNTIME as well as in the type: this is a
+  // published entry point, and the value reaching it comes from a JavaScript
+  // caller or a stored row as often as from a typed one.
+  if (typeof pattern.id !== "string" || pattern.id === "") {
+    return { problem: "invalid-source" };
+  }
 
   const stored = storedRefusal(document, pattern.document);
   if (stored !== undefined) return stored;

--- a/packages/blocks-engine/src/composition-planners.ts
+++ b/packages/blocks-engine/src/composition-planners.ts
@@ -116,7 +116,9 @@ export type PlanProblem =
   /** The stored pattern spells one rendered id on two of its own nodes. */
   | "duplicate-dom-id"
   /** One of the documents cannot be edited at all, whatever the ops say. */
-  | "unusable-document";
+  | "unusable-document"
+  /** The pattern was handed over without an identity to record. */
+  | "invalid-source";
 
 /** A refusal, with whatever the surface needs to phrase it. */
 export interface PlanRefusal {
@@ -338,9 +340,13 @@ export type InsertTarget = OpPosition | "document";
  * The one refusal left to the apply is the machine cap on depth and size, which
  * depends on limits the caller passes there.
  *
- * Nothing records where the copy came from. A pattern is copy-on-insert and
- * keeps no link back, so the inserted nodes are ordinary content from the
- * moment they land.
+ * **Each inserted root records where it came from.** A pattern is still
+ * copy-on-insert and keeps no link back — nothing re-reads the pattern to
+ * update the copy — but the roots carry an inert `origin` naming the pattern
+ * and the digest it was copied at, so a surface can later ask whether the
+ * source has moved on. Only the roots: the run is what was inserted, and
+ * marking every node would make detaching one child read as a second
+ * insertion.
  */
 export function planInsertPattern(
   document: BlockDocument,
@@ -348,6 +354,12 @@ export function planInsertPattern(
   target: InsertTarget,
   nesting: NestingSource
 ): PlanResult<never> {
+  // The identity BEFORE anything is built on it. An empty id produces a record
+  // `isBlockOrigin` refuses, so the plan would succeed and the insert throw —
+  // and the type cannot say this, because every non-empty string is legal and
+  // only the empty one is not.
+  if (pattern.id === "") return { problem: "invalid-source" };
+
   const stored = storedRefusal(document, pattern.document);
   if (stored !== undefined) return stored;
 

--- a/packages/blocks-engine/src/entry-surface.test.ts
+++ b/packages/blocks-engine/src/entry-surface.test.ts
@@ -2,23 +2,20 @@
  * Every primitive in the format and tree modules is reachable from the package
  * entry.
  *
- * This exists because the same gap has now been found three times by a reader
- * rather than a test, and each time the symbol's own docblock had already
- * claimed the thing that was not true: `idReferenceTokens` said it was
- * published so a second copier would not re-split an IDREFS value;
- * `isBlockOrigin` was moved beside its type so both roads into storage could
- * ask one question; `isPartName` says it is "the ONE answer" for the same
- * reason its exported sibling `isBlockType` is.
+ * `export` in a module makes a symbol importable WITHIN the package. A consumer
+ * gets only what the entry re-exports, and the two are independent: a symbol can
+ * satisfy every internal caller and be unreachable from outside.
  *
- * A rule nobody can import is a rule the next surface writes again, and the
- * second spelling is the defect — so "is it exported from the module" and "can
- * a consumer reach it" are two different claims, and only the second one
- * matters to the argument these docblocks make.
+ * That difference matters most for the symbols these two modules hold, because
+ * each is written as the single answer to a question — what a stored value IS,
+ * what a copied id reference means, how a forest is rewritten. A single answer
+ * a caller cannot import is one they write again, and the second spelling is
+ * the defect: it admits what the first refuses, and no test compares them.
  *
- * Scoped to the two modules that publish primitives OTHER code is meant to
- * reuse rather than to every module, because that is the claim being checked:
- * `document.ts` states what a stored document IS, and `tree.ts` holds the
- * traversal and copying rules a caller is not supposed to rewrite.
+ * Scoped to these two modules rather than to every module, because that is
+ * where the claim is made: `document.ts` states what a stored document is, and
+ * `tree.ts` holds the traversal and copying rules a caller is not meant to
+ * rewrite.
  */
 import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
@@ -47,11 +44,11 @@ function exportedFunctions(module: string): string[] {
 const reachable = new Set(Object.keys(entry));
 
 /**
- * Known unreachable, with the reason.
+ * Names the entry does not re-export.
  *
- * `isPartName` predates this guard and its own docblock argues it should be
- * published — it is left alone here rather than exported as a side effect of an
- * unrelated change, and filed instead.
+ * A record of what the entry holds today, not a judgement that it should: the
+ * assertion below fails on a name listed here that IS reachable, so the list
+ * cannot quietly outlive the state it describes.
  */
 const KNOWN_UNPUBLISHED = new Set(["isPartName"]);
 

--- a/packages/blocks-engine/src/entry-surface.test.ts
+++ b/packages/blocks-engine/src/entry-surface.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Every primitive in the format and tree modules is reachable from the package
+ * entry.
+ *
+ * This exists because the same gap has now been found three times by a reader
+ * rather than a test, and each time the symbol's own docblock had already
+ * claimed the thing that was not true: `idReferenceTokens` said it was
+ * published so a second copier would not re-split an IDREFS value;
+ * `isBlockOrigin` was moved beside its type so both roads into storage could
+ * ask one question; `isPartName` says it is "the ONE answer" for the same
+ * reason its exported sibling `isBlockType` is.
+ *
+ * A rule nobody can import is a rule the next surface writes again, and the
+ * second spelling is the defect — so "is it exported from the module" and "can
+ * a consumer reach it" are two different claims, and only the second one
+ * matters to the argument these docblocks make.
+ *
+ * Scoped to the two modules that publish primitives OTHER code is meant to
+ * reuse rather than to every module, because that is the claim being checked:
+ * `document.ts` states what a stored document IS, and `tree.ts` holds the
+ * traversal and copying rules a caller is not supposed to rewrite.
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+import * as entry from "./index";
+
+/** Every `export function` name a module declares. */
+function exportedFunctions(module: string): string[] {
+  const source = readFileSync(
+    new URL(`./${module}.ts`, import.meta.url),
+    "utf8"
+  );
+  return [...source.matchAll(/^export function (\w+)/gm)].map(
+    match => match[1]!
+  );
+}
+
+/**
+ * Reachable from the entry, asked of the MODULE OBJECT rather than of the
+ * index source.
+ *
+ * Reading `index.ts` for names would pass on a re-export that does not resolve,
+ * and would need a parser for every export form the file uses. What a consumer
+ * gets is the module object, so that is what is asked.
+ */
+const reachable = new Set(Object.keys(entry));
+
+/**
+ * Known unreachable, with the reason.
+ *
+ * `isPartName` predates this guard and its own docblock argues it should be
+ * published — it is left alone here rather than exported as a side effect of an
+ * unrelated change, and filed instead.
+ */
+const KNOWN_UNPUBLISHED = new Set(["isPartName"]);
+
+describe("the package entry reaches every primitive that claims to be shared", () => {
+  for (const module of ["document", "tree"]) {
+    it(`re-exports every function ${module}.ts exports`, () => {
+      const declared = exportedFunctions(module);
+
+      // The control: a parse that found nothing would make this pass while
+      // testing no symbol at all.
+      expect(declared.length).toBeGreaterThan(5);
+
+      const missing = declared.filter(
+        name => !reachable.has(name) && !KNOWN_UNPUBLISHED.has(name)
+      );
+      expect(missing).toEqual([]);
+    });
+  }
+
+  it("still names something the entry genuinely does not export", () => {
+    // The allowlist has to describe reality, or it is a place defects hide.
+    for (const name of KNOWN_UNPUBLISHED) {
+      expect(reachable.has(name)).toBe(false);
+    }
+  });
+});

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -138,6 +138,10 @@ export {
   // helpers still has to know which attributes carry an id.
   ID_REFERENCE_ATTRIBUTES,
   remapIdReferences,
+  // And what such a value IS, once its separators are gone. A consumer that
+  // fingerprints or compares copied content has to tokenise it exactly where
+  // the remapper does, and a `split` of their own agrees only until one moves.
+  idReferenceTokens,
   duplicateNode,
   updateNode,
 } from "./tree";
@@ -194,6 +198,11 @@ export type {
 // style compiler stops: a class applied to a node the compiler styled but the
 // counter never reached is absent from the record a safe-delete check reads,
 // and absence there is indistinguishable from "not used".
+// The one answer to whether a stored value is a whole provenance record. A
+// consumer holding `BlockOrigin` and no way to check one has to write the check
+// again, and a second spelling of it admits records this package refuses.
+export { isBlockOrigin } from "./document";
+
 export { selectNodes } from "./select-nodes";
 export type {
   NodeSelection,

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -111,6 +111,11 @@ export {
   makeNode,
   expandSlotDefaults,
   walkNodes,
+  // The one forest rewrite. A caller changing a field across a stored tree
+  // needs its three learned behaviours — a cycle entry dropped, a malformed
+  // entry passed through, a malformed slot preserved — and writing a second
+  // traversal inherits none of them.
+  mapForest,
   findNode,
   locateNode,
   insertNode,
@@ -170,10 +175,12 @@ export type {
 // create and the ops the page needs. Split from the doing so the caller can put
 // both writes in one unit of work and roll the create back — and so the dry run
 // and the real run are the same function rather than two that agree for now.
+export { patternDigest } from "./pattern-digest";
 export { planInsertPattern, planSaveAsPattern } from "./composition-planners";
 export type {
   CompositionPlan,
   InsertTarget,
+  StoredPattern,
   PlacementTarget,
   PatternTarget,
   PlanProblem,

--- a/packages/blocks-engine/src/insert-pattern.test.ts
+++ b/packages/blocks-engine/src/insert-pattern.test.ts
@@ -10,7 +10,7 @@
 import { describe, expect, it } from "vitest";
 
 import { applyOps } from "./ops";
-import { planInsertPattern } from "./composition-planners";
+import { planInsertPattern, type StoredPattern } from "./composition-planners";
 import { DOCUMENT_FORMAT_VERSION } from "./document";
 import type { BlockDocument, BlockNode } from "./document";
 import { walkNodes } from "./tree";
@@ -40,10 +40,20 @@ const page = (
   ...(settings === undefined ? {} : { settings }),
 });
 
-const pattern = (nodes: BlockNode[]): BlockDocument => ({
-  formatVersion: DOCUMENT_FORMAT_VERSION,
-  kind: "pattern",
-  nodes,
+/** A stored pattern: a document plus the identity the store gave it. */
+const pattern = (nodes: BlockNode[], id = "hero-pattern"): StoredPattern => ({
+  id,
+  document: {
+    formatVersion: DOCUMENT_FORMAT_VERSION,
+    kind: "pattern",
+    nodes,
+  },
+});
+
+/** The same, for a document this planner should refuse outright. */
+const stored = (document: BlockDocument): StoredPattern => ({
+  id: "hero-pattern",
+  document,
 });
 
 const anyParent = { parentsOf: () => undefined };
@@ -374,7 +384,7 @@ describe("what it refuses before the op layer would", () => {
 
     const plan = planInsertPattern(
       page([node("a")]),
-      malformed,
+      stored(malformed),
       { index: 1 },
       anyParent
     );
@@ -501,7 +511,8 @@ describe("what it refuses before the op layer would", () => {
     };
 
     expect(
-      planInsertPattern(page([]), notAPattern, "document", anyParent).problem
+      planInsertPattern(page([]), stored(notAPattern), "document", anyParent)
+        .problem
     ).toBe("not-a-pattern");
   });
 

--- a/packages/blocks-engine/src/pattern-digest.ts
+++ b/packages/blocks-engine/src/pattern-digest.ts
@@ -22,12 +22,23 @@
  * non-cryptographic hash is the right size — this is a change hint, and paying
  * for a cryptographic digest would buy a guarantee no caller needs.
  *
- * ## Why the whole document is not hashed
+ * ## What is hashed is what a COPY would carry
  *
  * Only `nodes`. A pattern's settings are not copied into a page, so a change to
  * them is not a change to what any copy holds — and reporting one as an
  * upstream change would ask an author to accept an edit that would not alter
  * their page.
+ *
+ * And within the nodes, a ROOT's own `origin` is excluded, because inserting
+ * overwrites it: the copy records the pattern it came from, never whatever the
+ * stored pattern happened to say. Hashing it would make clearing an inert field
+ * nothing copies report every existing copy as stale. Origins DEEPER than a
+ * root are hashed, because those are copied as they stand.
+ *
+ * The exclusion lives here rather than at the call site so the fingerprint and
+ * the thing it fingerprints cannot be asked about different content — a later
+ * staleness check hashes the pattern as it stands now and compares, and it must
+ * be running the identical rule.
  *
  * @module pattern-digest
  */
@@ -49,5 +60,12 @@ import { hashId } from "./style/node-class";
  * the op layer's document rule first; the planners do.
  */
 export function patternDigest(nodes: readonly BlockNode[]): string {
-  return hashId(JSON.stringify(nodes));
+  return hashId(JSON.stringify(nodes.map(withoutOwnOrigin)));
+}
+
+/** One node without its own provenance record; its children are untouched. */
+function withoutOwnOrigin(node: BlockNode): BlockNode {
+  if (node.origin === undefined) return node;
+  const { origin: _origin, ...rest } = node;
+  return rest;
 }

--- a/packages/blocks-engine/src/pattern-digest.ts
+++ b/packages/blocks-engine/src/pattern-digest.ts
@@ -49,6 +49,19 @@
  * insert and put back by the same group; and an `origin` deeper than a root,
  * which is copied as it stands.
  *
+ * NORMALISED rather than kept verbatim: an id-reference attribute is hashed as
+ * its tokens, because the copier writes it back that way — `"hero   label"` and
+ * `"hero label"` name the same two references and every copy carries the
+ * second. Through the copier's own {@link idReferenceTokens}, not a second
+ * `split` that would agree until one of them moved.
+ *
+ * The copier only rewrites those attributes when it mints at least one DOM id,
+ * so a pattern carrying none keeps its spacing verbatim while this canonicalises
+ * anyway. The asymmetry is deliberate and it only ever costs a MISSED
+ * whitespace-only edit, which no consumer of an IDREFS list can observe —
+ * where hashing the spacing costs a false stale signal on every copy, which is
+ * the failure this rule exists to prevent.
+ *
  * The exclusion lives here rather than at the call site so the fingerprint and
  * the thing it fingerprints cannot be asked about different content — a later
  * staleness check hashes the pattern as it stands now and compares, and it must
@@ -58,6 +71,7 @@
  */
 import type { BlockNode } from "./document";
 import { hashId } from "./style/node-class";
+import { ID_REFERENCE_ATTRIBUTES, idReferenceTokens } from "./tree";
 
 /**
  * The digest of a pattern's stored nodes.
@@ -78,6 +92,26 @@ export function patternDigest(nodes: readonly BlockNode[]): string {
 }
 
 /**
+ * A node's attributes with every id reference reduced to its tokens.
+ *
+ * Only the reference-valued ones. An ordinary attribute is content, and
+ * collapsing whitespace inside one would hide an edit a copy really carries.
+ */
+function canonicalAttributes(
+  attributes: Record<string, string>
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [name, value] of Object.entries(attributes)) {
+    out[name] =
+      ID_REFERENCE_ATTRIBUTES.includes(name.toLowerCase()) &&
+      typeof value === "string"
+        ? idReferenceTokens(value).join(" ")
+        : value;
+  }
+  return out;
+}
+
+/**
  * One node reduced to what a copy of it would carry.
  *
  * Structure-aware rather than a `JSON.stringify` replacer keyed on the name
@@ -90,8 +124,10 @@ export function patternDigest(nodes: readonly BlockNode[]): string {
  * this very input, so it adds no limit the caller did not already have.
  */
 function copiedShape(node: BlockNode, isRoot: boolean): unknown {
-  const { id: _id, origin, slots, ...rest } = node;
+  const { id: _id, origin, slots, attributes, ...rest } = node;
   const shape: Record<string, unknown> = { ...rest };
+  if (attributes !== undefined)
+    shape.attributes = canonicalAttributes(attributes);
   // A root's record is overwritten on insert; a deeper one travels with the copy.
   if (!isRoot && origin !== undefined) shape.origin = origin;
   if (slots !== undefined) {

--- a/packages/blocks-engine/src/pattern-digest.ts
+++ b/packages/blocks-engine/src/pattern-digest.ts
@@ -70,6 +70,7 @@
  * @module pattern-digest
  */
 import type { BlockNode } from "./document";
+import { defineEntry } from "./safe-record";
 import { hashId } from "./style/node-class";
 import { ID_REFERENCE_ATTRIBUTES, idReferenceTokens } from "./tree";
 
@@ -102,11 +103,19 @@ function canonicalAttributes(
 ): Record<string, string> {
   const out: Record<string, string> = {};
   for (const [name, value] of Object.entries(attributes)) {
-    out[name] =
+    // `defineEntry`, not assignment. These names came from stored JSON, and
+    // assigning to `"__proto__"` runs the legacy prototype setter instead of
+    // creating an own property — so the attribute would vanish from what is
+    // hashed while the copier carries it, and editing it would produce the
+    // same digest and no upstream-change notice.
+    defineEntry(
+      out,
+      name,
       ID_REFERENCE_ATTRIBUTES.includes(name.toLowerCase()) &&
-      typeof value === "string"
+        typeof value === "string"
         ? idReferenceTokens(value).join(" ")
-        : value;
+        : value
+    );
   }
   return out;
 }

--- a/packages/blocks-engine/src/pattern-digest.ts
+++ b/packages/blocks-engine/src/pattern-digest.ts
@@ -1,0 +1,53 @@
+/**
+ * A short, stable fingerprint of a pattern's content.
+ *
+ * It exists to answer one question later: has the pattern a copy came from
+ * changed since the copy was taken? A copy records the digest it was made at,
+ * and a surface asking "is this out of date" hashes the pattern as it stands
+ * now and compares.
+ *
+ * ## Content, not a version number
+ *
+ * The engine is handed a document and never an entry row — it can hash what it
+ * was given and cannot see what the store calls it. Content is also the better
+ * answer to the question being asked: a re-save that changed nothing bumps a
+ * version and leaves a digest alone, so a version comparison reports "changed"
+ * for every touch and trains a reader to ignore it.
+ *
+ * ## What it is NOT
+ *
+ * Not a security boundary and not a deduplication key. Two different patterns
+ * can collide, and nothing here depends on them not doing so: the worst a
+ * collision costs is one missed "upstream changed" notice. That is why a short
+ * non-cryptographic hash is the right size — this is a change hint, and paying
+ * for a cryptographic digest would buy a guarantee no caller needs.
+ *
+ * ## Why the whole document is not hashed
+ *
+ * Only `nodes`. A pattern's settings are not copied into a page, so a change to
+ * them is not a change to what any copy holds — and reporting one as an
+ * upstream change would ask an author to accept an edit that would not alter
+ * their page.
+ *
+ * @module pattern-digest
+ */
+import type { BlockNode } from "./document";
+import { hashId } from "./style/node-class";
+
+/**
+ * The digest of a pattern's stored nodes.
+ *
+ * Serialized with `JSON.stringify`, which is what makes this comparable across
+ * reads: the pattern is stored as JSON and parsed back with its key order
+ * intact, so two reads of one unchanged row serialize identically. Node field
+ * order is normalised by the op layer whenever a document is edited through it,
+ * and prop order is authored data that the format treats as meaningful — so
+ * neither is something this should reorder on its own.
+ *
+ * A node the serializer cannot carry makes this throw, which is the same answer
+ * every other reader of such a document gives. Callers that must not throw ask
+ * the op layer's document rule first; the planners do.
+ */
+export function patternDigest(nodes: readonly BlockNode[]): string {
+  return hashId(JSON.stringify(nodes));
+}

--- a/packages/blocks-engine/src/pattern-digest.ts
+++ b/packages/blocks-engine/src/pattern-digest.ts
@@ -29,11 +29,25 @@
  * upstream change would ask an author to accept an edit that would not alter
  * their page.
  *
- * And within the nodes, a ROOT's own `origin` is excluded, because inserting
- * overwrites it: the copy records the pattern it came from, never whatever the
- * stored pattern happened to say. Hashing it would make clearing an inert field
- * nothing copies report every existing copy as stale. Origins DEEPER than a
- * root are hashed, because those are copied as they stand.
+ * The rule inside the nodes is one question asked of each field: does a copy
+ * carry this, or does inserting regenerate it? A field the copy regenerates
+ * contributes nothing to any copy, so hashing it reports changes no author can
+ * see — and after an identity-only rewrite that means every existing copy reads
+ * as stale at once.
+ *
+ * EXCLUDED, because inserting replaces them outright:
+ *
+ * - every node `id`, which `reidForestWithMap` mints fresh at every depth;
+ * - a ROOT's own `origin`, which the insert overwrites with the pattern it is
+ *   copying from.
+ *
+ * KEPT, because the copy derives from them and a change to one is visible in
+ * every copy: `cssId` and `attributes.id`, whose minted replacements are built
+ * FROM the stored value (`pricing` becomes `pricing-<suffix>`, so renaming it
+ * to `plans` changes what every copy renders); the id-reference attributes and
+ * fragment props remapped alongside them; `locked`, which is taken off for the
+ * insert and put back by the same group; and an `origin` deeper than a root,
+ * which is copied as it stands.
  *
  * The exclusion lives here rather than at the call site so the fingerprint and
  * the thing it fingerprints cannot be asked about different content — a later
@@ -60,12 +74,37 @@ import { hashId } from "./style/node-class";
  * the op layer's document rule first; the planners do.
  */
 export function patternDigest(nodes: readonly BlockNode[]): string {
-  return hashId(JSON.stringify(nodes.map(withoutOwnOrigin)));
+  return hashId(JSON.stringify(nodes.map(node => copiedShape(node, true))));
 }
 
-/** One node without its own provenance record; its children are untouched. */
-function withoutOwnOrigin(node: BlockNode): BlockNode {
-  if (node.origin === undefined) return node;
-  const { origin: _origin, ...rest } = node;
-  return rest;
+/**
+ * One node reduced to what a copy of it would carry.
+ *
+ * Structure-aware rather than a `JSON.stringify` replacer keyed on the name
+ * `id`: a replacer drops every `id` anywhere in the tree, which would silently
+ * exclude a prop an author named `id` and an `attributes.id` the copy does
+ * carry. The field being dropped is the NODE's identity, and only a walk that
+ * knows where it is can say that.
+ *
+ * Recursion is bounded by the same depth `JSON.stringify` already imposes on
+ * this very input, so it adds no limit the caller did not already have.
+ */
+function copiedShape(node: BlockNode, isRoot: boolean): unknown {
+  const { id: _id, origin, slots, ...rest } = node;
+  const shape: Record<string, unknown> = { ...rest };
+  // A root's record is overwritten on insert; a deeper one travels with the copy.
+  if (!isRoot && origin !== undefined) shape.origin = origin;
+  if (slots !== undefined) {
+    shape.slots = Object.fromEntries(
+      Object.entries(slots).map(([name, children]) => [
+        name,
+        // A malformed slot value is carried through rather than normalised: it
+        // is content the copy would carry too, and changing it is a change.
+        Array.isArray(children)
+          ? children.map(child => copiedShape(child, false))
+          : children,
+      ])
+    );
+  }
+  return shape;
 }

--- a/packages/blocks-engine/src/provenance.test.ts
+++ b/packages/blocks-engine/src/provenance.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Where a copy says it came from, across the save and the insert together.
+ *
+ * Tested as a ROUND TRIP rather than one planner at a time. Each planner is
+ * correct on a hand-built fixture and the property that matters only exists
+ * between them: what a save stores is what an insert is given, and the record
+ * has to survive that hop saying the right thing.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  planInsertPattern,
+  planSaveAsPattern,
+  type StoredPattern,
+} from "./composition-planners";
+import { DOCUMENT_FORMAT_VERSION } from "./document";
+import type { BlockDocument, BlockNode, BlockOrigin } from "./document";
+import { applyOps } from "./ops";
+import { patternDigest } from "./pattern-digest";
+import { walkNodes } from "./tree";
+
+const node = (
+  id: string,
+  extra: Partial<BlockNode> = {},
+  slots?: Record<string, BlockNode[]>
+): BlockNode => ({
+  id,
+  type: "core/box",
+  version: 1,
+  props: {},
+  ...extra,
+  ...(slots === undefined ? {} : { slots }),
+});
+
+const page = (nodes: BlockNode[]): BlockDocument => ({
+  formatVersion: DOCUMENT_FORMAT_VERSION,
+  kind: "page",
+  nodes,
+});
+
+const anyParent = { parentsOf: () => undefined };
+const target = {
+  collection: "patterns",
+  fields: { title: "Hero", slug: "hero" },
+};
+
+/** Every origin record in a forest. */
+function originsIn(nodes: BlockNode[]): (BlockOrigin | undefined)[] {
+  const out: (BlockOrigin | undefined)[] = [];
+  walkNodes(nodes, n => out.push(n.origin));
+  return out;
+}
+
+describe("an inserted pattern records where it came from", () => {
+  const saved: StoredPattern = {
+    id: "hero-pattern",
+    document: {
+      formatVersion: DOCUMENT_FORMAT_VERSION,
+      kind: "pattern",
+      nodes: [node("p1"), node("p2")],
+    },
+  };
+
+  it("marks every inserted ROOT with the pattern and its digest", () => {
+    const doc = page([node("a")]);
+
+    const plan = planInsertPattern(doc, saved, { index: 1 }, anyParent);
+    const applied = applyOps(doc, (plan.pageOps ?? []) as never);
+
+    const inserted = applied.document.nodes.filter(n => n.id !== "a");
+    expect(inserted).toHaveLength(2);
+    for (const root of inserted) {
+      expect(root.origin).toEqual({
+        from: "pattern",
+        id: "hero-pattern",
+        digest: patternDigest(saved.document.nodes),
+      });
+    }
+  });
+
+  it("marks the roots ONLY, so a detached child is not a second insertion", () => {
+    const nested: StoredPattern = {
+      id: "hero-pattern",
+      document: {
+        formatVersion: DOCUMENT_FORMAT_VERSION,
+        kind: "pattern",
+        nodes: [node("p1", {}, { body: [node("child")] })],
+      },
+    };
+    const doc = page([node("a")]);
+
+    const plan = planInsertPattern(doc, nested, { index: 1 }, anyParent);
+    const applied = applyOps(doc, (plan.pageOps ?? []) as never);
+
+    const marked = originsIn(applied.document.nodes).filter(Boolean);
+    expect(marked).toHaveLength(1);
+  });
+
+  it("OVERWRITES a record an earlier copy left behind", () => {
+    // A root can arrive carrying provenance from a previous insertion. Filling
+    // in only where absent would attribute this insertion to a pattern it has
+    // nothing to do with, and a later staleness check would compare against the
+    // wrong source and answer confidently.
+    const carried: StoredPattern = {
+      id: "second-pattern",
+      document: {
+        formatVersion: DOCUMENT_FORMAT_VERSION,
+        kind: "pattern",
+        nodes: [
+          node("p1", {
+            origin: { from: "pattern", id: "an-older-pattern", digest: "old" },
+          }),
+        ],
+      },
+    };
+    const doc = page([node("a")]);
+
+    const plan = planInsertPattern(doc, carried, { index: 1 }, anyParent);
+    const applied = applyOps(doc, (plan.pageOps ?? []) as never);
+
+    const inserted = applied.document.nodes.find(n => n.id !== "a");
+    expect(inserted?.origin).toEqual({
+      from: "pattern",
+      id: "second-pattern",
+      digest: patternDigest(carried.document.nodes),
+    });
+  });
+
+  it("changes the digest when the pattern's content changes", () => {
+    const edited = {
+      ...saved.document,
+      nodes: [node("p1", { props: { text: "new" } }), node("p2")],
+    };
+
+    expect(patternDigest(edited.nodes)).not.toBe(
+      patternDigest(saved.document.nodes)
+    );
+  });
+});
+
+describe("a saved pattern carries no inherited provenance", () => {
+  it("STRIPS an origin the selection was already carrying", () => {
+    // A stored pattern's nodes came from the page, not from wherever the
+    // page's nodes came from. Carrying it across would make this pattern claim
+    // a source it never had.
+    const doc = page([
+      node("a", {
+        origin: { from: "pattern", id: "an-older-pattern", digest: "old" },
+      }),
+      node("b"),
+    ]);
+
+    const plan = planSaveAsPattern(doc, ["a", "b"], target, anyParent);
+
+    expect(originsIn(plan.create?.document.nodes ?? [])).toEqual([
+      undefined,
+      undefined,
+    ]);
+  });
+
+  it("strips it at every depth, not only at the roots", () => {
+    const doc = page([
+      node(
+        "a",
+        {},
+        {
+          body: [
+            node("deep", {
+              origin: { from: "component", id: "some-component" },
+            }),
+          ],
+        }
+      ),
+    ]);
+
+    const plan = planSaveAsPattern(doc, ["a"], target, anyParent);
+
+    expect(
+      originsIn(plan.create?.document.nodes ?? []).filter(Boolean)
+    ).toEqual([]);
+  });
+});
+
+describe("the round trip between the two planners", () => {
+  it("SAVES A RUN, INSERTS IT BACK, AND ATTRIBUTES IT TO THE RIGHT PATTERN", () => {
+    // The property neither planner has on its own: what a save stores is what
+    // an insert is handed, and the record has to survive that hop.
+    const source = page([
+      node("a", {
+        origin: { from: "pattern", id: "an-older-pattern", digest: "old" },
+      }),
+      node("b"),
+    ]);
+
+    const save = planSaveAsPattern(source, ["a", "b"], target, anyParent);
+    const stored: StoredPattern = {
+      id: "the-new-pattern",
+      document: save.create?.document as BlockDocument,
+    };
+
+    const destination = page([node("x")]);
+    const plan = planInsertPattern(
+      destination,
+      stored,
+      { index: 1 },
+      anyParent
+    );
+    const applied = applyOps(destination, (plan.pageOps ?? []) as never);
+
+    const inserted = applied.document.nodes.filter(n => n.id !== "x");
+    expect(inserted).toHaveLength(2);
+    for (const root of inserted) {
+      // The NEW pattern, never the one the original selection came from.
+      expect(root.origin?.id).toBe("the-new-pattern");
+      expect(root.origin?.from).toBe("pattern");
+    }
+  });
+});

--- a/packages/blocks-engine/src/provenance.test.ts
+++ b/packages/blocks-engine/src/provenance.test.ts
@@ -138,6 +138,39 @@ describe("an inserted pattern records where it came from", () => {
   });
 });
 
+describe("the digest describes what a COPY would carry", () => {
+  it("IGNORES a root's own origin, which inserting overwrites anyway", () => {
+    // Clearing an inert field that nothing copies must not report every
+    // existing copy as stale.
+    const bare = [node("p1"), node("p2")];
+    const marked = [
+      node("p1", {
+        origin: { from: "pattern", id: "an-older-pattern", digest: "old" },
+      }),
+      node("p2"),
+    ];
+
+    expect(patternDigest(marked)).toBe(patternDigest(bare));
+  });
+
+  it("does NOT ignore an origin deeper than a root, which IS copied", () => {
+    // Insert overwrites the roots only, so a descendant's record travels into
+    // the page and a change to it is a change to what a copy holds.
+    const bare = [node("p1", {}, { body: [node("deep")] })];
+    const marked = [
+      node(
+        "p1",
+        {},
+        {
+          body: [node("deep", { origin: { from: "component", id: "c" } })],
+        }
+      ),
+    ];
+
+    expect(patternDigest(marked)).not.toBe(patternDigest(bare));
+  });
+});
+
 describe("a saved pattern carries no inherited provenance", () => {
   it("STRIPS an origin the selection was already carrying", () => {
     // A stored pattern's nodes came from the page, not from wherever the
@@ -178,6 +211,31 @@ describe("a saved pattern carries no inherited provenance", () => {
     expect(
       originsIn(plan.create?.document.nodes ?? []).filter(Boolean)
     ).toEqual([]);
+  });
+});
+
+describe("a pattern handed over without an identity", () => {
+  it("is refused rather than given a record the op layer rejects", () => {
+    // Every non-empty string is a legal id and only the empty one is not, so
+    // the type cannot say this and a check has to.
+    const nameless: StoredPattern = {
+      id: "",
+      document: {
+        formatVersion: DOCUMENT_FORMAT_VERSION,
+        kind: "pattern",
+        nodes: [node("p1")],
+      },
+    };
+
+    const plan = planInsertPattern(
+      page([node("a")]),
+      nameless,
+      { index: 1 },
+      anyParent
+    );
+
+    expect(plan.problem).toBe("invalid-source");
+    expect(plan.pageOps).toBeUndefined();
   });
 });
 

--- a/packages/blocks-engine/src/provenance.test.ts
+++ b/packages/blocks-engine/src/provenance.test.ts
@@ -357,6 +357,27 @@ describe("a pattern handed over without an identity", () => {
     expect(plan.problem).toBe("invalid-source");
     expect(plan.pageOps).toBeUndefined();
   });
+
+  it("refuses an id that is not a string at all", () => {
+    // This is a published entry point, and the value reaching it comes from a
+    // JavaScript caller or a stored row as often as from a typed one — so the
+    // type is a claim about the callers it can see, not about the input.
+    for (const id of [42, null, undefined, {}]) {
+      const odd = {
+        id,
+        document: {
+          formatVersion: DOCUMENT_FORMAT_VERSION,
+          kind: "pattern",
+          nodes: [node("p1")],
+        },
+      } as unknown as StoredPattern;
+
+      expect(
+        planInsertPattern(page([node("a")]), odd, { index: 1 }, anyParent)
+          .problem
+      ).toBe("invalid-source");
+    }
+  });
 });
 
 describe("the round trip between the two planners", () => {

--- a/packages/blocks-engine/src/provenance.test.ts
+++ b/packages/blocks-engine/src/provenance.test.ts
@@ -19,6 +19,14 @@ import { applyOps } from "./ops";
 import { patternDigest } from "./pattern-digest";
 import { reidForestWithMap, walkNodes } from "./tree";
 
+/**
+ * A minimal node: enough to be well formed, and nothing that carries meaning.
+ *
+ * The defaults matter to what these tests can conclude. No `origin`, so a
+ * record appearing in a result was written by a planner rather than inherited
+ * from a fixture; empty `props` and one block type throughout, so a digest that
+ * differs differs because of the field under test.
+ */
 const node = (
   id: string,
   extra: Partial<BlockNode> = {},
@@ -32,19 +40,39 @@ const node = (
   ...(slots === undefined ? {} : { slots }),
 });
 
+/** A destination document. Kind `page`, because a pattern is inserted INTO one. */
 const page = (nodes: BlockNode[]): BlockDocument => ({
   formatVersion: DOCUMENT_FORMAT_VERSION,
   kind: "page",
   nodes,
 });
 
+/**
+ * A nesting source that restricts nothing.
+ *
+ * Explicit rather than defaulted: every planner here takes one, and a source
+ * that refused a placement would fail these tests for a reason that has nothing
+ * to do with provenance.
+ */
 const anyParent = { parentsOf: () => undefined };
+/**
+ * Where a saved pattern is stored, in the caller's vocabulary.
+ *
+ * Passed through by the planner untouched, so its contents are irrelevant here
+ * beyond being present — what these tests read is the document it wraps.
+ */
 const target = {
   collection: "patterns",
   fields: { title: "Hero", slug: "hero" },
 };
 
-/** Every origin record in a forest. */
+/**
+ * Every origin record in a forest, at every depth, in walk order.
+ *
+ * Collected rather than checked node by node because the assertions are about
+ * HOW MANY records exist and where — that only the roots are marked, or that a
+ * save left none anywhere — and both are claims about the whole forest.
+ */
 function originsIn(nodes: BlockNode[]): (BlockOrigin | undefined)[] {
   const out: (BlockOrigin | undefined)[] = [];
   walkNodes(nodes, n => out.push(n.origin));
@@ -179,6 +207,40 @@ describe("the digest describes what a COPY would carry", () => {
     // the name would drop this too, and it is content.
     const before = [node("p1", { props: { id: "left" } })];
     const after = [node("p1", { props: { id: "right" } })];
+
+    expect(patternDigest(after)).not.toBe(patternDigest(before));
+  });
+
+  it("IGNORES whitespace inside an id reference, which the copier collapses", () => {
+    // `"hero   label"` and `"hero label"` name the same two references and the
+    // copier writes both back as the second, so every copy carries the same
+    // value and a spacing edit is not a change any copy can show.
+    const spaced = [
+      node("t", { cssId: "hero" }),
+      node("p1", { attributes: { "aria-labelledby": "hero   label" } }),
+    ];
+    const tight = [
+      node("t", { cssId: "hero" }),
+      node("p1", { attributes: { "aria-labelledby": "hero label" } }),
+    ];
+
+    expect(patternDigest(spaced)).toBe(patternDigest(tight));
+  });
+
+  it("still notices a reference pointing somewhere else", () => {
+    // The control against collapsing the whole value: which ids are named IS
+    // carried, and changing one changes every copy.
+    const before = [node("p1", { attributes: { "aria-labelledby": "hero" } })];
+    const after = [node("p1", { attributes: { "aria-labelledby": "footer" } })];
+
+    expect(patternDigest(after)).not.toBe(patternDigest(before));
+  });
+
+  it("does NOT collapse whitespace in an ordinary attribute", () => {
+    // An attribute that holds no reference is content, and a copy carries its
+    // spacing exactly.
+    const before = [node("p1", { attributes: { "data-note": "a   b" } })];
+    const after = [node("p1", { attributes: { "data-note": "a b" } })];
 
     expect(patternDigest(after)).not.toBe(patternDigest(before));
   });

--- a/packages/blocks-engine/src/provenance.test.ts
+++ b/packages/blocks-engine/src/provenance.test.ts
@@ -17,7 +17,7 @@ import { DOCUMENT_FORMAT_VERSION } from "./document";
 import type { BlockDocument, BlockNode, BlockOrigin } from "./document";
 import { applyOps } from "./ops";
 import { patternDigest } from "./pattern-digest";
-import { walkNodes } from "./tree";
+import { reidForestWithMap, walkNodes } from "./tree";
 
 const node = (
   id: string,
@@ -151,6 +151,43 @@ describe("the digest describes what a COPY would carry", () => {
     ];
 
     expect(patternDigest(marked)).toBe(patternDigest(bare));
+  });
+
+  it("IGNORES regenerated node ids, at every depth", () => {
+    // Inserting mints every id fresh, so no stored id reaches a copy. Hashing
+    // them made an identity-only rewrite of the pattern report every existing
+    // copy as stale at once.
+    const before = [node("p1", {}, { body: [node("deep")] })];
+    const after = reidForestWithMap([...before]).nodes;
+
+    expect(after[0]!.id).not.toBe("p1");
+    expect(patternDigest(after)).toBe(patternDigest(before));
+  });
+
+  it("still notices a cssId rename, which every copy DOES render", () => {
+    // The control against over-excluding. A minted replacement is built from
+    // the stored value — `pricing` becomes `pricing-<suffix>` — so renaming it
+    // changes what every copy renders and must change the digest.
+    const before = [node("p1", { cssId: "pricing" })];
+    const after = [node("p1", { cssId: "plans" })];
+
+    expect(patternDigest(after)).not.toBe(patternDigest(before));
+  });
+
+  it("still hashes a PROP an author happened to name id", () => {
+    // The control against the shortcut: a `JSON.stringify` replacer keyed on
+    // the name would drop this too, and it is content.
+    const before = [node("p1", { props: { id: "left" } })];
+    const after = [node("p1", { props: { id: "right" } })];
+
+    expect(patternDigest(after)).not.toBe(patternDigest(before));
+  });
+
+  it("still hashes an attributes.id, which the copy derives from", () => {
+    const before = [node("p1", { attributes: { id: "hero" } })];
+    const after = [node("p1", { attributes: { id: "banner" } })];
+
+    expect(patternDigest(after)).not.toBe(patternDigest(before));
   });
 
   it("does NOT ignore an origin deeper than a root, which IS copied", () => {

--- a/packages/blocks-engine/src/provenance.test.ts
+++ b/packages/blocks-engine/src/provenance.test.ts
@@ -236,6 +236,27 @@ describe("the digest describes what a COPY would carry", () => {
     expect(patternDigest(after)).not.toBe(patternDigest(before));
   });
 
+  it("HASHES AN ATTRIBUTE STORED UNDER __proto__, which the copy keeps", () => {
+    // A name that came from persisted JSON can be `__proto__`, and assigning
+    // to it runs the legacy prototype setter rather than creating an own
+    // property. The attribute would then be absent from what is hashed while
+    // the copier carries it, so editing it would produce the same digest and
+    // no upstream-change notice.
+    const attributesWith = (value: string): Record<string, string> =>
+      JSON.parse(`{"__proto__":${JSON.stringify(value)}}`) as Record<
+        string,
+        string
+      >;
+
+    // The control: the key really is an OWN property, not the prototype.
+    expect(Object.hasOwn(attributesWith("a"), "__proto__")).toBe(true);
+
+    const before = [node("p1", { attributes: attributesWith("a") })];
+    const after = [node("p1", { attributes: attributesWith("b") })];
+
+    expect(patternDigest(after)).not.toBe(patternDigest(before));
+  });
+
   it("does NOT collapse whitespace in an ordinary attribute", () => {
     // An attribute that holds no reference is content, and a copy carries its
     // spacing exactly.

--- a/packages/blocks-engine/src/tree.ts
+++ b/packages/blocks-engine/src/tree.ts
@@ -731,8 +731,14 @@ function queueSlotRebuilds(
  * would let any unrelated edit silently destroy stored content that a caller
  * may still need to read or repair, which is a worse outcome than the throw it
  * replaced: the throw was loud and lost nothing.
+ *
+ * Published because those three are exactly what a caller rewriting one field
+ * across a stored forest gets wrong, and each was learned here rather than
+ * guessed. A planner stripping a lock or a provenance record wrote its own walk
+ * and inherited none of them; the rule is that a forest rewrite is this
+ * function with a different `fn`, not a new traversal.
  */
-function mapForest(
+export function mapForest(
   nodes: BlockNode[],
   fn: (node: BlockNode) => BlockNode
 ): BlockNode[] {

--- a/packages/blocks-engine/src/tree.ts
+++ b/packages/blocks-engine/src/tree.ts
@@ -1272,6 +1272,23 @@ const ID_REFERENCE_SET = new Set(ID_REFERENCE_ATTRIBUTES);
  * Returns the SAME record when nothing referenced anything, so the ordinary
  * node allocates nothing.
  */
+/**
+ * An IDREFS value as its tokens, with the separators gone.
+ *
+ * The single statement of what such a value MEANS: a list of ids, where runs of
+ * whitespace are one separator and a leading or trailing one is nothing. Every
+ * parser reads `"hero   label"` and `"hero label"` as the same two references,
+ * and {@link remapIdReferences} writes both back as the second.
+ *
+ * Published because a second reader now depends on that being true rather than
+ * merely doing the same thing: a fingerprint of what a copy carries has to
+ * normalise exactly where the copier normalises, and a parallel `split`
+ * elsewhere would agree until one of them changed.
+ */
+export function idReferenceTokens(value: string): string[] {
+  return value.split(/\s+/).filter(token => token !== "");
+}
+
 export function remapIdReferences(
   attributes: Record<string, string>,
   domIds: ReadonlyMap<string, string>
@@ -1288,11 +1305,10 @@ export function remapIdReferences(
       defineEntry(next, name, value as string);
       continue;
     }
-    // Split on whitespace so an IDREFS list is rewritten token by token; the
-    // separator is normalised to one space, which is what every parser reads
-    // the original as anyway.
-    const tokens = value.split(/\s+/).filter(token => token !== "");
-    const mapped = tokens.map(token => domIds.get(token) ?? token);
+    // Token by token, through the one spelling of what an IDREFS list IS.
+    const mapped = idReferenceTokens(value).map(
+      token => domIds.get(token) ?? token
+    );
     const rewritten = mapped.join(" ");
     if (rewritten !== value) changed = true;
     defineEntry(next, name, rewritten);

--- a/packages/blocks-engine/src/tree.ts
+++ b/packages/blocks-engine/src/tree.ts
@@ -1257,22 +1257,6 @@ export const ID_REFERENCE_ATTRIBUTES: readonly string[] = [
 const ID_REFERENCE_SET = new Set(ID_REFERENCE_ATTRIBUTES);
 
 /**
- * Point a node's id REFERENCES at wherever those ids ended up.
- *
- * Applied as a second pass, after every id has been minted, and that ordering
- * is the whole reason it is a separate function: a node may reference an id
- * defined on a node the walk has not reached yet, so rewriting during the copy
- * would leave every forward reference pointing at the original.
- *
- * A token with no entry in the map is left ALONE rather than dropped. It
- * addresses something outside the copied subtree — an element the host page
- * owns, or one the application renders — and rewriting or removing it would
- * break a relationship that was working.
- *
- * Returns the SAME record when nothing referenced anything, so the ordinary
- * node allocates nothing.
- */
-/**
  * An IDREFS value as its tokens, with the separators gone.
  *
  * The single statement of what such a value MEANS: a list of ids, where runs of
@@ -1289,6 +1273,22 @@ export function idReferenceTokens(value: string): string[] {
   return value.split(/\s+/).filter(token => token !== "");
 }
 
+/**
+ * Point a node's id REFERENCES at wherever those ids ended up.
+ *
+ * Applied as a second pass, after every id has been minted, and that ordering
+ * is the whole reason it is a separate function: a node may reference an id
+ * defined on a node the walk has not reached yet, so rewriting during the copy
+ * would leave every forward reference pointing at the original.
+ *
+ * A token with no entry in the map is left ALONE rather than dropped. It
+ * addresses something outside the copied subtree — an element the host page
+ * owns, or one the application renders — and rewriting or removing it would
+ * break a relationship that was working.
+ *
+ * Returns the SAME record when nothing referenced anything, so the ordinary
+ * node allocates nothing.
+ */
 export function remapIdReferences(
   attributes: Record<string, string>,
   domIds: ReadonlyMap<string, string>


### PR DESCRIPTION
Plan 06 (Phase 5). The follow-up promised on #1557 and #1558, now that the field and both planners are on `main` together. Implements the founder's ruling on **Q12 = A**.

Closes the P1 Codex raised on #1557 ("Record provenance when inserting a pattern"), including the part of it I had not seen.

## What ships

Each inserted root carries `origin: { from: "pattern", id, digest }`, so **"the pattern this section came from has changed — do you want the change?"** becomes answerable later. It cannot be added retroactively: a page built before this can never be told where its blocks came from, which is why it lands now rather than with the feature that reads it.

## Three decisions worth arguing

**The roots only.** The run is what was inserted. A descendant did not come from the pattern separately, and marking every node would make an author detaching one child look like a second insertion.

**Overwritten, never filled in where absent — and stripped on save.** This is the half of the finding I had missed, and it is why this is not simply setting a field. `reidForestWithMap` preserves ordinary fields, so:

- a root can arrive already carrying a record from an earlier copy;
- a pattern saved out of already-inserted content would carry that record into the library and claim a source it never had.

Both are **worse than no record**, because a staleness check would compare against the wrong pattern and answer confidently. So insert overwrites, and save strips at every depth.

**The digest is content, not a version.** The engine is handed a document and never an entry row — it can hash what it was given and cannot see what the store calls it. Content also answers the question more precisely: a re-save that changed nothing bumps a version and leaves a digest alone, and a signal that fires on every touch trains a reader to ignore it.

It is a **change hint, not a security boundary**. A collision costs one missed notice, which is why it is a short non-cryptographic hash. Only `nodes` is hashed: a pattern's settings are not copied into a page, so a change to them is not a change to what any copy holds.

## An API change, deliberately

`planInsertPattern` now takes the pattern's identity and document as **one value**:

```ts
interface StoredPattern { id: string; document: BlockDocument }
```

Two arguments can be supplied out of step, and an id belonging to different nodes writes provenance that reads as authoritative and is wrong. Safe to change: `planInsertPattern` has no product consumer yet — T-3 has not shipped.

## `mapForest` is published

Two planners had hand-rolled the walk `tree.ts` already owns. Its docblock names three behaviours it learned by getting each wrong — a cycle entry **dropped** rather than kept as a childless copy, a malformed entry **passed through** rather than mapped, a malformed slot value **preserved** exactly — and a hand-rolled traversal inherits none of them. Both rewrites now go through it, so this removes a duplicate walk rather than adding a third.

## Verification

**Tested as a round trip across both planners**, not one at a time. Each is correct on a hand-built fixture; the property that matters only exists between them — what a save stores is what an insert is handed, and the record has to survive that hop naming the right pattern. That is the lesson from #1557's locked-pattern finding, where two individually-correct planners produced a library row nothing could place.

Break-verified, each killing only its own tests:

| Wrong implementation | Killed |
|---|---|
| do not record provenance at all | 4 |
| fill it in only where absent instead of overwriting | 1 |
| mark every node rather than only the roots | 1 |
| keep the inherited origin when saving | 2 |

## Gates

| Gate | Exit |
|---|---|
| `fallow audit --gate new-only --base origin/main` | **0** — `pass`, 6 files, **0 introduced** in every category |
| `npm run check:comments` | **0** |
| `npx changeset status` | **0** |
| `npx turbo run check-types` | **0** — 42/42 |
| `eslint` on the touched files | **0** |

Suites: `blocks-engine` 48 files / 2017 tests, plus `builder`, `blocks-react`, `plugin-page-builder` and `plugin-sdk` all green. The engine `dist` was cleared before measuring — after a branch switch an orphaned chunk survives a rebuild and stays reachable.

## Still open in this row

`planSaveAsComponent`, `planConvertToComponent`, `planDetach` (which must inline the **resolved** subtree through `resolveComponentInstances`, not a second traversal), `planUpdatePatternFromSelection`, `planDuplicateComponent`, then the write-side cycle check. `planDetach` is where the `{ from: "component" }` arm of `origin` gets its writer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pattern provenance is preserved when patterns are saved and inserted.
  * Inserted pattern roots include source identification and content fingerprints.
  * Pattern and tree utilities are available through the public API.
* **Bug Fixes**
  * Invalid pattern sources are detected and rejected.
  * Lock states remain preserved when inserting patterns.
  * Existing source metadata is correctly replaced during insertion.
  * Saving patterns consistently removes inherited provenance.
  * Pattern content comparisons now handle ID references consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->