### PR TITLE
fix(plugin-page-builder): list Pages once, and keep the menu for what pages are built from

### DIFF
--- a/.changeset/pages-is-listed-once.md
+++ b/.changeset/pages-is-listed-once.md
@@ -1,0 +1,51 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Pages is listed once, with the rest of your content.
+
+The page-builder plugin contributed a "Pages" menu entry pointing at a
+collection the Collections listing already offered, so the same screen appeared
+under two names. The entry is gone; the menu now holds the three libraries —
+patterns, components and layouts — which are the pieces pages are built from and
+are genuinely global.
+
+It was also a claim the code does not support. The page builder is a FIELD TYPE:
+any collection may declare `blocks` and a Single may too, and nothing in the
+engine, the builder or the plugin knows the slug `pages`. A menu promising that
+the page builder means Pages gets less true the moment a second collection
+declares the field, and nothing would ever have added that one.
+
+Switching page while building is unaffected — the editor's own left rail carries
+a Pages panel, which is where that job belongs.
+
+A note repeated in the three library collections is corrected at the same time.
+It claimed two automatic navigation sources reach them and that plugin ownership
+cannot move a duplicate. Only one source reaches them, because the other lists
+`admin.isPlugin` collections and this package never sets that flag; and declared
+PLACEMENT does move a listing, which is the distinction ownership and placement
+are separate questions about.

--- a/packages/plugin-page-builder/src/collections/components.ts
+++ b/packages/plugin-page-builder/src/collections/components.ts
@@ -73,16 +73,23 @@ export function componentsCollection() {
     // menu entry for the store and two sources listing one screen is the
     // problem rather than the belt-and-braces it looks like.
     //
-    // There are two automatic sources and `hidden` is the only thing that
-    // excludes both. `isInCollectionsSection` (admin `lib/sidebar-landing`)
-    // admits every collection that is not hidden and claims no sidebar group,
-    // which is the Collections listing; `DynamicPluginNav` lists every
-    // collection marked `isPlugin`, and `SidebarNavigation` renders it
-    // immediately above this plugin's own menu — so claiming plugin ownership
-    // does not move the duplicate, it puts both copies in one section, side by
-    // side. Hidden costs nothing else: the collection keeps its URL, its API
-    // and its permissions, and only stops being offered by navigation nobody
-    // asked for.
+    // ONE automatic source reaches this collection, and `hidden` is what
+    // excludes it: `isInCollectionsSection` (admin `lib/sidebar-landing`)
+    // admits every collection that is not hidden and claims no sidebar group.
+    //
+    // The other automatic source, `DynamicPluginNav`, lists only collections
+    // marked `admin.isPlugin`, which is a presentation flag this package never
+    // sets — so it never reaches these at all. That flag is also what an
+    // earlier note here conflated with PLACEMENT: a plugin declaring
+    // `placement` does move its collections out of the Plugins panel, through
+    // `isCollectionPlacedElsewhere`, but only for collections that opted into
+    // being listed there in the first place. Ownership and placement are
+    // separate questions, which is the distinction `collection-placement.ts`
+    // exists to draw.
+    //
+    // Hidden costs nothing else: the collection keeps its URL, its API and its
+    // permissions, and only stops being offered by navigation nobody asked
+    // for — this plugin's own menu links to it explicitly.
     admin: { useAsTitle: "title", hidden: true },
   });
 }

--- a/packages/plugin-page-builder/src/collections/composition-stores.test.ts
+++ b/packages/plugin-page-builder/src/collections/composition-stores.test.ts
@@ -17,6 +17,7 @@ import { pageBuilder } from "../plugin";
 import { LAYOUT_AREAS } from "./areas";
 import { COMPONENTS_SLUG, componentsCollection } from "./components";
 import { LAYOUTS_SLUG, layoutsCollection } from "./layouts";
+import { pagesCollection } from "./pages";
 import { PATTERNS_SLUG, patternsCollection } from "./patterns";
 
 /** A field as the collection config carries it, before any narrowing. */
@@ -302,6 +303,58 @@ describe("exactly one navigation source claims each store", () => {
       expect(menu.filter(item => item.collection === slug)).toHaveLength(1);
     }
   );
