### PR TITLE
docs(nextly): document the API key prefix the service actually issues

### DIFF
--- a/docs/configuration/nextly-config.mdx
+++ b/docs/configuration/nextly-config.mdx
@@ -121,7 +121,7 @@ export default defineConfig({
 | `typescript` | `TypeScriptConfig` | See below | Generated types path and module augmentation. |
 | `db` | `DatabaseConfig` | See below | Where Drizzle schema and migration files are written. |
 | `rateLimit` | `RateLimitingConfig` | Enabled (100 read / 30 write per minute) | Global API rate limiting. |
-| `apiKeys` | `ApiKeysConfig` | 1000 req/hour, 1-hour window | Per-API-key rate limit (applies when `Authorization: Bearer sk_...` is used). |
+| `apiKeys` | `ApiKeysConfig` | 1000 req/hour, 1-hour window | Per-API-key rate limit (applies when `Authorization: Bearer nx_live_...` is used). |
 | `auth` | `AuthConfig` | `{ revealRegistrationConflict: false }` | Auth-related opt-in flags. |
 | `storage` | `StoragePlugin[]` | `[]` (local disk used) | Cloud storage plugins. Default storage is local disk under `./public/uploads/`. |
 | `plugins` | `PluginDefinition[]` | `[]` | Plugins extending Nextly with collections, hooks, sidebar items, etc. |
@@ -297,7 +297,7 @@ rateLimit: {
 apiKeys?: { rateLimit?: { requestsPerHour?: number; windowMs?: number } };
 ```
 
-Per-key rate limit applied when a request authenticates with an API key (`Authorization: Bearer sk_...`). Session-cookie requests use the global `rateLimit` block instead. Omitting this block falls back to built-in defaults.
+Per-key rate limit applied when a request authenticates with an API key (`Authorization: Bearer nx_live_...`). Session-cookie requests use the global `rateLimit` block instead. Omitting this block falls back to built-in defaults.
 
 | Property | Type | Default | Description |
 |---|---|---|---|

--- a/docs/guides/authentication.mdx
+++ b/docs/guides/authentication.mdx
@@ -7,7 +7,7 @@ Nextly ships a complete custom authentication system. It is **not** built on Nex
 
 - Email + password sign-up and login (bcrypt hashing, password-strength validation, email verification).
 - Stateless JWT access tokens (jose, HS256) plus opaque refresh tokens stored hashed in the database.
-- API key authentication (`Authorization: Bearer sk_...`) with read-only / full-access / role-based scopes.
+- API key authentication (`Authorization: Bearer nx_live_...`) with read-only / full-access / role-based scopes.
 - Role-Based Access Control (RBAC) with code-defined and database-managed permissions.
 - A super-admin bootstrap flow at `/admin/setup` that creates the first user.
 
@@ -159,7 +159,7 @@ export default defineCollection({
 
 ## API key authentication
 
-Nextly supports API keys via the `Authorization: Bearer sk_...` header (no `X-API-Key` header). Keys are created and managed in the admin UI at **Settings -> API Keys**.
+Nextly supports API keys via the `Authorization: Bearer nx_live_...` header (no `X-API-Key` header). Keys are created and managed in the admin UI at **Settings -> API Keys**.
 
 ### Token types
 

--- a/packages/nextly/src/domains/auth/services/api-key-service.ts
+++ b/packages/nextly/src/domains/auth/services/api-key-service.ts
@@ -124,6 +124,20 @@ export interface UpdateApiKeyInput {
   description?: string | null;
 }
 
+/**
+ * The prefix every issued key carries.
+ *
+ * `scripts/check-docs-claims.mjs` reads this declaration and compares the
+ * documentation's bearer examples against it, so this is the one place the key
+ * format is stated. The docs had drifted to `sk_`, another vendor's prefix, in
+ * four places, including one file that used the real prefix a few lines away
+ * from the wrong one. Nothing catches that at runtime: a key is looked up by
+ * hash, so a wrong prefix is an ordinary authentication failure with no hint
+ * that the format was the problem.
+ *
+ * Not exported. The guard reads the declaration rather than importing it,
+ * because it runs under plain Node before any TypeScript is built.
+ */
 const KEY_PREFIX = "nx_live_";
 
 /**

--- a/packages/nextly/src/domains/auth/services/api-key-service.ts
+++ b/packages/nextly/src/domains/auth/services/api-key-service.ts
@@ -129,11 +129,10 @@ export interface UpdateApiKeyInput {
  *
  * `scripts/check-docs-claims.mjs` reads this declaration and compares the
  * documentation's bearer examples against it, so this is the one place the key
- * format is stated. The docs had drifted to `sk_`, another vendor's prefix, in
- * four places, including one file that used the real prefix a few lines away
- * from the wrong one. Nothing catches that at runtime: a key is looked up by
- * hash, so a wrong prefix is an ordinary authentication failure with no hint
- * that the format was the problem.
+ * format is stated and a second copy of it anywhere is a claim that can go
+ * stale. Nothing catches a wrong one at runtime: a key is looked up by hash, so
+ * a documented prefix that does not match this authenticates as an ordinary
+ * failure, with no hint that the format was the problem.
  *
  * Not exported. The guard reads the declaration rather than importing it,
  * because it runs under plain Node before any TypeScript is built.

--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -735,8 +735,15 @@ const KEY_PREFIX_DECLARATION = /^[ \t]*(?:export[ \t]+)?const[ \t]+KEY_PREFIX[ \
  * A bearer example naming a concrete key rather than a placeholder.
  *
  * `Bearer <key>` and `Bearer <token>` are left alone: those are something a reader substitutes,
- * not a claim about the format. The scheme is matched case-insensitively, and `\s+` spans a
- * newline so an example wrapped after the scheme is still one example.
+ * not a claim about the format. `\s+` spans a newline so an example wrapped after the scheme is
+ * still one example.
+ *
+ * The SCHEME is matched case-insensitively because RFC 7235 makes it so: `bearer` is a valid
+ * HTTP request. The CREDENTIAL is compared case-sensitively, and the two are not the same
+ * decision. A key is authenticated by `sha256` of the whole string, so `NX_LIVE_...` hashes to
+ * something else and can never match a stored key. Documentation showing it teaches a header
+ * that cannot work, which is exactly what this check is for, so it is reported rather than
+ * excused.
  */
 const BEARER_EXAMPLE = /Bearer\s+([A-Za-z][A-Za-z0-9]*_[A-Za-z0-9_]*)/gi;
 

--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -720,16 +720,41 @@ function retiredKeywords(repoRoot, packages, findings) {
 
 /** Where the API key prefix is declared. One file, so a moved declaration is a refusal. */
 const KEY_PREFIX_SOURCE = "packages/nextly/src/domains/auth/services/api-key-service.ts";
-const KEY_PREFIX_DECLARATION = /\bKEY_PREFIX\s*=\s*"([^"]+)"/g;
+
+/**
+ * The declaration itself, anchored so prose cannot stand in for it.
+ *
+ * `^[ \t]*(?:export )?const` is the load-bearing part. Matching the name anywhere in the file
+ * would accept `// const KEY_PREFIX = "nx_live_"` left behind for context after the live
+ * constant was renamed, and the check would then hold the docs to a value the service no longer
+ * issues while reporting clean.
+ */
+const KEY_PREFIX_DECLARATION = /^[ \t]*(?:export[ \t]+)?const[ \t]+KEY_PREFIX[ \t]*=[ \t]*"([^"]+)"/gm;
 
 /**
  * A bearer example naming a concrete key rather than a placeholder.
  *
  * `Bearer <key>` and `Bearer <token>` are left alone: those are something a reader substitutes,
- * not a claim about the format.
+ * not a claim about the format. The scheme is matched case-insensitively, and `\s+` spans a
+ * newline so an example wrapped after the scheme is still one example.
  */
 const BEARER_EXAMPLE = /Bearer\s+([A-Za-z][A-Za-z0-9]*_[A-Za-z0-9_]*)/gi;
 
+/** HTML and MDX comments, which a reader never sees and a generator never publishes. */
+const NON_RENDERED_COMMENT = /<!--[\s\S]*?-->|\{\s*\/\*[\s\S]*?\*\/\s*\}/g;
+
+/**
+ * Blank out comments while keeping every offset and line break where it was.
+ *
+ * `renderedProse` would be the obvious reuse and is wrong here: it also strips fenced blocks,
+ * and the fenced blocks are where the bearer examples live. This removes only what a reader
+ * cannot see, and pads rather than deletes so a match's offset still names its real line.
+ */
+function blankComments(text) {
+  return text.replace(NON_RENDERED_COMMENT, match =>
+    match.replace(/[^\n]/g, " ")
+  );
+}
 
 /**
  * The documented API key prefix, compared against the one the service issues.
@@ -740,14 +765,14 @@ const BEARER_EXAMPLE = /Bearer\s+([A-Za-z][A-Za-z0-9]*_[A-Za-z0-9_]*)/gi;
  * ordinary authentication failure with no hint that the format was the problem. The docs are
  * also the source of `llms-full.txt`, so the wrong format reached coding agents too.
  *
- * The prefix is READ from the service rather than restated here. Two copies of "what a key looks
- * like" is how the docs and the code came apart in the first place.
+ * The prefix is READ from the declaration rather than restated here. Two copies of "what a key
+ * looks like" is how the docs and the code came apart in the first place.
  *
  * This lives here rather than in a vitest suite in `packages/nextly` for two reasons, both
  * measured: that package is not in the CI `Test` step's filter list, so the suite ran in no job
  * at all; and `packages/nextly/turbo.json` names a single docs file as an external input, so a
- * change to any other docs page leaves the task hash unmoved and turbo replays the previous
- * pass. This script runs in the `comments` job, which is deliberately not gated on the inert
+ * change to any other page leaves the task hash unmoved and turbo replays the previous pass.
+ * This script runs in the `comments` job, which is deliberately not gated on the inert
  * decision, so it runs on a docs-only commit, which is exactly when this regresses.
  */
 function documentedKeyPrefix(repoRoot, tracked, findings, isExempt) {
@@ -756,7 +781,8 @@ function documentedKeyPrefix(repoRoot, tracked, findings, isExempt) {
       check: "key-prefix-source-missing",
       file: KEY_PREFIX_SOURCE,
       line: null,
-      message: "the file declaring the API key prefix is not tracked, so the docs cannot be checked against it",
+      message:
+        "the file declaring the API key prefix is not tracked, so the docs cannot be checked against it",
     });
     return;
   }
@@ -769,7 +795,8 @@ function documentedKeyPrefix(repoRoot, tracked, findings, isExempt) {
       check: "key-prefix-source-missing",
       file: KEY_PREFIX_SOURCE,
       line: null,
-      message: "could not be read, so the documented key prefix has nothing to be compared against",
+      message:
+        "could not be read, so the documented key prefix has nothing to be compared against",
     });
     return;
   }
@@ -788,13 +815,16 @@ function documentedKeyPrefix(repoRoot, tracked, findings, isExempt) {
   }
   const prefix = declarations[0][1];
 
-  // Counted so the scan can prove it looked at something. A docs tree that moved, changed
-  // extension, or stopped using the syntax this matches would otherwise leave the loop with
-  // nothing to judge and the check reporting clean.
+  // Every prose surface, not just `docs/`. ARCHITECTURE.md publishes a bearer example too, and
+  // a scope that named one directory would have left it unguarded.
+  const prose = proseFiles(tracked).filter(rel => {
+    const ext = extname(rel);
+    return ext === ".md" || ext === ".mdx";
+  });
+
   let examined = 0;
 
