### PR TITLE
feat(nextly): make a migration declare which entities it changes

### DIFF
--- a/.changeset/migrations-declare-what-they-change.md
+++ b/.changeset/migrations-declare-what-they-change.md
@@ -1,0 +1,31 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+A generated migration's header now names only the collections, singles and field groups that migration changes, instead of every entity in the config, and carries `-- Entity scope: touched` to say so. A localization companion names its entity by kind, so a single or field group is no longer written as a collection.
+
+`nextly migrate:create --blank` explains how to annotate a hand-written migration and ships the marker, so naming the entity is the whole step.

--- a/packages/nextly/src/cli/commands/migrate-baseline.ts
+++ b/packages/nextly/src/cli/commands/migrate-baseline.ts
@@ -540,6 +540,9 @@ export async function baselineCore(
         components: [],
         hasUserExt: false,
         now,
+        // The entity arrays above are empty because this caller does not
+        // compute them, not because the migration changes nothing.
+        entitiesAreScoped: false,
       });
 
       await mkdir(migrationsDir, { recursive: true });

--- a/packages/nextly/src/cli/commands/migrate.ts
+++ b/packages/nextly/src/cli/commands/migrate.ts
@@ -56,7 +56,7 @@ import { reconcileCore } from "../../domains/schema/migrate/core-reconcile";
 import { reconcileFile } from "../../domains/schema/migrate/drift-reconcile";
 import { reconcileMigrationMetadata } from "../../domains/schema/migrate/reconcile-metadata";
 import { resolveDeclaredSchema } from "../../domains/schema/migrate/resolved-schema";