+});
+
+describe("exactly one navigation source claims Pages", () => {
+  // Pages is the case the store assertions above do not cover, and it was the
+  // one being listed twice. It is an ordinary collection that happens to
+  // declare a `blocks` field, so the Collections listing is where it belongs —
+  // with the rest of an author's content — and this plugin's menu holds the
+  // pieces pages are built FROM.
+  //
+  // Asserted as the OUTCOME, for the reason the store block gives: the levers
+  // are three separate settings and satisfying any two of them still shows the
+  // author one screen under two names.
+  it("is offered by the Collections listing", () => {
+    const collection = pagesCollection() as {
+      admin?: { hidden?: boolean; sidebarGroup?: string };
+    };
+
+    // `isInCollectionsSection` admits a collection that is not hidden and
+    // claims no sidebar group. Both halves, since either one would exclude it.
+    expect(collection.admin?.hidden).not.toBe(true);
+    expect(collection.admin?.sidebarGroup).toBeUndefined();
+  });
+
+  it("is not also offered by the plugin-collection nav", () => {
+    const collection = pagesCollection() as { admin?: { isPlugin?: boolean } };
+    expect(collection.admin?.isPlugin).toBeUndefined();
+  });
+
+  it("is not also offered by this plugin's own menu", () => {
+    const menu = (pageBuilder().contributes?.admin?.menu ?? []) as {
+      label?: string;
+      to?: string;
+      collection?: string;
+    }[];
+
+    expect(
+      menu.filter(
+        item =>
+          item.collection === "pages" ||
+          item.to === "/admin/collections/pages" ||
+          item.label === "Pages"
+      )
+    ).toEqual([]);
+
+    // The control. Without it an empty menu — or one this test could not read
+    // — satisfies the assertion above while saying nothing.
+    expect(menu.map(item => item.collection)).toEqual([
+      PATTERNS_SLUG,
+      COMPONENTS_SLUG,
+      LAYOUTS_SLUG,
+    ]);
+  });
 });
 
 describe("a Layout row names no variant", () => {

--- a/packages/plugin-page-builder/src/collections/layouts.ts
+++ b/packages/plugin-page-builder/src/collections/layouts.ts
@@ -147,16 +147,23 @@ export function layoutsCollection() {
     // menu entry for the store and two sources listing one screen is the
     // problem rather than the belt-and-braces it looks like.
     //
-    // There are two automatic sources and `hidden` is the only thing that
-    // excludes both. `isInCollectionsSection` (admin `lib/sidebar-landing`)
-    // admits every collection that is not hidden and claims no sidebar group,
-    // which is the Collections listing; `DynamicPluginNav` lists every
-    // collection marked `isPlugin`, and `SidebarNavigation` renders it
-    // immediately above this plugin's own menu — so claiming plugin ownership
-    // does not move the duplicate, it puts both copies in one section, side by
-    // side. Hidden costs nothing else: the collection keeps its URL, its API
-    // and its permissions, and only stops being offered by navigation nobody
-    // asked for.
+    // ONE automatic source reaches this collection, and `hidden` is what
+    // excludes it: `isInCollectionsSection` (admin `lib/sidebar-landing`)
+    // admits every collection that is not hidden and claims no sidebar group.
+    //
+    // The other automatic source, `DynamicPluginNav`, lists only collections
+    // marked `admin.isPlugin`, which is a presentation flag this package never
+    // sets — so it never reaches these at all. That flag is also what an
+    // earlier note here conflated with PLACEMENT: a plugin declaring
+    // `placement` does move its collections out of the Plugins panel, through
+    // `isCollectionPlacedElsewhere`, but only for collections that opted into
+    // being listed there in the first place. Ownership and placement are
+    // separate questions, which is the distinction `collection-placement.ts`
+    // exists to draw.
+    //
+    // Hidden costs nothing else: the collection keeps its URL, its API and its
+    // permissions, and only stops being offered by navigation nobody asked
+    // for — this plugin's own menu links to it explicitly.
     admin: { useAsTitle: "title", hidden: true },
   });
 }