-  for (const rel of tracked) {
-    if (!rel.startsWith("docs/") || !rel.endsWith(".mdx")) continue;
+  for (const rel of prose) {
     let text;
     try {
       text = readFileSync(join(repoRoot, rel), "utf-8");
@@ -802,27 +832,24 @@ function documentedKeyPrefix(repoRoot, tracked, findings, isExempt) {
       continue; // unreadable-manifest already reports a file the index names and disk lacks
     }
     const lines = text.split("\n");
-    for (let index = 0; index < lines.length; index++) {
-      for (const [, token] of lines[index].matchAll(BEARER_EXAMPLE)) {
-        examined += 1;
-        if (token.startsWith(prefix)) continue;
-        // A page legitimately documenting another service's credential is
-        // exempted per line, in the allowlist, the same way every other check
-        // here handles a true statement it would otherwise report.
-        //
-        // NOT by recognising the vendor's prefix, which was the first attempt:
-        // ownership cannot be read off a credential. `Bearer sk_test_...` in
-        // `guides/authentication.mdx` is a Nextly regression and looks exactly
-        // like a Stripe example, so skipping by prefix put a hole through the
-        // middle of the check it belongs to.
-        if (isExempt(rel, lines[index])) continue;
-        findings.push({
-          check: "documented-key-prefix",
-          file: rel,
-          line: index + 1,
-          message: `documents \`Bearer ${token}\`; keys are issued with the prefix "${prefix}"`,
-        });
-      }
+    // Matched over the whole file rather than line by line, so an example wrapped after the
+    // scheme is still found. Offsets survive comment blanking, so the line number is real.
+    const scanned = blankComments(text);
+    for (const match of scanned.matchAll(BEARER_EXAMPLE)) {
+      const line = scanned.slice(0, match.index).split("\n").length;
+      const token = match[1];
+      // Counted AFTER the exemption, so the population is the examples this actually judged.
+      // Counting before it meant a tree whose only remaining example was exempted reported
+      // neither a finding nor a refusal.
+      if (isExempt(rel, lines[line - 1] ?? "")) continue;
+      examined += 1;
+      if (token.startsWith(prefix)) continue;
+      findings.push({
+        check: "documented-key-prefix",
+        file: rel,
+        line,
+        message: `documents \`Bearer ${token}\`; keys are issued with the prefix "${prefix}"`,
+      });
     }
   }
 

--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -718,6 +718,128 @@ function retiredKeywords(repoRoot, packages, findings) {
   }
 }
 
+/** Where the API key prefix is declared. One file, so a moved declaration is a refusal. */
+const KEY_PREFIX_SOURCE = "packages/nextly/src/domains/auth/services/api-key-service.ts";
+const KEY_PREFIX_DECLARATION = /\bKEY_PREFIX\s*=\s*"([^"]+)"/g;
+
+/**
+ * A bearer example naming a concrete key rather than a placeholder.
+ *
+ * `Bearer <key>` and `Bearer <token>` are left alone: those are something a reader substitutes,
+ * not a claim about the format.
+ */
+const BEARER_EXAMPLE = /Bearer\s+([A-Za-z][A-Za-z0-9]*_[A-Za-z0-9_]*)/gi;
+
+
+/**
+ * The documented API key prefix, compared against the one the service issues.
+ *
+ * Four bearer examples said `sk_`, which is another vendor's prefix, and one file used the real
+ * prefix in a code sample and the wrong one in the sentence describing the header a few lines
+ * away. Nothing catches this at runtime: a key is looked up by hash, so a wrong prefix is an
+ * ordinary authentication failure with no hint that the format was the problem. The docs are
+ * also the source of `llms-full.txt`, so the wrong format reached coding agents too.
+ *
+ * The prefix is READ from the service rather than restated here. Two copies of "what a key looks
+ * like" is how the docs and the code came apart in the first place.
+ *
+ * This lives here rather than in a vitest suite in `packages/nextly` for two reasons, both
+ * measured: that package is not in the CI `Test` step's filter list, so the suite ran in no job
+ * at all; and `packages/nextly/turbo.json` names a single docs file as an external input, so a
+ * change to any other docs page leaves the task hash unmoved and turbo replays the previous
+ * pass. This script runs in the `comments` job, which is deliberately not gated on the inert
+ * decision, so it runs on a docs-only commit, which is exactly when this regresses.
+ */
+function documentedKeyPrefix(repoRoot, tracked, findings, isExempt) {
+  if (!tracked.includes(KEY_PREFIX_SOURCE)) {
+    findings.push({
+      check: "key-prefix-source-missing",
+      file: KEY_PREFIX_SOURCE,
+      line: null,
+      message: "the file declaring the API key prefix is not tracked, so the docs cannot be checked against it",
+    });
+    return;
+  }
+
+  let source;
+  try {
+    source = readFileSync(join(repoRoot, KEY_PREFIX_SOURCE), "utf-8");
+  } catch {
+    findings.push({
+      check: "key-prefix-source-missing",
+      file: KEY_PREFIX_SOURCE,
+      line: null,
+      message: "could not be read, so the documented key prefix has nothing to be compared against",
+    });
+    return;
+  }
+
+  // Fails closed. If the declaration is renamed, moved or duplicated, this refuses rather than
+  // quietly checking the docs against nothing.
+  const declarations = [...source.matchAll(KEY_PREFIX_DECLARATION)];
+  if (declarations.length !== 1) {
+    findings.push({
+      check: "key-prefix-undeclared",
+      file: KEY_PREFIX_SOURCE,
+      line: null,
+      message: `expected exactly one KEY_PREFIX declaration to read, found ${String(declarations.length)}`,
+    });
+    return;
+  }
+  const prefix = declarations[0][1];
+
+  // Counted so the scan can prove it looked at something. A docs tree that moved, changed
+  // extension, or stopped using the syntax this matches would otherwise leave the loop with
+  // nothing to judge and the check reporting clean.
+  let examined = 0;
+
+  for (const rel of tracked) {
+    if (!rel.startsWith("docs/") || !rel.endsWith(".mdx")) continue;
+    let text;
+    try {
+      text = readFileSync(join(repoRoot, rel), "utf-8");
+    } catch {
+      continue; // unreadable-manifest already reports a file the index names and disk lacks
+    }
+    const lines = text.split("\n");
+    for (let index = 0; index < lines.length; index++) {
+      for (const [, token] of lines[index].matchAll(BEARER_EXAMPLE)) {
+        examined += 1;
+        if (token.startsWith(prefix)) continue;
+        // A page legitimately documenting another service's credential is
+        // exempted per line, in the allowlist, the same way every other check
+        // here handles a true statement it would otherwise report.
+        //
+        // NOT by recognising the vendor's prefix, which was the first attempt:
+        // ownership cannot be read off a credential. `Bearer sk_test_...` in
+        // `guides/authentication.mdx` is a Nextly regression and looks exactly
+        // like a Stripe example, so skipping by prefix put a hole through the
+        // middle of the check it belongs to.
+        if (isExempt(rel, lines[index])) continue;
+        findings.push({
+          check: "documented-key-prefix",
+          file: rel,
+          line: index + 1,
+          message: `documents \`Bearer ${token}\`; keys are issued with the prefix "${prefix}"`,
+        });
+      }
+    }
+  }
+
+  // An absence check with an empty population is satisfied by everything. Reaching here having
+  // judged no example means the docs moved, were renamed, or stopped using a syntax this
+  // recognises, and every one of those should be looked at rather than reported as clean.
+  if (examined === 0) {
+    findings.push({
+      check: "key-prefix-unexamined",
+      file: "docs/",
+      line: null,
+      message:
+        "no API key example was found to check, so this reported clean without examining anything",
+    });
+  }
+}
+
 function readmeSkeleton(repoRoot, packages, findings) {
   for (const pkg of packages) {
     const readme = join(pkg.dir, "README.md");
@@ -976,6 +1098,7 @@ export async function runChecks({
 
   readmeSkeleton(repoRoot, packages, findings);
   retiredKeywords(repoRoot, packages, findings);
+  documentedKeyPrefix(repoRoot, tracked, findings, exemption("documented-key-prefix"));
   internalLinks(repoRoot, tracked, findings);
   metaReachability(repoRoot, tracked, findings);
 

--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -772,17 +772,45 @@ function isCredential(token) {
  * issue.
  *
  * `Bearer YOUR_API_KEY` is an instruction, not a format, and reporting it would have the
- * always-run docs job block a correct page. The test is the absence of a lowercase letter:
- * prefixes are issued lowercase, so no real key can be spelled this way, and capitals are how
- * documentation everywhere says "replace me".
+ * always-run docs job block a correct page.
  *
- * A token that spells the issued prefix in capitals is NOT a placeholder. `NX_LIVE_...` is a
- * mis-cased key, and a key is authenticated by `sha256` of the whole string, so that header
- * cannot work. Excusing it would make this check tolerate the one defect it exists to catch.
+ * Recognised by its WORDS rather than by being capitals. Reading every uppercase token as a
+ * placeholder excuses any retired prefix spelled in caps: `SK_LIVE_EXAMPLE` would be waved
+ * through while the docs taught a header that cannot authenticate. Every segment has to be a
+ * word documentation uses to mean "replace me", so `YOUR_API_KEY` qualifies and `SK_LIVE_` does
+ * not, because `SK` and `LIVE` name a vendor and an environment.
+ *
+ * That also keeps `NX_LIVE_...` reported. It is a mis-cased key, and a key is authenticated by
+ * `sha256` of the whole string, so that header cannot work; excusing it would make this check
+ * tolerate the one defect it exists to catch.
  */
-function isPlaceholder(token, prefix) {
+const PLACEHOLDER_WORDS = new Set([
+  "YOUR",
+  "MY",
+  "THE",
+  "A",
+  "AN",
+  "API",
+  "KEY",
+  "KEYS",
+  "TOKEN",
+  "SECRET",
+  "VALUE",
+  "PLACEHOLDER",
+  "EXAMPLE",
+  "HERE",
+  "REPLACE",
+  "INSERT",
+  "PASTE",
+  "XXX",
+  "XXXX",
+  "ABC",
+  "TODO",
+]);
+
+function isPlaceholder(token) {
   if (/[a-z]/.test(token)) return false;
-  return !token.toLowerCase().startsWith(prefix.toLowerCase());
+  return token.split(/[-_]/).every(word => PLACEHOLDER_WORDS.has(word));
 }
 
 /** Tests and fixtures, whose bearer headers are for other services and prove nothing here. */
@@ -835,6 +863,17 @@ const KEY_VOCABULARY = /\bkeys?\b/i;
 
 /** A doc comment, matched against text `sourceComments` has already reduced to those. */
 const DOC_COMMENT = /\/\*\*[\s\S]*?\*\//g;
+
+/**
+ * A Markdown paragraph, which is the sentence a bare format sits in.
+ *
+ * A fenced block counts as one, because a key format is usually shown inside one and the
+ * heading or sentence that introduces it is not what the fence contains. Splitting on blank
+ * lines therefore keeps the fence with nothing, so `KEY_VOCABULARY` has to find the word inside
+ * it: `nx_live_<base64url-32-bytes>` sits under a `Key Format` heading, and the fenced examples
+ * in this repository all carry the word themselves.
+ */
+const PARAGRAPH = /[^\n]+(?:\n[^\n]+)*/g;
 
 /** HTML and MDX comments, which a reader never sees and a generator never publishes. */
 const NON_RENDERED_COMMENT = /<!--[\s\S]*?-->|\{\s*\/\*[\s\S]*?\*\/\s*\}/g;
@@ -939,6 +978,8 @@ function blankComments(text) {
 function partitionSource(text, keep) {
   let out = "";
   let index = 0;
+  // A short tail of the code emitted so far, enough to see a closing bracket or a keyword.
+  let previous = "";
   const blank = character => (character === "\n" ? "\n" : " ");
   // Three kinds, not two. "is this a comment" decides blanking and "is this documentation"
   // decides extraction, and they disagree on a `//` note and a plain `/*` block: both are
@@ -965,6 +1006,41 @@ function partitionSource(text, keep) {
         text[index + 2] === "*" && text[index + 3] !== "/" ? "doc" : "comment";
       for (; index < stop; index += 1) out += emit(text[index], kind);
       continue;
+    }
+    // A regex literal, which is the other thing that can hold a stray slash-star.
+    //
+    // `/[/*]/` before a doc comment opened a comment at the character-class slash and ate
+    // through the JSDoc terminator. That direction was documented here as costing a refusal
+    // rather than a false pass, which was true only of reading the DECLARATION: on the
+    // extraction side the doc comment is silently dropped and the check reports clean.
+    //
+    // Comments are recognised first, exactly as a JavaScript lexer does, so `/*` and `//` never
+    // reach here and only the ambiguity between division and a regex is left. The previous
+    // significant character settles it: a value can end with a name, a number or a closing
+    // bracket, and a slash after one of those is division.
+    if (here === "/" && next !== "/" && next !== "*") {
+      if (!/[\w$)\]]$/.test(previous) || /\b(?:return|typeof|case|in|of|new|delete|void|throw)$/.test(previous)) {
+        out += emit(here, "code");
+        index += 1;
+        let inClass = false;
+        while (index < text.length && text[index] !== "\n") {
+          const character = text[index];
+          out += emit(character, "code");
+          index += 1;
+          if (character === "\\") {
+            if (index < text.length) {
+              out += emit(text[index], "code");
+              index += 1;
+            }
+            continue;
+          }
+          if (character === "[") inClass = true;
+          else if (character === "]") inClass = false;
+          else if (character === "/" && !inClass) break;
+        }
+        previous = "/";
+        continue;
+      }
     }
     if (here === '"' || here === "'" || here === "`") {
       // Only a template literal spans lines. A quoted string cannot hold a raw newline, so
@@ -1002,9 +1078,11 @@ function partitionSource(text, keep) {
         out += emit(text[index], "code");
         index += 1;
       }
+      previous = "x";
       continue;
     }
     out += emit(here, "code");
+    if (!/\s/.test(here)) previous = (previous + here).slice(-8);
     index += 1;
   }
   return out;
@@ -1083,8 +1161,15 @@ function documentedKeyPrefix(repoRoot, tracked, packages, findings, isExempt) {
   const privatePackages = new Set(
     withManifest.filter(name => !published.has(name))
   );
+  //
+  // Changesets are dropped for the reason the per-line checks drop them: they quote the claim
+  // being corrected, so a note saying "replace `Bearer sk_old_EXAMPLE`" describes the fix and
+  // is not a page anyone reads.
   const prose = proseFiles(tracked).filter(
-    rel => !TEST_FILE.test(rel) && !privatePackages.has(rel.split("/")[1])
+    rel =>
+      !TEST_FILE.test(rel) &&
+      !rel.startsWith(".changeset/") &&
+      !privatePackages.has(rel.split("/")[1])
   );
 
   let examined = 0;
@@ -1116,17 +1201,17 @@ function documentedKeyPrefix(repoRoot, tracked, packages, findings, isExempt) {
     // Bare formats are read wherever a doc comment is talking about a key. `rbac.ts` publishes
     // three of them with no scheme, in JSDoc that ships in the package's declarations, so
     // scoping this to the declaring file left editor-visible examples free to go stale.
-    if (markdown) {
-      for (const match of scanned.matchAll(KEY_FORMAT_EXAMPLE)) {
-        if (!candidates.has(match.index)) candidates.set(match.index, match);
-      }
-    } else {
-      for (const block of scanned.matchAll(DOC_COMMENT)) {
-        if (!KEY_VOCABULARY.test(block[0])) continue;
-        for (const match of block[0].matchAll(KEY_FORMAT_EXAMPLE)) {
-          const start = block.index + match.index;
-          if (!candidates.has(start)) candidates.set(start, match);
-        }
+    // The unit of context differs by file type and the test does not: a paragraph in Markdown,
+    // a doc comment in source. Without it on both sides, a page explaining that the generated
+    // index is `idx_comp_<slug>_parent` is read as documenting an API key prefix.
+    const contexts = markdown
+      ? [...scanned.matchAll(PARAGRAPH)]
+      : [...scanned.matchAll(DOC_COMMENT)];
+    for (const context of contexts) {
+      if (!KEY_VOCABULARY.test(context[0])) continue;
+      for (const match of context[0].matchAll(KEY_FORMAT_EXAMPLE)) {
+        const start = context.index + match.index;
+        if (!candidates.has(start)) candidates.set(start, match);
       }
     }
 
@@ -1146,7 +1231,7 @@ function documentedKeyPrefix(repoRoot, tracked, packages, findings, isExempt) {
       // "send a Bearer token" is prose about the scheme, not an example of a credential.
       if (!isCredential(token)) continue;
       // A placeholder is not an example of the format, so it is neither judged nor counted.
-      if (isPlaceholder(token, prefix)) continue;
+      if (isPlaceholder(token)) continue;
       examined += 1;
       if (DOCUMENTED_PREFIX.exec(token)?.[0] === prefix) continue;
       findings.push({

--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -734,9 +734,9 @@ const KEY_PREFIX_DECLARATION = /^[ \t]*(?:export[ \t]+)?const[ \t]+KEY_PREFIX[ \
 /**
  * A bearer example naming a concrete key rather than a placeholder.
  *
- * `Bearer <key>` and `Bearer <token>` are left alone: those are something a reader substitutes,
- * not a claim about the format. `\s+` spans a newline so an example wrapped after the scheme is
- * still one example.
+ * `Bearer <key>` and `Bearer <token>` never reach here, since the leading `[A-Za-z]` cannot
+ * match `<`. Symbolic placeholders can, and `isPlaceholder` decides those. `\s+` spans a
+ * newline so an example wrapped after the scheme is still one example.
  *
  * The SCHEME is matched case-insensitively because RFC 7235 makes it so: `bearer` is a valid
  * HTTP request. The CREDENTIAL is compared case-sensitively, and the two are not the same
@@ -746,6 +746,27 @@ const KEY_PREFIX_DECLARATION = /^[ \t]*(?:export[ \t]+)?const[ \t]+KEY_PREFIX[ \
  * excused.
  */
 const BEARER_EXAMPLE = /Bearer\s+([A-Za-z][A-Za-z0-9]*_[A-Za-z0-9_]*)/gi;
+
+/**
+ * Whether a token is a placeholder a reader substitutes rather than a key the docs claim to
+ * issue.
+ *
+ * `Bearer YOUR_API_KEY` is an instruction, not a format, and reporting it would have the
+ * always-run docs job block a correct page. The test is the absence of a lowercase letter:
+ * prefixes are issued lowercase, so no real key can be spelled this way, and capitals are how
+ * documentation everywhere says "replace me".
+ *
+ * A token that spells the issued prefix in capitals is NOT a placeholder. `NX_LIVE_...` is a
+ * mis-cased key, and a key is authenticated by `sha256` of the whole string, so that header
+ * cannot work. Excusing it would make this check tolerate the one defect it exists to catch.
+ */
+function isPlaceholder(token, prefix) {
+  if (/[a-z]/.test(token)) return false;
+  return !token.toLowerCase().startsWith(prefix.toLowerCase());
+}
+
+/** Tests and fixtures, whose bearer headers are for other services and prove nothing here. */
+const TEST_FILE = /(?:^|\/)__tests__\/|\.(?:test|spec)\.[cm]?tsx?$/;
 
 /** HTML and MDX comments, which a reader never sees and a generator never publishes. */
 const NON_RENDERED_COMMENT = /<!--[\s\S]*?-->|\{\s*\/\*[\s\S]*?\*\/\s*\}/g;
@@ -766,14 +787,14 @@ function blankComments(text) {
 /**
  * The documented API key prefix, compared against the one the service issues.
  *
- * Four bearer examples said `sk_`, which is another vendor's prefix, and one file used the real
- * prefix in a code sample and the wrong one in the sentence describing the header a few lines
- * away. Nothing catches this at runtime: a key is looked up by hash, so a wrong prefix is an
- * ordinary authentication failure with no hint that the format was the problem. The docs are
- * also the source of `llms-full.txt`, so the wrong format reached coding agents too.
+ * A documented prefix belonging to another vendor, or differing between a code sample and the
+ * sentence describing it a few lines away, is invisible without this. Nothing catches it at
+ * runtime: a key is looked up by hash, so a wrong prefix is an ordinary authentication failure
+ * with no hint that the format was the problem. The docs are also the source of
+ * `llms-full.txt`, so a wrong format reaches coding agents as readily as readers.
  *
- * The prefix is READ from the declaration rather than restated here. Two copies of "what a key
- * looks like" is how the docs and the code came apart in the first place.
+ * The prefix is READ from the declaration rather than restated here. A second copy of "what a
+ * key looks like" is the thing that lets the docs and the code drift apart.
  *
  * This lives here rather than in a vitest suite in `packages/nextly` for two reasons, both
  * measured: that package is not in the CI `Test` step's filter list, so the suite ran in no job
@@ -782,6 +803,69 @@ function blankComments(text) {
  * This script runs in the `comments` job, which is deliberately not gated on the inert
  * decision, so it runs on a docs-only commit, which is exactly when this regresses.
  */
+/**
+ * Blank TypeScript comments, keeping every offset and line break where it was.
+ *
+ * `KEY_PREFIX_DECLARATION` is anchored to the start of a line, which stops a `//`-commented
+ * copy standing in for the real thing. A block comment does not indent what it contains, so
+ * `/*` on its own line followed by `const KEY_PREFIX = "nx_old_";` matches as readily as the
+ * declaration. Where issuance has since moved to a differently named constant, that stale copy
+ * is the only match, and the check reads it and holds the docs to a value nothing issues.
+ *
+ * String literals are tracked rather than skipped over, because `//` inside one begins no
+ * comment and blanking from it would swallow the rest of the line, the declaration included.
+ * A regex literal containing a slash pair is read as a comment and over-blanks; that costs a
+ * `key-prefix-undeclared` refusal rather than a false pass, which is the direction to be wrong
+ * in, and this file has none.
+ */
+function blankSourceComments(text) {
+  let out = "";
+  let index = 0;
+  const blank = character => (character === "\n" ? "\n" : " ");
+  while (index < text.length) {
+    const here = text[index];
+    const next = text[index + 1];
+    if (here === "/" && next === "/") {
+      while (index < text.length && text[index] !== "\n") {
+        out += " ";
+        index += 1;
+      }
+      continue;
+    }
+    if (here === "/" && next === "*") {
+      const close = text.indexOf("*/", index + 2);
+      const stop = close === -1 ? text.length : close + 2;
+      for (; index < stop; index += 1) out += blank(text[index]);
+      continue;
+    }
+    if (here === '"' || here === "'" || here === "`") {
+      out += here;
+      index += 1;
+      while (index < text.length && text[index] !== here) {
+        if (text[index] === "\\") {
+          out += text[index];
+          index += 1;
+          if (index < text.length) {
+            out += text[index];
+            index += 1;
+          }
+          continue;
+        }
+        out += text[index];
+        index += 1;
+      }
+      if (index < text.length) {
+        out += text[index];
+        index += 1;
+      }
+      continue;
+    }
+    out += here;
+    index += 1;
+  }
+  return out;
+}
+
 function documentedKeyPrefix(repoRoot, tracked, findings, isExempt) {
   if (!tracked.includes(KEY_PREFIX_SOURCE)) {
     findings.push({
@@ -810,7 +894,7 @@ function documentedKeyPrefix(repoRoot, tracked, findings, isExempt) {
 
   // Fails closed. If the declaration is renamed, moved or duplicated, this refuses rather than
   // quietly checking the docs against nothing.
-  const declarations = [...source.matchAll(KEY_PREFIX_DECLARATION)];
+  const declarations = [...blankSourceComments(source).matchAll(KEY_PREFIX_DECLARATION)];
   if (declarations.length !== 1) {
     findings.push({
       check: "key-prefix-undeclared",
@@ -824,10 +908,15 @@ function documentedKeyPrefix(repoRoot, tracked, findings, isExempt) {
 
   // Every prose surface, not just `docs/`. ARCHITECTURE.md publishes a bearer example too, and
   // a scope that named one directory would have left it unguarded.
-  const prose = proseFiles(tracked).filter(rel => {
-    const ext = extname(rel);
-    return ext === ".md" || ext === ".mdx";
-  });
+  //
+  // TypeScript under `packages/` is in scope for the same reason. `shared/types/config.ts`
+  // documents `Authorization: Bearer nx_live_...` in JSDoc that ships in the package's
+  // declarations, so it is an example a reader is shown in their editor, and a Markdown-only
+  // scope would let it go stale while every published page was updated and the check passed.
+  //
+  // Tests are dropped. Their bearer headers belong to other services and to fixtures, so
+  // judging them against the Nextly prefix would report a defect that is not one.
+  const prose = proseFiles(tracked).filter(rel => !TEST_FILE.test(rel));
 
   let examined = 0;
 
@@ -838,17 +927,24 @@ function documentedKeyPrefix(repoRoot, tracked, findings, isExempt) {
     } catch {
       continue; // unreadable-manifest already reports a file the index names and disk lacks
     }
-    const lines = text.split("\n");
     // Matched over the whole file rather than line by line, so an example wrapped after the
     // scheme is still found. Offsets survive comment blanking, so the line number is real.
     const scanned = blankComments(text);
     for (const match of scanned.matchAll(BEARER_EXAMPLE)) {
       const line = scanned.slice(0, match.index).split("\n").length;
       const token = match[1];
-      // Counted AFTER the exemption, so the population is the examples this actually judged.
-      // Counting before it meant a tree whose only remaining example was exempted reported
-      // neither a finding nor a refusal.
-      if (isExempt(rel, lines[line - 1] ?? "")) continue;
+      // The exemption is digested from the whole matched example rather than from the line the
+      // match starts on. An allowlisted third-party example that wraps after `Bearer` puts its
+      // credential on the next line, so a line digest would cover the scheme and not the thing
+      // being excused, and swapping in a wrong Nextly prefix would inherit the exemption while
+      // other pages held the examined count above zero. `digestLine` collapses whitespace, so
+      // wrapping the same example a different way still matches.
+      //
+      // Counted AFTER the exemption, so the population is the examples this actually judged: a
+      // tree whose only remaining example was exempted must report a refusal, not silence.
+      if (isExempt(rel, match[0])) continue;
+      // A placeholder is not an example of the format, so it is neither judged nor counted.
+      if (isPlaceholder(token, prefix)) continue;
       examined += 1;
       if (token.startsWith(prefix)) continue;
       findings.push({

--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -760,11 +760,17 @@ const BEARER_EXAMPLE =
  * copy and neither can authenticate. Deciding here rather than in the pattern keeps the two
  * questions apart, since "what follows Bearer" and "is that a key" have different answers.
  *
- * A separator or a digit is what tells them apart. Prose says "send a Bearer token" and "a
- * Bearer header was present", and those words carry neither.
+ * A separator or a digit is what tells them apart in running prose, which says "send a Bearer
+ * token" and "a Bearer header was present", and those words carry neither.
+ *
+ * A header written out in full needs no such guess. `Authorization: Bearer abcdef` is a line a
+ * reader copies, and it cannot authenticate whatever its shape, so the scheme having been
+ * spelled with its header name is enough on its own.
  */
-function isCredential(token) {
-  return /[_-]/.test(token) || /[0-9]/.test(token);
+const EXPLICIT_HEADER = /Authorization:[ \t]*$/i;
+
+function isCredential(token, explicitHeader) {
+  return explicitHeader || /[_-]/.test(token) || /[0-9]/.test(token);
 }
 
 /**
@@ -839,10 +845,12 @@ const TEST_FILE = /(?:^|\/)__tests__\/|\.(?:test|spec)\.[cm]?[jt]sx?$/;
 const KEY_FORMAT_EXAMPLE = /\b([a-z][a-z0-9]*(?:_[a-z0-9]+)+_)(?=<|\.\.\.)/g;
 
 /**
- * A key written out in full rather than trailed off, as `"nx_live_abcdefgh"`.
+ * A key written out in full rather than trailed off, as `"nx_live_abcdefgh"`, or the prefix
+ * quoted on its own, as "keys carry the `nx_live_` prefix".
  *
- * The file that declares the prefix shows one twice, as the display prefix a masked UI renders,
- * and those are as able to go stale as any header example.
+ * The file that declares the prefix does both: the display prefix a masked UI renders, and a
+ * bare mention of the prefix in the paragraph explaining what it is for. Neither trails off, so
+ * neither is visible to the placeholder form, and both are as able to go stale as any header.
  *
  * Read in that file and nowhere else, and the measurement is the reason: this pattern applied
  * across every key-talking context reports twenty-two database identifiers, `change_column_type`
@@ -850,7 +858,7 @@ const KEY_FORMAT_EXAMPLE = /\b([a-z][a-z0-9]*(?:_[a-z0-9]+)+_)(?=<|\.\.\.)/g;
  * "key column" are sentences about keys too. Inside the declaring file it reports that one
  * example and nothing else, since every comment there is about this credential.
  */
-const CONCRETE_KEY_EXAMPLE = /["'`]([a-z][a-z0-9]*(?:_[a-z0-9]+)+_[A-Za-z0-9]+)["'`]/g;
+const CONCRETE_KEY_EXAMPLE = /["'`]([a-z][a-z0-9]*(?:_[a-z0-9]+)+_[A-Za-z0-9]*)["'`]/g;
 
 /**
  * The prefix an example claims, which is its leading run of underscore-separated segments.
@@ -1215,7 +1223,13 @@ function documentedKeyPrefix(repoRoot, tracked, packages, findings, isExempt) {
     // and is one example rather than two.
     const candidates = new Map();
     for (const match of scanned.matchAll(BEARER_EXAMPLE)) {
-      candidates.set(match.index + match[0].length - match[1].length, match);
+      const explicitHeader = EXPLICIT_HEADER.test(
+        scanned.slice(Math.max(0, match.index - 24), match.index)
+      );
+      candidates.set(match.index + match[0].length - match[1].length, {
+        match,
+        explicitHeader,
+      });
     }
     // Bare formats are read wherever a doc comment is talking about a key. `rbac.ts` publishes
     // three of them with no scheme, in JSDoc that ships in the package's declarations, so
@@ -1226,8 +1240,13 @@ function documentedKeyPrefix(repoRoot, tracked, packages, findings, isExempt) {
     const contexts = markdown
       ? [...scanned.matchAll(PARAGRAPH)]
       : [...scanned.matchAll(DOC_COMMENT)];
-    for (const context of contexts) {
-      if (!KEY_VOCABULARY.test(context[0])) continue;
+    for (const [position, context] of contexts.entries()) {
+      // The block before counts as part of the context. Markdown introduces a format with a
+      // heading or a sentence and then puts the value in its own fence, and a fence holds no
+      // blank line so it is a paragraph of its own: judged alone, `## API key format` above it
+      // says nothing about what follows.
+      const introduced = (contexts[position - 1]?.[0] ?? "") + "\n" + context[0];
+      if (!KEY_VOCABULARY.test(introduced)) continue;
       const patterns =
         rel === KEY_PREFIX_SOURCE
           ? [KEY_FORMAT_EXAMPLE, CONCRETE_KEY_EXAMPLE]
@@ -1236,12 +1255,16 @@ function documentedKeyPrefix(repoRoot, tracked, packages, findings, isExempt) {
         for (const match of context[0].matchAll(pattern)) {
           // The capture, not the whole match: the concrete form takes its quotes with it.
           const start = context.index + match.index + match[0].indexOf(match[1]);
-          if (!candidates.has(start)) candidates.set(start, match);
+          if (!candidates.has(start)) {
+            candidates.set(start, { match, explicitHeader: false });
+          }
         }
       }
     }
 
-    for (const [start, match] of [...candidates].sort((a, b) => a[0] - b[0])) {
+    for (const [start, { match, explicitHeader }] of [...candidates].sort(
+      (a, b) => a[0] - b[0]
+    )) {
       const line = scanned.slice(0, start).split("\n").length;
       const token = match[1];
       // The exemption is digested from the whole matched example rather than from the line the
@@ -1255,7 +1278,7 @@ function documentedKeyPrefix(repoRoot, tracked, packages, findings, isExempt) {
       // tree whose only remaining example was exempted must report a refusal, not silence.
       if (isExempt(rel, match[0])) continue;
       // "send a Bearer token" is prose about the scheme, not an example of a credential.
-      if (!isCredential(token)) continue;
+      if (!isCredential(token, explicitHeader)) continue;
       // A placeholder is not an example of the format, so it is neither judged nor counted.
       if (isPlaceholder(token)) continue;
       examined += 1;

--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -735,8 +735,12 @@ const KEY_PREFIX_DECLARATION = /^[ \t]*(?:export[ \t]+)?const[ \t]+KEY_PREFIX[ \
  * A bearer example naming a concrete key rather than a placeholder.
  *
  * `Bearer <key>` and `Bearer <token>` never reach here, since the leading `[A-Za-z]` cannot
- * match `<`. Symbolic placeholders can, and `isPlaceholder` decides those. `\s+` spans a
- * newline so an example wrapped after the scheme is still one example.
+ * match `<`. Symbolic placeholders can, and `isPlaceholder` decides those.
+ *
+ * The separator allows AT MOST ONE line break, so an example wrapped after the scheme is still
+ * one example while `Bearer` ending a paragraph is not joined to an underscored word opening
+ * the next. Markdown renders a single break as a space and a blank line as a boundary, and this
+ * is where that distinction has to be drawn.
  *
  * The SCHEME is matched case-insensitively because RFC 7235 makes it so: `bearer` is a valid
  * HTTP request. The CREDENTIAL is compared case-sensitively, and the two are not the same
@@ -745,7 +749,8 @@ const KEY_PREFIX_DECLARATION = /^[ \t]*(?:export[ \t]+)?const[ \t]+KEY_PREFIX[ \
  * that cannot work, which is exactly what this check is for, so it is reported rather than
  * excused.
  */
-const BEARER_EXAMPLE = /Bearer\s+([A-Za-z][A-Za-z0-9]*_[A-Za-z0-9_]*)/gi;
+const BEARER_EXAMPLE =
+  /Bearer(?:[ \t]+|[ \t]*\r?\n[ \t]*)([A-Za-z][A-Za-z0-9]*_[A-Za-z0-9_]*)/gi;
 
 /**
  * Whether a token is a placeholder a reader substitutes rather than a key the docs claim to
@@ -768,8 +773,29 @@ function isPlaceholder(token, prefix) {
 /** Tests and fixtures, whose bearer headers are for other services and prove nothing here. */
 const TEST_FILE = /(?:^|\/)__tests__\/|\.(?:test|spec)\.[cm]?tsx?$/;
 
+/**
+ * A key format documented without the authorization scheme.
+ *
+ * `nx_live_<base64url-32-bytes>` and `nx_live_...` state what a key looks like as plainly as a
+ * bearer header does, and the file that DECLARES the prefix documents it this way three times.
+ * Matching only `Bearer` examples would let those advertise a retired prefix indefinitely while
+ * one updated bearer example kept the population guard satisfied.
+ *
+ * Read ONLY in that declaring file, and the narrowness is the point. Nothing in the shape of a
+ * token says it is a credential: run against the tree, this pattern reads
+ * `idx_comp_<slug>_parent` in `api/field-groups.ts` as a key prefix, which is an index name.
+ * The declaring file's comments are the canonical specification of the format, so a token there
+ * shaped like a prefix and differing from the declared one is a stale spelling of it; the same
+ * token anywhere else is a snake_case identifier that happens to precede a placeholder.
+ * Everywhere else documents the HEADER, and `BEARER_EXAMPLE` covers that with no such ambiguity.
+ */
+const KEY_FORMAT_EXAMPLE = /\b([a-z][a-z0-9]*(?:_[a-z0-9]+)+_)(?=<|\.\.\.)/g;
+
 /** HTML and MDX comments, which a reader never sees and a generator never publishes. */
 const NON_RENDERED_COMMENT = /<!--[\s\S]*?-->|\{\s*\/\*[\s\S]*?\*\/\s*\}/g;
+
+/** Fenced blocks, closed or running to end of file, as `renderedProse` also counts them. */
+const FENCED_BLOCK = /^ {0,3}(`{3,}|~{3,})[\s\S]*?^ {0,3}\1[^\n]*$|^ {0,3}(?:`{3,}|~{3,})[\s\S]*$/gm;
 
 /**
  * Blank out comments while keeping every offset and line break where it was.
@@ -777,10 +803,21 @@ const NON_RENDERED_COMMENT = /<!--[\s\S]*?-->|\{\s*\/\*[\s\S]*?\*\/\s*\}/g;
  * `renderedProse` would be the obvious reuse and is wrong here: it also strips fenced blocks,
  * and the fenced blocks are where the bearer examples live. This removes only what a reader
  * cannot see, and pads rather than deletes so a match's offset still names its real line.
+ *
+ * Comment SYNTAX inside a fence is not a comment. A fenced TSX sample showing
+ * `{/* Authorization: Bearer sk_live_... *\/}` is printed to the reader verbatim, so blanking it
+ * would hide a wrong prefix from the check while every other example kept the population above
+ * zero. Fences are located first and anything starting inside one is left exactly as it is.
  */
 function blankComments(text) {
-  return text.replace(NON_RENDERED_COMMENT, match =>
-    match.replace(/[^\n]/g, " ")
+  const fences = [];
+  for (const fence of text.matchAll(FENCED_BLOCK)) {
+    fences.push([fence.index, fence.index + fence[0].length]);
+  }
+  return text.replace(NON_RENDERED_COMMENT, (match, offset) =>
+    fences.some(([open, close]) => offset >= open && offset < close)
+      ? match
+      : match.replace(/[^\n]/g, " ")
   );
 }
 
@@ -804,13 +841,21 @@ function blankComments(text) {
  * decision, so it runs on a docs-only commit, which is exactly when this regresses.
  */
 /**
- * Blank TypeScript comments, keeping every offset and line break where it was.
+ * Split TypeScript into its comments and its code, keeping every offset and line break.
  *
- * `KEY_PREFIX_DECLARATION` is anchored to the start of a line, which stops a `//`-commented
- * copy standing in for the real thing. A block comment does not indent what it contains, so
- * `/*` on its own line followed by `const KEY_PREFIX = "nx_old_";` matches as readily as the
- * declaration. Where issuance has since moved to a differently named constant, that stale copy
- * is the only match, and the check reads it and holds the docs to a value nothing issues.
+ * Both halves are needed and for opposite reasons.
+ *
+ * Blanking the COMMENTS is how `KEY_PREFIX_DECLARATION` is read. That pattern is anchored to
+ * the start of a line, which stops a `//`-commented copy standing in for the real thing, but a
+ * block comment does not indent what it contains, so `/*` on its own line followed by
+ * `const KEY_PREFIX = "nx_old_";` matches as readily as the declaration. Where issuance has
+ * since moved to a differently named constant, that stale copy is the only match, and the check
+ * reads it and holds the docs to a value nothing issues.
+ *
+ * Keeping ONLY the comments is how a TypeScript file is read as documentation. What a reader is
+ * shown of a `.ts` file is its JSDoc, and the code beside it is machinery: an email provider
+ * that builds `Authorization: "Bearer vendor_key"` at runtime is doing its job, not documenting
+ * a Nextly key, and judging it would block an always-run job over a correct integration.
  *
  * String literals are tracked rather than skipped over, because `//` inside one begins no
  * comment and blanking from it would swallow the rest of the line, the declaration included.
@@ -818,16 +863,19 @@ function blankComments(text) {
  * `key-prefix-undeclared` refusal rather than a false pass, which is the direction to be wrong
  * in, and this file has none.
  */
-function blankSourceComments(text) {
+function partitionSource(text, keep) {
   let out = "";
   let index = 0;
   const blank = character => (character === "\n" ? "\n" : " ");
+  // A region is emitted verbatim when it is the half asked for, and padded out when it is not.
+  const take = (character, isComment) =>
+    (isComment === (keep === "comments") ? character : blank(character));
   while (index < text.length) {
     const here = text[index];
     const next = text[index + 1];
     if (here === "/" && next === "/") {
       while (index < text.length && text[index] !== "\n") {
-        out += " ";
+        out += take(text[index], true);
         index += 1;
       }
       continue;
@@ -835,36 +883,42 @@ function blankSourceComments(text) {
     if (here === "/" && next === "*") {
       const close = text.indexOf("*/", index + 2);
       const stop = close === -1 ? text.length : close + 2;
-      for (; index < stop; index += 1) out += blank(text[index]);
+      for (; index < stop; index += 1) out += take(text[index], true);
       continue;
     }
     if (here === '"' || here === "'" || here === "`") {
-      out += here;
+      out += take(here, false);
       index += 1;
       while (index < text.length && text[index] !== here) {
         if (text[index] === "\\") {
-          out += text[index];
+          out += take(text[index], false);
           index += 1;
           if (index < text.length) {
-            out += text[index];
+            out += take(text[index], false);
             index += 1;
           }
           continue;
         }
-        out += text[index];
+        out += take(text[index], false);
         index += 1;
       }
       if (index < text.length) {
-        out += text[index];
+        out += take(text[index], false);
         index += 1;
       }
       continue;
     }
-    out += here;
+    out += take(here, false);
     index += 1;
   }
   return out;
 }
+
+/** The file with its comments padded out, leaving the code a parser would see. */
+const blankSourceComments = text => partitionSource(text, "code");
+
+/** The file with its code padded out, leaving what a reader is shown of it. */
+const sourceComments = text => partitionSource(text, "comments");
 
 function documentedKeyPrefix(repoRoot, tracked, findings, isExempt) {
   if (!tracked.includes(KEY_PREFIX_SOURCE)) {
@@ -927,11 +981,31 @@ function documentedKeyPrefix(repoRoot, tracked, findings, isExempt) {
     } catch {
       continue; // unreadable-manifest already reports a file the index names and disk lacks
     }
+    // Read each file as what it SHOWS a reader. In Markdown that is everything except the
+    // comments a generator never publishes; in TypeScript it is exactly the comments, since
+    // the code beside them builds headers rather than documenting Nextly's.
+    //
     // Matched over the whole file rather than line by line, so an example wrapped after the
-    // scheme is still found. Offsets survive comment blanking, so the line number is real.
-    const scanned = blankComments(text);
+    // scheme is still found. Both readers pad rather than delete, so a match's offset still
+    // names its real line.
+    const markdown = rel.endsWith(".md") || rel.endsWith(".mdx");
+    const scanned = markdown ? blankComments(text) : sourceComments(text);
+
+    // A bearer header and a bare format claim the same thing, so they are judged together.
+    // Keyed by where the token starts, because `Bearer nx_live_...` satisfies both patterns
+    // and is one example rather than two.
+    const candidates = new Map();
     for (const match of scanned.matchAll(BEARER_EXAMPLE)) {
-      const line = scanned.slice(0, match.index).split("\n").length;
+      candidates.set(match.index + match[0].length - match[1].length, match);
+    }
+    if (rel === KEY_PREFIX_SOURCE) {
+      for (const match of scanned.matchAll(KEY_FORMAT_EXAMPLE)) {
+        if (!candidates.has(match.index)) candidates.set(match.index, match);
+      }
+    }
+
+    for (const [start, match] of [...candidates].sort((a, b) => a[0] - b[0])) {
+      const line = scanned.slice(0, start).split("\n").length;
       const token = match[1];
       // The exemption is digested from the whole matched example rather than from the line the
       // match starts on. An allowlisted third-party example that wraps after `Bearer` puts its
@@ -951,7 +1025,7 @@ function documentedKeyPrefix(repoRoot, tracked, findings, isExempt) {
         check: "documented-key-prefix",
         file: rel,
         line,
-        message: `documents \`Bearer ${token}\`; keys are issued with the prefix "${prefix}"`,
+        message: `documents \`${match[0].trim()}\`; keys are issued with the prefix "${prefix}"`,
       });
     }
   }
@@ -1020,6 +1094,16 @@ export async function runChecks({
    * file-wide bypass wearing the shape of a single exception. Digests are per-line and match
    * `comment-convention-allowlist.json`.
    */
+  /**
+   * An exemption is spent, not held. `count` says how many occurrences in a file an entry
+   * excuses, and it was carried in the allowlist and read by nobody: one entry excused every
+   * duplicate of its line, so a second copy of an allowlisted claim could be added anywhere in
+   * the same file and inherit permission granted to the first. The declared number is now the
+   * budget, and going over it reports the surplus rather than absorbing it.
+   *
+   * Absent, it falls back to the number of digests, which is what a one-line-per-digest entry
+   * means and what every entry written so far says.
+   */
   const exemption = check => {
     const forCheck = allowlist[check] ?? {};
     const byPath = new Map();
@@ -1029,11 +1113,31 @@ export async function runChecks({
     // rather than as an error.
     const posix = value => value.split(sep).join("/");
     for (const [path, entry] of Object.entries(forCheck)) {
-      byPath.set(posix(path), new Set(entry.digests ?? []));
+      const digests = entry.digests ?? [];
+      byPath.set(posix(path), {
+        digests: new Set(digests),
+        budget: entry.count ?? digests.length,
+        spent: 0,
+        reported: false,
+      });
     }
     return (relPath, line) => {
-      const digests = byPath.get(posix(relPath));
-      return digests ? digests.has(digestLine(line)) : false;
+      const entry = byPath.get(posix(relPath));
+      if (!entry || !entry.digests.has(digestLine(line))) return false;
+      entry.spent += 1;
+      if (entry.spent <= entry.budget) return true;
+      // Said once per file. The surplus occurrences are each reported by the check that found
+      // them, and repeating this beside every one of them would bury that.
+      if (!entry.reported) {
+        entry.reported = true;
+        findings.push({
+          check: "allowlist-count-exceeded",
+          file: posix(relPath),
+          line: null,
+          message: `the "${check}" entry allows ${String(entry.budget)} occurrence(s) and the file has more; raise the count with a reason, or fix the extra one`,
+        });
+      }
+      return false;
     };
   };
 

--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -852,10 +852,17 @@ function blankComments(text) {
  * since moved to a differently named constant, that stale copy is the only match, and the check
  * reads it and holds the docs to a value nothing issues.
  *
- * Keeping ONLY the comments is how a TypeScript file is read as documentation. What a reader is
- * shown of a `.ts` file is its JSDoc, and the code beside it is machinery: an email provider
- * that builds `Authorization: "Bearer vendor_key"` at runtime is doing its job, not documenting
- * a Nextly key, and judging it would block an always-run job over a correct integration.
+ * Keeping only the DOC COMMENTS is how a TypeScript file is read as documentation. What a
+ * reader is shown of a `.ts` file is its JSDoc; the code beside it is machinery, and so is a
+ * `//` note to whoever maintains it. An email provider that builds
+ * `Authorization: "Bearer vendor_key"` at runtime, or explains in a line comment that the
+ * vendor wants one, is doing its job rather than documenting a Nextly key, and judging either
+ * would block an always-run job over a correct integration.
+ *
+ * `/**` and not `/*`, so the boundary is the form that gets published. Attachment to an
+ * exported declaration would be the stricter rule and is the wrong one: the key format is
+ * stated in `api-key-service.ts`'s file-level block, which is attached to nothing, and
+ * requiring an export would drop exactly the examples this check exists to hold.
  *
  * String literals are tracked rather than skipped over, because `//` inside one begins no
  * comment and blanking from it would swallow the rest of the line, the declaration included.
@@ -867,15 +874,18 @@ function partitionSource(text, keep) {
   let out = "";
   let index = 0;
   const blank = character => (character === "\n" ? "\n" : " ");
-  // A region is emitted verbatim when it is the half asked for, and padded out when it is not.
-  const take = (character, isComment) =>
-    (isComment === (keep === "comments") ? character : blank(character));
+  // Three kinds, not two. "is this a comment" decides blanking and "is this documentation"
+  // decides extraction, and they disagree on a `//` note and a plain `/*` block: both are
+  // comments, neither is published. Collapsing them leaves ordinary block comments emitted
+  // verbatim while reading the declaration, which is the case the anchor exists to refuse.
+  const emit = (character, kind) =>
+    (keep === "code" ? kind === "code" : kind === "doc") ? character : blank(character);
   while (index < text.length) {
     const here = text[index];
     const next = text[index + 1];
     if (here === "/" && next === "/") {
       while (index < text.length && text[index] !== "\n") {
-        out += take(text[index], true);
+        out += emit(text[index], "comment");
         index += 1;
       }
       continue;
@@ -883,32 +893,36 @@ function partitionSource(text, keep) {
     if (here === "/" && next === "*") {
       const close = text.indexOf("*/", index + 2);
       const stop = close === -1 ? text.length : close + 2;
-      for (; index < stop; index += 1) out += take(text[index], true);
+      // `/**` is the published form. `/*` is a note, and `/**/` is an empty one rather than a
+      // doc block, so the character after the second star has to be something.
+      const kind =
+        text[index + 2] === "*" && text[index + 3] !== "/" ? "doc" : "comment";
+      for (; index < stop; index += 1) out += emit(text[index], kind);
       continue;
     }
     if (here === '"' || here === "'" || here === "`") {
-      out += take(here, false);
+      out += emit(here, "code");
       index += 1;
       while (index < text.length && text[index] !== here) {
         if (text[index] === "\\") {
-          out += take(text[index], false);
+          out += emit(text[index], "code");
           index += 1;
           if (index < text.length) {
-            out += take(text[index], false);
+            out += emit(text[index], "code");
             index += 1;
           }
           continue;
         }
-        out += take(text[index], false);
+        out += emit(text[index], "code");
         index += 1;
       }
       if (index < text.length) {
-        out += take(text[index], false);
+        out += emit(text[index], "code");
         index += 1;
       }
       continue;
     }
-    out += take(here, false);
+    out += emit(here, "code");
     index += 1;
   }
   return out;

--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -750,7 +750,22 @@ const KEY_PREFIX_DECLARATION = /^[ \t]*(?:export[ \t]+)?const[ \t]+KEY_PREFIX[ \
  * excused.
  */
 const BEARER_EXAMPLE =
-  /Bearer(?:[ \t]+|[ \t]*\r?\n[ \t]*)([A-Za-z][A-Za-z0-9]*_[A-Za-z0-9_]*)/gi;
+  /Bearer(?:[ \t]+|[ \t]*\r?\n[ \t]*)([A-Za-z][A-Za-z0-9_-]*)/gi;
+
+/**
+ * Whether a bearer token is a credential rather than the word "token".
+ *
+ * The pattern deliberately matches any word after the scheme, because requiring an underscore
+ * missed `Bearer sk-live-EXAMPLE` and `Bearer abc123`: both are concrete headers a reader would
+ * copy and neither can authenticate. Deciding here rather than in the pattern keeps the two
+ * questions apart, since "what follows Bearer" and "is that a key" have different answers.
+ *
+ * A separator or a digit is what tells them apart. Prose says "send a Bearer token" and "a
+ * Bearer header was present", and those words carry neither.
+ */
+function isCredential(token) {
+  return /[_-]/.test(token) || /[0-9]/.test(token);
+}
 
 /**
  * Whether a token is a placeholder a reader substitutes rather than a key the docs claim to
@@ -771,7 +786,7 @@ function isPlaceholder(token, prefix) {
 }
 
 /** Tests and fixtures, whose bearer headers are for other services and prove nothing here. */
-const TEST_FILE = /(?:^|\/)__tests__\/|\.(?:test|spec)\.[cm]?tsx?$/;
+const TEST_FILE = /(?:^|\/)__tests__\/|\.(?:test|spec)\.[cm]?[jt]sx?$/;
 
 /**
  * A key format documented without the authorization scheme.
@@ -791,11 +806,54 @@ const TEST_FILE = /(?:^|\/)__tests__\/|\.(?:test|spec)\.[cm]?tsx?$/;
  */
 const KEY_FORMAT_EXAMPLE = /\b([a-z][a-z0-9]*(?:_[a-z0-9]+)+_)(?=<|\.\.\.)/g;
 
+/**
+ * The prefix an example claims, which is its leading run of underscore-separated segments.
+ *
+ * Compared for EQUALITY against the declaration rather than with `startsWith`, which passes
+ * anything the declared value is a prefix of. Shortening `nx_live_` to `nx_` would leave every
+ * `nx_live_...` example in the tree satisfying `startsWith("nx_")`, so the docs and the source
+ * could both keep advertising a format nothing issues while this reported clean.
+ *
+ * An example writing out a full literal key whose random half contains an underscore reads as a
+ * different prefix and is reported. That is the right answer twice over: the documented form is
+ * `nx_live_...` or `nx_live_<random>`, and a real key in documentation is something a person
+ * should look at.
+ */
+const DOCUMENTED_PREFIX = /^[A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+)*_/;
+
+/**
+ * Doc comments that are talking about an API key.
+ *
+ * A bare `something_<placeholder>` says nothing about what it is. Run against the tree, a
+ * pattern for that shape reads `idx_comp_<slug>_parent` in `api/field-groups.ts`, which is an
+ * index name, so the surrounding sentence has to decide. Every block that documents the key
+ * format says so plainly: `api-key-service.ts` heads its with "Key Format", and
+ * `direct-api/types/rbac.ts` calls its examples the raw key value. The index-name block does
+ * not use the word at all.
+ */
+const KEY_VOCABULARY = /\bkeys?\b/i;
+
+/** A doc comment, matched against text `sourceComments` has already reduced to those. */
+const DOC_COMMENT = /\/\*\*[\s\S]*?\*\//g;
+
 /** HTML and MDX comments, which a reader never sees and a generator never publishes. */
 const NON_RENDERED_COMMENT = /<!--[\s\S]*?-->|\{\s*\/\*[\s\S]*?\*\/\s*\}/g;
 
 /** Fenced blocks, closed or running to end of file, as `renderedProse` also counts them. */
 const FENCED_BLOCK = /^ {0,3}(`{3,}|~{3,})[\s\S]*?^ {0,3}\1[^\n]*$|^ {0,3}(?:`{3,}|~{3,})[\s\S]*$/gm;
+
+/**
+ * An inline code span, which prints its contents as typed.
+ *
+ * A span cannot cross a blank line in CommonMark, and holding it to a single line here is the
+ * safe direction: reading too far would protect ordinary prose and stop a genuine hidden
+ * comment from being blanked.
+ *
+ * Indented code blocks are deliberately not protected. Four spaces means a code block after a
+ * blank line and a continuation inside a list item, and guessing wrong the other way blocks a
+ * correct page on a job that always runs. A comment example that matters can be fenced.
+ */
+const INLINE_CODE = /(`+)(?:(?!\1)[^\n])+\1/g;
 
 /**
  * Blank out comments while keeping every offset and line break where it was.
@@ -804,18 +862,26 @@ const FENCED_BLOCK = /^ {0,3}(`{3,}|~{3,})[\s\S]*?^ {0,3}\1[^\n]*$|^ {0,3}(?:`{3
  * and the fenced blocks are where the bearer examples live. This removes only what a reader
  * cannot see, and pads rather than deletes so a match's offset still names its real line.
  *
- * Comment SYNTAX inside a fence is not a comment. A fenced TSX sample showing
- * `{/* Authorization: Bearer sk_live_... *\/}` is printed to the reader verbatim, so blanking it
- * would hide a wrong prefix from the check while every other example kept the population above
- * zero. Fences are located first and anything starting inside one is left exactly as it is.
+ * Comment SYNTAX inside rendered code is not a comment. A fenced TSX sample, or an inline span
+ * showing `{/* Authorization: Bearer sk_live_... *\/}`, is printed to the reader verbatim, so
+ * blanking it would hide a wrong prefix from the check while every other example kept the
+ * population above zero. Both are located first and anything starting inside one is left
+ * exactly as it is.
  */
 function blankComments(text) {
-  const fences = [];
+  const rendered = [];
   for (const fence of text.matchAll(FENCED_BLOCK)) {
-    fences.push([fence.index, fence.index + fence[0].length]);
+    rendered.push([fence.index, fence.index + fence[0].length]);
+  }
+  // Spans are collected from the text with fences already accounted for, so a stray backtick
+  // inside a fenced block cannot pair with one outside it.
+  for (const span of text.matchAll(INLINE_CODE)) {
+    const start = span.index;
+    if (rendered.some(([open, close]) => start >= open && start < close)) continue;
+    rendered.push([start, start + span[0].length]);
   }
   return text.replace(NON_RENDERED_COMMENT, (match, offset) =>
-    fences.some(([open, close]) => offset >= open && offset < close)
+    rendered.some(([open, close]) => offset >= open && offset < close)
       ? match
       : match.replace(/[^\n]/g, " ")
   );
@@ -950,7 +1016,7 @@ const blankSourceComments = text => partitionSource(text, "code");
 /** The file with its code padded out, leaving what a reader is shown of it. */
 const sourceComments = text => partitionSource(text, "comments");
 
-function documentedKeyPrefix(repoRoot, tracked, findings, isExempt) {
+function documentedKeyPrefix(repoRoot, tracked, packages, findings, isExempt) {
   if (!tracked.includes(KEY_PREFIX_SOURCE)) {
     findings.push({
       check: "key-prefix-source-missing",
@@ -1000,7 +1066,26 @@ function documentedKeyPrefix(repoRoot, tracked, findings, isExempt) {
   //
   // Tests are dropped. Their bearer headers belong to other services and to fixtures, so
   // judging them against the Nextly prefix would report a defect that is not one.
-  const prose = proseFiles(tracked).filter(rel => !TEST_FILE.test(rel));
+  //
+  // So are private packages. `eslint-config`, `tsconfig` and their neighbours are build
+  // machinery that npm never receives, so a comment in one reaches no consumer and documents
+  // nothing. `publishedPackages` already decides this for every other check here, and asking
+  // it again is what keeps the two answers from drifting apart.
+  //
+  // Derived as "has a manifest that publishing did not return", not as "was returned by
+  // publishing". A directory whose manifest is missing or unreadable stays IN scope, so a
+  // package cannot drop out of this check by losing the file that describes it. Unreadable is
+  // separately reported.
+  const published = new Set(packages.map(pkg => basename(pkg.dir)));
+  const withManifest = tracked
+    .filter(rel => /^packages\/[^/]+\/package\.json$/.test(rel))
+    .map(rel => rel.split("/")[1]);
+  const privatePackages = new Set(
+    withManifest.filter(name => !published.has(name))
+  );
+  const prose = proseFiles(tracked).filter(
+    rel => !TEST_FILE.test(rel) && !privatePackages.has(rel.split("/")[1])
+  );
 
   let examined = 0;
 
@@ -1028,9 +1113,20 @@ function documentedKeyPrefix(repoRoot, tracked, findings, isExempt) {
     for (const match of scanned.matchAll(BEARER_EXAMPLE)) {
       candidates.set(match.index + match[0].length - match[1].length, match);
     }
-    if (rel === KEY_PREFIX_SOURCE) {
+    // Bare formats are read wherever a doc comment is talking about a key. `rbac.ts` publishes
+    // three of them with no scheme, in JSDoc that ships in the package's declarations, so
+    // scoping this to the declaring file left editor-visible examples free to go stale.
+    if (markdown) {
       for (const match of scanned.matchAll(KEY_FORMAT_EXAMPLE)) {
         if (!candidates.has(match.index)) candidates.set(match.index, match);
+      }
+    } else {
+      for (const block of scanned.matchAll(DOC_COMMENT)) {
+        if (!KEY_VOCABULARY.test(block[0])) continue;
+        for (const match of block[0].matchAll(KEY_FORMAT_EXAMPLE)) {
+          const start = block.index + match.index;
+          if (!candidates.has(start)) candidates.set(start, match);
+        }
       }
     }
 
@@ -1047,10 +1143,12 @@ function documentedKeyPrefix(repoRoot, tracked, findings, isExempt) {
       // Counted AFTER the exemption, so the population is the examples this actually judged: a
       // tree whose only remaining example was exempted must report a refusal, not silence.
       if (isExempt(rel, match[0])) continue;
+      // "send a Bearer token" is prose about the scheme, not an example of a credential.
+      if (!isCredential(token)) continue;
       // A placeholder is not an example of the format, so it is neither judged nor counted.
       if (isPlaceholder(token, prefix)) continue;
       examined += 1;
-      if (token.startsWith(prefix)) continue;
+      if (DOCUMENTED_PREFIX.exec(token)?.[0] === prefix) continue;
       findings.push({
         check: "documented-key-prefix",
         file: rel,
@@ -1362,7 +1460,7 @@ export async function runChecks({
 
   readmeSkeleton(repoRoot, packages, findings);
   retiredKeywords(repoRoot, packages, findings);
-  documentedKeyPrefix(repoRoot, tracked, findings, exemption("documented-key-prefix"));
+  documentedKeyPrefix(repoRoot, tracked, packages, findings, exemption("documented-key-prefix"));
   internalLinks(repoRoot, tracked, findings);
   metaReachability(repoRoot, tracked, findings);
 

--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -824,15 +824,33 @@ const TEST_FILE = /(?:^|\/)__tests__\/|\.(?:test|spec)\.[cm]?[jt]sx?$/;
  * Matching only `Bearer` examples would let those advertise a retired prefix indefinitely while
  * one updated bearer example kept the population guard satisfied.
  *
- * Read ONLY in that declaring file, and the narrowness is the point. Nothing in the shape of a
+ * Read wherever the surrounding text is talking about a key, since nothing in the shape of a
  * token says it is a credential: run against the tree, this pattern reads
  * `idx_comp_<slug>_parent` in `api/field-groups.ts` as a key prefix, which is an index name.
- * The declaring file's comments are the canonical specification of the format, so a token there
- * shaped like a prefix and differing from the declared one is a stale spelling of it; the same
- * token anywhere else is a snake_case identifier that happens to precede a placeholder.
- * Everywhere else documents the HEADER, and `BEARER_EXAMPLE` covers that with no such ambiguity.
+ * The sentence is what separates them, so `KEY_VOCABULARY` gates every surface.
+ *
+ * The trailing placeholder is the other half of that narrowness. Requiring `<` or `...` is what
+ * keeps this to a STATED FORMAT rather than any snake_case token: measured across the tree,
+ * dropping it and matching concrete tokens instead reports `change_column_type`,
+ * `actor_user_id`, `single_pricings_pkey` and nineteen more like them, because a doc comment
+ * that says "primary key" or "key column" satisfies the vocabulary as readily as one about
+ * credentials. `CONCRETE_KEY_EXAMPLE` covers the concrete form where that is safe.
  */
 const KEY_FORMAT_EXAMPLE = /\b([a-z][a-z0-9]*(?:_[a-z0-9]+)+_)(?=<|\.\.\.)/g;
+
+/**
+ * A key written out in full rather than trailed off, as `"nx_live_abcdefgh"`.
+ *
+ * The file that declares the prefix shows one twice, as the display prefix a masked UI renders,
+ * and those are as able to go stale as any header example.
+ *
+ * Read in that file and nowhere else, and the measurement is the reason: this pattern applied
+ * across every key-talking context reports twenty-two database identifiers, `change_column_type`
+ * and `single_pricings_pkey` among them, against one real example, because "primary key" and
+ * "key column" are sentences about keys too. Inside the declaring file it reports that one
+ * example and nothing else, since every comment there is about this credential.
+ */
+const CONCRETE_KEY_EXAMPLE = /["'`]([a-z][a-z0-9]*(?:_[a-z0-9]+)+_[A-Za-z0-9]+)["'`]/g;
 
 /**
  * The prefix an example claims, which is its leading run of underscore-separated segments.
@@ -1009,10 +1027,11 @@ function partitionSource(text, keep) {
     }
     // A regex literal, which is the other thing that can hold a stray slash-star.
     //
-    // `/[/*]/` before a doc comment opened a comment at the character-class slash and ate
-    // through the JSDoc terminator. That direction was documented here as costing a refusal
-    // rather than a false pass, which was true only of reading the DECLARATION: on the
-    // extraction side the doc comment is silently dropped and the check reports clean.
+    // `/[/*]/` sitting before a doc comment must not open one at the character-class slash and
+    // eat through the JSDoc terminator. Which way that fails depends on what the caller wants:
+    // reading the DECLARATION it over-blanks and the check refuses, and reading the file as
+    // documentation it drops the doc comment and the check reports clean. The second is a
+    // silent pass, so the literal is consumed here rather than left to either.
     //
     // Comments are recognised first, exactly as a JavaScript lexer does, so `/*` and `//` never
     // reach here and only the ambiguity between division and a regex is left. The previous
@@ -1209,9 +1228,16 @@ function documentedKeyPrefix(repoRoot, tracked, packages, findings, isExempt) {
       : [...scanned.matchAll(DOC_COMMENT)];
     for (const context of contexts) {
       if (!KEY_VOCABULARY.test(context[0])) continue;
-      for (const match of context[0].matchAll(KEY_FORMAT_EXAMPLE)) {
-        const start = context.index + match.index;
-        if (!candidates.has(start)) candidates.set(start, match);
+      const patterns =
+        rel === KEY_PREFIX_SOURCE
+          ? [KEY_FORMAT_EXAMPLE, CONCRETE_KEY_EXAMPLE]
+          : [KEY_FORMAT_EXAMPLE];
+      for (const pattern of patterns) {
+        for (const match of context[0].matchAll(pattern)) {
+          // The capture, not the whole match: the concrete form takes its quotes with it.
+          const start = context.index + match.index + match[0].indexOf(match[1]);
+          if (!candidates.has(start)) candidates.set(start, match);
+        }
       }
     }
 

--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -901,9 +901,22 @@ function partitionSource(text, keep) {
       continue;
     }
     if (here === '"' || here === "'" || here === "`") {
+      // Only a template literal spans lines. A quoted string cannot hold a raw newline, so
+      // ending the scan at one is exact, and it is what stops an apostrophe in JSX text from
+      // opening a span that never closes: `<p>don't</p>` would otherwise run to the next
+      // apostrophe in the file and blank every doc comment in between, which is a bearer
+      // example this never judges while other files hold the examined count above zero.
+      //
+      // A backslash-newline continuation is still a string, and stays one: the escape branch
+      // consumes that newline before this test can see it.
+      const spansLines = here === "`";
       out += emit(here, "code");
       index += 1;
-      while (index < text.length && text[index] !== here) {
+      while (
+        index < text.length &&
+        text[index] !== here &&
+        (spansLines || text[index] !== "\n")
+      ) {
         if (text[index] === "\\") {
           out += emit(text[index], "code");
           index += 1;
@@ -916,7 +929,10 @@ function partitionSource(text, keep) {
         out += emit(text[index], "code");
         index += 1;
       }
-      if (index < text.length) {
+      // Consumes the closing delimiter. An unterminated string stopped at a newline instead,
+      // and that newline belongs to the file rather than to the string, so it is left for the
+      // outer loop and the line count stays right.
+      if (index < text.length && text[index] === here) {
         out += emit(text[index], "code");
         index += 1;
       }

--- a/scripts/check-docs-claims.test.mjs
+++ b/scripts/check-docs-claims.test.mjs
@@ -39,6 +39,19 @@ const pkg = (extra = {}) =>
 
 const REFS = new Set(["main", "feature/docs-refresh", "v1.2.3"]);
 
+/** The full findings, for the few assertions that are about more than the check name. */
+async function findingsFor(spec, opts = {}) {
+  const { root, files } = await fixture(spec);
+  const { findings } = await runChecks({
+    repoRoot: root,
+    files,
+    remoteRefs: REFS,
+    hasLocalCommit: () => true,
+    ...opts,
+  });
+  return findings;
+}
+
 async function checksFor(spec, opts = {}) {
   const { root, files } = await fixture(spec);
   const { findings } = await runChecks({
@@ -1335,16 +1348,42 @@ describe("documented-key-prefix", () => {
     ).not.toContain("key-prefix-undeclared");
   });
 
-  it("refuses when a second occurrence makes the value ambiguous", async () => {
-    // A comment showing the old format is the realistic way this happens, and it
-    // is exactly the case where guessing which one is live would be wrong.
-    const checks = await checksFor(
-      tree(
-        { "docs/guides/authentication.mdx": "Use `Authorization: Bearer nx_live_...`\n" },
-        '// Was KEY_PREFIX = "sk_" before the rename.\nconst KEY_PREFIX = "nx_live_";'
-      )
-    );
-    expect(checks).toContain("key-prefix-undeclared");
+  it("ignores a commented-out declaration left behind after a rename", async () => {
+    // The regex used to match the name anywhere. A stale
+    // `// const KEY_PREFIX = "nx_live_"` kept for context would then be the one
+    // declaration it found, and the docs would be held to a value the service
+    // no longer issues, reported clean.
+    expect(
+      await checksFor(
+        tree(
+          { "docs/guides/authentication.mdx": "Use Authorization: Bearer nx_live_EXAMPLE\n" },
+          '// const KEY_PREFIX = "nx_live_";\nconst API_KEY_PREFIX = "nx_v2_";',
+        ),
+      ),
+    ).toContain("key-prefix-undeclared");
+  });
+
+  it("refuses when two real declarations disagree", async () => {
+    expect(
+      await checksFor(
+        tree(
+          { "docs/guides/authentication.mdx": "Use Authorization: Bearer nx_live_EXAMPLE\n" },
+          'const KEY_PREFIX = "nx_live_";\nconst KEY_PREFIX = "sk_";',
+        ),
+      ),
+    ).toContain("key-prefix-undeclared");
+  });
+
+  it("accepts an exported declaration", async () => {
+    // Anchoring must not become so tight that the ordinary form stops matching.
+    expect(
+      await checksFor(
+        tree(
+          { "docs/guides/authentication.mdx": "Use Authorization: Bearer nx_live_EXAMPLE\n" },
+          'export const KEY_PREFIX = "nx_live_";',
+        ),
+      ),
+    ).not.toContain("key-prefix-undeclared");
   });
 
   it("refuses when the declaring file is not tracked at all", async () => {
@@ -1384,6 +1423,78 @@ describe("documented-key-prefix", () => {
         ),
       ).toContain("documented-key-prefix");
     }
+  });
+
+  it("covers prose outside docs/, such as ARCHITECTURE.md", async () => {
+    // The first scope named one directory. ARCHITECTURE.md publishes a bearer
+    // example too, and was unguarded.
+    expect(
+      await checksFor(
+        tree({ "ARCHITECTURE.md": "API keys: Authorization: Bearer sk_live_EXAMPLE\n" }),
+      ),
+    ).toContain("documented-key-prefix");
+  });
+
+  it("finds an example wrapped after the scheme", async () => {
+    // Markdown renders the break as whitespace, so this is one example to a
+    // reader. Matching line by line saw two halves and judged neither.
+    expect(
+      await checksFor(
+        tree({
+          "docs/guides/authentication.mdx": "Send Authorization: Bearer\nsk_wrapped_EXAMPLE now\n",
+        }),
+      ),
+    ).toContain("documented-key-prefix");
+  });
+
+  it("ignores a wrong prefix nobody can see", async () => {
+    // An HTML or MDX comment is not published. Reporting it blocks a merge over
+    // text that reaches no reader and no generated file.
+    for (const comment of [
+      "<!-- Old: Authorization: Bearer sk_dead_EXAMPLE -->",
+      "{/* Old: Authorization: Bearer sk_dead_EXAMPLE */}",
+    ]) {
+      const checks = await checksFor(
+        tree({
+          "docs/guides/authentication.mdx":
+            comment + "\nUse Authorization: Bearer nx_live_EXAMPLE\n",
+        }),
+      );
+      expect(checks).not.toContain("documented-key-prefix");
+      expect(checks).not.toContain("key-prefix-unexamined");
+    }
+  });
+
+  it("reports the real line number even after a comment above it", async () => {
+    // Comments are blanked rather than removed, so offsets still name the line
+    // a reader would open.
+    const findings = await findingsFor(
+      tree({
+        "docs/guides/authentication.mdx":
+          "<!-- a\nmultiline\ncomment -->\nUse Authorization: Bearer sk_EXAMPLE\n",
+      }),
+    );
+    const hit = findings.find(f => f.check === "documented-key-prefix");
+    expect(hit.line).toBe(4);
+  });
+
+  it("refuses when the only remaining example is exempted", async () => {
+    // The population must count what was JUDGED. Counting before the exemption
+    // meant a tree whose last example was allowlisted reported neither a
+    // finding nor a refusal, having checked no Nextly key at all.
+    const line = "Use Authorization: Bearer partner_EXAMPLE";
+    expect(
+      await checksFor(
+        tree({ "docs/guides/integrations.mdx": line + "\n" }),
+        {
+          allowlist: {
+            "documented-key-prefix": {
+              "docs/guides/integrations.mdx": { count: 1, digests: [digestLine(line)] },
+            },
+          },
+        },
+      ),
+    ).toContain("key-prefix-unexamined");
   });
 
   it("refuses when it examined no example at all", async () => {

--- a/scripts/check-docs-claims.test.mjs
+++ b/scripts/check-docs-claims.test.mjs
@@ -1266,6 +1266,152 @@ describe("namesRetiredCategory", () => {
   });
 });
 
+describe("documented-key-prefix", () => {
+  const SOURCE = "packages/nextly/src/domains/auth/services/api-key-service.ts";
+  const tree = (docs, declaration = 'const KEY_PREFIX = "nx_live_";') => ({
+    "README.md": "# nextly\n\n@nextlyhq/thing\n",
+    [SOURCE]: `${declaration}\nexport function make() { return KEY_PREFIX; }\n`,
+    ...docs,
+  });
+
+  it("fires on a bearer example using another vendor's prefix", async () => {
+    // The real defect: four examples said `sk_`, which is Stripe's.
+    expect(
+      await checksFor(tree({ "docs/guides/authentication.mdx": "Use `Authorization: Bearer sk_...`\n" }))
+    ).toContain("documented-key-prefix");
+  });
+
+  it("accepts the prefix the source declares", async () => {
+    expect(
+      await checksFor(tree({ "docs/guides/authentication.mdx": "Use `Authorization: Bearer nx_live_...`\n" }))
+    ).not.toContain("documented-key-prefix");
+  });
+
+  it("reads the prefix from source rather than assuming it", async () => {
+    // Change the declaration and the same docs page becomes wrong. Without this
+    // the check could be passing on a hardcoded copy of the prefix.
+    expect(
+      await checksFor(
+        tree(
+          { "docs/guides/authentication.mdx": "Use `Authorization: Bearer nx_live_...`\n" },
+          'const KEY_PREFIX = "nx_prod_";'
+        )
+      )
+    ).toContain("documented-key-prefix");
+  });
+
+  it("leaves placeholders alone", async () => {
+    // `Bearer <key>` is something a reader substitutes, not a format claim.
+    expect(
+      await checksFor(
+        tree({ "docs/api-reference/rest-api.mdx": "Send `Authorization: Bearer <key>` or `Bearer <token>`.\n" })
+      )
+    ).not.toContain("documented-key-prefix");
+  });
+
+  it("refuses when the declaration cannot be found, rather than passing", async () => {
+    // Renaming or moving the constant must not silently leave the docs unchecked.
+    const checks = await checksFor(
+      tree(
+        { "docs/guides/authentication.mdx": "Use `Authorization: Bearer sk_...`\n" },
+        'const SOMETHING_ELSE = "nx_live_";'
+      )
+    );
+    expect(checks).toContain("key-prefix-undeclared");
+    expect(checks).not.toContain("documented-key-prefix");
+  });
+
+  it("is not fooled by a longer name that ends in the same word", async () => {
+    // `OTHER_KEY_PREFIX` is a different constant. The word boundary is what keeps
+    // it out, and without this test a looser pattern would read it as a second
+    // declaration and refuse on a perfectly good file.
+    expect(
+      await checksFor(
+        tree(
+          { "docs/guides/authentication.mdx": "Use `Authorization: Bearer nx_live_...`\n" },
+          'const OTHER_KEY_PREFIX = "sk_";\nconst KEY_PREFIX = "nx_live_";'
+        )
+      )
+    ).not.toContain("key-prefix-undeclared");
+  });
+
+  it("refuses when a second occurrence makes the value ambiguous", async () => {
+    // A comment showing the old format is the realistic way this happens, and it
+    // is exactly the case where guessing which one is live would be wrong.
+    const checks = await checksFor(
+      tree(
+        { "docs/guides/authentication.mdx": "Use `Authorization: Bearer nx_live_...`\n" },
+        '// Was KEY_PREFIX = "sk_" before the rename.\nconst KEY_PREFIX = "nx_live_";'
+      )
+    );
+    expect(checks).toContain("key-prefix-undeclared");
+  });
+
+  it("refuses when the declaring file is not tracked at all", async () => {
+    expect(
+      await checksFor({
+        "README.md": "# nextly\n\n@nextlyhq/thing\n",
+        "docs/guides/authentication.mdx": "Use `Authorization: Bearer sk_...`\n",
+      })
+    ).toContain("key-prefix-source-missing");
+  });
+
+  it("reports another service's token unless a line is exempted", async () => {
+    // Ownership cannot be read off a credential. An earlier version skipped any
+    // recognised vendor prefix, which meant a Stripe-shaped token in the Nextly
+    // auth guide was silently treated as a Stripe example rather than a
+    // regression, while other pages kept the examined count above zero.
+    expect(
+      await checksFor(
+        tree({
+          "docs/guides/authentication.mdx":
+            "Use Authorization: Bearer sk_test_EXAMPLE\n",
+        }),
+      ),
+    ).toContain("documented-key-prefix");
+  });
+
+  it("matches the scheme whatever its casing", async () => {
+    // A lowercase scheme reached no comparison at all, and other pages kept the
+    // examined count above zero, so CI stayed green on a wrong prefix.
+    for (const scheme of ["bearer", "BEARER", "BeArEr"]) {
+      expect(
+        await checksFor(
+          tree({
+            "docs/guides/authentication.mdx":
+              "Use Authorization: " + scheme + " sk_EXAMPLE\n",
+          }),
+        ),
+      ).toContain("documented-key-prefix");
+    }
+  });
+
+  it("refuses when it examined no example at all", async () => {
+    // The population assertion. Without it a docs tree that moved, was renamed,
+    // or stopped using this syntax leaves the loop with nothing to judge and the
+    // check reports clean having looked at nothing.
+    expect(await checksFor(tree({}))).toContain("key-prefix-unexamined");
+  });
+
+  it("does not refuse once a real example is present", async () => {
+    expect(
+      await checksFor(tree({ "docs/guides/authentication.mdx": "Use `Authorization: Bearer nx_live_...`\n" }))
+    ).not.toContain("key-prefix-unexamined");
+  });
+
+  it("only reads docs, not every tracked file", async () => {
+    // A changelog or a test fixture quoting an old key is not a documentation claim.
+    expect(
+      await checksFor(
+        tree({
+          "CHANGELOG.md": "fixed `Authorization: Bearer sk_...` handling\n",
+          "docs/guides/authentication.mdx": "Use `Authorization: Bearer nx_live_...`\n",
+        })
+      )
+    ).not.toContain("documented-key-prefix");
+  });
+});
+
 describe("packageKeywords", () => {
   it("reads both manifest shapes as the same list", () => {
     expect(packageKeywords({ keywords: ["cms", "framework"] })).toEqual(["cms", "framework"]);

--- a/scripts/check-docs-claims.test.mjs
+++ b/scripts/check-docs-claims.test.mjs
@@ -1425,6 +1425,22 @@ describe("documented-key-prefix", () => {
     }
   });
 
+  it("reports a credential whose case does not match what is issued", async () => {
+    // The scheme is case-insensitive and the credential is not, and conflating
+    // them would excuse a real defect. A key is authenticated by sha256 of the
+    // whole string, so NX_LIVE_ hashes to something else and can never match a
+    // stored key. Documentation showing it teaches a header that cannot work.
+    for (const token of ["NX_LIVE_EXAMPLE", "Nx_Live_EXAMPLE"]) {
+      expect(
+        await checksFor(
+          tree({
+            "docs/guides/authentication.mdx": "Use Authorization: Bearer " + token + "\n",
+          }),
+        ),
+      ).toContain("documented-key-prefix");
+    }
+  });
+
   it("covers prose outside docs/, such as ARCHITECTURE.md", async () => {
     // The first scope named one directory. ARCHITECTURE.md publishes a bearer
     // example too, and was unguarded.

--- a/scripts/check-docs-claims.test.mjs
+++ b/scripts/check-docs-claims.test.mjs
@@ -1743,6 +1743,70 @@ describe("documented-key-prefix", () => {
     ).not.toContain("documented-key-prefix");
   });
 
+  it("judges the prefix quoted on its own, with nothing after it", async () => {
+    // The declaring file explains what the prefix is for and names it bare. Nothing trails it,
+    // so the placeholder form never saw it, and it goes stale like any other statement.
+    expect(
+      await checksFor(
+        tree(
+          { "docs/guides/authentication.mdx": "Use Authorization: Bearer nx_live_EXAMPLE\n" },
+          '/** Keys carry the `sk_live_` prefix for identification in logs. */\nconst KEY_PREFIX = "nx_live_";',
+        ),
+      ),
+    ).toContain("documented-key-prefix");
+  });
+
+  it("judges an alphabetic credential when the header is spelled out", async () => {
+    // `Authorization: Bearer abcdef` is a line a reader copies and it cannot authenticate,
+    // whatever its shape. Naming the header is what separates it from prose about the scheme,
+    // so no guess from punctuation is needed.
+    expect(
+      await checksFor(
+        tree({
+          "docs/guides/authentication.mdx": "Send `Authorization: Bearer abcdef` with each call.\n",
+        }),
+      ),
+    ).toContain("documented-key-prefix");
+  });
+
+  it("still leaves prose about the scheme alone", async () => {
+    // The other side of that, or naming the header would read as "report every word".
+    const checks = await checksFor(
+      tree({
+        "docs/guides/authentication.mdx":
+          "Send a Bearer token. A Bearer header was present.\nUse Authorization: Bearer nx_live_EXAMPLE\n",
+      }),
+    );
+    expect(checks).not.toContain("documented-key-prefix");
+  });
+
+  it("reads a heading as the introduction to the fence below it", async () => {
+    // A fence holds no blank line, so it is a paragraph of its own, and the heading that
+    // announces what it contains is a different one. Judged alone the fence says nothing about
+    // keys and the stale format inside it goes unexamined.
+    expect(
+      await checksFor(
+        tree({
+          "docs/guides/authentication.mdx":
+            "## API key format\n\n```\nsk_live_<random>...\n```\n",
+        }),
+      ),
+    ).toContain("documented-key-prefix");
+  });
+
+  it("does not carry that introduction further than one block", async () => {
+    // The window is the block before, not the whole page: a page that mentions keys once
+    // would otherwise put every fenced identifier in it under suspicion.
+    expect(
+      await checksFor(
+        tree({
+          "docs/guides/authentication.mdx":
+            "Use Authorization: Bearer nx_live_EXAMPLE\n\nSome unrelated prose here.\n\n```\nidx_comp_<slug>_parent\n```\n",
+        }),
+      ),
+    ).not.toContain("documented-key-prefix");
+  });
+
   it("does not read a database identifier elsewhere as a concrete key", async () => {
     // The reason the concrete form is confined to the declaring file. A comment saying
     // "primary key" satisfies the vocabulary as readily as one about credentials, and across

--- a/scripts/check-docs-claims.test.mjs
+++ b/scripts/check-docs-claims.test.mjs
@@ -143,6 +143,50 @@ describe("forbidden-status-phrase", () => {
     expect(findings.map(f => f.check)).not.toContain("forbidden-status-phrase");
   });
 
+  it("spends the exemption, so a second copy of the line is still reported", async () => {
+    // `count` is the budget, not a label. One entry excusing every duplicate of its line
+    // means a second copy can be added anywhere in the same file and inherit permission
+    // granted to the first.
+    const exempt = "returns a coming soon placeholder";
+    const { root, files } = await fixture({ "docs/a.mdx": `${exempt}\n${exempt}\n` });
+    const { findings } = await runChecks({
+      repoRoot: root,
+      files,
+      remoteRefs: REFS,
+      hasLocalCommit: () => true,
+      allowlist: {
+        "forbidden-status-phrase": {
+          "docs/a.mdx": { count: 1, digests: [digestLine(exempt)] },
+        },
+      },
+    });
+    const phrase = findings.filter(f => f.check === "forbidden-status-phrase");
+    expect(phrase).toHaveLength(1);
+    expect(phrase[0].line).toBe(2);
+    // Said once, naming the budget, rather than repeated beside every surplus occurrence.
+    expect(findings.filter(f => f.check === "allowlist-count-exceeded")).toHaveLength(1);
+  });
+
+  it("excuses as many occurrences as the count declares", async () => {
+    // The positive control for the budget. Without it a helper that spent every exemption
+    // immediately would pass the test above just as well.
+    const exempt = "returns a coming soon placeholder";
+    const { root, files } = await fixture({ "docs/a.mdx": `${exempt}\n${exempt}\n` });
+    const { findings } = await runChecks({
+      repoRoot: root,
+      files,
+      remoteRefs: REFS,
+      hasLocalCommit: () => true,
+      allowlist: {
+        "forbidden-status-phrase": {
+          "docs/a.mdx": { count: 2, digests: [digestLine(exempt)] },
+        },
+      },
+    });
+    expect(findings.map(f => f.check)).not.toContain("forbidden-status-phrase");
+    expect(findings.map(f => f.check)).not.toContain("allowlist-count-exceeded");
+  });
+
   it("still fires on a DIFFERENT claim in the same allowlisted file", async () => {
     const exempt = "returns a coming soon placeholder";
     const { root, files } = await fixture({
@@ -1601,6 +1645,90 @@ describe("documented-key-prefix", () => {
         tree({ "docs/guides/authentication.mdx": "Use Authorization: Bearer NX_LIVE_KEY\n" }),
       ),
     ).toContain("documented-key-prefix");
+  });
+
+  it("reads a TypeScript file by its comments, not by its code", async () => {
+    // What a reader is shown of a `.ts` file is its JSDoc. An email provider that builds
+    // `Authorization: "Bearer vendor_key"` at runtime is doing its job, not documenting a
+    // Nextly key, and judging it would block an always-run job over a correct integration.
+    const checks = await checksFor(
+      tree({
+        "docs/guides/authentication.mdx": "Use Authorization: Bearer nx_live_EXAMPLE\n",
+        "packages/nextly/src/domains/email/provider.ts":
+          'const headers = { Authorization: "Bearer vendor_key_LIVE" };\n',
+      }),
+    );
+    expect(checks).not.toContain("documented-key-prefix");
+  });
+
+  it("does not join a bearer at a paragraph end to the next paragraph", async () => {
+    // A single line break renders as a space, so a wrapped example is one example. A blank
+    // line is a boundary, and reading across it invents a header nobody wrote.
+    expect(
+      await checksFor(
+        tree({
+          "docs/guides/authentication.mdx":
+            "Supported scheme: Bearer\n\nsk_test_EXAMPLE is Stripe's test key\n" +
+            "and here is ours: Authorization: Bearer nx_live_EXAMPLE\n",
+        }),
+      ),
+    ).not.toContain("documented-key-prefix");
+  });
+
+  it("judges comment syntax a fence makes visible", async () => {
+    // Inside a fenced sample the braces and slashes are printed verbatim, so this is an
+    // example a reader copies. Blanking it hides a wrong prefix while every other example
+    // keeps the population above zero.
+    expect(
+      await checksFor(
+        tree({
+          "docs/guides/authentication.mdx":
+            "```tsx\n{/* Authorization: Bearer sk_live_EXAMPLE */}\n```\n",
+        }),
+      ),
+    ).toContain("documented-key-prefix");
+  });
+
+  it("still ignores a comment the reader never sees", async () => {
+    // The other side of the same rule, outside any fence. Without this the fence change
+    // would read as "blank nothing" and pass just as well.
+    expect(
+      await checksFor(
+        tree({
+          "docs/guides/authentication.mdx":
+            "<!-- Authorization: Bearer sk_live_EXAMPLE -->\nUse Authorization: Bearer nx_live_EXAMPLE\n",
+        }),
+      ),
+    ).not.toContain("documented-key-prefix");
+  });
+
+  it("checks a key format documented without the scheme, where it is declared", async () => {
+    // The declaring file states the format three times and none of them carry `Bearer`. A
+    // scheme-only scan lets those advertise a retired prefix while one updated bearer
+    // example keeps the population guard satisfied.
+    expect(
+      await checksFor(
+        tree(
+          { "docs/guides/authentication.mdx": "Use Authorization: Bearer nx_live_EXAMPLE\n" },
+          '/** Key format: `nx_old_<base64url-32-bytes>` */\nconst KEY_PREFIX = "nx_live_";',
+        ),
+      ),
+    ).toContain("documented-key-prefix");
+  });
+
+  it("does not read a snake_case identifier elsewhere as a key format", async () => {
+    // `idx_comp_<slug>_parent` is an index name, and nothing in the shape of a token says it
+    // is a credential. Outside the declaring file only the header form is read, which
+    // carries no such ambiguity.
+    expect(
+      await checksFor(
+        tree({
+          "docs/guides/authentication.mdx": "Use Authorization: Bearer nx_live_EXAMPLE\n",
+          "packages/nextly/src/api/field-groups.ts":
+            "/** The index is named `idx_comp_<slug>_parent`. */\nexport const x = 1;\n",
+        }),
+      ),
+    ).not.toContain("documented-key-prefix");
   });
 
   it("checks bearer examples published in TypeScript documentation", async () => {

--- a/scripts/check-docs-claims.test.mjs
+++ b/scripts/check-docs-claims.test.mjs
@@ -1773,6 +1773,42 @@ describe("documented-key-prefix", () => {
     ).not.toContain("documented-key-prefix");
   });
 
+  it("is not derailed by an apostrophe in JSX text", async () => {
+    // An apostrophe is not a string delimiter here, and a quoted string cannot hold a raw
+    // newline, so the scan ends at the line. Running on would blank every doc comment until
+    // the next apostrophe in the file, and the bearer examples in them would never be judged
+    // while other files held the examined count above zero. Thirty files in this repository
+    // open such a span, the longest running 195 lines.
+    expect(
+      await checksFor(
+        tree({
+          "packages/nextly/src/admin/Panel.tsx":
+            "export const P = () => <p>don't</p>;\n" +
+            "/** Authenticate with `Authorization: Bearer sk_live_EXAMPLE`. */\n" +
+            "export const Q = () => <p>won't</p>;\n",
+        }),
+      ),
+    ).toContain("documented-key-prefix");
+  });
+
+  it("still reads a template literal across lines", async () => {
+    // The exception the rule needs, asserted on content INSIDE the literal, which is the
+    // only place the difference shows. A codegen module holding a sample is all code, so
+    // nothing in it is documentation this site publishes. Ending the literal at the first
+    // newline turns the rest of the sample back into ordinary source, and the comment in it
+    // is then read as a claim the package makes about its own keys.
+    const backtick = String.fromCharCode(96);
+    expect(
+      await checksFor(
+        tree({
+          "docs/guides/authentication.mdx": "Use Authorization: Bearer nx_live_EXAMPLE\n",
+          "packages/nextly/src/cli/templates.ts":
+            `const sample = ${backtick}\n/** Authorization: Bearer sk_live_EXAMPLE */\n${backtick};\n`,
+        }),
+      ),
+    ).not.toContain("documented-key-prefix");
+  });
+
   it("judges a doc comment, which is the form that gets published", async () => {
     // The other side of the same rule. Without it, restricting the scan to
     // JSDoc would read as "scan nothing" and pass just as well.

--- a/scripts/check-docs-claims.test.mjs
+++ b/scripts/check-docs-claims.test.mjs
@@ -1716,6 +1716,49 @@ describe("documented-key-prefix", () => {
     ).toContain("documented-key-prefix");
   });
 
+  it("judges a key written out in full where it is declared", async () => {
+    // The declaring file shows the display prefix a masked UI renders, `"nx_live_abcdefgh"`,
+    // which trails off nowhere and so is invisible to the placeholder form. It goes stale
+    // exactly as a header example does.
+    expect(
+      await checksFor(
+        tree(
+          { "docs/guides/authentication.mdx": "Use Authorization: Bearer nx_live_EXAMPLE\n" },
+          '/** Display prefix: first 16 chars ("sk_live_abcdefgh") for the masked key. */\nconst KEY_PREFIX = "nx_live_";',
+        ),
+      ),
+    ).toContain("documented-key-prefix");
+  });
+
+  it("accepts the concrete example when it matches what is issued", async () => {
+    // The positive control. Without it a rule reporting every concrete token would pass the
+    // case above just as well.
+    expect(
+      await checksFor(
+        tree(
+          { "docs/guides/authentication.mdx": "Use Authorization: Bearer nx_live_EXAMPLE\n" },
+          '/** Display prefix: first 16 chars ("nx_live_abcdefgh") for the masked key. */\nconst KEY_PREFIX = "nx_live_";',
+        ),
+      ),
+    ).not.toContain("documented-key-prefix");
+  });
+
+  it("does not read a database identifier elsewhere as a concrete key", async () => {
+    // The reason the concrete form is confined to the declaring file. A comment saying
+    // "primary key" satisfies the vocabulary as readily as one about credentials, and across
+    // the tree that shape reports twenty-two column, table and index names against one real
+    // example.
+    expect(
+      await checksFor(
+        tree({
+          "docs/guides/authentication.mdx": "Use Authorization: Bearer nx_live_EXAMPLE\n",
+          "packages/nextly/src/schema/columns.ts":
+            '/** The primary key column is named `"single_pricings_pkey"` by the dialect. */\nexport const x = 1;\n',
+        }),
+      ),
+    ).not.toContain("documented-key-prefix");
+  });
+
   it("does not read a snake_case identifier elsewhere as a key format", async () => {
     // `idx_comp_<slug>_parent` is an index name, and nothing in the shape of a token says it
     // is a credential. Outside the declaring file only the header form is read, which

--- a/scripts/check-docs-claims.test.mjs
+++ b/scripts/check-docs-claims.test.mjs
@@ -1923,6 +1923,89 @@ describe("documented-key-prefix", () => {
     ).not.toContain("documented-key-prefix");
   });
 
+  it("keeps a doc comment that follows a regex literal", async () => {
+    // `/[/*]/` holds a slash-star, and reading it as a comment ate through the doc comment
+    // below it. That drops a published example and the check then reports clean, so this
+    // direction is a false pass rather than the refusal the declaration read would give.
+    expect(
+      await checksFor(
+        tree({
+          "packages/nextly/src/api/parse.ts":
+            "const SLASHES = /[/*]/;\n" +
+            "/** Authenticate with `Authorization: Bearer sk_live_EXAMPLE`. */\n" +
+            "export const P = SLASHES;\n",
+        }),
+      ),
+    ).toContain("documented-key-prefix");
+  });
+
+  it("still reads a division sign as division", async () => {
+    // The other side. Treating `a / b` as a regex start would run to the next slash and
+    // swallow whatever is between, so the previous token has to decide.
+    expect(
+      await checksFor(
+        tree({
+          "packages/nextly/src/api/rate.ts":
+            "const half = total / 2;\n" +
+            "/** Authenticate with `Authorization: Bearer sk_live_EXAMPLE`. */\n" +
+            "export const R = half;\n",
+        }),
+      ),
+    ).toContain("documented-key-prefix");
+  });
+
+  it("does not excuse a retired prefix spelled in capitals", async () => {
+    // Reading every uppercase token as a placeholder waves through any prefix that is no
+    // longer issued, and the docs then teach a header that cannot authenticate.
+    expect(
+      await checksFor(
+        tree({
+          "docs/guides/authentication.mdx": "Use Authorization: Bearer SK_LIVE_EXAMPLE\n",
+        }),
+      ),
+    ).toContain("documented-key-prefix");
+  });
+
+  it("does not judge a changeset quoting the claim it corrects", async () => {
+    // A changeset says what is being fixed, so it repeats the wrong example by design. The
+    // per-line checks already skip them for this reason.
+    expect(
+      await checksFor(
+        tree({
+          "docs/guides/authentication.mdx": "Use Authorization: Bearer nx_live_EXAMPLE\n",
+          ".changeset/brave-otters-shout.md":
+            "---\n'@nextlyhq/thing': patch\n---\n\nReplace `Authorization: Bearer sk_old_EXAMPLE` in the auth guide.\n",
+        }),
+      ),
+    ).not.toContain("documented-key-prefix");
+  });
+
+  it("does not read an index name in Markdown as a key format", async () => {
+    // The context test applies to both surfaces. A page explaining a generated index name is
+    // not documenting a credential, and only the surrounding sentence can say so.
+    expect(
+      await checksFor(
+        tree({
+          "docs/guides/authentication.mdx": "Use Authorization: Bearer nx_live_EXAMPLE\n",
+          "docs/reference/field-groups.mdx":
+            "## Index names\n\nThe generated index is `idx_comp_<slug>_parent`, which bounds the slug length.\n",
+        }),
+      ),
+    ).not.toContain("documented-key-prefix");
+  });
+
+  it("still judges a bare key format in Markdown that talks about keys", async () => {
+    // The positive control for that gate, or it would read as "never scan Markdown".
+    expect(
+      await checksFor(
+        tree({
+          "docs/guides/authentication.mdx":
+            "## Key format\n\nEvery API key looks like `sk_live_<random>...` when issued.\n",
+        }),
+      ),
+    ).toContain("documented-key-prefix");
+  });
+
   it("judges a doc comment, which is the form that gets published", async () => {
     // The other side of the same rule. Without it, restricting the scan to
     // JSDoc would read as "scan nothing" and pass just as well.

--- a/scripts/check-docs-claims.test.mjs
+++ b/scripts/check-docs-claims.test.mjs
@@ -1746,6 +1746,46 @@ describe("documented-key-prefix", () => {
     ).toContain("documented-key-prefix");
   });
 
+  it("does not judge a note to whoever maintains the code", async () => {
+    // A line comment is not published. An integration explaining which header a
+    // vendor wants is documenting that vendor, and an always-run job cannot
+    // block a correct one over it.
+    expect(
+      await checksFor(
+        tree({
+          "docs/guides/authentication.mdx": "Use Authorization: Bearer nx_live_EXAMPLE\n",
+          "packages/nextly/src/domains/email/provider.ts":
+            "// The vendor requires Authorization: Bearer vendor_key_LIVE\nexport const x = 1;\n",
+        }),
+      ),
+    ).not.toContain("documented-key-prefix");
+  });
+
+  it("does not judge an ordinary block comment either", async () => {
+    expect(
+      await checksFor(
+        tree({
+          "docs/guides/authentication.mdx": "Use Authorization: Bearer nx_live_EXAMPLE\n",
+          "packages/nextly/src/domains/email/provider.ts":
+            "/* Vendor wants Authorization: Bearer vendor_key_LIVE */\nexport const x = 1;\n",
+        }),
+      ),
+    ).not.toContain("documented-key-prefix");
+  });
+
+  it("judges a doc comment, which is the form that gets published", async () => {
+    // The other side of the same rule. Without it, restricting the scan to
+    // JSDoc would read as "scan nothing" and pass just as well.
+    expect(
+      await checksFor(
+        tree({
+          "packages/nextly/src/shared/types/config.ts":
+            "/** Authenticate with `Authorization: Bearer sk_live_EXAMPLE`. */\nexport type C = {};\n",
+        }),
+      ),
+    ).toContain("documented-key-prefix");
+  });
+
   it("does not judge bearer headers in tests, which belong to other services", async () => {
     // Fixtures authenticate against Resend, Stripe and stub receivers. Holding
     // those to the Nextly prefix reports a defect that is not one, and a job

--- a/scripts/check-docs-claims.test.mjs
+++ b/scripts/check-docs-claims.test.mjs
@@ -1288,7 +1288,8 @@ describe("documented-key-prefix", () => {
   });
 
   it("fires on a bearer example using another vendor's prefix", async () => {
-    // The real defect: four examples said `sk_`, which is Stripe's.
+    // `sk_` is Stripe's prefix, so a Nextly page documenting it sends a reader
+    // a header that cannot authenticate against this service.
     expect(
       await checksFor(tree({ "docs/guides/authentication.mdx": "Use `Authorization: Bearer sk_...`\n" }))
     ).toContain("documented-key-prefix");
@@ -1349,10 +1350,11 @@ describe("documented-key-prefix", () => {
   });
 
   it("ignores a commented-out declaration left behind after a rename", async () => {
-    // The regex used to match the name anywhere. A stale
-    // `// const KEY_PREFIX = "nx_live_"` kept for context would then be the one
-    // declaration it found, and the docs would be held to a value the service
-    // no longer issues, reported clean.
+    // A stale `// const KEY_PREFIX = "nx_live_"` kept for context is not a
+    // declaration, and counting it as one is how the docs get held to a value
+    // the service no longer issues while the check reports clean. The live
+    // constant here has a different name, so the commented line is the only
+    // text matching the old one.
     expect(
       await checksFor(
         tree(
@@ -1396,10 +1398,11 @@ describe("documented-key-prefix", () => {
   });
 
   it("reports another service's token unless a line is exempted", async () => {
-    // Ownership cannot be read off a credential. An earlier version skipped any
-    // recognised vendor prefix, which meant a Stripe-shaped token in the Nextly
-    // auth guide was silently treated as a Stripe example rather than a
-    // regression, while other pages kept the examined count above zero.
+    // Ownership cannot be read off a credential. A Stripe-shaped token in the
+    // Nextly auth guide is a regression, not a Stripe example, so the shape of
+    // the token decides nothing and only an exempted line is excused. The tree
+    // holds other valid examples, so the examined count stays above zero and
+    // the finding is what distinguishes this from a clean pass.
     expect(
       await checksFor(
         tree({
@@ -1411,8 +1414,10 @@ describe("documented-key-prefix", () => {
   });
 
   it("matches the scheme whatever its casing", async () => {
-    // A lowercase scheme reached no comparison at all, and other pages kept the
-    // examined count above zero, so CI stayed green on a wrong prefix.
+    // RFC 7235 makes the scheme case-insensitive, so `bearer` names the same
+    // header as `Bearer` and its credential is compared like any other. A
+    // scheme that reached no comparison would leave a wrong prefix unreported
+    // while the rest of the tree kept the examined count above zero.
     for (const scheme of ["bearer", "BEARER", "BeArEr"]) {
       expect(
         await checksFor(
@@ -1442,8 +1447,9 @@ describe("documented-key-prefix", () => {
   });
 
   it("covers prose outside docs/, such as ARCHITECTURE.md", async () => {
-    // The first scope named one directory. ARCHITECTURE.md publishes a bearer
-    // example too, and was unguarded.
+    // The scope is every prose surface rather than one directory.
+    // ARCHITECTURE.md publishes a bearer example too, and a scope named after
+    // `docs/` would leave it unguarded.
     expect(
       await checksFor(
         tree({ "ARCHITECTURE.md": "API keys: Authorization: Bearer sk_live_EXAMPLE\n" }),
@@ -1453,7 +1459,8 @@ describe("documented-key-prefix", () => {
 
   it("finds an example wrapped after the scheme", async () => {
     // Markdown renders the break as whitespace, so this is one example to a
-    // reader. Matching line by line saw two halves and judged neither.
+    // reader. A line-by-line match sees two halves and judges neither, and the
+    // wrong prefix goes out in a page that reads exactly like the correct one.
     expect(
       await checksFor(
         tree({
@@ -1495,22 +1502,136 @@ describe("documented-key-prefix", () => {
   });
 
   it("refuses when the only remaining example is exempted", async () => {
-    // The population must count what was JUDGED. Counting before the exemption
-    // meant a tree whose last example was allowlisted reported neither a
-    // finding nor a refusal, having checked no Nextly key at all.
-    const line = "Use Authorization: Bearer partner_EXAMPLE";
+    // The population must count what was JUDGED. A tree whose last example is
+    // allowlisted has checked no Nextly key at all, so it owes a refusal rather
+    // than the silence of a finding it did not look for.
+    const example = "Bearer partner_EXAMPLE";
     expect(
       await checksFor(
-        tree({ "docs/guides/integrations.mdx": line + "\n" }),
+        tree({ "docs/guides/integrations.mdx": `Use Authorization: ${example}\n` }),
         {
           allowlist: {
             "documented-key-prefix": {
-              "docs/guides/integrations.mdx": { count: 1, digests: [digestLine(line)] },
+              "docs/guides/integrations.mdx": { count: 1, digests: [digestLine(example)] },
             },
           },
         },
       ),
     ).toContain("key-prefix-unexamined");
+  });
+
+  it("does not let a wrapped exemption cover a credential it never saw", async () => {
+    // The exemption is digested from the whole example, not from the line the
+    // match starts on. A third-party example that wraps after `Bearer` puts its
+    // credential on the next line, so a line digest would name the scheme and
+    // leave the credential free to change underneath it: swapping in a wrong
+    // Nextly prefix would inherit the exemption while other pages held the
+    // examined count above zero and CI stayed green.
+    const wrapped = "Bearer\npartner_EXAMPLE";
+    const allowlist = {
+      "documented-key-prefix": {
+        "docs/guides/integrations.mdx": { count: 1, digests: [digestLine(wrapped)] },
+      },
+    };
+    // The example the allowlist was written for is excused.
+    expect(
+      await checksFor(
+        tree({ "docs/guides/integrations.mdx": `Use Authorization: ${wrapped}\n` }),
+        { allowlist },
+      ),
+    ).not.toContain("documented-key-prefix");
+    // The same first line with a different credential is not.
+    expect(
+      await checksFor(
+        tree({ "docs/guides/integrations.mdx": "Use Authorization: Bearer\nsk_EXAMPLE\n" }),
+        { allowlist },
+      ),
+    ).toContain("documented-key-prefix");
+  });
+
+  it("ignores a declaration inside a block comment", async () => {
+    // The anchor stops a `//`-commented copy standing in for the real thing,
+    // and a block comment does not indent what it contains, so a stale
+    // `const KEY_PREFIX` on its own line inside one matches the same anchor.
+    // Where issuance has moved to a differently named constant, that stale copy
+    // is the only match, and the docs are then held to a value nothing issues.
+    expect(
+      await checksFor(
+        tree(
+          { "docs/guides/authentication.mdx": "Use Authorization: Bearer nx_live_EXAMPLE\n" },
+          '/*\nconst KEY_PREFIX = "nx_live_";\n*/\nconst API_KEY_PREFIX = "nx_v2_";',
+        ),
+      ),
+    ).toContain("key-prefix-undeclared");
+  });
+
+  it("keeps a declaration whose line holds a string containing a slash pair", async () => {
+    // Blanking comments must track string literals: a `//` inside one begins no
+    // comment, and blanking from it would swallow the rest of the line and the
+    // declaration with it.
+    expect(
+      await checksFor(
+        tree(
+          { "docs/guides/authentication.mdx": "Use Authorization: Bearer nx_live_EXAMPLE\n" },
+          'const DOCS = "https://nextlyhq.com";\nconst KEY_PREFIX = "nx_live_";',
+        ),
+      ),
+    ).not.toContain("key-prefix-undeclared");
+  });
+
+  it("leaves a symbolic placeholder alone", async () => {
+    // `YOUR_API_KEY` instructs a reader to substitute something; it is not a
+    // claim about the format. Reporting it would have the always-run docs job
+    // block a correct page. Nothing was judged here, so the refusal is what is
+    // owed instead.
+    const checks = await checksFor(
+      tree({ "docs/guides/authentication.mdx": "Use Authorization: Bearer YOUR_API_KEY\n" }),
+    );
+    expect(checks).not.toContain("documented-key-prefix");
+    expect(checks).toContain("key-prefix-unexamined");
+  });
+
+  it("still reports a capitalised spelling of the issued prefix", async () => {
+    // The placeholder rule reads capitals as "replace me", and this is the one
+    // all-capitals token it must not excuse: `NX_LIVE_` spells the prefix the
+    // service issues, so it is a mis-cased key rather than an instruction, and
+    // sha256 of the whole string means that header cannot authenticate.
+    expect(
+      await checksFor(
+        tree({ "docs/guides/authentication.mdx": "Use Authorization: Bearer NX_LIVE_KEY\n" }),
+      ),
+    ).toContain("documented-key-prefix");
+  });
+
+  it("checks bearer examples published in TypeScript documentation", async () => {
+    // `shared/types/config.ts` documents the header in JSDoc that ships in the
+    // package's declarations, so it is an example a reader is shown in their
+    // editor. A Markdown-only scope lets it go stale while every published page
+    // is updated and the check passes.
+    expect(
+      await checksFor(
+        tree({
+          "packages/nextly/src/shared/types/config.ts":
+            "/** Authenticate with `Authorization: Bearer sk_live_EXAMPLE`. */\nexport type C = {};\n",
+        }),
+      ),
+    ).toContain("documented-key-prefix");
+  });
+
+  it("does not judge bearer headers in tests, which belong to other services", async () => {
+    // Fixtures authenticate against Resend, Stripe and stub receivers. Holding
+    // those to the Nextly prefix reports a defect that is not one, and a job
+    // that always runs cannot afford it.
+    const checks = await checksFor(
+      tree({
+        "docs/guides/authentication.mdx": "Use Authorization: Bearer nx_live_EXAMPLE\n",
+        "packages/nextly/src/domains/email/__tests__/resend.test.ts":
+          'const headers = { Authorization: "Bearer re_test_key" };\n',
+        "packages/nextly/src/utils/validate-url.test.ts":
+          'const headers = { authorization: "Bearer sk_test_key" };\n',
+      }),
+    );
+    expect(checks).not.toContain("documented-key-prefix");
   });
 
   it("refuses when it examined no example at all", async () => {

--- a/scripts/check-docs-claims.test.mjs
+++ b/scripts/check-docs-claims.test.mjs
@@ -1809,6 +1809,120 @@ describe("documented-key-prefix", () => {
     ).not.toContain("documented-key-prefix");
   });
 
+  it("judges a concrete credential that carries no underscore", async () => {
+    // Requiring an underscore missed these. Both are headers a reader would copy and neither
+    // can authenticate, so the shape of the separator decides nothing.
+    for (const token of ["sk-live-EXAMPLE", "abc123"]) {
+      expect(
+        await checksFor(
+          tree({
+            "docs/guides/authentication.mdx": `Use Authorization: Bearer ${token}\n`,
+          }),
+        ),
+      ).toContain("documented-key-prefix");
+    }
+  });
+
+  it("leaves prose about the scheme alone", async () => {
+    // The other side of matching any word after `Bearer`. "send a Bearer token" is a sentence
+    // about the header, and reporting it would block correct pages on a job that always runs.
+    const checks = await checksFor(
+      tree({
+        "docs/guides/authentication.mdx":
+          "Send a Bearer token. A Bearer header was present.\nUse Authorization: Bearer nx_live_EXAMPLE\n",
+      }),
+    );
+    expect(checks).not.toContain("documented-key-prefix");
+  });
+
+  it("does not judge a JavaScript test file", async () => {
+    // `proseFiles` includes package `.mjs`, and the test predicate named only TypeScript
+    // extensions, so a `.test.mjs` doc comment was read as Nextly documentation. Nine package
+    // test files in this repository are named that way.
+    expect(
+      await checksFor(
+        tree({
+          "docs/guides/authentication.mdx": "Use Authorization: Bearer nx_live_EXAMPLE\n",
+          "packages/nextly/src/domains/email/provider.test.mjs":
+            "/** Authenticate with `Authorization: Bearer vendor_bad_KEY`. */\nexport const x = 1;\n",
+        }),
+      ),
+    ).not.toContain("documented-key-prefix");
+  });
+
+  it("does not judge a package npm never receives", async () => {
+    // Build machinery reaches no consumer, so a comment in it documents nothing.
+    expect(
+      await checksFor({
+        "README.md": "# nextly\n\n@nextlyhq/thing\n",
+        [SOURCE]: 'const KEY_PREFIX = "nx_live_";\n',
+        "docs/guides/authentication.mdx": "Use Authorization: Bearer nx_live_EXAMPLE\n",
+        "packages/tsconfig/package.json": JSON.stringify({
+          name: "@nextlyhq/tsconfig",
+          private: true,
+        }),
+        "packages/tsconfig/src/index.ts":
+          "/** Authenticate with `Authorization: Bearer vendor_bad_KEY`. */\nexport const x = 1;\n",
+      }),
+    ).not.toContain("documented-key-prefix");
+  });
+
+  it("judges comment syntax an inline code span makes visible", async () => {
+    // A span prints its contents as typed, so this is an example a reader copies, exactly as
+    // a fenced one is.
+    expect(
+      await checksFor(
+        tree({
+          "docs/guides/authentication.mdx":
+            "Write `{/* Authorization: Bearer sk_bad_EXAMPLE */}` in the layout.\n",
+        }),
+      ),
+    ).toContain("documented-key-prefix");
+  });
+
+  it("reports a stale example when the prefix is SHORTENED", async () => {
+    // `startsWith` passes anything the declared value is a prefix of, so shortening
+    // `nx_live_` to `nx_` left every stale example in the tree satisfying it and the check
+    // reporting clean while nothing issued that format any more.
+    expect(
+      await checksFor(
+        tree(
+          { "docs/guides/authentication.mdx": "Use Authorization: Bearer nx_live_EXAMPLE\n" },
+          'const KEY_PREFIX = "nx_";',
+        ),
+      ),
+    ).toContain("documented-key-prefix");
+  });
+
+  it("judges a bare key format in any doc comment talking about keys", async () => {
+    // `direct-api/types/rbac.ts` publishes three of these with no scheme, in JSDoc that ships
+    // in the package's declarations, so scoping to the declaring file left editor-visible
+    // examples free to go stale.
+    expect(
+      await checksFor(
+        tree({
+          "docs/guides/authentication.mdx": "Use Authorization: Bearer nx_live_EXAMPLE\n",
+          "packages/nextly/src/direct-api/types/rbac.ts":
+            '/** The full raw key value (e.g., `"sk_live_<random>..."`). */\nexport type K = string;\n',
+        }),
+      ),
+    ).toContain("documented-key-prefix");
+  });
+
+  it("does not read an index name as a key format", async () => {
+    // The sentence decides, because the shape cannot: `idx_comp_<slug>_parent` in
+    // `api/field-groups.ts` is a database identifier, and its comment never says key.
+    expect(
+      await checksFor(
+        tree({
+          "docs/guides/authentication.mdx": "Use Authorization: Bearer nx_live_EXAMPLE\n",
+          "packages/nextly/src/api/field-groups.ts":
+            "/** The index is named `idx_comp_<slug>_parent`, which bounds the slug length. */\nexport const x = 1;\n",
+        }),
+      ),
+    ).not.toContain("documented-key-prefix");
+  });
+
   it("judges a doc comment, which is the form that gets published", async () => {
     // The other side of the same rule. Without it, restricting the scan to
     // JSDoc would read as "scan nothing" and pass just as well.


### PR DESCRIPTION
## The defect

Four bearer examples in the docs named `sk_`. The service issues `nx_live_` — [`api-key-service.ts:127`](https://github.com/nextlyhq/nextly/blob/main/packages/nextly/src/domains/auth/services/api-key-service.ts#L127).

`sk_` is another vendor's prefix. Nothing validates it on the way in: a key is looked up by hash, so a reader following the docs builds a header that can never authenticate and gets an ordinary authentication failure with **no hint that the format was the problem**.

**`guides/authentication.mdx` disagreed with itself** — `nx_live_` in a request example, `sk_` in the sentence describing the header a few lines away. A reader had no way to tell which was right.

The published docs are also the source of `llms-full.txt`, so this was being taught to coding agents as well as to people.

## The fix

Four occurrences corrected across `guides/authentication.mdx` and `configuration/nextly-config.mdx`.

`KEY_PREFIX` is now exported so a test compares the docs against what the service issues, rather than restating it beside the code.

## The guard, and why it is shaped this way

It reads the **real `.mdx` files**, not a fixture. A test over a sample of prose proves nothing about the prose that ships.

It asserts the **population before the rule**:

- the docs directory was found and holds more than 50 pages, including `guides/authentication.mdx`
- at least one concrete bearer example exists

Without those two, the rule is satisfied by a wrong path and by a regex that matches nothing — the check would pass having examined nothing.

Placeholders like `Bearer <key>` stay allowed. They are something a reader substitutes, not a claim about the format.

## Verified by breaking it

Re-introduced the `sk_` text and required a red:

```
AssertionError: expected [ Array(1) ] to deeply equal []
+   "guides/authentication.mdx: Bearer sk_",
```

It names the file and the token. Restored, and it passes. The two population tests stayed green throughout, which is correct: they assert the docs were found, not what they say.

## No changeset

`KEY_PREFIX` is not reachable from any of the package's 50 entry points, checked against `package.json` exports, so the published surface is unchanged. This is docs and a test.

`pnpm check:docs-claims` clean; 447 auth-domain tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated configuration and authentication guides to use the current `nx_live_...` API key format in bearer-token examples.
  - Aligned API key examples across the documentation for more consistent authentication guidance.

- **Quality Improvements**
  - Expanded automated checks to detect outdated or inconsistent API key prefixes across documentation and relevant reference comments.
  - Improved validation for duplicate, wrapped, commented, placeholder, and case-sensitive examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->