### PR TITLE
fix(nextly): register an entity only once its migration has run

### DIFF
--- a/.changeset/registration-proves-the-migration-ran.md
+++ b/.changeset/registration-proves-the-migration-ran.md
@@ -1,0 +1,49 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+`nextly migrate` no longer records an entity as applied because a snapshot
+mentions it. Registration reads every `*.snapshot.json` in the migrations
+directory and inserts each missing entity with `migrationStatus: "applied"` —
+so a `--step N` run exposed entities belonging to migrations it never reached
+as applied, while their tables may not exist. Nothing downstream could correct
+that: the pending sweep beside it only looks at rows still marked pending, and
+those rows were not.
+
+Registration now takes the evidence for the claim. A snapshot is read only when
+its migration is recorded applied in `nextly_schema_events`, through the same
+`isFileApplied` query the migrate command already uses to decide what is
+outstanding — so what registers and what executes read one source instead of
+two that can disagree.
+
+The pairing is by migration GROUP: `runFileMigrations` records `0001_x.sql`
+whether it executed `0001_x.sql` or `0001_x.mysql.sql`, and the snapshot beside
+it is `meta/0001_x.snapshot.json`.
+
+Omitting the check keeps the previous behaviour, which the development boot path
+relies on deliberately: it applies every pending migration immediately before
+registering, so it has no unapplied snapshot to skip.

--- a/packages/nextly/src/domains/schema/migrate/__tests__/metadata-register-applied.test.ts
+++ b/packages/nextly/src/domains/schema/migrate/__tests__/metadata-register-applied.test.ts
@@ -20,12 +20,18 @@ import { registerFromMigrations } from "../metadata-register";
 
 let dir: string;
 