--- a/packages/plugin-page-builder/src/collections/patterns.ts
+++ b/packages/plugin-page-builder/src/collections/patterns.ts
@@ -110,16 +110,23 @@ export function patternsCollection() {
     // menu entry for the store and two sources listing one screen is the
     // problem rather than the belt-and-braces it looks like.
     //
-    // There are two automatic sources and `hidden` is the only thing that
-    // excludes both. `isInCollectionsSection` (admin `lib/sidebar-landing`)
-    // admits every collection that is not hidden and claims no sidebar group,
-    // which is the Collections listing; `DynamicPluginNav` lists every
-    // collection marked `isPlugin`, and `SidebarNavigation` renders it
-    // immediately above this plugin's own menu — so claiming plugin ownership
-    // does not move the duplicate, it puts both copies in one section, side by
-    // side. Hidden costs nothing else: the collection keeps its URL, its API
-    // and its permissions, and only stops being offered by navigation nobody
-    // asked for.
+    // ONE automatic source reaches this collection, and `hidden` is what
+    // excludes it: `isInCollectionsSection` (admin `lib/sidebar-landing`)
+    // admits every collection that is not hidden and claims no sidebar group.
+    //
+    // The other automatic source, `DynamicPluginNav`, lists only collections
+    // marked `admin.isPlugin`, which is a presentation flag this package never
+    // sets — so it never reaches these at all. That flag is also what an
+    // earlier note here conflated with PLACEMENT: a plugin declaring
+    // `placement` does move its collections out of the Plugins panel, through
+    // `isCollectionPlacedElsewhere`, but only for collections that opted into
+    // being listed there in the first place. Ownership and placement are
+    // separate questions, which is the distinction `collection-placement.ts`
+    // exists to draw.
+    //
+    // Hidden costs nothing else: the collection keeps its URL, its API and its
+    // permissions, and only stops being offered by navigation nobody asked
+    // for — this plugin's own menu links to it explicitly.
     admin: { useAsTitle: "title", hidden: true },
   });
 }

--- a/packages/plugin-page-builder/src/plugin-admin-identity.test.ts
+++ b/packages/plugin-page-builder/src/plugin-admin-identity.test.ts
@@ -44,8 +44,10 @@ describe("page-builder admin identity", () => {
     // the placement assertion above mean anything: standalone placement is
     // only a duplication when something is already listed. Which entries
     // those are is not this test's question — asserting the whole list here
-    // made adding a screen look like a change to the plugin's identity.
+    // made adding a screen look like a change to the plugin's identity, and a
+    // line naming one of them did the same thing more quietly. Which sources
+    // offer which screen is asserted in `composition-stores.test.ts`, where
+    // the navigation reasoning lives.
     expect(menu.length).toBeGreaterThan(0);
-    expect(menu.map(item => item.label)).toContain("Pages");
   });
 });

--- a/packages/plugin-page-builder/src/plugin.ts
+++ b/packages/plugin-page-builder/src/plugin.ts
@@ -425,9 +425,9 @@ export const pageBuilder = (opts: PageBuilderOptions = {}) => {
       // How the plugin names itself wherever the admin lists it. Without this
       // the dashboard section and the plugins list fall back to `meta.name`,
       // which is the raw package specifier — `@nextlyhq/plugin-page-builder`
-      // shown where the form builder shows "Forms". The icon matches the Pages
-      // menu entry this plugin contributes, so one feature is not drawn two
-      // different ways in the same sidebar.
+      // shown where the form builder shows "Forms". `Layout` is the feature's
+      // own mark rather than any one menu entry's, so the plugins list and the
+      // sidebar heading draw the same feature the same way.
       appearance: { icon: "Layout", label: "Page Builder" },
       description:
         "Build pages visually from blocks with drag-and-drop editing",
@@ -584,26 +584,40 @@ export const pageBuilder = (opts: PageBuilderOptions = {}) => {
               },
             }
           : {}),
+        // The three LIBRARIES, and no link to Pages.
+        //
+        // Pages is an ordinary collection that happens to declare a `blocks`
+        // field — a title, a slug and the document — and the Collections
+        // listing already offers it, because it is not hidden and claims no
+        // sidebar group. A second entry here was the same screen named twice.
+        //
+        // It is also a claim the code does not support. The page builder is a
+        // FIELD TYPE, so any collection may declare it and a Single may too;
+        // nothing in the engine, the builder or this package knows the slug
+        // `pages`. A menu promising "the page builder lives here, and it means
+        // Pages" gets less true the moment a second collection declares the
+        // field, and nothing would ever add that one.
+        //
+        // So content sits with content, and this menu holds what is genuinely
+        // global: the pieces pages are built FROM. An author already switches
+        // page from inside the editor, whose left rail carries a Pages panel —
+        // which is where that job belongs, since it is done while building
+        // rather than while deciding what to build.
+        //
         // Each entry names the permission that makes its screen reachable, so
         // a role without it is not offered a link into a list it would be
-        // refused. Pages carries none for the same reason it always has: it is
-        // the plugin's front door, and a reader who cannot read pages has
-        // nothing to do here at all.
-        //
-        // They sit beside Pages rather than under a section of their own. The
-        // sidebar's section vocabulary is a closed list in core with no design
-        // entry, so grouping them would mean widening that list — a change to
-        // the admin's navigation model, which is a larger question than where
-        // three links go.
-        //
-        // Each of the three names its `collection`, so a host that renames one
+        // refused, and each names its `collection`, so a host that renames one
         // gets a link to the collection it actually registered and a gate on
         // the permission that slug actually seeds. Spelling either literally
         // would strand the link and hide the item from the readers who can
