### PR TITLE
feat(blocks-engine): plan a component save and a convert, re-aiming exposed pointers at the copy

### DIFF
--- a/.changeset/a-component-keeps-its-own-pointers.md
+++ b/.changeset/a-component-keeps-its-own-pointers.md
@@ -1,0 +1,49 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Saving a selection as a reusable component now plans the whole operation, and
+converting one replaces the blocks with a linked instance in the same plan.
+
+A component definition is not only a tree: its exposed properties and slot
+regions are pointers INTO that tree, and saving a selection re-mints every node
+id in it. A pointer carried across unchanged names a node the stored document
+does not contain — a definition that loads, renders, and offers the property in
+the inspector, where editing it writes an override that resolves to nothing.
+Every pointer is now re-aimed through the map the copy produced, and one that
+names a node outside the selection is refused with the reason rather than
+silently dropped.
+
+The exposure a caller nominates is judged by the same envelope rules that gate
+publishing, published as `componentEnvelopeIssues` so the plan and the gate
+cannot come to disagree. A converted run is refused for anything its ops would
+be refused for — a locked block, an ambiguous id, a container that will not
+take a component instance — while the author still has the selection in front
+of them.
+
+`PatternTarget` is now `LibraryTarget`: one type for all three library kinds,
+since a pattern, a component and a layout are stored the same way.

--- a/.changeset/a-component-keeps-its-own-pointers.md
+++ b/.changeset/a-component-keeps-its-own-pointers.md
@@ -47,3 +47,13 @@ of them.
 
 `PatternTarget` is now `LibraryTarget`: one type for all three library kinds,
 since a pattern, a component and a layout are stored the same way.
+
+A convert now refuses everything its own ops would be refused for, including a
+malformed node the author never selected and an id duplicated on a descendant of
+what it removes — `remove` rejects the whole subtree in that case, because the
+inverse it records could not put it back. That rule is published as
+`subtreeRemovalRefusal`, alongside the other refusals a planner has to be able
+to ask.
+
+A nomination naming a node id the selection holds twice is refused rather than
+silently re-aimed at whichever copy came last.

--- a/packages/blocks-engine/src/composition-planners.test.ts
+++ b/packages/blocks-engine/src/composition-planners.test.ts
@@ -11,9 +11,17 @@
  */
 import { describe, expect, it } from "vitest";
 
-import { planInsertPattern, planSaveAsPattern } from "./composition-planners";
-import { DOCUMENT_FORMAT_VERSION } from "./document";
-import type { BlockDocument, BlockNode } from "./document";
+import {
+  planConvertToComponent,
+  planInsertPattern,
+  planSaveAsComponent,
+  planSaveAsPattern,
+} from "./composition-planners";
+import type { PlanResult, PlannedCreate } from "./composition-planners";
+import { COMPONENT_INSTANCE_TYPE, DOCUMENT_FORMAT_VERSION } from "./document";
+import type { BlockDocument, BlockNode, ComponentDocument } from "./document";
+import { applyOps } from "./ops";
+import type { BuilderOp } from "./ops";
 import { walkNodes } from "./tree";
 
 function node(
@@ -437,5 +445,470 @@ describe("what it refuses, and why", () => {
       planSaveAsPattern(page([node("a")]), ["a", "ghost"], target, anyParent)
         .problem
     ).toBe("unknown");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Components
+// ---------------------------------------------------------------------------
+
+const componentTarget = {
+  collection: "components",
+  fields: { title: "Card", slug: "card" },
+};
+
+/**
+ * The row a plan proposes, or a failure naming the cause.
+ *
+ * A helper rather than a non-null assertion, so a test that stops planning for
+ * a reason nobody predicted says which reason instead of reporting that
+ * `undefined` has no `document`.
+ */
+function created<T>(plan: PlanResult<T>): PlannedCreate<T> {
+  if (plan.create === undefined) {
+    throw new Error(`no plan: ${String(plan.problem)}`);
+  }
+  return plan.create;
+}
+
+/** The definition a component plan would store. */
+function definition<T>(plan: PlanResult<T>): ComponentDocument {
+  return created(plan).document as ComponentDocument;
+}
+
+/** The page ops a plan proposes, or a failure naming the cause. */
+function pageOps<T>(plan: PlanResult<T>): readonly BuilderOp[] {
+  if (plan.pageOps === undefined) {
+    throw new Error(`no plan: ${String(plan.problem)}`);
+  }
+  return plan.pageOps;
+}
+
+/**
+ * A forest with every id replaced by its position in the walk.
+ *
+ * Two saves of one selection mint different node ids by design, so comparing
+ * them byte-for-byte would fail on the one difference that is supposed to be
+ * there. Normalising the ids leaves every other difference visible, which is
+ * what "the same document" has to mean here.
+ */
+function shapeOf(nodes: BlockNode[]): string {
+  const order = new Map<string, number>();
+  walkNodes(nodes, n => order.set(n.id, order.size));
+  return JSON.stringify(nodes, (key, value) =>
+    key === "id" && typeof value === "string"
+      ? (order.get(value) ?? value)
+      : value
+  );
+}
+
+/** A page whose selected card holds a headline the author might expose. */
+function cardPage(): BlockDocument {
+  return page([
+    node("outside", { props: { mark: "outside", text: "elsewhere" } }),
+    node(
+      "card",
+      { props: { mark: "card" } },
+      {
+        children: [
+          node("headline", { props: { mark: "headline", text: "Hi" } }),
+        ],
+      }
+    ),
+  ]);
+}
+
+/** One nominated text property, pointing wherever the test says. */
+function exposeText(nodeId: string, extra: Record<string, unknown> = {}) {
+  return {
+    properties: [
+      {
+        id: "p1",
+        label: "Headline",
+        nodeId,
+        propPath: "text",
+        type: "text" as const,
+        ...extra,
+      },
+    ],
+  };
+}
+
+describe("an exposed pointer follows the copy", () => {
+  it("re-aims nodeId at the STORED node, and that node is there", () => {
+    const stored = definition(
+      planSaveAsComponent(
+        cardPage(),
+        ["card"],
+        componentTarget,
+        exposeText("headline"),
+        anyParent
+      )
+    );
+
+    const headline = marked(stored.nodes, "headline");
+    expect(stored.exposed?.[0]?.nodeId).toBe(headline.id);
+    // The pointer resolving is the property that matters; the id merely
+    // differing from the page's would also be true of a random string.
+    expect(idsIn(stored.nodes)).toContain(stored.exposed?.[0]?.nodeId);
+    expect(stored.exposed?.[0]?.nodeId).not.toBe("headline");
+  });
+
+  it("re-aims a slot region the same way", () => {
+    const stored = definition(
+      planSaveAsComponent(
+        cardPage(),
+        ["card"],
+        componentTarget,
+        {
+          slots: { body: { label: "Body", nodeId: "card", slot: "children" } },
+        },
+        anyParent
+      )
+    );
+
+    expect(stored.slots?.body?.nodeId).toBe(marked(stored.nodes, "card").id);
+    expect(idsIn(stored.nodes)).toContain(stored.slots?.body?.nodeId);
+  });
+
+  it("refuses a nomination naming a node OUTSIDE the selection", () => {
+    const plan = planSaveAsComponent(
+      cardPage(),
+      ["card"],
+      componentTarget,
+      exposeText("outside"),
+      anyParent
+    );
+
+    expect(plan.problem).toBe("invalid-exposure");
+    expect(plan.issues?.map(one => one.code)).toContain("exposed-node-missing");
+    expect(plan.issues?.[0]?.path).toContain("/exposed/0");
+  });
+
+  it("does not alias the options array it was handed", () => {
+    const options = [{ value: "a", label: "A" }];
+    const stored = definition(
+      planSaveAsComponent(
+        cardPage(),
+        ["card"],
+        componentTarget,
+        exposeText("headline", { type: "select", options }),
+        anyParent
+      )
+    );
+
+    options.push({ value: "b", label: "B" });
+    expect(stored.exposed?.[0]?.options).toHaveLength(1);
+  });
+});
+
+describe("the envelope is judged by the rule that will publish it", () => {
+  const refusalFor = (properties: unknown[]) =>
+    planSaveAsComponent(
+      cardPage(),
+      ["card"],
+      componentTarget,
+      { properties } as never,
+      anyParent
+    );
+
+  it("refuses two exposures sharing one id", () => {
+    const one = exposeText("headline").properties[0];
+    const plan = refusalFor([one, { ...one, label: "Second" }]);
+    expect(plan.problem).toBe("invalid-exposure");
+    expect(plan.issues?.map(i => i.code)).toContain("exposed-duplicate-id");
+  });
+
+  it("refuses options on something that is not a select", () => {
+    const plan = refusalFor([
+      {
+        ...exposeText("headline").properties[0],
+        options: [{ value: "a", label: "A" }],
+      },
+    ]);
+    expect(plan.issues?.map(i => i.code)).toContain("exposed-options-invalid");
+  });
+
+  it("refuses a select with no options", () => {
+    const plan = refusalFor([
+      { ...exposeText("headline").properties[0], type: "select" },
+    ]);
+    expect(plan.issues?.map(i => i.code)).toContain("exposed-options-invalid");
+  });
+
+  it("refuses a type outside the vocabulary", () => {
+    const plan = refusalFor([
+      { ...exposeText("headline").properties[0], type: "colour" },
+    ]);
+    expect(plan.issues?.map(i => i.code)).toContain("exposed-property-invalid");
+  });
+
+  it("refuses a prop path that is not a path", () => {
+    const plan = refusalFor([
+      { ...exposeText("headline").properties[0], propPath: "text..deep" },
+    ]);
+    expect(plan.issues?.map(i => i.code)).toContain("exposed-path-invalid");
+  });
+
+  it("refuses a slot the node it points at does not declare", () => {
+    const plan = planSaveAsComponent(
+      cardPage(),
+      ["card"],
+      componentTarget,
+      { slots: { body: { label: "Body", nodeId: "card", slot: "footer" } } },
+      anyParent
+    );
+    expect(plan.issues?.map(i => i.code)).toContain("exposed-slot-missing");
+  });
+});
+
+describe("what a saved component is", () => {
+  it("is the tree a pattern save stores, under a component kind", () => {
+    const doc = cardPage();
+    const asPattern = created(
+      planSaveAsPattern(doc, ["card"], target, anyParent)
+    ).document;
+    const asComponent = definition(
+      planSaveAsComponent(doc, ["card"], componentTarget, {}, anyParent)
+    );
+
+    expect(shapeOf(asComponent.nodes)).toBe(shapeOf(asPattern.nodes));
+    expect(asComponent.kind).toBe("component");
+    expect(asComponent.formatVersion).toBe(doc.formatVersion);
+  });
+
+  it("declares no exposed field when nothing was nominated", () => {
+    const stored = definition(
+      planSaveAsComponent(cardPage(), ["card"], componentTarget, {}, anyParent)
+    );
+    // Absence is what the contract already reads as "exposes none", so writing
+    // an empty array would make two saves of one selection differ by whether
+    // the caller passed a list it had not filled.
+    expect("exposed" in stored).toBe(false);
+    expect("slots" in stored).toBe(false);
+  });
+
+  it("declares no exposed field for an EMPTY nomination either", () => {
+    // The separate case, because absent and empty arrive by different routes: a
+    // surface that builds the list from the author's ticks passes `[]` when
+    // they tick nothing, and a stored `[]` would make that save differ from one
+    // where the surface passed nothing at all.
+    const stored = definition(
+      planSaveAsComponent(
+        cardPage(),
+        ["card"],
+        componentTarget,
+        { properties: [], slots: {} },
+        anyParent
+      )
+    );
+    expect("exposed" in stored).toBe(false);
+    expect("slots" in stored).toBe(false);
+  });
+
+  it("leaves the page alone", () => {
+    expect(
+      planSaveAsComponent(cardPage(), ["card"], componentTarget, {}, anyParent)
+        .pageOps
+    ).toEqual([]);
+  });
+
+  it("refuses what a pattern save refuses about the selection", () => {
+    const doc = page([node("a"), node("b"), node("c")]);
+    expect(
+      planSaveAsComponent(doc, ["a", "c"], componentTarget, {}, anyParent)
+        .problem
+    ).toBe("gap");
+  });
+});
+
+describe("converting a run into an instance", () => {
+  it("removes the run and puts one instance where it stood", () => {
+    const doc = page([node("a"), node("b"), node("c")]);
+    const plan = planConvertToComponent(
+      doc,
+      ["a", "b"],
+      componentTarget,
+      "def-1",
+      {},
+      anyParent
+    );
+
+    expect(pageOps(plan).map(op => op.kind)).toEqual([
+      "remove",
+      "remove",
+      "insert",
+    ]);
+
+    // The plan IS the dry run, so the ops it proposes have to apply.
+    const after = applyOps(doc, pageOps(plan)).document;
+    expect(after.nodes.map(n => n.type)).toEqual([
+      COMPONENT_INSTANCE_TYPE,
+      "core/box",
+    ]);
+    expect(after.nodes[0]?.props?.componentId).toBe("def-1");
+  });
+
+  it("puts the instance back inside the container the run sat in", () => {
+    const doc = page([
+      node("wrap", {}, { children: [node("a"), node("b"), node("c")] }),
+    ]);
+    const plan = planConvertToComponent(
+      doc,
+      ["b"],
+      componentTarget,
+      "def-1",
+      {},
+      anyParent
+    );
+
+    const after = applyOps(doc, pageOps(plan)).document;
+    expect(after.nodes[0]?.slots?.children.map(n => n.type)).toEqual([
+      "core/box",
+      COMPONENT_INSTANCE_TYPE,
+      "core/box",
+    ]);
+  });
+
+  it("appends when the run ended the list", () => {
+    const doc = page([node("a"), node("b"), node("c")]);
+    const plan = planConvertToComponent(
+      doc,
+      ["b", "c"],
+      componentTarget,
+      "def-1",
+      {},
+      anyParent
+    );
+
+    const after = applyOps(doc, pageOps(plan)).document;
+    expect(after.nodes.map(n => n.type)).toEqual([
+      "core/box",
+      COMPONENT_INSTANCE_TYPE,
+    ]);
+  });
+
+  it("stores the definition a plain component save would store", () => {
+    const doc = cardPage();
+    const saved = definition(
+      planSaveAsComponent(
+        doc,
+        ["card"],
+        componentTarget,
+        exposeText("headline"),
+        anyParent
+      )
+    );
+    const converted = definition(
+      planConvertToComponent(
+        doc,
+        ["card"],
+        componentTarget,
+        "def-1",
+        exposeText("headline"),
+        anyParent
+      )
+    );
+
+    expect(shapeOf(converted.nodes)).toBe(shapeOf(saved.nodes));
+    expect(converted.exposed?.[0]?.nodeId).toBe(
+      marked(converted.nodes, "headline").id
+    );
+  });
+
+  it("names the row the instance points at", () => {
+    const plan = planConvertToComponent(
+      page([node("a")]),
+      ["a"],
+      componentTarget,
+      "def-1",
+      {},
+      anyParent
+    );
+    expect(created(plan).id).toBe("def-1");
+  });
+
+  it("refuses a component id that names nothing", () => {
+    const doc = page([node("a")]);
+    expect(
+      planConvertToComponent(doc, ["a"], componentTarget, "", {}, anyParent)
+        .problem
+    ).toBe("invalid-source");
+    expect(
+      planConvertToComponent(
+        doc,
+        ["a"],
+        componentTarget,
+        undefined as unknown as string,
+        {},
+        anyParent
+      ).problem
+    ).toBe("invalid-source");
+  });
+
+  it("refuses a selected root the document holds twice", () => {
+    // `remove` addresses by id and could not say which node it meant. The
+    // duplicate is reachable from a page nothing validated, and it sits where
+    // the selection does NOT: a nested copy of a top-level id, which
+    // `contiguousRun` resolves to one node without complaint.
+    const doc = page([
+      node("dup"),
+      node("other", {}, { children: [node("dup")] }),
+    ]);
+
+    expect(
+      planConvertToComponent(
+        doc,
+        ["dup"],
+        componentTarget,
+        "def-1",
+        {},
+        anyParent
+      ).problem
+    ).toBe("duplicate-destination");
+    expect(() => applyOps(doc, [{ kind: "remove", id: "dup" }])).toThrow();
+  });
+
+  it("refuses a locked block, which is what the remove would do", () => {
+    const doc = page([node("a", { locked: true })]);
+
+    expect(
+      planConvertToComponent(
+        doc,
+        ["a"],
+        componentTarget,
+        "def-1",
+        {},
+        anyParent
+      ).problem
+    ).toBe("destination-locked");
+    // The other direction of the dry-run contract: the refusal is the apply's
+    // own, not a rule this module invented that the apply does not share.
+    expect(() => applyOps(doc, [{ kind: "remove", id: "a" }])).toThrow();
+  });
+
+  it("asks the nesting rule about the INSTANCE, not about what it replaces", () => {
+    const instanceNeedsSection = {
+      parentsOf: (type: string) =>
+        type === COMPONENT_INSTANCE_TYPE ? ["core/section"] : undefined,
+    };
+    const doc = page([node("a")]);
+
+    // The run itself is unrestricted, so the SAVE half is happy.
+    expect(
+      planSaveAsComponent(doc, ["a"], componentTarget, {}, instanceNeedsSection)
+        .problem
+    ).toBeUndefined();
+    // The instance going back is not.
+    const plan = planConvertToComponent(
+      doc,
+      ["a"],
+      componentTarget,
+      "def-1",
+      {},
+      instanceNeedsSection
+    );
+    expect(plan.problem).toBe("restricted-at-root");
+    expect(plan.permitted).toEqual(["core/section"]);
   });
 });

--- a/packages/blocks-engine/src/composition-planners.test.ts
+++ b/packages/blocks-engine/src/composition-planners.test.ts
@@ -22,7 +22,8 @@ import { COMPONENT_INSTANCE_TYPE, DOCUMENT_FORMAT_VERSION } from "./document";
 import type { BlockDocument, BlockNode, ComponentDocument } from "./document";
 import { applyOps } from "./ops";
 import type { BuilderOp } from "./ops";
-import { MAX_ENVELOPE_ENTRIES } from "./limits";
+import { DEFAULT_LIMITS, MAX_ENVELOPE_ENTRIES } from "./limits";
+import type { DocumentLimits } from "./limits";
 import { walkNodes } from "./tree";
 
 function node(
@@ -1157,5 +1158,109 @@ describe("the exposure request itself is judged before its fields", () => {
 
     expect(plan({ slots }).problem).toBe("invalid-exposure");
     expect(reads).toBe(0);
+  });
+});
+
+describe("a caller-sized exposure costs a refusal, not a traversal", () => {
+  const plan = (exposure: unknown, limits?: DocumentLimits) =>
+    planSaveAsComponent(
+      cardPage(),
+      ["card"],
+      componentTarget,
+      exposure as never,
+      anyParent,
+      limits
+    );
+
+  it("does not read an over-cap list while checking for ambiguity", () => {
+    // The ambiguity pass runs BEFORE the mappers, so their caps do not cover
+    // it — and an over-cap list is refused by the envelope check whatever this
+    // pass concludes, which makes reading it work the cap exists to refuse.
+    let reads = 0;
+    const many = Array.from({ length: MAX_ENVELOPE_ENTRIES + 1 }, (_, i) => {
+      const entry: Record<string, unknown> = {
+        id: `p${String(i)}`,
+        label: "L",
+        propPath: "text",
+        type: "text",
+      };
+      Object.defineProperty(entry, "nodeId", {
+        enumerable: true,
+        get() {
+          reads += 1;
+          return "headline";
+        },
+      });
+      return entry;
+    });
+
+    expect(plan({ properties: many }).problem).toBe("invalid-exposure");
+    expect(reads).toBe(0);
+  });
+
+  it("refuses an array whose `map` the caller shadowed", () => {
+    // The entries and the array type are both valid here; only the inherited
+    // method is shadowed, so none of the entry guards sees anything wrong.
+    const shadowed: unknown[] = [exposeText("headline").properties[0]];
+    Object.defineProperty(shadowed, "map", {
+      value: "not a function",
+      enumerable: true,
+    });
+
+    let threw: unknown;
+    let result;
+    try {
+      result = plan({ properties: shadowed });
+    } catch (error) {
+      threw = error;
+    }
+    expect(threw).toBeUndefined();
+    expect(result?.problem).toBeUndefined();
+  });
+
+  it("indexes the envelope under the HOST's node cap, not its own", () => {
+    // A host may raise `maxNodes`, and strict validation — the gate this dry
+    // run predicts — is given the host's limits. Indexing under the default
+    // leaves a large definition's later nodes outside the index, so a sound
+    // exposure is reported as pointing at nothing and the planner refuses a
+    // component the apply would publish.
+    const children: BlockNode[] = [];
+    for (let i = 0; i < 5200; i += 1) children.push(node(`k${String(i)}`));
+    const doc = page([node("root", {}, { children })]);
+    const exposure = {
+      properties: [
+        {
+          id: "p1",
+          label: "L",
+          nodeId: "k5100",
+          propPath: "text",
+          type: "text" as const,
+        },
+      ],
+    };
+
+    const raised = planSaveAsComponent(
+      doc,
+      ["root"],
+      componentTarget,
+      exposure,
+      anyParent,
+      { ...DEFAULT_LIMITS, maxNodes: 6000 }
+    );
+    expect(raised.problem).toBeUndefined();
+
+    // The control: under the DEFAULT cap the same definition is refused, so
+    // the assertion above is about the limit being threaded rather than about
+    // the pointer happening to resolve.
+    const defaulted = planSaveAsComponent(
+      doc,
+      ["root"],
+      componentTarget,
+      exposure,
+      anyParent
+    );
+    expect(defaulted.issues?.map(i => i.code)).toContain(
+      "exposed-node-missing"
+    );
   });
 });

--- a/packages/blocks-engine/src/composition-planners.test.ts
+++ b/packages/blocks-engine/src/composition-planners.test.ts
@@ -912,3 +912,141 @@ describe("converting a run into an instance", () => {
     expect(plan.permitted).toEqual(["core/section"]);
   });
 });