-/** A snapshot paired with the migration file whose name the ledger records. */
-function snapshot(name: string, slug: string): void {
+/**
+ * A snapshot paired with the migration file whose name the ledger records.
+ *
+ * `fields` is a parameter because the shape is what distinguishes one snapshot
+ * of a slug from a later one: a test that cannot tell the two apart cannot see
+ * which of them registration wrote.
+ */
+function snapshot(name: string, slug: string, fields: unknown[] = []): void {
   writeFileSync(
     join(dir, "meta", `${name}.snapshot.json`),
     JSON.stringify({
-      collections: [{ slug, label: slug, tableName: `dc_${slug}`, fields: [] }],
+      collections: [{ slug, label: slug, tableName: `dc_${slug}`, fields }],
       singles: [],
     })
   );
@@ -45,16 +51,21 @@ afterEach(() => rmSync(dir, { recursive: true, force: true }));
  */
 function adapterStub() {
   const inserted: string[] = [];
+  const rows: { slug: string; fields: unknown[] }[] = [];
   return {
     inserted,
+    rows,
     adapter: {
       getDrizzle: () => ({
         select: () => ({
           from: () => ({ where: () => ({ limit: async () => [] }) }),
         }),
         insert: () => ({
-          values: async (row: { slug?: string }) => {
-            if (row?.slug) inserted.push(row.slug);
+          values: async (row: { slug?: string; fields?: unknown[] }) => {
+            if (row?.slug) {
+              inserted.push(row.slug);
+              rows.push({ slug: row.slug, fields: row.fields ?? [] });
+            }
           },
         }),
       }),
@@ -136,5 +147,114 @@ describe("registerFromMigrations honours the applied ledger", () => {
     });
 
     expect(inserted).toContain("notes");
+  });
+  /*
+   * 🔴 The shape decides, not merely the presence of a row. A slug described by
+   * an applied snapshot AND by a later pending one has an unsettled shape:
+   * registration inserts once and returns early on every run after, so writing
+   * the earlier shape now writes it for good — the later migration lands and
+   * nothing revisits the row. Withheld until the newest snapshot naming it is
+   * applied, which is the first run that can write the shape it will keep.
+   */
+  it("withholds a slug whose newest snapshot has not been applied", async () => {
+    snapshot("0001_init", "posts", [{ name: "title" }]);
+    snapshot("0002_add_body", "posts", [{ name: "title" }, { name: "body" }]);
+    const { adapter, inserted } = adapterStub();
+
+    await registerFromMigrations({
+      migrationsDir: dir,
+      adapter,
+      dialect: "sqlite",
+      logger: { warn: () => {}, debug: () => {} },
+      isApplied: async f => f === "0001_init.sql",
+    });
+
+    expect(inserted).not.toContain("posts");
+  });
+
+  it("registers that slug with the newer shape once its migration lands", async () => {
+    // The other half. Without it, withholding forever would satisfy the case
+    // above — and withholding forever is the "collection has no dashboard
+    // cards" defect this whole path exists to remove.
+    snapshot("0001_init", "posts", [{ name: "title" }]);
+    snapshot("0002_add_body", "posts", [{ name: "title" }, { name: "body" }]);
+    const { adapter, rows } = adapterStub();
+
+    await registerFromMigrations({
+      migrationsDir: dir,
+      adapter,
+      dialect: "sqlite",
+      logger: { warn: () => {}, debug: () => {} },
+      isApplied: async () => true,
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.fields).toEqual([{ name: "title" }, { name: "body" }]);
+  });
+
+  it("registers a slug the pending snapshot does not name", async () => {
+    // Withholding is per SLUG, not per run: an entity settled by the
+    // migrations that did apply is unaffected by a pending one beside it.
+    snapshot("0001_init", "posts", [{ name: "title" }]);
+    snapshot("0002_drafts", "drafts", [{ name: "title" }]);
+    const { adapter, inserted } = adapterStub();
+
+    await registerFromMigrations({
+      migrationsDir: dir,
+      adapter,
+      dialect: "sqlite",
+      logger: { warn: () => {}, debug: () => {} },
+      isApplied: async f => f === "0001_init.sql",
+    });
+
+    expect(inserted).toContain("posts");
+    expect(inserted).not.toContain("drafts");
+  });
+
+  /*
+   * 🔴 A ledger that cannot be read is a database failure, not a malformed
+   * snapshot file. Swallowed by the per-file guard it fails identically for
+   * every snapshot, so the whole set is dropped and the caller is handed the
+   * empty list that means "nothing to register" — announcing an up-to-date
+   * database while none of the metadata was written. Left to throw, it reaches
+   * the phase-level handler, which records the pass as unreadable.
+   */
+  it("propagates a ledger failure instead of reading it as a bad file", async () => {
+    snapshot("0001_init", "posts");
+    const { adapter, inserted } = adapterStub();
+
+    await expect(
+      registerFromMigrations({
+        migrationsDir: dir,
+        adapter,
+        dialect: "sqlite",
+        logger: { warn: () => {}, debug: () => {} },
+        isApplied: async () => {
+          throw new Error("ledger unreachable");
+        },
+      })
+    ).rejects.toThrow("ledger unreachable");
+
+    expect(inserted).toEqual([]);
+  });
+
+  it("still skips a malformed snapshot file without failing the pass", async () => {
+    // The control for the case above: the per-file guard is still there, and
+    // still does its own job. Without this, moving the ledger read out of it
+    // could have removed the guard entirely and nothing would say so.
+    writeFileSync(join(dir, "meta", "0001_broken.snapshot.json"), "{ not json");
+    snapshot("0002_ok", "notes");
+    const { adapter, inserted } = adapterStub();
+
+    const result = await registerFromMigrations({
+      migrationsDir: dir,
+      adapter,
+      dialect: "sqlite",
+      logger: { warn: () => {}, debug: () => {} },
+      isApplied: async () => true,
+    });
+
+    expect(inserted).toContain("notes");
+    expect(result.collectionsRegistered).toBe(1);
   });
 });

--- a/packages/nextly/src/domains/schema/migrate/__tests__/metadata-register-applied.test.ts
+++ b/packages/nextly/src/domains/schema/migrate/__tests__/metadata-register-applied.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Registration only claims `applied` for migrations that actually ran.
+ *
+ * 🔴 `registerFromMigrations` inserts every entity it finds with
+ * `migrationStatus: "applied"`, and it finds them by reading EVERY
+ * `*.snapshot.json` in the directory. Under `nextly migrate --step N` that
+ * includes snapshots for migrations the run never reached, so those entities
+ * were exposed as applied while their tables may not exist — and the pending
+ * sweep beside it cannot repair them, because a row asserted `applied` is not
+ * pending any more. The claim outran the evidence in the one direction nothing
+ * downstream can correct.
+ */
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { registerFromMigrations } from "../metadata-register";
+
+let dir: string;
+
+/** A snapshot paired with the migration file whose name the ledger records. */
+function snapshot(name: string, slug: string): void {
+  writeFileSync(
+    join(dir, "meta", `${name}.snapshot.json`),
+    JSON.stringify({
+      collections: [{ slug, label: slug, tableName: `dc_${slug}`, fields: [] }],
+      singles: [],
+    })
+  );
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "nextly-register-"));
+  mkdirSync(join(dir, "meta"));
+});
+
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+/**
+ * An adapter that reports every collection as missing, so registration always
+ * wants to insert — the filtering under test is the only thing that can stop
+ * it.
+ */
+function adapterStub() {
+  const inserted: string[] = [];
+  return {
+    inserted,
+    adapter: {
+      getDrizzle: () => ({
+        select: () => ({
+          from: () => ({ where: () => ({ limit: async () => [] }) }),
+        }),
+        insert: () => ({
+          values: async (row: { slug?: string }) => {
+            if (row?.slug) inserted.push(row.slug);
+          },
+        }),
+      }),
+    } as never,
+  };
+}
+
+describe("registerFromMigrations honours the applied ledger", () => {
+  it("registers an entity whose migration has been applied", async () => {
+    // The control. Without it, a filter that rejected EVERYTHING would satisfy
+    // the exclusion below while registering nothing at all.
+    snapshot("0001_init", "posts");
+    const { adapter, inserted } = adapterStub();
+
+    await registerFromMigrations({
+      migrationsDir: dir,
+      adapter,
+      dialect: "sqlite",
+      logger: { warn: () => {}, debug: () => {} },
+      isApplied: async () => true,
+    });
+
+    expect(inserted).toContain("posts");
+  });
+
+  it("skips an entity whose migration has NOT been applied", async () => {
+    snapshot("0002_later", "drafts");
+    const { adapter, inserted } = adapterStub();
+
+    await registerFromMigrations({
+      migrationsDir: dir,
+      adapter,
+      dialect: "sqlite",
+      logger: { warn: () => {}, debug: () => {} },
+      isApplied: async () => false,
+    });
+
+    expect(inserted).not.toContain("drafts");
+  });
+
+  /*
+   * The pairing is the part that can silently be wrong. The ledger records the
+   * migration GROUP's `.sql` name — `runFileMigrations` writes `0001_x.sql`
+   * whether it executed `0001_x.sql` or `0001_x.mysql.sql` — so a check built
+   * from the snapshot's own filename has to strip `.snapshot.json` and add
+   * `.sql`, not pass the snapshot name through.
+   */
+  it("asks the ledger for the migration's .sql name, not the snapshot's", async () => {
+    snapshot("0003_pages", "pages");
+    const { adapter } = adapterStub();
+    const isApplied = vi.fn(async () => true);
+
+    await registerFromMigrations({
+      migrationsDir: dir,
+      adapter,
+      dialect: "sqlite",
+      logger: { warn: () => {}, debug: () => {} },
+      isApplied,
+    });
+
+    expect(isApplied).toHaveBeenCalledWith("0003_pages.sql");
+  });
+
+  /*
+   * Omitting the check keeps the previous behaviour, and that is deliberate
+   * rather than an oversight: the dev boot path applies every pending
+   * migration immediately before registering, so it has no unapplied snapshot
+   * to skip and needs no ledger read to prove it.
+   */
+  it("registers everything when no ledger check is supplied", async () => {
+    snapshot("0004_any", "notes");
+    const { adapter, inserted } = adapterStub();
+
+    await registerFromMigrations({
+      migrationsDir: dir,
+      adapter,
+      dialect: "sqlite",
+      logger: { warn: () => {}, debug: () => {} },
+    });
+
+    expect(inserted).toContain("notes");
+  });
+});

