### PR TITLE
ci(root): check the repository metadata the file guards cannot see

### DIFF
--- a/.changeset/the-package-says-what-nextly-is-now.md
+++ b/.changeset/the-package-says-what-nextly-is-now.md
@@ -1,0 +1,32 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The npm listing for `nextly` no longer carries the keyword `framework`. The word
+could mean an application framework, a UI framework or a backend framework, which
+is why the project moved away from it; the GitHub topic had already been cleared
+and the package keyword had not.

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -104,6 +104,9 @@
 - name: "ci-dep-audit-failure"
   color: "b60205"
   description: "Filed automatically when the weekly dependency audit fails"
+- name: "ci-metadata-failure"
+  color: "b60205"
+  description: "Filed automatically when the scheduled repository-metadata check fails"
 
 # ── GitHub-native labels ── platform treats these specially in the UI
 - name: "good first issue"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,6 +225,12 @@ jobs:
       - name: Docs and README claims
         run: pnpm check:docs-claims
 
+      # The About line and topic list are repository settings, not files, so every
+      # check that reads git's index is blind to them. Reports unverifiable rather
+      # than failing when the API cannot be reached.
+      - name: Repository metadata
+        run: pnpm check:repo-metadata
+
   ci:
     name: Lint / Typecheck / Test / Build
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,15 @@ jobs:
           cache: pnpm
 
       - name: Install
+        id: install
         run: pnpm install --frozen-lockfile
+
+      # These three read different surfaces and answer independently, so each runs even after
+      # an earlier one has found something. On the default success() condition the first
+      # finding suppresses the rest, and a run that reports one problem while silently
+      # skipping the checks for two others is the shape that hides the second round of work.
+      # Gated on the install rather than on !cancelled() alone: without dependencies they
+      # cannot produce a verdict, only a confusing error.
 
       # The comments that predate this check are recorded in
       # scripts/comment-convention-allowlist.json with a per-file count and one
@@ -220,15 +228,18 @@ jobs:
       # than advisory, and it may only shrink: adding an entry to silence a new
       # comment is the one use it does not have.
       - name: Comment convention
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: pnpm check:comments
 
       - name: Docs and README claims
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: pnpm check:docs-claims
 
       # The About line and topic list are repository settings, not files, so every
       # check that reads git's index is blind to them. Reports unverifiable rather
       # than failing when the API cannot be reached.
       - name: Repository metadata
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: pnpm check:repo-metadata
 
   ci:

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -408,8 +408,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
+          # Matched on the title as well as the label. Taking the first issue carrying the
+          # label alone means any other workflow that adopts it, or anyone who applies it by
+          # hand, silently redirects these reports into an unrelated issue.
           existing=$(gh issue list --repo "${{ github.repository }}" \
-            --label ci-nightly-failure --state open --json number --jq '.[0].number // empty')
+            --label ci-nightly-failure --state open --json number,title \
+            --jq '[.[] | select(.title == "Nightly package smoke is failing")][0].number // empty')
           if [ -n "$existing" ]; then
             gh issue comment "$existing" --repo "${{ github.repository }}" \
               --body "Nightly package smoke failed again: $RUN_URL"