+
+describe("a nomination this cannot read is refused, never dropped or dereferenced", () => {
+  const plan = (exposure: unknown) =>
+    planSaveAsComponent(
+      cardPage(),
+      ["card"],
+      componentTarget,
+      exposure as never,
+      anyParent
+    );
+
+  it("refuses a properties value that is not a list", () => {
+    // Normalising it to absent reported SUCCESS for a nomination the caller
+    // made and this could not read.
+    const result = plan({ properties: "bad" });
+    expect(result.problem).toBe("invalid-exposure");
+    expect(result.issues?.map(i => i.code)).toContain(
+      "component-envelope-invalid"
+    );
+  });
+
+  it("refuses a null entry instead of throwing on it", () => {
+    let threw: unknown;
+    let result;
+    try {
+      result = plan({ properties: [null] });
+    } catch (error) {
+      threw = error;
+    }
+    expect(threw).toBeUndefined();
+    expect(result?.problem).toBe("invalid-exposure");
+  });
+
+  it("refuses a slots value that is not a record", () => {
+    expect(plan({ slots: "bad" }).problem).toBe("invalid-exposure");
+  });
+
+  it("does not run a prototype setter for a __proto__ slot key", () => {
+    // Assigning to it invokes the inherited setter rather than creating a
+    // property, so the slot the author asked for vanishes and the result gains
+    // a prototype — making the validator refuse what it accepts when the same
+    // document is stored directly.
+    const result = plan({
+      slots: { __proto__: { label: "B", nodeId: "card", slot: "children" } },
+    });
+    expect(result.problem).toBe("invalid-exposure");
+  });
+
+  it("copies each option RECORD, not only the list", () => {
+    // The weaker test — pushing a new element — stays green while every option
+    // object is still shared with the caller's request.
+    const options = [{ value: "a", label: "A" }];
+    const stored = definition(
+      planSaveAsComponent(
+        cardPage(),
+        ["card"],
+        componentTarget,
+        exposeText("headline", { type: "select", options }),
+        anyParent
+      )
+    );
+
+    options[0]!.label = "MUTATED";
+    expect(stored.exposed?.[0]?.options?.[0]?.label).toBe("A");
+  });
+
+  it("refuses a nomination naming an id the selection holds twice", () => {
+    // The map is keyed on the ORIGINAL id, so the second node's mapping
+    // replaces the first — and the pointer lands on whichever came last. It
+    // resolves, so the envelope check passes and every instance override then
+    // edits a block the author did not choose.
+    const doc = page([
+      node(
+        "wrap",
+        {},
+        {
+          children: [
+            node("dup", { props: { mark: "first" } }),
+            node("dup", { props: { mark: "second" } }),
+          ],
+        }
+      ),
+    ]);
+
+    expect(
+      planSaveAsComponent(
+        doc,
+        ["wrap"],
+        componentTarget,
+        exposeText("dup"),
+        anyParent
+      ).problem
+    ).toBe("ambiguous-exposure");
+  });
+});
+
+describe("a convert refuses everything its ops would meet", () => {
+  it("refuses when a sibling the author never selected is malformed", () => {
+    // `applyOps` walks the WHOLE forest before applying anything, so a plan
+    // that ignores an unselected malformed node succeeds and then throws on its
+    // first op — after the library row has been written.
+    const doc = page([node("a"), null as unknown as BlockNode]);
+
+    expect(
+      planConvertToComponent(
+        doc,
+        ["a"],
+        componentTarget,
+        "def-1",
+        {},
+        anyParent
+      ).problem
+    ).toBe("unusable-document");
+    expect(() => applyOps(doc, [{ kind: "remove", id: "a" }])).toThrow();
+  });
+
+  it("refuses a duplicate id on a DESCENDANT, not just on the root", () => {
+    // `remove` refuses when any id inside the subtree it takes occurs twice in
+    // the document, because its inverse could not put that subtree back. A
+    // root-only check passes this and the apply throws.
+    const doc = page([
+      node("a", {}, { children: [node("dup")] }),
+      node("other", {}, { children: [node("dup")] }),
+    ]);
+
+    expect(
+      planConvertToComponent(
+        doc,
+        ["a"],
+        componentTarget,
+        "def-1",
+        {},
+        anyParent
+      ).problem
+    ).toBe("duplicate-destination");
+    expect(() => applyOps(doc, [{ kind: "remove", id: "a" }])).toThrow();
+  });
+});

--- a/packages/blocks-engine/src/composition-planners.test.ts
+++ b/packages/blocks-engine/src/composition-planners.test.ts
@@ -1390,3 +1390,63 @@ describe("a list nested inside an exposure is bounded too", () => {
     expect(plan?.problem).toBeUndefined();
   });
 });
+
+describe("the request is read once, so two passes cannot disagree", () => {
+  /** A nomination whose `nodeId` answers differently on each read. */
+  function shiftingNomination(values: readonly string[]) {
+    let reads = 0;
+    const entry: Record<string, unknown> = {
+      id: "p1",
+      label: "L",
+      propPath: "text",
+      type: "text",
+    };
+    Object.defineProperty(entry, "nodeId", {
+      enumerable: true,
+      get() {
+        const value = values[Math.min(reads, values.length - 1)]!;
+        reads += 1;
+        return value;
+      },
+    });
+    return { entry, reads: () => reads };
+  }
+
+  it("reads a nominated nodeId exactly once", () => {
+    const { entry, reads } = shiftingNomination(["headline"]);
+
+    planSaveAsComponent(
+      cardPage(),
+      ["card"],
+      componentTarget,
+      { properties: [entry] } as never,
+      anyParent
+    );
+
+    // Three reads before this: twice while collecting ids for the ambiguity
+    // guard, once again in the mapper. A value that shifts between them let the
+    // guard clear one id while the mapper stored another.
+    expect(reads()).toBe(1);
+  });
+
+  it("judges the id it will store, not one it saw on the way", () => {
+    // The selection holds `dup` twice, so a nomination naming it must refuse.
+    // Reading three times let a getter show the guard a safe id and the mapper
+    // the ambiguous one — the plan succeeding, the pointer resolving, and every
+    // instance override editing a node the author never chose.
+    const doc = page([
+      node("wrap", {}, { children: [node("safe"), node("dup"), node("dup")] }),
+    ]);
+    const { entry } = shiftingNomination(["dup", "safe", "safe"]);
+
+    expect(
+      planSaveAsComponent(
+        doc,
+        ["wrap"],
+        componentTarget,
+        { properties: [entry] } as never,
+        anyParent
+      ).problem
+    ).toBe("ambiguous-exposure");
+  });
+});

--- a/packages/blocks-engine/src/composition-planners.test.ts
+++ b/packages/blocks-engine/src/composition-planners.test.ts
@@ -22,6 +22,7 @@ import { COMPONENT_INSTANCE_TYPE, DOCUMENT_FORMAT_VERSION } from "./document";
 import type { BlockDocument, BlockNode, ComponentDocument } from "./document";
 import { applyOps } from "./ops";
 import type { BuilderOp } from "./ops";
+import { MAX_ENVELOPE_ENTRIES } from "./limits";
 import { walkNodes } from "./tree";
 
 function node(
@@ -1048,5 +1049,113 @@ describe("a convert refuses everything its ops would meet", () => {
       ).problem
     ).toBe("duplicate-destination");
     expect(() => applyOps(doc, [{ kind: "remove", id: "a" }])).toThrow();
+  });
+});
+
+describe("the exposure request itself is judged before its fields", () => {
+  const plan = (exposure: unknown) =>
+    planSaveAsComponent(
+      cardPage(),
+      ["card"],
+      componentTarget,
+      exposure as never,
+      anyParent
+    );
+
+  it.each([
+    ["null", null],
+    ["a string", "bad"],
+    ["an array", []],
+    ["a number", 3],
+  ])("refuses %s as the whole request", (_name, exposure) => {
+    // `null` threw; a string and an array answered `undefined` to both field
+    // reads and were taken for "expose nothing", which reports success for a
+    // request nobody could honour.
+    let threw: unknown;
+    let result;
+    try {
+      result = plan(exposure);
+    } catch (error) {
+      threw = error;
+    }
+    expect(threw).toBeUndefined();
+    expect(result?.problem).toBe("invalid-exposure");
+  });
+
+  it("still treats an absent request as exposing nothing", () => {
+    // The one value that SAYS so, rather than failing to say anything.
+    const stored = definition(plan(undefined));
+    expect("exposed" in stored).toBe(false);
+  });
+
+  it("carries a malformed options value to the validator", () => {
+    // Omitting it turned a refusal into a success: the envelope check rejects a
+    // present `options` on anything but a select, and one that is not a list.
+    const result = plan({
+      properties: [{ ...exposeText("headline").properties[0], options: "bad" }],
+    });
+    expect(result.problem).toBe("invalid-exposure");
+    expect(result.issues?.map(i => i.code)).toContain(
+      "exposed-options-invalid"
+    );
+  });
+
+  it("carries a malformed slot allow-list to the validator", () => {
+    // Dropping it left an unrestricted slot the planner then reported as fine.
+    const result = plan({
+      slots: {
+        body: { label: "Body", nodeId: "card", slot: "children", allow: "bad" },
+      },
+    });
+    expect(result.problem).toBe("invalid-exposure");
+  });
+
+  it("refuses an over-cap properties list WITHOUT reading its entries", () => {
+    // The refusal alone does not discriminate: mapping the list first and then
+    // letting `eachBounded` reject it reaches the same answer, having done
+    // exactly the work the cap exists to refuse. So the entries count their own
+    // reads, and the assertion is that none happened.
+    let reads = 0;
+    const many = Array.from({ length: MAX_ENVELOPE_ENTRIES + 1 }, (_, i) => {
+      const entry: Record<string, unknown> = {
+        label: "L",
+        nodeId: "headline",
+        propPath: "text",
+        type: "text",
+      };
+      Object.defineProperty(entry, "id", {
+        enumerable: true,
+        get() {
+          reads += 1;
+          return `p${String(i)}`;
+        },
+      });
+      return entry;
+    });
+
+    expect(plan({ properties: many }).problem).toBe("invalid-exposure");
+    expect(reads).toBe(0);
+  });
+
+  it("refuses an over-cap slot map WITHOUT reading its entries", () => {
+    let reads = 0;
+    const slots: Record<string, unknown> = {};
+    for (let i = 0; i <= MAX_ENVELOPE_ENTRIES; i++) {
+      const entry: Record<string, unknown> = {
+        nodeId: "card",
+        slot: "children",
+      };
+      Object.defineProperty(entry, "label", {
+        enumerable: true,
+        get() {
+          reads += 1;
+          return "S";
+        },
+      });
+      slots[`s${String(i)}`] = entry;
+    }
+
+    expect(plan({ slots }).problem).toBe("invalid-exposure");
+    expect(reads).toBe(0);
   });
 });

--- a/packages/blocks-engine/src/composition-planners.test.ts
+++ b/packages/blocks-engine/src/composition-planners.test.ts
@@ -1264,3 +1264,129 @@ describe("a caller-sized exposure costs a refusal, not a traversal", () => {
     );
   });
 });
+
+describe("what the plan promises about the page it will edit", () => {
+  it("refuses a replacement that would push the page past its byte cap", () => {
+    // Only the APPLY can answer this: `assertFitsCaps` measures the document a
+    // node is going into, so a subtree with no destination cannot be judged
+    // against it — which `nodeShapeRefusal` says in as many words. A run
+    // replaced by a LARGER instance crosses a cap the page was inside.
+    const doc = page([node("a")]);
+    const limits = {
+      ...DEFAULT_LIMITS,
+      maxBytes: JSON.stringify(doc).length,
+    };
+
+    expect(
+      planConvertToComponent(
+        doc,
+        ["a"],
+        componentTarget,
+        "def-1",
+        {},
+        anyParent,
+        limits
+      ).problem
+    ).toBe("exceeds-limits");
+
+    // The other direction of the dry-run contract: the apply refuses it too.
+    expect(() =>
+      applyOps(
+        doc,
+        [
+          { kind: "remove", id: "a" },
+          {
+            kind: "insert",
+            node: {
+              id: "i1",
+              type: COMPONENT_INSTANCE_TYPE,
+              version: 1,
+              props: { componentId: "def-1" },
+            },
+            at: { index: 0 },
+          },
+        ],
+        limits
+      )
+    ).toThrow();
+  });
+
+  it("refuses a definition JSON could not write, envelope included", () => {
+    // The envelope is caller-supplied and the envelope check reads only `value`
+    // and `label`, so an option carrying a `BigInt` passes it and makes the
+    // whole document unstorable. The tree was already asked this question
+    // before it had an envelope; the completed definition is asked it again.
+    const plan = planSaveAsComponent(
+      cardPage(),
+      ["card"],
+      componentTarget,
+      exposeText("headline", {
+        type: "select",
+        options: [{ value: "x", label: "X", metadata: 1n }],
+      }) as never,
+      anyParent
+    );
+
+    expect(plan.problem).toBe("unusable-document");
+  });
+});
+
+describe("a list nested inside an exposure is bounded too", () => {
+  it("does not copy an over-cap options list", () => {
+    // Nothing outside the entry bounds a list inside it: the outer cap already
+    // admitted this single nomination.
+    let reads = 0;
+    const options: unknown[] = [];
+    for (let i = 0; i <= MAX_ENVELOPE_ENTRIES; i += 1) {
+      const option: Record<string, unknown> = { value: `v${String(i)}` };
+      Object.defineProperty(option, "label", {
+        enumerable: true,
+        get() {
+          reads += 1;
+          return "L";
+        },
+      });
+      options.push(option);
+    }
+
+    const plan = planSaveAsComponent(
+      cardPage(),
+      ["card"],
+      componentTarget,
+      exposeText("headline", { type: "select", options }) as never,
+      anyParent
+    );
+
+    expect(plan.problem).toBe("invalid-exposure");
+    expect(reads).toBe(0);
+  });
+
+  it("copies an allow-list without invoking its iterator", () => {
+    // A spread runs `Symbol.iterator`, which is inherited and so the caller's
+    // to shadow — on an array whose entries are all well formed, which is why
+    // the entry guards cannot see it.
+    const allow: unknown[] = ["core/box"];
+    Object.defineProperty(allow, Symbol.iterator, { value: "not a function" });
+
+    let threw: unknown;
+    let plan;
+    try {
+      plan = planSaveAsComponent(
+        page([node("card", {}, { children: [] })]),
+        ["card"],
+        componentTarget,
+        {
+          slots: {
+            body: { label: "B", nodeId: "card", slot: "children", allow },
+          },
+        } as never,
+        anyParent
+      );
+    } catch (error) {
+      threw = error;
+    }
+
+    expect(threw).toBeUndefined();
+    expect(plan?.problem).toBeUndefined();
+  });
+});