--- a/packages/nextly/src/domains/schema/migrate/__tests__/reconcile-metadata.test.ts
+++ b/packages/nextly/src/domains/schema/migrate/__tests__/reconcile-metadata.test.ts
@@ -25,6 +25,11 @@ const silent = {
 function adapterWith(tables: string[]) {
   return {
     tableExists: vi.fn(async (name: string) => tables.includes(name)),
+    // The sweep builds a `SchemaEventsRepository` to prove a snapshot's
+    // migration ran before registration may claim `applied`. These cases stub
+    // `registerFn`, so the repository is constructed and never queried — but
+    // constructing it is what needs a Drizzle handle.
+    getDrizzle: () => ({}),
   } as never;
 }
 

--- a/packages/nextly/src/domains/schema/migrate/metadata-register.ts
+++ b/packages/nextly/src/domains/schema/migrate/metadata-register.ts
@@ -133,6 +133,23 @@ export interface RegisterFromMigrationsOptions {
    * `0001_x.sql` whether it executed `0001_x.sql` or `0001_x.mysql.sql`, and
    * the snapshot beside it is `meta/0001_x.snapshot.json`.
    *
+   * 🔴 Answering it decides a SLUG, not a file. A slug is registered only when
+   * the newest snapshot describing it is applied, because that snapshot is the
+   * shape registration would write. Deciding per file instead registers the
+   * newest APPLIED shape of a slug whose later migration is still pending, and
+   * nothing ever revisits it: {@link registerCollection} and
+   * {@link registerSingle} insert once and return early forever after, so the
+   * row keeps the intermediate shape after the later migration lands.
+   *
+   * Withholding the row until its shape settles is the opposite trade from the
+   * localized-companion provisioning in the migrate command, which skips
+   * wholesale while anything is pending. That rule exists because provisioning
+   * early makes a later migration's unconditional `CREATE TABLE` fail — a hard
+   * collision with no equivalent here, where the only cost of registering an
+   * entity whose migrations have all run is nothing at all. So this withholds
+   * per slug rather than per run, and an entity settled by the migrations that
+   * did apply is registered normally.
+   *
    * OPTIONAL, and omitting it means "register everything". That is correct for
    * the dev boot path, which applies every pending migration immediately
    * before registering, so no unapplied snapshot can exist for it to skip. Any
@@ -152,56 +169,118 @@ export interface RegisterFromMigrationsOptions {
 }
 
 /**
+ * One snapshot file, with whether the migration it belongs to has run.
+ *
+ * The flag travels WITH the snapshot rather than filtering the list, because
+ * the decision it feeds is per slug: a slug's newest snapshot decides whether
+ * it may be registered, and finding that snapshot means looking at unapplied
+ * ones too. See {@link RegisterFromMigrationsOptions.isApplied}.
+ */
+interface LoadedSnapshot {
+  file: string;
+  snapshot: MigrationSnapshot;
+  applied: boolean;
+}
+
+/**
  * Read all migration snapshot files from the migrations/meta directory
  */
 async function readSnapshotFiles(
   migrationsDir: string,
   logger?: { warn?: (msg: string) => void; debug?: (msg: string) => void },
   isApplied?: (ledgerFilename: string) => Promise<boolean>
-): Promise<MigrationSnapshot[]> {
+): Promise<LoadedSnapshot[]> {
   const metaDir = resolve(migrationsDir, "meta");
 
+  let files: string[];
   try {
-    const files = await readdir(metaDir);
-    // Sort files lexicographically to ensure deterministic "later snapshot wins" behavior
-    const snapshotFiles = files
-      .filter(f => f.endsWith(".snapshot.json"))
-      .sort();
-
-    if (snapshotFiles.length === 0) {
-      return [];
-    }
-
-    const snapshots: MigrationSnapshot[] = [];
-
-    for (const file of snapshotFiles) {
-      try {
-        if (isApplied) {
-          // `X.snapshot.json` pairs with the migration group `X.sql`, which is
-          // the name the ledger records for every dialect variant.
-          const ledgerFilename = `${file.replace(/\.snapshot\.json$/, "")}.sql`;
-          if (!(await isApplied(ledgerFilename))) {
-            logger?.debug?.(
-              `[Migration Metadata] Skipping ${file}: ${ledgerFilename} has not been applied`
-            );
-            continue;
-          }
-        }
-        const filePath = join(metaDir, file);
-        const content = await readFile(filePath, "utf-8");
-        const snapshot = JSON.parse(content) as MigrationSnapshot;
-        snapshots.push(snapshot);
-      } catch (err) {
-        // Skip invalid snapshot files but continue processing others
-        logger?.warn?.(`Could not read snapshot file ${file}: ${String(err)}`);
-      }
-    }
-
-    return snapshots;
-  } catch (_err) {
+    files = await readdir(metaDir);
+  } catch {
     // Meta directory doesn't exist or isn't readable
     return [];
   }
+
+  // Sort files lexicographically to ensure deterministic "later snapshot wins" behavior
+  const snapshotFiles = files.filter(f => f.endsWith(".snapshot.json")).sort();
+
+  if (snapshotFiles.length === 0) {
+    return [];
+  }
+
+  const loaded: LoadedSnapshot[] = [];
+
+  for (const file of snapshotFiles) {
+    /*
+     * 🔴 The ledger read sits OUTSIDE the parse guard below, and outside the
+     * directory guard above. Both exist for a file that cannot be read, and a
+     * ledger that cannot be queried is neither: it fails identically for every
+     * snapshot, so swallowing it drops the whole set and returns the empty
+     * list that means "nothing to register". The caller then reports an
+     * up-to-date database while none of the metadata was written. Left to
+     * throw, it reaches the phase-level handler, which records the pass as
+     * unreadable and tells the operator to run `nextly migrate` again.
+     */
+    let applied = true;
+    if (isApplied) {
+      // `X.snapshot.json` pairs with the migration group `X.sql`, which is
+      // the name the ledger records for every dialect variant.
+      const ledgerFilename = `${file.replace(/\.snapshot\.json$/, "")}.sql`;
+      applied = await isApplied(ledgerFilename);
+    }
+
+    try {
+      const filePath = join(metaDir, file);
+      const content = await readFile(filePath, "utf-8");
+      const snapshot = JSON.parse(content) as MigrationSnapshot;
+      loaded.push({ file, snapshot, applied });
+    } catch (err) {
+      // Skip invalid snapshot files but continue processing others
+      logger?.warn?.(`Could not read snapshot file ${file}: ${String(err)}`);
+    }
+  }
+
+  return loaded;
+}
+
+/**
+ * The newest entry per slug, dropped when the snapshot it came from has not
+ * been applied.
+ *
+ * 🔴 The drop is decided on the WINNER, after later-wins resolution, not on
+ * each entry as it is read. A slug described by an applied snapshot and again
+ * by a pending one is withheld entirely: registration inserts once and never
+ * revisits a row, so writing the earlier shape now is writing it permanently.
+ */
+function newestApplied<T extends { slug: string }>(
+  loaded: LoadedSnapshot[],
+  entriesOf: (snapshot: MigrationSnapshot) => T[] | undefined,
+  logger?: { debug?: (msg: string) => void }
+): T[] {
+  const winners = new Map<
+    string,
+    { entry: T; applied: boolean; file: string }
+  >();
+
+  for (const { snapshot, applied, file } of loaded) {
+    for (const entry of entriesOf(snapshot) ?? []) {
+      if (entry.slug) {
+        winners.set(entry.slug, { entry, applied, file });
+      }
+    }
+  }
+
+  const registrable: T[] = [];
+  for (const [slug, winner] of winners) {
+    if (!winner.applied) {
+      logger?.debug?.(
+        `[Migration Metadata] Not registering "${slug}": its newest snapshot ${winner.file} has not been applied`
+      );
+      continue;
+    }
+    registrable.push(winner.entry);
+  }
+
+  return registrable;
 }
 
 /**
@@ -209,36 +288,20 @@ async function readSnapshotFiles(
  * Later snapshots override earlier ones for the same slug
  */
 function mergeCollections(
-  snapshots: MigrationSnapshot[]
+  loaded: LoadedSnapshot[],
+  logger?: { debug?: (msg: string) => void }
 ): SnapshotCollection[] {
-  const collectionMap = new Map<string, SnapshotCollection>();
-
-  for (const snapshot of snapshots) {
-    for (const collection of snapshot.collections ?? []) {
-      if (collection.slug) {
-        collectionMap.set(collection.slug, collection);
-      }
-    }
-  }
-
-  return Array.from(collectionMap.values());
+  return newestApplied(loaded, s => s.collections, logger);
 }
 
 /**
  * Merge singles from multiple snapshots
  */
-function mergeSingles(snapshots: MigrationSnapshot[]): SnapshotSingle[] {
-  const singleMap = new Map<string, SnapshotSingle>();
-
-  for (const snapshot of snapshots) {
-    for (const single of snapshot.singles ?? []) {
-      if (single.slug) {
-        singleMap.set(single.slug, single);
-      }
-    }
-  }
-
-  return Array.from(singleMap.values());
+function mergeSingles(
+  loaded: LoadedSnapshot[],
+  logger?: { debug?: (msg: string) => void }
+): SnapshotSingle[] {
+  return newestApplied(loaded, s => s.singles, logger);
 }
 
 /**
@@ -452,8 +515,8 @@ export async function registerFromMigrations(
   );
 
   // Step 2: Merge collections and singles from all snapshots
-  const collections = mergeCollections(snapshots);
-  const singles = mergeSingles(snapshots);
+  const collections = mergeCollections(snapshots, logger);
+  const singles = mergeSingles(snapshots, logger);
 
   // Step 3: Register each collection
   let collectionsRegistered = 0;

--- a/packages/nextly/src/domains/schema/migrate/metadata-register.ts
+++ b/packages/nextly/src/domains/schema/migrate/metadata-register.ts
@@ -119,6 +119,28 @@ export interface RegisterFromMigrationsOptions {
   dialect: SupportedDialect;
 
   /**
+   * Whether the migration a snapshot belongs to has actually been applied.
+   *
+   * 🔴 Registration inserts entities as `applied`, so without this it asserts
+   * something it has not checked. Every `*.snapshot.json` in the directory is
+   * read and merged, including snapshots for migrations a `--step N` run has
+   * not reached — and those entities are then exposed as applied while their
+   * tables may not exist, beyond the reach of the pending sweep that would
+   * otherwise repair them, because they are no longer pending.
+   *
+   * Called with the LEDGER filename, which is the migration group's `.sql`
+   * name rather than a dialect variant: `runFileMigrations` records
+   * `0001_x.sql` whether it executed `0001_x.sql` or `0001_x.mysql.sql`, and
+   * the snapshot beside it is `meta/0001_x.snapshot.json`.
+   *
+   * OPTIONAL, and omitting it means "register everything". That is correct for
+   * the dev boot path, which applies every pending migration immediately
+   * before registering, so no unapplied snapshot can exist for it to skip. Any
+   * caller that registers WITHOUT having just applied everything must pass it.
+   */
+  isApplied?: (ledgerFilename: string) => Promise<boolean>;
+
+  /**
    * Logger for output
    */
   logger?: {
@@ -134,7 +156,8 @@ export interface RegisterFromMigrationsOptions {
  */
 async function readSnapshotFiles(
   migrationsDir: string,
-  logger?: { warn?: (msg: string) => void }
+  logger?: { warn?: (msg: string) => void; debug?: (msg: string) => void },
+  isApplied?: (ledgerFilename: string) => Promise<boolean>
 ): Promise<MigrationSnapshot[]> {
   const metaDir = resolve(migrationsDir, "meta");
 
@@ -153,6 +176,17 @@ async function readSnapshotFiles(
 
     for (const file of snapshotFiles) {
       try {
+        if (isApplied) {
+          // `X.snapshot.json` pairs with the migration group `X.sql`, which is
+          // the name the ledger records for every dialect variant.
+          const ledgerFilename = `${file.replace(/\.snapshot\.json$/, "")}.sql`;
+          if (!(await isApplied(ledgerFilename))) {
+            logger?.debug?.(
+              `[Migration Metadata] Skipping ${file}: ${ledgerFilename} has not been applied`
+            );
+            continue;
+          }
+        }
         const filePath = join(metaDir, file);
         const content = await readFile(filePath, "utf-8");
         const snapshot = JSON.parse(content) as MigrationSnapshot;
@@ -402,7 +436,11 @@ export async function registerFromMigrations(
   const typedAdapter = adapter as DrizzleAdapter;
 
   // Step 1: Read all snapshot files
-  const snapshots = await readSnapshotFiles(migrationsDir, logger);
+  const snapshots = await readSnapshotFiles(
+    migrationsDir,
+    logger,
+    options.isApplied
+  );
 
   if (snapshots.length === 0) {
     logger.debug?.("[Migration Metadata] No snapshot files found");

--- a/packages/nextly/src/domains/schema/migrate/reconcile-metadata.ts
+++ b/packages/nextly/src/domains/schema/migrate/reconcile-metadata.ts
@@ -46,6 +46,7 @@ import type { SupportedDialect } from "../../../types/database";
 import { CollectionRegistryService } from "../../collections/services/collection-registry-service";
 import { FieldGroupRegistryService } from "../../field-groups/services/field-group-registry-service";
 import { SingleRegistryService } from "../../singles/services/single-registry-service";
+import { SchemaEventsRepository } from "../events/schema-events-repository";
 
 import { registerFromMigrations } from "./metadata-register";
 
@@ -217,14 +218,28 @@ export async function reconcileMigrationMetadata(
   const { adapter, dialect, migrationsDir, logger } = deps;
   const register = deps.registerFn ?? registerFromMigrations;
 
-  // Step 1: rows the snapshots describe that the registry does not have yet.
-  // These are inserted already `applied`, because the migration that carries
-  // their DDL is the one that just ran.
+  /*
+   * Step 1: rows the snapshots describe that the registry does not have yet.
+   *
+   * 🔴 Registration inserts them as `applied`, so it is given the evidence for
+   * that claim rather than asserting it. Every `*.snapshot.json` in the
+   * directory is otherwise read and merged, including snapshots belonging to
+   * migrations a `--step N` run never reached -- and those entities are then
+   * exposed as applied while their tables may not exist, out of reach of the
+   * sweep below, which only looks at rows that are still pending.
+   *
+   * The ledger is the evidence: `nextly_schema_events` records a `file_apply`
+   * per migration, and `isFileApplied` is the same query `runFileMigrations`
+   * already uses to decide what is outstanding — so registration and execution
+   * read one source rather than two that can disagree.
+   */
+  const events = new SchemaEventsRepository(adapter.getDrizzle(), dialect);
   const registered = await register({
     migrationsDir,
     adapter,
     dialect,
     logger,
+    isApplied: filename => events.isFileApplied(filename),
   });
 
   // Step 2: rows the registry already had, waiting on a table.


### PR DESCRIPTION
Follow-up to #1559, closing the first of the two P1s Codex raised there and verified after it merged.

## The defect

`registerFromMigrations` inserts every entity it finds with `migrationStatus: "applied"`, and it finds them by reading **every** `*.snapshot.json` in the migrations directory. Under `nextly migrate --step N` that includes snapshots for migrations the run never reached — so those entities were exposed as applied while their tables may not exist.

Nothing downstream could correct it. The pending sweep added in #1559 only looks at rows still marked `pending`, and a row asserted `applied` is not one. The claim outran the evidence in the one direction the repair path cannot reach.

## The evidence already existed and was not being read

`nextly_schema_events` records a `file_apply` per migration, and `SchemaEventsRepository.isFileApplied` is the **same query `runFileMigrations` already uses** to decide what is outstanding — lines 665 and 776 of `migrate.ts`. Registration now takes that check, so what registers and what executes read one source instead of two that can disagree.

Verified rather than assumed, since the design turns on it:

- `runFileMigrations` records the migration **group** name — `0001_x.sql` whether it executed `0001_x.sql` or `0001_x.mysql.sql` — so the ledger key is dialect-independent.
- Snapshots are 1:1 filename-paired with it: `templates/blog/migrations/0001_000000_blog_schema.sql` ↔ `meta/0001_000000_blog_schema.snapshot.json`.
- `last_migration_id` exists on all three registry tables and is **never populated by any migration path** — threaded as a pass-through parameter and read back, never assigned. So it is not the mapping, despite looking like it.

## The check is optional, deliberately

Omitting it keeps the previous behaviour, which the development boot path relies on: it applies every pending migration immediately *before* registering, so it has no unapplied snapshot to skip and needs no ledger read to prove it. Any caller that registers without having just applied everything must pass the check — the CLI and prod-boot path do, through `migrateCore`'s Phase 3.

## Verification

Break-verified against wrong implementations, control green either side:

| break | result |
| --- | --- |
| ignore the ledger (the shipped behaviour) | 2 fail |
| pass the snapshot's own filename through instead of the `.sql` pairing | 1 fail |
| reconcile stops supplying the check | lint fails on the now-unused repository |

That middle one is the case worth having: a check built from the snapshot's own name would look up a filename the ledger never records, skip everything, and fail in the direction that reads as *"nothing to register"* — a silent no-op wearing the shape of a fix. It is asserted directly.

| gate | result |
| --- | --- |
| `pnpm check-types` (both invocations) | exit 0 |
| `pnpm lint` | exit 0 |
| nextly unit | 893 files / 11379 passed, 42 skipped |
| integration, all three dialects | 37 files / 170 passed |
| fallow | `pass`, 0 introduced |
| `npx changeset status` | exit 0 |

## What this does NOT fix, stated rather than implied

The second P1 from #1559 remains: promotion still reads table **existence**, so an edited entity whose old table still stands is promoted while the column, status or localization change it awaits has not landed. I confirmed the mechanism — `collection-registry-service.ts:383` sets the row back to `pending` on a field, status or localization change while the physical table is untouched.

The path is now known: `buildDesiredTableFromFields` and `introspectLiveSnapshot` both already exist and are what the diff pipeline uses, so the desired and live shapes are comparable per entity. I did not append it here because it introduces a false negative that is worse than the defect — an over-broad desired spec withholds promotion, which silently reinstates the original "collection has no dashboard cards" bug — and getting that right needs coverage of the localized and component-field cases, where the desired columns deliberately live in other tables.

Tracked as `task:applied-status-must-come-from-evidence`, which stays open on that half.