--- a/.github/workflows/repo-metadata.yml
+++ b/.github/workflows/repo-metadata.yml
@@ -1,0 +1,75 @@
+name: Repository metadata
+
+# The About line and the topic list are repository settings, not files. Editing either
+# creates no push and no pull request, so a workflow triggered by code alone can never
+# observe the surface it guards: someone can set the About line back to the retired
+# category and every recorded run stays green until the next unrelated commit. That is
+# how the retired category survived in the About line while all six file surfaces were
+# clean. A schedule is the only trigger that sees a change a settings edit produced.
+#
+# The check in ci.yml stays. It gives fast feedback when the package description moves;
+# this one watches the setting itself.
+on:
+  schedule:
+    # Daily. The settings change rarely and a stale About line is a slow problem, so
+    # this trades detection latency for not spending a run per hour on an API call.
+    - cron: "17 7 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  metadata:
+    name: About line and topics
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version-file: .nvmrc
+
+      # No install. Both scripts import nothing outside Node's builtins, and a
+      # dependency tree this job does not need is a way for it to fail for a
+      # reason that has nothing to do with the metadata.
+      - name: Repository metadata
+        run: node scripts/check-repo-metadata.mjs
+
+  report:
+    name: File an issue on failure
+    needs: metadata
+    if: failure()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # The only job that writes anything, so it is the only one holding the
+    # permission to.
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Create or update the tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          existing=$(gh issue list --repo "${{ github.repository }}" \
+            --label ci-nightly-failure --state open --json number,title \
+            --jq '[.[] | select(.title == "Repository metadata no longer matches the category")][0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "${{ github.repository }}" \
+              --body "Repository metadata check failed again: $RUN_URL"
+          else
+            # printf keeps the multi-line body inside this YAML block scalar;
+            # a raw multi-line string here would dedent and break the file.
+            body=$(printf 'The scheduled repository-metadata check failed. Run: %s\n\nThe GitHub About line or the topic list no longer agrees with the category. These are repository settings rather than files, so no file check can see them and nothing in a commit can fix them.\n\nFix them in Settings, or with:\n\n```\ngh repo edit nextlyhq/nextly --description "..." --add-topic ... --remove-topic ...\n```' "$RUN_URL")
+            gh issue create --repo "${{ github.repository }}" \
+              --title "Repository metadata no longer matches the category" \
+              --label ci-nightly-failure \
+              --body "$body"
+          fi

--- a/.github/workflows/repo-metadata.yml
+++ b/.github/workflows/repo-metadata.yml
@@ -39,6 +39,11 @@ jobs:
       # dependency tree this job does not need is a way for it to fail for a
       # reason that has nothing to do with the metadata.
       - name: Repository metadata
+        env:
+          # An unauthenticated call gets 60 requests an hour shared across the whole runner
+          # IP. Exhausting it makes this job green having examined nothing, which is the one
+          # outcome it must never produce. The check still runs tokenless on a laptop.
+          GITHUB_TOKEN: ${{ github.token }}
         run: node scripts/check-repo-metadata.mjs
 
   report:
@@ -67,7 +72,7 @@ jobs:
           else
             # printf keeps the multi-line body inside this YAML block scalar;
             # a raw multi-line string here would dedent and break the file.
-            body=$(printf 'The scheduled repository-metadata check failed. Run: %s\n\nThe GitHub About line or the topic list no longer agrees with the category. These are repository settings rather than files, so no file check can see them and nothing in a commit can fix them.\n\nFix them in Settings, or with:\n\n```\ngh repo edit nextlyhq/nextly --description "..." --add-topic ... --remove-topic ...\n```' "$RUN_URL")
+            body=$(printf 'The scheduled repository-metadata check failed. Run: %s\n\nEither the GitHub About line or the topic list no longer agrees with the category, or the run could not read them at all. The logs say which.\n\nThese are repository settings rather than files, so no file check can see them and nothing in a commit can fix them. Fix them in Settings, or with:\n\n```\ngh repo edit nextlyhq/nextly --description "..." --add-topic ... --remove-topic ...\n```' "$RUN_URL")
             gh issue create --repo "${{ github.repository }}" \
               --title "Repository metadata no longer matches the category" \
               --label ci-nightly-failure \

--- a/.github/workflows/repo-metadata.yml
+++ b/.github/workflows/repo-metadata.yml
@@ -63,8 +63,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
+          # Its own label, matching the one-per-concern convention the repository already
+          # uses (ci-dep-audit-failure, ci-lighthouse-failure). Sharing the package-smoke
+          # label would have been read by that workflow's reporter, which takes the first
+          # open issue carrying it: a metadata issue standing open would have swallowed
+          # every package-smoke report and suppressed its own tracking issue entirely.
           existing=$(gh issue list --repo "${{ github.repository }}" \
-            --label ci-nightly-failure --state open --json number,title \
+            --label ci-metadata-failure --state open --json number,title \
             --jq '[.[] | select(.title == "Repository metadata no longer matches the category")][0].number // empty')
           if [ -n "$existing" ]; then
             gh issue comment "$existing" --repo "${{ github.repository }}" \
@@ -75,6 +80,6 @@ jobs:
             body=$(printf 'The scheduled repository-metadata check failed. Run: %s\n\nEither the GitHub About line or the topic list no longer agrees with the category, or the run could not read them at all. The logs say which.\n\nThese are repository settings rather than files, so no file check can see them and nothing in a commit can fix them. Fix them in Settings, or with:\n\n```\ngh repo edit nextlyhq/nextly --description "..." --add-topic ... --remove-topic ...\n```' "$RUN_URL")
             gh issue create --repo "${{ github.repository }}" \
               --title "Repository metadata no longer matches the category" \
-              --label ci-nightly-failure \
+              --label ci-metadata-failure \
               --body "$body"
           fi

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "check:dev-concurrency": "node scripts/check-dev-concurrency.mjs",
     "check:comments": "node scripts/check-comment-convention.mjs",
     "check:docs-claims": "node scripts/check-docs-claims.mjs",
+    "check:repo-metadata": "node scripts/check-repo-metadata.mjs",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "lint": "turbo run lint",
     "lint:design": "node scripts/lint-design.mjs",

--- a/packages/nextly/package.json
+++ b/packages/nextly/package.json
@@ -342,7 +342,6 @@
     "nextjs",
     "headless-cms",
     "page-builder",
-    "framework",
     "typescript",
     "react",
     "drizzle",

--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -97,7 +97,7 @@ export const CATEGORY_SURFACES = [
  * it both ways and a reader sees no difference, and an optional plural, because
  * "one of several app frameworks" is the same claim about the same category.
  */
-const RETIRED_CATEGORY = /\bapp(?:-|\s+)frameworks?\b/i;
+export const RETIRED_CATEGORY = /\bapp(?:-|\s+)frameworks?\b/i;
 
 /**
  * A document reduced to what a reader is shown.

--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -654,6 +654,34 @@ export function renderedProse(markdown) {
   );
 }
 
+/**
+ * A published package's keywords are a category claim, on the surface people search.
+ *
+ * The GitHub topic list forbids `framework` and `app-framework` for the reason the whole
+ * repositioning turned on: the word could mean an application framework, a UI framework or a
+ * backend framework, which made it the least informative word available. npm keywords are the
+ * same kind of surface and were left carrying it after the topic was cleared, so the rule is
+ * applied to both rather than to whichever one someone remembered.
+ *
+ * Matched whole, not as a substring: `page-builder` and `nextly-plugin` are keywords this must
+ * never touch.
+ */
+const RETIRED_KEYWORD = /^(?:app-)?frameworks?$/i;
+
+function retiredKeywords(repoRoot, packages, findings) {
+  for (const pkg of packages) {
+    for (const keyword of pkg.json?.keywords ?? []) {
+      if (!RETIRED_KEYWORD.test(keyword)) continue;
+      findings.push({
+        check: "retired-category-keyword",
+        file: relative(repoRoot, join(pkg.dir, "package.json")),
+        line: null,
+        message: `${pkg.name} publishes the keyword "${keyword}", which names the retired category`,
+      });
+    }
+  }
+}
+
 function readmeSkeleton(repoRoot, packages, findings) {
   for (const pkg of packages) {
     const readme = join(pkg.dir, "README.md");
@@ -919,6 +947,7 @@ export async function runChecks({
   }
 
   readmeSkeleton(repoRoot, packages, findings);
+  retiredKeywords(repoRoot, packages, findings);
   internalLinks(repoRoot, tracked, findings);
   metaReachability(repoRoot, tracked, findings);
 

--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -100,6 +100,32 @@ export const CATEGORY_SURFACES = [
 export const RETIRED_CATEGORY = /\bapp(?:-|\s+)frameworks?\b/i;
 
 /**
+ * The same category, as a whole tag rather than a phrase in prose.
+ *
+ * npm keywords and GitHub topics are both single tokens on a surface people search, and both
+ * were left carrying `framework` after the prose was cleared. The word is the one the whole
+ * repositioning turned on: it could mean an application framework, a UI framework or a backend
+ * framework, which made it the least informative word available.
+ *
+ * `RETIRED_CATEGORY` cannot serve here — it requires the `app` prefix, so a bare `framework`
+ * tag would pass. Anchored rather than substring-matched: `page-builder` and `nextly-plugin`
+ * are tags this must never touch.
+ */
+export const RETIRED_CATEGORY_TAG = /^(?:app-)?frameworks?$/i;
+
+/**
+ * npm accepts a bare string where `keywords` expects an array, and both forms reach the
+ * registry. Spreading the string form yields single characters, which match no whole tag, so
+ * the two readers of this field return different answers unless they share one normalisation.
+ */
+export function packageKeywords(manifest) {
+  const keywords = manifest?.keywords;
+  if (typeof keywords === "string") return [keywords];
+  if (!Array.isArray(keywords)) return [];
+  return keywords.filter(value => typeof value === "string");
+}
+
+/**
  * A document reduced to what a reader is shown.
  *
  * `renderedProse` drops fenced examples and commented-out blocks. This drops
@@ -654,24 +680,10 @@ export function renderedProse(markdown) {
   );
 }
 
-/**
- * A published package's keywords are a category claim, on the surface people search.
- *
- * The GitHub topic list forbids `framework` and `app-framework` for the reason the whole
- * repositioning turned on: the word could mean an application framework, a UI framework or a
- * backend framework, which made it the least informative word available. npm keywords are the
- * same kind of surface and were left carrying it after the topic was cleared, so the rule is
- * applied to both rather than to whichever one someone remembered.
- *
- * Matched whole, not as a substring: `page-builder` and `nextly-plugin` are keywords this must
- * never touch.
- */
-const RETIRED_KEYWORD = /^(?:app-)?frameworks?$/i;
-
 function retiredKeywords(repoRoot, packages, findings) {
   for (const pkg of packages) {
-    for (const keyword of pkg.json?.keywords ?? []) {
-      if (!RETIRED_KEYWORD.test(keyword)) continue;
+    for (const keyword of packageKeywords(pkg.json)) {
+      if (!RETIRED_CATEGORY_TAG.test(keyword)) continue;
       findings.push({
         check: "retired-category-keyword",
         file: relative(repoRoot, join(pkg.dir, "package.json")),
@@ -835,13 +847,9 @@ export async function runChecks({
     const rel = relative(repoRoot, join(pkg.dir, "package.json")).split(sep).join("/");
     // Each field on its own. Joined, a description ending in "app" and a keyword
     // "framework" would read as the phrase that neither of them contains.
-    // npm accepts a bare string where the array is expected, and spreading one
-    // would compare the pattern against single characters.
-    const keywords = pkg.json.keywords;
-    const published = [
-      pkg.json.description,
-      ...(typeof keywords === "string" ? [keywords] : (keywords ?? [])),
-    ].filter(value => typeof value === "string");
+    const published = [pkg.json.description, ...packageKeywords(pkg.json)].filter(
+      value => typeof value === "string"
+    );
     const claim = published.find(
       value => RETIRED_CATEGORY.test(value) && !categoryExempt(rel, value)
     );

--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -114,6 +114,20 @@ export const RETIRED_CATEGORY = /\bapp(?:-|\s+)frameworks?\b/i;
 export const RETIRED_CATEGORY_TAG = /^(?:app-)?frameworks?$/i;
 
 /**
+ * The single answer to "does this tag name the retired category", for every tag surface.
+ *
+ * A tag can carry the category two ways, and one pattern cannot see both: as the whole tag
+ * (`framework`), or with the phrase embedded in a longer one (`nextjs-app-framework`). Two
+ * checks used to answer this for npm keywords — the prose check matched the phrase, the
+ * keyword check matched the whole tag — so a keyword like `app-framework` was reported twice
+ * under two names, and their patterns were free to drift apart. This is now the only answer,
+ * shared by npm keywords and GitHub topics.
+ */
+export function namesRetiredCategory(tag) {
+  return typeof tag === "string" && (RETIRED_CATEGORY_TAG.test(tag) || RETIRED_CATEGORY.test(tag));
+}
+
+/**
  * npm accepts a bare string where `keywords` expects an array, and both forms reach the
  * registry. Spreading the string form yields single characters, which match no whole tag, so
  * the two readers of this field return different answers unless they share one normalisation.
@@ -683,7 +697,7 @@ export function renderedProse(markdown) {
 function retiredKeywords(repoRoot, packages, findings) {
   for (const pkg of packages) {
     for (const keyword of packageKeywords(pkg.json)) {
-      if (!RETIRED_CATEGORY_TAG.test(keyword)) continue;
+      if (!namesRetiredCategory(keyword)) continue;
       findings.push({
         check: "retired-category-keyword",
         file: relative(repoRoot, join(pkg.dir, "package.json")),
@@ -835,25 +849,21 @@ export async function runChecks({
     }
   }
 
-  // A published description and its keywords are read on npm rather than here,
-  // and say the same thing about the same product, so they are category surfaces
-  // too. A keyword is the searchable one: it is how the category is found rather
-  // than how it is stated.
+  // A published description is read on npm rather than here and says the same
+  // thing about the same product, so it is a category surface too.
+  //
+  // Keywords are deliberately not read here. `retired-category-keyword` owns
+  // them, and one field answered by two checks reports the same manifest twice
+  // under two names while letting the two patterns drift apart.
   //
   // Taken from the list `publishedPackages` already parsed. Enumerating the
   // manifests again here would be a second answer to "which packages ship",
   // free to disagree with the first.
   for (const pkg of packages) {
     const rel = relative(repoRoot, join(pkg.dir, "package.json")).split(sep).join("/");
-    // Each field on its own. Joined, a description ending in "app" and a keyword
-    // "framework" would read as the phrase that neither of them contains.
-    const published = [pkg.json.description, ...packageKeywords(pkg.json)].filter(
-      value => typeof value === "string"
-    );
-    const claim = published.find(
-      value => RETIRED_CATEGORY.test(value) && !categoryExempt(rel, value)
-    );
-    if (claim === undefined) continue;
+    const { description } = pkg.json;
+    if (typeof description !== "string") continue;
+    if (!RETIRED_CATEGORY.test(description) || categoryExempt(rel, description)) continue;
     findings.push({
       check: "retired-category",
       file: rel,

--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -128,15 +128,25 @@ export function namesRetiredCategory(tag) {
 }
 
 /**
+ * The keywords npm derives from a manifest, which is not always the keywords it was given.
+ *
  * npm accepts a bare string where `keywords` expects an array, and both forms reach the
- * registry. Spreading the string form yields single characters, which match no whole tag, so
- * the two readers of this field return different answers unless they share one normalisation.
+ * registry. Reading the string form as one value, or spreading it into characters, both
+ * answer a different question from the one the npm page shows.
+ *
+ * The split mirrors `fixKeywordsField` in npm's own `normalize-package-data` (verified
+ * against 8.0.0), including its quirk: the separator is a comma followed by whitespace, so
+ * `"cms, framework"` is two keywords and `"cms,framework"` stays one. Matching the quirk is
+ * the point — the guard has to evaluate what the registry publishes, not a tidier reading of
+ * it. Empty and non-string entries are dropped there too.
  */
+const NPM_KEYWORD_SEPARATOR = /,\s+/;
+
 export function packageKeywords(manifest) {
   const keywords = manifest?.keywords;
-  if (typeof keywords === "string") return [keywords];
-  if (!Array.isArray(keywords)) return [];
-  return keywords.filter(value => typeof value === "string");
+  const list = typeof keywords === "string" ? keywords.split(NPM_KEYWORD_SEPARATOR) : keywords;
+  if (!Array.isArray(list)) return [];
+  return list.filter(value => typeof value === "string" && value !== "");
 }
 
 /**

--- a/scripts/check-docs-claims.test.mjs
+++ b/scripts/check-docs-claims.test.mjs
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   digestLine,
+  namesRetiredCategory,
   packageKeywords,
   renderedProse,
   runChecks,
@@ -251,17 +252,19 @@ describe("retired-category", () => {
     ).toContain("retired-category");
   });
 
-  it("fires on a published keyword", async () => {
-    expect(
-      await checksFor({
-        "packages/nextly/package.json": JSON.stringify({
-          name: "nextly",
-          version: "1.0.0",
-          description: "A content platform.",
-          keywords: ["cms", "app-framework"],
-        }),
-      })
-    ).toContain("retired-category");
+  it("leaves a published keyword to the check that owns keywords", async () => {
+    // Still caught, under one name rather than two. `retired-category` reads the
+    // description; `retired-category-keyword` reads the keywords.
+    const checks = await checksFor({
+      "packages/nextly/package.json": JSON.stringify({
+        name: "nextly",
+        version: "1.0.0",
+        description: "A content platform.",
+        keywords: ["cms", "app-framework"],
+      }),
+    });
+    expect(checks).toContain("retired-category-keyword");
+    expect(checks).not.toContain("retired-category");
   });
 
   it("does not read a heading as running into the paragraph beneath it", async () => {
@@ -556,16 +559,16 @@ describe("retired-category", () => {
   });
 
   it("reads keywords given as a bare string, which npm accepts", async () => {
-    expect(
-      await checksFor({
-        "packages/nextly/package.json": JSON.stringify({
-          name: "nextly",
-          version: "1.0.0",
-          description: "A content platform.",
-          keywords: "app-framework",
-        }),
-      })
-    ).toContain("retired-category");
+    const checks = await checksFor({
+      "packages/nextly/package.json": JSON.stringify({
+        name: "nextly",
+        version: "1.0.0",
+        description: "A content platform.",
+        keywords: "app-framework",
+      }),
+    });
+    expect(checks).toContain("retired-category-keyword");
+    expect(checks).not.toContain("retired-category");
   });
 
   it("does not decode escapes in a single-quoted yaml value, which are literal", async () => {
@@ -1185,6 +1188,68 @@ describe("retired-category-keyword", () => {
           "# t\n\nin alpha\n\n## Install\n\n## Related packages\n\n## License\n",
       })
     ).not.toContain("retired-category-keyword");
+  });
+});
+
+describe("one classifier owns keywords", () => {
+  const manifest = keyword =>
+    ({
+      "README.md": "# nextly\n\n@nextlyhq/thing\n",
+      "packages/thing/package.json": JSON.stringify({
+        name: "@nextlyhq/thing",
+        keywords: [keyword],
+      }),
+      "packages/thing/README.md":
+        "# t\n\nin alpha\n\n## Install\n\n## Related packages\n\n## License\n",
+    });
+
+  it("reports a keyword once, not once per overlapping check", async () => {
+    // `app-framework` matched the whole-tag pattern AND the prose pattern, so the same
+    // manifest was reported under two check names by two classifiers free to drift apart.
+    const checks = await checksFor(manifest("app-framework"));
+    expect(checks.filter(c => c === "retired-category-keyword")).toHaveLength(1);
+    expect(checks).not.toContain("retired-category");
+  });
+
+  it("still catches the category embedded in a longer keyword", async () => {
+    // The whole-tag pattern alone cannot see this one, which is why the classifier asks
+    // both questions rather than the prose check being deleted outright.
+    expect(await checksFor(manifest("nextjs-app-framework"))).toContain(
+      "retired-category-keyword"
+    );
+  });
+
+  it("still reports a description that names the category", async () => {
+    expect(
+      await checksFor({
+        "README.md": "# nextly\n\n@nextlyhq/thing\n",
+        "packages/thing/package.json": JSON.stringify({
+          name: "@nextlyhq/thing",
+          description: "The app framework for Next.js.",
+        }),
+        "packages/thing/README.md":
+          "# t\n\nin alpha\n\n## Install\n\n## Related packages\n\n## License\n",
+      })
+    ).toContain("retired-category");
+  });
+});
+
+describe("namesRetiredCategory", () => {
+  it("answers for a whole tag and for the phrase inside one", () => {
+    for (const tag of ["framework", "frameworks", "app-framework", "nextjs-app-framework"]) {
+      expect(namesRetiredCategory(tag)).toBe(true);
+    }
+  });
+
+  it("leaves tags that merely contain the word alone", () => {
+    for (const tag of ["framework-agnostic", "page-builder", "nextly-plugin"]) {
+      expect(namesRetiredCategory(tag)).toBe(false);
+    }
+  });
+
+  it("is false for anything that is not a string", () => {
+    expect(namesRetiredCategory(undefined)).toBe(false);
+    expect(namesRetiredCategory(7)).toBe(false);
   });
 });
 

--- a/scripts/check-docs-claims.test.mjs
+++ b/scripts/check-docs-claims.test.mjs
@@ -1103,3 +1103,61 @@ describe("a fence marker inside a comment is not a fence", () => {
     ).toContain("readme-skeleton");
   });
 });
+
+describe("retired-category-keyword", () => {
+  it("fires on the bare 'framework' keyword", async () => {
+    expect(
+      await checksFor({
+        "README.md": "# nextly\n\n@nextlyhq/thing\n",
+        "packages/thing/package.json": JSON.stringify({
+          name: "@nextlyhq/thing",
+          keywords: ["cms", "framework"],
+        }),
+        "packages/thing/README.md": "# t\n\nin alpha\n\n## Install\n\n## Related packages\n\n## License\n",
+      })
+    ).toContain("retired-category-keyword");
+  });
+
+  it("fires on 'app-framework' and on the plural", async () => {
+    for (const keyword of ["app-framework", "frameworks", "App-Frameworks"]) {
+      expect(
+        await checksFor({
+          "README.md": "# nextly\n\n@nextlyhq/thing\n",
+          "packages/thing/package.json": JSON.stringify({
+            name: "@nextlyhq/thing",
+            keywords: [keyword],
+          }),
+          "packages/thing/README.md":
+            "# t\n\nin alpha\n\n## Install\n\n## Related packages\n\n## License\n",
+        })
+      ).toContain("retired-category-keyword");
+    }
+  });
+
+  it("does not fire on keywords that merely contain the word", async () => {
+    // `page-builder` and `nextly-plugin` are keywords this must never touch, and a substring
+    // match would have taken anything hyphenated with the word along with it.
+    expect(
+      await checksFor({
+        "README.md": "# nextly\n\n@nextlyhq/thing\n",
+        "packages/thing/package.json": JSON.stringify({
+          name: "@nextlyhq/thing",
+          keywords: ["page-builder", "nextly-plugin", "framework-agnostic"],
+        }),
+        "packages/thing/README.md":
+          "# t\n\nin alpha\n\n## Install\n\n## Related packages\n\n## License\n",
+      })
+    ).not.toContain("retired-category-keyword");
+  });
+
+  it("does not fire on a package with no keywords at all", async () => {
+    expect(
+      await checksFor({
+        "README.md": "# nextly\n\n@nextlyhq/thing\n",
+        "packages/thing/package.json": JSON.stringify({ name: "@nextlyhq/thing" }),
+        "packages/thing/README.md":
+          "# t\n\nin alpha\n\n## Install\n\n## Related packages\n\n## License\n",
+      })
+    ).not.toContain("retired-category-keyword");
+  });
+});

--- a/scripts/check-docs-claims.test.mjs
+++ b/scripts/check-docs-claims.test.mjs
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   digestLine,
+  packageKeywords,
   renderedProse,
   runChecks,
   splitRefAndPath,
@@ -1159,5 +1160,51 @@ describe("retired-category-keyword", () => {
           "# t\n\nin alpha\n\n## Install\n\n## Related packages\n\n## License\n",
       })
     ).not.toContain("retired-category-keyword");
+  });
+
+  it("fires on the bare-string form npm also accepts", async () => {
+    // `"keywords": "framework"` reaches the registry the same way the array does. Iterating
+    // the string yields single characters, none of which is a whole tag, so the check went
+    // green on the one manifest shape it exists to catch.
+    expect(
+      await checksFor({
+        "README.md": "# nextly\n\n@nextlyhq/thing\n",
+        "packages/thing/package.json": '{"name":"@nextlyhq/thing","keywords":"framework"}',
+        "packages/thing/README.md":
+          "# t\n\nin alpha\n\n## Install\n\n## Related packages\n\n## License\n",
+      })
+    ).toContain("retired-category-keyword");
+  });
+
+  it("does not fire on a bare-string keyword that is not the category", async () => {
+    expect(
+      await checksFor({
+        "README.md": "# nextly\n\n@nextlyhq/thing\n",
+        "packages/thing/package.json": '{"name":"@nextlyhq/thing","keywords":"page-builder"}',
+        "packages/thing/README.md":
+          "# t\n\nin alpha\n\n## Install\n\n## Related packages\n\n## License\n",
+      })
+    ).not.toContain("retired-category-keyword");
+  });
+});
+
+describe("packageKeywords", () => {
+  it("reads both manifest shapes as the same list", () => {
+    expect(packageKeywords({ keywords: ["cms", "framework"] })).toEqual(["cms", "framework"]);
+    expect(packageKeywords({ keywords: "framework" })).toEqual(["framework"]);
+  });
+
+  it("returns nothing for a manifest with no usable keywords", () => {
+    expect(packageKeywords({})).toEqual([]);
+    expect(packageKeywords(undefined)).toEqual([]);
+    expect(packageKeywords({ keywords: null })).toEqual([]);
+    expect(packageKeywords({ keywords: 7 })).toEqual([]);
+  });
+
+  it("drops non-string entries rather than passing them to a regex", () => {
+    expect(packageKeywords({ keywords: ["cms", null, 7, "framework"] })).toEqual([
+      "cms",
+      "framework",
+    ]);
   });
 });

--- a/scripts/check-docs-claims.test.mjs
+++ b/scripts/check-docs-claims.test.mjs
@@ -1179,6 +1179,19 @@ describe("retired-category-keyword", () => {
     ).toContain("retired-category-keyword");
   });
 
+  it("fires on a comma-separated keyword string, which npm splits", async () => {
+    // The bare-string fix read `"cms, framework"` as one value, which matches no whole tag,
+    // so the published `framework` keyword still produced nothing.
+    expect(
+      await checksFor({
+        "README.md": "# nextly\n\n@nextlyhq/thing\n",
+        "packages/thing/package.json": '{"name":"@nextlyhq/thing","keywords":"cms, framework"}',
+        "packages/thing/README.md":
+          "# t\n\nin alpha\n\n## Install\n\n## Related packages\n\n## License\n",
+      })
+    ).toContain("retired-category-keyword");
+  });
+
   it("does not fire on a bare-string keyword that is not the category", async () => {
     expect(
       await checksFor({
@@ -1257,6 +1270,27 @@ describe("packageKeywords", () => {
   it("reads both manifest shapes as the same list", () => {
     expect(packageKeywords({ keywords: ["cms", "framework"] })).toEqual(["cms", "framework"]);
     expect(packageKeywords({ keywords: "framework" })).toEqual(["framework"]);
+  });
+
+  it("splits a comma-separated string the way npm does", () => {
+    // npm's own normalize-package-data splits on /,\s+/, so this is what the registry
+    // publishes and therefore what the guard has to read.
+    expect(packageKeywords({ keywords: "cms, framework" })).toEqual(["cms", "framework"]);
+    expect(packageKeywords({ keywords: "cms,  app-framework,  nextjs" })).toEqual([
+      "cms",
+      "app-framework",
+      "nextjs",
+    ]);
+  });
+
+  it("keeps npm's quirk: a comma with no space does not split", () => {
+    // Verified against normalize-package-data 8.0.0. Splitting here too would evaluate
+    // keywords the registry never derives, which is a different check from the one intended.
+    expect(packageKeywords({ keywords: "cms,framework" })).toEqual(["cms,framework"]);
+  });
+
+  it("drops empty entries, as npm does", () => {
+    expect(packageKeywords({ keywords: ["cms", "", "framework"] })).toEqual(["cms", "framework"]);
   });
 
   it("returns nothing for a manifest with no usable keywords", () => {

--- a/scripts/check-repo-metadata.mjs
+++ b/scripts/check-repo-metadata.mjs
@@ -23,19 +23,20 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { RETIRED_CATEGORY } from "./check-docs-claims.mjs";
+import { RETIRED_CATEGORY, RETIRED_CATEGORY_TAG } from "./check-docs-claims.mjs";
 
 const OWNER = "nextlyhq";
 const REPO = "nextly";
 
 /**
- * Topics that describe the retired category, and topics the search descriptor commits to.
+ * Topics the search descriptor commits to.
  *
- * `framework` sits in the forbidden list beside `app-framework` because it is the word the
- * whole repositioning turned on: it could mean an application framework, a UI framework or a
- * backend framework, which is why it was the least informative word available in the title tag.
+ * There is no matching list of forbidden ones. A GitHub topic is the same kind of whole tag as
+ * an npm keyword, so which topics name the retired category is decided by the shared
+ * `RETIRED_CATEGORY_TAG` pattern. Listing them here instead would be a second copy of the
+ * definition, free to disagree with the first — and it did: the list held only the singular
+ * spellings, so `frameworks` and `app-frameworks` passed a check that rejects them as keywords.
  */
-const FORBIDDEN_TOPICS = ["app-framework", "framework"];
 const REQUIRED_TOPICS = [
   "cms",
   "headless-cms",
@@ -47,6 +48,22 @@ const REQUIRED_TOPICS = [
 /** The package whose description the About line must match. The root manifest has none. */
 const DESCRIPTION_SOURCE = "packages/nextly/package.json";
 
+/**
+ * Whether an HTTP status means the configured repository cannot be read, as opposed to a
+ * moment when GitHub could not answer.
+ *
+ * The distinction is the whole value of the unverifiable result. Rate limiting is the common
+ * outcome of an unauthenticated call from CI and says nothing about the metadata, so it stays
+ * unverifiable. A 404 is the opposite: it is what a renamed repository or a stale `OWNER`
+ * returns, and treating it as transient would leave this check green for as long as the
+ * mistake lasted, examining no metadata at all.
+ */
+export function isPermanentStatus(status) {
+  if (status === 403 || status === 429) return false; // rate limited, not unreadable
+  if (status >= 500) return false; // GitHub's side, and it recovers
+  return status >= 400;
+}
+
 export async function fetchRepoMetadata(owner = OWNER, repo = REPO) {
   // Unauthenticated on purpose: the repository is public, so this needs no token and runs the
   // same way on a laptop and in CI. A token would make the check pass locally for someone whose
@@ -55,7 +72,9 @@ export async function fetchRepoMetadata(owner = OWNER, repo = REPO) {
     headers: { accept: "application/vnd.github+json" },
   });
   if (!response.ok) {
-    throw new Error(`GitHub API returned ${response.status}`);
+    const error = new Error(`GitHub API returned ${response.status} for ${owner}/${repo}`);
+    error.permanent = isPermanentStatus(response.status);
+    throw error;
   }
   const body = await response.json();
   return { description: body.description ?? "", topics: body.topics ?? [] };
@@ -72,7 +91,18 @@ export function checkRepoMetadata({ metadata, expectedDescription }) {
     });
   }
 
-  if (expectedDescription && description !== expectedDescription) {
+  // Guarding the comparison on a truthy `expectedDescription` would disable it entirely the
+  // day the source manifest lost its description, letting any About line pass. The About line
+  // is only as trustworthy as the thing it is compared against, so an absent source is itself
+  // the finding.
+  if (typeof expectedDescription !== "string" || expectedDescription.trim() === "") {
+    findings.push({
+      check: "description-source-missing",
+      message:
+        `${DESCRIPTION_SOURCE} has no description, so there is nothing for the GitHub About ` +
+        `line to be checked against`,
+    });
+  } else if (description !== expectedDescription) {
     findings.push({
       check: "about-matches-package",
       message:
@@ -81,13 +111,12 @@ export function checkRepoMetadata({ metadata, expectedDescription }) {
     });
   }
 
-  for (const topic of FORBIDDEN_TOPICS) {
-    if (topics.includes(topic)) {
-      findings.push({
-        check: "topic-forbidden",
-        message: `the topic "${topic}" describes the retired category and should be removed`,
-      });
-    }
+  for (const topic of topics) {
+    if (!RETIRED_CATEGORY_TAG.test(topic)) continue;
+    findings.push({
+      check: "topic-forbidden",
+      message: `the topic "${topic}" names the retired category and should be removed`,
+    });
   }
 
   for (const topic of REQUIRED_TOPICS) {
@@ -106,16 +135,28 @@ const invokedDirectly =
   process.argv[1] && process.argv[1].endsWith("check-repo-metadata.mjs");
 
 if (invokedDirectly) {
-  const expectedDescription = JSON.parse(
+  // No `?? ""`: an absent description must stay absent so `description-source-missing` fires
+  // rather than being compared as an empty string.
+  const { description: expectedDescription } = JSON.parse(
     readFileSync(join(process.cwd(), DESCRIPTION_SOURCE), "utf-8")
-  ).description;
+  );
 
   let metadata;
   try {
     metadata = await fetchRepoMetadata();
   } catch (error) {
-    // Unverifiable, not failed. An unreachable API says nothing about the metadata, and a check
-    // that goes red when the network is down teaches people to wave this one through.
+    if (error.permanent) {
+      console.error(
+        `\nrepo metadata: ${OWNER}/${REPO} could not be read (${error.message})\n\n` +
+          `This status does not recover on its own. Either the repository was renamed or made ` +
+          `private and the constants in this script are stale, or it can no longer be read ` +
+          `without a token.\n`
+      );
+      process.exit(1);
+    }
+    // Unverifiable, not failed. A rate limit or an unreachable API says nothing about the
+    // metadata, and a check that goes red when the network is down teaches people to wave this
+    // one through.
     console.warn(
       `repo metadata: could not be read (${error.message}). Not counted as a failure.`
     );

--- a/scripts/check-repo-metadata.mjs
+++ b/scripts/check-repo-metadata.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+
+/**
+ * The repository's own GitHub metadata says what the project is, and no file check can see it.
+ *
+ * `check-docs-claims.mjs` reads git's index, so it enforces the category across README.md,
+ * AGENTS.md, docs and the published packages. The About line and the topic list are not files
+ * in the index — they are repository settings — so every one of those checks is blind to them.
+ * The result was measurable: with all six guarded surfaces clean and zero occurrences of the
+ * retired category in any tracked file, the About line still opened "the open-source, type-safe
+ * app framework for Next.js", which is the first sentence a visitor to a public repository
+ * reads.
+ *
+ * A release checklist would close it on the days someone remembers. This runs every time.
+ *
+ * The category pattern is imported rather than restated: two copies of the definition of what
+ * the project is no longer called is how the second one gets missed.
+ *
+ * Usage:
+ *   node scripts/check-repo-metadata.mjs
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { RETIRED_CATEGORY } from "./check-docs-claims.mjs";
+
+const OWNER = "nextlyhq";
+const REPO = "nextly";
+
+/**
+ * Topics that describe the retired category, and topics the search descriptor commits to.
+ *
+ * `framework` sits in the forbidden list beside `app-framework` because it is the word the
+ * whole repositioning turned on: it could mean an application framework, a UI framework or a
+ * backend framework, which is why it was the least informative word available in the title tag.
+ */
+const FORBIDDEN_TOPICS = ["app-framework", "framework"];
+const REQUIRED_TOPICS = [
+  "cms",
+  "headless-cms",
+  "page-builder",
+  "nextjs",
+  "content-platform",
+];
+
+/** The package whose description the About line must match. The root manifest has none. */
+const DESCRIPTION_SOURCE = "packages/nextly/package.json";
+
+export async function fetchRepoMetadata(owner = OWNER, repo = REPO) {
+  // Unauthenticated on purpose: the repository is public, so this needs no token and runs the
+  // same way on a laptop and in CI. A token would make the check pass locally for someone whose
+  // gh is logged in and fail in an environment that has none.
+  const response = await fetch(`https://api.github.com/repos/${owner}/${repo}`, {
+    headers: { accept: "application/vnd.github+json" },
+  });
+  if (!response.ok) {
+    throw new Error(`GitHub API returned ${response.status}`);
+  }
+  const body = await response.json();
+  return { description: body.description ?? "", topics: body.topics ?? [] };
+}
+
+export function checkRepoMetadata({ metadata, expectedDescription }) {
+  const findings = [];
+  const { description, topics } = metadata;
+
+  if (RETIRED_CATEGORY.test(description)) {
+    findings.push({
+      check: "about-retired-category",
+      message: `the GitHub About line still names the retired category: "${description}"`,
+    });
+  }
+
+  if (expectedDescription && description !== expectedDescription) {
+    findings.push({
+      check: "about-matches-package",
+      message:
+        `the GitHub About line differs from ${DESCRIPTION_SOURCE}. ` +
+        `About: "${description}" — package: "${expectedDescription}"`,
+    });
+  }
+
+  for (const topic of FORBIDDEN_TOPICS) {
+    if (topics.includes(topic)) {
+      findings.push({
+        check: "topic-forbidden",
+        message: `the topic "${topic}" describes the retired category and should be removed`,
+      });
+    }
+  }
+
+  for (const topic of REQUIRED_TOPICS) {
+    if (!topics.includes(topic)) {
+      findings.push({
+        check: "topic-missing",
+        message: `the topic "${topic}" is part of the search descriptor and is not set`,
+      });
+    }
+  }
+
+  return { findings };
+}
+
+const invokedDirectly =
+  process.argv[1] && process.argv[1].endsWith("check-repo-metadata.mjs");
+
+if (invokedDirectly) {
+  const expectedDescription = JSON.parse(
+    readFileSync(join(process.cwd(), DESCRIPTION_SOURCE), "utf-8")
+  ).description;
+
+  let metadata;
+  try {
+    metadata = await fetchRepoMetadata();
+  } catch (error) {
+    // Unverifiable, not failed. An unreachable API says nothing about the metadata, and a check
+    // that goes red when the network is down teaches people to wave this one through.
+    console.warn(
+      `repo metadata: could not be read (${error.message}). Not counted as a failure.`
+    );
+    process.exit(0);
+  }
+
+  const { findings } = checkRepoMetadata({ metadata, expectedDescription });
+
+  if (findings.length === 0) {
+    console.log("repo metadata: About line and topics agree with the category.");
+    process.exit(0);
+  }
+
+  console.error(`\nrepo metadata: ${findings.length} finding(s)\n`);
+  for (const finding of findings) {
+    console.error(`  ${finding.check}: ${finding.message}`);
+  }
+  console.error(
+    `\nThese are repository settings, not files. Fix them in Settings on GitHub, ` +
+      `or with:\n  gh repo edit ${OWNER}/${REPO} --description "..." --add-topic ... --remove-topic ...\n`
+  );
+  process.exit(1);
+}

--- a/scripts/check-repo-metadata.mjs
+++ b/scripts/check-repo-metadata.mjs
@@ -56,18 +56,21 @@ const DESCRIPTION_SOURCE = "packages/nextly/package.json";
  * repository or a stale `OWNER` returns, and treating it as transient would leave this check
  * green for as long as the mistake lasted, examining no metadata at all.
  *
- * 403 is the ambiguous one, and the headers are what resolve it: GitHub returns 403 both for
- * rate limiting, which recovers, and for a repository this credential may not read, which does
- * not. Reading only the status would classify a permanent refusal as a moment to try again.
+ * 403 is the ambiguous one, and it is read as transient. GitHub returns it both for rate
+ * limiting, which recovers, and for a repository this credential may not read, which does not
+ * — and its own guidance documents a secondary limit that identifies itself with NEITHER
+ * `retry-after` nor an exhausted quota, to be retried after at least a minute. So the headers
+ * cannot separate the two cases, and the choice is which way to be wrong.
+ *
+ * Transient is the safer error here, because the two costs are not symmetric. A permanent
+ * refusal read as transient is retried and then reported by the run that must verify, which
+ * fails on an unreadable API whatever the reason — the alarm still sounds, with a less
+ * specific message. A recoverable limit read as permanent files an issue immediately for
+ * something that would have cleared on its own, and an alarm that cries wolf is worse than
+ * none.
  */
-export function isPermanentStatus(status, headers) {
-  if (status === 429) return false;
-  if (status === 403) {
-    const remaining = headers?.get?.("x-ratelimit-remaining");
-    const retryAfter = headers?.get?.("retry-after");
-    // Primary limit exhausts the quota; a secondary limit answers with retry-after instead.
-    return !(remaining === "0" || retryAfter);
-  }
+export function isPermanentStatus(status) {
+  if (status === 403 || status === 429) return false; // rate limited, or indistinguishable from it
   if (status >= 500) return false; // GitHub's side, and it recovers
   return status >= 400;
 }
@@ -118,7 +121,7 @@ const MAX_RETRY_WAIT_MS = 60_000;
  * clear — the retries are spent, and a scheduled run files an issue for a limit that had a
  * published recovery time.
  */
-export function retryDelayMs(headers, attempt, now = Date.now()) {
+export function retryDelayMs({ headers, attempt, status, now = Date.now() } = {}) {
   const retryAfter = Number(headers?.get?.("retry-after"));
   if (Number.isFinite(retryAfter) && retryAfter > 0) return retryAfter * 1000;
 
@@ -127,6 +130,11 @@ export function retryDelayMs(headers, attempt, now = Date.now()) {
     const wait = reset * 1000 - now;
     if (wait > 0) return wait;
   }
+
+  // GitHub's documented fallback for a secondary limit that named no interval: wait at least
+  // a minute. Its own backoff below is for failures that are not a limit at all, and a second
+  // is far too soon for one that is.
+  if (status === 403) return 60_000;
 
   return attempt * 1000;
 }
@@ -150,9 +158,9 @@ export async function fetchRepoMetadata(owner = OWNER, repo = REPO, { fetchImpl 
         };
       }
       const error = new Error(`GitHub API returned ${response.status} for ${owner}/${repo}`);
-      error.permanent = isPermanentStatus(response.status, response.headers);
+      error.permanent = isPermanentStatus(response.status);
       if (error.permanent) throw error;
-      error.retryIn = retryDelayMs(response.headers, attempt);
+      error.retryIn = retryDelayMs({ headers: response.headers, attempt, status: response.status });
       lastError = error;
     } catch (error) {
       if (error.permanent) throw error;
@@ -274,7 +282,9 @@ if (invokedDirectly) {
               `made private and the constants in this script are stale, or it can no longer ` +
               `be read without a token.\n`
             : `This run exists to observe the About line and the topics, and it examined ` +
-              `neither, so it cannot report a pass. Re-run it once the API is reachable.\n`)
+              `neither, so it cannot report a pass. Usually a rate limit, which clears on ` +
+              `its own. If it repeats, check that the repository is still readable by this ` +
+              `token — a 403 from a repository made private looks the same from here.\n`)
       );
       process.exit(1);
     }

--- a/scripts/check-repo-metadata.mjs
+++ b/scripts/check-repo-metadata.mjs
@@ -52,32 +52,78 @@ const DESCRIPTION_SOURCE = "packages/nextly/package.json";
  * Whether an HTTP status means the configured repository cannot be read, as opposed to a
  * moment when GitHub could not answer.
  *
- * The distinction is the whole value of the unverifiable result. Rate limiting is the common
- * outcome of an unauthenticated call from CI and says nothing about the metadata, so it stays
- * unverifiable. A 404 is the opposite: it is what a renamed repository or a stale `OWNER`
- * returns, and treating it as transient would leave this check green for as long as the
- * mistake lasted, examining no metadata at all.
+ * The distinction is the whole value of the unverifiable result. A 404 is what a renamed
+ * repository or a stale `OWNER` returns, and treating it as transient would leave this check
+ * green for as long as the mistake lasted, examining no metadata at all.
+ *
+ * 403 is the ambiguous one, and the headers are what resolve it: GitHub returns 403 both for
+ * rate limiting, which recovers, and for a repository this credential may not read, which does
+ * not. Reading only the status would classify a permanent refusal as a moment to try again.
  */
-export function isPermanentStatus(status) {
-  if (status === 403 || status === 429) return false; // rate limited, not unreadable
+export function isPermanentStatus(status, headers) {
+  if (status === 429) return false;
+  if (status === 403) {
+    const remaining = headers?.get?.("x-ratelimit-remaining");
+    const retryAfter = headers?.get?.("retry-after");
+    // Primary limit exhausts the quota; a secondary limit answers with retry-after instead.
+    return !(remaining === "0" || retryAfter);
+  }
   if (status >= 500) return false; // GitHub's side, and it recovers
   return status >= 400;
 }
 
-export async function fetchRepoMetadata(owner = OWNER, repo = REPO) {
-  // Unauthenticated on purpose: the repository is public, so this needs no token and runs the
-  // same way on a laptop and in CI. A token would make the check pass locally for someone whose
-  // gh is logged in and fail in an environment that has none.
-  const response = await fetch(`https://api.github.com/repos/${owner}/${repo}`, {
-    headers: { accept: "application/vnd.github+json" },
-  });
-  if (!response.ok) {
-    const error = new Error(`GitHub API returned ${response.status} for ${owner}/${repo}`);
-    error.permanent = isPermanentStatus(response.status);
-    throw error;
+/**
+ * Whether an unreadable API must fail the run rather than report itself unverifiable.
+ *
+ * The scheduled run exists only to observe a setting no file check can see, so a scheduled
+ * run that examined nothing did not do the one thing it is for, and reporting success would
+ * make it indistinguishable from a clean pass. Everywhere else the softer result is right: a
+ * check that goes red because a laptop is offline teaches people to wave this one through.
+ */
+export function verificationRequired(env = process.env) {
+  return env.GITHUB_EVENT_NAME === "schedule" || env.GITHUB_EVENT_NAME === "workflow_dispatch";
+}
+
+/**
+ * The token is used when one is offered and the call is unauthenticated otherwise.
+ *
+ * The repository is public, so no token is needed to read this and a laptop should not have to
+ * hold one. But an unauthenticated caller gets 60 requests an hour shared across everything on
+ * that IP, and a runner that exhausts it turns this check into a silent pass — the result is
+ * "unverifiable", which is not a failure, so the run goes green having examined nothing. A
+ * workflow token raises the ceiling far above anything this job could reach.
+ */
+function authHeaders(env = process.env) {
+  const token = env.GITHUB_TOKEN || env.GH_TOKEN;
+  return token ? { authorization: `Bearer ${token}` } : {};
+}
+
+const TRANSIENT_ATTEMPTS = 3;
+
+export async function fetchRepoMetadata(owner = OWNER, repo = REPO, { fetchImpl = fetch, env = process.env, delay = ms => new Promise(r => setTimeout(r, ms)) } = {}) {
+  let lastError;
+  for (let attempt = 1; attempt <= TRANSIENT_ATTEMPTS; attempt += 1) {
+    try {
+      const response = await fetchImpl(`https://api.github.com/repos/${owner}/${repo}`, {
+        headers: { accept: "application/vnd.github+json", ...authHeaders(env) },
+      });
+      if (response.ok) {
+        const body = await response.json();
+        return { description: body.description ?? "", topics: body.topics ?? [] };
+      }
+      const error = new Error(`GitHub API returned ${response.status} for ${owner}/${repo}`);
+      error.permanent = isPermanentStatus(response.status, response.headers);
+      if (error.permanent) throw error;
+      lastError = error;
+    } catch (error) {
+      if (error.permanent) throw error;
+      lastError = error;
+    }
+    // Retried because a single blip should not file an issue. A permanent status never
+    // reaches here, so this never delays the answer that matters.
+    if (attempt < TRANSIENT_ATTEMPTS) await delay(attempt * 1000);
   }
-  const body = await response.json();
-  return { description: body.description ?? "", topics: body.topics ?? [] };
+  throw lastError;
 }
 
 /**
@@ -163,12 +209,15 @@ if (invokedDirectly) {
   try {
     metadata = await fetchRepoMetadata();
   } catch (error) {
-    if (error.permanent) {
+    if (error.permanent || verificationRequired()) {
       console.error(
         `\nrepo metadata: ${OWNER}/${REPO} could not be read (${error.message})\n\n` +
-          `This status does not recover on its own. Either the repository was renamed or made ` +
-          `private and the constants in this script are stale, or it can no longer be read ` +
-          `without a token.\n`
+          (error.permanent
+            ? `This status does not recover on its own. Either the repository was renamed or ` +
+              `made private and the constants in this script are stale, or it can no longer ` +
+              `be read without a token.\n`
+            : `This run exists to observe the About line and the topics, and it examined ` +
+              `neither, so it cannot report a pass. Re-run it once the API is reachable.\n`)
       );
       process.exit(1);
     }

--- a/scripts/check-repo-metadata.mjs
+++ b/scripts/check-repo-metadata.mjs
@@ -100,6 +100,37 @@ function authHeaders(env = process.env) {
 
 const TRANSIENT_ATTEMPTS = 3;
 
+/**
+ * The longest this will wait before giving up on a transient failure.
+ *
+ * A primary rate limit can reset an hour out. Sleeping through that would hold a runner open
+ * for an hour to answer one question, so past this the honest report is that the run could not
+ * verify the metadata, which the scheduled run then treats as a failure.
+ */
+const MAX_RETRY_WAIT_MS = 60_000;
+
+/**
+ * How long to wait before retrying, preferring the interval GitHub named.
+ *
+ * A secondary rate limit answers with `retry-after` and a primary one with the epoch second
+ * the quota resets. Reading those headers to decide the failure is transient and then waiting
+ * an arbitrary second anyway burns every attempt inside a window GitHub already said would not
+ * clear — the retries are spent, and a scheduled run files an issue for a limit that had a
+ * published recovery time.
+ */
+export function retryDelayMs(headers, attempt, now = Date.now()) {
+  const retryAfter = Number(headers?.get?.("retry-after"));
+  if (Number.isFinite(retryAfter) && retryAfter > 0) return retryAfter * 1000;
+
+  const reset = Number(headers?.get?.("x-ratelimit-reset"));
+  if (Number.isFinite(reset) && reset > 0) {
+    const wait = reset * 1000 - now;
+    if (wait > 0) return wait;
+  }
+
+  return attempt * 1000;
+}
+
 export async function fetchRepoMetadata(owner = OWNER, repo = REPO, { fetchImpl = fetch, env = process.env, delay = ms => new Promise(r => setTimeout(r, ms)) } = {}) {
   let lastError;
   for (let attempt = 1; attempt <= TRANSIENT_ATTEMPTS; attempt += 1) {
@@ -109,11 +140,19 @@ export async function fetchRepoMetadata(owner = OWNER, repo = REPO, { fetchImpl 
       });
       if (response.ok) {
         const body = await response.json();
-        return { description: body.description ?? "", topics: body.topics ?? [] };
+        return {
+          description: body.description ?? "",
+          topics: body.topics ?? [],
+          // Carried so strictness can ask whether this run is on the branch whose manifest
+          // the About line is supposed to match. Reading it from the same response keeps it
+          // from being a second, separately-wrong answer to "what is the default branch".
+          defaultBranch: body.default_branch ?? null,
+        };
       }
       const error = new Error(`GitHub API returned ${response.status} for ${owner}/${repo}`);
       error.permanent = isPermanentStatus(response.status, response.headers);
       if (error.permanent) throw error;
+      error.retryIn = retryDelayMs(response.headers, attempt);
       lastError = error;
     } catch (error) {
       if (error.permanent) throw error;
@@ -121,7 +160,12 @@ export async function fetchRepoMetadata(owner = OWNER, repo = REPO, { fetchImpl 
     }
     // Retried because a single blip should not file an issue. A permanent status never
     // reaches here, so this never delays the answer that matters.
-    if (attempt < TRANSIENT_ATTEMPTS) await delay(attempt * 1000);
+    if (attempt >= TRANSIENT_ATTEMPTS) break;
+    const wait = lastError.retryIn ?? attempt * 1000;
+    // Nothing is gained by sleeping through a window longer than this run should live;
+    // stopping now reports the same answer sooner.
+    if (wait > MAX_RETRY_WAIT_MS) break;
+    await delay(wait);
   }
   throw lastError;
 }
@@ -136,11 +180,24 @@ export async function fetchRepoMetadata(owner = OWNER, repo = REPO, { fetchImpl 
  * correct change teaches people to wave it through, so drift is advisory on a pull request and
  * blocking everywhere the setting can actually be brought back into line.
  *
+ * The event alone does not identify those places. A manual dispatch can run against any branch,
+ * and a branch that legitimately moved the package description is in exactly the position a
+ * pull request is: compared against one global value it has not landed yet. So the question is
+ * which ref is checked out, not which event fired — the About line is only required to match
+ * the manifest on the branch it was written from.
+ *
+ * With no ref at all this is a laptop, where someone ran the check deliberately and should get
+ * the strict answer.
+ *
  * The category checks are unconditional. Those are absolute claims about what the project is,
  * not a comparison against a value the branch is allowed to move.
  */
-export function strictDescriptionMatch(env = process.env) {
-  return env.GITHUB_EVENT_NAME !== "pull_request";
+export function strictDescriptionMatch(env = process.env, defaultBranch = null) {
+  if (env.GITHUB_EVENT_NAME === "pull_request") return false;
+  const ref = env.GITHUB_REF_NAME;
+  if (!ref) return true;
+  if (!defaultBranch) return true; // unknown: keep the stricter answer
+  return ref === defaultBranch;
 }
 
 export function checkRepoMetadata({ metadata, expectedDescription, strictDescription = true }) {
@@ -233,7 +290,7 @@ if (invokedDirectly) {
   const { findings } = checkRepoMetadata({
     metadata,
     expectedDescription,
-    strictDescription: strictDescriptionMatch(),
+    strictDescription: strictDescriptionMatch(process.env, metadata.defaultBranch),
   });
 
   const advisory = findings.filter(finding => finding.advisory);
@@ -242,7 +299,8 @@ if (invokedDirectly) {
   for (const finding of advisory) {
     console.warn(`repo metadata: ${finding.check}: ${finding.message}`);
     console.warn(
-      `  Not failing this run: the About line is a repository setting a pull request cannot change.\n`
+      `  Not failing this run: the About line is one global repository setting, and this ref ` +
+        `has not landed on the default branch yet.\n`
     );
   }
 

--- a/scripts/check-repo-metadata.mjs
+++ b/scripts/check-repo-metadata.mjs
@@ -23,7 +23,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { RETIRED_CATEGORY, RETIRED_CATEGORY_TAG } from "./check-docs-claims.mjs";
+import { RETIRED_CATEGORY, namesRetiredCategory } from "./check-docs-claims.mjs";
 
 const OWNER = "nextlyhq";
 const REPO = "nextly";
@@ -31,9 +31,9 @@ const REPO = "nextly";
 /**
  * Topics the search descriptor commits to.
  *
- * There is no matching list of forbidden ones. A GitHub topic is the same kind of whole tag as
- * an npm keyword, so which topics name the retired category is decided by the shared
- * `RETIRED_CATEGORY_TAG` pattern. Listing them here instead would be a second copy of the
+ * There is no matching list of forbidden ones. A GitHub topic is the same kind of tag as an
+ * npm keyword, so which topics name the retired category is decided by the shared
+ * `namesRetiredCategory` classifier. Listing them here instead would be a second copy of the
  * definition, free to disagree with the first — and it did: the list held only the singular
  * spellings, so `frameworks` and `app-frameworks` passed a check that rejects them as keywords.
  */
@@ -80,7 +80,24 @@ export async function fetchRepoMetadata(owner = OWNER, repo = REPO) {
   return { description: body.description ?? "", topics: body.topics ?? [] };
 }
 
-export function checkRepoMetadata({ metadata, expectedDescription }) {
+/**
+ * Whether the About line must match the package description exactly, or only be reported.
+ *
+ * The About line is one global repository setting, and a pull request cannot change it. A PR
+ * that legitimately edits the package description would otherwise be unmergeable until someone
+ * edited the live setting first — which would then fail every other open PR still carrying the
+ * old description, and is impossible for a fork author regardless. A check that goes red on a
+ * correct change teaches people to wave it through, so drift is advisory on a pull request and
+ * blocking everywhere the setting can actually be brought back into line.
+ *
+ * The category checks are unconditional. Those are absolute claims about what the project is,
+ * not a comparison against a value the branch is allowed to move.
+ */
+export function strictDescriptionMatch(env = process.env) {
+  return env.GITHUB_EVENT_NAME !== "pull_request";
+}
+
+export function checkRepoMetadata({ metadata, expectedDescription, strictDescription = true }) {
   const findings = [];
   const { description, topics } = metadata;
 
@@ -105,6 +122,7 @@ export function checkRepoMetadata({ metadata, expectedDescription }) {
   } else if (description !== expectedDescription) {
     findings.push({
       check: "about-matches-package",
+      advisory: !strictDescription,
       message:
         `the GitHub About line differs from ${DESCRIPTION_SOURCE}. ` +
         `About: "${description}" — package: "${expectedDescription}"`,
@@ -112,7 +130,7 @@ export function checkRepoMetadata({ metadata, expectedDescription }) {
   }
 
   for (const topic of topics) {
-    if (!RETIRED_CATEGORY_TAG.test(topic)) continue;
+    if (!namesRetiredCategory(topic)) continue;
     findings.push({
       check: "topic-forbidden",
       message: `the topic "${topic}" names the retired category and should be removed`,
@@ -163,15 +181,29 @@ if (invokedDirectly) {
     process.exit(0);
   }
 
-  const { findings } = checkRepoMetadata({ metadata, expectedDescription });
+  const { findings } = checkRepoMetadata({
+    metadata,
+    expectedDescription,
+    strictDescription: strictDescriptionMatch(),
+  });
 
-  if (findings.length === 0) {
+  const advisory = findings.filter(finding => finding.advisory);
+  const blocking = findings.filter(finding => !finding.advisory);
+
+  for (const finding of advisory) {
+    console.warn(`repo metadata: ${finding.check}: ${finding.message}`);
+    console.warn(
+      `  Not failing this run: the About line is a repository setting a pull request cannot change.\n`
+    );
+  }
+
+  if (blocking.length === 0) {
     console.log("repo metadata: About line and topics agree with the category.");
     process.exit(0);
   }
 
-  console.error(`\nrepo metadata: ${findings.length} finding(s)\n`);
-  for (const finding of findings) {
+  console.error(`\nrepo metadata: ${blocking.length} finding(s)\n`);
+  for (const finding of blocking) {
     console.error(`  ${finding.check}: ${finding.message}`);
   }
   console.error(

--- a/scripts/check-repo-metadata.test.mjs
+++ b/scripts/check-repo-metadata.test.mjs
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { checkRepoMetadata, isPermanentStatus } from "./check-repo-metadata.mjs";
+import {
+  checkRepoMetadata,
+  isPermanentStatus,
+  strictDescriptionMatch,
+} from "./check-repo-metadata.mjs";
 
 /**
  * Metadata is injected rather than fetched. The network is not the subject, and a test that
@@ -87,6 +91,14 @@ describe("topics", () => {
     }
   });
 
+  it("fires on a topic with the category embedded in a longer tag", () => {
+    // Topics share the classifier with npm keywords, so this is caught for the same
+    // reason `nextjs-app-framework` is caught as a keyword.
+    expect(
+      run({ description: GOOD_DESCRIPTION, topics: [...goodTopics, "nextjs-app-framework"] })
+    ).toContain("topic-forbidden");
+  });
+
   it("does not fire on topics that merely contain the word", () => {
     expect(
       run({
@@ -134,6 +146,61 @@ describe("description-source-missing", () => {
     expect(run({ description: GOOD_DESCRIPTION, topics: goodTopics })).not.toContain(
       "description-source-missing"
     );
+  });
+});
+
+describe("drift is advisory where it cannot be acted on", () => {
+  const drifted = { description: "Something else entirely.", topics: goodTopics };
+  const findingsFor = strictDescription =>
+    checkRepoMetadata({
+      metadata: drifted,
+      expectedDescription: GOOD_DESCRIPTION,
+      strictDescription,
+    }).findings;
+
+  it("marks a description mismatch advisory when the setting cannot be changed", () => {
+    // A pull request cannot edit one global repository setting, and a fork author cannot
+    // edit it at all. Failing their build on it would be a red on a correct change.
+    const drift = findingsFor(false).find(f => f.check === "about-matches-package");
+    expect(drift.advisory).toBe(true);
+  });
+
+  it("blocks on the same mismatch where the setting can be brought into line", () => {
+    const drift = findingsFor(true).find(f => f.check === "about-matches-package");
+    expect(drift.advisory).toBeFalsy();
+  });
+
+  it("never makes a category finding advisory", () => {
+    // These are absolute claims about what the project is, not a comparison against a
+    // value the branch is allowed to move, so a pull request does not get a pass on them.
+    const { findings } = checkRepoMetadata({
+      metadata: { description: "The app framework for Next.js.", topics: ["framework"] },
+      expectedDescription: GOOD_DESCRIPTION,
+      strictDescription: false,
+    });
+    const category = findings.filter(f => f.check !== "about-matches-package");
+    expect(category.length).toBeGreaterThan(0);
+    expect(category.every(f => !f.advisory)).toBe(true);
+  });
+
+  it("blocks by default, so a caller that forgets the flag gets the strict answer", () => {
+    const drift = checkRepoMetadata({
+      metadata: drifted,
+      expectedDescription: GOOD_DESCRIPTION,
+    }).findings.find(f => f.check === "about-matches-package");
+    expect(drift.advisory).toBeFalsy();
+  });
+});
+
+describe("strictDescriptionMatch", () => {
+  it("is lenient only on a pull request", () => {
+    expect(strictDescriptionMatch({ GITHUB_EVENT_NAME: "pull_request" })).toBe(false);
+  });
+
+  it("is strict on a schedule, a push, and on a laptop with no event at all", () => {
+    expect(strictDescriptionMatch({ GITHUB_EVENT_NAME: "schedule" })).toBe(true);
+    expect(strictDescriptionMatch({ GITHUB_EVENT_NAME: "push" })).toBe(true);
+    expect(strictDescriptionMatch({})).toBe(true);
   });
 });
 

--- a/scripts/check-repo-metadata.test.mjs
+++ b/scripts/check-repo-metadata.test.mjs
@@ -4,6 +4,7 @@ import {
   checkRepoMetadata,
   fetchRepoMetadata,
   isPermanentStatus,
+  retryDelayMs,
   strictDescriptionMatch,
   verificationRequired,
 } from "./check-repo-metadata.mjs";
@@ -195,14 +196,85 @@ describe("drift is advisory where it cannot be acted on", () => {
 });
 
 describe("strictDescriptionMatch", () => {
-  it("is lenient only on a pull request", () => {
-    expect(strictDescriptionMatch({ GITHUB_EVENT_NAME: "pull_request" })).toBe(false);
+  it("is lenient on a pull request whatever the ref says", () => {
+    expect(
+      strictDescriptionMatch(
+        { GITHUB_EVENT_NAME: "pull_request", GITHUB_REF_NAME: "main" },
+        "main"
+      )
+    ).toBe(false);
   });
 
-  it("is strict on a schedule, a push, and on a laptop with no event at all", () => {
-    expect(strictDescriptionMatch({ GITHUB_EVENT_NAME: "schedule" })).toBe(true);
-    expect(strictDescriptionMatch({ GITHUB_EVENT_NAME: "push" })).toBe(true);
-    expect(strictDescriptionMatch({})).toBe(true);
+  it("is strict on the default branch, where the setting can be brought into line", () => {
+    expect(
+      strictDescriptionMatch({ GITHUB_EVENT_NAME: "schedule", GITHUB_REF_NAME: "main" }, "main")
+    ).toBe(true);
+    expect(
+      strictDescriptionMatch({ GITHUB_EVENT_NAME: "push", GITHUB_REF_NAME: "main" }, "main")
+    ).toBe(true);
+  });
+
+  it("is lenient on a manual run against a branch that has not landed", () => {
+    // A dispatch can target any ref. A branch that legitimately moved the package
+    // description is in the same position a pull request is, and failing it would file an
+    // issue for a mismatch that is expected.
+    expect(
+      strictDescriptionMatch(
+        { GITHUB_EVENT_NAME: "workflow_dispatch", GITHUB_REF_NAME: "task/rename" },
+        "main"
+      )
+    ).toBe(false);
+    expect(
+      strictDescriptionMatch(
+        { GITHUB_EVENT_NAME: "schedule", GITHUB_REF_NAME: "task/rename" },
+        "main"
+      )
+    ).toBe(false);
+  });
+
+  it("is strict on a laptop, where someone ran the check deliberately", () => {
+    expect(strictDescriptionMatch({}, "main")).toBe(true);
+  });
+
+  it("keeps the stricter answer when the default branch is unknown", () => {
+    expect(strictDescriptionMatch({ GITHUB_REF_NAME: "main" }, null)).toBe(true);
+  });
+});
+
+describe("retryDelayMs", () => {
+  const headers = entries => ({ get: name => entries[name] ?? null });
+
+  it("waits the interval a secondary limit named", () => {
+    expect(retryDelayMs(headers({ "retry-after": "60" }), 1)).toBe(60_000);
+  });
+
+  it("waits until a primary limit resets", () => {
+    const now = 1_000_000_000_000;
+    const reset = String(now / 1000 + 45);
+    expect(retryDelayMs(headers({ "x-ratelimit-reset": reset }), 1, now)).toBe(45_000);
+  });
+
+  it("prefers retry-after when both are present", () => {
+    const now = 1_000_000_000_000;
+    expect(
+      retryDelayMs(
+        headers({ "retry-after": "5", "x-ratelimit-reset": String(now / 1000 + 900) }),
+        1,
+        now
+      )
+    ).toBe(5_000);
+  });
+
+  it("backs off on its own when GitHub named no interval", () => {
+    expect(retryDelayMs(headers({}), 1)).toBe(1_000);
+    expect(retryDelayMs(undefined, 2)).toBe(2_000);
+  });
+
+  it("ignores a reset already in the past", () => {
+    const now = 1_000_000_000_000;
+    expect(retryDelayMs(headers({ "x-ratelimit-reset": String(now / 1000 - 10) }), 3, now)).toBe(
+      3_000
+    );
   });
 });
 
@@ -310,7 +382,7 @@ describe("fetchRepoMetadata", () => {
       delay: noWait,
     });
     expect(calls).toBe(2);
-    expect(metadata).toEqual({ description: "d", topics: ["cms"] });
+    expect(metadata).toEqual({ description: "d", topics: ["cms"], defaultBranch: null });
   });
 
   it("does not retry a permanent failure", async () => {
@@ -327,6 +399,56 @@ describe("fetchRepoMetadata", () => {
       })
     ).rejects.toMatchObject({ permanent: true });
     expect(calls).toBe(1);
+  });
+
+  it("sleeps for the interval GitHub named rather than its own backoff", async () => {
+    // Reading retry-after to classify the failure and then waiting a second anyway spends
+    // every attempt inside a window GitHub already said would not clear.
+    const waits = [];
+    let calls = 0;
+    await fetchRepoMetadata("o", "r", {
+      fetchImpl: async () => {
+        calls += 1;
+        return calls === 1
+          ? bad(403, { "retry-after": "30" })
+          : ok({ description: "d", topics: [] });
+      },
+      env: {},
+      delay: async ms => {
+        waits.push(ms);
+      },
+    });
+    expect(waits).toEqual([30_000]);
+  });
+
+  it("stops rather than sleeping through a window longer than the run should live", async () => {
+    // An hour-long primary limit is not something to hold a runner open for; the honest
+    // report is that this run could not verify the metadata.
+    let calls = 0;
+    const waits = [];
+    await expect(
+      fetchRepoMetadata("o", "r", {
+        fetchImpl: async () => {
+          calls += 1;
+          return bad(403, { "retry-after": "3600" });
+        },
+        env: {},
+        delay: async ms => {
+          waits.push(ms);
+        },
+      })
+    ).rejects.toMatchObject({ permanent: false });
+    expect(calls).toBe(1);
+    expect(waits).toEqual([]);
+  });
+
+  it("carries the default branch, so strictness has a ref to compare against", async () => {
+    const metadata = await fetchRepoMetadata("o", "r", {
+      fetchImpl: async () => ok({ description: "d", topics: [], default_branch: "main" }),
+      env: {},
+      delay: noWait,
+    });
+    expect(metadata.defaultBranch).toBe("main");
   });
 
   it("gives up after the last attempt and reports the failure as transient", async () => {

--- a/scripts/check-repo-metadata.test.mjs
+++ b/scripts/check-repo-metadata.test.mjs
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+
+import { checkRepoMetadata } from "./check-repo-metadata.mjs";
+
+/**
+ * Metadata is injected rather than fetched. The network is not the subject, and a test that
+ * reached GitHub would fail offline and pass or fail depending on when it ran.
+ */
+const GOOD_DESCRIPTION =
+  "Nextly is an open-source CMS and visual page builder for Next.js. Model content, build pages, localize, version and release from your own stack.";
+
+const goodTopics = [
+  "cms",
+  "headless-cms",
+  "page-builder",
+  "nextjs",
+  "content-platform",
+  "typescript",
+];
+
+const run = (metadata, expectedDescription = GOOD_DESCRIPTION) =>
+  checkRepoMetadata({ metadata, expectedDescription }).findings.map(f => f.check);
+
+describe("about-retired-category", () => {
+  it("fires when the About line names the retired category", () => {
+    expect(
+      run({ description: "The open-source app framework for Next.js.", topics: goodTopics })
+    ).toContain("about-retired-category");
+  });
+
+  it("catches the hyphenated spelling too", () => {
+    expect(
+      run({ description: "An app-framework for Next.js.", topics: goodTopics })
+    ).toContain("about-retired-category");
+  });
+
+  it("does not fire on the current descriptor", () => {
+    expect(run({ description: GOOD_DESCRIPTION, topics: goodTopics })).not.toContain(
+      "about-retired-category"
+    );
+  });
+});
+
+describe("about-matches-package", () => {
+  it("fires when About drifts from the package description", () => {
+    expect(
+      run({ description: "Something else entirely.", topics: goodTopics })
+    ).toContain("about-matches-package");
+  });
+
+  it("does not fire when they agree", () => {
+    expect(run({ description: GOOD_DESCRIPTION, topics: goodTopics })).not.toContain(
+      "about-matches-package"
+    );
+  });
+});
+
+describe("topics", () => {
+  it("fires on a forbidden topic", () => {
+    expect(
+      run({ description: GOOD_DESCRIPTION, topics: [...goodTopics, "app-framework"] })
+    ).toContain("topic-forbidden");
+  });
+
+  it("fires on the bare 'framework' topic, which is the word the repositioning turned on", () => {
+    expect(
+      run({ description: GOOD_DESCRIPTION, topics: [...goodTopics, "framework"] })
+    ).toContain("topic-forbidden");
+  });
+
+  it("fires once per missing required topic, naming which", () => {
+    const { findings } = checkRepoMetadata({
+      metadata: { description: GOOD_DESCRIPTION, topics: ["cms", "nextjs"] },
+      expectedDescription: GOOD_DESCRIPTION,
+    });
+    const missing = findings.filter(f => f.check === "topic-missing");
+    expect(missing).toHaveLength(3);
+    expect(missing.map(f => f.message).join(" ")).toContain("page-builder");
+    expect(missing.map(f => f.message).join(" ")).toContain("content-platform");
+  });
+
+  it("passes clean metadata with nothing to report", () => {
+    expect(run({ description: GOOD_DESCRIPTION, topics: goodTopics })).toHaveLength(0);
+  });
+});
+
+describe("the live repository's current state", () => {
+  it("is exactly what this check was written to catch", () => {
+    // The values read from the GitHub API on 6 September, kept as a fixture so the check has a
+    // known-answer case that does not depend on the network or on the settings being left wrong.
+    const asFoundToday = {
+      description:
+        "Nextly is the open-source, type-safe app framework for Next.js. Define content with TypeScript or build it visually in the admin. Auth, RBAC, media, hooks, plugins.",
+      topics: [
+        "admin-dashboard",
+        "app-framework",
+        "cms",
+        "content-management",
+        "drizzle-orm",
+        "framework",
+        "headless-cms",
+        "monorepo",
+        "mysql",
+        "nextjs",
+        "nodejs",
+        "open-source",
+        "postgresql",
+        "react",
+        "sqlite",
+        "type-safe",
+        "typescript",
+      ],
+    };
+    const checks = run(asFoundToday);
+    expect(checks).toContain("about-retired-category");
+    expect(checks).toContain("about-matches-package");
+    expect(checks.filter(c => c === "topic-forbidden")).toHaveLength(2);
+    expect(checks.filter(c => c === "topic-missing")).toHaveLength(2);
+  });
+});

--- a/scripts/check-repo-metadata.test.mjs
+++ b/scripts/check-repo-metadata.test.mjs
@@ -245,36 +245,50 @@ describe("retryDelayMs", () => {
   const headers = entries => ({ get: name => entries[name] ?? null });
 
   it("waits the interval a secondary limit named", () => {
-    expect(retryDelayMs(headers({ "retry-after": "60" }), 1)).toBe(60_000);
+    expect(retryDelayMs({ headers: headers({ "retry-after": "60" }), attempt: 1 })).toBe(60_000);
   });
 
   it("waits until a primary limit resets", () => {
     const now = 1_000_000_000_000;
     const reset = String(now / 1000 + 45);
-    expect(retryDelayMs(headers({ "x-ratelimit-reset": reset }), 1, now)).toBe(45_000);
+    expect(
+      retryDelayMs({ headers: headers({ "x-ratelimit-reset": reset }), attempt: 1, now })
+    ).toBe(45_000);
   });
 
   it("prefers retry-after when both are present", () => {
     const now = 1_000_000_000_000;
     expect(
-      retryDelayMs(
-        headers({ "retry-after": "5", "x-ratelimit-reset": String(now / 1000 + 900) }),
-        1,
-        now
-      )
+      retryDelayMs({
+        headers: headers({ "retry-after": "5", "x-ratelimit-reset": String(now / 1000 + 900) }),
+        attempt: 1,
+        now,
+      })
     ).toBe(5_000);
   });
 
-  it("backs off on its own when GitHub named no interval", () => {
-    expect(retryDelayMs(headers({}), 1)).toBe(1_000);
-    expect(retryDelayMs(undefined, 2)).toBe(2_000);
+  it("waits GitHub's documented minute for a 403 that named no interval", () => {
+    // Its own backoff is for failures that are not a limit at all; a second is far too soon
+    // for a secondary limit that identified itself with neither header.
+    expect(retryDelayMs({ headers: headers({}), attempt: 1, status: 403 })).toBe(60_000);
+    expect(retryDelayMs({ attempt: 1, status: 403 })).toBe(60_000);
+  });
+
+  it("backs off on its own when GitHub named no interval and it is not a limit", () => {
+    expect(retryDelayMs({ headers: headers({}), attempt: 1, status: 503 })).toBe(1_000);
+    expect(retryDelayMs({ attempt: 2, status: 503 })).toBe(2_000);
   });
 
   it("ignores a reset already in the past", () => {
     const now = 1_000_000_000_000;
-    expect(retryDelayMs(headers({ "x-ratelimit-reset": String(now / 1000 - 10) }), 3, now)).toBe(
-      3_000
-    );
+    expect(
+      retryDelayMs({
+        headers: headers({ "x-ratelimit-reset": String(now / 1000 - 10) }),
+        attempt: 3,
+        status: 503,
+        now,
+      })
+    ).toBe(3_000);
   });
 });
 
@@ -289,8 +303,8 @@ describe("isPermanentStatus", () => {
 
   it("treats rate limiting and server errors as transient", () => {
     // An unauthenticated call from CI hits the rate limit routinely, and it says nothing
-    // about the metadata. 403 is not in this list: it means two different things and the
-    // headers are what separate them, which the "403 is two different answers" suite covers.
+    // about the metadata.
+    expect(isPermanentStatus(403)).toBe(false);
     expect(isPermanentStatus(429)).toBe(false);
     expect(isPermanentStatus(500)).toBe(false);
     expect(isPermanentStatus(502)).toBe(false);
@@ -302,7 +316,7 @@ describe("isPermanentStatus", () => {
   });
 });
 
-describe("403 is two different answers", () => {
+describe("403 is read as transient", () => {
   const headers = entries => ({ get: name => entries[name] ?? null });
 
   it("is transient when the quota is exhausted", () => {
@@ -313,13 +327,18 @@ describe("403 is two different answers", () => {
     expect(isPermanentStatus(403, headers({ "retry-after": "60" }))).toBe(false);
   });
 
-  it("is permanent when the credential simply may not read the repository", () => {
-    // Reading the status alone would call this a moment to try again, forever.
-    expect(isPermanentStatus(403, headers({ "x-ratelimit-remaining": "4999" }))).toBe(true);
+  it("is transient when NEITHER header identifies it", () => {
+    // GitHub documents a secondary limit carrying no retry-after and a nonzero remaining
+    // quota. Reading that as a permission failure files an issue for a limit that clears.
+    expect(isPermanentStatus(403, headers({ "x-ratelimit-remaining": "4999" }))).toBe(false);
+    expect(isPermanentStatus(403, undefined)).toBe(false);
   });
 
-  it("is permanent when there are no headers to consult", () => {
-    expect(isPermanentStatus(403, undefined)).toBe(true);
+  it("still calls the statuses that cannot recover permanent", () => {
+    // A repository this credential may not read answers 403 too, and nothing separates it
+    // from a limit — but 404 and 401 are unambiguous and must not be retried forever.
+    expect(isPermanentStatus(404)).toBe(true);
+    expect(isPermanentStatus(401)).toBe(true);
   });
 });
 

--- a/scripts/check-repo-metadata.test.mjs
+++ b/scripts/check-repo-metadata.test.mjs
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import {
   checkRepoMetadata,
+  fetchRepoMetadata,
   isPermanentStatus,
   strictDescriptionMatch,
+  verificationRequired,
 } from "./check-repo-metadata.mjs";
 
 /**
@@ -215,8 +217,8 @@ describe("isPermanentStatus", () => {
 
   it("treats rate limiting and server errors as transient", () => {
     // An unauthenticated call from CI hits the rate limit routinely, and it says nothing
-    // about the metadata.
-    expect(isPermanentStatus(403)).toBe(false);
+    // about the metadata. 403 is not in this list: it means two different things and the
+    // headers are what separate them, which the "403 is two different answers" suite covers.
     expect(isPermanentStatus(429)).toBe(false);
     expect(isPermanentStatus(500)).toBe(false);
     expect(isPermanentStatus(502)).toBe(false);
@@ -225,6 +227,121 @@ describe("isPermanentStatus", () => {
   it("does not call a success permanent", () => {
     expect(isPermanentStatus(200)).toBe(false);
     expect(isPermanentStatus(304)).toBe(false);
+  });
+});
+
+describe("403 is two different answers", () => {
+  const headers = entries => ({ get: name => entries[name] ?? null });
+
+  it("is transient when the quota is exhausted", () => {
+    expect(isPermanentStatus(403, headers({ "x-ratelimit-remaining": "0" }))).toBe(false);
+  });
+
+  it("is transient when a secondary limit asks us to wait", () => {
+    expect(isPermanentStatus(403, headers({ "retry-after": "60" }))).toBe(false);
+  });
+
+  it("is permanent when the credential simply may not read the repository", () => {
+    // Reading the status alone would call this a moment to try again, forever.
+    expect(isPermanentStatus(403, headers({ "x-ratelimit-remaining": "4999" }))).toBe(true);
+  });
+
+  it("is permanent when there are no headers to consult", () => {
+    expect(isPermanentStatus(403, undefined)).toBe(true);
+  });
+});
+
+describe("verificationRequired", () => {
+  it("is true for the runs whose only purpose is to observe the setting", () => {
+    expect(verificationRequired({ GITHUB_EVENT_NAME: "schedule" })).toBe(true);
+    expect(verificationRequired({ GITHUB_EVENT_NAME: "workflow_dispatch" })).toBe(true);
+  });
+
+  it("is false where an unreachable API should not turn the run red", () => {
+    expect(verificationRequired({ GITHUB_EVENT_NAME: "pull_request" })).toBe(false);
+    expect(verificationRequired({ GITHUB_EVENT_NAME: "push" })).toBe(false);
+    expect(verificationRequired({})).toBe(false);
+  });
+});
+
+describe("fetchRepoMetadata", () => {
+  const ok = body => ({ ok: true, json: async () => body });
+  const bad = (status, entries = {}) => ({
+    ok: false,
+    status,
+    headers: { get: name => entries[name] ?? null },
+  });
+  const noWait = async () => {};
+
+  it("sends the token when one is offered", async () => {
+    let seen;
+    await fetchRepoMetadata("o", "r", {
+      fetchImpl: async (_url, init) => {
+        seen = init.headers;
+        return ok({ description: "d", topics: [] });
+      },
+      env: { GITHUB_TOKEN: "t0ken" },
+      delay: noWait,
+    });
+    expect(seen.authorization).toBe("Bearer t0ken");
+  });
+
+  it("stays unauthenticated when there is no token, so a laptop needs none", async () => {
+    let seen;
+    await fetchRepoMetadata("o", "r", {
+      fetchImpl: async (_url, init) => {
+        seen = init.headers;
+        return ok({ description: "d", topics: [] });
+      },
+      env: {},
+      delay: noWait,
+    });
+    expect(seen.authorization).toBeUndefined();
+  });
+
+  it("retries a transient failure and succeeds", async () => {
+    let calls = 0;
+    const metadata = await fetchRepoMetadata("o", "r", {
+      fetchImpl: async () => {
+        calls += 1;
+        return calls === 1 ? bad(503) : ok({ description: "d", topics: ["cms"] });
+      },
+      env: {},
+      delay: noWait,
+    });
+    expect(calls).toBe(2);
+    expect(metadata).toEqual({ description: "d", topics: ["cms"] });
+  });
+
+  it("does not retry a permanent failure", async () => {
+    // A 404 is the same answer every time, and retrying it only delays the report.
+    let calls = 0;
+    await expect(
+      fetchRepoMetadata("o", "r", {
+        fetchImpl: async () => {
+          calls += 1;
+          return bad(404);
+        },
+        env: {},
+        delay: noWait,
+      })
+    ).rejects.toMatchObject({ permanent: true });
+    expect(calls).toBe(1);
+  });
+
+  it("gives up after the last attempt and reports the failure as transient", async () => {
+    let calls = 0;
+    await expect(
+      fetchRepoMetadata("o", "r", {
+        fetchImpl: async () => {
+          calls += 1;
+          return bad(403, { "x-ratelimit-remaining": "0" });
+        },
+        env: {},
+        delay: noWait,
+      })
+    ).rejects.toMatchObject({ permanent: false });
+    expect(calls).toBe(3);
   });
 });
 

--- a/scripts/check-repo-metadata.test.mjs
+++ b/scripts/check-repo-metadata.test.mjs
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { checkRepoMetadata } from "./check-repo-metadata.mjs";
+import { checkRepoMetadata, isPermanentStatus } from "./check-repo-metadata.mjs";
 
 /**
  * Metadata is injected rather than fetched. The network is not the subject, and a test that
@@ -19,6 +19,14 @@ const goodTopics = [
 ];
 
 const run = (metadata, expectedDescription = GOOD_DESCRIPTION) =>
+  checkRepoMetadata({ metadata, expectedDescription }).findings.map(f => f.check);
+
+/**
+ * The same call with no default for the description, because `run`'s default is applied to an
+ * explicit `undefined` — which silently substituted a valid description into the very tests
+ * written to prove an absent one is caught.
+ */
+const runWithDescription = (metadata, expectedDescription) =>
   checkRepoMetadata({ metadata, expectedDescription }).findings.map(f => f.check);
 
 describe("about-retired-category", () => {
@@ -68,6 +76,26 @@ describe("topics", () => {
     ).toContain("topic-forbidden");
   });
 
+  it("fires on the plural spellings a hand-written list missed", () => {
+    // The forbidden topics used to be listed here rather than derived from the shared tag
+    // pattern, and the list held only the singular forms — so these two passed a check that
+    // rejects the very same strings as npm keywords.
+    for (const topic of ["frameworks", "app-frameworks", "App-Framework"]) {
+      expect(run({ description: GOOD_DESCRIPTION, topics: [...goodTopics, topic] })).toContain(
+        "topic-forbidden"
+      );
+    }
+  });
+
+  it("does not fire on topics that merely contain the word", () => {
+    expect(
+      run({
+        description: GOOD_DESCRIPTION,
+        topics: [...goodTopics, "framework-agnostic", "page-builder"],
+      })
+    ).not.toContain("topic-forbidden");
+  });
+
   it("fires once per missing required topic, naming which", () => {
     const { findings } = checkRepoMetadata({
       metadata: { description: GOOD_DESCRIPTION, topics: ["cms", "nextjs"] },
@@ -81,6 +109,55 @@ describe("topics", () => {
 
   it("passes clean metadata with nothing to report", () => {
     expect(run({ description: GOOD_DESCRIPTION, topics: goodTopics })).toHaveLength(0);
+  });
+});
+
+describe("description-source-missing", () => {
+  it("fires when the package has no description to compare against", () => {
+    for (const expected of [undefined, "", "   "]) {
+      expect(
+        runWithDescription({ description: "anything at all", topics: goodTopics }, expected)
+      ).toContain("description-source-missing");
+    }
+  });
+
+  it("reports the missing source rather than a drift it cannot judge", () => {
+    // Reporting both would state a mismatch against a value that does not exist.
+    const checks = runWithDescription(
+      { description: "anything at all", topics: goodTopics },
+      undefined
+    );
+    expect(checks).not.toContain("about-matches-package");
+  });
+
+  it("does not fire when the package has a description", () => {
+    expect(run({ description: GOOD_DESCRIPTION, topics: goodTopics })).not.toContain(
+      "description-source-missing"
+    );
+  });
+});
+
+describe("isPermanentStatus", () => {
+  it("treats a repository that cannot be read as permanent", () => {
+    // A stale OWNER or a renamed repository returns 404, and calling that transient would
+    // leave the check green forever without examining any metadata.
+    expect(isPermanentStatus(404)).toBe(true);
+    expect(isPermanentStatus(401)).toBe(true);
+    expect(isPermanentStatus(410)).toBe(true);
+  });
+
+  it("treats rate limiting and server errors as transient", () => {
+    // An unauthenticated call from CI hits the rate limit routinely, and it says nothing
+    // about the metadata.
+    expect(isPermanentStatus(403)).toBe(false);
+    expect(isPermanentStatus(429)).toBe(false);
+    expect(isPermanentStatus(500)).toBe(false);
+    expect(isPermanentStatus(502)).toBe(false);
+  });
+
+  it("does not call a success permanent", () => {
+    expect(isPermanentStatus(200)).toBe(false);
+    expect(isPermanentStatus(304)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Re-checking G6's shipped work against **revision 4** of the positioning strategy turned up exactly one gap, and it was in the guard I built.

Revision 4 §0 names it: *"the GitHub About text, the GitHub topics … The CI guard cannot see any of them."* That is true, and the reason is structural. `check-docs-claims.mjs` reads **git's index**, which is what makes it reliable and also what makes it blind to repository *settings*.

**The gap was not theoretical.** With all six guarded surfaces clean and **zero** occurrences of the retired category in any tracked file, the live About line still read:

> "Nextly is the open-source, type-safe **app framework** for Next.js…"

That is the first sentence a visitor to a public repository reads. Topics carried both `app-framework` and `framework` while missing `page-builder` and `content-platform`.

## What this adds

**`scripts/check-repo-metadata.mjs`** — four checks: the About line must not name the retired category, it must match `packages/nextly/package.json`, forbidden topics absent, descriptor topics present.

Three design points worth review:

- **The category pattern is imported from `check-docs-claims.mjs`, not restated.** Two definitions of what the project is no longer called is how the second one gets missed. `RETIRED_CATEGORY` is now exported for that.
- **Unauthenticated.** The repository is public, so the check behaves identically on a laptop and in CI, rather than passing for whoever happens to be logged into `gh`.
- **An unreachable API reports *unverifiable*, not failed** — the same posture as the link checker's ref resolution. A check that goes red when the network is down teaches people to wave it through.

**A second, smaller instance of the same class:** the GitHub topic `framework` had been cleared; the npm keyword had not. Same kind of surface, same word, and only `nextly` carried it — which is what made it easy to miss. Removed, with a `retired-category-keyword` check over the manifests the README checks already load. Matched **whole, not as a substring**: `page-builder`, `nextly-plugin` and `framework-agnostic` must never be touched, and a substring rule would have taken all three.

## A deliberate departure from the doc

Appendix A files this as *"release checklist additions (**manual, outside CI**)"*. I automated it instead, and want that visible rather than buried.

The reason is this group's own evidence: the docs deploy hook never fired for months, the committed docs snapshot drifted 30 pages behind, and three changesets merged malformed — every one a thing a checklist was meant to catch. If it can be checked, it should be. Say the word and I will drop the CI wiring and leave the script runnable by hand.

## Test plan

- **The check reported 6 findings against the live repository before the settings were corrected, and 0 after.** One test pins the values as read on 6 September as a known-answer case, so it keeps a positive control now that the defect is gone.
- `retired-category-keyword` verified by restoring `framework` to the real `packages/nextly/package.json` and watching the check report it, then restoring the file.
- `pnpm test:scripts` — **27 files, 820 tests passed** (14 new).
- `pnpm check:docs-claims` and `pnpm check:repo-metadata` both clean.
- `pnpm lint:design`, `pnpm lint:workspace`, full `turbo lint` + `build` + `test` via the pre-push hook — passed, no bypass.

## Also verified, and needing no change

Everything else G6 shipped was measured against revision 4's revised claims policy and holds: 0 mentions of document locking, 0 `defineComponent()`, 0 "Writer" as a role name (every hit is `single-writer` or "the writer" as actor), no Payload Cloud price, no image-optimization claim, 20 core blocks. §2.5 confirms Model / Compose / Operate / Extend stays as the docs sidebar, so #1538 needed no revision.

## Changeset

One `patch` covering the full lockstep group, for the `nextly` keyword change. Keywords ship in the published manifest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Removed the retired “framework” keyword from package metadata.
  - Added automated validation for repository descriptions, topics, and package metadata.
  - Metadata checks retry temporary service failures and fail on permanent errors.
  - Added scheduled and manual metadata validation with issue tracking for failures.
  - Documentation and metadata checks run only after successful installation and stop when workflows are cancelled.

- **Tests**
  - Added coverage for keyword formats, description mismatches, forbidden or missing topics, HTTP status handling, retries, and valid repository metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->