### PR TITLE
fix(blocks-engine): scope only the DOM id a composed node renders, not both spellings of it

### DIFF
--- a/.changeset/a-shadowed-id-is-not-an-address.md
+++ b/.changeset/a-shadowed-id-is-not-an-address.md
@@ -1,0 +1,46 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A link inside a component pointed at nothing once the component was composed.
+
+A node can spell an HTML id two ways — the modelled `cssId` and the `attributes`
+escape hatch — and it renders at most one of them: `cssId` shadows the bag.
+Composition was scoping both spellings independently, so a shadowed value got a
+per-instance id minted for it as well. That value is what the reference table is
+keyed on, so every `aria-describedby`, `<label for>` and `#fragment` naming it
+was rewritten to point at an id nothing renders.
+
+Shadowed ids are usually shadowed for a reason: a definition referring to one
+was referring to an element in the HOST page, where it resolved. Composition was
+breaking exactly those references, which is strictly worse than leaving them
+alone.
+
+Only the id a node actually renders is scoped now, through the same published
+rule the pattern copier uses. Two spellings carrying one value still move
+together to one replacement, so a document that spelled its id both ways keeps
+answering to a single address.

--- a/.changeset/a-shadowed-id-is-not-an-address.md
+++ b/.changeset/a-shadowed-id-is-not-an-address.md
@@ -44,3 +44,9 @@ Only the id a node actually renders is scoped now, through the same published
 rule the pattern copier uses. Two spellings carrying one value still move
 together to one replacement, so a document that spelled its id both ways keeps
 answering to a single address.
+
+The bag is also measured before the rendered id is derived from it. The rule
+mirrors the renderer, so it accepts shapes the rewrite refuses and reads every
+key to do so — which on a malformed definition published a mapping for an id
+that then stayed on the element, and did the reading unbounded once per
+instance.

--- a/packages/blocks-engine/src/document.ts
+++ b/packages/blocks-engine/src/document.ts
@@ -779,7 +779,10 @@ export type ExposedPropertyType = (typeof EXPOSED_PROPERTY_TYPES)[number];
  * - reading "any present `cssId`" instead of "a string" hid a bag id that does
  *   render, and left two elements answering to one id.
  */