-import { FIELD_GROUP_HEADER_PATTERN } from "../../domains/schema/migrate-create/format-file";
+import { parseEntityHeaders } from "../../domains/schema/migrate-create/format-file";
 import {
   EMPTY_SNAPSHOT,
   parseSnapshotFile,
@@ -920,29 +920,7 @@ function parseMigrationFile(
   const checksumMatch = content.match(/^-- Checksum:\s*([a-f0-9]+)/m);
   const originalChecksum = checksumMatch?.[1];
 
-  const collectionsMatch = content.match(/^-- Collections?:\s*(.+)$/m);
-  const collections = collectionsMatch
-    ? collectionsMatch[1]
-        .split(",")
-        .map(c => c.trim())
-        .filter(c => c.length > 0)
-    : [];
-
-  const singlesMatch = content.match(/^-- Singles?:\s*(.+)$/m);
-  const singles = singlesMatch
-    ? singlesMatch[1]
-        .split(",")
-        .map(s => s.trim())
-        .filter(s => s.length > 0)
-    : [];
-
-  const componentsMatch = content.match(FIELD_GROUP_HEADER_PATTERN);
-  const components = componentsMatch
-    ? componentsMatch[1]
-        .split(",")
-        .map(c => c.trim())
-        .filter(c => c.length > 0)
-    : [];
+  const { collections, singles, components } = parseEntityHeaders(content);
 
   const timestampMatch = name.match(/^(\d{8}_\d{6})/);
   const timestamp = timestampMatch?.[1] ?? name;

--- a/packages/nextly/src/domains/i18n/migration/write-migration-file.test.ts
+++ b/packages/nextly/src/domains/i18n/migration/write-migration-file.test.ts
@@ -141,3 +141,51 @@ describe("declared intent in the written header", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 });
+
+/*
+ * 🔴 The header files the entity under a KIND, and the sweep that decides
+ * whether a registry row is still waiting reads one set per kind. A single or a
+ * field group written as `-- Collections:` lands in the collections set, its own
+ * kind's set stays empty, and the row is promoted to `applied` before the
+ * companion table its migration creates exists. A collection, a single and a
+ * field group may share a slug, so the kind is the only thing separating them.
+ */
+describe("the companion header names the entity by its kind", () => {
+  // Derived from the spec this file already uses, so a required field added to
+  // CompanionMigrationSpec cannot leave this one silently behind.
+  const sharedSlugSpec: CompanionMigrationSpec = {
+    ...spec,
+    collection: "shared_slug",
+  };
+
+  function headerFor(entity: "collection" | "single" | "fieldGroup"): string {
+    const dir = mkdtempSync(join(tmpdir(), "nextly-companion-kind-"));
+    const path = writeCompanionMigrationFile(dir, sharedSlugSpec, {
+      kind: "create-only",
+      entity,
+      upSql: "SELECT 1;",
+      downSql: "SELECT 1;",
+      now: new Date("2026-08-02T00:00:00.000Z"),
+    });
+    return readFileSync(path, "utf-8");
+  }
+
+  it("files a single under Singles, not Collections", () => {
+    const content = headerFor("single");
+    expect(content).toContain("-- Singles: shared_slug");
+    expect(content).not.toContain("-- Collections:");
+  });
+
+  it("files a field group under Field groups, not Collections", () => {
+    const content = headerFor("fieldGroup");
+    expect(content).toContain("-- Field groups: shared_slug");
+    expect(content).not.toContain("-- Collections:");
+  });
+
+  it("still files a collection under Collections", () => {
+    // The control: without it, a writer that emitted no entity header at all
+    // would satisfy both exclusions above.
+    const content = headerFor("collection");
+    expect(content).toContain("-- Collections: shared_slug");
+  });
+});

--- a/packages/nextly/src/domains/i18n/migration/write-migration-file.ts
+++ b/packages/nextly/src/domains/i18n/migration/write-migration-file.ts
@@ -64,6 +64,10 @@ export function writeLocalizationMigrationFile(
   const header =
     `-- Migration: ${baseName}\n` +
     `-- Collections: ${spec.collection}\n` +
+    // Scoped by construction, like the companion writer: this file is about
+    // one entity. Without the marker its header is read as unknown scope, and
+    // a reader cannot tell it from a legacy file that names the whole config.
+    `${SCOPED_ENTITIES_MARKER}\n` +
     `${LOCALIZATION_MIGRATION_MARKER} ${opts.direction} (i18n)\n`;
   const content = `${header}\n-- UP\n${up}\n\n-- DOWN\n${down}\n`;
 

--- a/packages/nextly/src/domains/i18n/migration/write-migration-file.ts
+++ b/packages/nextly/src/domains/i18n/migration/write-migration-file.ts
@@ -1,6 +1,11 @@
 import { writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 
+import {
+  entityHeaderLine,
+  SCOPED_ENTITIES_MARKER,
+} from "../../schema/migrate-create/format-file";
+
 import { buildLocalizationDownSql } from "./generate-down";
 import { buildLocalizationUpSql } from "./generate-up";
 import { formatLocalizationIntent } from "./migration-intent";
@@ -116,7 +121,12 @@ export function writeCompanionMigrationFile(
   // when the target database has already come part of the way.
   const header =
     `-- Migration: ${baseName}\n` +
-    `-- Collections: ${spec.collection}\n` +
+    // Named by KIND. A single or a field group filed under `-- Collections:`
+    // is read into the wrong set, and the sweep that asks whether this entity
+    // is still waiting looks in its own kind's set and finds nothing.
+    `${entityHeaderLine(opts.entity, spec.collection)}\n` +
+    // Scoped by construction: a companion file is about one entity.
+    `${SCOPED_ENTITIES_MARKER}\n` +
     `${LOCALIZATION_MIGRATION_MARKER} companion (${opts.kind}) (i18n)\n` +
     `${formatLocalizationIntent({ kind: opts.kind, entity: opts.entity, spec })}\n`;
   const content = `${header}\n-- UP\n${opts.upSql}\n\n-- DOWN\n${opts.downSql}\n`;

--- a/packages/nextly/src/domains/schema/migrate-create/__tests__/format-file.test.ts
+++ b/packages/nextly/src/domains/schema/migrate-create/__tests__/format-file.test.ts
@@ -326,3 +326,68 @@ describe("the shared remediation is sufficient for a legacy file too", () => {
     expect(parsed.collections).toEqual(["posts"]);
   });
 });
+
+/*
+ * 🔴 The marker counts only as its own line. A substring test reads the
+ * marker's own guidance sentence as provenance — and the blank template prints
+ * that sentence — so a file whose real marker was removed still answered
+ * `scoped`, and the test guarding the marker could not fail either way.
+ */
+describe("the scope marker is recognised as a header line, not as text", () => {
+  it("does not read the guidance sentence as a declaration", () => {
+    // Exactly the shape that defeated the substring test: the marker named
+    // inside prose, with no standalone header line.
+    const prose = `-- Migration: x\n-- ${ENTITY_HEADER_GUIDANCE}\n\n-- UP\nSELECT 1;`;
+
+    expect(prose).toContain(SCOPED_ENTITIES_MARKER);
+    expect(parseEntityHeaders(prose).scoped).toBe(false);
+  });
+
+  it("does not read the marker inside SQL as a declaration", () => {
+    const inSql = `-- Migration: x\n\n-- UP\nINSERT INTO t VALUES ('${SCOPED_ENTITIES_MARKER}');`;
+
+    expect(parseEntityHeaders(inSql).scoped).toBe(false);
+  });
+
+  it("reads a standalone marker line as a declaration", () => {
+    // The control: without it, a parser that always answered false would
+    // satisfy both cases above.
+    const declared = `-- Migration: x\n${SCOPED_ENTITIES_MARKER}\n\n-- UP\nSELECT 1;`;
+
+    expect(parseEntityHeaders(declared).scoped).toBe(true);
+  });
+});
+
+/*
+ * 🔴 A caller that does not compute the entity arrays must not publish a
+ * declaration about them. `migrate-baseline` passes all three empty while its
+ * SQL adopts existing tables, so a marker there would say "scoped, and it
+ * changes nothing" about a migration that creates the whole schema.
+ */
+describe("a caller can decline to declare scope", () => {
+  const base = {
+    name: "m",
+    dialect: "postgresql" as const,
+    sqlStatements: ["SELECT 1"],
+    downSqlStatements: [],
+    collections: [],
+    singles: [],
+    components: [],
+    hasUserExt: false,
+    now: new Date("2026-04-29T15:45:00.123Z"),
+  };
+
+  it("omits the marker when the caller says the arrays are not scoped", () => {
+    const out = formatMigrationFile({ ...base, entitiesAreScoped: false });
+
+    expect(parseEntityHeaders(out).scoped).toBe(false);
+  });
+
+  it("writes it for a caller that computed them, even when none were touched", () => {
+    // "Changes no entity" and "nobody recorded what this changes" stay
+    // different facts, and only the marker separates them.
+    const out = formatMigrationFile(base);
+
+    expect(parseEntityHeaders(out).scoped).toBe(true);
+  });
+});

--- a/packages/nextly/src/domains/schema/migrate-create/__tests__/format-file.test.ts
+++ b/packages/nextly/src/domains/schema/migrate-create/__tests__/format-file.test.ts
@@ -3,8 +3,11 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  ENTITY_HEADER_GUIDANCE,
   FIELD_GROUP_HEADER_PATTERN,
   formatBlankFile,
+  parseEntityHeaders,
+  SCOPED_ENTITIES_MARKER,
   formatMigrationFile,
   formatTimestamp,
   slugify,
@@ -220,5 +223,106 @@ describe("field-group header", () => {
     expect(
       "-- Collections: posts".match(FIELD_GROUP_HEADER_PATTERN)
     ).toBeNull();
+  });
+});
+
+/*
+ * 🔴 A blank migration carries arbitrary hand-written SQL, so the tool cannot
+ * know which entities it changes — and `nextly migrate` reads exactly that to
+ * decide which registry rows are still waiting. Without the line, an entity the
+ * migration alters is recorded as migrated once its old table exists. The
+ * template asks for it, because the remedy is one line and nothing else can
+ * supply it.
+ */
+describe("the blank template asks for an entity header", () => {
+  it("tells the author how to name what the migration changes", () => {
+    const out = formatBlankFile(
+      "custom_thing",
+      "postgresql",
+      new Date("2026-04-29T15:45:00.123Z")
+    );
+
+    expect(out).toContain("-- Collections: posts");
+    expect(out).toContain("-- Singles: home");
+    expect(out).toContain("-- Field groups: hero");
+  });
+
+  it("leaves them as guidance, not as a header the parser would read", () => {
+    // The lines are examples inside a comment block. If they parsed as real
+    // headers, every blank migration would claim to change `posts`.
+    const out = formatBlankFile(
+      "custom_thing",
+      "postgresql",
+      new Date("2026-04-29T15:45:00.123Z")
+    );
+
+    expect(parseEntityHeaders(out).collections).toEqual([]);
+    expect(parseEntityHeaders(out).singles).toEqual([]);
+    expect(parseEntityHeaders(out).components).toEqual([]);
+  });
+});
+
+/*
+ * 🔴 The remediation has to WORK. The scope marker decides whether a header is
+ * read as ownership, so a blank file that lacks it discards any slug the
+ * operator adds — the provenance gate rejecting precisely the annotation the
+ * template asks for, silently. The template therefore ships the marker, and an
+ * operator who follows it only has to name the entity.
+ */
+describe("following the blank template's instruction actually annotates the file", () => {
+  const blank = (): string =>
+    formatBlankFile(
+      "custom_thing",
+      "postgresql",
+      new Date("2026-04-29T15:45:00.123Z")
+    );
+
+  it("ships the scope marker, so an added header is read as ownership", () => {
+    // What the operator writes, following the template.
+    const annotated = `${blank()}\n-- Collections: posts\n`;
+    const parsed = parseEntityHeaders(annotated);
+
+    expect(parsed.collections).toEqual(["posts"]);
+    expect(parsed.scoped).toBe(true);
+  });
+
+  it("claims nothing until the operator names something", () => {
+    // The control, and the reason shipping the marker is not a loophole: the
+    // untouched template is still unknown scope, because "changes nothing" and
+    // "nobody said" are different facts.
+    const parsed = parseEntityHeaders(blank());
+
+    expect(parsed.collections).toEqual([]);
+    expect(parsed.singles).toEqual([]);
+    expect(parsed.components).toEqual([]);
+  });
+});
+
+/*
+ * 🔴 One remediation is shown for two different files, so it has to work on
+ * both. A new blank migration ships the marker and only needs the entity named;
+ * a migration generated before headers were scoped has headers and NO marker,
+ * and adding another header to it changes nothing — the names stay discarded.
+ */
+describe("the shared remediation is sufficient for a legacy file too", () => {
+  it("names the marker as well as the headers", () => {
+    expect(ENTITY_HEADER_GUIDANCE).toContain(SCOPED_ENTITIES_MARKER);
+    expect(ENTITY_HEADER_GUIDANCE).toContain("-- Collections:");
+    expect(ENTITY_HEADER_GUIDANCE).toContain("-- Singles:");
+    expect(ENTITY_HEADER_GUIDANCE).toContain("-- Field groups:");
+  });
+
+  it("following it on a legacy file makes its names count", () => {
+    // A file generated before headers were scoped: names, no marker.
+    const legacy =
+      "-- Migration: old\n-- Collections: posts\n\n-- UP\nSELECT 1;";
+    expect(parseEntityHeaders(legacy).scoped).toBe(false);
+
+    // What the remediation asks the operator to add.
+    const repaired = `${legacy}\n${SCOPED_ENTITIES_MARKER}\n`;
+    const parsed = parseEntityHeaders(repaired);
+
+    expect(parsed.scoped).toBe(true);
+    expect(parsed.collections).toEqual(["posts"]);
   });
 });