--- a/packages/blocks-engine/src/composition-planners.test.ts
+++ b/packages/blocks-engine/src/composition-planners.test.ts
@@ -1214,8 +1214,16 @@ describe("a caller-sized exposure costs a refusal, not a traversal", () => {
     } catch (error) {
       threw = error;
     }
+
+    // Not a native error, which is the property this test was written for.
     expect(threw).toBeUndefined();
-    expect(result?.problem).toBeUndefined();
+    // And refused, which it was not when this test was first written. An own
+    // `map` is a non-index key on an array, and `JSON.stringify` writes an
+    // array by position — so the key is silently lost and the list does not
+    // round-trip. The op layer refuses such a list outright, and asking that
+    // rule here rather than only avoiding `map` is what closed the accessor
+    // case beside it.
+    expect(result?.problem).toBe("invalid-exposure");
   });
 
   it("indexes the envelope under the HOST's node cap, not its own", () => {
@@ -1448,5 +1456,116 @@ describe("the request is read once, so two passes cannot disagree", () => {
         anyParent
       ).problem
     ).toBe("ambiguous-exposure");
+  });
+});
+
+describe("what a definition may not be", () => {
+  it("refuses one that would exceed the caller's byte cap", () => {
+    // An exposure only ever makes a document bigger, so a page that fits can
+    // become a definition that does not — and `documentRefusal` answers whether
+    // a document can be EDITED, which is a different question from whether it
+    // fits.
+    const doc = page([node("a")]);
+    const limits = {
+      ...DEFAULT_LIMITS,
+      maxBytes: JSON.stringify(doc).length + 10,
+    };
+
+    expect(
+      planSaveAsComponent(
+        doc,
+        ["a"],
+        componentTarget,
+        {
+          properties: [
+            {
+              id: "p1",
+              label: "A label long enough to carry it over the cap",
+              nodeId: "a",
+              propPath: "text",
+              type: "text" as const,
+            },
+          ],
+        },
+        anyParent,
+        limits
+      ).problem
+    ).toBe("exceeds-limits");
+  });
+
+  it("refuses one that would contain an instance of itself", () => {
+    // The selection can already hold an instance of the component about to be
+    // created — a dangling one on the page. The resolver classifies that as a
+    // cycle and leaves it unresolved, so a conversion whose dry run succeeded
+    // replaces visible content with a broken placeholder.
+    const doc = page([
+      {
+        id: "i1",
+        type: COMPONENT_INSTANCE_TYPE,
+        version: 1,
+        props: { componentId: "def-1" },
+      },
+    ]);
+
+    expect(
+      planConvertToComponent(
+        doc,
+        ["i1"],
+        componentTarget,
+        "def-1",
+        {},
+        anyParent
+      ).problem
+    ).toBe("self-reference");
+
+    // The control: converting it under a DIFFERENT id is fine, so the refusal
+    // is about the self-reference rather than about instances in a selection.
+    expect(
+      planConvertToComponent(
+        doc,
+        ["i1"],
+        componentTarget,
+        "def-2",
+        {},
+        anyParent
+      ).problem
+    ).toBeUndefined();
+  });
+
+  it("refuses an exposure list whose indices are accessors", () => {
+    // A genuine array, with entries that would be well formed, that computes
+    // them. Neither the array check nor the entry guards see it, and reading
+    // one index runs the caller's code — while a getter that appends extends
+    // `length` underneath the loop the cap is supposed to hold.
+    //
+    // Refused rather than carried to the validator: carrying works for a value
+    // the envelope check can READ, and this one explodes wherever it is first
+    // touched, which only moves the failure into validation.
+    const computed: unknown[] = [];
+    Object.defineProperty(computed, "0", {
+      enumerable: true,
+      configurable: true,
+      get() {
+        throw new Error("read me and find out");
+      },
+    });
+    Object.defineProperty(computed, "length", { value: 1, writable: true });
+
+    let threw: unknown;
+    let result;
+    try {
+      result = planSaveAsComponent(
+        cardPage(),
+        ["card"],
+        componentTarget,
+        { properties: computed } as never,
+        anyParent
+      );
+    } catch (error) {
+      threw = error;
+    }
+
+    expect(threw).toBeUndefined();
+    expect(result?.problem).toBe("invalid-exposure");
   });
 });

--- a/packages/blocks-engine/src/composition-planners.ts
+++ b/packages/blocks-engine/src/composition-planners.ts
@@ -973,14 +973,18 @@ function componentDocument(
   }
   const asked: ComponentExposure = exposure ?? {};
 
-  const ambiguous = ambiguousNomination(saved.selected, asked);
+  // ONCE, before either pass. Both work from the result, so the id the guard
+  // judges is the id the mapper stores.
+  const read = readExposure(asked);
+
+  const ambiguous = ambiguousNomination(saved.selected, read);
   if (ambiguous !== undefined) return ambiguous;
 
   const definition: ComponentDocument = {
     ...saved.stored,
     kind: "component",
-    ...exposedProperties(asked.properties, saved.nodeIds),
-    ...exposedSlots(asked.slots, saved.nodeIds),
+    ...exposedProperties(read, saved.nodeIds),
+    ...exposedSlots(read, saved.nodeIds),
   };
 
   // The HOST's limits, not this module's default. The envelope check indexes