-export function renderedDomId(node: BlockNode): string | undefined {
+export function renderedDomId(node: {
+  readonly cssId?: unknown;
+  readonly attributes?: unknown;
+}): string | undefined {
   const modelled = typeof node.cssId === "string" ? node.cssId : undefined;
   const rendered = modelled ?? renderedDomIdIn(node.attributes);
   return rendered === "" ? undefined : rendered;
@@ -809,6 +812,13 @@ export function renderedDomId(node: BlockNode): string | undefined {
  * renderer emit right now", and the answer has to be the renderer's.
  *
  * `Object.entries(null)` throws and an array is not a bag, so both are absent.
+ *
+ * UNBOUNDED, deliberately, because the renderer it mirrors is: every key is
+ * assigned. A caller that must not do work proportional to a bag it has not
+ * measured should bound the bag first and hand only a measured one to
+ * {@link renderedDomId} — reading a cap into this would make it answer
+ * differently from the renderer for exactly the documents where the answer
+ * matters.
  */
 export function renderedDomIdIn(attributes: unknown): string | undefined {
   if (typeof attributes !== "object" || attributes === null) return undefined;

--- a/packages/blocks-engine/src/resolve-instances.test.ts
+++ b/packages/blocks-engine/src/resolve-instances.test.ts
@@ -1547,6 +1547,38 @@ describe("a node that spells a DOM id twice and renders one", () => {
     expect(nodes[1]!.attributes!["aria-describedby"]).toBe("hero");
   });
 
+  it("reads the bag once, so a value that changes cannot split the two", () => {
+    // A bag entry can be a getter or a Proxy trap that answers differently each
+    // time. Deriving the rendered id from one reading and rewriting from a
+    // second let them disagree: `hero` reached the reference table while
+    // `other` stayed on the element. Survives a prototype of exactly
+    // `Object.prototype`, so neither earlier guard catches it.
+    let reads = 0;
+    const shifting: Record<string, unknown> = {};
+    Object.defineProperty(shifting, "id", {
+      enumerable: true,
+      get() {
+        reads += 1;
+        return reads === 1 ? "hero" : "other";
+      },
+    });
+    const doc = page([instance("i1", "hero")]);
+    const definitions = defs({
+      hero: component([
+        stored(node("d1") as ResolvedBlockNode, { attributes: shifting }),
+        node("d2", { attributes: { "aria-describedby": "hero" } }),
+      ]),
+    });
+
+    const nodes = resolveComponentInstances(doc, definitions).document.nodes;
+
+    // The invariant, whichever value won: no reference names an id that is not
+    // on the element it points at.
+    expect(nodes[1]!.attributes!["aria-describedby"]).toBe(
+      nodes[0]!.attributes!.id
+    );
+  });
+
   it("still scopes a cssId when the bag beside it is unreadable", () => {
     // The boundary: a string `cssId` shadows the bag, so the rendered id does
     // not depend on reading it. Refusing to scope here would leave two

--- a/packages/blocks-engine/src/resolve-instances.test.ts
+++ b/packages/blocks-engine/src/resolve-instances.test.ts
@@ -1443,6 +1443,90 @@ describe("resolveComponentInstances bounds", () => {
   });
 });
 
+describe("a node that spells a DOM id twice and renders one", () => {
+  it("leaves a SHADOWED attribute id alone, and every reference to it", () => {
+    // The measured reproduction. `cssId` shadows the bag, so this node renders
+    // `actual` and never `hero` — and `hero` was therefore a reference to an
+    // element in the HOST, which resolved before composition. Scoping it points
+    // it at an id nothing renders, which is strictly worse than leaving it.
+    const doc = page([instance("i1", "hero")]);
+    const definitions = defs({
+      hero: component([
+        node("d1", {
+          cssId: "actual",
+          attributes: { id: "hero", "aria-describedby": "hero" },
+        }),
+      ]),
+    });
+
+    const nodes = resolveComponentInstances(doc, definitions).document.nodes;
+
+    expect(nodes[0]!.cssId).toContain("actual");
+    expect(nodes[0]!.cssId).not.toBe("actual");
+    expect(nodes[0]!.attributes!.id).toBe("hero");
+    expect(nodes[0]!.attributes!["aria-describedby"]).toBe("hero");
+  });
+
+  it("moves both spellings together when they carry one value", () => {
+    // Nothing is shadowed here: the two spell the SAME id, so the node renders
+    // it and both have to arrive at one replacement, or the copy answers to two
+    // addresses where the original answered to one.
+    const doc = page([instance("i1", "hero")]);
+    const definitions = defs({
+      hero: component([
+        node("d1", { cssId: "signup", attributes: { id: "signup" } }),
+      ]),
+    });
+
+    const nodes = resolveComponentInstances(doc, definitions).document.nodes;
+
+    expect(nodes[0]!.attributes!.id).toBe(nodes[0]!.cssId);
+    expect(nodes[0]!.cssId).not.toBe("signup");
+  });
+
+  it("scopes an id the node carries ONLY in its attribute bag", () => {
+    // Nothing shadows it, so this bag id is what the node renders — and two
+    // instances of one definition would otherwise both put it on the page.
+    const doc = page([instance("i1", "hero"), instance("i2", "hero")]);
+    const definitions = defs({
+      hero: component([
+        node("d1", { attributes: { id: "hero", "aria-describedby": "hero" } }),
+      ]),
+    });
+
+    const nodes = resolveComponentInstances(doc, definitions).document.nodes;
+
+    expect(nodes[0]!.attributes!.id).not.toBe("hero");
+    expect(nodes[0]!.attributes!.id).toContain("hero");
+    expect(nodes[0]!.attributes!.id).not.toBe(nodes[1]!.attributes!.id);
+    // And the reference inside the definition follows it, since the id it named
+    // IS the one this node renders.
+    expect(nodes[0]!.attributes!["aria-describedby"]).toBe(
+      nodes[0]!.attributes!.id
+    );
+  });
+
+  it("scopes nothing for a node that renders no id at all", () => {
+    // An empty `cssId` still SHADOWS, so this node emits no usable id — and a
+    // bag value nothing renders must not reach the memo that rewrites
+    // references, for the reason the shadowed case above gives.
+    const doc = page([instance("i1", "hero")]);
+    const definitions = defs({
+      hero: component([
+        stored(node("d1") as ResolvedBlockNode, {
+          cssId: "",
+          attributes: { id: "hero", "aria-describedby": "hero" },
+        }),
+      ]),
+    });
+
+    const nodes = resolveComponentInstances(doc, definitions).document.nodes;
+
+    expect(nodes[0]!.attributes!.id).toBe("hero");
+    expect(nodes[0]!.attributes!["aria-describedby"]).toBe("hero");
+  });
+});
+
 describe("resolveComponentInstances defensive reads and references", () => {
   it("rewrites an IDREF attribute to the id it now points at", () => {
     const doc = page([instance("i1", "hero"), instance("i2", "hero")]);

--- a/packages/blocks-engine/src/resolve-instances.test.ts
+++ b/packages/blocks-engine/src/resolve-instances.test.ts
@@ -1506,6 +1506,69 @@ describe("a node that spells a DOM id twice and renders one", () => {
     );
   });
 
+  it("publishes no mapping for a bag it cannot rewrite", () => {
+    // `renderedDomId` mirrors the RENDERER, which emits an own `id` off any
+    // non-array object — including one with a custom prototype. The rewrite
+    // below is narrower. Asking the wide rule first published `hero -> minted`
+    // while the element kept `hero`, so a sibling reference was retargeted at
+    // an id nothing renders: strictly worse than leaving it.
+    const bag = Object.create({ inherited: true }) as Record<string, unknown>;
+    bag.id = "hero";
+    const doc = page([instance("i1", "hero")]);
+    const definitions = defs({
+      hero: component([
+        stored(node("d1") as ResolvedBlockNode, { attributes: bag }),
+        node("d2", { attributes: { "aria-describedby": "hero" } }),
+      ]),
+    });
+
+    const nodes = resolveComponentInstances(doc, definitions).document.nodes;
+
+    expect(nodes[1]!.attributes!["aria-describedby"]).toBe("hero");
+  });
+
+  it("publishes no mapping for a bag past the envelope cap", () => {
+    // Same failure by the other route, and it is also where the unbounded read
+    // was: deriving the rendered id walked every key of a bag the resolver had
+    // not measured, once per instance.
+    const wide: Record<string, unknown> = { id: "hero" };
+    for (let i = 0; i <= MAX_ENVELOPE_ENTRIES; i++)
+      wide[`data-${String(i)}`] = "x";
+    const doc = page([instance("i1", "hero")]);
+    const definitions = defs({
+      hero: component([
+        stored(node("d1") as ResolvedBlockNode, { attributes: wide }),
+        node("d2", { attributes: { "aria-describedby": "hero" } }),
+      ]),
+    });
+
+    const nodes = resolveComponentInstances(doc, definitions).document.nodes;
+
+    expect(nodes[1]!.attributes!["aria-describedby"]).toBe("hero");
+  });
+
+  it("still scopes a cssId when the bag beside it is unreadable", () => {
+    // The boundary: a string `cssId` shadows the bag, so the rendered id does
+    // not depend on reading it. Refusing to scope here would leave two
+    // instances answering to one address.
+    const bag = Object.create({ inherited: true }) as Record<string, unknown>;
+    bag.id = "hero";
+    const doc = page([instance("i1", "hero"), instance("i2", "hero")]);
+    const definitions = defs({
+      hero: component([
+        stored(node("d1") as ResolvedBlockNode, {
+          cssId: "actual",
+          attributes: bag,
+        }),
+      ]),
+    });
+
+    const nodes = resolveComponentInstances(doc, definitions).document.nodes;
+
+    expect(nodes[0]!.cssId).toContain("actual");
+    expect(nodes[0]!.cssId).not.toBe(nodes[1]!.cssId);
+  });
+
   it("scopes nothing for a node that renders no id at all", () => {
     // An empty `cssId` still SHADOWS, so this node emits no usable id — and a
     // bag value nothing renders must not reach the memo that rewrites

--- a/packages/blocks-engine/src/resolve-instances.ts
+++ b/packages/blocks-engine/src/resolve-instances.ts
@@ -1824,25 +1824,43 @@ function scopeNode(
 /**
  * Give this copy of the definition its own DOM ids.
  *
- * One definition inlined into two instances publishes its `cssId` and its
- * `id` attribute twice, which is a duplicate HTML id — so an anchor, a
- * `<label for>` or an id selector reaches whichever instance the browser
- * happens to find first. Node ids are already scoped; these are the other
- * addresses a document carries and they were being spread through untouched.
+ * One definition inlined into two instances publishes its `cssId` and its `id`
+ * attribute twice, which is a duplicate HTML id — so an anchor, a `<label for>`
+ * or an id selector reaches whichever instance the browser happens to find
+ * first. Node ids are already scoped; these are the other addresses a document
+ * carries and they were being spread through untouched.
  *
- * `mintDomId` rather than a rule of its own: pattern insert solves exactly
- * this when it copies a subtree, a page may hold the output of both, and two
+ * `mintDomId` rather than a rule of its own: pattern insert solves exactly this
+ * when it copies a subtree, a page may hold the output of both, and two
  * spellings of one replacement would put two ids on one target.
  */
 function applyScopedDomIds(
   scoped: ResolvedBlockNode,
   ctx: InlineContext
 ): void {
-  // ONE id per node, through the published rule, because a node SPELLS a DOM
-  // id two ways and emits at most one of them. Asking the two spellings
-  // independently mints a scoped id for a value nothing renders and — since
-  // this memo is what rewrites references — retargets every reference to it.
-  const rendered = renderedDomId(scoped);
+  // The bag is measured BEFORE the rendered id is asked for, and the answer is
+  // asked of what this can actually rewrite.
+  //
+  // `renderedDomId` mirrors the renderer, so it accepts shapes the rewrite
+  // below refuses — a custom prototype, or a bag past the envelope cap — and it
+  // reads every key to do so. Asking it first therefore did two wrong things at
+  // once on a malformed definition: it published a mapping for an id that then
+  // STAYED on the element, retargeting every reference to an id nothing
+  // renders; and it did that reading unbounded, once per instance, defeating
+  // the cap this walk is otherwise held to.
+  //
+  // Handing it the bag only when the bag is usable makes the two agree. A
+  // string `cssId` shadows the bag anyway, so a node with one still gets its
+  // rendered id and its scoped replacement; only a node relying on an
+  // unreadable bag now scopes nothing, which is the honest answer for an
+  // address this cannot rewrite.
+  const names = isPlainRecord(scoped.attributes)
+    ? boundedOwnKeys(scoped.attributes, MAX_ENVELOPE_ENTRIES)
+    : null;
+  const rendered = renderedDomId({
+    cssId: scoped.cssId,
+    attributes: names === null ? undefined : scoped.attributes,
+  });
   const minted =
     rendered === undefined ? undefined : scopedDomId(rendered, scoped.id, ctx);
 
@@ -1851,8 +1869,13 @@ function applyScopedDomIds(
   if (minted !== undefined && typeof scoped.cssId === "string") {
     scoped.cssId = minted;
   }
-  const next = attributesWithScopedId(scoped.attributes, rendered, minted);
-  if (next !== undefined) scoped.attributes = next;
+  if (names === null) return;
+  scoped.attributes = attributesWithScopedId(
+    scoped.attributes as Record<string, unknown>,
+    names,
+    rendered,
+    minted
+  );
 }
 
 /**
@@ -1875,12 +1898,11 @@ function scopedDomId(
 }
 
 /**
- * The attribute bag with the RENDERED id replaced, or `undefined` to leave the
- * stored one alone.
+ * The attribute bag with the RENDERED id replaced.
  *
- * `undefined` rather than an empty record for a bag this cannot read: returning
- * `{}` would delete a node's attributes during a render, which is a rewrite of
- * stored content rather than a refusal to scope it.
+ * Takes the names its caller already measured rather than reading the bag a
+ * second time: two readings of one record can disagree, and the first is the
+ * one the rendered id was derived from.
  *
  * A SHADOWED id is left verbatim. It puts nothing on the page, so it cannot
  * collide with another instance of the same definition, and it is a value the
@@ -1894,13 +1916,11 @@ function scopedDomId(
  * to a single address.
  */
 function attributesWithScopedId(
-  attributes: unknown,
+  attributes: Record<string, unknown>,
+  names: readonly string[],
   rendered: string | undefined,
   minted: string | undefined
-): Record<string, string> | undefined {
-  if (!isPlainRecord(attributes)) return undefined;
-  const names = boundedOwnKeys(attributes, MAX_ENVELOPE_ENTRIES);
-  if (names === null) return undefined;
+): Record<string, string> {
   const next: Record<string, string> = {};
   for (const name of names) {
     const value = ownEntry(attributes, name);

--- a/packages/blocks-engine/src/resolve-instances.ts
+++ b/packages/blocks-engine/src/resolve-instances.ts
@@ -48,6 +48,7 @@ import {
   COMPONENT_INSTANCE_TYPE,
   isComponentDocument,
   isUnsetOverride,
+  renderedDomId,
   type BlockDocument,
   type BlockNode,
   type ComponentDocument,
@@ -1837,31 +1838,80 @@ function applyScopedDomIds(
   scoped: ResolvedBlockNode,
   ctx: InlineContext
 ): void {
-  const remap = (value: string): string => {
-    const existing = ctx.domIds.get(value);
-    if (existing !== undefined) return existing;
-    const minted = claimDomId(ctx.run, mintDomId(value, scoped.id));
-    ctx.domIds.set(value, minted);
-    return minted;
-  };
+  // ONE id per node, through the published rule, because a node SPELLS a DOM
+  // id two ways and emits at most one of them. Asking the two spellings
+  // independently mints a scoped id for a value nothing renders and — since
+  // this memo is what rewrites references — retargets every reference to it.
+  const rendered = renderedDomId(scoped);
+  const minted =
+    rendered === undefined ? undefined : scopedDomId(rendered, scoped.id, ctx);
 
-  if (typeof scoped.cssId === "string" && scoped.cssId !== "") {
-    scoped.cssId = remap(scoped.cssId);
+  // Only when it is a string is `cssId` the id this node renders, which is
+  // exactly when `renderedDomId` answered with it.
+  if (minted !== undefined && typeof scoped.cssId === "string") {
+    scoped.cssId = minted;
   }
-  if (!isPlainRecord(scoped.attributes)) return;
-  const names = boundedOwnKeys(scoped.attributes, MAX_ENVELOPE_ENTRIES);
-  if (names === null) return;
+  const next = attributesWithScopedId(scoped.attributes, rendered, minted);
+  if (next !== undefined) scoped.attributes = next;
+}
+
+/**
+ * The per-instance replacement for one of a definition's DOM ids.
+ *
+ * Memoized on the ORIGINAL value, so a definition spelling one id on two nodes
+ * still addresses one target after composition — and so the reference pass
+ * downstream can look up what a given id became.
+ */
+function scopedDomId(
+  value: string,
+  nodeId: string,
+  ctx: InlineContext
+): string {
+  const existing = ctx.domIds.get(value);
+  if (existing !== undefined) return existing;
+  const minted = claimDomId(ctx.run, mintDomId(value, nodeId));
+  ctx.domIds.set(value, minted);
+  return minted;
+}
+
+/**
+ * The attribute bag with the RENDERED id replaced, or `undefined` to leave the
+ * stored one alone.
+ *
+ * `undefined` rather than an empty record for a bag this cannot read: returning
+ * `{}` would delete a node's attributes during a render, which is a rewrite of
+ * stored content rather than a refusal to scope it.
+ *
+ * A SHADOWED id is left verbatim. It puts nothing on the page, so it cannot
+ * collide with another instance of the same definition, and it is a value the
+ * definition may still reference: a `hero` shadowed inside a definition was
+ * naming an element in the HOST, where it resolved. Minting a scoped id for it
+ * breaks that reference and aims it at nothing, which is strictly worse than
+ * leaving it.
+ *
+ * A document that spells ONE id both ways is unaffected: both spellings equal
+ * `rendered`, so both receive the same replacement and the copy keeps answering
+ * to a single address.
+ */
+function attributesWithScopedId(
+  attributes: unknown,
+  rendered: string | undefined,
+  minted: string | undefined
+): Record<string, string> | undefined {
+  if (!isPlainRecord(attributes)) return undefined;
+  const names = boundedOwnKeys(attributes, MAX_ENVELOPE_ENTRIES);
+  if (names === null) return undefined;
   const next: Record<string, string> = {};
   for (const name of names) {
-    const value = ownEntry(scoped.attributes, name);
+    const value = ownEntry(attributes, name);
     if (typeof value !== "string") continue;
     // Case-insensitively, because HTML attribute names are: a stored `ID` and
-    // a stored `id` address the same thing to a browser, and remapping only
-    // the lowercase spelling leaves the other duplicated.
-    const isId = name.toLowerCase() === "id" && value !== "";
-    defineEntry(next, name, isId ? remap(value) : value);
+    // a stored `id` address the same thing to a browser.
+    const isRenderedId =
+      minted !== undefined && name.toLowerCase() === "id" && value === rendered;
+    defineEntry(next, name, isRenderedId ? minted : value);
   }
-  scoped.attributes = next;
+  return next;
 }
 
 /**

--- a/packages/blocks-engine/src/resolve-instances.ts
+++ b/packages/blocks-engine/src/resolve-instances.ts
@@ -1854,12 +1854,10 @@ function applyScopedDomIds(
   // rendered id and its scoped replacement; only a node relying on an
   // unreadable bag now scopes nothing, which is the honest answer for an
   // address this cannot rewrite.
-  const names = isPlainRecord(scoped.attributes)
-    ? boundedOwnKeys(scoped.attributes, MAX_ENVELOPE_ENTRIES)
-    : null;
+  const bag = snapshotAttributes(scoped.attributes);
   const rendered = renderedDomId({
     cssId: scoped.cssId,
-    attributes: names === null ? undefined : scoped.attributes,
+    attributes: bag ?? undefined,
   });
   const minted =
     rendered === undefined ? undefined : scopedDomId(rendered, scoped.id, ctx);
@@ -1869,13 +1867,42 @@ function applyScopedDomIds(
   if (minted !== undefined && typeof scoped.cssId === "string") {
     scoped.cssId = minted;
   }
-  if (names === null) return;
-  scoped.attributes = attributesWithScopedId(
-    scoped.attributes as Record<string, unknown>,
-    names,
-    rendered,
-    minted
-  );
+  if (bag === null) return;
+  scoped.attributes = attributesWithScopedId(bag, rendered, minted);
+}
+
+/**
+ * The attribute bag as DATA: bounded, own string entries, read exactly once.
+ *
+ * A bag is a stored record in the ordinary case and an arbitrary object in the
+ * hostile one, where a value can be a getter or a Proxy trap that answers
+ * differently each time it is asked. Deriving the rendered id from one reading
+ * and rewriting from a second let the two disagree: the id `hero` was published
+ * to the reference table while `other` stayed on the element, so every
+ * `aria-describedby="hero"` was retargeted at an id nothing renders — the same
+ * failure this module set out to close, by a route that survives a bag whose
+ * prototype is exactly `Object.prototype`.
+ *
+ * So the bag is read once, into a plain record, and both answers come from that
+ * snapshot. `null` for a bag this cannot use at all — not a plain record, or
+ * past the envelope cap — which is also what keeps the read bounded, since
+ * {@link renderedDomId} mirrors the renderer and reads every key it is given.
+ *
+ * Non-string values are dropped rather than carried, matching what the rewrite
+ * already emitted: the bag it produces has only ever held strings.
+ */
+function snapshotAttributes(
+  attributes: unknown
+): Record<string, string> | null {
+  if (!isPlainRecord(attributes)) return null;
+  const names = boundedOwnKeys(attributes, MAX_ENVELOPE_ENTRIES);
+  if (names === null) return null;
+  const snapshot: Record<string, string> = {};
+  for (const name of names) {
+    const value = ownEntry(attributes, name);
+    if (typeof value === "string") defineEntry(snapshot, name, value);
+  }
+  return snapshot;
 }
 
 /**
@@ -1900,9 +1927,9 @@ function scopedDomId(
 /**
  * The attribute bag with the RENDERED id replaced.
  *
- * Takes the names its caller already measured rather than reading the bag a
- * second time: two readings of one record can disagree, and the first is the
- * one the rendered id was derived from.
+ * Takes the SNAPSHOT its caller already read, never the stored bag: two
+ * readings of one record can disagree, and the rendered id was derived from the
+ * first — see {@link snapshotAttributes}.
  *
  * A SHADOWED id is left verbatim. It puts nothing on the page, so it cannot
  * collide with another instance of the same definition, and it is a value the
@@ -1916,15 +1943,12 @@ function scopedDomId(
  * to a single address.
  */
 function attributesWithScopedId(
-  attributes: Record<string, unknown>,
-  names: readonly string[],
+  snapshot: Record<string, string>,
   rendered: string | undefined,
   minted: string | undefined
 ): Record<string, string> {
   const next: Record<string, string> = {};
-  for (const name of names) {
-    const value = ownEntry(attributes, name);
-    if (typeof value !== "string") continue;
+  for (const [name, value] of Object.entries(snapshot)) {
     // Case-insensitively, because HTML attribute names are: a stored `ID` and
     // a stored `id` address the same thing to a browser.
     const isRenderedId =


### PR DESCRIPTION
A link inside a component pointed at nothing once the component was composed.

## The defect

A node spells an HTML id two ways — the modelled `cssId` and the `attributes` escape hatch — and it renders **at most one**: `cssId` shadows the bag. `applyScopedDomIds` scoped both spellings independently, so a shadowed value got a per-instance id minted for it too.

That matters because the memo it writes into (`ctx.domIds`) is keyed on the original value and is exactly what `remapIdReferences` / `remapFragmentProps` consult. So every `aria-describedby`, `<label for>` and `#fragment` naming the shadowed id was retargeted at an id nothing renders.

Measured on a real composed document. Definition node with `cssId: "actual"`, `attributes: { id: "hero", "aria-describedby": "hero" }`:

| | before |
|---|---|
| `cssId` (renders) | `actual-cxatr2eq` |
| shadowed `attributes.id` | `hero-cxatr2eq` |
| `aria-describedby` | `hero-cxatr2eq` ← names an id **nothing renders** |

Shadowed ids tend to be shadowed for a reason. Because `hero` was shadowed *inside the definition*, that reference was aiming at an element in the **host page**, where it resolved before composition and does not after. Minting a scoped id for it is strictly worse than leaving it verbatim.

## The fix

Only `renderedDomId(node)` enters the remapping table — the same published rule the pattern copier was fixed to use in #1563. This is the second site that carried its own copy of the question; both now ask one.

- A **shadowed** bag id is left verbatim. It puts nothing on the page, so it cannot collide with another instance, and it may still be a live reference into the host.
- Two spellings carrying **one** value still arrive at one replacement, since both equal the rendered id — a document that spells its id both ways keeps answering to a single address.
- A node that renders **no** id scopes nothing, which includes the `cssId: ""` case: an empty id still shadows, so the bag value must not reach the memo either.

`collectDomIds` also reads both spellings and is **deliberately left alone**. It feeds `claimDomId`, which only keeps minted ids off the host's, so over-inclusion there costs nothing and there is no avoid decision to get wrong. That was checked and recorded so nobody re-measures it — one defect here, not two.

`applyScopedDomIds` is split into `scopedDomId` (the mint) and `attributesWithScopedId` (the bag rewrite). Two jobs, and it keeps each inside the complexity gate.

## Evidence

- **The reproduction is the test, and it fails on the unfixed program.** I restored `origin/main`'s `resolve-instances.ts` under the new tests: 2 fail, both the reproductions. With the fix, 96 pass in that file.
- 2117 tests pass from the package directory (50 files), 4 new.
- **Break-verified by writing the wrong implementation.** The first round killed nothing on two breaks — one of which turned out to change no behaviour, while the other exposed a genuine gap: **there was no test for a node whose only id lives in the attribute bag**. That case is now covered, and the corrected breaks each die on the right test:
  - bag remaps any id again → the shadowed-id reproduction
  - rendered id read as `cssId` only → the bag-only test
  - nothing scoped at all → the two-instance scoping tests
- Gates from the worktree root: `fallow` **pass** (3 changed files; 0 introduced in every category), `check:comments` 0, `changeset status` 0, `check-types` 0.

Closes the defect recorded as `finding:be-resolver-remaps-a-shadowed-dom-id`, which Codex first raised against the copier on #1563.