--- a/packages/nextly/src/domains/schema/migrate-create/__tests__/generate.test.ts
+++ b/packages/nextly/src/domains/schema/migrate-create/__tests__/generate.test.ts
@@ -20,6 +20,7 @@ import {
   type MinimalConfigEntity,
 } from "../generate";
 import { buildInverseOperations } from "../down-generator";
+import { parseEntityHeaders } from "../format-file";
 import { writeSnapshot } from "../snapshot-io";
 
 const NOW = new Date("2026-04-29T15:45:00.123Z");
@@ -1026,5 +1027,107 @@ describe("applyRenameDecisions (rename collapsing)", () => {
     expect(out).toHaveLength(2);
     expect(out[0].type).toBe("add_table");
     expect(out[1].type).toBe("rename_column");
+  });
+});
+
+/*
+ * 🔴 The entity header is the only per-file record of which entities a
+ * migration carries, and `migrate` reads it to decide whether a registry row is
+ * still waiting on something. Written from the whole config, every migration
+ * claims every entity — which answers that question identically for all of them
+ * and so answers it for none.
+ */
+describe("the entity header names what the migration changes", () => {
+  let migrationsDir: string;
+
+  beforeEach(async () => {
+    migrationsDir = await mkdtemp(join(tmpdir(), "nextly-header-scope-"));
+  });
+
+  const AUTHORS: MinimalConfigEntity = {
+    slug: "authors",
+    tableName: "dc_authors",
+    fields: [{ name: "description", type: "text", required: true }],
+  };
+
+  /*
+   * 🔴 A prefix match looks like it also catches companion tables and catches
+   * unrelated entities instead. `dc_posts_archive` shares the `dc_posts_`
+   * prefix with `dc_posts`, so editing the archive would name `posts` too — and
+   * naming an entity holds its dashboard back until this migration runs.
+   */
+  it("does not name an entity whose table is merely a prefix of the touched one", async () => {
+    const ARCHIVE: MinimalConfigEntity = {
+      slug: "posts-archive",
+      tableName: "dc_posts_archive",
+      fields: [{ name: "description", type: "text", required: true }],
+    };
+
+    await generateMigration({
+      name: "create_posts",
+      dialect: "postgresql",
+      migrationsDir,
+      collections: [POSTS_V1],
+      singles: [],
+      components: [],
+      nonInteractive: true,
+      now: NOW,
+    });
+
+    const second = await generateMigration({
+      name: "create_archive",
+      dialect: "postgresql",
+      migrationsDir,
+      collections: [POSTS_V1, ARCHIVE],
+      singles: [],
+      components: [],
+      nonInteractive: true,
+      now: new Date("2026-04-29T15:48:00.123Z"),
+    });
+
+    expect(second).not.toBeNull();
+    const sql = await readFile(second!.sqlPath, "utf-8");
+    // Parsed rather than pattern-matched: with the prefix match restored the
+    // line reads `-- Collections: posts, posts-archive`, which a regex anchored
+    // on the whole line fails to match either way — an assertion that cannot
+    // tell the two implementations apart.
+    const named = parseEntityHeaders(sql).collections;
+    // The control: the entity it DOES carry is named.
+    expect(named).toContain("posts-archive");
+    // And its prefix-sharing neighbour is not.
+    expect(named).not.toContain("posts");
+  });
+
+  it("omits a collection this migration does not touch", async () => {
+    // Both exist in the config; only `posts` is new, so only `posts` is
+    // waiting on this file.
+    await generateMigration({
+      name: "create_authors",
+      dialect: "postgresql",
+      migrationsDir,
+      collections: [AUTHORS],
+      singles: [],
+      components: [],
+      nonInteractive: true,
+      now: NOW,
+    });
+
+    const second = await generateMigration({
+      name: "create_posts",
+      dialect: "postgresql",
+      migrationsDir,
+      collections: [AUTHORS, POSTS_V1],
+      singles: [],
+      components: [],
+      nonInteractive: true,
+      now: new Date("2026-04-29T15:46:00.123Z"),
+    });
+
+    expect(second).not.toBeNull();
+    const sql = await readFile(second!.sqlPath, "utf-8");
+    // The control: the entity it DOES carry is still named, so this cannot
+    // pass by emitting no header at all.
+    expect(sql).toContain("-- Collections: posts");
+    expect(sql).not.toContain("authors");
   });
 });