-        // open the list. Pages names none, keeping the destination and the
-        // absent gate it has always had.
+        // open the list.
+        //
+        // They sit under this plugin's own heading rather than a section of
+        // their own: the sidebar's section vocabulary is a closed list in core
+        // with no design entry, so grouping them elsewhere would mean widening
+        // that list — a change to the admin's navigation model, and a larger
+        // question than where three links go.
         menu: [
-          { label: "Pages", to: "/admin/collections/pages", icon: "Layout" },
           {
             label: "Patterns",
             collection: PATTERNS_SLUG,


### PR DESCRIPTION
Founder ruling on `decision:pb6-sidebar-which-reading-of-collections`. Prototype: https://claude.ai/code/artifact/eb67a280-1aa9-4812-80ce-6af5362c7d04

## What changes

The plugin contributed a `Pages` menu entry pointing at a collection the Collections listing already offered, so one screen appeared under two names. The entry is gone. The menu keeps the three libraries — patterns, components, layouts — which are the pieces pages are built **from**, and the part of this feature that is genuinely global.

## Why, and it is a fact about the code rather than a preference

The page builder is a **field type**. `blocks` can be declared by any collection, and `write-target.ts` already enumerates a Single as one of its cases. Nothing in the engine, the builder or this package knows the slug `pages` — the only two matches are its own declaration and a left-rail *panel* of the same name.

So a menu saying "the page builder lives here, and it means Pages" promises something the code does not grant, and it gets **less true over time**: the moment a second collection declares the field, the menu names one of two builder-enabled collections and no rule would ever add the other.

Switching page while building is unaffected. The editor's left rail carries a Pages panel, which is where that job belongs — it is done while building, not while deciding what to build. That is Webflow's arrangement; the split itself is Elementor's, which leaves Pages in WordPress's generic list and gives Templates its own menu.

## A measurement I got wrong, corrected here

I had recorded that Pages renders **three** times. Measured properly, it renders **twice**.

The third source, `DynamicPluginNav`, lists only collections marked `admin.isPlugin` — and that is a presentation flag this package never sets on any of its four collections. `di/register.ts` states the same thing from the other side: provenance comes from the plugin contribution list, "even when the plugin never sets that presentation flag."

That also makes the fix a single deleted menu entry rather than the three-part change the decision node described. No `placement` declaration is needed, because the placement branch in `isInCollectionsSection` is only reached for an `isPlugin` collection.

## The note repeated in all three library collections was wrong

It claimed two automatic sources reach them, that `hidden` is the only thing excluding both, and that claiming plugin ownership "does not move the duplicate".

- **One** source reaches them, for the reason above.
- A declared **placement** does move a listing, via `isCollectionPlacedElsewhere` — for a collection that opted into the Plugins panel in the first place.

Ownership and placement are separate questions, which is the distinction `collection-placement.ts` exists to draw. Corrected in all three, and `hidden` is still doing real work: it is what keeps the libraries out of the Collections listing.

## One assertion removed rather than updated

`plugin-admin-identity.test.ts` pinned `toContain("Pages")` **directly beneath a comment saying which entries those are is not that test's question** — the stale half of an edited paragraph. Its stated property, no standalone placement paired with a non-empty menu, survives untouched. Which source offers which screen is now asserted in `composition-stores.test.ts`, where the navigation reasoning already lives.

## Evidence

- Three new tests in `composition-stores.test.ts` covering Pages, mirroring the block that already covers the three stores: it is offered by the Collections listing, not by the plugin-collection nav, and not by the plugin menu. The menu one **fails on `origin/main`**; the other two are regression guards for facts this change relies on and does not alter.
- The menu test carries a control asserting the remaining three entries, so an empty or unreadable menu cannot satisfy it.
- 642 tests pass in `plugin-page-builder`; `turbo run check-types` 42/42; `fallow` **pass** (7 changed files, 0 introduced in every category); `check:comments` 0; `changeset status` 0.
- The pre-push design lint caught `#727` in a comment as a hardcoded colour. The reference is gone — AGENTS.md forbids naming a change in a comment anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Navigation**
  - The page-builder sidebar now lists Patterns, Components, and Layouts.
  - The Pages entry has been removed from the page-builder menu; Pages remains available through the Collections listing.

- **Documentation**
  - Updated navigation documentation to clarify how hidden collections and collection placement affect where items appear, while preserving their URLs, APIs, and permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->