@@ -1005,6 +1009,170 @@ function componentDocument(
 }
 
 /**
+ * The exposure request, read ONCE into plain data.
+ *
+ * Every value this module will use is taken here and never asked for again.
+ * That is the whole point: a request reaching a published entry point may hold
+ * accessors, and until this pass runs nothing about it is data. Reading a field
+ * where it is needed meant reading it several times — and a value that answers
+ * differently on each read makes two passes disagree about the same nomination.
+ *
+ * Measured before this existed: `nodeId` was read three times, twice by the
+ * ambiguity guard and once by the mapper. A getter answering `safe` twice and
+ * then `dup` walked past the guard and stored the ambiguous pointer the guard
+ * exists to refuse — the plan reporting success, the pointer resolving, and
+ * every instance override editing a node the author never chose.
+ *
+ * It is also the one place a bound belongs. Each collection was bounded
+ * wherever it happened to be traversed, which is three chances to add a fourth
+ * traversal and forget.
+ *
+ * SHAPE-PRESERVING, not shape-correcting. A value this cannot read is carried
+ * across exactly as given, because the envelope check is what says what is
+ * wrong with it, in the vocabulary the publish gate already uses. Normalising
+ * here would answer for a document nobody stores.
+ */
+interface ReadExposure {
+  /** The nominated properties. */
+  readonly properties: ReadCollection;
+  /** The nominated slot regions. */
+  readonly slots: ReadMap;
+  /**
+   * Every source node id the read entries name.
+   *
+   * Collected DURING the read rather than by a later pass over the result, and
+   * that is what makes the bound hold: a collection carried verbatim because it
+   * is over-cap or unreadable was never traversed, so it names nothing here and
+   * a second pass cannot go looking. A separate walk would have to re-apply the
+   * same bound, which is a second place to add a traversal and forget.
+   */
+  readonly named: readonly string[];
+}
+
+/**
+ * A collection this module READ, one it is CARRYING, or one that is absent.
+ *
+ * Three states with three names rather than one value standing for all of them,
+ * for the reason {@link PlacementTarget} gives about nullable parents: a
+ * collection carried verbatim — past the cap, or the wrong shape — is still an
+ * array as often as not, so anything reading it as "the entries" walks exactly
+ * what the cap refused. Measured twice while writing this. Only `"read"` holds
+ * entries, so only entries can be mapped, and the mistake stops being
+ * representable rather than merely being fixed.
+ */
+type ReadCollection =
+  | { readonly kind: "absent" }
+  | { readonly kind: "read"; readonly entries: readonly unknown[] }
+  | { readonly kind: "carried"; readonly value: unknown };
+
+/**
+ * The same three states for the slot MAP, whose keys are the exposure ids.
+ *
+ * Its own type rather than a list's, because the two are not interchangeable
+ * and one type covering both is how the carried case came to be walked as
+ * entries in the first place: a map read successfully is not a list of entries,
+ * and a map carried verbatim must not be read at all.
+ */
+type ReadMap =
+  | { readonly kind: "absent" }
+  | { readonly kind: "read"; readonly slots: Record<string, unknown> }
+  | { readonly kind: "carried"; readonly value: unknown };
+
+function readExposure(exposure: ComponentExposure): ReadExposure {
+  const named: string[] = [];
+  return {
+    properties: readEntries(exposure.properties, one =>
+      readProperty(one, named)
+    ),
+    slots: readSlotMap(exposure.slots, named),
+    named,
+  };
+}
+
+/**
+ * A list of entries, bounded and read by index; anything else verbatim.
+ *
+ * By index because `map` and `Symbol.iterator` are inherited members a caller
+ * may shadow, which throws where this module promises a refusal — on a list
+ * whose entries are all well formed. Bounded because the envelope check refuses
+ * an over-cap list in one step, so reading it first is precisely the work that
+ * cap exists to refuse; the over-cap value is handed on for that refusal.
+ */
+function readEntries(
+  value: unknown,
+  read: (one: unknown) => unknown
+): ReadCollection {
+  if (value === undefined) return { kind: "absent" };
+  if (!Array.isArray(value)) return { kind: "carried", value };
+  if (value.length > MAX_ENVELOPE_ENTRIES) return { kind: "carried", value };
+  const entries: unknown[] = [];
+  for (let index = 0; index < value.length; index += 1) {
+    entries.push(read(value[index]));
+  }
+  return { kind: "read", entries };
+}
+
+/** A nested list as the envelope should hold it, read or carried. */
+function nestedValue(collection: ReadCollection): unknown {
+  if (collection.kind === "absent") return undefined;
+  return collection.kind === "read" ? collection.entries : collection.value;
+}
+
+/** The slot map, bounded to its own keys; anything else verbatim. */
+function readSlotMap(value: unknown, named: string[]): ReadMap {
+  if (value === undefined) return { kind: "absent" };
+  if (!isPlainRecord(value)) return { kind: "carried", value };
+  const names = boundedOwnKeys(value, MAX_ENVELOPE_ENTRIES);
+  if (names === null) return { kind: "carried", value };
+  const slots: Record<string, unknown> = {};
+  // DEFINED rather than assigned: a stored record may carry an own `__proto__`,
+  // and assigning to it runs the inherited setter instead of making a property.
+  for (const name of names) {
+    defineEntry(slots, name, readSlot(value[name], named));
+  }
+  return { kind: "read", slots };
+}
+
+/** One nominated property, each field taken exactly once. */
+function readProperty(one: unknown, named: string[]): unknown {
+  if (!isPlainRecord(one)) return one;
+  const nodeId = one.nodeId;
+  if (typeof nodeId === "string") named.push(nodeId);
+  const options = one.options;
+  return {
+    id: one.id,
+    label: one.label,
+    nodeId,
+    propPath: one.propPath,
+    type: one.type,
+    ...(options === undefined
+      ? {}
+      : { options: nestedValue(readEntries(options, readOption)) }),
+  };
+}
+
+/** One `select` option, copied so the caller cannot edit the plan afterwards. */
+function readOption(one: unknown): unknown {
+  return isPlainRecord(one) ? { ...one } : one;
+}
+
+/** One nominated slot region, each field taken exactly once. */
+function readSlot(one: unknown, named: string[]): unknown {
+  if (!isPlainRecord(one)) return one;
+  const nodeId = one.nodeId;
+  if (typeof nodeId === "string") named.push(nodeId);
+  const allow = one.allow;
+  return {
+    label: one.label,
+    nodeId,
+    slot: one.slot,
+    ...(allow === undefined
+      ? {}
+      : { allow: nestedValue(readEntries(allow, entry => entry)) }),
+  };
+}
+
+/**
  * A nomination naming a source id the selection holds TWICE.
  *
  * The save re-mints ids one per node, but the map it returns is keyed on the
@@ -1022,51 +1190,18 @@ function componentDocument(
  * is a property of the page, which is saved under forgiving validation and may
  * legitimately hold one — refusing on it would reject a component whose every
  * exposure is unambiguous.
+ *
+ * Asked of the READ request, so the id it judges is the id that will be stored.
  */
 function ambiguousNomination(
   selected: readonly BlockNode[],
-  exposure: ComponentExposure
+  read: ReadExposure
 ): PlanRefusal | undefined {
   const roots = [...selected];
-  for (const id of nominatedIds(exposure)) {
+  for (const id of read.named) {
     if (countById(roots, id) > 1) return { problem: "ambiguous-exposure" };
   }
   return undefined;
-}
-
-/**
- * Every source node id a nomination points at, properties and slots alike.
- *
- * Both halves, because both are pointers and both are re-aimed through the same
- * map — a slot region naming an ambiguous id lands on the wrong container just
- * as a property does. Anything it cannot read a `nodeId` from is skipped rather
- * than reported: an entry that malformed is refused by the envelope check,
- * which says what is wrong with it in its own words.
- */
-function nominatedIds(exposure: ComponentExposure): string[] {
-  const named: string[] = [];
-  const properties = exposure.properties;
-  // BOUNDED, and read by index. An over-cap collection is refused by the
-  // envelope check whatever this pass concludes, so reading it to answer a
-  // question that refusal makes moot is precisely the work the cap exists to
-  // refuse — and this runs BEFORE the mappers, so their caps do not cover it.
-  if (Array.isArray(properties) && properties.length <= MAX_ENVELOPE_ENTRIES) {
-    for (let i = 0; i < properties.length; i += 1) {
-      collectNodeId(properties[i], named);
-    }
-  }
-  if (isPlainRecord(exposure.slots)) {
-    const keys = boundedOwnKeys(exposure.slots, MAX_ENVELOPE_ENTRIES);
-    for (const id of keys ?? []) collectNodeId(exposure.slots[id], named);
-  }
-  return named;
-}
-
-/** The `nodeId` this entry names, when it names one readable as a string. */
-function collectNodeId(one: unknown, into: string[]): void {
-  if (isPlainRecord(one) && typeof one.nodeId === "string") {
-    into.push(one.nodeId);
-  }
 }
 
 /**
@@ -1076,180 +1211,59 @@ function collectNodeId(one: unknown, into: string[]): void {
  * {@link ComponentDocument.exposed} says absence means. Writing `[]` would
  * store a field to say what its absence already says, and make two saves of one
  * selection differ by whether the caller passed a list it had not filled.
- *
- * The array is read defensively because this is reached from a published entry
- * point: a non-array here would otherwise throw where the module promises to
- * refuse. An unusable nomination becomes an envelope the check reports on.
  */
 function exposedProperties(
-  requested: readonly RequestedProperty[] | undefined,
+  read: ReadExposure,
   nodeIds: ReadonlyMap<string, string>
 ): { exposed?: ExposedProperty[] } {
-  if (requested === undefined) return {};
-  // A value that is not a list is CARRIED, not normalised away. Dropping it
-  // reports success for a nomination the caller made and this could not read,
-  // where handing it on lets `checkExposedList` refuse it in the words it
-  // already has — the same reason {@link storedId} keeps an id it cannot map.
-  if (!Array.isArray(requested)) {
-    return { exposed: requested as unknown as ExposedProperty[] };
+  const properties = read.properties;
+  if (properties.kind === "absent") return {};
+  if (properties.kind === "carried") {
+    return { exposed: properties.value as ExposedProperty[] };
   }
-  if (requested.length === 0) return {};
-  // The validator's own cap, applied BEFORE the mapping. `eachBounded` refuses
-  // a list past it in one step; cloning every entry first does the work the cap
-  // exists to refuse, on a list a decoded input controls the length of.
-  if (requested.length > MAX_ENVELOPE_ENTRIES) {
-    return { exposed: requested };
-  }
-  // BY INDEX, never through `map`. This is a caller's array and `map` is an
-  // inherited member the caller may shadow with a value of its own, which
-  // throws where this module promises a refusal — on an array whose entries are
-  // perfectly well formed. The envelope validator reads untrusted arrays the
-  // same way, for the reason the op layer avoids `Symbol.iterator`: an
-  // inherited member belongs to whoever supplied the object.
+  if (properties.entries.length === 0) return {};
   const exposed: ExposedProperty[] = [];
-  for (let i = 0; i < requested.length; i += 1) {
-    const one = requested[i];
-    // Per ENTRY. A `null` or a primitive is not something this can re-aim, and
-    // reading `one.id` off it throws — so it is carried for the validator to
-    // report rather than dereferenced here.
-    exposed.push(
-      isPlainRecord(one)
-        ? mappedProperty(one as unknown as RequestedProperty, nodeIds)
-        : one
-    );
+  for (const one of properties.entries) {
+    exposed.push(aimedProperty(one, nodeIds));
   }
   return { exposed };
 }
 
-/**
- * A slot's allow-list, copied by index and bounded.
- *
- * A spread invokes `Symbol.iterator`, which is inherited and therefore the
- * caller's to shadow — throwing where this module promises a refusal, on an
- * array whose entries are all well formed. The same reason the properties list
- * is not read through `map`. Bounded for the reason {@link clonedOptions} is:
- * nothing outside an entry bounds a list nested inside it.
- */
-function copiedAllow(allow: readonly unknown[]): ExposedSlot["allow"] {
-  if (allow.length > MAX_ENVELOPE_ENTRIES) return allow as ExposedSlot["allow"];
-  const copied: string[] = [];
-  for (let i = 0; i < allow.length; i += 1) copied.push(allow[i] as string);
-  return copied;
-}
-
-/**
- * The option records, copied one level deep and read by index.
- *
- * By index for the reason {@link exposedProperties} gives: `map` is the
- * caller's to shadow. One level deep because cloning the list alone leaves
- * every option object shared with the request, so editing a label after
- * planning would edit the document the plan said it would store.
- */
-function clonedOptions(
-  options: readonly unknown[]
-): ExposedProperty["options"] {
-  // The cap, before the copy. A nested list sits INSIDE an entry the outer cap
-  // already admitted, so nothing else bounds it — and the envelope check
-  // refuses an over-cap list in one step, which makes copying every entry first
-  // exactly the work that cap exists to refuse.
-  if (options.length > MAX_ENVELOPE_ENTRIES) {
-    return options as ExposedProperty["options"];
-  }
-  const copied: { value: string; label: string }[] = [];
-  for (let i = 0; i < options.length; i += 1) {
-    const option = options[i];
-    copied.push(
-      (isPlainRecord(option) ? { ...option } : option) as {
-        value: string;
-        label: string;
-      }
-    );
-  }
-  return copied;
-}
-
-/** One nominated property, re-aimed at the stored tree. */
-function mappedProperty(
-  one: RequestedProperty,
+/** One read property, with its pointer moved onto the stored node. */
+function aimedProperty(
+  one: unknown,
   nodeIds: ReadonlyMap<string, string>
 ): ExposedProperty {
-  return {
-    id: one.id,
-    label: one.label,
-    nodeId: storedId(one.nodeId, nodeIds),
-    propPath: one.propPath,
-    type: one.type,
-    // Copied to a DEPTH of one record, not just the array. Cloning the list
-    // alone leaves every option object shared with the caller's request, so
-    // editing a label after planning silently edits the document the plan says
-    // it would store — an alias a test that only appends to the list cannot see.
-    //
-    // A value that is not a list is CARRIED rather than dropped, on the same
-    // terms as the nomination that holds it: the validator refuses a present
-    // `options` on anything but a select, and one that is not an array, so
-    // omitting it here turns a refusal into a success.
-    ...(one.options === undefined
-      ? {}
-      : {
-          options: Array.isArray(one.options)
-            ? clonedOptions(one.options)
-            : one.options,
-        }),
-  };
+  if (!isPlainRecord(one)) return one as ExposedProperty;
+  return { ...one, nodeId: storedId(one.nodeId, nodeIds) } as ExposedProperty;
 }
 
 /** The nominated slot regions, re-aimed, on the same terms as the properties. */
 function exposedSlots(
-  requested: Readonly<Record<string, RequestedSlot>> | undefined,
+  read: ReadExposure,
   nodeIds: ReadonlyMap<string, string>
 ): { slots?: Record<string, ExposedSlot> } {
-  if (requested === undefined) return {};
-  if (!isPlainRecord(requested)) {
-    return { slots: requested };
+  const requested = read.slots;
+  if (requested.kind === "absent") return {};
+  if (requested.kind === "carried") {
+    return { slots: requested.value as Record<string, ExposedSlot> };
   }
-  // Own keys only, and BOUNDED, for the two reasons those are separate rules.
-  // A record reached from a published entry point may inherit a key, and a key
-  // that is not the caller's own is a region no author asked for — while
-  // `structuredClone` and object spreads copy neither, so the guard and the
-  // writer would otherwise disagree about the same field. And materialising
-  // every key of a caller-sized record does the work the validator's cap exists
-  // to refuse in one step.
-  const named = boundedOwnKeys(requested, MAX_ENVELOPE_ENTRIES);
-  if (named === null) {
-    return { slots: requested };
-  }
-  if (named.length === 0) return {};
+  const names = Object.keys(requested.slots);
+  if (names.length === 0) return {};
   const slots: Record<string, ExposedSlot> = {};
-  for (const id of named) {
-    const one = requested[id];
-    // DEFINED rather than assigned. A stored record may carry an own
-    // `__proto__` key, and assigning to it runs the inherited setter instead of
-    // creating a property — so the slot the author asked for disappears and the
-    // result gains a prototype, making the validator refuse a nomination it
-    // accepts when the same document is stored directly.
-    defineEntry(
-      slots,
-      id,
-      isPlainRecord(one)
-        ? {
-            label: one.label,
-            nodeId: storedId(one.nodeId, nodeIds),
-            slot: one.slot,
-            // Carried when it is not a list, not dropped: the validator refuses
-            // a present non-array allow-list, and dropping it leaves an
-            // unrestricted slot the planner then reports as fine.
-            ...(one.allow === undefined
-              ? {}
-              : {
-                  allow: Array.isArray(one.allow)
-                    ? copiedAllow(one.allow)
-                    : (one.allow as ExposedSlot["allow"]),
-                }),
-          }
-        : (one as unknown as ExposedSlot)
-    );
+  for (const id of names) {
+    defineEntry(slots, id, aimedSlot(requested.slots[id], nodeIds));
   }
   return { slots };
+}
+
+/** One read slot, with its pointer moved onto the stored node. */
+function aimedSlot(
+  one: unknown,
+  nodeIds: ReadonlyMap<string, string>
+): ExposedSlot {
+  if (!isPlainRecord(one)) return one as ExposedSlot;
+  return { ...one, nodeId: storedId(one.nodeId, nodeIds) } as ExposedSlot;
 }
 
 /**
@@ -1265,9 +1279,10 @@ function exposedSlots(
  * ones, so a surviving source id is never one of them.
  */
 function storedId(
-  sourceId: string,
+  sourceId: unknown,
   nodeIds: ReadonlyMap<string, string>
-): string {
+): unknown {
+  if (typeof sourceId !== "string") return sourceId;
   return nodeIds.get(sourceId) ?? sourceId;
 }
 

--- a/packages/blocks-engine/src/composition-planners.ts
+++ b/packages/blocks-engine/src/composition-planners.ts
@@ -35,6 +35,7 @@ import type {
 } from "./document";
 import { DEFAULT_LIMITS, MAX_ENVELOPE_ENTRIES } from "./limits";
 import type { DocumentLimits } from "./limits";
+import { surveyDocument } from "./measure-bytes";
 import {
   canBeRoot,
   canNest,
@@ -46,6 +47,7 @@ import {
 import {
   applyOps,
   documentRefusal,
+  listRefusal,
   forestRefusal,
   lockedWithin,
   nodeShapeRefusal,
@@ -56,6 +58,7 @@ import {
 } from "./ops";
 import { patternDigest } from "./pattern-digest";
 import { isPlainRecord } from "./plain-record";
+import { componentIdsIn } from "./resolve-instances";
 import { boundedOwnKeys, defineEntry } from "./safe-record";
 import { contiguousRun, type RunProblem } from "./sibling-run";
 import {
@@ -218,7 +221,16 @@ export type PlanProblem =
    * their exposure: the page is at its ceiling, and what has to change is the
    * page or the ceiling.
    */
-  | "exceeds-limits";
+  | "exceeds-limits"
+  /**
+   * The definition would contain an instance of itself.
+   *
+   * Its own cause because nothing about the selection or the exposure is
+   * malformed: the run being converted already referenced the component about
+   * to be created, and the author has to remove that instance or create the
+   * component under a different id.
+   */
+  | "self-reference";
 
 /** A refusal, with whatever the surface needs to phrase it. */
 export interface PlanRefusal {
@@ -918,6 +930,16 @@ export function planConvertToComponent<TFields>(
   const definition = componentDocument(saved, exposure, limits);
   if (definition.problem !== undefined) return definition;
 
+  // A definition holding an instance of ITSELF. The selection can already
+  // contain one — a dangling `def-1` on the page, converted while creating
+  // `def-1` — and the resolver classifies that as a cycle and leaves it
+  // unresolved, so a conversion whose dry run succeeded replaces visible
+  // content with a broken placeholder. Asked through the resolver's own
+  // published index, not a walk of this module's own.
+  if (componentIdsIn(definition.document.nodes).includes(componentId)) {
+    return { problem: "self-reference" };
+  }
+
   const replaced = replaceOps(document, saved, componentId, nesting, limits);
   if (replaced.problem !== undefined) return replaced;
 
@@ -977,6 +999,12 @@ function componentDocument(
   // judges is the id the mapper stores.
   const read = readExposure(asked);
 
+  // A collection nothing may read is refused HERE rather than handed on. The
+  // envelope check is what names what is wrong with a value this cannot map —
+  // but only for a value it can itself read, and an array with an accessor
+  // index explodes wherever it is first touched.
+  if (unreadable(read)) return { problem: "invalid-exposure" };
+
   const ambiguous = ambiguousNomination(saved.selected, read);
   if (ambiguous !== undefined) return ambiguous;
 
@@ -1003,9 +1031,7 @@ function componentDocument(
   // make the whole document unstorable: an option carrying a `BigInt` survives
   // the envelope check, which reads `value` and `label`, and JSON cannot write
   // it. The plan would report success and the create would fail on save.
-  return documentRefusal(definition) === undefined
-    ? { document: definition }
-    : { problem: "unusable-document" };
+  return definitionRefusal(definition, limits) ?? { document: definition };
 }
 
 /**
@@ -1063,7 +1089,17 @@ interface ReadExposure {
 type ReadCollection =
   | { readonly kind: "absent" }
   | { readonly kind: "read"; readonly entries: readonly unknown[] }
-  | { readonly kind: "carried"; readonly value: unknown };
+  | { readonly kind: "carried"; readonly value: unknown }
+  /**
+   * A collection nothing may read — not this module, and not the validator.
+   *
+   * Distinct from `"carried"`, which hands a value on for the envelope check to
+   * refuse in its own words. That only works for a value the check can READ: an
+   * array whose indices are accessors explodes wherever it is first touched, so
+   * carrying it moves the explosion into validation instead of preventing it.
+   * Measured exactly that way.
+   */
+  | { readonly kind: "unreadable" };
 
 /**
  * The same three states for the slot MAP, whose keys are the exposure ids.
@@ -1076,7 +1112,8 @@ type ReadCollection =
 type ReadMap =
   | { readonly kind: "absent" }
   | { readonly kind: "read"; readonly slots: Record<string, unknown> }
-  | { readonly kind: "carried"; readonly value: unknown };
+  | { readonly kind: "carried"; readonly value: unknown }
+  | { readonly kind: "unreadable" };
 
 function readExposure(exposure: ComponentExposure): ReadExposure {
   const named: string[] = [];
@@ -1104,6 +1141,16 @@ function readEntries(
 ): ReadCollection {
   if (value === undefined) return { kind: "absent" };
   if (!Array.isArray(value)) return { kind: "carried", value };
+  // The list is DATA before a single index of it is read. An index can be an
+  // accessor even on a genuine array whose entries are all well formed, so
+  // neither the array check above nor the entry guards below see it — and
+  // reading one runs the caller's code: a throwing getter escapes as a native
+  // error, and one that appends extends `length` underneath the very bound that
+  // is supposed to hold this loop. Carried for the validator to refuse, which
+  // is what happens to every value this cannot read.
+  if (listRefusal(value, "an exposure list") !== undefined) {
+    return { kind: "unreadable" };
+  }
   if (value.length > MAX_ENVELOPE_ENTRIES) return { kind: "carried", value };
   const entries: unknown[] = [];
   for (let index = 0; index < value.length; index += 1) {
@@ -1115,7 +1162,11 @@ function readEntries(
 /** A nested list as the envelope should hold it, read or carried. */
 function nestedValue(collection: ReadCollection): unknown {
   if (collection.kind === "absent") return undefined;
-  return collection.kind === "read" ? collection.entries : collection.value;
+  if (collection.kind === "read") return collection.entries;
+  // An unreadable nested list becomes an empty one rather than travelling into
+  // the envelope: it is a list nothing may touch, and the entry holding it is
+  // refused by the caller of this read anyway.
+  return collection.kind === "carried" ? collection.value : [];
 }
 
 /** The slot map, bounded to its own keys; anything else verbatim. */
@@ -1204,6 +1255,44 @@ function ambiguousNomination(
   return undefined;
 }
 
+/** Whether either collection is one nothing may read. */
+function unreadable(read: ReadExposure): boolean {
+  return (
+    read.properties.kind === "unreadable" || read.slots.kind === "unreadable"
+  );
+}
+
+/**
+ * Why the completed definition could not be stored, or `undefined`.
+ *
+ * Two questions the envelope check does not answer, asked of the document WITH
+ * its envelope on.
+ *
+ * Whether it can be stored at all — `savedPatternDocument` asks that of the
+ * tree, before there is an envelope, and the envelope is caller-supplied, so a
+ * field the envelope check does not read can still make the whole document
+ * unwritable.
+ *
+ * And whether it FITS. An exposure only ever makes a document bigger, so a page
+ * inside the caller's caps can become a definition that is not — and being
+ * editable is a different question from being small enough. Measured through
+ * the survey the publish gate uses, so the two cannot come to disagree about
+ * the size of one document.
+ */
+function definitionRefusal(
+  definition: ComponentDocument,
+  limits: DocumentLimits
+): PlanRefusal | undefined {
+  if (documentRefusal(definition) !== undefined) {
+    return { problem: "unusable-document" };
+  }
+  const survey = surveyDocument(definition, limits);
+  if (survey.tooLarge || survey.tooDeep || survey.tooManyNodes) {
+    return { problem: "exceeds-limits" };
+  }
+  return undefined;
+}
+
 /**
  * The nominated properties, re-aimed at the stored tree.
  *
@@ -1217,7 +1306,9 @@ function exposedProperties(
   nodeIds: ReadonlyMap<string, string>
 ): { exposed?: ExposedProperty[] } {
   const properties = read.properties;
-  if (properties.kind === "absent") return {};
+  if (properties.kind === "absent" || properties.kind === "unreadable") {
+    return {};
+  }
   if (properties.kind === "carried") {
     return { exposed: properties.value as ExposedProperty[] };
   }
@@ -1244,7 +1335,9 @@ function exposedSlots(
   nodeIds: ReadonlyMap<string, string>
 ): { slots?: Record<string, ExposedSlot> } {
   const requested = read.slots;
-  if (requested.kind === "absent") return {};
+  if (requested.kind === "absent" || requested.kind === "unreadable") {
+    return {};
+  }
   if (requested.kind === "carried") {
     return { slots: requested.value as Record<string, ExposedSlot> };
   }

--- a/packages/blocks-engine/src/composition-planners.ts
+++ b/packages/blocks-engine/src/composition-planners.ts
@@ -44,6 +44,7 @@ import {
   type NestingVerdict,
 } from "./nesting";
 import {
+  applyOps,
   documentRefusal,
   forestRefusal,
   lockedWithin,
@@ -209,7 +210,15 @@ export type PlanProblem =
    * malformed — the pointer resolves, to one of two nodes that answered to the
    * name — so the author's remedy is to pick a node rather than to fix a field.
    */
-  | "ambiguous-exposure";
+  | "ambiguous-exposure"
+  /**
+   * Applying the plan would put the page past a limit the caller set.
+   *
+   * Its own cause because the remedy is neither the author's selection nor
+   * their exposure: the page is at its ceiling, and what has to change is the
+   * page or the ceiling.
+   */
+  | "exceeds-limits";
 
 /** A refusal, with whatever the surface needs to phrase it. */
 export interface PlanRefusal {
@@ -909,7 +918,7 @@ export function planConvertToComponent<TFields>(
   const definition = componentDocument(saved, exposure, limits);
   if (definition.problem !== undefined) return definition;
 
-  const replaced = replaceOps(document, saved, componentId, nesting);
+  const replaced = replaceOps(document, saved, componentId, nesting, limits);
   if (replaced.problem !== undefined) return replaced;
 
   return {
@@ -982,9 +991,17 @@ function componentDocument(
   // is given the host's limits; a dry run using its own would refuse a
   // component the apply would publish, which is the direction nobody can debug.
   const issues = componentEnvelopeIssues(definition, limits);
-  return issues.length === 0
+  if (issues.length > 0) return { problem: "invalid-exposure", issues };
+
+  // The stored-document rule, asked of the definition WITH its envelope on.
+  // `savedPatternDocument` asks it of the tree, before there is an envelope —
+  // and the envelope is caller-supplied, so a field this cannot judge can still
+  // make the whole document unstorable: an option carrying a `BigInt` survives
+  // the envelope check, which reads `value` and `label`, and JSON cannot write
+  // it. The plan would report success and the create would fail on save.
+  return documentRefusal(definition) === undefined
     ? { document: definition }
-    : { problem: "invalid-exposure", issues };
+    : { problem: "unusable-document" };
 }
 
 /**
@@ -1105,6 +1122,22 @@ function exposedProperties(
 }
 
 /**
+ * A slot's allow-list, copied by index and bounded.
+ *
+ * A spread invokes `Symbol.iterator`, which is inherited and therefore the
+ * caller's to shadow — throwing where this module promises a refusal, on an
+ * array whose entries are all well formed. The same reason the properties list
+ * is not read through `map`. Bounded for the reason {@link clonedOptions} is:
+ * nothing outside an entry bounds a list nested inside it.
+ */
+function copiedAllow(allow: readonly unknown[]): ExposedSlot["allow"] {
+  if (allow.length > MAX_ENVELOPE_ENTRIES) return allow as ExposedSlot["allow"];
+  const copied: string[] = [];
+  for (let i = 0; i < allow.length; i += 1) copied.push(allow[i] as string);
+  return copied;
+}
+
+/**
  * The option records, copied one level deep and read by index.
  *
  * By index for the reason {@link exposedProperties} gives: `map` is the
@@ -1115,6 +1148,13 @@ function exposedProperties(
 function clonedOptions(
   options: readonly unknown[]
 ): ExposedProperty["options"] {
+  // The cap, before the copy. A nested list sits INSIDE an entry the outer cap
+  // already admitted, so nothing else bounds it — and the envelope check
+  // refuses an over-cap list in one step, which makes copying every entry first
+  // exactly the work that cap exists to refuse.
+  if (options.length > MAX_ENVELOPE_ENTRIES) {
+    return options as ExposedProperty["options"];
+  }
   const copied: { value: string; label: string }[] = [];
   for (let i = 0; i < options.length; i += 1) {
     const option = options[i];
@@ -1202,7 +1242,7 @@ function exposedSlots(
               ? {}
               : {
                   allow: Array.isArray(one.allow)
-                    ? [...one.allow]
+                    ? copiedAllow(one.allow)
                     : (one.allow as ExposedSlot["allow"]),
                 }),
           }
@@ -1242,7 +1282,8 @@ function replaceOps(
   document: BlockDocument,
   saved: PlannedSave,
   componentId: string,
-  nesting: NestingSource
+  nesting: NestingSource,
+  limits: DocumentLimits
 ): RestampOps | PlanRefusal {
   // Everything `applyOp` asks BEFORE it looks at an op — the envelope, then the
   // whole forest, because it walks every node before applying anything. A
@@ -1286,14 +1327,30 @@ function replaceOps(
   );
   if (placement !== undefined) return placement;
 
-  return {
-    ops: [
-      ...saved.selected.map(
-        (root): BuilderOp => ({ kind: "remove", id: root.id })
-      ),
-      { kind: "insert", node: instance, at: position.at },
-    ],
-  };
+  const ops: BuilderOp[] = [
+    ...saved.selected.map(
+      (root): BuilderOp => ({ kind: "remove", id: root.id })
+    ),
+    { kind: "insert", node: instance, at: position.at },
+  ];
+
+  // The BYTE cap, asked of the apply, because the apply is the only place that
+  // can answer it. `nodeShapeRefusal` says so in as many words: `assertFitsCaps`
+  // measures the document a node is going INTO, so a subtree with no
+  // destination cannot be judged against it. A run replaced by a larger
+  // instance can cross a cap the page was inside, and the plan would be handed
+  // over with its library row already written.
+  //
+  // Applied to a copy rather than re-derived: `applyOps` is pure, and a second
+  // reading of the same rule is one more thing that can come to disagree with
+  // the run it predicts.
+  try {
+    applyOps(document, ops, limits);
+  } catch {
+    return { problem: "exceeds-limits" };
+  }
+
+  return { ops };
 }
 
 /**

--- a/packages/blocks-engine/src/composition-planners.ts
+++ b/packages/blocks-engine/src/composition-planners.ts
@@ -47,10 +47,13 @@ import {
   lockedWithin,
   nodeShapeRefusal,
   positionRefusal,
+  subtreeRemovalRefusal,
   type BuilderOp,
   type OpPosition,
 } from "./ops";
 import { patternDigest } from "./pattern-digest";
+import { isPlainRecord } from "./plain-record";
+import { defineEntry } from "./safe-record";
 import { contiguousRun, type RunProblem } from "./sibling-run";
 import {
   findNode,
@@ -196,7 +199,15 @@ export type PlanProblem =
    * author does next, where this names a property they nominated and can
    * withdraw. {@link PlanRefusal.issues} carries which one.
    */
-  | "invalid-exposure";
+  | "invalid-exposure"
+  /**
+   * A nomination names a node id the selection holds more than once.
+   *
+   * Told apart from `"invalid-exposure"` because nothing about the envelope is
+   * malformed — the pointer resolves, to one of two nodes that answered to the
+   * name — so the author's remedy is to pick a node rather than to fix a field.
+   */
+  | "ambiguous-exposure";
 
 /** A refusal, with whatever the surface needs to phrase it. */
 export interface PlanRefusal {
@@ -934,6 +945,9 @@ function componentDocument(
   saved: PlannedSave,
   exposure: ComponentExposure
 ): SavedComponent | PlanRefusal {
+  const ambiguous = ambiguousNomination(saved.selected, exposure);
+  if (ambiguous !== undefined) return ambiguous;
+
   const definition: ComponentDocument = {
     ...saved.stored,
     kind: "component",
@@ -945,6 +959,65 @@ function componentDocument(
   return issues.length === 0
     ? { document: definition }
     : { problem: "invalid-exposure", issues };
+}
+
+/**
+ * A nomination naming a source id the selection holds TWICE.
+ *
+ * The save re-mints ids one per node, but the map it returns is keyed on the
+ * ORIGINAL id — so two nodes sharing one lose the first mapping to the second,
+ * and a pointer re-aimed through it lands on whichever copy came last. The
+ * stored document is well formed and the envelope check passes, because the
+ * pointer does resolve; it simply resolves to a node the author did not choose,
+ * and every instance override then edits the wrong block.
+ *
+ * Refused rather than resolved, because the nomination is genuinely ambiguous:
+ * two nodes answered to the name the author gave, and nothing here can know
+ * which was meant. The same stance `"duplicate-destination"` takes elsewhere.
+ *
+ * Only the ids actually NOMINATED. A duplicate somewhere else in the selection
+ * is a property of the page, which is saved under forgiving validation and may
+ * legitimately hold one — refusing on it would reject a component whose every
+ * exposure is unambiguous.
+ */
+function ambiguousNomination(
+  selected: readonly BlockNode[],
+  exposure: ComponentExposure
+): PlanRefusal | undefined {
+  const roots = [...selected];
+  for (const id of nominatedIds(exposure)) {
+    if (countById(roots, id) > 1) return { problem: "ambiguous-exposure" };
+  }
+  return undefined;
+}
+
+/**
+ * Every source node id a nomination points at, properties and slots alike.
+ *
+ * Both halves, because both are pointers and both are re-aimed through the same
+ * map — a slot region naming an ambiguous id lands on the wrong container just
+ * as a property does. Anything it cannot read a `nodeId` from is skipped rather
+ * than reported: an entry that malformed is refused by the envelope check,
+ * which says what is wrong with it in its own words.
+ */
+function nominatedIds(exposure: ComponentExposure): string[] {
+  const named: string[] = [];
+  if (Array.isArray(exposure.properties)) {
+    for (const one of exposure.properties) collectNodeId(one, named);
+  }
+  if (isPlainRecord(exposure.slots)) {
+    for (const id of Object.keys(exposure.slots)) {
+      collectNodeId(exposure.slots[id], named);
+    }
+  }
+  return named;
+}
+
+/** The `nodeId` this entry names, when it names one readable as a string. */
+function collectNodeId(one: unknown, into: string[]): void {
+  if (isPlainRecord(one) && typeof one.nodeId === "string") {
+    into.push(one.nodeId);
+  }
 }
 
 /**
@@ -963,18 +1036,49 @@ function exposedProperties(
   requested: readonly RequestedProperty[] | undefined,
   nodeIds: ReadonlyMap<string, string>
 ): { exposed?: ExposedProperty[] } {
-  if (!Array.isArray(requested) || requested.length === 0) return {};
+  if (requested === undefined) return {};
+  // A value that is not a list is CARRIED, not normalised away. Dropping it
+  // reports success for a nomination the caller made and this could not read,
+  // where handing it on lets `checkExposedList` refuse it in the words it
+  // already has — the same reason {@link storedId} keeps an id it cannot map.
+  if (!Array.isArray(requested)) {
+    return { exposed: requested as unknown as ExposedProperty[] };
+  }
+  if (requested.length === 0) return {};
   return {
-    exposed: requested.map(one => ({
-      id: one.id,
-      label: one.label,
-      nodeId: storedId(one.nodeId, nodeIds),
-      propPath: one.propPath,
-      type: one.type,
-      // Copied rather than aliased: the stored document must not share an array
-      // with the caller's request, which the caller is free to go on editing.
-      ...(Array.isArray(one.options) ? { options: [...one.options] } : {}),
-    })),
+    exposed: requested.map(one =>
+      // Per ENTRY, for the same reason. A `null` or a primitive in the list is
+      // not something this can re-aim, and reading `one.id` off it throws where
+      // the module promises a refusal.
+      isPlainRecord(one)
+        ? mappedProperty(one as unknown as RequestedProperty, nodeIds)
+        : one
+    ),
+  };
+}
+
+/** One nominated property, re-aimed at the stored tree. */
+function mappedProperty(
+  one: RequestedProperty,
+  nodeIds: ReadonlyMap<string, string>
+): ExposedProperty {
+  return {
+    id: one.id,
+    label: one.label,
+    nodeId: storedId(one.nodeId, nodeIds),
+    propPath: one.propPath,
+    type: one.type,
+    // Copied to a DEPTH of one record, not just the array. Cloning the list
+    // alone leaves every option object shared with the caller's request, so
+    // editing a label after planning silently edits the document the plan says
+    // it would store — an alias a test that only appends to the list cannot see.
+    ...(Array.isArray(one.options)
+      ? {
+          options: one.options.map(option =>
+            isPlainRecord(option) ? { ...option } : option
+          ),
+        }
+      : {}),
   };
 }
 
@@ -983,7 +1087,10 @@ function exposedSlots(
   requested: Readonly<Record<string, RequestedSlot>> | undefined,
   nodeIds: ReadonlyMap<string, string>
 ): { slots?: Record<string, ExposedSlot> } {
-  if (requested === null || typeof requested !== "object") return {};
+  if (requested === undefined) return {};
+  if (!isPlainRecord(requested)) {
+    return { slots: requested };
+  }
   // Own keys only. A record reached from a published entry point may inherit
   // one, and a key that is not the caller's own is a region no author asked
   // for — while `structuredClone` and object spreads copy neither, so the guard
@@ -993,13 +1100,23 @@ function exposedSlots(
   const slots: Record<string, ExposedSlot> = {};
   for (const id of named) {
     const one = requested[id];
-    if (one === null || typeof one !== "object") continue;
-    slots[id] = {
-      label: one.label,
-      nodeId: storedId(one.nodeId, nodeIds),
-      slot: one.slot,
-      ...(Array.isArray(one.allow) ? { allow: [...one.allow] } : {}),
-    };
+    // DEFINED rather than assigned. A stored record may carry an own
+    // `__proto__` key, and assigning to it runs the inherited setter instead of
+    // creating a property — so the slot the author asked for disappears and the
+    // result gains a prototype, making the validator refuse a nomination it
+    // accepts when the same document is stored directly.
+    defineEntry(
+      slots,
+      id,
+      isPlainRecord(one)
+        ? {
+            label: one.label,
+            nodeId: storedId(one.nodeId, nodeIds),
+            slot: one.slot,
+            ...(Array.isArray(one.allow) ? { allow: [...one.allow] } : {}),
+          }
+        : (one as unknown as ExposedSlot)
+    );
   }
   return { slots };
 }
@@ -1036,9 +1153,21 @@ function replaceOps(
   componentId: string,
   nesting: NestingSource
 ): RestampOps | PlanRefusal {
+  // Everything `applyOp` asks BEFORE it looks at an op — the envelope, then the
+  // whole forest, because it walks every node before applying anything. A
+  // malformed sibling the author never selected refuses the first remove of a
+  // group whose library row has already been written, which is the rollback the
+  // plan/apply split exists to avoid. Asked exactly as {@link restampOps} asks
+  // it, since both planners emit ops against the same document.
+  if (
+    documentRefusal(document) !== undefined ||
+    forestRefusal(document.nodes) !== undefined
+  ) {
+    return { problem: "unusable-document" };
+  }
+
   const refusal =
-    lockRefusal(saved.selected) ??
-    ambiguousRootRefusal(document, saved.selected);
+    lockRefusal(saved.selected) ?? removableRefusal(document, saved.selected);
   if (refusal !== undefined) return refusal;
 
   const position = replacementPosition(saved.at);
@@ -1074,6 +1203,28 @@ function replaceOps(
       { kind: "insert", node: instance, at: position.at },
     ],
   };
+}
+
+/**
+ * A selected root this document will not let a `remove` take.
+ *
+ * The op layer's own rule rather than a count of the root's id, and the two are
+ * not the same question: `remove` refuses when ANY id inside the subtree it
+ * takes occurs more than once in the document, because the inverse it records
+ * could not put that subtree back. A root can be unique while a node three
+ * levels down collides with something across the page — and the plan then
+ * succeeds, the library row is written, and the first op throws.
+ */
+function removableRefusal(
+  document: BlockDocument,
+  roots: readonly BlockNode[]
+): PlanRefusal | undefined {
+  for (const root of roots) {
+    if (subtreeRemovalRefusal(document.nodes, root) !== undefined) {
+      return { problem: "duplicate-destination" };
+    }
+  }
+  return undefined;
 }
 
 /**

--- a/packages/blocks-engine/src/composition-planners.ts
+++ b/packages/blocks-engine/src/composition-planners.ts
@@ -33,6 +33,7 @@ import type {
   ExposedPropertyType,
   ExposedSlot,
 } from "./document";
+import { MAX_ENVELOPE_ENTRIES } from "./limits";
 import {
   canBeRoot,
   canNest,
@@ -53,7 +54,7 @@ import {
 } from "./ops";
 import { patternDigest } from "./pattern-digest";
 import { isPlainRecord } from "./plain-record";
-import { defineEntry } from "./safe-record";
+import { boundedOwnKeys, defineEntry } from "./safe-record";
 import { contiguousRun, type RunProblem } from "./sibling-run";
 import {
   findNode,
@@ -945,14 +946,28 @@ function componentDocument(
   saved: PlannedSave,
   exposure: ComponentExposure
 ): SavedComponent | PlanRefusal {
-  const ambiguous = ambiguousNomination(saved.selected, exposure);
+  // The CONTAINER, before either field is read off it. The guards below judge
+  // the fields and their entries; none of them can be reached at all if the
+  // request itself is not a record — `null` throws, and a string or an array
+  // answers `undefined` to both reads and is silently taken for "expose
+  // nothing", which reports success for a request nobody could honour.
+  //
+  // `undefined` is the exception and means exactly that: a caller with nothing
+  // to expose. It is the one value that says so rather than failing to say
+  // anything.
+  if (exposure !== undefined && !isPlainRecord(exposure)) {
+    return { problem: "invalid-exposure" };
+  }
+  const asked: ComponentExposure = exposure ?? {};
+
+  const ambiguous = ambiguousNomination(saved.selected, asked);
   if (ambiguous !== undefined) return ambiguous;
 
   const definition: ComponentDocument = {
     ...saved.stored,
     kind: "component",
-    ...exposedProperties(exposure.properties, saved.nodeIds),
-    ...exposedSlots(exposure.slots, saved.nodeIds),
+    ...exposedProperties(asked.properties, saved.nodeIds),
+    ...exposedSlots(asked.slots, saved.nodeIds),
   };
 
   const issues = componentEnvelopeIssues(definition);
@@ -1045,6 +1060,12 @@ function exposedProperties(
     return { exposed: requested as unknown as ExposedProperty[] };
   }
   if (requested.length === 0) return {};
+  // The validator's own cap, applied BEFORE the mapping. `eachBounded` refuses
+  // a list past it in one step; cloning every entry first does the work the cap
+  // exists to refuse, on a list a decoded input controls the length of.
+  if (requested.length > MAX_ENVELOPE_ENTRIES) {
+    return { exposed: requested };
+  }
   return {
     exposed: requested.map(one =>
       // Per ENTRY, for the same reason. A `null` or a primitive in the list is
@@ -1072,13 +1093,20 @@ function mappedProperty(
     // alone leaves every option object shared with the caller's request, so
     // editing a label after planning silently edits the document the plan says
     // it would store — an alias a test that only appends to the list cannot see.
-    ...(Array.isArray(one.options)
-      ? {
-          options: one.options.map(option =>
-            isPlainRecord(option) ? { ...option } : option
-          ),
-        }
-      : {}),
+    //
+    // A value that is not a list is CARRIED rather than dropped, on the same
+    // terms as the nomination that holds it: the validator refuses a present
+    // `options` on anything but a select, and one that is not an array, so
+    // omitting it here turns a refusal into a success.
+    ...(one.options === undefined
+      ? {}
+      : {
+          options: Array.isArray(one.options)
+            ? one.options.map(option =>
+                isPlainRecord(option) ? { ...option } : option
+              )
+            : one.options,
+        }),
   };
 }
 
@@ -1091,11 +1119,17 @@ function exposedSlots(
   if (!isPlainRecord(requested)) {
     return { slots: requested };
   }
-  // Own keys only. A record reached from a published entry point may inherit
-  // one, and a key that is not the caller's own is a region no author asked
-  // for — while `structuredClone` and object spreads copy neither, so the guard
-  // and the writer would otherwise disagree about the same field.
-  const named = Object.keys(requested);
+  // Own keys only, and BOUNDED, for the two reasons those are separate rules.
+  // A record reached from a published entry point may inherit a key, and a key
+  // that is not the caller's own is a region no author asked for — while
+  // `structuredClone` and object spreads copy neither, so the guard and the
+  // writer would otherwise disagree about the same field. And materialising
+  // every key of a caller-sized record does the work the validator's cap exists
+  // to refuse in one step.
+  const named = boundedOwnKeys(requested, MAX_ENVELOPE_ENTRIES);
+  if (named === null) {
+    return { slots: requested };
+  }
   if (named.length === 0) return {};
   const slots: Record<string, ExposedSlot> = {};
   for (const id of named) {
@@ -1113,7 +1147,16 @@ function exposedSlots(
             label: one.label,
             nodeId: storedId(one.nodeId, nodeIds),
             slot: one.slot,
-            ...(Array.isArray(one.allow) ? { allow: [...one.allow] } : {}),
+            // Carried when it is not a list, not dropped: the validator refuses
+            // a present non-array allow-list, and dropping it leaves an
+            // unrestricted slot the planner then reports as fine.
+            ...(one.allow === undefined
+              ? {}
+              : {
+                  allow: Array.isArray(one.allow)
+                    ? [...one.allow]
+                    : (one.allow as ExposedSlot["allow"]),
+                }),
           }
         : (one as unknown as ExposedSlot)
     );

--- a/packages/blocks-engine/src/composition-planners.ts
+++ b/packages/blocks-engine/src/composition-planners.ts
@@ -23,8 +23,16 @@
  *
  * @module composition-planners
  */
-import { renderedDomId } from "./document";
-import type { BlockDocument, BlockNode, BlockOrigin } from "./document";
+import { COMPONENT_INSTANCE_TYPE, renderedDomId } from "./document";
+import type {
+  BlockDocument,
+  BlockNode,
+  BlockOrigin,
+  ComponentDocument,
+  ExposedProperty,
+  ExposedPropertyType,
+  ExposedSlot,
+} from "./document";
 import {
   canBeRoot,
   canNest,
@@ -48,9 +56,12 @@ import {
   findNode,
   hiddenSubtreeNodes,
   mapForest,
+  newId,
   reidForestWithMap,
   walkNodes,
 } from "./tree";
+import { componentEnvelopeIssues } from "./validation";
+import type { ValidationIssue } from "./validation";
 
 /** A library row a planner asks the caller to create. */
 export interface PlannedCreate<TFields> {
@@ -63,6 +74,22 @@ export interface PlannedCreate<TFields> {
    * collection exists that it cannot see.
    */
   readonly collection: string;
+  /**
+   * The id to create it under, when the page ops already name it.
+   *
+   * Absent for a save that only fills the library: nothing points at the row,
+   * so whichever id the collection assigns is the right one. Present for a
+   * CONVERT, where the instance left on the page carries the definition's id
+   * in its props — the ops and the row have to agree, and the only moment they
+   * can be made to is before either is written. So the caller decides the id
+   * and the plan echoes it back, rather than the plan minting one in a format
+   * it cannot know the collection accepts.
+   *
+   * Not a nullable id standing in for the create/overwrite distinction, which
+   * {@link CompositionPlan.update} exists to keep separate: this says WHERE,
+   * never WHETHER.
+   */
+  readonly id?: string;
   /** The document to store, with its own ids. */
   readonly document: BlockDocument;
   /** The collection's own metadata fields, passed through untouched. */
@@ -117,6 +144,7 @@ export interface CompositionPlan<TFields> {
   // Declared on the success member too, so a caller reads either field off the
   // union without narrowing first and cannot read a refusal's detail off a plan.
   readonly permitted?: undefined;
+  readonly issues?: undefined;
 }
 
 /**
@@ -159,7 +187,16 @@ export type PlanProblem =
   /** One of the documents cannot be edited at all, whatever the ops say. */
   | "unusable-document"
   /** The pattern was handed over without an identity to record. */
-  | "invalid-source";
+  | "invalid-source"
+  /**
+   * The exposure nominated would not survive the definition's publish gate.
+   *
+   * Its own cause rather than folded into `"unusable-document"`, because the
+   * two have opposite remedies: an unusable document is refused whatever the
+   * author does next, where this names a property they nominated and can
+   * withdraw. {@link PlanRefusal.issues} carries which one.
+   */
+  | "invalid-exposure";
 
 /** A refusal, with whatever the surface needs to phrase it. */
 export interface PlanRefusal {
@@ -172,6 +209,16 @@ export interface PlanRefusal {
    * `NestingVerdict` carries it.
    */
   readonly permitted?: readonly string[];
+  /**
+   * For `"invalid-exposure"`: what the envelope check said, unabridged.
+   *
+   * The issues rather than a count or a first cause, because the surface that
+   * asked for this plan is the one holding the list of properties the author
+   * nominated, and each issue carries the `/exposed/<i>` path that names which.
+   * Reporting "the exposure is invalid" would send them back to re-check every
+   * one of them.
+   */
+  readonly issues?: readonly ValidationIssue[];
   readonly create?: undefined;
   readonly update?: undefined;
   readonly pageOps?: undefined;
@@ -179,8 +226,15 @@ export interface PlanRefusal {
 
 export type PlanResult<TFields> = CompositionPlan<TFields> | PlanRefusal;
 
-/** Where a saved selection is stored, in the caller's vocabulary. */
-export interface PatternTarget<TFields> {
+/**
+ * Where a saved selection is stored, in the caller's vocabulary.
+ *
+ * One type for all three library kinds rather than one per planner. A pattern,
+ * a component and a layout are stored the same way — a collection slug and
+ * whatever metadata that collection declares — so three identical interfaces
+ * would be three things to keep in step for a distinction none of them draws.
+ */
+export interface LibraryTarget<TFields> {
   readonly collection: string;
   readonly fields: TFields;
 }
@@ -234,7 +288,7 @@ export interface PatternUpdateTarget {
 export function planSaveAsPattern<TFields>(
   document: BlockDocument,
   selectedIds: readonly string[],
-  target: PatternTarget<TFields>,
+  target: LibraryTarget<TFields>,
   nesting: NestingSource
 ): PlanResult<TFields> {
   const saved = plannedSave(document, selectedIds, nesting);
@@ -254,6 +308,10 @@ export function planSaveAsPattern<TFields>(
 interface PlannedSave {
   readonly selected: readonly BlockNode[];
   readonly stored: BlockDocument;
+  /** Page node id to stored node id — see {@link SavedPattern.nodeIds}. */
+  readonly nodeIds: ReadonlyMap<string, string>;
+  /** Where the run sat, for a planner that must put something back there. */
+  readonly at: RunPlacement;
   readonly problem?: undefined;
   readonly permitted?: undefined;
 }
@@ -280,12 +338,32 @@ function plannedSave(
   const stored = savedPatternDocument(document, run.selected);
   if (stored.problem !== undefined) return stored;
 
-  return { selected: run.selected, stored: stored.document };
+  return {
+    selected: run.selected,
+    stored: stored.document,
+    nodeIds: stored.nodeIds,
+    at: run.at,
+  };
 }
 
 /** The pattern document a save would store, or why it could not. */
 interface SavedPattern {
   readonly document: BlockDocument;
+  /**
+   * Each selected node's id ON THE PAGE, mapped to the id it was stored under.
+   *
+   * Carried rather than discarded because a caller that points INTO the
+   * selection — a component definition exposing one of its nodes' props — names
+   * those nodes in the page's vocabulary, and the save re-mints every one of
+   * them. Without the map a pointer that was correct when it was nominated
+   * names a pre-copy id the stored document does not contain: a definition that
+   * loads, renders, offers the property in the inspector, and writes overrides
+   * that resolve to nothing.
+   *
+   * Empty of DOM ids on purpose. Those are KEPT by this save, so there is no
+   * remapping to publish — see {@link savedPatternDocument}.
+   */
+  readonly nodeIds: ReadonlyMap<string, string>;
   readonly problem?: undefined;
   readonly permitted?: undefined;
 }
@@ -293,8 +371,27 @@ interface SavedPattern {
 /** A selection that may be lifted into a document of its own. */
 interface SavableRun {
   readonly selected: readonly BlockNode[];
+  readonly at: RunPlacement;
   readonly problem?: undefined;
   readonly permitted?: undefined;
+}
+
+/**
+ * Where a run sat in the document it was selected from.
+ *
+ * Reported as the run gave it — the two container fields independently
+ * optional — rather than as an {@link OpPosition}, which ties them together.
+ * Narrowing here would mean deciding what a half-set container MEANS at the
+ * point that has the least to go on, and the honest answer is that it is not a
+ * position at all. {@link replaceOps} refuses it as one.
+ */
+interface RunPlacement {
+  /** The node whose slot held the run, absent at the top level. */
+  readonly parentId?: string;
+  /** The slot within that parent, absent at the top level. */
+  readonly slot?: string;
+  /** The index of the run's FIRST node in that sibling list. */
+  readonly index: number;
 }
 
 /**
@@ -351,7 +448,21 @@ function savableRun(
     shapeRefusal(selected) ??
     placementRefusal(selected, { kind: "root" }, nesting) ??
     internalNestingRefusal(selected, nesting);
-  return refusal ?? { selected };
+  if (refusal !== undefined) return refusal;
+
+  // Read off the run rather than searched for again. A second lookup of one id
+  // can answer differently from the first, which is the mistake this module has
+  // already made once — and `places` is sorted, so the first entry is the one
+  // an insert has to land on.
+  const { parentId, slot } = result.run;
+  return {
+    selected,
+    at: {
+      ...(parentId === undefined ? {} : { parentId }),
+      ...(slot === undefined ? {} : { slot }),
+      index: result.run.places[0].index,
+    },
+  };
 }
 
 /**
@@ -409,10 +520,13 @@ function savedPatternDocument(
   document: BlockDocument,
   selected: readonly BlockNode[]
 ): SavedPattern | PlanRefusal {
+  const copied = reidForestWithMap([...selected], "keep");
   const stored: BlockDocument = {
     formatVersion: document.formatVersion,
     kind: "pattern",
-    nodes: withoutOrigin(reidForestWithMap([...selected], "keep").nodes),
+    // Through the shared forest rewrite, which preserves every id it was given
+    // — so the map `reidForestWithMap` returned still describes these nodes.
+    nodes: withoutOrigin(copied.nodes),
   };
   // Asked of what is STORED rather than of the selection, for the reason the
   // envelope question below is: the stored document is what an insert will
@@ -428,7 +542,7 @@ function savedPatternDocument(
   // Judging the source would refuse that second case for nothing, which is the
   // difference between asking about the thing and asking about its origin.
   return documentRefusal(stored) === undefined
-    ? { document: stored }
+    ? { document: stored, nodeIds: copied.nodeIds }
     : { problem: "unusable-document" };
 }
 
@@ -571,23 +685,450 @@ function restampOps(
     return { problem: "unusable-document" };
   }
 
-  const ops: BuilderOp[] = [];
-  for (const root of stale) {
-    // `update` addresses a node by id and refuses one the document holds
-    // twice, because it could not say which node the patch was meant for.
-    // Asked only of the roots actually addressed: a duplicate elsewhere in the
-    // page is not something these ops would meet, and refusing on it would
-    // block a save the apply would have accepted.
-    if (countById(document.nodes, root.id) > 1) {
-      return { problem: "duplicate-destination" };
-    }
-    ops.push({
+  // Of the roots actually addressed, which for this planner is the stale ones:
+  // a duplicate elsewhere in the page is not something these ops would meet.
+  const ambiguous = ambiguousRootRefusal(document, stale);
+  if (ambiguous !== undefined) return ambiguous;
+
+  return {
+    ops: stale.map(root => ({
       kind: "update",
       id: root.id,
       patch: { origin: { from: "pattern", id: patternId, digest } },
-    });
+    })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Components — a selection saved as a LINKED definition
+// ---------------------------------------------------------------------------
+
+/**
+ * One property of the saved definition an instance will be allowed to override.
+ *
+ * Named in the PAGE's vocabulary: `nodeId` is a node id as it stands in the
+ * document being saved from, because that is the only id the surface that
+ * nominated it has ever seen. The save re-mints every one of them, and the
+ * planner re-aims the pointer — see {@link SavedPattern.nodeIds}.
+ *
+ * ## Why the caller nominates these and the planner does not derive them
+ *
+ * Which of a block's props is a headline and which is a spacing knob is a
+ * property of that block's DEFINITION, and the engine cannot read one: a
+ * planner is pure and holds no registry, by ruling, so the vocabulary it would
+ * have to classify by is not reachable from here. The same boundary already
+ * stops this module synthesising an `assets` index and stops the envelope
+ * validator resolving a `propPath` against a schema.
+ *
+ * That is a division of labour rather than a limitation. The surface doing the
+ * nominating has the registry, and it also has the author — and every
+ * comparable tool measured (Webflow, Figma, Framer, Builder.io, WordPress
+ * synced patterns) makes the author confirm each editable field rather than
+ * committing silently. A pre-selection is a suggestion to review; the planner's
+ * job is to say whether the reviewed answer will survive being stored.
+ */
+export interface RequestedProperty {
+  /** The stable slug instances will key their overrides by. */
+  readonly id: string;
+  /** What the inspector will call it. */
+  readonly label: string;
+  /** A node id in the SOURCE document, inside the selection. */
+  readonly nodeId: string;
+  /** Dot path into that node's props, in the binding-path grammar. */
+  readonly propPath: string;
+  readonly type: ExposedPropertyType;
+  /** The choices, for `select` only. */
+  readonly options?: readonly { value: string; label: string }[];
+}
+
+/**
+ * A region of the saved definition an instance will be allowed to fill.
+ *
+ * `nodeId` is a SOURCE document id, on the same terms as
+ * {@link RequestedProperty.nodeId}. No `id` field: the key of
+ * {@link ComponentExposure.slots} is the id, for the reason {@link ExposedSlot}
+ * gives — one spelling makes a disagreement between key and field
+ * unrepresentable rather than merely detectable.
+ */
+export interface RequestedSlot {
+  readonly label: string;
+  readonly nodeId: string;
+  /** Which of that node's slots. */
+  readonly slot: string;
+  /** Block types the slot accepts; unset accepts whatever the container does. */
+  readonly allow?: readonly string[];
+}
+
+/** What the author chose to leave editable on the component being saved. */
+export interface ComponentExposure {
+  readonly properties?: readonly RequestedProperty[];
+  readonly slots?: Readonly<Record<string, RequestedSlot>>;
+}
+
+/**
+ * Save a contiguous run of blocks as a component DEFINITION.
+ *
+ * **The page is not touched**, exactly as {@link planSaveAsPattern} does not
+ * touch it: this fills the library and leaves the original blocks where they
+ * are. Replacing them with an instance is {@link planConvertToComponent}, and
+ * the difference between the two is that one line of ops and nothing else.
+ *
+ * **The tree it stores is byte-for-byte the tree a pattern save would store**
+ * from the same selection — one builder, {@link savedPatternDocument}, for the
+ * reason given there. A component is that document plus an envelope and a
+ * `kind`, not a second way of copying a selection.
+ *
+ * ## The envelope is where the ids stop matching
+ *
+ * `exposed` and `slots` are POINTERS into the tree, and the save re-mints every
+ * node id in it. A pointer copied across unchanged names a pre-copy id the
+ * stored document does not contain — and that definition loads, renders, and
+ * offers the property in the inspector, where editing it writes an override
+ * that resolves to nothing. The failure surfaces on every instance in the site
+ * as "my change did nothing", far from the save that caused it.
+ *
+ * So each pointer is re-aimed through the map the copy returned. A nomination
+ * naming a node OUTSIDE the selection has no entry in that map and is carried
+ * across untouched, which the envelope check then reports for exactly what it
+ * is. That is deliberate: minting a fresh id makes the collision impossible, so
+ * a surviving page id cannot be mistaken for a stored one, and the rule that
+ * says whether a pointer resolves stays in one place instead of two.
+ *
+ * ## What it refuses
+ *
+ * Everything {@link planSaveAsPattern} refuses about the selection, through the
+ * same call — plus everything the definition's own publish gate would refuse
+ * about the envelope, asked as {@link componentEnvelopeIssues} rather than
+ * re-implemented: a pointer at a node that is not there, two exposures sharing
+ * an id, a prop path that is not a path, options on something that is not a
+ * `select` and a `select` without them, a slot the node does not declare, and a
+ * type outside the vocabulary. Strict validation is the publish gate for this
+ * collection, so a definition that fails it is one an author could save and
+ * never publish; refusing here happens while they still have the selection in
+ * front of them.
+ */
+export function planSaveAsComponent<TFields>(
+  document: BlockDocument,
+  selectedIds: readonly string[],
+  target: LibraryTarget<TFields>,
+  exposure: ComponentExposure,
+  nesting: NestingSource
+): PlanResult<TFields> {
+  const saved = plannedSave(document, selectedIds, nesting);
+  if (saved.problem !== undefined) return saved;
+
+  const definition = componentDocument(saved, exposure);
+  if (definition.problem !== undefined) return definition;
+
+  return {
+    create: {
+      collection: target.collection,
+      document: definition.document,
+      fields: target.fields,
+    },
+    pageOps: [],
+  };
+}
+
+/**
+ * Save a run as a component AND replace it on the page with one instance.
+ *
+ * {@link planSaveAsComponent} plus the ops that take the run out and put a
+ * linked instance where it stood. Built here beside it rather than in a second
+ * module, because the two have to agree about what was stored and where it came
+ * from, and a save whose replacement is written somewhere else is a round trip
+ * nothing tests end to end.
+ *
+ * ## The definition's id comes from the caller
+ *
+ * The instance carries the definition's id in its props, so the ops and the row
+ * they point at have to agree — and the only moment they can be made to is
+ * before either is written. A planner cannot mint one: the id format belongs to
+ * the collection the row lands in, which the engine cannot see. So the caller
+ * decides it, the ops name it, and {@link PlannedCreate.id} echoes it back so
+ * the plan is executable without its caller having to remember what it passed.
+ *
+ * A caller that creates the row under a DIFFERENT id has built an instance
+ * pointing at nothing. That is the one failure this shape cannot refuse, and it
+ * is refusable by construction on the other side: the create and the ops are
+ * one unit of work, and the id is an input to both.
+ *
+ * ## Ops, in this order
+ *
+ * Every selected root is removed, then one instance is inserted at the index
+ * the first of them held. The run is contiguous and sorted, so after the
+ * removes that index is where the run began — including when the run ended the
+ * list, where it is an append.
+ *
+ * ## What it refuses that the save alone does not
+ *
+ * The plan IS the dry run, so every refusal these ops would meet is made here:
+ * a locked block on the page, which `remove` refuses for a reason no re-ordering
+ * of the group can satisfy; a selected root the document holds twice, which
+ * `remove` refuses because it could not say which it meant; a container that is
+ * gone or duplicated; and a slot whose own rules will not take a component
+ * instance. The nesting question is asked of the INSTANCE rather than of the
+ * blocks it replaces — they are not the node going in, and a slot that accepted
+ * a heading need not accept a component.
+ */
+export function planConvertToComponent<TFields>(
+  document: BlockDocument,
+  selectedIds: readonly string[],
+  target: LibraryTarget<TFields>,
+  componentId: string,
+  exposure: ComponentExposure,
+  nesting: NestingSource
+): PlanResult<TFields> {
+  // Before anything is built on it, at runtime as well as in the type, for the
+  // reason the save-over checks its target id: this is a published entry point
+  // and the value reaching it comes from a JavaScript caller as often as from a
+  // typed one. An empty id yields an instance that references nothing, and no
+  // later stage looks at it again.
+  if (typeof componentId !== "string" || componentId === "") {
+    return { problem: "invalid-source" };
   }
-  return { ops };
+
+  const saved = plannedSave(document, selectedIds, nesting);
+  if (saved.problem !== undefined) return saved;
+
+  const definition = componentDocument(saved, exposure);
+  if (definition.problem !== undefined) return definition;
+
+  const replaced = replaceOps(document, saved, componentId, nesting);
+  if (replaced.problem !== undefined) return replaced;
+
+  return {
+    create: {
+      collection: target.collection,
+      id: componentId,
+      document: definition.document,
+      fields: target.fields,
+    },
+    pageOps: replaced.ops,
+  };
+}
+
+/** The definition a component save would store, or why it could not. */
+interface SavedComponent {
+  readonly document: ComponentDocument;
+  readonly problem?: undefined;
+  readonly permitted?: undefined;
+  readonly issues?: undefined;
+}
+
+/**
+ * The saved tree, plus the envelope the author nominated, re-aimed and checked.
+ *
+ * ONE implementation, called by both component planners, for the reason
+ * {@link savedPatternDocument} is: save and convert must produce the identical
+ * definition from the identical selection, and two builders that agreed today
+ * would diverge the day one of them moved.
+ *
+ * The envelope is checked on what is STORED rather than on what was nominated.
+ * Only some of a nomination travels — the pointer is re-aimed and the rest is
+ * carried verbatim — so judging the request would answer about a document
+ * nobody stores. The same distinction {@link savedPatternDocument} draws, and
+ * it has caught a defect on each side of it.
+ */
+function componentDocument(
+  saved: PlannedSave,
+  exposure: ComponentExposure
+): SavedComponent | PlanRefusal {
+  const definition: ComponentDocument = {
+    ...saved.stored,
+    kind: "component",
+    ...exposedProperties(exposure.properties, saved.nodeIds),
+    ...exposedSlots(exposure.slots, saved.nodeIds),
+  };
+
+  const issues = componentEnvelopeIssues(definition);
+  return issues.length === 0
+    ? { document: definition }
+    : { problem: "invalid-exposure", issues };
+}
+
+/**
+ * The nominated properties, re-aimed at the stored tree.
+ *
+ * Absent rather than an empty array when nothing was nominated, matching what
+ * {@link ComponentDocument.exposed} says absence means. Writing `[]` would
+ * store a field to say what its absence already says, and make two saves of one
+ * selection differ by whether the caller passed a list it had not filled.
+ *
+ * The array is read defensively because this is reached from a published entry
+ * point: a non-array here would otherwise throw where the module promises to
+ * refuse. An unusable nomination becomes an envelope the check reports on.
+ */
+function exposedProperties(
+  requested: readonly RequestedProperty[] | undefined,
+  nodeIds: ReadonlyMap<string, string>
+): { exposed?: ExposedProperty[] } {
+  if (!Array.isArray(requested) || requested.length === 0) return {};
+  return {
+    exposed: requested.map(one => ({
+      id: one.id,
+      label: one.label,
+      nodeId: storedId(one.nodeId, nodeIds),
+      propPath: one.propPath,
+      type: one.type,
+      // Copied rather than aliased: the stored document must not share an array
+      // with the caller's request, which the caller is free to go on editing.
+      ...(Array.isArray(one.options) ? { options: [...one.options] } : {}),
+    })),
+  };
+}
+
+/** The nominated slot regions, re-aimed, on the same terms as the properties. */
+function exposedSlots(
+  requested: Readonly<Record<string, RequestedSlot>> | undefined,
+  nodeIds: ReadonlyMap<string, string>
+): { slots?: Record<string, ExposedSlot> } {
+  if (requested === null || typeof requested !== "object") return {};
+  // Own keys only. A record reached from a published entry point may inherit
+  // one, and a key that is not the caller's own is a region no author asked
+  // for — while `structuredClone` and object spreads copy neither, so the guard
+  // and the writer would otherwise disagree about the same field.
+  const named = Object.keys(requested);
+  if (named.length === 0) return {};
+  const slots: Record<string, ExposedSlot> = {};
+  for (const id of named) {
+    const one = requested[id];
+    if (one === null || typeof one !== "object") continue;
+    slots[id] = {
+      label: one.label,
+      nodeId: storedId(one.nodeId, nodeIds),
+      slot: one.slot,
+      ...(Array.isArray(one.allow) ? { allow: [...one.allow] } : {}),
+    };
+  }
+  return { slots };
+}
+
+/**
+ * A source node id, as the stored document spells it.
+ *
+ * An id with no entry in the map is returned UNCHANGED rather than dropped or
+ * replaced. It names a node outside the selection, and leaving it makes the
+ * envelope check report it as the dangling pointer it is — one rule, asked
+ * once, in the module that owns it. Dropping it would silently discard a
+ * property the author nominated and tell them the save succeeded.
+ *
+ * It cannot collide with a real stored id by accident: the save mints fresh
+ * ones, so a surviving source id is never one of them.
+ */
+function storedId(
+  sourceId: string,
+  nodeIds: ReadonlyMap<string, string>
+): string {
+  return nodeIds.get(sourceId) ?? sourceId;
+}
+
+/**
+ * Take the run off the page and put one instance where it stood.
+ *
+ * Asked of the document as it stands BEFORE the removes, which is what the ops
+ * will meet: the container has to exist and be unambiguous when the group is
+ * applied, and the group is applied to this document.
+ */
+function replaceOps(
+  document: BlockDocument,
+  saved: PlannedSave,
+  componentId: string,
+  nesting: NestingSource
+): RestampOps | PlanRefusal {
+  const refusal =
+    lockRefusal(saved.selected) ??
+    ambiguousRootRefusal(document, saved.selected);
+  if (refusal !== undefined) return refusal;
+
+  const position = replacementPosition(saved.at);
+  if (position.problem !== undefined) return position;
+
+  const instance: BlockNode = {
+    id: newId(),
+    type: COMPONENT_INSTANCE_TYPE,
+    version: 1,
+    props: { componentId },
+  };
+
+  // The insert path's own resolution, rather than a second reading of the same
+  // position: it asks the op layer whether the position names anywhere, finds
+  // the container once, and hands back the parent TYPE the nesting rule needs.
+  const destination = destinationOf(document, position.at);
+  if (destination.problem !== undefined) return destination;
+
+  // Asked of the INSTANCE, not of the blocks it replaces. They are not the node
+  // going in, and a slot that accepted a heading need not accept a component.
+  const placement = placementRefusal(
+    [instance],
+    destination.place.where,
+    nesting
+  );
+  if (placement !== undefined) return placement;
+
+  return {
+    ops: [
+      ...saved.selected.map(
+        (root): BuilderOp => ({ kind: "remove", id: root.id })
+      ),
+      { kind: "insert", node: instance, at: position.at },
+    ],
+  };
+}
+
+/**
+ * A root the ops are about to ADDRESS that the document holds twice.
+ *
+ * `update` and `remove` both address a node by id and both refuse one the
+ * document holds twice, because neither could say which node was meant — and a
+ * selection can be built against a document nothing validated.
+ *
+ * Takes the roots rather than reading the selection, because the two planners
+ * address different subsets of it and the rule is about what is ADDRESSED. A
+ * save-over touches only the roots whose provenance it repairs; a convert
+ * removes every one of them. Asking about the whole selection would refuse a
+ * save-over the apply would have accepted, on a duplicate its ops never reach.
+ *
+ * The destination side of the same question is {@link destinationOf}, which
+ * asks it about a container.
+ */
+function ambiguousRootRefusal(
+  document: BlockDocument,
+  roots: readonly BlockNode[]
+): PlanRefusal | undefined {
+  for (const root of roots) {
+    if (countById(document.nodes, root.id) > 1) {
+      return { problem: "duplicate-destination" };
+    }
+  }
+  return undefined;
+}
+
+/** Where the replacement goes, or why the run names nowhere to put it. */
+interface ReplacementPosition {
+  readonly at: OpPosition;
+  readonly problem?: undefined;
+  readonly permitted?: undefined;
+  readonly issues?: undefined;
+}
+
+/**
+ * The run's own place, as the position an op would put something back at.
+ *
+ * The narrowing {@link RunPlacement} deliberately does not do, in the one place
+ * that has to commit to an answer. `contiguousRun` sets the two container
+ * fields together or leaves both, so a parent named without its slot is a shape
+ * it does not emit — but the fields are independently optional in its result,
+ * and guessing which half to believe would either move a block to the top level
+ * or address a slot nobody named. Refused as what it is instead, through the
+ * cause `applyOp` would give the position it cannot be built into.
+ */
+function replacementPosition(
+  at: RunPlacement
+): ReplacementPosition | PlanRefusal {
+  if (at.parentId === undefined) return { at: { index: at.index } };
+  if (at.slot === undefined) return { problem: "invalid-position" };
+  return { at: { parentId: at.parentId, slot: at.slot, index: at.index } };
 }
 
 /**

--- a/packages/blocks-engine/src/composition-planners.ts
+++ b/packages/blocks-engine/src/composition-planners.ts
@@ -33,7 +33,8 @@ import type {
   ExposedPropertyType,
   ExposedSlot,
 } from "./document";
-import { MAX_ENVELOPE_ENTRIES } from "./limits";
+import { DEFAULT_LIMITS, MAX_ENVELOPE_ENTRIES } from "./limits";
+import type { DocumentLimits } from "./limits";
 import {
   canBeRoot,
   canNest,
@@ -824,12 +825,13 @@ export function planSaveAsComponent<TFields>(
   selectedIds: readonly string[],
   target: LibraryTarget<TFields>,
   exposure: ComponentExposure,
-  nesting: NestingSource
+  nesting: NestingSource,
+  limits: DocumentLimits = DEFAULT_LIMITS
 ): PlanResult<TFields> {
   const saved = plannedSave(document, selectedIds, nesting);
   if (saved.problem !== undefined) return saved;
 
-  const definition = componentDocument(saved, exposure);
+  const definition = componentDocument(saved, exposure, limits);
   if (definition.problem !== undefined) return definition;
 
   return {
@@ -889,7 +891,8 @@ export function planConvertToComponent<TFields>(
   target: LibraryTarget<TFields>,
   componentId: string,
   exposure: ComponentExposure,
-  nesting: NestingSource
+  nesting: NestingSource,
+  limits: DocumentLimits = DEFAULT_LIMITS
 ): PlanResult<TFields> {
   // Before anything is built on it, at runtime as well as in the type, for the
   // reason the save-over checks its target id: this is a published entry point
@@ -903,7 +906,7 @@ export function planConvertToComponent<TFields>(
   const saved = plannedSave(document, selectedIds, nesting);
   if (saved.problem !== undefined) return saved;
 
-  const definition = componentDocument(saved, exposure);
+  const definition = componentDocument(saved, exposure, limits);
   if (definition.problem !== undefined) return definition;
 
   const replaced = replaceOps(document, saved, componentId, nesting);
@@ -944,7 +947,8 @@ interface SavedComponent {
  */
 function componentDocument(
   saved: PlannedSave,
-  exposure: ComponentExposure
+  exposure: ComponentExposure,
+  limits: DocumentLimits
 ): SavedComponent | PlanRefusal {
   // The CONTAINER, before either field is read off it. The guards below judge
   // the fields and their entries; none of them can be reached at all if the
@@ -970,7 +974,14 @@ function componentDocument(
     ...exposedSlots(asked.slots, saved.nodeIds),
   };
 
-  const issues = componentEnvelopeIssues(definition);
+  // The HOST's limits, not this module's default. The envelope check indexes
+  // the forest under whatever node cap it is given, and a host that raised
+  // `maxNodes` can hold a definition larger than the default — whose later
+  // nodes then fall outside a default-sized index, so its exposures are
+  // reported as pointing at nothing. Strict validation, the gate this predicts,
+  // is given the host's limits; a dry run using its own would refuse a
+  // component the apply would publish, which is the direction nobody can debug.
+  const issues = componentEnvelopeIssues(definition, limits);
   return issues.length === 0
     ? { document: definition }
     : { problem: "invalid-exposure", issues };
@@ -1017,13 +1028,19 @@ function ambiguousNomination(
  */
 function nominatedIds(exposure: ComponentExposure): string[] {
   const named: string[] = [];
-  if (Array.isArray(exposure.properties)) {
-    for (const one of exposure.properties) collectNodeId(one, named);
+  const properties = exposure.properties;
+  // BOUNDED, and read by index. An over-cap collection is refused by the
+  // envelope check whatever this pass concludes, so reading it to answer a
+  // question that refusal makes moot is precisely the work the cap exists to
+  // refuse — and this runs BEFORE the mappers, so their caps do not cover it.
+  if (Array.isArray(properties) && properties.length <= MAX_ENVELOPE_ENTRIES) {
+    for (let i = 0; i < properties.length; i += 1) {
+      collectNodeId(properties[i], named);
+    }
   }
   if (isPlainRecord(exposure.slots)) {
-    for (const id of Object.keys(exposure.slots)) {
-      collectNodeId(exposure.slots[id], named);
-    }
+    const keys = boundedOwnKeys(exposure.slots, MAX_ENVELOPE_ENTRIES);
+    for (const id of keys ?? []) collectNodeId(exposure.slots[id], named);
   }
   return named;
 }
@@ -1066,16 +1083,49 @@ function exposedProperties(
   if (requested.length > MAX_ENVELOPE_ENTRIES) {
     return { exposed: requested };
   }
-  return {
-    exposed: requested.map(one =>
-      // Per ENTRY, for the same reason. A `null` or a primitive in the list is
-      // not something this can re-aim, and reading `one.id` off it throws where
-      // the module promises a refusal.
+  // BY INDEX, never through `map`. This is a caller's array and `map` is an
+  // inherited member the caller may shadow with a value of its own, which
+  // throws where this module promises a refusal — on an array whose entries are
+  // perfectly well formed. The envelope validator reads untrusted arrays the
+  // same way, for the reason the op layer avoids `Symbol.iterator`: an
+  // inherited member belongs to whoever supplied the object.
+  const exposed: ExposedProperty[] = [];
+  for (let i = 0; i < requested.length; i += 1) {
+    const one = requested[i];
+    // Per ENTRY. A `null` or a primitive is not something this can re-aim, and
+    // reading `one.id` off it throws — so it is carried for the validator to
+    // report rather than dereferenced here.
+    exposed.push(
       isPlainRecord(one)
         ? mappedProperty(one as unknown as RequestedProperty, nodeIds)
         : one
-    ),
-  };
+    );
+  }
+  return { exposed };
+}
+
+/**
+ * The option records, copied one level deep and read by index.
+ *
+ * By index for the reason {@link exposedProperties} gives: `map` is the
+ * caller's to shadow. One level deep because cloning the list alone leaves
+ * every option object shared with the request, so editing a label after
+ * planning would edit the document the plan said it would store.
+ */
+function clonedOptions(
+  options: readonly unknown[]
+): ExposedProperty["options"] {
+  const copied: { value: string; label: string }[] = [];
+  for (let i = 0; i < options.length; i += 1) {
+    const option = options[i];
+    copied.push(
+      (isPlainRecord(option) ? { ...option } : option) as {
+        value: string;
+        label: string;
+      }
+    );
+  }
+  return copied;
 }
 
 /** One nominated property, re-aimed at the stored tree. */
@@ -1102,9 +1152,7 @@ function mappedProperty(
       ? {}
       : {
           options: Array.isArray(one.options)
-            ? one.options.map(option =>
-                isPlainRecord(option) ? { ...option } : option
-              )
+            ? clonedOptions(one.options)
             : one.options,
         }),
   };

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -187,22 +187,27 @@ export type {
 // and the real run are the same function rather than two that agree for now.
 export { patternDigest } from "./pattern-digest";
 export {
+  planConvertToComponent,
   planInsertPattern,
+  planSaveAsComponent,
   planSaveAsPattern,
   planUpdatePatternFromSelection,
 } from "./composition-planners";
 export type {
+  ComponentExposure,
   CompositionPlan,
   InsertTarget,
   StoredPattern,
   PlacementTarget,
-  PatternTarget,
+  LibraryTarget,
   PlanProblem,
   PlanRefusal,
   PlanResult,
   PlannedCreate,
   PlannedUpdate,
   PatternUpdateTarget,
+  RequestedProperty,
+  RequestedSlot,
 } from "./composition-planners";
 
 // The node selection every reader of a stored document shares. Public because
@@ -274,6 +279,7 @@ export type { NestingSource, NestingVerdict, NestingRefusal } from "./nesting";
 // contract that then drifts from the first.
 export type { ByteMeasurement } from "./measure-bytes";
 export {
+  componentEnvelopeIssues,
   validate,
   validateDocument,
   ISSUE_CODES,

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -746,6 +746,7 @@ export {
   // The apply's own position rule, asked without applying: a planner that
   // wrote its own copy would agree until one of the two moved.
   positionRefusal,
+  subtreeRemovalRefusal,
   positionOf,
   sameStoredValue,
   sameStyleValue,

--- a/packages/blocks-engine/src/measure-bytes.ts
+++ b/packages/blocks-engine/src/measure-bytes.ts
@@ -593,6 +593,42 @@ interface Frame {
 }
 
 /**
+ * A limit, validated as one that can actually bound a walk.
+ *
+ * Published because more than one walk is held to these numbers and they have
+ * to agree about what counts as a bound. A helper that accepts what
+ * {@link surveyDocument} rejects reports success on a document the gate refuses
+ * to measure at all — and it does so having walked the whole thing, which is
+ * the resource bound gone as well as the verdict wrong.
+ *
+ * A PRIMITIVE NUMBER, then the deliberately supported infinities. Testing for
+ * `NaN` alone was not enough: `Number.isNaN(undefined)` is false, and so is
+ * `Number.isNaN("wat")`, while every later `>` comparison coerces both to `NaN`
+ * and is false in turn. A JavaScript caller omitting a bound therefore removed
+ * it and was told the document fitted.
+ *
+ * `Infinity` is deliberately NOT rejected: an infinite byte limit is the
+ * supported way to ask for an exact count.
+ *
+ * Throws rather than refusing, because a limit is the CALLER's own
+ * configuration rather than the untrusted document — the same reason the survey
+ * throws for it — and a caller cannot be told about a bad bound through a list
+ * of issues describing a document.
+ */
+export function boundedLimit(
+  limit: number,
+  name: string,
+  subject: string
+): number {
+  if (typeof limit !== "number" || Number.isNaN(limit)) {
+    throw new RangeError(
+      `${subject}: ${name} must be a number, and ${String(limit)} would remove the bound it exists to impose.`
+    );
+  }
+  return limit;
+}
+
+/**
  * The array index a property name denotes, or -1 if it denotes none.
  *
  * `JSON.stringify` emits positions `0..length-1` and nothing else, so a name is
@@ -620,19 +656,8 @@ export function surveyDocument(
   // Infinity is deliberately NOT rejected: an infinite byte limit is the
   // supported way to ask for an exact count, and the walk terminates there on
   // the cycle set rather than on the cap.
-  const bounded = (limit: number, name: string): number => {
-    // A PRIMITIVE NUMBER, then the deliberately supported infinities. Testing
-    // for `NaN` alone was not enough: `Number.isNaN(undefined)` is false, and so
-    // is `Number.isNaN("wat")`, while every later `>` comparison coerces both to
-    // `NaN` and is false in turn. A JavaScript caller omitting a bound therefore
-    // removed it and was told the document fitted.
-    if (typeof limit !== "number" || Number.isNaN(limit)) {
-      throw new RangeError(
-        `surveyDocument: ${name} must be a number, and ${String(limit)} would remove the bound it exists to impose.`
-      );
-    }
-    return limit;
-  };
+  const bounded = (limit: number, name: string): number =>
+    boundedLimit(limit, name, "surveyDocument");
   // SNAPSHOT the validated numbers. Validating and then re-reading `limits.*`
   // through the walk lets an accessor or proxy answer `100` to the check and
   // `undefined` afterwards, and a document-supplied hook can mutate a shared

--- a/packages/blocks-engine/src/ops.ts
+++ b/packages/blocks-engine/src/ops.ts
@@ -2407,6 +2407,31 @@ export function documentRefusal(document: unknown): string | undefined {
 }
 
 /**
+ * Why this list cannot be treated as stored data, or `undefined`.
+ *
+ * Published for the reason the other refusals here are: a planner reads lists a
+ * caller supplied, and reading one whose INDICES are accessors runs that
+ * caller's code — a throwing getter escaping as a native error where the module
+ * promises a refusal, and a getter that appends extending `length` underneath
+ * the loop that is supposed to be bounded by it.
+ *
+ * Neither the array type nor a shadowed-method check answers this: the value
+ * can be a genuine array, with well-formed entries, and still compute them.
+ */
+export function listRefusal(
+  list: unknown,
+  subject: string
+): string | undefined {
+  try {
+    assertListIsData(list, subject);
+    return undefined;
+  } catch (error) {
+    if (error instanceof OpError) return error.message;
+    throw error;
+  }
+}
+
+/**
  * Why removing this subtree would be refused, or `undefined`.
  *
  * Published for the reason {@link nodeShapeRefusal} and {@link positionRefusal}

--- a/packages/blocks-engine/src/ops.ts
+++ b/packages/blocks-engine/src/ops.ts
@@ -2407,6 +2407,34 @@ export function documentRefusal(document: unknown): string | undefined {
 }
 
 /**
+ * Why removing this subtree would be refused, or `undefined`.
+ *
+ * Published for the reason {@link nodeShapeRefusal} and {@link positionRefusal}
+ * are: a planner that emits a `remove` has to know whether the apply will take
+ * it, and the rule is not the one a caller would guess. `remove` refuses when
+ * any id ANYWHERE IN THE SUBTREE it is about to take occurs more than once in
+ * the document — not merely when the root's own id does — because the inverse
+ * it records could not put that subtree back.
+ *
+ * A planner checking only the root passes a selection whose deep child shares an
+ * id with a node elsewhere on the page, and the apply then throws on the first
+ * op of a group whose library row has already been written. That is the failure
+ * the plan/apply split exists to prevent.
+ */
+export function subtreeRemovalRefusal(
+  nodes: BlockNode[],
+  root: BlockNode
+): string | undefined {
+  try {
+    assertSubtreeIdsAreUnique(nodes, root, "remove");
+    return undefined;
+  } catch (error) {
+    if (error instanceof OpError) return error.message;
+    throw error;
+  }
+}
+
+/**
  * Why this node would be refused as an insert's subtree, or `undefined`.
  *
  * The companion to {@link positionRefusal} and published for the same reason: a

--- a/packages/blocks-engine/src/validation.test.ts
+++ b/packages/blocks-engine/src/validation.test.ts
@@ -2751,6 +2751,62 @@ describe("componentEnvelopeIssues reads a stored value defensively", () => {
   });
 });
 
+describe("componentEnvelopeIssues holds itself to a real bound", () => {
+  it.each([
+    ["NaN", Number.NaN],
+    ["undefined", undefined],
+    ["a string", "500"],
+  ])("refuses %s as a node cap, as the survey does", (_name, maxNodes) => {
+    // A bound that is not a number is not a bound: every comparison against it
+    // in the walk is false, so the index is built over the whole forest and a
+    // dangling pointer is reported as sound — with the resource bound gone as
+    // well as the verdict wrong.
+    const doc = {
+      formatVersion: 1,
+      kind: "component",
+      nodes: [{ id: "a", type: "core/text", version: 1, props: {} }],
+      exposed: [
+        { id: "p", label: "L", nodeId: "ghost", propPath: "t", type: "text" },
+      ],
+    } as unknown as BlockDocument;
+
+    expect(() =>
+      componentEnvelopeIssues(doc, {
+        ...DEFAULT_LIMITS,
+        maxNodes: maxNodes as number,
+      })
+    ).toThrow(RangeError);
+
+    // The gate this predicts refuses the same limits, which is why refusing is
+    // the answer rather than falling back to a default: the two must not
+    // disagree about what counts as a bound.
+    expect(() =>
+      validate(doc, {
+        breakpoints: FIXTURE_BREAKPOINTS,
+        mode: "strict",
+        limits: { ...DEFAULT_LIMITS, maxNodes: maxNodes as number },
+      })
+    ).toThrow(RangeError);
+  });
+
+  it("still answers for a sound cap", () => {
+    // The control: without it, a helper that threw for every limit would pass
+    // every assertion above.
+    const doc = {
+      formatVersion: 1,
+      kind: "component",
+      nodes: [{ id: "a", type: "core/text", version: 1, props: {} }],
+      exposed: [
+        { id: "p", label: "L", nodeId: "ghost", propPath: "t", type: "text" },
+      ],
+    } as unknown as BlockDocument;
+
+    expect(componentEnvelopeIssues(doc).map(i => i.code)).toContain(
+      "exposed-node-missing"
+    );
+  });
+});
+
 describe("validate and compile agree on which breakpoints a site defines", () => {
   // The validate-then-compile contract. A caller runs `validate()` and, seeing
   // no issue, stores the document; the compiler then drops a definition

--- a/packages/blocks-engine/src/validation.test.ts
+++ b/packages/blocks-engine/src/validation.test.ts
@@ -21,7 +21,12 @@ import type { NestingSource } from "./nesting";
 import type { BlockTypeLookup } from "./validation";
 import { compilePageCss } from "./style/compile-page";
 import { measureBytes } from "./measure-bytes";
-import { ISSUE_CODES, validate, validateDocument } from "./validation";
+import {
+  ISSUE_CODES,
+  componentEnvelopeIssues,
+  validate,
+  validateDocument,
+} from "./validation";
 
 function lookup(types: string[]): BlockTypeLookup {
   const set = new Set(types);
@@ -2719,6 +2724,30 @@ describe("an unstorable document does not have its values parsed", () => {
     // shape long before its style values matter. The exposure that closes is
     // the parsing of whatever the getter returns, not the single invocation.
     expect(reads).toBeGreaterThan(0);
+  });
+});
+
+describe("componentEnvelopeIssues reads a stored value defensively", () => {
+  it.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["a string", "bad"],
+    ["a number", 3],
+  ])("answers rather than throwing for %s", (_name, doc) => {
+    // A published entry point whose own docblock names a stored row as an
+    // input, and a row can be any of these. Dereferencing `.kind` took a native
+    // error out of a function that promises a list.
+    let threw: unknown;
+    let issues;
+    try {
+      issues = componentEnvelopeIssues(doc as never);
+    } catch (error) {
+      threw = error;
+    }
+    expect(threw).toBeUndefined();
+    // Whether such a document is READABLE is `validateDocument`'s question; an
+    // unreadable one simply has no envelope to be wrong about.
+    expect(issues).toEqual([]);
   });
 });
 

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -29,7 +29,7 @@ import {
   MAX_ENVELOPE_ENTRIES,
 } from "./limits";
 import type { DocumentLimits } from "./limits";
-import { surveyDocument } from "./measure-bytes";
+import { boundedLimit, surveyDocument } from "./measure-bytes";
 import type { DocumentSurvey } from "./measure-bytes";
 import { canBeRoot, canNest, canNestInSlot } from "./nesting";
 import type { NestingSource } from "./nesting";
@@ -1804,7 +1804,14 @@ export function componentEnvelopeIssues(
   validateComponentEnvelope(
     doc,
     Array.isArray(doc.nodes) ? doc.nodes : [],
-    limits.maxNodes,
+    // Through the SAME rule the survey applies, because a bound that is not a
+    // number is not a bound: every comparison against `NaN` in the walk is
+    // false, so the index is built over the whole forest and a dangling pointer
+    // is reported as sound — with the resource bound gone as well as the
+    // verdict wrong. `validateDocument`, the gate this predicts, refuses those
+    // limits outright, so accepting them here is the dry run disagreeing with
+    // the thing it exists to foresee.
+    boundedLimit(limits.maxNodes, "maxNodes", "componentEnvelopeIssues"),
     issues
   );
   return issues;

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -1757,6 +1757,54 @@ function validateComponentEnvelope(
 }
 
 /**
+ * The issues a component definition's ENVELOPE would be refused for, alone.
+ *
+ * The same walk {@link validateDocument} runs for a `kind: "component"`
+ * document, published so a planner can ask it before it proposes storing one.
+ *
+ * Narrow deliberately, and the narrowness is what makes it reachable from a
+ * planner at all. Full validation needs a breakpoint set, and a planner has
+ * none: breakpoints are the host's configuration and a plan is pure. The
+ * envelope rules need none of it — they resolve pointers against the
+ * document's own forest and nothing else, which is why this question can be
+ * asked in isolation where the style and class ones cannot.
+ *
+ * The alternative is a planner that re-implements "does this pointer resolve",
+ * and one rule spelled twice is the failure this package keeps paying for: the
+ * two readings agree until one moves, and the one that moves is the one nobody
+ * is looking at. A dry run that disagrees with the gate it predicts is worse
+ * than no dry run, because it is believed.
+ *
+ * Every issue it can return is an `error` in both modes — a dangling pointer
+ * is a broken reference to this document's own tree rather than a value a
+ * future build understands — so a caller may read a non-empty result as a
+ * refusal without inspecting severities.
+ *
+ * Empty for a document that is not a component, matching where the per-kind
+ * rules run: a pattern has no envelope to be wrong about, and answering
+ * otherwise would make "no issues" mean two different things.
+ *
+ * The node array is read defensively because this is a published entry point
+ * and the value reaching it comes from a stored row as often as from a typed
+ * caller. A corrupt forest is reported by the main walk; refusing to index it
+ * here would throw where this module promises to answer.
+ */
+export function componentEnvelopeIssues(
+  doc: BlockDocument,
+  limits: DocumentLimits = DEFAULT_LIMITS
+): ValidationIssue[] {
+  if (doc.kind !== "component") return [];
+  const issues: ValidationIssue[] = [];
+  validateComponentEnvelope(
+    doc as unknown as Record<string, unknown>,
+    Array.isArray(doc.nodes) ? doc.nodes : [],
+    limits.maxNodes,
+    issues
+  );
+  return issues;
+}
+
+/**
  * The `exposed` list, returning the ids it declared.
  *
  * The ids are the return value because the variants below address them: a

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -1793,10 +1793,16 @@ export function componentEnvelopeIssues(
   doc: BlockDocument,
   limits: DocumentLimits = DEFAULT_LIMITS
 ): ValidationIssue[] {
-  if (doc.kind !== "component") return [];
+  // The DOCUMENT, before its kind is read off it. This is a published entry
+  // point whose own docblock names a stored row as an input, and a row can be
+  // `null` or a string — where dereferencing `.kind` throws a native error out
+  // of a function that promises a list. Whether such a document is READABLE at
+  // all is `validateDocument`'s question and a planner asks it separately; this
+  // one answers only about an envelope, and an unreadable document has none.
+  if (!isPlainRecord(doc) || doc.kind !== "component") return [];
   const issues: ValidationIssue[] = [];
   validateComponentEnvelope(
-    doc as unknown as Record<string, unknown>,
+    doc,
     Array.isArray(doc.nodes) ? doc.nodes : [],
     limits.maxNodes,
     issues


### PR DESCRIPTION
Plan 06 T-2. Adds `planSaveAsComponent` and `planConvertToComponent` as a pair, because the round-trip property lives across them.

## The defect this exists to prevent

A component definition is not only a tree. `ExposedProperty.nodeId` and `ExposedSlot.nodeId` are **pointers into that tree**, and saving a selection re-mints every node id in it.

A pointer carried across unchanged names a node the stored document does not contain. That definition loads, renders, and offers the property in the inspector — where editing it writes an override that resolves to nothing. It surfaces on every instance in the site as "my change did nothing", far from the save that caused it. And because strict validation is the publish gate for this collection, it is also a definition an author can save and never publish, with one error per exposure.

So the save now keeps the map its copy produced (`reidForestWithMap` already returned it; `savedPatternDocument` was discarding it) and re-aims every pointer through it.

## What happens to a nomination outside the selection

It is carried across **untouched**, and the envelope check reports it as the dangling pointer it is. Deliberate: the save mints fresh ids, so a surviving source id can never collide with a stored one — which means the rule that says whether a pointer resolves stays in one place instead of two. Dropping it silently would tell the author the save succeeded.

## One rule, not a second copy of it

`componentEnvelopeIssues` is published from `validation.ts` — the same walk strict validation runs for a `kind: "component"` document.

A planner cannot call `validateDocument`: it needs a `BreakpointSet`, which is host configuration a pure planner has no road to. The envelope rules need none of it — they resolve pointers against the document's own forest and nothing else, which is why they can be asked alone. Re-implementing "does this pointer resolve" inside the planner would be a dry run that disagrees with the gate it predicts, which is worse than no dry run because it is believed.

That one call covers eight rules: dangling pointer, duplicate exposed id, bad prop path, options on a non-`select`, a `select` with none, an unknown type, a slot the node does not declare, and a variant naming nothing exposed.

## Why the caller nominates the exposure

Which of a block's props is a headline and which is a spacing knob is a property of that block's **definition**, and a planner holds no registry (`decision:pb6-can-a-planner-see-the-block-registry` = B). Confirmed twice in the code: even `checkExposedPointer`, handed a `BlockTypeLookup`, states that "the schema is not reachable from here"; and this module already declines to synthesise an `assets` index for the same reason.

Prior art agrees with the division rather than merely permitting it: Webflow, Figma, Framer, Builder.io and WordPress synced patterns all make the author confirm each editable field, none of them commits silently. The surface doing the nominating has the registry *and* the author; the planner's job is to say whether the reviewed answer survives being stored.

## The convert half

Removes every selected root, then inserts one instance at the index the run began at — which after the removes is where the run was, including when the run ended the list.

Refuses what those ops would be refused for: a locked block on the page, a root the document holds twice, a container that is gone or duplicated, and a slot whose rules will not take a component instance. The nesting question is asked of the **instance**, not of the blocks it replaces — a slot that accepted a heading need not accept a component.

The definition's id comes from the caller and `PlannedCreate.id` echoes it back. A planner cannot mint one: the id format belongs to the collection the row lands in, which the engine cannot see. The ops and the row they point at have to agree, and the only moment they can be made to is before either is written.

## Convergence

`restampOps` spelled the duplicate-root rule inline. Both planners now ask one helper, parameterised by the roots each actually addresses — a save-over touches only the roots whose provenance it repairs, a convert removes every one of them, so the subject is "what is ADDRESSED" rather than "the selection".

`PatternTarget` is now `LibraryTarget`: one type for the three library kinds, which are stored the same way. No consumer outside this package (measured).

## Evidence

- 2137 tests pass from the package directory (50 files), 22 of them new.
- **Break-verified by writing the wrong implementation**, not by mutating: 20 wrong implementations across two rounds. Every one is killed, by the test that names the behaviour. Two rounds were needed — the first found that one of my breaks changed no observable behaviour, and a later one found that **the convert path had no test for the ambiguous-root refusal at all**, which is now covered.
- The dry-run contract is asserted in both directions: the convert plan's ops are applied through `applyOps` and the result inspected, and each refusal is paired with an assertion that the apply refuses the same thing.
- Gates from the worktree root: `fallow` **pass** (5 changed files; introduced dead code 0, complexity 0, duplication 0, styling 0), `check:comments` 0, `changeset status` 0, `turbo run check-types` 42/42.
- `replaceOps` first landed at cyclomatic 10 and failed the fallow gate; split into `replacementPosition` and `ambiguousRootRefusal`, which is also what surfaced the duplicated rule above. Break-verification was re-run against the refactored program.

## Not in this change

Recording what an insert renamed (ruled A, its own change, needs a migration path), `planDuplicateComponent`, `planDetach`.

One question worth a ruling, filed rather than guessed: converting a run collapses several nodes into one instance, and an author-typed DOM anchor inside that run travels into the definition, where composition scopes ids per instance. Whether an on-page `#anchor` should survive a convert is not something the design settles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for saving selected content as reusable components.
  * Added support for converting existing content into linked component instances.
  * Added validation for exposed properties, slots, and variants.
  * Invalid component configurations now provide detailed validation issues.

* **Bug Fixes**
  * Improved handling of node references and placement during component creation and conversion.
  * Added safeguards for ambiguous requests, malformed content, and document size limits.

* **Tests**
  * Expanded coverage for component creation, conversion, validation, limits, placement, and refusal scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->