### PR TITLE
fix(blocks-engine): check a node's provenance on the field write road too

### DIFF
--- a/.changeset/provenance-on-both-roads.md
+++ b/.changeset/provenance-on-both-roads.md
@@ -1,0 +1,43 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A node's provenance record is now checked on both roads into storage.
+
+A document reaches storage two ways — an op through the edit vocabulary, and a
+field write through the document validator — and only the op road checked
+`origin`. So an import or a script could persist `{ from: "pattern", id: "",
+digest: "" }`, and every later provenance reader would take it at face value: a
+staleness check comparing against a pattern with no id answers confidently and
+wrongly, and a save-over restoring the DOM ids an insert renamed reads a record
+it cannot trust.
+
+Both roads now ask the same published predicate, so a record one admits and the
+other refuses — one that exists in the database and cannot be edited — is not
+representable. It is an error in both validation modes: a half-written record is
+not a value a future build understands, it is a claim about history with a piece
+missing.

--- a/packages/blocks-engine/src/validation.test.ts
+++ b/packages/blocks-engine/src/validation.test.ts
@@ -7,6 +7,7 @@ import {
 } from "./document";
 import type { BlockDocument, BlockNode, BreakpointSet } from "./document";
 import { DEFAULT_LIMITS, documentBytes } from "./limits";
+import { applyOps } from "./ops";
 import {
   MAX_SITE_LOOKUPS,
   MAX_SITE_ISSUES,
@@ -2804,6 +2805,91 @@ describe("componentEnvelopeIssues holds itself to a real bound", () => {
     expect(componentEnvelopeIssues(doc).map(i => i.code)).toContain(
       "exposed-node-missing"
     );
+  });
+});
+
+describe("a node's provenance record is checked on both roads to storage", () => {
+  /** A one-node page whose node carries this origin. */
+  function withOrigin(origin: unknown): BlockDocument {
+    return {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [{ id: "n1", type: "core/text", version: 1, props: {}, origin }],
+    } as unknown as BlockDocument;
+  }
+
+  const codesFor = (origin: unknown, mode: "strict" | "forgiving" = "strict") =>
+    validate(withOrigin(origin), {
+      breakpoints: FIXTURE_BREAKPOINTS,
+      mode,
+    }).map(issue => issue.code);
+
+  it.each([
+    ["a pattern with no digest", { from: "pattern", id: "p1" }],
+    [
+      "a pattern with an empty digest",
+      { from: "pattern", id: "p1", digest: "" },
+    ],
+    ["a pattern with an empty id", { from: "pattern", id: "", digest: "d" }],
+    ["a component with no id", { from: "component" }],
+    ["an unknown arm", { from: "elsewhere", id: "x" }],
+    ["not a record", "pattern"],
+  ])("refuses %s", (_name, origin) => {
+    // An import or a script can write one of these through the FIELD road, and
+    // every later provenance reader takes it at face value: a staleness check
+    // against a pattern with no id answers confidently and wrongly.
+    expect(codesFor(origin)).toContain("invalid-origin");
+  });
+
+  it.each([
+    ["a whole pattern record", { from: "pattern", id: "p1", digest: "d1" }],
+    ["a whole component record", { from: "component", id: "c1" }],
+  ])("accepts %s", (_name, origin) => {
+    // The controls. Without them a check that refused every record would pass
+    // every assertion above.
+    expect(codesFor(origin)).not.toContain("invalid-origin");
+  });
+
+  it("accepts a node with no record at all", () => {
+    const codes = validate(
+      {
+        formatVersion: 1,
+        kind: "page",
+        nodes: [{ id: "n1", type: "core/text", version: 1, props: {} }],
+      } as unknown as BlockDocument,
+      { breakpoints: FIXTURE_BREAKPOINTS, mode: "strict" }
+    ).map(issue => issue.code);
+
+    expect(codes).not.toContain("invalid-origin");
+  });
+
+  it("refuses it in FORGIVING mode too", () => {
+    // Forgiving mode keeps a document readable when a future build wrote
+    // something this one does not understand. A half-written record is not a
+    // future value — it is a claim about history with a piece missing, and a
+    // reader cannot tell which piece.
+    expect(codesFor({ from: "pattern", id: "p1" }, "forgiving")).toContain(
+      "invalid-origin"
+    );
+  });
+
+  it("agrees with the road an op takes", () => {
+    // The point of the check: a record one road admits and the other refuses is
+    // one that exists in the database and cannot be edited. Both ask
+    // `isBlockOrigin`, so this asserts the SAME record is refused by both.
+    const half = { from: "pattern", id: "p1" };
+
+    expect(codesFor(half)).toContain("invalid-origin");
+    expect(() =>
+      applyOps(
+        {
+          formatVersion: 1,
+          kind: "page",
+          nodes: [{ id: "n1", type: "core/text", version: 1, props: {} }],
+        } as unknown as BlockDocument,
+        [{ kind: "update", id: "n1", patch: { origin: half } }] as never
+      )
+    ).toThrow();
   });
 });
 