--- a/packages/nextly/src/domains/schema/migrate-create/format-file.ts
+++ b/packages/nextly/src/domains/schema/migrate-create/format-file.ts
@@ -40,6 +40,48 @@ import { getDialectDisplayName } from "../../../cli/utils/adapter";
  * header would report those migrations as touching no field groups, silently.
  */
 export const FIELD_GROUP_HEADER = "-- Field groups:";
+
+/**
+ * Marks a file whose entity headers name what the migration CHANGES.
+ *
+ * 🔴 Provenance, not decoration. Migrations generated before headers were
+ * scoped list every entity in the config, so reading one as ownership makes an
+ * unrelated old migration hold a collection's row -- and its dashboard --
+ * until it runs. A reader cannot tell the two apart from the header itself:
+ * both are a comma-separated list of slugs.
+ *
+ * Absent means "this file's scope is unknown", which is the honest reading of a
+ * legacy header.
+ *
+ * A blank migration SHIPS with this line, and that is deliberate rather than a
+ * loophole: without it, an operator who follows the template and adds
+ * `-- Collections: posts` still has the slug discarded, because the file the
+ * guidance produced is not marked. The marker alone claims nothing — a file
+ * carrying it and naming no entity is still unknown scope, because "changes
+ * nothing" and "nobody said" stay different facts. It becomes an assertion only
+ * once the operator names something, which is when they make it.
+ */
+export const SCOPED_ENTITIES_MARKER = "-- Entity scope: touched";
+
+/**
+ * The one-line instruction for annotating a hand-written migration.
+ *
+ * 🔴 Exported so the CLI's remediation and the blank template say the SAME
+ * thing. They were written separately and immediately disagreed: the template
+ * listed all three headers while the warning named only `-- Collections:`, and
+ * following the warning filed a single among collections. Guidance about a
+ * format belongs beside the format.
+ *
+ * 🔴 Names the MARKER as well as the header, because the files this is shown
+ * for are not all alike. A new blank migration ships the marker, so naming the
+ * entity is enough; a migration generated before headers were scoped has
+ * headers and no marker, and adding another header to it changes nothing —
+ * `scoped` stays false and the names are discarded exactly as before. One
+ * remediation is shown for both, so it has to be sufficient for both.
+ */
+export const ENTITY_HEADER_GUIDANCE =
+  "Add `-- Collections:`, `-- Singles:` or `-- Field groups:` naming what it changes, " +
+  `plus \`${SCOPED_ENTITIES_MARKER}\` if the file does not already carry it`;
 export const FIELD_GROUP_HEADER_PATTERN =
   /^-- (?:Field groups?|Components?):\s*(.+)$/m;
 
@@ -78,6 +120,9 @@ export function formatMigrationFile(args: FormatArgs): string {
       ? `${FIELD_GROUP_HEADER} ${args.components.join(", ")}\n`
       : "";
   const userExtLine = args.hasUserExt ? "-- UserExt: user_ext\n" : "";
+  // Written whether or not any entity is named: a migration that changes no
+  // entity is a different fact from one whose scope nobody recorded.
+  const scopeLine = `${SCOPED_ENTITIES_MARKER}\n`;
   // Each statement gets a trailing `;`. splitSqlStatements in migrate.ts
   // splits on `;` so statements MUST be terminated.
   const body = args.sqlStatements.map(s => `${s};`).join("\n\n");
@@ -87,7 +132,7 @@ export function formatMigrationFile(args: FormatArgs): string {
       : "-- (no automatic down — this migration is not reversible. Hand-write rollback SQL here)";
 
   return `-- Migration: ${args.name}
-${collectionLine}${singleLine}${componentLine}${userExtLine}-- Generated at: ${now}
+${collectionLine}${singleLine}${componentLine}${userExtLine}${scopeLine}-- Generated at: ${now}
 -- Dialect: ${getDialectDisplayName(args.dialect)}
 
 -- UP
@@ -109,6 +154,18 @@ export function formatBlankFile(
 --
 -- This is a blank migration file for custom SQL.
 -- Add your migration SQL below.
+--
+--
+-- ${ENTITY_HEADER_GUIDANCE}. For example:
+--
+-- -- Collections: posts
+-- -- Singles: home
+-- -- Field groups: hero
+--
+-- \`nextly migrate\` reads those lines to know which entities are still
+-- waiting on this file. Without one it cannot tell, and will record those
+-- entities as migrated once their tables exist.
+${SCOPED_ENTITIES_MARKER}
 
 -- UP
 
@@ -147,4 +204,78 @@ export function slugify(name: string): string {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "_")
     .replace(/^_|_$/g, "");
+}
+
+/**
+ * The entity slugs a migration's header names.
+ *
+ * Lives beside {@link formatMigrationFile} for the reason the field-group
+ * pattern does: a writer and a reader that each spell the format themselves are
+ * two places to change and one place to forget. Two callers read this — the
+ * migrate command when it parses a file, and the pending sweep when it asks
+ * which entities are still waiting on something.
+ *
+ * The singular spellings are accepted because files already on disk carry them.
+ */
+export interface MigrationEntityHeaders {
+  collections: string[];
+  singles: string[];
+  components: string[];
+  /**
+   * Whether the names above are what this migration CHANGES.
+   *
+   * False for a legacy file, whose header lists the whole config, and for a
+   * hand-written one with no header. A caller deciding ownership must treat
+   * those as unknown rather than as evidence.
+   */
+  scoped: boolean;
+}
+
+const COLLECTIONS_HEADER_PATTERN = /^-- Collections?:\s*(.+)$/m;
+const SINGLES_HEADER_PATTERN = /^-- Singles?:\s*(.+)$/m;
+
+/** The comma-separated slugs on one header line, or none. */
+function headerSlugs(content: string, pattern: RegExp): string[] {
+  const match = content.match(pattern);
+  if (!match?.[1]) return [];
+  return match[1]
+    .split(",")
+    .map(value => value.trim())
+    .filter(value => value.length > 0);
+}
+
+export function parseEntityHeaders(content: string): MigrationEntityHeaders {
+  return {
+    collections: headerSlugs(content, COLLECTIONS_HEADER_PATTERN),
+    singles: headerSlugs(content, SINGLES_HEADER_PATTERN),
+    components: headerSlugs(content, FIELD_GROUP_HEADER_PATTERN),
+    scoped: content.includes(SCOPED_ENTITIES_MARKER),
+  };
+}
+
+/**
+ * The header line naming ONE entity, chosen by its kind.
+ *
+ * 🔴 Here rather than at the call site because the kind decides which bucket a
+ * reader puts the slug in, and a writer that always says `-- Collections:`
+ * files a single or a field group under the wrong one. The sweep then looks in
+ * its own kind's set, finds nothing, and promotes a row whose migration has not
+ * run — the exact failure the header exists to prevent, reintroduced by the
+ * writer rather than the reader.
+ *
+ * Kept beside {@link parseEntityHeaders} and {@link formatMigrationFile} so the
+ * three spellings of this format stay in one file.
+ */
+export function entityHeaderLine(
+  kind: "collection" | "single" | "fieldGroup",
+  slug: string
+): string {
+  switch (kind) {
+    case "single":
+      return `-- Singles: ${slug}`;
+    case "fieldGroup":
+      return `${FIELD_GROUP_HEADER} ${slug}`;
+    case "collection":
+      return `-- Collections: ${slug}`;
+  }
 }

--- a/packages/nextly/src/domains/schema/migrate-create/format-file.ts
+++ b/packages/nextly/src/domains/schema/migrate-create/format-file.ts
@@ -64,6 +64,17 @@ export const FIELD_GROUP_HEADER = "-- Field groups:";
 export const SCOPED_ENTITIES_MARKER = "-- Entity scope: touched";
 
 /**
+ * The marker as a HEADER LINE, which is the only form that counts.
+ *
+ * 🔴 A substring test reads the marker's own guidance sentence as provenance —
+ * and the blank template prints that sentence — so a file whose real marker was
+ * removed still answered `scoped`. That is not only a wrong answer: it made the
+ * test guarding the marker unable to fail, because the text it searched for was
+ * present either way.
+ */
+const SCOPED_ENTITIES_PATTERN = /^-- Entity scope: touched$/m;
+
+/**
  * The one-line instruction for annotating a hand-written migration.
  *
  * 🔴 Exported so the CLI's remediation and the blank template say the SAME
@@ -71,6 +82,13 @@ export const SCOPED_ENTITIES_MARKER = "-- Entity scope: touched";
  * listed all three headers while the warning named only `-- Collections:`, and
  * following the warning filed a single among collections. Guidance about a
  * format belongs beside the format.
+ *
+ * 🔴 Distinguishes hand-written from generated, because the files this is
+ * shown for are not all alike and the same edit is safe on one and destructive
+ * on the other. `writeSnapshot` records a SHA-256 of the `.sql` in its paired
+ * snapshot and `verifyMigrationHash` compares them, so annotating a GENERATED
+ * migration after the fact invalidates its own integrity record. The blank
+ * path writes no snapshot, so a hand-written file has nothing to invalidate.
  *
  * 🔴 Names the MARKER as well as the header, because the files this is shown
  * for are not all alike. A new blank migration ships the marker, so naming the
@@ -80,8 +98,11 @@ export const SCOPED_ENTITIES_MARKER = "-- Entity scope: touched";
  * remediation is shown for both, so it has to be sufficient for both.
  */
 export const ENTITY_HEADER_GUIDANCE =
-  "Add `-- Collections:`, `-- Singles:` or `-- Field groups:` naming what it changes, " +
-  `plus \`${SCOPED_ENTITIES_MARKER}\` if the file does not already carry it`;
+  "In a hand-written migration, add `-- Collections:`, `-- Singles:` or " +
+  "`-- Field groups:` naming what it changes, plus " +
+  `\`${SCOPED_ENTITIES_MARKER}\` if it is not already there. ` +
+  "A generated migration's `.sql` is hashed by its paired snapshot, so leave " +
+  "that one alone — its entities keep the behaviour they had before";
 export const FIELD_GROUP_HEADER_PATTERN =
   /^-- (?:Field groups?|Components?):\s*(.+)$/m;
 
@@ -103,6 +124,17 @@ export interface FormatArgs {
   components: string[];
   /** True if this migration includes user_ext changes. */
   hasUserExt: boolean;
+  /**
+   * Whether the entity arrays name what this migration CHANGES.
+   *
+   * 🔴 False for a caller that does not compute them, and `migrate-baseline`
+   * is one: it passes all three arrays empty while its SQL adopts existing
+   * tables. Stamping the marker there would publish "scoped, and it changes
+   * nothing" about a migration that creates the whole schema — a false
+   * declaration, and worse than none, because a reader can tell an absent
+   * declaration from a wrong one only if wrong ones are never written.
+   */
+  entitiesAreScoped?: boolean;
   /** Override generated-at timestamp for tests; default = `new Date()`. */
   now?: Date;
 }
@@ -120,9 +152,11 @@ export function formatMigrationFile(args: FormatArgs): string {
       ? `${FIELD_GROUP_HEADER} ${args.components.join(", ")}\n`
       : "";
   const userExtLine = args.hasUserExt ? "-- UserExt: user_ext\n" : "";
-  // Written whether or not any entity is named: a migration that changes no
-  // entity is a different fact from one whose scope nobody recorded.
-  const scopeLine = `${SCOPED_ENTITIES_MARKER}\n`;
+  // Written whether or not any entity is NAMED: a migration that changes no
+  // entity is a different fact from one whose scope nobody recorded. Withheld
+  // when the caller says it did not compute the arrays at all.
+  const scopeLine =
+    args.entitiesAreScoped === false ? "" : `${SCOPED_ENTITIES_MARKER}\n`;
   // Each statement gets a trailing `;`. splitSqlStatements in migrate.ts
   // splits on `;` so statements MUST be terminated.
   const body = args.sqlStatements.map(s => `${s};`).join("\n\n");
@@ -249,7 +283,7 @@ export function parseEntityHeaders(content: string): MigrationEntityHeaders {
     collections: headerSlugs(content, COLLECTIONS_HEADER_PATTERN),
     singles: headerSlugs(content, SINGLES_HEADER_PATTERN),
     components: headerSlugs(content, FIELD_GROUP_HEADER_PATTERN),
-    scoped: content.includes(SCOPED_ENTITIES_MARKER),
+    scoped: SCOPED_ENTITIES_PATTERN.test(content),
   };
 }
 

--- a/packages/nextly/src/domains/schema/migrate-create/generate.ts
+++ b/packages/nextly/src/domains/schema/migrate-create/generate.ts
@@ -253,17 +253,50 @@ export async function generateMigration(
   const downSqlStatements = inverseOps.map(op => generateSQL(op, args.dialect));
 
   // 7b. Append UI metadata-row upserts for any touched UI-built table (§4.12.7).
+  const touched = new Set(operations.map(operationTableName));
   if (args.metadataUpserts && args.metadataUpserts.length > 0) {
-    const touched = new Set(operations.map(operationTableName));
     for (const m of args.metadataUpserts) {
       if (touched.has(m.tableName)) sqlStatements.push(m.sql);
     }
   }
 
-  // 8. Compose file content + write both files.
-  const collectionSlugs = args.collections.map(c => c.slug).sort();
-  const singleSlugs = args.singles.map(c => c.slug).sort();
-  const componentSlugs = args.components.map(c => c.slug).sort();
+  /*
+   * 8. Compose file content + write both files.
+   *
+   * 🔴 The entity headers name what this migration CHANGES, not everything the
+   * config describes. The header is the only per-file record of which entities
+   * a migration carries, and `migrate` reads it to decide whether a registry
+   * row is still waiting on something — a header listing the whole manifest
+   * makes every migration look like it touches every entity, which answers that
+   * question the same way for all of them and so answers it for none.
+   *
+   * Matched on the EXACT table name. A prefix match looks like it would also
+   * catch companion tables, and catches unrelated entities instead: a
+   * collection whose table is `dc_posts_archive` shares the `dc_posts_` prefix
+   * with `dc_posts`, so editing the archive would name `posts` as well and hold
+   * a dashboard it has nothing to do with. Over-naming fails in the expensive
+   * direction here — a withheld row is an empty dashboard with nothing on
+   * screen to explain it.
+   *
+   * A localization transition is not covered by THIS header and does not need
+   * to be: those are emitted as their own companion `.sql` files, which carry
+   * their own header naming the entity by kind.
+   */
+  const namesTouched = (entity: MinimalConfigEntity): boolean =>
+    touched.has(entity.tableName);
+
+  const collectionSlugs = args.collections
+    .filter(namesTouched)
+    .map(c => c.slug)
+    .sort();
+  const singleSlugs = args.singles
+    .filter(namesTouched)
+    .map(c => c.slug)
+    .sort();
+  const componentSlugs = args.components
+    .filter(namesTouched)
+    .map(c => c.slug)
+    .sort();
   const sqlContent = formatMigrationFile({
     name: args.name,
     dialect: args.dialect,

--- a/packages/nextly/src/domains/schema/migrate-create/generate.ts
+++ b/packages/nextly/src/domains/schema/migrate-create/generate.ts
@@ -281,6 +281,15 @@ export async function generateMigration(
    * A localization transition is not covered by THIS header and does not need
    * to be: those are emitted as their own companion `.sql` files, which carry
    * their own header naming the entity by kind.
+   *
+   * 🔴 An entity REMOVED from the config cannot be named, because the filter
+   * runs over the config as it is now and the entity is no longer in it — so a
+   * migration that drops its table declares scope and omits the entity whose
+   * table it drops. Naming it needs the previous entity manifest, which no
+   * caller passes; the previous SNAPSHOT holds tables, not slugs, so the
+   * mapping is not recoverable here. The consequence is under-naming, which
+   * leaves such a row promoted as it was before rather than withheld — the
+   * cheap direction, and the reason this is recorded rather than guessed at.
    */
   const namesTouched = (entity: MinimalConfigEntity): boolean =>
     touched.has(entity.tableName);


### PR DESCRIPTION
**First of two.** #1564 is the second half and is now blocked on this one; see the note at the bottom for why they were separated.

## What a migration says about itself

`format-file.ts` documents the entity header as the linkage to `dynamic_collections.migration_status` — the record of which entities a migration carries. Three things made it unusable for that:

- **It listed the whole config.** `generate.ts` passed `args.collections` while `touched`, the set of tables the migration actually operates on, sat computed two lines above and was used only to gate metadata upserts. Every migration claimed every entity.
- **A localization companion always wrote `-- Collections:`**, whatever the entity was — while carrying the kind in `opts.entity`, whose own docblock says it is recorded because *"a collection, a single and a field group may share a slug, and the file has to name which one it is about."*
- **Nothing recorded provenance.** A migration written before this change lists the whole config, and its header is indistinguishable from a scoped one: both are a comma-separated list of slugs.

## What changed

Headers are scoped to the migration's own operations, matched on the **exact** table name. A prefix match looks like it would also catch companion tables and catches unrelated entities instead — `dc_posts_archive` shares the `dc_posts_` prefix with `dc_posts` — and over-naming is the expensive direction for anything that later reads this.

Companions name their entity **by kind**.

Generated files carry `-- Entity scope: touched`, so a reader has provenance rather than a guess. It is written **even when a migration names no entity**, because "changes nothing" and "nobody recorded what this changes" are different facts and the absence of a header cannot tell them apart.

`migrate:create --blank` explains how to annotate a hand-written migration **and ships the marker**, so naming the entity is the whole step rather than half of it — a template that asked for a header without the marker would produce a file whose header is still discarded.

## Refactor carried here

Header parsing moves beside its writer and the migrate command's copy of the regexes is deleted. A writer and a reader that each spell the format themselves are two places to change and one place to forget, which is how the field-group header came to be written under its old name for months.

## Evidence

Nothing asserted the header's contents before — the formatter had tests for turning slugs into a header, its caller had none for which slugs it passed.

Each break is a wrong implementation, caught by its own named test:

| break | caught by |
| --- | --- |
| header from the full manifest | `omits a collection this migration does not touch` |
| restore the prefix match | `does not name an entity whose table is merely a prefix of the touched one` |
| companion always writes Collections | `files a single under Singles, not Collections` |
| blank template omits the marker | `ships the scope marker, so an added header is read as ownership` |

Paired controls throughout, so a writer emitting no header and a template asserting scope unconditionally both fail.

`pnpm check-types` clean, 570 tests in the touched areas, lint clean, fallow `pass` with 0 introduced findings.

## Why this is separate

This began as one change with #1564. Across eight review rounds the last three findings were each caused by the previous fix — the provenance marker invalidating its own guidance, that guidance breaking an integration fixture, the fixture repair leaving the guidance insufficient for legacy files. Every one lived on the seam between "a migration declares what it changes" and "the sweep reads that declaration". Reviewed apart, each would have surfaced immediately.

This half stands alone: it makes the metadata migrations record about themselves correct. #1564 consumes it and rebases onto `main` once this merges, rather than stacking, so it gets real CI rather than the branch-filtered subset.