--- a/packages/blocks-engine/src/validation.test.ts
+++ b/packages/blocks-engine/src/validation.test.ts
@@ -2873,6 +2873,82 @@ describe("a node's provenance record is checked on both roads to storage", () =>
     );
   });
 
+  it.each([
+    [
+      "a throwing getter",
+      () => {
+        throw new Error("boom");
+      },
+    ],
+    ["a benign getter", () => ({ from: "pattern", id: "p1", digest: "d1" })],
+  ])("never invokes an origin that is %s", (_name, get) => {
+    // `surveyDocument` refuses to invoke an accessor and already reports such a
+    // document unreadable, so reading one here would run the document's own
+    // code inside the check deciding whether to trust it. Measured before the
+    // descriptor read: the throwing one escaped `validate()` as a native error,
+    // and the benign one was invoked TWICE — once per read.
+    let reads = 0;
+    const node: Record<string, unknown> = {
+      id: "n1",
+      type: "core/text",
+      version: 1,
+      props: {},
+    };
+    Object.defineProperty(node, "origin", {
+      enumerable: true,
+      get() {
+        reads += 1;
+        return get();
+      },
+    });
+
+    let escaped: unknown;
+    let codes: string[] = [];
+    try {
+      codes = validate(
+        {
+          formatVersion: 1,
+          kind: "page",
+          nodes: [node],
+        } as unknown as BlockDocument,
+        { breakpoints: FIXTURE_BREAKPOINTS, mode: "strict" }
+      ).map(issue => issue.code);
+    } catch (error) {
+      escaped = error;
+    }
+
+    expect(escaped).toBeUndefined();
+    expect(reads).toBe(0);
+    // The verdict that already covers it, rather than a second one from here:
+    // a document whose fields compute themselves is refused as a whole.
+    expect(codes).toContain("document-unreadable");
+    expect(codes).not.toContain("invalid-origin");
+  });
+
+  it("ignores an origin inherited from a prototype", () => {
+    // `structuredClone` and object spreads copy OWN properties, so a value
+    // reached through the prototype is not what would be stored — the rule this
+    // engine applies to every other field.
+    const node = Object.create({
+      origin: { from: "pattern", id: "" },
+    }) as Record<string, unknown>;
+    node.id = "n1";
+    node.type = "core/text";
+    node.version = 1;
+    node.props = {};
+
+    const codes = validate(
+      {
+        formatVersion: 1,
+        kind: "page",
+        nodes: [node],
+      } as unknown as BlockDocument,
+      { breakpoints: FIXTURE_BREAKPOINTS, mode: "strict" }
+    ).map(issue => issue.code);
+
+    expect(codes).not.toContain("invalid-origin");
+  });
+
   it("agrees with the road an op takes", () => {
     // The point of the check: a record one road admits and the other refuses is
     // one that exists in the database and cannot be edited. Both ask

--- a/packages/blocks-engine/src/validation.test.ts
+++ b/packages/blocks-engine/src/validation.test.ts
@@ -2925,28 +2925,68 @@ describe("a node's provenance record is checked on both roads to storage", () =>
     expect(codes).not.toContain("invalid-origin");
   });
 
-  it("ignores an origin inherited from a prototype", () => {
-    // `structuredClone` and object spreads copy OWN properties, so a value
-    // reached through the prototype is not what would be stored — the rule this
-    // engine applies to every other field.
-    const node = Object.create({
-      origin: { from: "pattern", id: "" },
-    }) as Record<string, unknown>;
-    node.id = "n1";
-    node.type = "core/text";
-    node.version = 1;
-    node.props = {};
+  it("never invokes an accessor INSIDE the record either", () => {
+    // One level deeper than the property itself: a data-property `origin` whose
+    // `digest` is a getter. `isBlockOrigin` reaches its fields through
+    // `ownEntry`, which reads values — so guarding only the outer property left
+    // the predicate to invoke them on the way in.
+    const origin: Record<string, unknown> = { from: "pattern", id: "p1" };
+    let reads = 0;
+    Object.defineProperty(origin, "digest", {
+      enumerable: true,
+      get() {
+        reads += 1;
+        throw new Error("boom");
+      },
+    });
 
-    const codes = validate(
-      {
-        formatVersion: 1,
-        kind: "page",
-        nodes: [node],
-      } as unknown as BlockDocument,
-      { breakpoints: FIXTURE_BREAKPOINTS, mode: "strict" }
-    ).map(issue => issue.code);
+    let escaped: unknown;
+    let codes: string[] = [];
+    try {
+      codes = validate(
+        {
+          formatVersion: 1,
+          kind: "page",
+          nodes: [
+            { id: "n1", type: "core/text", version: 1, props: {}, origin },
+          ],
+        } as unknown as BlockDocument,
+        { breakpoints: FIXTURE_BREAKPOINTS, mode: "strict" }
+      ).map(issue => issue.code);
+    } catch (error) {
+      escaped = error;
+    }
 
-    expect(codes).not.toContain("invalid-origin");
+    expect(escaped).toBeUndefined();
+    expect(reads).toBe(0);
+    // The verdict that already covers such a document, rather than a second one.
+    expect(codes).toContain("document-unreadable");
+  });
+
+  it("ignores an origin inherited from the prototype", () => {
+    // Through `Object.prototype`, which is the reachable case: a node built with
+    // `Object.create(custom)` fails `isPlainRecord` and never reaches this check
+    // at all, so a test written that way proves nothing about it.
+    //
+    // `structuredClone` and object spreads copy OWN properties, so an inherited
+    // value is not what would be stored — the rule this engine applies to every
+    // other field.
+    const polluted = Object.prototype as unknown as Record<string, unknown>;
+    polluted.origin = { from: "pattern", id: "" };
+    try {
+      const codes = validate(
+        {
+          formatVersion: 1,
+          kind: "page",
+          nodes: [{ id: "n1", type: "core/text", version: 1, props: {} }],
+        } as unknown as BlockDocument,
+        { breakpoints: FIXTURE_BREAKPOINTS, mode: "strict" }
+      ).map(issue => issue.code);
+
+      expect(codes).not.toContain("invalid-origin");
+    } finally {
+      delete polluted.origin;
+    }
   });
 
   it("agrees with the road an op takes", () => {

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -19,6 +19,7 @@ import {
   MAX_CLASSES_PER_NODE,
   STYLE_STATES,
   isBindingSource,
+  isBlockOrigin,
   isBlockType,
   renderedDomId,
 } from "./document";
@@ -203,6 +204,8 @@ export const ISSUE_CODES = {
   "invalid-document": "The document is not an object.",
   "nodes-not-array": "The document nodes field is not an array.",
   "invalid-node": "A node is not an object.",
+  "invalid-origin":
+    "A node's provenance record is missing a field it needs to be trusted.",
   "depth-exceeded": "The node tree is nested deeper than the allowed maximum.",
   "node-count-exceeded":
     "The document has more nodes than the allowed maximum.",
@@ -949,6 +952,118 @@ interface NodeCheckState {
   skipValueParsing: boolean;
 }
 
+/**
+ * A node's id: present, non-empty, and unique across the whole document.
+ *
+ * Its own function because the node check is already at the complexity this
+ * repo's gate allows, and because "which id is this, and has it been seen" is a
+ * question with its own state — the seen-ids map — that nothing else there
+ * touches. Early returns rather than nesting, which says the same thing with
+ * one level less of it.
+ */
+function checkNodeId(
+  node: Record<string, unknown>,
+  path: string,
+  state: NodeCheckState
+): void {
+  const { issues } = state;
+  if (typeof node.id !== "string" || node.id.length === 0) {
+    issues.push({
+      path: pointer(path, "id"),
+      code: "missing-node-id",
+      severity: "error",
+      message: "Every node needs a non-empty string id.",
+    });
+    return;
+  }
+  const firstSeenAt = state.seenIds.get(node.id);
+  if (firstSeenAt !== undefined) {
+    issues.push({
+      path: pointer(path, "id"),
+      code: "duplicate-node-id",
+      severity: "error",
+      message: `Node id "${describeValue(node.id)}" is already used at ${firstSeenAt}.`,
+      suggestion: "Give every node a unique id.",
+    });
+    return;
+  }
+  state.seenIds.set(node.id, pointer(path, "id"));
+}
+
+/** A node's type: a namespaced slug, and — given a registry — registered. */
+function checkNodeType(
+  node: Record<string, unknown>,
+  path: string,
+  state: NodeCheckState
+): void {
+  const { issues } = state;
+  if (!isNodeType(node.type)) {
+    issues.push({
+      path: pointer(path, "type"),
+      code: "invalid-node-type",
+      severity: "error",
+      message: `Node type "${describeValue(node.type)}" must be a namespaced slug like "core/heading".`,
+    });
+    return;
+  }
+  if (
+    state.ctx.registry &&
+    // Engine-owned synthetic types are not registrable blocks and so are never
+    // present in a block registry; exempt them from the registration check.
+    !ENGINE_NODE_TYPES.has(node.type) &&
+    !state.ctx.registry.has(node.type)
+  ) {
+    issues.push({
+      path: pointer(path, "type"),
+      code: "unknown-node-type",
+      severity: state.unknownSeverity,
+      message: `Node type "${describeValue(node.type)}" is not registered.`,
+      suggestion: "Register the block or remove the node.",
+    });
+  }
+}
+
+/**
+ * A node's provenance record, if it carries one.
+ *
+ * A document reaches storage by two roads — an op through `applyOp`, and a
+ * field write through this validator — and only the op road asked this. So an
+ * import or a script could persist `{ from: "pattern", id: "", digest: "" }`,
+ * which every later provenance reader takes at face value: a staleness check
+ * comparing against a pattern with no id answers confidently and wrongly, and a
+ * save-over restoring the DOM ids an insert renamed reads a record it cannot
+ * trust.
+ *
+ * Through {@link isBlockOrigin}, which is the op road's own predicate and lives
+ * beside the type it describes. A record one road admits and the other refuses
+ * is one that exists in the database and cannot be edited, so both ask the same
+ * question rather than two that agree for now.
+ *
+ * ERROR in both modes. Forgiving mode exists to keep a document READABLE when a
+ * future build wrote something this one does not understand; a half-written
+ * record is not a future value but a claim about history with a piece missing,
+ * and a reader cannot tell which piece.
+ *
+ * The asymmetry this closes is pre-existing and general rather than new: this
+ * validator does not check `migrationFailed` either. `origin` joins that set
+ * instead of creating it, and it is the one a planner now reads back.
+ */
+function checkNodeOrigin(
+  node: Record<string, unknown>,
+  path: string,
+  issues: ValidationIssue[]
+): void {
+  if (node.origin === undefined || isBlockOrigin(node.origin)) return;
+  issues.push({
+    path: pointer(path, "origin"),
+    code: "invalid-origin",
+    severity: "error",
+    message:
+      "A node's origin must say where it came from, whole: a pattern needs an id and a digest, a component an id.",
+    suggestion: "Remove the record, or write it complete.",
+  });
+}
+
 function validateNode(
   node: BlockNode,
   path: string,
@@ -966,52 +1081,9 @@ function validateNode(
     return;
   }
 
-  // id: present, non-empty, unique across the whole document.
-  if (typeof node.id !== "string" || node.id.length === 0) {
-    issues.push({
-      path: pointer(path, "id"),
-      code: "missing-node-id",
-      severity: "error",
-      message: "Every node needs a non-empty string id.",
-    });
-  } else {
-    const firstSeenAt = state.seenIds.get(node.id);
-    if (firstSeenAt !== undefined) {
-      issues.push({
-        path: pointer(path, "id"),
-        code: "duplicate-node-id",
-        severity: "error",
-        message: `Node id "${describeValue(node.id)}" is already used at ${firstSeenAt}.`,
-        suggestion: "Give every node a unique id.",
-      });
-    } else {
-      state.seenIds.set(node.id, pointer(path, "id"));
-    }
-  }
-
-  // type: namespaced slug, and — if a registry is supplied — registered.
-  if (!isNodeType(node.type)) {
-    issues.push({
-      path: pointer(path, "type"),
-      code: "invalid-node-type",
-      severity: "error",
-      message: `Node type "${describeValue(node.type)}" must be a namespaced slug like "core/heading".`,
-    });
-  } else if (
-    state.ctx.registry &&
-    // Engine-owned synthetic types are not registrable blocks and so are never
-    // present in a block registry; exempt them from the registration check.
-    !ENGINE_NODE_TYPES.has(node.type) &&
-    !state.ctx.registry.has(node.type)
-  ) {
-    issues.push({
-      path: pointer(path, "type"),
-      code: "unknown-node-type",
-      severity: state.unknownSeverity,
-      message: `Node type "${describeValue(node.type)}" is not registered.`,
-      suggestion: "Register the block or remove the node.",
-    });
-  }
+  checkNodeId(node, path, state);
+  checkNodeType(node, path, state);
+  checkNodeOrigin(node, path, issues);
 
   // version: positive integer.
   if (!isNodeVersion(node.version)) {

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -1048,6 +1048,26 @@ function checkNodeType(
  * validator does not check `migrationFailed` either. `origin` joins that set
  * instead of creating it, and it is the one a planner now reads back.
  */
+/**
+ * Whether a record computes any of its own fields.
+ *
+ * Answered from DESCRIPTORS, so nothing runs. A caller supplying accessors here
+ * has already made the document one `surveyDocument` refuses to measure and
+ * reports `document-unreadable`; this only stops a later predicate reaching in
+ * and invoking them on the way to a second, less useful verdict.
+ *
+ * Not a plain record is not this question's business: the predicate that
+ * follows refuses such a value on its shape, and it reads nothing to do so.
+ */
+function holdsAnAccessor(value: unknown): boolean {
+  if (!isPlainRecord(value)) return false;
+  for (const name of Object.getOwnPropertyNames(value)) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, name);
+    if (descriptor !== undefined && descriptor.get !== undefined) return true;
+  }
+  return false;
+}
+
 function checkNodeOrigin(
   node: Record<string, unknown>,
   path: string,
@@ -1071,7 +1091,14 @@ function checkNodeOrigin(
   const descriptor = Object.getOwnPropertyDescriptor(node, "origin");
   if (descriptor === undefined || descriptor.get !== undefined) return;
   const origin: unknown = descriptor.value;
-  if (origin === undefined || isBlockOrigin(origin)) return;
+  if (origin === undefined) return;
+  // The record's OWN fields, before the predicate reads them. `isBlockOrigin`
+  // reaches `from`, `id` and `digest` through `ownEntry`, which reads values —
+  // so a data property holding a record whose FIELDS are accessors escaped this
+  // guard by one level. The document is already refused as a whole for holding
+  // them, which is the verdict this defers to rather than adding a second.
+  if (holdsAnAccessor(origin)) return;
+  if (isBlockOrigin(origin)) return;
   issues.push({
     path: pointer(path, "origin"),
     code: "invalid-origin",

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -1053,7 +1053,25 @@ function checkNodeOrigin(
   path: string,
   issues: ValidationIssue[]
 ): void {
-  if (node.origin === undefined || isBlockOrigin(node.origin)) return;
+  // Through the DESCRIPTOR, never an ordinary read. `surveyDocument` refuses to
+  // invoke an accessor and already reports such a document `document-unreadable`
+  // — so reading one here runs the document's own code inside the check deciding
+  // whether to trust it, which is the rule `ops.ts` states about node fields.
+  // Measured before this: a throwing getter escaped `validate()` as a native
+  // error, and a benign one was invoked TWICE, once per read below.
+  //
+  // An accessor is left to the verdict that already covers it rather than given
+  // a second one here: a document whose fields compute themselves is refused as
+  // a whole, and reporting its `origin` as malformed would send an author to fix
+  // a record that may be perfectly well formed.
+  //
+  // An INHERITED `origin` is absent for the same reason it is elsewhere in this
+  // engine: `structuredClone` and object spreads copy own properties, so a value
+  // reached through the prototype is not what would be stored.
+  const descriptor = Object.getOwnPropertyDescriptor(node, "origin");
+  if (descriptor === undefined || descriptor.get !== undefined) return;
+  const origin: unknown = descriptor.value;
+  if (origin === undefined || isBlockOrigin(origin)) return;
   issues.push({
     path: pointer(path, "origin"),
     code: "invalid-origin",


### PR DESCRIPTION
Closes `task:pb6-validate-origin-on-the-field-write-path`, found by Codex on #1558.

## The defect

A document reaches storage two ways — an op through the edit vocabulary, and a field write through the document validator — and **only the op road checked `origin`**. So an import or a script could persist `{ from: "pattern", id: "", digest: "" }`, and every later provenance reader takes it at face value: a staleness check comparing against a pattern with no id answers confidently and wrongly.

That matters more now than when it was filed. #1572 makes a save-over **read this record back** to restore the DOM ids an insert renamed, so a half-written record is no longer merely inert.

Both roads ask `isBlockOrigin` now — the op road's own predicate, living beside the type it describes. A record one road admits and the other refuses is one that exists in the database and cannot be edited, so they ask one question rather than two that agree for now.

An **error in both modes**. Forgiving mode exists to keep a document readable when a future build wrote something this one does not understand; a half-written record is not a future value but a claim about history with a piece missing, and a reader cannot tell which piece.

## The task's premise was wrong, in a useful direction

It specified reducing `validateDocument` (257 lines, cyclomatic 26) below the blocking tier — a risky decomposition of this module's core — because that is where the 3 added lines were measured to trip the gate.

But `origin` is a **node** field, so the check belongs in the node walk, not the document one. Reducing `validateNode` instead meant extracting two cohesive blocks: the id question, which owns the seen-ids map, and the type question, which owns the registry lookup. Neither is touched by anything else there.

**Result: `validateNode` has dropped out of the complexity findings entirely.** `validateDocument` is untouched at the number it already was, and the six remaining findings are all inherited. Materially smaller and less risky than the task anticipated.

## A correction to something I said earlier

I claimed this would unblock `task:be-validate-visibility-getter-escapes`. It **partly** does. Eight of the ten fields that escape as native errors are read in `validateNode`, now under the gate — but `visibility` and `slots` are read in `validateDocument`'s walk, which still needs the decomposition. I am updating `finding:be-validate-cannot-be-guarded-without-decomposing-it` rather than leaving the broader claim standing.

## Scope, stated rather than implied

This closes the `origin` half of a **general** asymmetry, not the asymmetry. The same validator still does not check `migrationFailed`, which `NODE_FIELDS` names. `origin` joins that set rather than creating it — it is simply the one a planner now reads back. The task body said the same; repeating it here so severity is not overstated in review.

## Evidence

- Eight refusal cases — a pattern with no digest, an empty digest, an empty id, a component with no id, an unknown arm, a non-record — **all fail on `origin/main`**, checked by restoring main's `validation.ts` under the new tests.
- Three controls (a whole pattern record, a whole component record, no record at all) pass on both, so a check that refused everything could not satisfy the suite.
- One test asserts the two roads agree on the **same** record: this validator reports it and `applyOps` throws on it.
- 2193 tests pass. Gates: `fallow` **pass** (0 introduced in every category), `turbo run check-types` 0, `check:comments` 0, `changeset status` 0, design lint 0.

Four suite failures on the first run were load artifacts with ~917-second durations; re-run alone, all 234 pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Node validation now detects malformed or incomplete origin information.
  - Invalid provenance is consistently reported as an `invalid-origin` validation issue in both strict and forgiving modes.
  - Valid pattern and component origins, as well as nodes without origin information, continue to be accepted.
  - Validation now aligns with update operations when rejecting incomplete origin records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->