### PR TITLE
feat(nextly): let a widget declare what a reader may change, and let them change it

### DIFF
--- a/.changeset/per-widget-settings.md
+++ b/.changeset/per-widget-settings.md
@@ -31,3 +31,5 @@ A dashboard widget can declare `settings` — what a reader may change about tha
 A setting named `limit` and typed `number` sets how many rows its card asks for. Anything a widget does not declare is ignored, and a stored value the declaration no longer recognises falls back to the declared default rather than breaking the card.
 
 `WidgetSetting` is exported from `@nextlyhq/plugin-sdk`, and `contributes.admin.widgets` accepts `settings`, so a plugin declaring one can name its type. The same card placed twice keeps its own settings and its own data.
+
+A card with settings gains a settings control in the dashboard's edit mode, opening a panel drawn by the field renderer the rest of the admin uses. A widget that draws itself receives its resolved settings and its placement id as props, so a `text`, `checkbox` or `select` setting reaches the component that declared it rather than only the row count reaching the query.

--- a/.changeset/per-widget-settings.md
+++ b/.changeset/per-widget-settings.md
@@ -1,0 +1,31 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+A dashboard widget can declare `settings` — what a reader may change about that card — and a reader's stored choices now reach the query the card asks. Settings are declared as field definitions, so the admin draws them with the renderer it already has and a plugin author needs no new vocabulary.
+
+A setting named `limit` and typed `number` sets how many rows its card asks for. Anything a widget does not declare is ignored, and a stored value the declaration no longer recognises falls back to the declared default rather than breaking the card.

--- a/.changeset/per-widget-settings.md
+++ b/.changeset/per-widget-settings.md
@@ -29,3 +29,5 @@
 A dashboard widget can declare `settings` — what a reader may change about that card — and a reader's stored choices now reach the query the card asks. Settings are declared as field definitions, so the admin draws them with the renderer it already has and a plugin author needs no new vocabulary.
 
 A setting named `limit` and typed `number` sets how many rows its card asks for. Anything a widget does not declare is ignored, and a stored value the declaration no longer recognises falls back to the declared default rather than breaking the card.
+
+`WidgetSetting` is exported from `@nextlyhq/plugin-sdk`, and `contributes.admin.widgets` accepts `settings`, so a plugin declaring one can name its type. The same card placed twice keeps its own settings and its own data.

--- a/.changeset/widget-settings-sheet.md
+++ b/.changeset/widget-settings-sheet.md
@@ -1,0 +1,31 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+A dashboard card can now be configured from the dashboard itself. Editing the arrangement gives every card that declares settings a Settings button, which opens a panel drawn from the widget's own declaration — so a plugin author gets a settings form without writing one.
+
+Settings belong to the card, not the widget: the same widget placed twice keeps separate settings for each copy. A value left at its declared default is not stored, so a card keeps following the default if the author later changes it.

--- a/packages/admin/src/components/features/widgets/WidgetGrid.tsx
+++ b/packages/admin/src/components/features/widgets/WidgetGrid.tsx
@@ -178,29 +178,33 @@ export function WidgetGrid() {
   /*
    * The cards the batch asks for, with each reader's own settings applied.
    *
-   * 🔴 Applied HERE rather than inside the batch, because this is the last
-   * place a card and the placement that put it there are both in scope: the
-   * batch takes widgets, and a widget does not know which placement it is being
-   * drawn for — the same widget can sit on the dashboard twice with different
-   * settings.
+   * Applied HERE rather than inside the batch, because the stored config
+   * belongs to the placement and the batch has no reason to read a layout. The
+   * ROW is carried through rather than the widget alone, so the answer comes
+   * back keyed to the placement that asked: the same widget placed twice with
+   * different settings asks two different questions, and keying those by widget
+   * filed both under one entry.
    *
    * `applyWidgetSettings` returns the query it was given when nothing applies,
    * so a card with no settings keeps its identity through this map and the
    * batch's memoisation does not see a new object every render.
    */
-  const widgets = useMemo(
+  const cards = useMemo(
     () =>
       visible.map(row =>
         row.widget.query
           ? {
-              ...row.widget,
-              query: applyWidgetSettings(
-                row.widget.query,
-                row.widget.settings,
-                row.config
-              ),
+              ...row,
+              widget: {
+                ...row.widget,
+                query: applyWidgetSettings(
+                  row.widget.query,
+                  row.widget.settings,
+                  row.config
+                ),
+              },
             }
-          : row.widget
+          : row
       ),
     [visible]
   );
@@ -214,7 +218,7 @@ export function WidgetGrid() {
     counted,
     failed,
     settling,
-  } = useWidgetBatch(widgets);
+  } = useWidgetBatch(cards);
 
   const { announcement, announceColumn: announceSettledColumn } =
     useGridAnnouncer(settling, counted, failed);

--- a/packages/admin/src/components/features/widgets/WidgetGrid.tsx
+++ b/packages/admin/src/components/features/widgets/WidgetGrid.tsx
@@ -292,6 +292,7 @@ export function WidgetGrid() {
           onMoveColumn={moveColumn}
           onToggleHidden={editor.toggleHidden}
           onRemove={editor.remove}
+          onSaveSettings={editor.setConfig}
         />
       </DndContext>
 

--- a/packages/admin/src/components/features/widgets/WidgetGrid.tsx
+++ b/packages/admin/src/components/features/widgets/WidgetGrid.tsx
@@ -21,6 +21,7 @@
  */
 
 import { DndContext, closestCorners } from "@dnd-kit/core";
+import { applyWidgetSettings } from "nextly/config";
 import { useCallback, useMemo, useRef } from "react";
 
 import {
@@ -174,7 +175,35 @@ export function WidgetGrid() {
     [declared]
   );
 
-  const widgets = useMemo(() => visible.map(row => row.widget), [visible]);
+  /*
+   * The cards the batch asks for, with each reader's own settings applied.
+   *
+   * 🔴 Applied HERE rather than inside the batch, because this is the last
+   * place a card and the placement that put it there are both in scope: the
+   * batch takes widgets, and a widget does not know which placement it is being
+   * drawn for — the same widget can sit on the dashboard twice with different
+   * settings.
+   *
+   * `applyWidgetSettings` returns the query it was given when nothing applies,
+   * so a card with no settings keeps its identity through this map and the
+   * batch's memoisation does not see a new object every render.
+   */
+  const widgets = useMemo(
+    () =>
+      visible.map(row =>
+        row.widget.query
+          ? {
+              ...row.widget,
+              query: applyWidgetSettings(
+                row.widget.query,
+                row.widget.settings,
+                row.config
+              ),
+            }
+          : row.widget
+      ),
+    [visible]
+  );
 
   const {
     slots,

--- a/packages/admin/src/components/features/widgets/WidgetRenderer.tsx
+++ b/packages/admin/src/components/features/widgets/WidgetRenderer.tsx
@@ -70,12 +70,34 @@ export interface WidgetRendererProps {
    * way to know the dashboard was reading again.
    */
   isFetching?: boolean;
+  /**
+   * Which CARD this render is, and what its reader configured.
+   *
+   * 🔴 Handed to a plugin's own component, because nothing else can reach it.
+   * `plugin-sdk` is an author's only stable import surface, so a component that
+   * cannot receive its settings as props cannot observe them at all — a widget
+   * could declare a `text`, `checkbox` or `select` setting, a reader could
+   * choose a value, and the component drawing the card would never learn of it.
+   * Only `limit` reaches anything otherwise, through the query.
+   *
+   * The ID travels with them because `widgetId` does not identify a card. The
+   * same widget can sit on a dashboard twice with different settings, and a
+   * component keying anything — local state, a fetch, a chart instance — on the
+   * widget id would have the two copies overwrite each other.
+   *
+   * Optional, and the fallback is the layout's own rule rather than a guess:
+   * `defaultPlacements` names each placement after its widget, because an
+   * unarranged dashboard is the one case where the two are genuinely
+   * one-to-one. A render outside an arrangement is exactly that case.
+   */
+  placement?: { id: string; settings: Record<string, unknown> };
 }
 
 export function WidgetRenderer({
   definition,
   slot,
   slotFor,
+  placement,
   updatedAt = null,
   isFetching = false,
 }: WidgetRendererProps) {
@@ -86,6 +108,16 @@ export function WidgetRenderer({
   };
 
   const outcome = resolveWidgetOutcome(definition, slot, slotFor);
+
+  // Built once, so the two `chrome` branches below cannot drift into handing a
+  // component different props depending on whether its card is framed.
+  const componentProps = {
+    widgetId: definition.id,
+    placementId: placement?.id ?? definition.id,
+    settings: placement?.settings ?? {},
+    slot,
+    isFetching,
+  };
 
   // The escape hatch. A plugin component draws its own body, so the card
   // asserts nothing about its loading or empty states -- the component knows
@@ -127,12 +159,7 @@ export function WidgetRenderer({
     // `empty:hidden` can collapse it. Anything drawn here to "help" would fill
     // the cell and reinstate the blank row.
     if (definition.chrome === "none") {
-      return (
-        <PluginSlot
-          path={definition.component}
-          props={{ widgetId: definition.id, slot, isFetching }}
-        />
-      );
+      return <PluginSlot path={definition.component} props={componentProps} />;
     }
 
     return (
@@ -149,10 +176,7 @@ export function WidgetRenderer({
         updatedAt={slot?.ok === false ? null : updatedAt}
         isLoading={isFetching}
       >
-        <PluginSlot
-          path={definition.component}
-          props={{ widgetId: definition.id, slot, isFetching }}
-        />
+        <PluginSlot path={definition.component} props={componentProps} />
       </WidgetCard>
     );
   }

--- a/packages/admin/src/components/features/widgets/__tests__/WidgetRenderer.test.tsx
+++ b/packages/admin/src/components/features/widgets/__tests__/WidgetRenderer.test.tsx
@@ -234,6 +234,58 @@ describe("WidgetRenderer — custom", () => {
     expect(screen.getByText("Acme panel")).toBeInTheDocument();
   });
 
+  /*
+   * 🔴 A plugin's component is the ONLY thing that can consume a `text`,
+   * `checkbox` or `select` setting -- core reads just the `limit` query knob.
+   * `plugin-sdk` is an author's only stable import surface, so a value it
+   * cannot receive as a prop it cannot observe at all: a reader could choose
+   * one and the card drawing it would never learn of it.
+   *
+   * The placement id travels with them because `widgetId` does not identify a
+   * card. The same widget can sit on a dashboard twice with different
+   * settings, and a component keying local state or a fetch on the widget id
+   * would have the two copies overwrite each other -- the defect the batch
+   * already had, one layer along.
+   */
+  it("hands the plugin component its placement and resolved settings", () => {
+    registerComponent(
+      "@acme/admin#Panel",
+      ({
+        placementId,
+        settings,
+      }: {
+        placementId?: string;
+        settings?: Record<string, unknown>;
+      }) => <div>{`${placementId}:${JSON.stringify(settings)}`}</div>
+    );
+    render(
+      <WidgetRenderer
+        definition={custom}
+        slot={undefined}
+        placement={{ id: "p-2", settings: { mode: "grid" } }}
+      />
+    );
+    expect(screen.getByText('p-2:{"mode":"grid"}')).toBeInTheDocument();
+  });
+
+  it("falls back to the widget id when rendered outside an arrangement", () => {
+    // The layout's own rule rather than a guess: `defaultPlacements` names each
+    // placement after its widget, because an unarranged dashboard is the one
+    // case where the two are genuinely one-to-one.
+    registerComponent(
+      "@acme/admin#Panel",
+      ({
+        placementId,
+        settings,
+      }: {
+        placementId?: string;
+        settings?: Record<string, unknown>;
+      }) => <div>{`${placementId}:${JSON.stringify(settings)}`}</div>
+    );
+    render(<WidgetRenderer definition={custom} slot={undefined} />);
+    expect(screen.getByText("acme/panel:{}")).toBeInTheDocument();
+  });
+
   it("isolates a throwing plugin component behind the boundary", () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     registerComponent("@acme/admin#Panel", () => {

--- a/packages/admin/src/components/features/widgets/__tests__/layout-editor.test.ts
+++ b/packages/admin/src/components/features/widgets/__tests__/layout-editor.test.ts
@@ -19,6 +19,7 @@ import {
   newPlacementId,
   removePlacement,
   renumber,
+  setPlacementConfig,
   togglePlacementHidden,
 } from "../layout-editor";
 
@@ -756,5 +757,61 @@ describe("which side of a card a drop landed on", () => {
     // that cannot be taken costs the old behaviour rather than an arbitrary one.
     expect(dropSide(null, { top: 100, height: 40 })).toBe("before");
     expect(dropSide({ top: 100, height: 40 }, undefined)).toBe("before");
+  });
+});
+
+describe("recording what a reader chose for one card", () => {
+  const one = (config?: Record<string, unknown>): WidgetPlacement[] => [
+    {
+      id: "a",
+      widgetId: "core/a",
+      order: 0,
+      hidden: false,
+      ...(config === undefined ? {} : { config }),
+    },
+    { id: "b", widgetId: "core/b", order: 1, hidden: false },
+  ];
+
+  it("stores the answer against its own placement", () => {
+    const next = setPlacementConfig(one(), "a", { limit: 12 });
+    expect(next[0].config).toEqual({ limit: 12 });
+    // The control: the card next to it is untouched, so a settings save
+    // cannot quietly rewrite a neighbour.
+    expect(next[1].config).toBeUndefined();
+  });
+
+  /*
+   * 🔴 REPLACES rather than merges. A merge cannot express clearing a setting —
+   * a reader who empties a field sends a key that is simply absent, and merging
+   * leaves the old value in place, so the field would refuse to be cleared with
+   * nothing on screen explaining why.
+   */
+  it("replaces the stored answer rather than merging into it", () => {
+    const next = setPlacementConfig(one({ limit: 12, compact: true }), "a", {
+      limit: 3,
+    });
+    expect(next[0].config).toEqual({ limit: 3 });
+    expect("compact" in (next[0].config ?? {})).toBe(false);
+  });
+
+  it("drops the key entirely when nothing is left", () => {
+    // A missing config and an empty one read identically, so keeping `{}`
+    // would be a difference the layout carries and nothing can observe — and
+    // it would make a card look edited for having been opened.
+    const next = setPlacementConfig(one({ limit: 12 }), "a", {});
+    expect(next[0].config).toBeUndefined();
+    expect("config" in next[0]).toBe(false);
+  });
+
+  it("leaves the arrangement alone when no placement matches", () => {
+    const before = one({ limit: 1 });
+    const next = setPlacementConfig(before, "missing", { limit: 9 });
+    expect(next).toEqual(before);
+  });
+
+  it("does not mutate the placements it was given", () => {
+    const before = one({ limit: 1 });
+    setPlacementConfig(before, "a", { limit: 2 });
+    expect(before[0].config).toEqual({ limit: 1 });
   });
 });

--- a/packages/admin/src/components/features/widgets/__tests__/layout-editor.test.ts
+++ b/packages/admin/src/components/features/widgets/__tests__/layout-editor.test.ts
@@ -200,6 +200,44 @@ describe("whether anything changed", () => {
     const resized = [{ ...before[0], size: "xl" }];
     expect(hasChanges(before, resized)).toBe(true);
   });
+
+  /*
+   * 🔴 `config` is the only field a settings edit touches, exactly as `column`
+   * is the only one a sideways move touches. Left out of the comparison, a
+   * card whose settings the reader just changed compares as untouched, Save
+   * stays disabled, and the value they typed refuses to persist with nothing
+   * on screen saying why.
+   */
+  it("notices a settings change alone", () => {
+    const before = placements("a");
+    const configured = [{ ...before[0], config: { limit: 12 } }];
+    expect(hasChanges(before, configured)).toBe(true);
+    // And a change to an EXISTING config, not only its arrival.
+    expect(
+      hasChanges(configured, [{ ...before[0], config: { limit: 3 } }])
+    ).toBe(true);
+  });
+
+  it("says no when a config holds the same values in another order", () => {
+    // The control, and the reason this is a value comparison rather than
+    // `JSON.stringify`. The server returns a stored config in whatever order it
+    // holds and the form rebuilds it in declaration order, so a text comparison
+    // reports a card nobody touched as dirty and leaves Save enabled forever.
+    const before = [
+      { ...placements("a")[0], config: { limit: 12, mode: "x" } },
+    ];
+    const same = [{ ...placements("a")[0], config: { mode: "x", limit: 12 } }];
+    expect(hasChanges(before, same)).toBe(false);
+  });
+
+  it("treats an absent config and an emptied one as the same state", () => {
+    // `setPlacementConfig` DROPS the key rather than storing `{}`, so these are
+    // one state. Compared as different, clearing the last setting would leave
+    // the card permanently dirty.
+    const before = placements("a");
+    const empty = [{ ...before[0], config: {} }];
+    expect(hasChanges(before, empty)).toBe(false);
+  });
 });
 
 describe("addPlacement at the write contract's ceiling", () => {

--- a/packages/admin/src/components/features/widgets/__tests__/resolve-widgets.test.ts
+++ b/packages/admin/src/components/features/widgets/__tests__/resolve-widgets.test.ts
@@ -367,6 +367,76 @@ describe("a widget declared through BOTH channels keeps its new fields", () => {
     expect(widget.chrome).toBe("none");
   });
 
+  it("keeps settings the contribution declared and the registration does not", () => {
+    /*
+     * 🔴 The registration is authoritative only where it STATES a value. A
+     * plugin may register the widget for its query and contribute the settings,
+     * and taking `registration.settings` unconditionally replaced them with
+     * `undefined` -- the merged widget offered nothing to configure, and every
+     * stored config on its placements became a key nothing recognised. The
+     * same field-by-field rebuild the case above guards, one field along.
+     */
+    const contribution = {
+      id: "shared",
+      title: "Shared",
+      archetype: "custom",
+      defaultSize: "sm",
+      component: "@acme/p/admin#X",
+      settings: [{ name: "limit", type: "number", defaultValue: 5 }],
+    } as unknown as RegisteredWidgetMeta;
+
+    const registration = {
+      id: "shared",
+      title: "Shared",
+      archetype: "custom",
+      defaultSize: "sm",
+      component: "@acme/p/admin#X",
+    } as unknown as RegisteredWidgetMeta;
+
+    const [widget] = resolveDashboardWidgets(
+      contributing([contribution]),
+      [registration],
+      allow
+    );
+
+    expect(widget?.settings).toEqual([
+      { name: "limit", type: "number", defaultValue: 5 },
+    ]);
+  });
+
+  it("prefers the registration's settings when it declares its own", () => {
+    // The other half: `preferRegistered` must still prefer the registration,
+    // or the fix above would have inverted the rule rather than completed it.
+    const declared = (defaultValue: number) => [
+      { name: "limit", type: "number", defaultValue },
+    ];
+    const [widget] = resolveDashboardWidgets(
+      contributing([
+        {
+          id: "shared",
+          title: "Shared",
+          archetype: "custom",
+          defaultSize: "sm",
+          component: "@acme/p/admin#X",
+          settings: declared(5),
+        },
+      ] as unknown as RegisteredWidgetMeta[]),
+      [
+        {
+          id: "shared",
+          title: "Shared",
+          archetype: "custom",
+          defaultSize: "sm",
+          component: "@acme/p/admin#X",
+          settings: declared(9),
+        },
+      ] as unknown as RegisteredWidgetMeta[],
+      allow
+    );
+
+    expect(widget?.settings).toEqual(declared(9));
+  });
+
   it("sorts the merged widget by the order it kept", () => {
     // The consequence, asserted on the OUTCOME rather than on the merged
     // object: a dropped order is invisible until something reads it.

--- a/packages/admin/src/components/features/widgets/__tests__/widget-batch-placement.test.tsx
+++ b/packages/admin/src/components/features/widgets/__tests__/widget-batch-placement.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * An answer belongs to the PLACEMENT that asked, not to the widget it draws.
+ *
+ * 🔴 `WidgetPlacement` is a full snapshot with its own identity precisely so
+ * one widget can sit on a dashboard twice carrying different `config`, and a
+ * setting that drives the query makes those two cards genuinely different
+ * questions. Keyed by widget id, both questions filed into a single entry: the
+ * later response overwrote the earlier one, `ArrangedColumns` read that one
+ * entry for both cards, and each reader's own choice was visible on neither.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { WidgetQuery } from "nextly/config";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { protectedApi } from "@admin/lib/api/protectedApi";
+import type { DashboardWidget } from "@admin/types/dashboard/widgets";
+
+import { useWidgetBatch, type BatchCard } from "../useWidgetBatch";
+
+vi.mock("@admin/lib/api/protectedApi", () => ({
+  protectedApi: { post: vi.fn() },
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retryDelay: 0, gcTime: 0 } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+/** A card drawn by a plugin component, so `worthAsking` never withholds it. */
+function card(placementId: string, limit: number): BatchCard {
+  const query: WidgetQuery = { source: "collection:posts", op: "list", limit };
+  const widget: DashboardWidget = {
+    // The SAME widget in both cards. That is the whole fixture: two placements
+    // of one widget is the state the old key could not represent.
+    id: "core/posts",
+    title: "Posts",
+    archetype: "custom",
+    size: "md",
+    query,
+  };
+  return { placementId, widget };
+}
+
+beforeEach(() => vi.clearAllMocks());
+afterEach(() => vi.restoreAllMocks());
+
+describe("two placements of one widget are two questions", () => {
+  it("asks both, and files each answer under its own placement", async () => {
+    vi.mocked(protectedApi.post).mockResolvedValue({
+      results: [
+        { ok: true, result: { op: "list", items: [{ id: "a" }] } },
+        { ok: true, result: { op: "list", items: [{ id: "b" }, { id: "c" }] } },
+      ],
+    });
+
+    const { result } = renderHook(
+      () => useWidgetBatch([card("p1", 1), card("p2", 2)]),
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(Object.keys(result.current.slots)).toHaveLength(2);
+    });
+
+    // Both questions left the browser. Keyed by widget id the two requests
+    // still went out -- the loss was on the way back -- so the count alone
+    // cannot separate the implementations, and the slots below are what does.
+    const body = vi.mocked(protectedApi.post).mock.calls[0]?.[1] as {
+      queries: WidgetQuery[];
+    };
+    expect(body.queries.map(q => q.limit)).toEqual([1, 2]);
+
+    // The separating assertion. Under the widget-id key there was ONE entry
+    // under `core/posts` holding whichever answer arrived last, and both cards
+    // drew it.
+    const first = result.current.slots.p1;
+    const second = result.current.slots.p2;
+    expect(
+      first?.ok && first.result.op === "list" && first.result.items
+    ).toEqual([{ id: "a" }]);
+    expect(
+      second?.ok && second.result.op === "list" && second.result.items
+    ).toEqual([{ id: "b" }, { id: "c" }]);
+  });
+
+  it("reports both placements as having taken part", async () => {
+    // `requested` gates each card's freshness line and its busy state. Built
+    // from widget ids it held ONE member for two cards, so whichever card the
+    // set did not name sat with no timestamp through every refetch.
+    vi.mocked(protectedApi.post).mockResolvedValue({
+      results: [
+        { ok: true, result: { op: "list", items: [] } },
+        { ok: true, result: { op: "list", items: [] } },
+      ],
+    });
+
+    const { result } = renderHook(
+      () => useWidgetBatch([card("p1", 1), card("p2", 2)]),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.requested.size).toBe(2));
+    expect([...result.current.requested].sort()).toEqual(["p1", "p2"]);
+  });
+});

--- a/packages/admin/src/components/features/widgets/edit/ArrangedCell.tsx
+++ b/packages/admin/src/components/features/widgets/edit/ArrangedCell.tsx
@@ -12,7 +12,8 @@
  * @module components/features/widgets/edit/ArrangedCell
  */
 
-import { useState } from "react";
+import { resolveWidgetSettings } from "nextly/config";
+import { useMemo, useState } from "react";
 
 import { cn } from "@admin/lib/utils";
 import type { WidgetSlot } from "@admin/types/dashboard/widgets";
@@ -92,6 +93,19 @@ export function ArrangedCell({
   const hasSettings = (row.widget.settings?.length ?? 0) > 0;
 
   const widget = row.widget;
+  /*
+   * Resolved HERE, the one place a card's declaration and its reader's stored
+   * config are both in scope -- the same reason the grid applies settings to
+   * the query where it does. `resolveWidgetSettings` returns only DECLARED
+   * names, so a component cannot act on a key its widget never offered.
+   */
+  const placement = useMemo(
+    () => ({
+      id: row.placementId,
+      settings: resolveWidgetSettings(widget.settings, row.config),
+    }),
+    [row.placementId, widget.settings, row.config]
+  );
   /*
    * Bound once here rather than written inline in the JSX below. Each is the
    * cell supplying the one thing its caller's handler cannot know — which
@@ -208,7 +222,7 @@ export function ArrangedCell({
           a live one; the controls that act on it stay legible. */}
       {row.hidden ? (
         <div className="opacity-50">
-          <WidgetRenderer definition={widget} {...data} />
+          <WidgetRenderer definition={widget} placement={placement} {...data} />
         </div>
       ) : (
         // 🔴 A DIRECT child when nothing is dimmed, because the cell's
@@ -218,7 +232,7 @@ export function ArrangedCell({
         // blank slot with its margins. Nothing is lost by branching: a hidden
         // card is only ever drawn while editing, where the controls above are
         // themselves a child and the cell can never be empty anyway.
-        <WidgetRenderer definition={widget} {...data} />
+        <WidgetRenderer definition={widget} placement={placement} {...data} />
       )}
     </SortableWidgetCell>
   );

--- a/packages/admin/src/components/features/widgets/edit/ArrangedCell.tsx
+++ b/packages/admin/src/components/features/widgets/edit/ArrangedCell.tsx
@@ -12,6 +12,8 @@
  * @module components/features/widgets/edit/ArrangedCell
  */
 
+import { useState } from "react";
+
 import { cn } from "@admin/lib/utils";
 import type { WidgetSlot } from "@admin/types/dashboard/widgets";
 
@@ -23,54 +25,87 @@ import { WidgetRenderer } from "../WidgetRenderer";
 import { SortableWidgetCell } from "./SortableWidgetCell";
 import type { ArrangedWidget } from "./useDashboardArrangement";
 import { WidgetEditControls } from "./WidgetEditControls";
+import { WidgetSettingsSheet } from "./WidgetSettingsSheet";
 
 export interface ArrangedCellProps {
   row: ArrangedWidget;
-  index: number;
-  count: number;
   isEditing: boolean;
-  slot: WidgetSlot | undefined;
-  /** How a `stats` card reaches each cell's answer; absent for other archetypes. */
-  slotFor?: CellSlotLookup;
-  /** `null` when this card took no part in the batch. */
-  updatedAt: Date | null;
-  isFetching: boolean;
   /**
-   * Move this card one step within ITS OWN column.
+   * Where this card sits, and among how many.
    *
-   * 🔴 Bound by the caller rather than resolved from an index here. `index` is
-   * a position within the rendered column, and the cell has no way to turn one
-   * into the neighbour it should swap with -- the arrangement is interleaved
-   * across columns, so the card before this one in the whole sequence usually
-   * sits in a different column entirely.
+   * Grouped because the four are one fact read four ways: they decide which
+   * moves are possible, and they are what the controls announce. `index` and
+   * `count` are positions within THIS column rather than the whole
+   * arrangement — the sequence is interleaved across columns, so a global
+   * index would offer a move whose neighbour the reader cannot see.
    */
-  onMove: (delta: number) => void;
-  /** How many columns the dashboard is drawn in, for the sideways controls. */
-  columnCount: number;
-  /** The column this card is DRAWN in, which a stored value may differ from. */
-  column: number;
-  onMoveColumn: (placementId: string, targetColumn: number) => void;
-  onToggleHidden: (placementId: string) => void;
-  onRemove: (placementId: string) => void;
+  at: { index: number; count: number; column: number; columnCount: number };
+  /**
+   * What the batch answered for this card, or its absence.
+   *
+   * One group because it is one answer: the renderer takes all four together,
+   * and `updatedAt`/`isFetching` are `null`/`false` for a card that took no
+   * part in the batch rather than being separately meaningful.
+   */
+  data: {
+    slot: WidgetSlot | undefined;
+    /** How a `stats` card reaches each cell's answer; absent otherwise. */
+    slotFor?: CellSlotLookup;
+    /** `null` when this card took no part in the batch. */
+    updatedAt: Date | null;
+    isFetching: boolean;
+  };
+  /**
+   * What acting on this card does.
+   *
+   * 🔴 Every one is bound by the CALLER rather than resolved here. `at.index`
+   * is a position within the rendered column, and the cell has no way to turn
+   * one into the neighbour it should swap with; the writes are keyed by
+   * placement, and the cell should not have to know how the editor addresses
+   * one.
+   */
+  on: {
+    /** Move this card one step within ITS OWN column. */
+    move: (delta: number) => void;
+    moveColumn: (placementId: string, targetColumn: number) => void;
+    toggleHidden: (placementId: string) => void;
+    remove: (placementId: string) => void;
+    /** Records what a reader chose for THIS card. */
+    saveSettings: (config: Record<string, unknown>) => void;
+  };
 }
 
 export function ArrangedCell({
   row,
-  index,
-  count,
   isEditing,
-  slot,
-  slotFor,
-  updatedAt,
-  isFetching,
-  onMove,
-  columnCount,
-  column,
-  onMoveColumn,
-  onToggleHidden,
-  onRemove,
+  at,
+  data,
+  on,
 }: ArrangedCellProps) {
+  const { index, count, column, columnCount } = at;
+  /*
+   * Open state lives with the CELL rather than with the grid: the sheet belongs
+   * to one card, and hoisting it would make the grid track which of many is
+   * open for no benefit to either.
+   */
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const hasSettings = (row.widget.settings?.length ?? 0) > 0;
+
   const widget = row.widget;
+  /*
+   * Bound once here rather than written inline in the JSX below. Each is the
+   * cell supplying the one thing its caller's handler cannot know — which
+   * placement, or which direction — and inline they turned a flat list of
+   * controls into seven nested closures a reader has to step into to see what
+   * each button does.
+   */
+  const moveUp = () => on.move(-1);
+  const moveDown = () => on.move(1);
+  const moveLeft = () => on.moveColumn(row.placementId, column - 1);
+  const moveRight = () => on.moveColumn(row.placementId, column + 1);
+  const toggleHidden = () => on.toggleHidden(row.placementId);
+  const remove = () => on.remove(row.placementId);
+  const openSettings = () => setSettingsOpen(true);
   const { canMoveUp, canMoveDown } = moveAffordance(index, count);
   // Derived from the column this card is DRAWN in. A card stored past the
   // current count is folded into the last column, so computing from the stored
@@ -124,22 +159,45 @@ export function ArrangedCell({
     >
       {isEditing ? (
         <WidgetEditControls
+          card={{
+            title: widget.title,
+            position: index + 1,
+            count,
+            // 1-based for the labels, which say "column 2 of 3" to a reader
+            // who counts from one.
+            column: column + 1,
+            columnCount,
+            hidden: row.hidden,
+          }}
+          can={{
+            up: canMoveUp,
+            down: canMoveDown,
+            left: canMoveLeft,
+            right: canMoveRight,
+          }}
+          on={{
+            moveUp,
+            moveDown,
+            moveLeft,
+            moveRight,
+            toggleHidden,
+            remove,
+            ...(hasSettings ? { openSettings } : {}),
+          }}
+        />
+      ) : null}
+      {/* Mounted whenever the widget offers settings, not only while editing.
+          A closed `Sheet` renders nothing, so this costs a card nothing — and
+          it is what lets the panel outlive edit mode rather than being torn
+          out from under a reader who is still filling it in. */}
+      {hasSettings ? (
+        <WidgetSettingsSheet
+          open={settingsOpen}
+          onOpenChange={setSettingsOpen}
           title={widget.title}
-          position={index + 1}
-          count={count}
-          hidden={row.hidden}
-          canMoveUp={canMoveUp}
-          canMoveDown={canMoveDown}
-          column={column + 1}
-          columnCount={columnCount}
-          canMoveLeft={canMoveLeft}
-          canMoveRight={canMoveRight}
-          onMoveUp={() => onMove(-1)}
-          onMoveDown={() => onMove(1)}
-          onMoveLeft={() => onMoveColumn(row.placementId, column - 1)}
-          onMoveRight={() => onMoveColumn(row.placementId, column + 1)}
-          onToggleHidden={() => onToggleHidden(row.placementId)}
-          onRemove={() => onRemove(row.placementId)}
+          settings={widget.settings ?? []}
+          config={row.config}
+          onSave={on.saveSettings}
         />
       ) : null}
       {/* The dimming wraps the BODY only. Applied to the cell it composited
@@ -150,13 +208,7 @@ export function ArrangedCell({
           a live one; the controls that act on it stay legible. */}
       {row.hidden ? (
         <div className="opacity-50">
-          <WidgetRenderer
-            definition={widget}
-            slot={slot}
-            slotFor={slotFor}
-            updatedAt={updatedAt}
-            isFetching={isFetching}
-          />
+          <WidgetRenderer definition={widget} {...data} />
         </div>
       ) : (
         // 🔴 A DIRECT child when nothing is dimmed, because the cell's
@@ -166,13 +218,7 @@ export function ArrangedCell({
         // blank slot with its margins. Nothing is lost by branching: a hidden
         // card is only ever drawn while editing, where the controls above are
         // themselves a child and the cell can never be empty anyway.
-        <WidgetRenderer
-          definition={widget}
-          slot={slot}
-          slotFor={slotFor}
-          updatedAt={updatedAt}
-          isFetching={isFetching}
-        />
+        <WidgetRenderer definition={widget} {...data} />
       )}
     </SortableWidgetCell>
   );

--- a/packages/admin/src/components/features/widgets/edit/ArrangedColumns.tsx
+++ b/packages/admin/src/components/features/widgets/edit/ArrangedColumns.tsx
@@ -37,6 +37,11 @@ export interface ArrangedColumnsProps {
   onMoveColumn: (placementId: string, targetColumn: number) => void;
   onToggleHidden: (placementId: string) => void;
   onRemove: (placementId: string) => void;
+  /** Records what a reader chose for one card's settings. */
+  onSaveSettings: (
+    placementId: string,
+    config: Record<string, unknown>
+  ) => void;
 }
 
 function EmptyArrangement({
@@ -74,6 +79,7 @@ export function ArrangedColumns({
   onMoveColumn,
   onToggleHidden,
   onRemove,
+  onSaveSettings,
 }: ArrangedColumnsProps) {
   return (
     <section
@@ -105,53 +111,57 @@ export function ArrangedColumns({
             <ArrangedCell
               key={row.placementId}
               row={row}
-              // 🔴 The SAME list the click resolves against. Derived from the
-              // global sequence instead, the first card of column 2 gets an
-              // enabled Up whose neighbour is not in its column -- an enabled
-              // control that does nothing, which is the failure SC 2.5.7 is
-              // about rather than a cosmetic one.
-              index={indexInColumn}
-              count={rowsInColumn.length}
               isEditing={isEditing}
-              slot={slots[row.placementId]}
-              // Built HERE, where the whole record is, so the composite key
-              // format stays with the batch that writes it rather than being
-              // spelled again inside an archetype.
-              // This card's own answers, by cell key. Nested rather than a
-              // composite string, so no id can collide with another.
-              slotFor={key => cellSlots[row.placementId]?.[key]}
-              // Only a widget that actually ASKED can be waiting on an answer. A
-              // card drawn entirely by a plugin component took no part in the
-              // batch, and neither did one whose archetype nothing can draw, so a
-              // refetch says nothing about either.
-              updatedAt={requested.has(row.placementId) ? updatedAt : null}
-              isFetching={requested.has(row.placementId) ? isFetching : false}
-              // The arrangement hook announces, because it is the one that
-              // resolves the destination -- announcing here would name a
-              // position computed a second time, and the two would drift.
-              // 🔴 Resolved against THIS column, not the whole arrangement.
-              // The sequence is interleaved across columns, so the row before
-              // this one globally is usually in a different column, and moving
-              // toward it swaps two cards a reader cannot see move.
-              onMove={(delta: number) => {
-                const neighbour = rowsInColumn[indexInColumn + delta];
-                // The delta already says which way the reader asked to go, so
-                // it says which side of that neighbour the card lands on. Up
-                // is above it, down is below -- and below is the side that
-                // makes the bottom of a column reachable at all.
-                if (neighbour) {
-                  onMove(
-                    row.placementId,
-                    neighbour.placementId,
-                    delta < 0 ? "before" : "after"
-                  );
-                }
+              at={{
+                // 🔴 The SAME list the click resolves against. Derived from
+                // the global sequence instead, the first card of column 2 gets
+                // an enabled Up whose neighbour is not in its column -- an
+                // enabled control that does nothing, which is the failure SC
+                // 2.5.7 is about rather than a cosmetic one.
+                index: indexInColumn,
+                count: rowsInColumn.length,
+                column: columnIndex,
+                columnCount,
               }}
-              columnCount={columnCount}
-              column={columnIndex}
-              onMoveColumn={onMoveColumn}
-              onToggleHidden={onToggleHidden}
-              onRemove={onRemove}
+              data={{
+                slot: slots[row.placementId],
+                // This card's own answers, by cell key. Nested rather than a
+                // composite string, so no id can collide with another.
+                slotFor: key => cellSlots[row.placementId]?.[key],
+                // Only a card that actually ASKED can be waiting on an answer.
+                // One drawn entirely by a plugin component took no part in the
+                // batch, and neither did one whose archetype nothing can draw,
+                // so a refetch says nothing about either.
+                updatedAt: requested.has(row.placementId) ? updatedAt : null,
+                isFetching: requested.has(row.placementId) ? isFetching : false,
+              }}
+              on={{
+                // 🔴 Resolved against THIS column, not the whole arrangement.
+                // The sequence is interleaved across columns, so the row
+                // before this one globally is usually in a different column,
+                // and moving toward it swaps two cards a reader cannot see
+                // move. The arrangement hook announces, because it is the one
+                // that resolves the destination -- announcing here would name
+                // a position computed a second time, and the two would drift.
+                move: (delta: number) => {
+                  const neighbour = rowsInColumn[indexInColumn + delta];
+                  // The delta already says which way the reader asked to go,
+                  // so it says which side of that neighbour the card lands on.
+                  // Up is above it, down is below -- and below is the side
+                  // that makes the bottom of a column reachable at all.
+                  if (neighbour) {
+                    onMove(
+                      row.placementId,
+                      neighbour.placementId,
+                      delta < 0 ? "before" : "after"
+                    );
+                  }
+                },
+                moveColumn: onMoveColumn,
+                toggleHidden: onToggleHidden,
+                remove: onRemove,
+                saveSettings: config => onSaveSettings(row.placementId, config),
+              }}
             />
           ))}
         </WidgetColumn>

--- a/packages/admin/src/components/features/widgets/edit/ArrangedColumns.tsx
+++ b/packages/admin/src/components/features/widgets/edit/ArrangedColumns.tsx
@@ -113,19 +113,19 @@ export function ArrangedColumns({
               index={indexInColumn}
               count={rowsInColumn.length}
               isEditing={isEditing}
-              slot={slots[row.widget.id]}
+              slot={slots[row.placementId]}
               // Built HERE, where the whole record is, so the composite key
               // format stays with the batch that writes it rather than being
               // spelled again inside an archetype.
               // This card's own answers, by cell key. Nested rather than a
               // composite string, so no id can collide with another.
-              slotFor={key => cellSlots[row.widget.id]?.[key]}
+              slotFor={key => cellSlots[row.placementId]?.[key]}
               // Only a widget that actually ASKED can be waiting on an answer. A
               // card drawn entirely by a plugin component took no part in the
               // batch, and neither did one whose archetype nothing can draw, so a
               // refetch says nothing about either.
-              updatedAt={requested.has(row.widget.id) ? updatedAt : null}
-              isFetching={requested.has(row.widget.id) ? isFetching : false}
+              updatedAt={requested.has(row.placementId) ? updatedAt : null}
+              isFetching={requested.has(row.placementId) ? isFetching : false}
               // The arrangement hook announces, because it is the one that
               // resolves the destination -- announcing here would name a
               // position computed a second time, and the two would drift.

--- a/packages/admin/src/components/features/widgets/edit/WidgetEditControls.tsx
+++ b/packages/admin/src/components/features/widgets/edit/WidgetEditControls.tsx
@@ -30,48 +30,162 @@
  */
 
 import { Button } from "@nextlyhq/ui";
+import type { ComponentType } from "react";
 
 import * as Icons from "@admin/components/icons";
+import { cn } from "@admin/lib/utils";
 
-export interface WidgetEditControlsProps {
-  /** What the reader calls this card, so every label can name it. */
-  title: string;
-  position: number;
-  count: number;
-  hidden: boolean;
-  canMoveUp: boolean;
-  canMoveDown: boolean;
-  /** Which column this card is in, 1-based, for what the labels announce. */
-  column: number;
-  columnCount: number;
-  canMoveLeft: boolean;
-  canMoveRight: boolean;
-  onMoveUp: () => void;
-  onMoveDown: () => void;
-  onMoveLeft: () => void;
-  onMoveRight: () => void;
-  onToggleHidden: () => void;
-  onRemove: () => void;
+/**
+ * One control in the toolbar: an icon, a label, and what it does.
+ *
+ * Every control here is the same button wearing a different icon, and spelling
+ * that button out seven times put the component's shape in the way of what it
+ * actually offers — a reader counting the controls had to read past four
+ * identical presentation props each time to find the next one. Named so the
+ * toolbar below reads as the list of affordances it is.
+ *
+ * The label is REQUIRED rather than optional: each of these is an icon alone,
+ * so a missing label leaves a control a screen reader announces as "button".
+ */
+function ControlButton({
+  icon: Icon,
+  label,
+  testId,
+  onClick,
+  disabled,
+  className,
+}: {
+  icon: ComponentType<{ "aria-hidden"?: boolean; className?: string }>;
+  label: string;
+  testId: string;
+  onClick: () => void;
+  disabled?: boolean;
+  className?: string;
+}) {
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      className={cn("size-7", className)}
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={label}
+      data-testid={testId}
+    >
+      <Icon aria-hidden className="size-4" />
+    </Button>
+  );
 }
 
-export function WidgetEditControls({
+export interface WidgetEditControlsProps {
+  /**
+   * What this card is called and where it sits, which every label names.
+   *
+   * Grouped rather than listed one field at a time: the six travel together
+   * because every one of them exists to be said aloud — "Move Posts up,
+   * currently position 2 of 5, column 1 of 3" is assembled from all of them,
+   * and spreading them across the signature hid that they are one sentence.
+   */
+  card: {
+    title: string;
+    position: number;
+    count: number;
+    /** Which column this card is in, 1-based, for what the labels announce. */
+    column: number;
+    columnCount: number;
+    hidden: boolean;
+  };
+  /**
+   * Which moves are available.
+   *
+   * `moveAffordance` and `columnAffordance` already answer in exactly this
+   * shape; unpacking their pairs only to list the four separately put a
+   * spelling between the caller and the helper that decides.
+   */
+  can: { up: boolean; down: boolean; left: boolean; right: boolean };
+  /**
+   * What each control does.
+   *
+   * 🔴 `openSettings` is ABSENT rather than disabled when a widget declares no
+   * settings. A disabled control tells a reader something exists that they
+   * cannot reach and does not say why; a widget with no settings has nothing
+   * to reach, so the honest affordance is no button.
+   */
+  on: {
+    moveUp: () => void;
+    moveDown: () => void;
+    moveLeft: () => void;
+    moveRight: () => void;
+    toggleHidden: () => void;
+    remove: () => void;
+    openSettings?: () => void;
+  };
+}
+
+/**
+ * Sideways moves, which only exist on a multi-column dashboard.
+ *
+ * Its own component because the whole group is conditional, and a conditional
+ * wrapping half a component's JSX is what pushes the parent past what a reader
+ * can hold — the parent now reads as a flat list of controls, which is what it
+ * is.
+ */
+function ColumnMoveControls({
   title,
-  position,
-  count,
-  hidden,
-  canMoveUp,
-  canMoveDown,
   column,
   columnCount,
   canMoveLeft,
   canMoveRight,
-  onMoveUp,
-  onMoveDown,
   onMoveLeft,
   onMoveRight,
-  onToggleHidden,
-  onRemove,
-}: WidgetEditControlsProps) {
+}: {
+  title: string;
+  column: number;
+  columnCount: number;
+  canMoveLeft: boolean;
+  canMoveRight: boolean;
+  onMoveLeft: () => void;
+  onMoveRight: () => void;
+}) {
+  if (columnCount <= 1) return null;
+  return (
+    <>
+      <ControlButton
+        icon={Icons.ChevronLeft}
+        // The column travels in the label for the same reason the position
+        // does: the grid does not say which column a card landed in, and a
+        // reader who just moved one needs to know.
+        label={`Move ${title} to the previous column, currently column ${column} of ${columnCount}`}
+        testId="widget-move-left"
+        onClick={onMoveLeft}
+        disabled={!canMoveLeft}
+      />
+      <ControlButton
+        icon={Icons.ChevronRight}
+        label={`Move ${title} to the next column, currently column ${column} of ${columnCount}`}
+        testId="widget-move-right"
+        onClick={onMoveRight}
+        disabled={!canMoveRight}
+      />
+    </>
+  );
+}
+
+export function WidgetEditControls({ card, can, on }: WidgetEditControlsProps) {
+  const { title, position, count, column, columnCount, hidden } = card;
+  /*
+   * Both halves of the hide control resolved BEFORE the JSX, rather than as two
+   * ternaries inside it. The pair says one thing — which direction this control
+   * currently goes — and reading it as a branch in the icon and a second,
+   * identical branch in the label made the toolbar's shape depend on a decision
+   * that is really about a single word.
+   */
+  const hiddenLabel = hidden
+    ? `Show ${title} again, in the position it was hidden from`
+    : `Hide ${title}, keeping its position and settings`;
+  const HiddenIcon = hidden ? Icons.Eye : Icons.EyeOff;
+
   return (
     <div
       // `pl-9` reserves the drag handle's column. The handle is absolutely
@@ -87,34 +201,24 @@ export function WidgetEditControls({
         <span className="sr-only">{`, position ${position} of ${count}`}</span>
       </span>
 
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon"
-        className="size-7"
-        onClick={onMoveUp}
-        disabled={!canMoveUp}
+      <ControlButton
+        icon={Icons.ChevronUp}
         // The position travels in the label, because a reader who has just
         // moved a card needs to know where it landed and the visible grid does
         // not say it. `aria-label` rather than `title`: a title is not reliably
         // announced and is unreachable by touch.
-        aria-label={`Move ${title} up, currently position ${position} of ${count}`}
-        data-testid="widget-move-up"
-      >
-        <Icons.ChevronUp aria-hidden className="size-4" />
-      </Button>
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon"
-        className="size-7"
-        onClick={onMoveDown}
-        disabled={!canMoveDown}
-        aria-label={`Move ${title} down, currently position ${position} of ${count}`}
-        data-testid="widget-move-down"
-      >
-        <Icons.ChevronDown aria-hidden className="size-4" />
-      </Button>
+        label={`Move ${title} up, currently position ${position} of ${count}`}
+        testId="widget-move-up"
+        onClick={on.moveUp}
+        disabled={!can.up}
+      />
+      <ControlButton
+        icon={Icons.ChevronDown}
+        label={`Move ${title} down, currently position ${position} of ${count}`}
+        testId="widget-move-down"
+        onClick={on.moveDown}
+        disabled={!can.down}
+      />
 
       {/* 🔴 Crossing columns is reachable by CLICK, not only by dragging.
           Dragging a card into another column is new functionality, and SC
@@ -125,70 +229,42 @@ export function WidgetEditControls({
           Rendered only where there is more than one column, because a control
           that can never be enabled is noise in a toolbar a reader tabs
           through. */}
-      {columnCount > 1 ? (
-        <>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            className="size-7"
-            onClick={onMoveLeft}
-            disabled={!canMoveLeft}
-            // The column travels in the label for the same reason the position
-            // does: the grid does not say which column a card landed in, and a
-            // reader who just moved one needs to know.
-            aria-label={`Move ${title} to the previous column, currently column ${column} of ${columnCount}`}
-            data-testid="widget-move-left"
-          >
-            <Icons.ChevronLeft aria-hidden className="size-4" />
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            className="size-7"
-            onClick={onMoveRight}
-            disabled={!canMoveRight}
-            aria-label={`Move ${title} to the next column, currently column ${column} of ${columnCount}`}
-            data-testid="widget-move-right"
-          >
-            <Icons.ChevronRight aria-hidden className="size-4" />
-          </Button>
-        </>
-      ) : null}
+      <ColumnMoveControls
+        title={title}
+        column={column}
+        columnCount={columnCount}
+        canMoveLeft={can.left}
+        canMoveRight={can.right}
+        onMoveLeft={on.moveLeft}
+        onMoveRight={on.moveRight}
+      />
 
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon"
-        className="size-7"
-        onClick={onToggleHidden}
+      <ControlButton
+        icon={HiddenIcon}
         // Names the OUTCOME, and says what hiding preserves. "Hide" alone reads
         // as a synonym for "remove" to somebody deciding between the two.
-        aria-label={
-          hidden
-            ? `Show ${title} again, in the position it was hidden from`
-            : `Hide ${title}, keeping its position and settings`
-        }
-        data-testid="widget-toggle-hidden"
-      >
-        {hidden ? (
-          <Icons.Eye aria-hidden className="size-4" />
-        ) : (
-          <Icons.EyeOff aria-hidden className="size-4" />
-        )}
-      </Button>
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon"
-        className="size-7 text-muted-foreground hover:text-destructive"
-        onClick={onRemove}
-        aria-label={`Remove ${title} from the dashboard, losing its position and settings`}
-        data-testid="widget-remove"
-      >
-        <Icons.X aria-hidden className="size-4" />
-      </Button>
+        label={hiddenLabel}
+        testId="widget-toggle-hidden"
+        onClick={on.toggleHidden}
+      />
+      {on.openSettings ? (
+        <ControlButton
+          icon={Icons.Settings}
+          // Names the CARD, because several cards carry this control and a
+          // screen reader hears them in sequence — "Settings" alone would be
+          // the same label repeated down the column.
+          label={`Settings for ${title}, applying to this card only`}
+          testId="widget-open-settings"
+          onClick={on.openSettings}
+        />
+      ) : null}
+      <ControlButton
+        icon={Icons.X}
+        label={`Remove ${title} from the dashboard, losing its position and settings`}
+        testId="widget-remove"
+        onClick={on.remove}
+        className="text-muted-foreground hover:text-destructive"
+      />
     </div>
   );
 }

--- a/packages/admin/src/components/features/widgets/edit/WidgetSettingsSheet.tsx
+++ b/packages/admin/src/components/features/widgets/edit/WidgetSettingsSheet.tsx
@@ -76,9 +76,26 @@ export function initialValues(
  */
 export function toStoredConfig(
   settings: readonly WidgetSetting[],
-  values: Record<string, unknown>
+  values: Record<string, unknown>,
+  existing: Record<string, unknown> | undefined
 ): Record<string, unknown> {
   const stored: Record<string, unknown> = Object.create(null);
+
+  /*
+   * 🔴 A stored key the declaration does not know is CARRIED, not dropped.
+   * `resolveWidgetSettings` keeps such a key deliberately — a plugin that
+   * renames a setting or is uninstalled must not cost a reader the values they
+   * chose, because reinstalling it restores them. This form is built from the
+   * DECLARATION, so it never sees those keys; rebuilding the config from it
+   * alone, and writing that back over the whole `config`, discarded exactly
+   * what the reading layer went out of its way to preserve. Opening the panel
+   * and pressing Save was enough to lose them.
+   */
+  const declared = new Set(settings.map(setting => setting.name));
+  for (const key of Object.keys(existing ?? {})) {
+    if (!declared.has(key)) stored[key] = existing?.[key];
+  }
+
   for (const setting of settings) {
     /*
      * 🔴 Read through `hasOwn`, not by indexing. `values` comes back from the
@@ -113,10 +130,10 @@ export function WidgetSettingsSheet({
 
   const submit = useCallback(
     (values: Record<string, unknown>) => {
-      onSave(toStoredConfig(settings, values));
+      onSave(toStoredConfig(settings, values, config));
       onOpenChange(false);
     },
-    [onSave, onOpenChange, settings]
+    [onSave, onOpenChange, settings, config]
   );
 
   return (

--- a/packages/admin/src/components/features/widgets/edit/WidgetSettingsSheet.tsx
+++ b/packages/admin/src/components/features/widgets/edit/WidgetSettingsSheet.tsx
@@ -1,0 +1,164 @@
+/**
+ * What one reader may change about one card.
+ *
+ * 🔴 Keyed by PLACEMENT, not by widget. The same widget can sit on a dashboard
+ * twice — a "recent entries" card for posts beside one for pages — and settings
+ * belong to the card the reader is looking at, not to the definition behind it.
+ * Every save goes through `setConfig(placementId, …)` for that reason.
+ *
+ * The form is drawn by `FieldRenderer`, the same component the entry editor
+ * uses, because a widget setting IS a field definition. A reader meets the
+ * inputs they already know, and a plugin author gets a settings form without
+ * writing one.
+ */
+import {
+  Button,
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@nextlyhq/ui";
+import type { WidgetSetting } from "nextly/config";
+import { useCallback, useMemo } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+
+import { FieldRenderer } from "@admin/components/features/entries/fields/FieldRenderer";
+
+export interface WidgetSettingsSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** The card being configured, for the heading a reader reads. */
+  title: string;
+  settings: WidgetSetting[];
+  /** What this placement has stored, if anything. */
+  config: Record<string, unknown> | undefined;
+  onSave: (config: Record<string, unknown>) => void;
+}
+
+/**
+ * The values the form opens with.
+ *
+ * 🔴 Built from the DECLARATION rather than from the stored config, so a
+ * setting the reader has never touched still opens at its default instead of
+ * blank — and a key the declaration no longer knows about does not appear as a
+ * ghost field. This mirrors `resolveWidgetSettings` on purpose: what the form
+ * shows is what the card is actually using.
+ */
+export function initialValues(
+  settings: readonly WidgetSetting[],
+  config: Record<string, unknown> | undefined
+): Record<string, unknown> {
+  /*
+   * 🔴 Prototype-free, because the KEYS are setting names a plugin chose. On a
+   * `{}` dictionary `__proto__` is not data: assigning it invokes the legacy
+   * prototype setter, so a setting of that name never reached the form and
+   * opened blank instead of at its default. `resolveWidgetSettings` is
+   * prototype-free for the same reason, and this function exists to mirror it.
+   */
+  const values: Record<string, unknown> = Object.create(null);
+  for (const setting of settings) {
+    const stored = config?.[setting.name];
+    values[setting.name] = stored ?? setting.defaultValue ?? "";
+  }
+  return values;
+}
+
+/**
+ * What to store, given what the form holds.
+ *
+ * 🔴 A value equal to its declared default is DROPPED rather than written. The
+ * stored config is the reader's departure from the author's intent, so writing
+ * the default back would pin today's default forever — a card would stop
+ * following a later change to it, silently, and only for readers who happened
+ * to open the panel.
+ */
+export function toStoredConfig(
+  settings: readonly WidgetSetting[],
+  values: Record<string, unknown>
+): Record<string, unknown> {
+  const stored: Record<string, unknown> = Object.create(null);
+  for (const setting of settings) {
+    /*
+     * 🔴 Read through `hasOwn`, not by indexing. `values` comes back from the
+     * form, and on an ordinary object `values["__proto__"]` answers
+     * `Object.prototype` rather than `undefined` — so a setting of that name
+     * passed both guards below and was written to storage as the prototype
+     * object, for a field the reader never filled in.
+     */
+    if (!Object.hasOwn(values, setting.name)) continue;
+    const value = values[setting.name];
+    if (value === undefined || value === "") continue;
+    if (value === setting.defaultValue) continue;
+    stored[setting.name] = value;
+  }
+  return stored;
+}
+
+export function WidgetSettingsSheet({
+  open,
+  onOpenChange,
+  title,
+  settings,
+  config,
+  onSave,
+}: WidgetSettingsSheetProps) {
+  const defaultValues = useMemo(
+    () => initialValues(settings, config),
+    [settings, config]
+  );
+
+  const form = useForm({ defaultValues });
+
+  const submit = useCallback(
+    (values: Record<string, unknown>) => {
+      onSave(toStoredConfig(settings, values));
+      onOpenChange(false);
+    },
+    [onSave, onOpenChange, settings]
+  );
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-full sm:max-w-md">
+        <SheetHeader>
+          <SheetTitle>{title} settings</SheetTitle>
+          <SheetDescription>
+            These apply to this card only. Another copy of the same widget keeps
+            its own.
+          </SheetDescription>
+        </SheetHeader>
+
+        <FormProvider {...form}>
+          <form
+            // `handleSubmit` answers with a promise and `onSubmit` expects
+            // nothing back, so the result is voided deliberately rather than
+            // handed to an attribute that would ignore it silently.
+            onSubmit={event => {
+              void form.handleSubmit(submit)(event);
+            }}
+            className="flex flex-1 flex-col gap-4 overflow-y-auto px-4"
+          >
+            {settings.map(setting => (
+              // No cast: `WidgetSetting` is assignable to `FieldConfig`, and
+              // `settings.compat.test-d.ts` is what keeps that true.
+              <FieldRenderer key={setting.name} field={setting} mode="edit" />
+            ))}
+
+            <SheetFooter className="mt-auto flex-row justify-end gap-2 px-0">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit">Save</Button>
+            </SheetFooter>
+          </form>
+        </FormProvider>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/packages/admin/src/components/features/widgets/edit/__tests__/WidgetSettingsSheet.test.ts
+++ b/packages/admin/src/components/features/widgets/edit/__tests__/WidgetSettingsSheet.test.ts
@@ -75,12 +75,12 @@ describe("a setting named __proto__ is data, both ways", () => {
       string,
       unknown
     >;
-    expect(toStoredConfig([odd], typed)["__proto__"]).toBe("typed");
+    expect(toStoredConfig([odd], typed, undefined)["__proto__"]).toBe("typed");
 
     // The other direction: an ordinary form object that never carried this key
     // answers `Object.prototype` when indexed, which is neither `undefined`
     // nor `""` and so reached storage.
-    expect(Object.keys(toStoredConfig([odd], {}))).toEqual([]);
+    expect(Object.keys(toStoredConfig([odd], {}, undefined))).toEqual([]);
   });
 });
 
@@ -92,20 +92,47 @@ describe("what is stored on save", () => {
    * later change to it, silently, and only for readers who opened the panel.
    */
   it("does not store a value that equals the declared default", () => {
-    expect(toStoredConfig([limit], { limit: 5 })).toEqual({});
+    expect(toStoredConfig([limit], { limit: 5 }, undefined)).toEqual({});
   });
 
   it("stores a value that departs from the default", () => {
-    expect(toStoredConfig([limit], { limit: 12 })).toEqual({ limit: 12 });
+    expect(toStoredConfig([limit], { limit: 12 }, undefined)).toEqual({
+      limit: 12,
+    });
   });
 
   it("drops an emptied field rather than storing a blank", () => {
-    expect(toStoredConfig([title], { title: "" })).toEqual({});
+    expect(toStoredConfig([title], { title: "" }, undefined)).toEqual({});
   });
 
   it("ignores a value for something the widget does not declare", () => {
-    expect(toStoredConfig([limit], { limit: 12, stray: "x" })).toEqual({
+    expect(
+      toStoredConfig([limit], { limit: 12, stray: "x" }, undefined)
+    ).toEqual({
       limit: 12,
     });
+  });
+
+  /*
+   * 🔴 A stored key the declaration does not know SURVIVES the save. The
+   * reading layer keeps such a key deliberately -- a plugin that renames a
+   * setting or is uninstalled must not cost a reader the values they chose,
+   * because reinstalling it restores them. This form is built from the
+   * DECLARATION and never sees those keys, so rebuilding the config from it
+   * alone discarded exactly what the reader was promised: opening the panel and
+   * pressing Save was enough to lose them.
+   */
+  it("carries a stored key the declaration no longer knows", () => {
+    expect(
+      toStoredConfig([limit], { limit: 12 }, { legacy: "kept", limit: 3 })
+    ).toEqual({ legacy: "kept", limit: 12 });
+  });
+
+  it("still lets the form clear a key the declaration DOES know", () => {
+    // The other half. Carrying the old config must not resurrect a value the
+    // reader just emptied, which is what a plain merge would do.
+    expect(
+      toStoredConfig([title], { title: "" }, { title: "old", legacy: "kept" })
+    ).toEqual({ legacy: "kept" });
   });
 });

--- a/packages/admin/src/components/features/widgets/edit/__tests__/WidgetSettingsSheet.test.ts
+++ b/packages/admin/src/components/features/widgets/edit/__tests__/WidgetSettingsSheet.test.ts
@@ -1,0 +1,111 @@
+/**
+ * What the settings form opens with, and what it stores.
+ *
+ * The two functions the sheet's correctness rests on, tested apart from the
+ * rendering: what a reader SEES when they open the panel, and what is written
+ * when they save. Both are pure, and both encode a decision the component
+ * cannot express on its own.
+ */
+import { describe, expect, it } from "vitest";
+
+import { initialValues, toStoredConfig } from "../WidgetSettingsSheet";
+import type { WidgetSetting } from "nextly/config";
+
+const limit: WidgetSetting = { name: "limit", type: "number", defaultValue: 5 };
+const title: WidgetSetting = { name: "title", type: "text" };
+
+describe("what the form opens with", () => {
+  it("shows the stored answer when there is one", () => {
+    expect(initialValues([limit], { limit: 12 })).toEqual({ limit: 12 });
+  });
+
+  /*
+   * 🔴 Built from the DECLARATION, not from the stored config. A setting the
+   * reader has never touched opens at its default rather than blank — the form
+   * shows what the card is actually using, which is what
+   * `resolveWidgetSettings` decides on the read side.
+   */
+  it("shows the declared default for an untouched setting", () => {
+    expect(initialValues([limit], undefined)).toEqual({ limit: 5 });
+  });
+
+  it("does not show a stored key the declaration no longer knows", () => {
+    // A ghost field for a setting the widget dropped would be uneditable and
+    // unexplainable.
+    const values = initialValues([limit], { limit: 3, gone: "x" });
+    expect(values).toEqual({ limit: 3 });
+  });
+
+  it("opens a setting with no default and no answer as empty", () => {
+    expect(initialValues([title], undefined)).toEqual({ title: "" });
+  });
+});
+
+/*
+ * 🔴 A setting NAME is chosen by a plugin, and on an ordinary object
+ * `__proto__` is not data. Written, it invokes the prototype setter and the
+ * value never lands; read, it answers `Object.prototype` rather than
+ * `undefined`. Both halves are exercised, because they fail in opposite
+ * directions: the form opened blank, and the save wrote the prototype object
+ * to storage for a field nobody filled in.
+ */
+describe("a setting named __proto__ is data, both ways", () => {
+  const odd: WidgetSetting = {
+    name: "__proto__",
+    type: "text",
+    defaultValue: "d",
+  };
+
+  it("opens at its stored value rather than blank", () => {
+    const config = JSON.parse('{"__proto__":"stored"}') as Record<
+      string,
+      unknown
+    >;
+    const values = initialValues([odd], config);
+    expect(Object.keys(values)).toEqual(["__proto__"]);
+    expect(values["__proto__"]).toBe("stored");
+  });
+
+  it("stores what the reader typed, and nothing when they typed nothing", () => {
+    // 🔴 Built through `JSON.parse`, not an object literal. In literal syntax
+    // `{ __proto__: x }` is the PROTOTYPE SETTER and creates no own property,
+    // so a fixture written that way tests nothing -- the same trap the code
+    // under test exists to survive.
+    const typed = JSON.parse('{"__proto__":"typed"}') as Record<
+      string,
+      unknown
+    >;
+    expect(toStoredConfig([odd], typed)["__proto__"]).toBe("typed");
+
+    // The other direction: an ordinary form object that never carried this key
+    // answers `Object.prototype` when indexed, which is neither `undefined`
+    // nor `""` and so reached storage.
+    expect(Object.keys(toStoredConfig([odd], {}))).toEqual([]);
+  });
+});
+
+describe("what is stored on save", () => {
+  /*
+   * 🔴 A value equal to its declared default is DROPPED. The stored config is
+   * the reader's departure from the author's intent, so writing the default
+   * back would pin today's default forever — the card would stop following a
+   * later change to it, silently, and only for readers who opened the panel.
+   */
+  it("does not store a value that equals the declared default", () => {
+    expect(toStoredConfig([limit], { limit: 5 })).toEqual({});
+  });
+
+  it("stores a value that departs from the default", () => {
+    expect(toStoredConfig([limit], { limit: 12 })).toEqual({ limit: 12 });
+  });
+
+  it("drops an emptied field rather than storing a blank", () => {
+    expect(toStoredConfig([title], { title: "" })).toEqual({});
+  });
+
+  it("ignores a value for something the widget does not declare", () => {
+    expect(toStoredConfig([limit], { limit: 12, stray: "x" })).toEqual({
+      limit: 12,
+    });
+  });
+});

--- a/packages/admin/src/components/features/widgets/edit/useDashboardArrangement.ts
+++ b/packages/admin/src/components/features/widgets/edit/useDashboardArrangement.ts
@@ -47,6 +47,17 @@ export interface ArrangedWidget {
   /** Which column this card is drawn in. Absent on a pre-column arrangement. */
   column?: number;
   /**
+   * The settings this reader stored for this card, as stored.
+   *
+   * Carried RAW rather than resolved, for the reason `size` is carried as a
+   * string: it may have been written against a newer core, or by a plugin whose
+   * settings have since changed, and the reading that turns it into values is
+   * the widget's declaration — which lives with the widget, not here. This
+   * layer's job is to keep a placement's answer attached to the card it
+   * answers for.
+   */
+  config?: Record<string, unknown>;
+  /**
    * Its position within that column.
    *
    * Carried so the ONE grouping helper can order these rows, rather than the
@@ -185,6 +196,7 @@ export function useDashboardArrangement(
         hidden: placement.hidden,
         ...(placement.size === undefined ? {} : { size: placement.size }),
         ...(placement.column === undefined ? {} : { column: placement.column }),
+        ...(placement.config === undefined ? {} : { config: placement.config }),
         order: placement.order,
       });
     }

--- a/packages/admin/src/components/features/widgets/edit/useLayoutEditor.ts
+++ b/packages/admin/src/components/features/widgets/edit/useLayoutEditor.ts
@@ -109,6 +109,8 @@ export interface LayoutEditor {
    */
   columnCount: number;
   toggleHidden: (placementId: string) => void;
+  /** Records what a reader chose for one card's settings. */
+  setConfig: (placementId: string, config: Record<string, unknown>) => void;
   remove: (placementId: string) => void;
   add: (widgetId: string) => void;
 }
@@ -192,10 +194,8 @@ export function useLayoutEditor(
     []
   );
 
-  const { move, dropOn, toggleHidden, remove } = usePlacementMutations(
-    setDraft,
-    columnCount
-  );
+  const { move, dropOn, toggleHidden, remove, setConfig } =
+    usePlacementMutations(setDraft, columnCount);
 
   const add = useCallback(
     (widgetId: string) =>
@@ -259,6 +259,7 @@ export function useLayoutEditor(
     setColumnCount,
     columnCount,
     toggleHidden,
+    setConfig,
     remove,
     add,
   };

--- a/packages/admin/src/components/features/widgets/edit/usePlacementMutations.ts
+++ b/packages/admin/src/components/features/widgets/edit/usePlacementMutations.ts
@@ -21,6 +21,7 @@ import type { WidgetPlacement } from "@admin/types/dashboard/widgets";
 import {
   movePlacementTo,
   removePlacement,
+  setPlacementConfig,
   resolveDrop,
   type DropTarget,
   togglePlacementHidden,
@@ -29,6 +30,14 @@ import {
 import type { LayoutDraft } from "./useLayoutEditor";
 
 export interface PlacementMutations {
+  /**
+   * Records what a reader chose for one card.
+   *
+   * Takes the WHOLE answer rather than one field, because the form that calls
+   * it knows every setting it drew — and a per-field write could not express
+   * clearing one, since an emptied field arrives as an absent key.
+   */
+  setConfig: (placementId: string, config: Record<string, unknown>) => void;
   move: (fromId: string, toId: string) => void;
   dropOn: (activeId: string, target: DropTarget | null) => void;
   toggleHidden: (placementId: string) => void;
@@ -86,5 +95,13 @@ export function usePlacementMutations(
     [mutatePlacements]
   );
 
-  return { move, dropOn, toggleHidden, remove };
+  const setConfig = useCallback(
+    (placementId: string, config: Record<string, unknown>) =>
+      mutatePlacements(placements =>
+        setPlacementConfig(placements, placementId, config)
+      ),
+    [mutatePlacements]
+  );
+
+  return { move, dropOn, toggleHidden, remove, setConfig };
 }

--- a/packages/admin/src/components/features/widgets/layout-editor.ts
+++ b/packages/admin/src/components/features/widgets/layout-editor.ts
@@ -110,6 +110,36 @@ export function togglePlacementHidden(
   );
 }
 
+/**
+ * Records what a reader chose for ONE card.
+ *
+ * 🔴 Replaces the whole `config` rather than merging into it, because a merge
+ * cannot express clearing a setting: a reader who empties a field would send
+ * a key whose value is absent, and merging leaves the old value in place. The
+ * caller holds the full answer for that card — the settings form knows every
+ * field it drew — so replacement is the honest write.
+ *
+ * An EMPTY object is stored as no config at all. `resolveWidgetSettings` reads
+ * a missing config and an empty one identically, so keeping `{}` would be a
+ * difference the layout carries and nothing can observe — and it would make
+ * `hasChanges` report a card as edited for having been opened.
+ */
+export function setPlacementConfig(
+  placements: readonly WidgetPlacement[],
+  placementId: string,
+  config: Record<string, unknown>
+): WidgetPlacement[] {
+  const empty = Object.keys(config).length === 0;
+  return placements.map(placement => {
+    if (placement.id !== placementId) return placement;
+    if (empty) {
+      const { config: _dropped, ...rest } = placement;
+      return rest;
+    }
+    return { ...placement, config };
+  });
+}
+
 /** Drops a card from the arrangement entirely. */
 export function removePlacement(
   placements: readonly WidgetPlacement[],

--- a/packages/admin/src/components/features/widgets/layout-editor.ts
+++ b/packages/admin/src/components/features/widgets/layout-editor.ts
@@ -241,27 +241,95 @@ export function renumber(
  * every editor operation returns new objects and a reference check would report
  * a change for a move that put a card back where it started.
  */
+/**
+ * Whether two stored configs hold the same values.
+ *
+ * By VALUE, not by identity and not by serialised text. The draft's config is
+ * rebuilt from the form on every save, so identity always differs; and
+ * `JSON.stringify` is key-ORDER sensitive, so a config the server returned in
+ * one order and the form rebuilt in another would compare as changed and leave
+ * Save enabled on a card nobody touched.
+ *
+ * The values are whatever survived the layout writer, which admits any JSON the
+ * placement's size and depth caps allow -- so this walks arrays and nested
+ * objects rather than assuming the scalars the settings contract writes today.
+ * A shallow comparison would be right for the values this form produces and
+ * wrong the moment a refetch replaces the saved config with fresh objects,
+ * which `refetchOnWindowFocus` does mid-edit.
+ */
+function sameConfig(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (Array.isArray(a) && Array.isArray(b)) return sameItems(a, b);
+  if (isRecord(a) && isRecord(b)) return sameEntries(a, b);
+  return false;
+}
+
+/** Whether two arrays hold equal values in the same order. */
+function sameItems(a: readonly unknown[], b: readonly unknown[]): boolean {
+  return a.length === b.length && a.every((it, i) => sameConfig(it, b[i]));
+}
+
+/** Whether two records carry the same keys, each holding an equal value. */
+function sameEntries(
+  a: Record<string, unknown>,
+  b: Record<string, unknown>
+): boolean {
+  const keys = Object.keys(a);
+  if (keys.length !== Object.keys(b).length) return false;
+  // `hasOwn` rather than an index check: a config key comes from a plugin's
+  // setting name, and `b["__proto__"]` answers on any ordinary object.
+  return keys.every(key => Object.hasOwn(b, key) && sameConfig(a[key], b[key]));
+}
+
+/** A non-null object that is not an array. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * A placement reduced to the values a comparison should see.
+ *
+ * 🔴 The return type names EVERY field of `WidgetPlacement`, so the compiler
+ * refuses a field added to the placement and not normalised here. That refusal
+ * is the point: this comparison is rebuilt field by field, and a field left out
+ * of it compares as untouched — an arrangement the reader can see changed, with
+ * Save disabled and nothing saying why. It has happened twice, for `column` and
+ * again for `config`, and a list nothing enforces would let it happen a third
+ * time.
+ *
+ * The defaults fold the states that are one state: a card in no stated column
+ * is in column 0, and a config that was emptied is DROPPED rather than stored
+ * as `{}`, so absent and empty must compare equal or clearing the last setting
+ * would leave the card permanently dirty. `null` for the absent geometry so an
+ * explicit `undefined` and a missing key do not read as two different values.
+ */
+function comparable(
+  placement: WidgetPlacement
+): Record<keyof WidgetPlacement, unknown> {
+  return {
+    id: placement.id,
+    widgetId: placement.widgetId,
+    order: placement.order,
+    column: placement.column ?? 0,
+    hidden: placement.hidden,
+    size: placement.size ?? null,
+    height: placement.height ?? null,
+    config: placement.config ?? {},
+  };
+}
+
 export function hasChanges(
   original: readonly WidgetPlacement[],
   edited: readonly WidgetPlacement[]
 ): boolean {
   if (original.length !== edited.length) return true;
-  return renumber(original).some((placement, index) => {
-    const other = renumber(edited)[index];
-    return (
-      placement.id !== other.id ||
-      placement.widgetId !== other.widgetId ||
-      placement.order !== other.order ||
-      // 🔴 `column` is the only field a sideways move touches. Left out, an
-      // arrangement whose cards changed columns compares as untouched, Save
-      // stays disabled, and the reader watches work they can see refuse to
-      // persist.
-      (placement.column ?? 0) !== (other.column ?? 0) ||
-      placement.hidden !== other.hidden ||
-      placement.size !== other.size ||
-      placement.height !== other.height
-    );
-  });
+  // Renumbered ONCE. Read inside the loop it was recomputed for every
+  // placement, which is the whole list rebuilt per card.
+  const after = renumber(edited);
+  return renumber(original).some(
+    (placement, index) =>
+      !sameConfig(comparable(placement), comparable(after[index]))
+  );
 }
 
 /** Whether a card at `column` may move left or right, given the count. */

--- a/packages/admin/src/components/features/widgets/resolve-widgets.ts
+++ b/packages/admin/src/components/features/widgets/resolve-widgets.ts
@@ -352,7 +352,14 @@ function mergeCollision(
     size: contribution.size,
     requiredPermission: registration.requiredPermission,
     query: registration.query,
-    settings: registration.settings,
+    // 🔴 `preferRegistered`, not the registration alone. Both channels can
+    // declare settings, so taking the registration's unconditionally replaced a
+    // contributed declaration with `undefined` -- the merged widget offered no
+    // settings at all, and every stored config on its placements became a key
+    // nothing recognised. That is the defect the comment above this list warns
+    // about, arriving through a field added to the contract and not to this
+    // list.
+    settings: preferRegistered(registration.settings, contribution.settings),
     link: preferRegistered(registration.link, contribution.link),
     component: preferRegistered(registration.component, contribution.component),
     actions: preferRegistered(registration.actions, contribution.actions),

--- a/packages/admin/src/components/features/widgets/resolve-widgets.ts
+++ b/packages/admin/src/components/features/widgets/resolve-widgets.ts
@@ -19,6 +19,7 @@ import type {
   WidgetSize,
   WidgetStatCell,
   WidgetChrome,
+  WidgetSetting,
 } from "nextly/config";
 import { widgetGateHolds } from "nextly/widget-gate";
 
@@ -79,6 +80,11 @@ function readableActions(
  * below as the things that actually refuse a declaration that says nothing.
  */
 export interface ReadableWidgetDeclaration {
+  /**
+   * The settings this widget offers, carried from whichever channel declared
+   * it. The reader's stored answers live on the placement.
+   */
+  settings?: WidgetSetting[];
   id: string;
   size?: "full" | "half";
   requiredPermission?: string | readonly string[];
@@ -219,6 +225,7 @@ function resolveOne(
     size: meta.defaultSize ?? legacySizeToWidgetSize(meta.size),
     ...(meta.defaultHeight === undefined ? {} : { height: meta.defaultHeight }),
     query: meta.query,
+    settings: meta.settings,
     component: meta.component,
     actions: readableActions(meta.actions, hasPermission),
     cells: meta.cells,
@@ -264,6 +271,7 @@ function resolveRegistered(
     size: meta.defaultSize,
     ...(meta.defaultHeight === undefined ? {} : { height: meta.defaultHeight }),
     query: meta.query,
+    settings: meta.settings,
     component: meta.component,
     actions: readableActions(meta.actions, hasPermission),
     cells: meta.cells,
@@ -344,6 +352,7 @@ function mergeCollision(
     size: contribution.size,
     requiredPermission: registration.requiredPermission,
     query: registration.query,
+    settings: registration.settings,
     link: preferRegistered(registration.link, contribution.link),
     component: preferRegistered(registration.component, contribution.component),
     actions: preferRegistered(registration.actions, contribution.actions),

--- a/packages/admin/src/components/features/widgets/useWidgetBatch.ts
+++ b/packages/admin/src/components/features/widgets/useWidgetBatch.ts
@@ -25,13 +25,27 @@ import type {
 
 import { coreDraws, resolveWidgetOutcome, type WidgetOutcome } from "./outcome";
 
+/**
+ * One card in the batch: which placement asked, and what it is asking.
+ *
+ * 🔴 The batch takes PLACEMENTS rather than widgets, because a widget is not
+ * what a question belongs to. The same widget can sit on a dashboard twice with
+ * different settings, so two placements of it ask two different questions and
+ * must receive two different answers. `ArrangedWidget` already satisfies this
+ * shape, so the grid passes its rows through unchanged.
+ */
+export interface BatchCard {
+  placementId: string;
+  widget: DashboardWidget;
+}
+
 export interface WidgetBatch {
   slots: Record<string, WidgetSlot>;
-  /** A `stats` card's answers, by widget id then cell key. */
+  /** A `stats` card's answers, by placement id then cell key. */
   cellSlots: CellSlots;
   isFetching: boolean;
   updatedAt: Date | null;
-  /** Whether this widget took part in the batch at all. */
+  /** Which PLACEMENTS took part in the batch at all. */
   requested: ReadonlySet<string>;
   /** How many cards the announcement should describe, and how many failed. */
   counted: number;
@@ -71,15 +85,16 @@ function worthAsking(widget: DashboardWidget): boolean {
  * that fetched separately would also be paging past `MAX_QUERIES_PER_REQUEST`
  * on its own, outside the partitioning that keeps the batch legal.
  */
-function questionsFor(widget: DashboardWidget): WidgetQueryRequest[] {
+function questionsFor(card: BatchCard): WidgetQueryRequest[] {
+  const { placementId, widget } = card;
   if (widget.cells?.length) {
     return widget.cells.map(cell => ({
-      widgetId: widget.id,
+      placementId,
       cellKey: cell.key,
       query: cell.query,
     }));
   }
-  return widget.query ? [{ widgetId: widget.id, query: widget.query }] : [];
+  return widget.query ? [{ placementId, query: widget.query }] : [];
 }
 
 /**
@@ -105,39 +120,38 @@ export function widgetOutcome(
   return resolveWidgetOutcome(widget, slot, key => answers?.[key]);
 }
 
-export function useWidgetBatch(widgets: DashboardWidget[]): WidgetBatch {
+export function useWidgetBatch(cards: BatchCard[]): WidgetBatch {
   // 🔴 Sorted by ID, not left in display order. `useWidgetQueries` puts the
   // request partitions into its TanStack query keys, so a key built from the
   // visual arrangement CHANGES every time a card moves — and every drag or
   // button press re-issued the whole batch, spending access-checked database
   // reads and blanking cards mid-edit, though not one data question had
   // changed. A stable identity order makes the key describe what is being
-  // asked rather than where it happens to sit; results are keyed back by widget
-  // id, which never depended on order.
+  // asked rather than where it happens to sit; results are keyed back by
+  // placement id, which never depended on order.
   const requests = useMemo<WidgetQueryRequest[]>(
     () =>
-      widgets
-        .filter(worthAsking)
+      cards
+        .filter(card => worthAsking(card.widget))
         .flatMap(questionsFor)
-        // Sorted by the SLOT key rather than by widget id alone, so a card's
-        // cells keep a stable order between renders. Sorting on the id left
-        // siblings in whatever order `flatMap` produced, which is stable today
-        // and is not a property the query key should rest on.
-        // By widget id, then by cell key: the pair identifies a question, and
-        // a stable order keeps the query key describing WHAT is asked rather
-        // than the order the widgets happen to sit in.
+        // By placement id, then by cell key: the pair identifies a question,
+        // and a stable order keeps the query key describing WHAT is asked
+        // rather than the order the cards happen to sit in. Sorting on the
+        // placement alone left a card's cells in whatever order `flatMap`
+        // produced, which is stable today and is not a property the query key
+        // should rest on.
         .sort(
           (a, b) =>
-            a.widgetId.localeCompare(b.widgetId) ||
+            a.placementId.localeCompare(b.placementId) ||
             (a.cellKey ?? "").localeCompare(b.cellKey ?? "")
         ),
-    [widgets]
+    [cards]
   );
 
   const { slots, cellSlots, isFetching, updatedAt } =
     useWidgetQueries(requests);
 
-  // Which widgets are actually IN the batch, taken from the requests that were
+  // Which cards are actually IN the batch, taken from the requests that were
   // sent rather than re-derived from `widget.query`.
   //
   // Those two disagree, and the disagreement is the point: a widget declaring a
@@ -146,7 +160,7 @@ export function useWidgetBatch(widgets: DashboardWidget[]): WidgetBatch {
   // gave such a card a freshness line for a request that never ran, and marked
   // it `aria-busy` during someone else's refetch.
   const requested = useMemo(
-    () => new Set(requests.map(request => request.widgetId)),
+    () => new Set(requests.map(request => request.placementId)),
     [requests]
   );
 
@@ -161,16 +175,20 @@ export function useWidgetBatch(widgets: DashboardWidget[]): WidgetBatch {
   // would put a number in the reader's ear that nothing on screen supports.
   const outcomes = useMemo(
     () =>
-      widgets
+      cards
         // A `stats` card is one CARD in the announcement, however many numbers
         // it draws: the reader is told how many cards updated, not how many
         // queries ran.
-        .filter(widget => widget.query ?? widget.cells?.length)
-        .map(widget =>
-          widgetOutcome(widget, slots[widget.id], cellSlots[widget.id])
+        .filter(card => card.widget.query ?? card.widget.cells?.length)
+        .map(card =>
+          widgetOutcome(
+            card.widget,
+            slots[card.placementId],
+            cellSlots[card.placementId]
+          )
         )
         .filter(outcome => outcome.state !== "self-drawn"),
-    [widgets, slots, cellSlots]
+    [cards, slots, cellSlots]
   );
 
   return {

--- a/packages/admin/src/hooks/queries/useWidgetQueries.test.tsx
+++ b/packages/admin/src/hooks/queries/useWidgetQueries.test.tsx
@@ -59,7 +59,7 @@ describe("useWidgetQueries", () => {
       () =>
         useWidgetQueries([
           {
-            widgetId: "__proto__",
+            placementId: "__proto__",
             cellKey: "total",
             query: countQuery("collection:posts"),
           },
@@ -92,9 +92,9 @@ describe("useWidgetQueries", () => {
     const { result } = renderHook(
       () =>
         useWidgetQueries([
-          { widgetId: "core/a", query: countQuery("collection:posts") },
-          { widgetId: "core/b", query: countQuery("collection:pages") },
-          { widgetId: "core/c", query: countQuery("collection:media") },
+          { placementId: "core/a", query: countQuery("collection:posts") },
+          { placementId: "core/b", query: countQuery("collection:pages") },
+          { placementId: "core/c", query: countQuery("collection:media") },
         ]),
       { wrapper }
     );
@@ -126,8 +126,8 @@ describe("useWidgetQueries", () => {
     const { result } = renderHook(
       () =>
         useWidgetQueries([
-          { widgetId: "core/posts", query: countQuery("collection:posts") },
-          { widgetId: "core/pages", query: countQuery("collection:pages") },
+          { placementId: "core/posts", query: countQuery("collection:posts") },
+          { placementId: "core/pages", query: countQuery("collection:pages") },
         ]),
       { wrapper }
     );
@@ -156,8 +156,8 @@ describe("useWidgetQueries", () => {
     const { result } = renderHook(
       () =>
         useWidgetQueries([
-          { widgetId: "core/broken", query: countQuery("collection:gone") },
-          { widgetId: "core/fine", query: countQuery("collection:posts") },
+          { placementId: "core/broken", query: countQuery("collection:gone") },
+          { placementId: "core/fine", query: countQuery("collection:posts") },
         ]),
       { wrapper }
     );
@@ -195,8 +195,8 @@ describe("useWidgetQueries", () => {
     const { result } = renderHook(
       () =>
         useWidgetQueries([
-          { widgetId: "core/a", query: countQuery("collection:posts") },
-          { widgetId: "core/b", query: countQuery("collection:pages") },
+          { placementId: "core/a", query: countQuery("collection:posts") },
+          { placementId: "core/b", query: countQuery("collection:pages") },
         ]),
       { wrapper }
     );
@@ -217,8 +217,8 @@ describe("useWidgetQueries", () => {
     const { result } = renderHook(
       () =>
         useWidgetQueries([
-          { widgetId: "core/a", query: countQuery("collection:posts") },
-          { widgetId: "core/b", query: countQuery("collection:pages") },
+          { placementId: "core/a", query: countQuery("collection:posts") },
+          { placementId: "core/b", query: countQuery("collection:pages") },
         ]),
       { wrapper }
     );
@@ -241,7 +241,7 @@ describe("useWidgetQueries", () => {
     const { result } = renderHook(
       () =>
         useWidgetQueries([
-          { widgetId: "core/a", query: countQuery("collection:posts") },
+          { placementId: "core/a", query: countQuery("collection:posts") },
         ]),
       { wrapper }
     );
@@ -257,7 +257,7 @@ describe("useWidgetQueries", () => {
     const { result } = renderHook(
       () =>
         useWidgetQueries([
-          { widgetId: "core/a", query: countQuery("collection:posts") },
+          { placementId: "core/a", query: countQuery("collection:posts") },
         ]),
       { wrapper }
     );
@@ -276,8 +276,8 @@ describe("useWidgetQueries", () => {
     const { result } = renderHook(
       () =>
         useWidgetQueries([
-          { widgetId: "core/a", query: countQuery("collection:posts") },
-          { widgetId: "core/b", query: countQuery("collection:pages") },
+          { placementId: "core/a", query: countQuery("collection:posts") },
+          { placementId: "core/b", query: countQuery("collection:pages") },
         ]),
       { wrapper }
     );
@@ -295,7 +295,7 @@ describe("useWidgetQueries", () => {
     // at once, over a limit none of them individually crossed.
     const over = MAX_QUERIES_PER_REQUEST + 1;
     const requests = Array.from({ length: over }, (_, i) => ({
-      widgetId: `core/${i}`,
+      placementId: `core/${i}`,
       query: countQuery(`collection:c${i}`),
     }));
     vi.mocked(protectedApi.post).mockImplementation(
@@ -342,7 +342,7 @@ describe("useWidgetQueries", () => {
     const requests = Array.from(
       { length: MAX_QUERIES_PER_REQUEST },
       (_, i) => ({
-        widgetId: `core/${i}`,
+        placementId: `core/${i}`,
         query: countQuery(`collection:c${i}`),
       })
     );
@@ -368,7 +368,7 @@ describe("useWidgetQueries", () => {
   it("fails only the partition that failed, not the widgets beside it", async () => {
     const over = MAX_QUERIES_PER_REQUEST + 1;
     const requests = Array.from({ length: over }, (_, i) => ({
-      widgetId: `core/${i}`,
+      placementId: `core/${i}`,
       query: countQuery(`collection:c${i}`),
     }));
     vi.mocked(protectedApi.post).mockImplementation(
@@ -407,7 +407,7 @@ describe("useWidgetQueries", () => {
       const { result } = renderHook(
         () =>
           useWidgetQueries([
-            { widgetId: "core/a", query: countQuery("collection:posts") },
+            { placementId: "core/a", query: countQuery("collection:posts") },
           ]),
         { wrapper }
       );
@@ -611,7 +611,7 @@ describe("useWidgetQueries", () => {
     const { result } = renderHook(
       () =>
         useWidgetQueries([
-          { widgetId: "core/a", query: countQuery("collection:posts") },
+          { placementId: "core/a", query: countQuery("collection:posts") },
         ]),
       { wrapper }
     );

--- a/packages/admin/src/hooks/queries/useWidgetQueries.ts
+++ b/packages/admin/src/hooks/queries/useWidgetQueries.ts
@@ -4,9 +4,9 @@
  *
  * `POST /api/dashboard/query` takes `{ queries: WidgetQuery[] }` and answers
  * `{ results }` POSITIONALLY — `results[i]` belongs to `queries[i]` and carries
- * no widget id of its own. Re-keying that back onto widget ids is this hook's
- * whole job, and it is the reason a dashboard of ten cards costs one request
- * rather than ten.
+ * no identity of its own. Re-keying that back onto the PLACEMENT that asked is
+ * this hook's whole job, and it is the reason a dashboard of ten cards costs
+ * one request rather than ten.
  *
  * It also REFUSES a body above `MAX_QUERIES_PER_REQUEST`, so "one request for
  * everything" stops being correct at the thirty-first widget: a single batch
@@ -41,14 +41,29 @@ import type {
   WidgetSlot,
 } from "@admin/types/dashboard/widgets";
 
-/** One widget's request: the id to key the answer back to, and what to ask. */
+/** One card's request: the id to key the answer back to, and what to ask. */
 export interface WidgetQueryRequest {
-  widgetId: string;
+  /**
+   * Which PLACEMENT asked, not which widget.
+   *
+   * 🔴 The widget id cannot key an answer, because it does not identify a
+   * question. `WidgetPlacement` is a full snapshot with its own identity
+   * precisely so one widget can sit on a dashboard twice carrying different
+   * `config` — and a setting that drives the query makes those two cards
+   * genuinely different questions. Keyed by widget, both filed into one entry:
+   * the second response overwrote the first and both cards drew the same rows,
+   * each reader's own choice visible on neither.
+   *
+   * A placement id is unique within a layout and opaque, so it needs no
+   * composite key and no encoding — which is the same reason the cell answers
+   * below are nested rather than joined into one string.
+   */
+  placementId: string;
   /**
    * Which of the widget's cells this answer belongs to, for a `stats` card.
    *
    * Absent for every archetype that asks ONE question, so their slot key stays
-   * the bare widget id and every existing reader is untouched.
+   * the bare placement id and only a `stats` card is nested.
    */
   cellKey?: string;
   query: WidgetQuery;
@@ -58,9 +73,9 @@ export interface WidgetQueryRequest {
 export type CellSlots = Record<string, Record<string, WidgetSlot>>;
 
 export interface UseWidgetQueriesResult {
-  /** Keyed by `widgetId`. A widget with no answer yet is simply absent. */
+  /** Keyed by `placementId`. A card with no answer yet is simply absent. */
   slots: Record<string, WidgetSlot>;
-  /** Keyed by `widgetId`, then by cell key. Only `stats` cards appear here. */
+  /** Keyed by `placementId`, then by cell key. Only `stats` cards appear. */
   cellSlots: CellSlots;
   isLoading: boolean;
   /**
@@ -106,15 +121,14 @@ function emptyRecord<T>(): Record<string, T> {
 }
 
 /**
- * Files one answer where its widget will look for it.
+ * Files one answer where its card will look for it.
  *
- * 🔴 Two maps rather than one map with a composite key. A contributed widget id
- * is checked only for being usable TEXT, not against the registry's slug
- * pattern, so it may contain any character -- including whichever separator a
- * composite key chose. `core/a` cell `b` and a contributed widget literally
- * named `core/a#b` would then file into the same entry and one card would draw
- * the other's number. Nesting removes the encoding, and with it the class of
- * bug: there is no string to collide.
+ * 🔴 Two maps rather than one map with a composite key. A placement id is
+ * checked only for being usable TEXT, so it may contain any character --
+ * including whichever separator a composite key chose. Placement `a` cell `b`
+ * and a placement literally named `a#b` would then file into the same entry and
+ * one card would draw the other's number. Nesting removes the encoding, and
+ * with it the class of bug: there is no string to collide.
  */
 function fileAnswer(
   slots: Record<string, WidgetSlot>,
@@ -123,10 +137,10 @@ function fileAnswer(
   slot: WidgetSlot
 ): void {
   if (entry.cellKey === undefined) {
-    slots[entry.widgetId] = slot;
+    slots[entry.placementId] = slot;
     return;
   }
-  (cellSlots[entry.widgetId] ??= emptyRecord())[entry.cellKey] = slot;
+  (cellSlots[entry.placementId] ??= emptyRecord())[entry.cellKey] = slot;
 }
 
 /** What a widget is told when the batch came back shorter than it went out. */

--- a/packages/admin/src/types/dashboard/widgets.ts
+++ b/packages/admin/src/types/dashboard/widgets.ts
@@ -22,6 +22,7 @@
  */
 
 import type {
+  WidgetSetting,
   WidgetAction,
   WidgetArchetype,
   WidgetHeight,
@@ -131,6 +132,15 @@ export interface DashboardWidget {
   height?: WidgetHeight;
   /** Present for the data archetypes; absent for `text`, `actions`, `custom`. */
   query?: WidgetQuery;
+  /**
+   * What a reader may change about this card, as the widget declared it.
+   *
+   * The OFFER, not one reader's answer: the stored values live on the
+   * placement, and `applyWidgetSettings` reads one against the other. Carried
+   * here because the declaration is what says whether a stored key means
+   * anything at all.
+   */
+  settings?: WidgetSetting[];
   /**
    * Present for `stats`: one entry per number the card draws.
    *

--- a/packages/nextly/src/config.ts
+++ b/packages/nextly/src/config.ts
@@ -215,6 +215,7 @@ export type {
   QuerylessWidgetArchetype,
   CellWidgetArchetype,
   WidgetDefinition,
+  WidgetSetting,
   WidgetAction,
   WidgetStatCell,
   WidgetHeight,
@@ -228,6 +229,15 @@ export type { WidgetQuery } from "./domains/widgets/query";
 // copies of that mapping is two answers to one question, and the copies had
 // already drifted -- only one of them existed.
 export { legacySizeToWidgetSize } from "./domains/widgets/definition";
+/*
+ * The admin applies a reader's stored settings to the query it composes, so the
+ * rule that decides which setting drives which knob is exported rather than
+ * restated there — one implementation of a question two layers ask.
+ */
+export {
+  applyWidgetSettings,
+  resolveWidgetSettings,
+} from "./domains/widgets/settings";
 // Which field NAMES an entry. The admin draws a column with it, the activity
 // feed labels a row with it, and the dashboard's generated list widgets pick a
 // row label with it -- so it is one answer here rather than one per consumer.

--- a/packages/nextly/src/domains/widgets/__tests__/settings.compat.test-d.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/settings.compat.test-d.ts
@@ -39,3 +39,38 @@ expectTypeOf<TextSetting>().not.toBeNever();
 expectTypeOf<NumberSetting>().not.toBeNever();
 expectTypeOf<CheckboxSetting>().not.toBeNever();
 expectTypeOf<SelectSetting>().not.toBeNever();
+
+/*
+ * 🔴 Assignability is not enough, and the gap is not academic: `toMatchTypeOf`
+ * permits EXTRA properties, so every assertion above passed while `description`
+ * sat at the top level — where `FieldWrapper`, which reads help text from
+ * `field.admin.description`, never looks. The setting was a valid field config
+ * AND its description was silently undrawable, which is precisely the state
+ * this file exists to make impossible.
+ *
+ * So each variant is also required to introduce NO top-level key its field
+ * counterpart lacks. A property in the wrong PLACE is a key the field type does
+ * not have, so it fails here rather than by never rendering.
+ */
+type TextField = Extract<FieldConfig, { type: "text" }>;
+type NumberField = Extract<FieldConfig, { type: "number" }>;
+type CheckboxField = Extract<FieldConfig, { type: "checkbox" }>;
+type SelectField = Extract<FieldConfig, { type: "select" }>;
+
+expectTypeOf<Exclude<keyof TextSetting, keyof TextField>>().toBeNever();
+expectTypeOf<Exclude<keyof NumberSetting, keyof NumberField>>().toBeNever();
+expectTypeOf<Exclude<keyof CheckboxSetting, keyof CheckboxField>>().toBeNever();
+expectTypeOf<Exclude<keyof SelectSetting, keyof SelectField>>().toBeNever();
+
+/*
+ * The control for the four above, and it is a different one from the control
+ * for assignability. `Extract` resolving to `never` makes `keyof` the set of
+ * ALL property names, so `Exclude` would be enormous rather than empty and the
+ * assertions would fail loudly — but `keyof never` is `string | number | symbol`
+ * only because `never` is the empty union, and a reader has no reason to know
+ * which way that falls. These say the field side resolved to something real.
+ */
+expectTypeOf<TextField>().not.toBeNever();
+expectTypeOf<NumberField>().not.toBeNever();
+expectTypeOf<CheckboxField>().not.toBeNever();
+expectTypeOf<SelectField>().not.toBeNever();

--- a/packages/nextly/src/domains/widgets/__tests__/settings.compat.test-d.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/settings.compat.test-d.ts
@@ -1,0 +1,41 @@
+/**
+ * A widget setting is still a field config, checked by the compiler.
+ *
+ * `WidgetSetting` is declared structurally rather than as the collections field
+ * union, because importing that union drags `collections/fields/types/base`
+ * into the type graph of every package that reads a widget definition — and the
+ * admin is one, where that module's own imports do not resolve. The whole
+ * benefit of the structural declaration is that the admin can still draw a
+ * setting with `FieldRenderer`, which takes a `FieldConfig`.
+ *
+ * That benefit is an assumption the moment nothing checks it. This checks it,
+ * from inside the package where the field types DO resolve: every variant must
+ * remain assignable to `FieldConfig`, so a field added to one side or a type
+ * narrowed on the other fails here rather than in the admin at runtime.
+ */
+import { expectTypeOf } from "vitest";
+
+import type { FieldConfig } from "../../../collections/fields/types";
+import type { WidgetSetting } from "../settings";
+
+// Each variant, named individually: a union asserted as a whole passes when
+// only one member matches, which is exactly the drift worth catching.
+type TextSetting = Extract<WidgetSetting, { type: "text" }>;
+type NumberSetting = Extract<WidgetSetting, { type: "number" }>;
+type CheckboxSetting = Extract<WidgetSetting, { type: "checkbox" }>;
+type SelectSetting = Extract<WidgetSetting, { type: "select" }>;
+
+expectTypeOf<TextSetting>().toMatchTypeOf<FieldConfig>();
+expectTypeOf<NumberSetting>().toMatchTypeOf<FieldConfig>();
+expectTypeOf<CheckboxSetting>().toMatchTypeOf<FieldConfig>();
+expectTypeOf<SelectSetting>().toMatchTypeOf<FieldConfig>();
+
+/*
+ * The positive control. `Extract` returning `never` would satisfy every
+ * assertion above — `never` is assignable to anything — so a renamed or
+ * removed variant would pass silently. These say the variants exist.
+ */
+expectTypeOf<TextSetting>().not.toBeNever();
+expectTypeOf<NumberSetting>().not.toBeNever();
+expectTypeOf<CheckboxSetting>().not.toBeNever();
+expectTypeOf<SelectSetting>().not.toBeNever();

--- a/packages/nextly/src/domains/widgets/__tests__/settings.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/settings.test.ts
@@ -9,6 +9,7 @@
  */
 import { describe, expect, it } from "vitest";
 
+import { NextlyError } from "../../../errors/nextly-error";
 import {
   applyWidgetSettings,
   MAX_WIDGET_SETTINGS,
@@ -173,6 +174,84 @@ describe("validateWidgetSettings refuses what an author can fix", () => {
     ).not.toThrow();
   });
 
+  it("refuses a select option whose value is blank", () => {
+    // `FieldRenderer` hands each option to a Radix `SelectItem`, which reserves
+    // the empty string for "nothing selected" and throws rather than rendering
+    // -- so an author's blank value crashes the panel for the first reader to
+    // open it. Whitespace too: it is blank to everything except `!== ""`.
+    for (const value of ["", "   "]) {
+      expect(() =>
+        validateWidgetSettings(
+          [
+            {
+              name: "mode",
+              type: "select",
+              options: [{ label: "None", value }],
+            },
+          ],
+          "core/x"
+        )
+      ).toThrow(/options/);
+    }
+  });
+
+  it("refuses a number default outside the range the setting declares", () => {
+    expect(() =>
+      validateWidgetSettings(
+        [{ name: "limit", type: "number", min: 1, max: 10, defaultValue: 20 }],
+        "core/x"
+      )
+    ).toThrow(/range/);
+  });
+
+  it("accepts a number default inside the range", () => {
+    // The control for the pair: a bounds check that refused everything would
+    // satisfy the case above while making a bounded setting undeclarable.
+    expect(() =>
+      validateWidgetSettings(
+        [{ name: "limit", type: "number", min: 1, max: 10, defaultValue: 5 }],
+        "core/x"
+      )
+    ).not.toThrow();
+  });
+
+  it("refuses bounds that are not finite numbers, or a range nothing satisfies", () => {
+    expect(() =>
+      validateWidgetSettings(
+        [{ name: "limit", type: "number", min: "one" }],
+        "core/x"
+      )
+    ).toThrow(/finite number/);
+    // An empty range makes every value fall back -- including the default,
+    // which falls back to itself -- so the setting is permanently unusable.
+    expect(() =>
+      validateWidgetSettings(
+        [{ name: "limit", type: "number", min: 10, max: 1 }],
+        "core/x"
+      )
+    ).toThrow(/no value can satisfy/);
+  });
+
+  /*
+   * 🔴 The refusal must survive the value it is describing. `JSON.stringify`
+   * throws on a BigInt, so building the diagnostic threw a native `TypeError`
+   * before the `NextlyError` it was describing could be raised -- and the
+   * author saw an error naming neither the widget nor the setting.
+   */
+  it("refuses a BigInt default as a NextlyError, not a TypeError", () => {
+    let caught: unknown;
+    try {
+      validateWidgetSettings(
+        [{ name: "limit", type: "number", defaultValue: 1n }],
+        "core/x"
+      );
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(NextlyError);
+    expect((caught as Error).message).toMatch(/limit/);
+  });
+
   it("refuses more settings than the ceiling allows", () => {
     const many = Array.from({ length: MAX_WIDGET_SETTINGS + 1 }, (_, i) => ({
       name: `s${i}`,
@@ -263,6 +342,67 @@ describe("resolveWidgetSettings reads a stored value without punishing it", () =
     expect(resolveWidgetSettings([mode], { mode: "grid" })).toEqual({
       mode: "grid",
     });
+  });
+
+  it("falls back when a stored number leaves the declared range", () => {
+    // The same rule the select case follows: a value the declaration no longer
+    // accepts takes the default. An author narrowing a range, or a config
+    // written straight through the API, produces exactly this.
+    const bounded: WidgetSetting = {
+      name: "limit",
+      type: "number",
+      min: 1,
+      max: 10,
+      defaultValue: 5,
+    };
+    expect(resolveWidgetSettings([bounded], { limit: 20 })).toEqual({
+      limit: 5,
+    });
+    expect(resolveWidgetSettings([bounded], { limit: 0 })).toEqual({
+      limit: 5,
+    });
+  });
+
+  it("keeps a stored number inside the declared range", () => {
+    // The control. Refusing every bounded number would satisfy the case above
+    // while making the setting impossible to change.
+    const bounded: WidgetSetting = {
+      name: "limit",
+      type: "number",
+      min: 1,
+      max: 10,
+      defaultValue: 5,
+    };
+    expect(resolveWidgetSettings([bounded], { limit: 7 })).toEqual({
+      limit: 7,
+    });
+  });
+
+  /*
+   * 🔴 A setting NAME is chosen by a plugin, so the record it fills cannot be a
+   * plain object. `resolved["__proto__"] = v` invokes the legacy prototype
+   * setter rather than creating an own property, so the declared setting
+   * vanished from the result and read back as `Object.prototype`. A stored
+   * config reaches this through `JSON.parse`, which creates `__proto__` as a
+   * real own property -- so the value genuinely arrives.
+   */
+  it("resolves a setting named __proto__ as data", () => {
+    const odd: WidgetSetting = {
+      name: "__proto__",
+      type: "text",
+      defaultValue: "d",
+    };
+    const stored = JSON.parse('{"__proto__":"stored"}') as Record<
+      string,
+      unknown
+    >;
+
+    const resolved = resolveWidgetSettings([odd], stored);
+
+    expect(Object.keys(resolved)).toEqual(["__proto__"]);
+    expect(resolved["__proto__"]).toBe("stored");
+    // And nothing leaked onto the prototype every other object inherits.
+    expect(({} as Record<string, unknown>).stored).toBeUndefined();
   });
 
   it("answers empty for a widget that declares nothing", () => {

--- a/packages/nextly/src/domains/widgets/__tests__/settings.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/settings.test.ts
@@ -75,6 +75,104 @@ describe("validateWidgetSettings refuses what an author can fix", () => {
     ).toThrow(/function default/);
   });
 
+  /*
+   * 🔴 A default is judged by the SAME predicate a stored value is. A stored
+   * value that fails it falls back to the default; a DEFAULT that fails it is
+   * what everything falls back to, so nothing downstream can correct it — the
+   * string reached the query where a row count goes.
+   */
+  it("refuses a default that is not a value of its own type", () => {
+    expect(() =>
+      validateWidgetSettings(
+        [{ name: "limit", type: "number", defaultValue: "ten" }],
+        "core/x"
+      )
+    ).toThrow(/limit/);
+    expect(() =>
+      validateWidgetSettings(
+        [{ name: "compact", type: "checkbox", defaultValue: "yes" }],
+        "core/x"
+      )
+    ).toThrow(/compact/);
+  });
+
+  it("accepts a default that IS a value of its own type", () => {
+    // The control. A rule that refused every default would satisfy the case
+    // above while making `defaultValue` undeclarable.
+    expect(() =>
+      validateWidgetSettings(
+        [{ name: "limit", type: "number", defaultValue: 10 }],
+        "core/x"
+      )
+    ).not.toThrow();
+  });
+
+  it("refuses a number default JSON cannot carry", () => {
+    // `NaN` and the infinities are numbers that serialize to `null`, so a
+    // default declared as one arrives at the admin absent -- the same outcome
+    // as the function default beside it, reached by a different route.
+    expect(() =>
+      validateWidgetSettings(
+        [{ name: "limit", type: "number", defaultValue: Number.NaN }],
+        "core/x"
+      )
+    ).toThrow(/limit/);
+  });
+
+  it("refuses a select that offers no options", () => {
+    // A select with nothing to choose can hold no value at all, so every
+    // stored one falls back and the form draws an empty control.
+    expect(() =>
+      validateWidgetSettings([{ name: "mode", type: "select" }], "core/x")
+    ).toThrow(/options/);
+    expect(() =>
+      validateWidgetSettings(
+        [{ name: "mode", type: "select", options: [] }],
+        "core/x"
+      )
+    ).toThrow(/options/);
+    expect(() =>
+      validateWidgetSettings(
+        [{ name: "mode", type: "select", options: [{ value: "a" }] }],
+        "core/x"
+      )
+    ).toThrow(/options/);
+  });
+
+  it("refuses a select default that is not one of its options", () => {
+    expect(() =>
+      validateWidgetSettings(
+        [
+          {
+            name: "mode",
+            type: "select",
+            defaultValue: "gone",
+            options: [{ label: "A", value: "a" }],
+          },
+        ],
+        "core/x"
+      )
+    ).toThrow(/gone/);
+  });
+
+  it("accepts a select default that IS one of its options", () => {
+    // The control for the pair above: the options rule must still permit a
+    // well-formed select, or the two refusals could be one rule rejecting all.
+    expect(() =>
+      validateWidgetSettings(
+        [
+          {
+            name: "mode",
+            type: "select",
+            defaultValue: "a",
+            options: [{ label: "A", value: "a" }],
+          },
+        ],
+        "core/x"
+      )
+    ).not.toThrow();
+  });
+
   it("refuses more settings than the ceiling allows", () => {
     const many = Array.from({ length: MAX_WIDGET_SETTINGS + 1 }, (_, i) => ({
       name: `s${i}`,
@@ -126,6 +224,45 @@ describe("resolveWidgetSettings reads a stored value without punishing it", () =
     // nothing and the author offered nothing" from "the value is the default".
     const title: WidgetSetting = { name: "title", type: "text" };
     expect(resolveWidgetSettings([title], {})).toEqual({});
+  });
+
+  /*
+   * 🔴 A select's stored value is checked against its OPTIONS, not merely
+   * against being a string. A plugin that renames or retires a choice leaves
+   * every reader who picked it holding a value the declaration no longer
+   * offers: the card drew it and the settings form could not show it, which is
+   * the upgrade this whole reading exists to survive.
+   */
+  it("falls back when a stored select value is no longer offered", () => {
+    const mode: WidgetSetting = {
+      name: "mode",
+      type: "select",
+      defaultValue: "list",
+      options: [
+        { label: "List", value: "list" },
+        { label: "Grid", value: "grid" },
+      ],
+    };
+    expect(resolveWidgetSettings([mode], { mode: "gallery" })).toEqual({
+      mode: "list",
+    });
+  });
+
+  it("keeps a stored select value the declaration still offers", () => {
+    // The control. Without it, refusing every select value would satisfy the
+    // case above while making the setting impossible to change.
+    const mode: WidgetSetting = {
+      name: "mode",
+      type: "select",
+      defaultValue: "list",
+      options: [
+        { label: "List", value: "list" },
+        { label: "Grid", value: "grid" },
+      ],
+    };
+    expect(resolveWidgetSettings([mode], { mode: "grid" })).toEqual({
+      mode: "grid",
+    });
   });
 
   it("answers empty for a widget that declares nothing", () => {

--- a/packages/nextly/src/domains/widgets/__tests__/settings.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/settings.test.ts
@@ -1,0 +1,195 @@
+/**
+ * What a widget may declare, and what a stored value means.
+ *
+ * 🔴 The two halves pull in opposite directions on purpose. A malformed
+ * DECLARATION is refused, because it belongs to the author running the boot who
+ * can fix it. A malformed stored VALUE is tolerated, because it belongs to a
+ * reader who cannot — and a card that refuses to draw is a worse answer than
+ * one drawn the way its author intended.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  applyWidgetSettings,
+  MAX_WIDGET_SETTINGS,
+  resolveWidgetSettings,
+  validateWidgetSettings,
+  type WidgetSetting,
+} from "../settings";
+
+const limit: WidgetSetting = {
+  name: "limit",
+  type: "number",
+  label: "Rows",
+  defaultValue: 5,
+};
+const compact: WidgetSetting = {
+  name: "compact",
+  type: "checkbox",
+  defaultValue: false,
+};
+
+describe("validateWidgetSettings refuses what an author can fix", () => {
+  it("accepts a declaration and undefined alike", () => {
+    expect(() =>
+      validateWidgetSettings([limit, compact], "core/x")
+    ).not.toThrow();
+    expect(() => validateWidgetSettings(undefined, "core/x")).not.toThrow();
+  });
+
+  it("refuses a duplicate name", () => {
+    // Two settings of one name make the resolved value depend on read order,
+    // which the author cannot see.
+    expect(() =>
+      validateWidgetSettings([limit, { ...limit, label: "Other" }], "core/x")
+    ).toThrow(/duplicate setting "limit"/);
+  });
+
+  it("refuses a type the admin cannot draw", () => {
+    expect(() =>
+      validateWidgetSettings(
+        [{ name: "body", type: "richText" } as never],
+        "core/x"
+      )
+    ).toThrow(/expected one of/);
+  });
+
+  it("refuses a nameless setting", () => {
+    expect(() =>
+      validateWidgetSettings([{ type: "text" } as never], "core/x")
+    ).toThrow(/non-empty "name"/);
+  });
+
+  /*
+   * 🔴 A function default is refused rather than called. `defaultValue` may be
+   * a thunk on a collection field; a widget definition is serialized to the
+   * admin as JSON, where a function simply disappears — so the setting would
+   * silently have no default at all.
+   */
+  it("refuses a function default, which could not cross the wire", () => {
+    expect(() =>
+      validateWidgetSettings(
+        [{ name: "limit", type: "number", defaultValue: () => 5 } as never],
+        "core/x"
+      )
+    ).toThrow(/function default/);
+  });
+
+  it("refuses more settings than the ceiling allows", () => {
+    const many = Array.from({ length: MAX_WIDGET_SETTINGS + 1 }, (_, i) => ({
+      name: `s${i}`,
+      type: "text" as const,
+    }));
+    expect(() => validateWidgetSettings(many, "core/x")).toThrow(/at most/);
+  });
+});
+
+describe("resolveWidgetSettings reads a stored value without punishing it", () => {
+  const declared = [limit, compact];
+
+  it("takes a stored value that matches its declared type", () => {
+    expect(resolveWidgetSettings(declared, { limit: 10 })).toEqual({
+      limit: 10,
+      compact: false,
+    });
+  });
+
+  it("defaults a setting the stored config does not mention", () => {
+    expect(resolveWidgetSettings(declared, {})).toEqual({
+      limit: 5,
+      compact: false,
+    });
+  });
+
+  /*
+   * 🔴 The upgrade case. A plugin that changes a setting's type across a
+   * release leaves every stored value wrongly typed, and refusing would take
+   * the card down for readers who never touched it.
+   */
+  it("falls back to the default when the stored value is the wrong type", () => {
+    expect(resolveWidgetSettings(declared, { limit: "ten" })).toEqual({
+      limit: 5,
+      compact: false,
+    });
+  });
+
+  it("ignores a key no setting declares", () => {
+    // Returned config carries only declared names, so a caller cannot act on
+    // something the widget never offered.
+    const resolved = resolveWidgetSettings(declared, { limit: 3, stray: "x" });
+    expect(resolved).toEqual({ limit: 3, compact: false });
+    expect("stray" in resolved).toBe(false);
+  });
+
+  it("omits a declared setting that has no default and no stored value", () => {
+    // Absent is different from defaulted: a caller can tell "the reader chose
+    // nothing and the author offered nothing" from "the value is the default".
+    const title: WidgetSetting = { name: "title", type: "text" };
+    expect(resolveWidgetSettings([title], {})).toEqual({});
+  });
+
+  it("answers empty for a widget that declares nothing", () => {
+    expect(resolveWidgetSettings(undefined, { limit: 9 })).toEqual({});
+    expect(resolveWidgetSettings([], { limit: 9 })).toEqual({});
+  });
+
+  it("rejects a non-finite number, which JSON cannot round-trip", () => {
+    expect(resolveWidgetSettings(declared, { limit: Number.NaN })).toEqual({
+      limit: 5,
+      compact: false,
+    });
+  });
+});
+
+describe("applyWidgetSettings drives only the knobs it declares", () => {
+  const base = { source: "collection:posts", op: "list" as const, limit: 5 };
+
+  it("takes the reader's row count", () => {
+    const out = applyWidgetSettings(base, [limit], { limit: 12 });
+    expect(out.limit).toBe(12);
+  });
+
+  it("falls back to the declared default when the reader chose nothing", () => {
+    expect(applyWidgetSettings(base, [limit], {}).limit).toBe(5);
+  });
+
+  /*
+   * 🔴 The name is the contract AND so is the type. A `text` setting called
+   * `limit` drives nothing rather than putting a string where a row count goes
+   * — which would reach the query compiler as `LIMIT "ten"`.
+   */
+  it("ignores a setting whose name matches but whose type does not", () => {
+    const textLimit: WidgetSetting = { name: "limit", type: "text" };
+    const out = applyWidgetSettings(base, [textLimit], { limit: "ten" });
+    expect(out.limit).toBe(5);
+  });
+
+  it("ignores a setting that drives no knob", () => {
+    const out = applyWidgetSettings(base, [compact], { compact: true });
+    expect(out.limit).toBe(5);
+  });
+
+  it("returns the very same object when nothing applies", () => {
+    // Identity, not equality: callers apply this to every card, and a copy per
+    // card would break the memoisation the grid relies on to avoid refetching.
+    expect(applyWidgetSettings(base, undefined, { limit: 9 })).toBe(base);
+    expect(applyWidgetSettings(base, [compact], {})).toBe(base);
+  });
+
+  it("does not mutate the query it was given", () => {
+    const out = applyWidgetSettings(base, [limit], { limit: 12 });
+    expect(base.limit).toBe(5);
+    expect(out).not.toBe(base);
+  });
+
+  /*
+   * Deliberately NOT clamped here. `validateReadWidgetQuery` bounds every query
+   * the endpoint accepts, and a second implementation of that rule in this
+   * module would agree on the day it was written and drift afterwards.
+   */
+  it("passes an out-of-range value through for the endpoint to bound", () => {
+    expect(applyWidgetSettings(base, [limit], { limit: 100000 }).limit).toBe(
+      100000
+    );
+  });
+});

--- a/packages/nextly/src/domains/widgets/definition.ts
+++ b/packages/nextly/src/domains/widgets/definition.ts
@@ -13,6 +13,14 @@ import { NextlyError } from "../../errors/nextly-error";
 
 import { requiredPermissionSlugs } from "./gate";
 import type { WidgetQuery } from "./query";
+import { validateWidgetSettings, type WidgetSetting } from "./settings";
+
+/*
+ * Re-exported from the contract's home so a caller reading a definition finds
+ * the type of one of its fields in the same place, rather than having to know
+ * which module the validation happens to live in.
+ */
+export type { WidgetSetting } from "./settings";
 
 // The gate rule lives in a module with no imports so the BROWSER can read it
 // too (`nextly/widget-gate`). Validation asks the same reader the gate asks,
@@ -198,6 +206,15 @@ export interface WidgetDefinition {
   /** Groups the widget in the "add widget" picker. */
   category?: string;
   archetype: WidgetArchetype;
+  /**
+   * What a reader may change about THIS card, per placement.
+   *
+   * Declared as field configs so the admin draws them with the renderer it
+   * already has and a plugin author needs no new vocabulary. The stored values
+   * live on the placement, not here: this is the offer, and the placement is
+   * one reader's answer to it.
+   */
+  settings?: WidgetSetting[];
   defaultSize: WidgetSize;
   /**
    * Where this widget sits by default, ascending. Omitted means "after
@@ -1093,4 +1110,5 @@ export function validateWidgetDefinition(
   validateCells(d);
   validateDefaultOrder(d);
   validateChrome(d);
+  validateWidgetSettings(d.settings, d.id ?? "widget");
 }

--- a/packages/nextly/src/domains/widgets/index.ts
+++ b/packages/nextly/src/domains/widgets/index.ts
@@ -16,6 +16,7 @@ export {
   validateWidgetDefinition,
   type WidgetDefinition,
   type WidgetAction,
+  type WidgetSetting,
   type WidgetStatCell,
   type WidgetSize,
   type WidgetChrome,

--- a/packages/nextly/src/domains/widgets/settings.ts
+++ b/packages/nextly/src/domains/widgets/settings.ts
@@ -27,7 +27,7 @@
  *
  * - a key no setting declares is IGNORED, and kept in storage;
  * - a declared key that is absent takes the setting's default;
- * - a value of the wrong type takes the default too.
+ * - a value the declaration no longer accepts takes the default too.
  *
  * 🔴 Rejecting unknown keys at write time would make a saved layout unwritable
  * the moment a plugin renames a setting or is uninstalled, and plugins version
@@ -45,7 +45,19 @@ import { NextlyError } from "../../errors/nextly-error";
 export interface WidgetSettingBase {
   name: string;
   label?: string;
-  description?: string;
+  /**
+   * Presentation the field system owns, and where help text lives.
+   *
+   * 🔴 `description` sits HERE rather than at the top level, and the renderer
+   * is why. The premise of this whole type is that `FieldRenderer` draws a
+   * setting with no adapter — and `FieldWrapper` reads help text from
+   * `field.admin.description`, nowhere else. Declared at the top level it
+   * compiled, travelled to the admin intact, and was silently never drawn: an
+   * author would write a description, see nothing on screen, and have no
+   * failure anywhere to look at. Being a field config has to mean being one
+   * where the renderer reads, not only where the compiler agrees.
+   */
+  admin?: { description?: string };
 }
 
 /**
@@ -62,8 +74,9 @@ export interface WidgetSettingBase {
  *
  * The shape is still a field config, so `FieldRenderer` draws it with no
  * adapter. `__tests__/settings.compat.test-d.ts` asserts that each variant is
- * assignable to `FieldConfig`, inside the package where that import resolves —
- * so the compatibility this rests on is checked rather than asserted in prose.
+ * assignable to `FieldConfig` AND that it introduces no top-level key the field
+ * types do not have, inside the package where that import resolves — so the
+ * compatibility this rests on is checked rather than asserted in prose.
  */
 export type WidgetSetting =
   | (WidgetSettingBase & { type: "text"; defaultValue?: string })
@@ -80,8 +93,70 @@ export type WidgetSetting =
       options: { label: string; value: string }[];
     });
 
-/** The field types a widget setting may use. */
-const SETTING_TYPES = new Set(["text", "number", "checkbox", "select"]);
+/**
+ * Whether a value is usable as a setting of each type.
+ *
+ * 🔴 ONE table, read in both directions this module judges a value in: a
+ * STORED value being read back for a card, and a DEFAULT being declared by an
+ * author. Only the stored direction existed before, so
+ * `{ type: "number", defaultValue: "ten" }` passed boot, resolved to the string
+ * it declared, and put text where a row count goes — the author's mistake
+ * surfacing as a query that quietly did something else. Two tables could
+ * answer one question two ways; this one cannot.
+ *
+ * The keys are also the vocabulary. A type is one a setting may declare
+ * exactly when this table can judge its values, so adding a type here is the
+ * whole of adding a type.
+ */
+const USABLE_AS: Record<
+  WidgetSetting["type"],
+  (value: unknown, options: readonly { value: string }[] | undefined) => boolean
+> = {
+  text: value => typeof value === "string",
+  number: value => typeof value === "number" && Number.isFinite(value),
+  checkbox: value => typeof value === "boolean",
+  /*
+   * 🔴 The OPTIONS decide, not the type alone. A stored select value stays a
+   * string after its option is renamed or removed, so a type-only check went on
+   * accepting a choice the declaration no longer offers: the card drew a value
+   * its own settings form could not show, and the fall back to the default that
+   * this reading exists for never happened for the one type whose declaration
+   * can retire a value.
+   */
+  select: (value, options) =>
+    typeof value === "string" &&
+    options !== undefined &&
+    options.some(option => option.value === value),
+};
+
+/** Whether this is a type a setting may declare. */
+function isSettingType(value: unknown): value is WidgetSetting["type"] {
+  // `Object.hasOwn` rather than `in`, because the type name comes from a
+  // plugin's declaration: `"toString"` is `in` every object literal.
+  return typeof value === "string" && Object.hasOwn(USABLE_AS, value);
+}
+
+/** Whether this is a usable set of choices for a select. */
+function isSelectOptions(
+  value: unknown
+): value is { label: string; value: string }[] {
+  return (
+    Array.isArray(value) &&
+    // Empty is refused: a select with no choices can never hold a value, so
+    // every stored one falls back and the form draws a control with nothing in
+    // it. That is a declaration mistake rather than a state to render.
+    value.length > 0 &&
+    value.every(
+      option =>
+        typeof option === "object" &&
+        option !== null &&
+        "value" in option &&
+        typeof option.value === "string" &&
+        "label" in option &&
+        typeof option.label === "string"
+    )
+  );
+}
 
 /**
  * How many settings one widget may declare.
@@ -105,6 +180,141 @@ function fail(message: string): never {
 }
 
 /**
+ * Why this declaration cannot be used, or `undefined` when it can.
+ *
+ * 🔴 Returns the problem rather than throwing it, because the two channels into
+ * the registry need the same rules in different shapes: `registerWidget` throws
+ * on a bad definition, while `validatedAdminWidgets` walks a list of rules that
+ * each return a sentence and names the plugin that shipped the widget. Written
+ * as a throwing validator, only the registry could call it — which is exactly
+ * what happened: a contributed `settings` reached the admin having passed no
+ * settings rule at all, and `settings: {}` from an untyped declaration got as
+ * far as the grid before failing, taking the dashboard down instead of the
+ * install. One rule set answering both channels is the thing
+ * `plugins/__tests__/channel-divergence` exists to protect.
+ */
+export function widgetSettingsProblem(settings: unknown): string | undefined {
+  if (settings === undefined) return undefined;
+  if (!Array.isArray(settings)) return '"settings" must be an array';
+  if (settings.length > MAX_WIDGET_SETTINGS) {
+    return `at most ${MAX_WIDGET_SETTINGS} settings, got ${settings.length}`;
+  }
+
+  const seen = new Set<string>();
+  for (const setting of settings) {
+    const problem = settingProblem(setting, seen);
+    if (problem !== undefined) return problem;
+  }
+  return undefined;
+}
+
+/**
+ * Why one setting cannot be used, or `undefined` when it can.
+ *
+ * Separate from the collection check because they answer different questions —
+ * whether this declaration is well formed, against whether the SET of them is
+ * (no duplicates, not too many) — and reading them interleaved made both harder
+ * to follow than either is alone.
+ *
+ * `seen` is passed rather than returned because uniqueness is a property of the
+ * set, and the only place that can observe it is the loop.
+ */
+function settingProblem(
+  setting: unknown,
+  seen: Set<string>
+): string | undefined {
+  if (typeof setting !== "object" || setting === null) {
+    return "every setting must be an object";
+  }
+  const { name, type, defaultValue, options } = setting as {
+    name?: unknown;
+    type?: unknown;
+    defaultValue?: unknown;
+    options?: unknown;
+  };
+
+  if (typeof name !== "string" || name === "") {
+    return 'every setting needs a non-empty "name"';
+  }
+  if (seen.has(name)) {
+    // Two settings of one name make the resolved value depend on which was
+    // read last, and the author cannot see which that is.
+    return `duplicate setting "${name}"`;
+  }
+  seen.add(name);
+
+  if (!isSettingType(type)) {
+    return `setting "${name}" has type ${JSON.stringify(type)}; expected one of ${Object.keys(USABLE_AS).join(", ")}`;
+  }
+
+  return problemForType(type, options, defaultValue, name);
+}
+
+/**
+ * Why this setting's TYPE-SPECIFIC parts are unusable, or `undefined`.
+ *
+ * The options a select must offer and the default any setting may declare are
+ * the two rules that depend on WHICH type this is; everything above is asked of
+ * every setting alike. Kept apart so the general checks read as one list rather
+ * than as a list interrupted by a branch about selects — and because the two
+ * are ordered: a default can only be judged against options already known good.
+ */
+function problemForType(
+  type: WidgetSetting["type"],
+  options: unknown,
+  defaultValue: unknown,
+  name: string
+): string | undefined {
+  if (type === "select" && !isSelectOptions(options)) {
+    return `setting "${name}" is a select and needs a non-empty "options" array of { label, value } entries`;
+  }
+
+  return defaultProblem(
+    type,
+    isSelectOptions(options) ? options : undefined,
+    defaultValue,
+    name
+  );
+}
+
+/** Why this setting's declared default is unusable, or `undefined`. */
+function defaultProblem(
+  type: WidgetSetting["type"],
+  options: readonly { value: string }[] | undefined,
+  defaultValue: unknown,
+  name: string
+): string | undefined {
+  /*
+   * 🔴 A FUNCTION default is refused rather than called. `defaultValue` may be
+   * a thunk on a collection field, where it is evaluated on the server that
+   * holds it — but a widget definition is serialized to the admin through
+   * `/api/admin-meta/workspace`, and a function does not survive JSON. Accepted
+   * here it would simply be absent by the time anything could use it, so the
+   * setting would silently have no default at all. Refusing puts that in front
+   * of the author, who is the only one who can fix it.
+   */
+  if (typeof defaultValue === "function") {
+    return `setting "${name}" has a function default; widget settings cross the wire as JSON, so a default must be a literal`;
+  }
+  if (defaultValue === undefined) return undefined;
+
+  /*
+   * 🔴 Judged by the SAME table a stored value is, because a default that fails
+   * it is worse than a wrong stored value rather than better: a stored value
+   * falls back to the default, while a bad default is what everything falls
+   * back TO. `resolveWidgetSettings` handed it straight out, so a `number`
+   * setting defaulting to `"ten"` reached the query as a string with nothing
+   * left to correct it. The refusal is at boot because that is where the author
+   * who wrote it is standing.
+   */
+  if (USABLE_AS[type](defaultValue, options)) return undefined;
+
+  return type === "select"
+    ? `setting "${name}" defaults to ${JSON.stringify(defaultValue)}, which is not one of its options`
+    : `setting "${name}" is typed "${type}" but defaults to ${JSON.stringify(defaultValue)}`;
+}
+
+/**
  * Refuse a declaration the admin could not draw or the reader could not use.
  *
  * 🔴 Refuses at BOOT rather than degrading, which is the opposite of how the
@@ -117,89 +327,16 @@ export function validateWidgetSettings(
   settings: unknown,
   widgetId: string
 ): asserts settings is WidgetSetting[] | undefined {
-  if (settings === undefined) return;
-  if (!Array.isArray(settings))
-    fail(`${widgetId}: "settings" must be an array`);
-  if (settings.length > MAX_WIDGET_SETTINGS) {
-    fail(
-      `${widgetId}: at most ${MAX_WIDGET_SETTINGS} settings, got ${settings.length}`
-    );
-  }
-
-  const seen = new Set<string>();
-  for (const setting of settings) {
-    validateOneSetting(setting, widgetId, seen);
-  }
-}
-
-/**
- * Refuse one setting the admin could not draw or the reader could not use.
- *
- * Separate from the collection check because they answer different questions —
- * whether this declaration is well formed, against whether the SET of them is
- * (no duplicates, not too many) — and reading them interleaved made both harder
- * to follow than either is alone.
- *
- * `seen` is passed rather than returned because uniqueness is a property of the
- * set, and the only place that can observe it is the loop.
- */
-function validateOneSetting(
-  setting: unknown,
-  widgetId: string,
-  seen: Set<string>
-): void {
-  if (typeof setting !== "object" || setting === null) {
-    fail(`${widgetId}: every setting must be an object`);
-  }
-  const { name, type, defaultValue } = setting as {
-    name?: unknown;
-    type?: unknown;
-    defaultValue?: unknown;
-  };
-
-  if (typeof name !== "string" || name === "") {
-    fail(`${widgetId}: every setting needs a non-empty "name"`);
-  }
-  if (seen.has(name)) {
-    // Two settings of one name make the resolved value depend on which was
-    // read last, and the author cannot see which that is.
-    fail(`${widgetId}: duplicate setting "${name}"`);
-  }
-  seen.add(name);
-
-  if (typeof type !== "string" || !SETTING_TYPES.has(type)) {
-    fail(
-      `${widgetId}: setting "${name}" has type ${JSON.stringify(type)}; expected one of ${[...SETTING_TYPES].join(", ")}`
-    );
-  }
-
-  /*
-   * 🔴 A FUNCTION default is refused rather than called. `defaultValue` may be
-   * a thunk on a collection field, where it is evaluated on the server that
-   * holds it — but a widget definition is serialized to the admin through
-   * `/api/admin-meta/workspace`, and a function does not survive JSON. Accepted
-   * here it would simply be absent by the time anything could use it, so the
-   * setting would silently have no default at all. Refusing puts that in front
-   * of the author, who is the only one who can fix it.
-   */
-  if (typeof defaultValue === "function") {
-    fail(
-      `${widgetId}: setting "${name}" has a function default; widget settings cross the wire as JSON, so a default must be a literal`
-    );
-  }
+  const problem = widgetSettingsProblem(settings);
+  if (problem !== undefined) fail(`${widgetId}: ${problem}`);
 }
 
 /** Whether a stored value is usable as this setting's type. */
 function matchesType(setting: WidgetSetting, value: unknown): boolean {
-  switch (setting.type) {
-    case "number":
-      return typeof value === "number" && Number.isFinite(value);
-    case "checkbox":
-      return typeof value === "boolean";
-    case "text":
-    case "select":
-      return typeof value === "string";
-  }
+  return USABLE_AS[setting.type](
+    value,
+    setting.type === "select" ? setting.options : undefined
+  );
 }
 
 /** The default a setting declares, or `undefined` when it declares none. */
@@ -228,10 +365,11 @@ export function resolveWidgetSettings(
       resolved[setting.name] = value;
       continue;
     }
-    // A wrong-typed value takes the default rather than refusing: the reader
-    // did not necessarily write it -- a plugin changing a setting's type across
-    // an upgrade produces exactly this -- and a card that refuses to draw is a
-    // worse answer than one drawn the way its author intended.
+    // A value the declaration no longer accepts takes the default rather than
+    // refusing: the reader did not necessarily write it -- a plugin changing a
+    // setting's type, or retiring a select option, across an upgrade produces
+    // exactly this -- and a card that refuses to draw is a worse answer than
+    // one drawn the way its author intended.
     const fallback = declaredDefault(setting);
     if (fallback !== undefined) resolved[setting.name] = fallback;
   }

--- a/packages/nextly/src/domains/widgets/settings.ts
+++ b/packages/nextly/src/domains/widgets/settings.ts
@@ -108,26 +108,56 @@ export type WidgetSetting =
  * exactly when this table can judge its values, so adding a type here is the
  * whole of adding a type.
  */
+/**
+ * What a setting's own declaration narrows its values to, beyond the type.
+ *
+ * 🔴 The DECLARATION decides, not the type alone — and that is one rule rather
+ * than two. A stored select value stays a string after its option is renamed,
+ * and a stored number stays a number after its author narrows the range; both
+ * are a value the widget no longer offers, and both must fall back to the
+ * default the same way. Judging only the select case left the number one
+ * accepting `20` for a setting declared `{ min: 1, max: 10 }`, which then
+ * reached the query — the endpoint bounds its own global limit and has never
+ * heard of this author's.
+ */
+interface SettingLimits {
+  options?: readonly { value: string }[];
+  min?: number;
+  max?: number;
+}
+
 const USABLE_AS: Record<
   WidgetSetting["type"],
-  (value: unknown, options: readonly { value: string }[] | undefined) => boolean
+  (value: unknown, limits: SettingLimits) => boolean
 > = {
   text: value => typeof value === "string",
-  number: value => typeof value === "number" && Number.isFinite(value),
+  number: (value, limits) =>
+    typeof value === "number" &&
+    Number.isFinite(value) &&
+    withinBounds(value, limits),
   checkbox: value => typeof value === "boolean",
-  /*
-   * 🔴 The OPTIONS decide, not the type alone. A stored select value stays a
-   * string after its option is renamed or removed, so a type-only check went on
-   * accepting a choice the declaration no longer offers: the card drew a value
-   * its own settings form could not show, and the fall back to the default that
-   * this reading exists for never happened for the one type whose declaration
-   * can retire a value.
-   */
-  select: (value, options) =>
+  select: (value, limits) =>
     typeof value === "string" &&
-    options !== undefined &&
-    options.some(option => option.value === value),
+    limits.options !== undefined &&
+    limits.options.some(option => option.value === value),
 };
+
+/** Whether a finite number sits inside the range its setting declares. */
+function withinBounds(value: number, limits: SettingLimits): boolean {
+  // An absent bound is not a bound. Written as two independent tests rather
+  // than one range check so a setting may declare either end alone, which is
+  // the common case -- `{ min: 1 }` on a row count states the only end that
+  // has a meaning.
+  if (limits.min !== undefined && value < limits.min) return false;
+  return !(limits.max !== undefined && value > limits.max);
+}
+
+/** What this setting's declaration narrows its values to. */
+function limitsOf(setting: WidgetSetting): SettingLimits {
+  if (setting.type === "select") return { options: setting.options };
+  if (setting.type === "number") return { min: setting.min, max: setting.max };
+  return {};
+}
 
 /** Whether this is a type a setting may declare. */
 function isSettingType(value: unknown): value is WidgetSetting["type"] {
@@ -152,6 +182,14 @@ function isSelectOptions(
         option !== null &&
         "value" in option &&
         typeof option.value === "string" &&
+        // 🔴 A BLANK value is refused, not merely an absent one. These are
+        // drawn by `FieldRenderer`, whose `SelectInput` hands each option
+        // straight to a Radix `SelectItem` -- and Radix reserves the empty
+        // string for "nothing is selected", so it throws rather than
+        // rendering. Caught here, the plugin author sees it at boot; left to
+        // the renderer, the first reader to open the settings panel gets the
+        // crash.
+        option.value.trim() !== "" &&
         "label" in option &&
         typeof option.label === "string"
     )
@@ -167,6 +205,29 @@ function isSelectOptions(
  * opens the settings panel.
  */
 export const MAX_WIDGET_SETTINGS = 24;
+
+/**
+ * A value named in a diagnostic, without the formatter itself throwing.
+ *
+ * 🔴 `JSON.stringify` is not total. A BigInt throws `TypeError`, and so does a
+ * circular object — so a declaration carrying `defaultValue: 1n` produced a
+ * native `TypeError` from inside the message-building, BEFORE the refusal it
+ * was describing could be raised as a `NextlyError`. The author saw the wrong
+ * error, naming neither the widget nor the setting.
+ *
+ * `String()` is the fallback rather than a fixed placeholder, because it
+ * survives everything `JSON.stringify` does not and still names the value: a
+ * BigInt reads `1`, a symbol reads `Symbol(x)`.
+ */
+function describeValue(value: unknown): string {
+  try {
+    // `undefined` and a function both stringify to `undefined` rather than to
+    // text, so the fallback covers them too.
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
 
 /*
  * `invalidInput` rather than `validation`, matching the widget definition's own
@@ -226,11 +287,13 @@ function settingProblem(
   if (typeof setting !== "object" || setting === null) {
     return "every setting must be an object";
   }
-  const { name, type, defaultValue, options } = setting as {
+  const { name, type, defaultValue, ...rest } = setting as {
     name?: unknown;
     type?: unknown;
     defaultValue?: unknown;
     options?: unknown;
+    min?: unknown;
+    max?: unknown;
   };
 
   if (typeof name !== "string" || name === "") {
@@ -244,10 +307,10 @@ function settingProblem(
   seen.add(name);
 
   if (!isSettingType(type)) {
-    return `setting "${name}" has type ${JSON.stringify(type)}; expected one of ${Object.keys(USABLE_AS).join(", ")}`;
+    return `setting "${name}" has type ${describeValue(type)}; expected one of ${Object.keys(USABLE_AS).join(", ")}`;
   }
 
-  return problemForType(type, options, defaultValue, name);
+  return problemForType(type, rest, defaultValue, name);
 }
 
 /**
@@ -261,26 +324,58 @@ function settingProblem(
  */
 function problemForType(
   type: WidgetSetting["type"],
-  options: unknown,
+  setting: { options?: unknown; min?: unknown; max?: unknown },
   defaultValue: unknown,
   name: string
 ): string | undefined {
-  if (type === "select" && !isSelectOptions(options)) {
-    return `setting "${name}" is a select and needs a non-empty "options" array of { label, value } entries`;
-  }
+  const limits = declaredLimits(type, setting);
+  if (typeof limits === "string") return `setting "${name}" ${limits}`;
+  return defaultProblem(type, limits, defaultValue, name);
+}
 
-  return defaultProblem(
-    type,
-    isSelectOptions(options) ? options : undefined,
-    defaultValue,
-    name
+/**
+ * What this declaration narrows its values to, or why it cannot be read.
+ *
+ * Returns the LIMITS on success and a problem fragment on failure, because the
+ * two questions are one: a bound that cannot be read is not a bound to check
+ * against, and validating it separately would leave the predicate below
+ * comparing against a value it had never confirmed was a number.
+ */
+function declaredLimits(
+  type: WidgetSetting["type"],
+  setting: { options?: unknown; min?: unknown; max?: unknown }
+): SettingLimits | string {
+  if (type === "select") {
+    return isSelectOptions(setting.options)
+      ? { options: setting.options }
+      : 'is a select and needs a non-empty "options" array of { label, value } entries with non-blank values';
+  }
+  if (type !== "number") return {};
+
+  const { min, max } = setting;
+  if (!isOptionalFiniteNumber(min) || !isOptionalFiniteNumber(max)) {
+    return 'declares a "min" or "max" that is not a finite number';
+  }
+  // An empty range accepts nothing, so every stored value AND the declared
+  // default fall back -- and the default falls back to itself, leaving the
+  // setting permanently unusable with nothing on screen to say why.
+  if (min !== undefined && max !== undefined && min > max) {
+    return `declares min ${min} above max ${max}, a range no value can satisfy`;
+  }
+  return { min, max };
+}
+
+/** Whether an optional bound is absent or a number JSON can carry. */
+function isOptionalFiniteNumber(value: unknown): value is number | undefined {
+  return (
+    value === undefined || (typeof value === "number" && Number.isFinite(value))
   );
 }
 
 /** Why this setting's declared default is unusable, or `undefined`. */
 function defaultProblem(
   type: WidgetSetting["type"],
-  options: readonly { value: string }[] | undefined,
+  limits: SettingLimits,
   defaultValue: unknown,
   name: string
 ): string | undefined {
@@ -307,11 +402,15 @@ function defaultProblem(
    * left to correct it. The refusal is at boot because that is where the author
    * who wrote it is standing.
    */
-  if (USABLE_AS[type](defaultValue, options)) return undefined;
+  if (USABLE_AS[type](defaultValue, limits)) return undefined;
 
-  return type === "select"
-    ? `setting "${name}" defaults to ${JSON.stringify(defaultValue)}, which is not one of its options`
-    : `setting "${name}" is typed "${type}" but defaults to ${JSON.stringify(defaultValue)}`;
+  if (type === "select") {
+    return `setting "${name}" defaults to ${describeValue(defaultValue)}, which is not one of its options`;
+  }
+  const bounded = limits.min !== undefined || limits.max !== undefined;
+  return bounded && typeof defaultValue === "number"
+    ? `setting "${name}" defaults to ${defaultValue}, outside the range it declares`
+    : `setting "${name}" is typed "${type}" but defaults to ${describeValue(defaultValue)}`;
 }
 
 /**
@@ -333,10 +432,7 @@ export function validateWidgetSettings(
 
 /** Whether a stored value is usable as this setting's type. */
 function matchesType(setting: WidgetSetting, value: unknown): boolean {
-  return USABLE_AS[setting.type](
-    value,
-    setting.type === "select" ? setting.options : undefined
-  );
+  return USABLE_AS[setting.type](value, limitsOf(setting));
 }
 
 /** The default a setting declares, or `undefined` when it declares none. */
@@ -358,7 +454,18 @@ export function resolveWidgetSettings(
 ): Record<string, unknown> {
   if (!settings || settings.length === 0) return {};
 
-  const resolved: Record<string, unknown> = {};
+  /*
+   * 🔴 A record with NO prototype, because the KEYS are setting names a plugin
+   * chose. On a `{}` dictionary `__proto__` is not data: assigning it invokes
+   * the legacy prototype setter, so a declared setting of that name was
+   * silently dropped from the result and read back as `Object.prototype`. And
+   * a stored config reaches this from `JSON.parse`, which DOES create
+   * `__proto__` as an own property, so the value arrives to be assigned.
+   *
+   * The admin's query-slot map is prototype-free for exactly this reason;
+   * `constructor` and `toString` misbehave the same way without the confusion.
+   */
+  const resolved: Record<string, unknown> = Object.create(null);
   for (const setting of settings) {
     const value = stored?.[setting.name];
     if (value !== undefined && matchesType(setting, value)) {

--- a/packages/nextly/src/domains/widgets/settings.ts
+++ b/packages/nextly/src/domains/widgets/settings.ts
@@ -1,0 +1,294 @@
+/**
+ * What a reader may change about ONE card, and what a stored value means.
+ *
+ * A placement already carries `config`, validated on write and persisted with
+ * the layout. Nothing declared what belonged in it and nothing read it, so a
+ * card looked the same for everyone. This is the declaration and the reading.
+ *
+ * ## Settings are FIELD definitions, not a vocabulary of their own
+ *
+ * A widget declares its settings as the same field configs the rest of the
+ * product uses, so `FieldRenderer` draws them with no adapter and a plugin
+ * author learns nothing new to expose a setting. Directus takes this route for
+ * panel options and it is why its panels all feel alike; WordPress gives every
+ * widget its own settings form, which is why none of its do.
+ *
+ * The union is deliberately NARROW. `FieldConfig` also covers relationships,
+ * rich text, repeaters and field groups — none of them a sensible dashboard
+ * setting, and each dragging real editing UI behind it. A label, a count, a
+ * toggle and a choice cover what a card wants, and widening later is additive
+ * where narrowing would not be.
+ *
+ * ## Shape is checked on WRITE; meaning is decided on READ
+ *
+ * The layout writer already refuses a config that is not a plain object, nests
+ * too deeply, or makes the payload too large, and that stays where it is. The
+ * DECLARATION is applied here instead, when the value is read:
+ *
+ * - a key no setting declares is IGNORED, and kept in storage;
+ * - a declared key that is absent takes the setting's default;
+ * - a value of the wrong type takes the default too.
+ *
+ * 🔴 Rejecting unknown keys at write time would make a saved layout unwritable
+ * the moment a plugin renames a setting or is uninstalled, and plugins version
+ * independently of core — so the strict reading punishes exactly the upgrade it
+ * is supposed to survive. Keeping the unknown key rather than stripping it is
+ * the other half: reinstalling the plugin restores its settings instead of
+ * silently having discarded them.
+ *
+ * @module domains/widgets/settings
+ */
+
+import { NextlyError } from "../../errors/nextly-error";
+
+/** What every setting carries, whatever kind it is. */
+export interface WidgetSettingBase {
+  name: string;
+  label?: string;
+  description?: string;
+}
+
+/**
+ * One thing a reader may change about a card.
+ *
+ * 🔴 Declared STRUCTURALLY rather than as the collections field union, and the
+ * compiler is why. Importing `TextFieldConfig` and its siblings pulls
+ * `collections/fields/types/base` into the type graph of every package that
+ * reads a widget definition — and the admin is one, where that module's own
+ * `@nextly/hooks/types` import does not resolve. `WidgetDefinition` travels
+ * through `nextly/config`, the entry point that exists to keep weight out of a
+ * user's config file, so dragging the field graph behind it is the weight that
+ * entry point refuses by design.
+ *
+ * The shape is still a field config, so `FieldRenderer` draws it with no
+ * adapter. `__tests__/settings.compat.test-d.ts` asserts that each variant is
+ * assignable to `FieldConfig`, inside the package where that import resolves —
+ * so the compatibility this rests on is checked rather than asserted in prose.
+ */
+export type WidgetSetting =
+  | (WidgetSettingBase & { type: "text"; defaultValue?: string })
+  | (WidgetSettingBase & {
+      type: "number";
+      defaultValue?: number;
+      min?: number;
+      max?: number;
+    })
+  | (WidgetSettingBase & { type: "checkbox"; defaultValue?: boolean })
+  | (WidgetSettingBase & {
+      type: "select";
+      defaultValue?: string;
+      options: { label: string; value: string }[];
+    });
+
+/** The field types a widget setting may use. */
+const SETTING_TYPES = new Set(["text", "number", "checkbox", "select"]);
+
+/**
+ * How many settings one widget may declare.
+ *
+ * A ceiling rather than a guess at what is reasonable: the settings travel in
+ * the workspace metadata every admin page load reads, and a definition that
+ * declared hundreds would cost every reader that weight whether or not anyone
+ * opens the settings panel.
+ */
+export const MAX_WIDGET_SETTINGS = 24;
+
+/*
+ * `invalidInput` rather than `validation`, matching the widget definition's own
+ * refusal: this is a developer's declaration rather than a reader's input, so
+ * the message is developer-facing and safe to surface verbatim.
+ */
+function fail(message: string): never {
+  throw NextlyError.invalidInput({
+    message: `Invalid widget settings: ${message}`,
+  });
+}
+
+/**
+ * Refuse a declaration the admin could not draw or the reader could not use.
+ *
+ * 🔴 Refuses at BOOT rather than degrading, which is the opposite of how the
+ * stored value is treated a few lines below, and deliberately so. A malformed
+ * declaration is the author's mistake and they are the one running the boot; a
+ * malformed stored value belongs to a reader who cannot fix it and may not have
+ * caused it. The strictness goes where the feedback lands.
+ */
+export function validateWidgetSettings(
+  settings: unknown,
+  widgetId: string
+): asserts settings is WidgetSetting[] | undefined {
+  if (settings === undefined) return;
+  if (!Array.isArray(settings))
+    fail(`${widgetId}: "settings" must be an array`);
+  if (settings.length > MAX_WIDGET_SETTINGS) {
+    fail(
+      `${widgetId}: at most ${MAX_WIDGET_SETTINGS} settings, got ${settings.length}`
+    );
+  }
+
+  const seen = new Set<string>();
+  for (const setting of settings) {
+    validateOneSetting(setting, widgetId, seen);
+  }
+}
+
+/**
+ * Refuse one setting the admin could not draw or the reader could not use.
+ *
+ * Separate from the collection check because they answer different questions —
+ * whether this declaration is well formed, against whether the SET of them is
+ * (no duplicates, not too many) — and reading them interleaved made both harder
+ * to follow than either is alone.
+ *
+ * `seen` is passed rather than returned because uniqueness is a property of the
+ * set, and the only place that can observe it is the loop.
+ */
+function validateOneSetting(
+  setting: unknown,
+  widgetId: string,
+  seen: Set<string>
+): void {
+  if (typeof setting !== "object" || setting === null) {
+    fail(`${widgetId}: every setting must be an object`);
+  }
+  const { name, type, defaultValue } = setting as {
+    name?: unknown;
+    type?: unknown;
+    defaultValue?: unknown;
+  };
+
+  if (typeof name !== "string" || name === "") {
+    fail(`${widgetId}: every setting needs a non-empty "name"`);
+  }
+  if (seen.has(name)) {
+    // Two settings of one name make the resolved value depend on which was
+    // read last, and the author cannot see which that is.
+    fail(`${widgetId}: duplicate setting "${name}"`);
+  }
+  seen.add(name);
+
+  if (typeof type !== "string" || !SETTING_TYPES.has(type)) {
+    fail(
+      `${widgetId}: setting "${name}" has type ${JSON.stringify(type)}; expected one of ${[...SETTING_TYPES].join(", ")}`
+    );
+  }
+
+  /*
+   * 🔴 A FUNCTION default is refused rather than called. `defaultValue` may be
+   * a thunk on a collection field, where it is evaluated on the server that
+   * holds it — but a widget definition is serialized to the admin through
+   * `/api/admin-meta/workspace`, and a function does not survive JSON. Accepted
+   * here it would simply be absent by the time anything could use it, so the
+   * setting would silently have no default at all. Refusing puts that in front
+   * of the author, who is the only one who can fix it.
+   */
+  if (typeof defaultValue === "function") {
+    fail(
+      `${widgetId}: setting "${name}" has a function default; widget settings cross the wire as JSON, so a default must be a literal`
+    );
+  }
+}
+
+/** Whether a stored value is usable as this setting's type. */
+function matchesType(setting: WidgetSetting, value: unknown): boolean {
+  switch (setting.type) {
+    case "number":
+      return typeof value === "number" && Number.isFinite(value);
+    case "checkbox":
+      return typeof value === "boolean";
+    case "text":
+    case "select":
+      return typeof value === "string";
+  }
+}
+
+/** The default a setting declares, or `undefined` when it declares none. */
+function declaredDefault(setting: WidgetSetting): unknown {
+  const { defaultValue } = setting as { defaultValue?: unknown };
+  return defaultValue;
+}
+
+/**
+ * What this card's settings actually are, for a stored config.
+ *
+ * Returns only DECLARED names, so a caller reading the result cannot
+ * accidentally act on a key the widget never offered. The stored object keeps
+ * its unknown keys; this is a reading of it, not a rewrite.
+ */
+export function resolveWidgetSettings(
+  settings: readonly WidgetSetting[] | undefined,
+  stored: Record<string, unknown> | undefined
+): Record<string, unknown> {
+  if (!settings || settings.length === 0) return {};
+
+  const resolved: Record<string, unknown> = {};
+  for (const setting of settings) {
+    const value = stored?.[setting.name];
+    if (value !== undefined && matchesType(setting, value)) {
+      resolved[setting.name] = value;
+      continue;
+    }
+    // A wrong-typed value takes the default rather than refusing: the reader
+    // did not necessarily write it -- a plugin changing a setting's type across
+    // an upgrade produces exactly this -- and a card that refuses to draw is a
+    // worse answer than one drawn the way its author intended.
+    const fallback = declaredDefault(setting);
+    if (fallback !== undefined) resolved[setting.name] = fallback;
+  }
+  return resolved;
+}
+
+/**
+ * Query knobs a setting may drive, and the setting type each requires.
+ *
+ * 🔴 A closed set, matched by NAME. That is the contract and it is stated
+ * rather than inferred: a setting called `limit` and typed `number` changes how
+ * many rows the card asks for, and nothing else a widget declares touches the
+ * query at all. The alternative — a mapping from each setting to the knob it
+ * feeds — is a small DSL to learn, to document and to validate, for a set that
+ * currently has one member.
+ *
+ * The type is part of the match, so a `text` setting named `limit` drives
+ * nothing rather than putting a string where a row count goes.
+ */
+const QUERY_KNOBS: Record<string, WidgetSetting["type"]> = {
+  limit: "number",
+};
+
+/**
+ * The query this card should ask, given what its reader chose.
+ *
+ * 🔴 Nothing is clamped or re-validated here. `validateReadWidgetQuery` bounds
+ * every query the endpoint accepts — `clampLimit` already turns a hostile or
+ * absurd limit into a legal one — and the caller composing this query is the
+ * admin, whose requests go through exactly that gate. Re-checking here would be
+ * a second implementation of a rule this module cannot see, agreeing on the day
+ * it is written and drifting afterwards, which is the mistake
+ * `executeWidgetQuery` warns about for filters.
+ *
+ * Returns the query UNCHANGED when nothing applies, so a caller can use the
+ * result unconditionally without asking whether it needed to.
+ */
+export function applyWidgetSettings<T extends { limit?: number }>(
+  query: T,
+  settings: readonly WidgetSetting[] | undefined,
+  stored: Record<string, unknown> | undefined
+): T {
+  if (!settings || settings.length === 0) return query;
+
+  const resolved = resolveWidgetSettings(settings, stored);
+  let next = query;
+
+  for (const setting of settings) {
+    if (QUERY_KNOBS[setting.name] !== setting.type) continue;
+    const value = resolved[setting.name];
+    if (value === undefined) continue;
+    // Copied on first write rather than up front: a card whose settings drive
+    // no knob hands back the query it was given, which is what lets a caller
+    // apply this to every card without a branch.
+    if (next === query) next = { ...query };
+    (next as { limit?: number }).limit = value as number;
+  }
+
+  return next;
+}

--- a/packages/nextly/src/index.ts
+++ b/packages/nextly/src/index.ts
@@ -503,6 +503,7 @@ export {
   MAX_WIDGET_LIMIT,
   type WidgetDefinition,
   type WidgetAction,
+  type WidgetSetting,
   type WidgetStatCell,
   type WidgetQuery,
   type WidgetSize,

--- a/packages/nextly/src/plugins/__tests__/channel-divergence.test.ts
+++ b/packages/nextly/src/plugins/__tests__/channel-divergence.test.ts
@@ -452,6 +452,64 @@ const MUST_AGREE: Array<{
       actions: [42],
     },
   },
+  /*
+   * The settings rules. This channel had NO settings check at all, so
+   * `settings: {}` passed the JSON gate, was published, and threw out of
+   * `applyWidgetSettings` while the grid rendered -- the dashboard going down
+   * rather than the one install that declared it. Both validators now read the
+   * same `widgetSettingsProblem`, and these rows are what says so.
+   */
+  {
+    case: "settings that are not an array",
+    expect: /"settings" must be an array/,
+    widget: {
+      id: "acme/thing",
+      title: "T",
+      archetype: "custom",
+      defaultSize: "sm",
+      component: "p#X",
+      settings: {},
+    },
+  },
+  {
+    case: "a setting default that is not a value of its type",
+    expect: /defaults to/,
+    widget: {
+      id: "acme/thing",
+      title: "T",
+      archetype: "custom",
+      defaultSize: "sm",
+      component: "p#X",
+      settings: [{ name: "limit", type: "number", defaultValue: "ten" }],
+    },
+  },
+  {
+    case: "a select setting that offers no options",
+    expect: /needs a non-empty "options"/,
+    widget: {
+      id: "acme/thing",
+      title: "T",
+      archetype: "custom",
+      defaultSize: "sm",
+      component: "p#X",
+      settings: [{ name: "mode", type: "select" }],
+    },
+  },
+  {
+    case: "two settings of one name",
+    expect: /duplicate setting/,
+    widget: {
+      id: "acme/thing",
+      title: "T",
+      archetype: "custom",
+      defaultSize: "sm",
+      component: "p#X",
+      settings: [
+        { name: "limit", type: "number" },
+        { name: "limit", type: "text" },
+      ],
+    },
+  },
   {
     case: "a chrome that is not a string",
     expect: /chrome, when given, must be a string/,

--- a/packages/nextly/src/plugins/admin-contributions.ts
+++ b/packages/nextly/src/plugins/admin-contributions.ts
@@ -7,6 +7,7 @@ import type {
   QuerylessWidgetArchetype,
   WidgetArchetype,
   WidgetQuery,
+  WidgetSetting,
   WidgetSize,
 } from "../domains/widgets";
 
@@ -229,6 +230,16 @@ interface PluginAdminWidgetBase {
    * resolver's channel ordering happened to leave it.
    */
   defaultOrder?: number;
+  /**
+   * What a reader may change about this card, drawn by the settings panel.
+   *
+   * On the BASE for the same reason `defaultOrder` is: any widget may offer
+   * settings, whatever draws its body. Declaring it only on the archetypes core
+   * draws would leave a plugin shipping its own component unable to expose one
+   * through the supported surface — while `validatedAdminWidgets` published the
+   * field anyway, so the contract would be narrower than the channel.
+   */
+  settings?: WidgetSetting[];
 }
 
 /**

--- a/packages/nextly/src/plugins/validate-admin-widgets.ts
+++ b/packages/nextly/src/plugins/validate-admin-widgets.ts
@@ -31,6 +31,7 @@ import {
   widgetValueProblem,
   WIDGET_ARCHETYPES,
 } from "../domains/widgets/definition";
+import { widgetSettingsProblem } from "../domains/widgets/settings";
 import { getNextlyLogger } from "../observability/logger";
 
 import type { PluginAdminWidget } from "./admin-contributions";
@@ -316,6 +317,14 @@ const FIELD_RULES: ReadonlyArray<
   // as equal to whatever it was measured against and the explicit orders around
   // it quietly stopped holding.
   widget => defaultOrderProblem(widget.defaultOrder),
+
+  // Through the SAME rule the registry applies, and it is the rule ITSELF
+  // rather than a second spelling of it. This channel had no settings check at
+  // all, so `settings: {}` from an untyped declaration passed the JSON gate,
+  // travelled to the admin, and threw out of `applyWidgetSettings` while the
+  // grid was rendering -- taking the whole dashboard down rather than the one
+  // install that declared it.
+  widget => widgetSettingsProblem(widget.settings),
 
   // Through the SAME rule the registry applies. Without it a contributed
   // `{ archetype: "metric", chrome: "none" }` passed boot while the registry

--- a/packages/plugin-sdk/src/__snapshots__/plugin-surface.test.ts.snap
+++ b/packages/plugin-sdk/src/__snapshots__/plugin-surface.test.ts.snap
@@ -294,6 +294,7 @@ exports[`plugin-sdk public export surface > \`.\` (index) surface is unchanged 1
   "WidgetHeight (type)",
   "WidgetOp (type)",
   "WidgetQuery (type)",
+  "WidgetSetting (type)",
   "WidgetSize (type)",
   "WidgetSource (type)",
   "WidgetSourceField (type)",

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -464,6 +464,7 @@ export {
   registerSource,
   type WidgetDefinition,
   type WidgetAction,
+  type WidgetSetting,
   type WidgetQuery,
   type WidgetSize,
   type WidgetChrome,


### PR DESCRIPTION
**First of two.** This is the contract and the delivery; the settings sheet follows in its own PR. See the bottom for why they are separate.

## What was there

`WidgetPlacement.config` was validated on write, persisted with the layout, and **read by nothing** — the only two references in the tree were its validator and its serializer. So the storage that would let a card differ per reader was already built and tested, and every dashboard looked the same anyway.

## What this adds

A widget declares `settings`, and a reader's stored answers reach the query its card asks.

## Settings are field definitions

The Directus shape rather than the WordPress one: a Directus panel declares its options in the product's own field vocabulary and gets a familiar form for free, where a WordPress widget renders its own settings form and no two look alike. `FieldRenderer` already dispatches a field config to an input, so a plugin author learns no new vocabulary and the admin writes no form code.

**Declared structurally rather than as the collections field union — because the compiler refused the alternative.** Importing `TextFieldConfig` and its siblings drags `collections/fields/types/base` into the type graph of every package that reads a widget definition, and the admin is one, where that module's own imports do not resolve. `WidgetDefinition` travels through `nextly/config`, the entry point that exists to keep weight out of a user's config file.

`__tests__/settings.compat.test-d.ts` pins that compatibility from inside the package where the field types *do* resolve, with a positive control so a variant collapsing to `never` cannot pass silently.

The union is narrow on purpose. `FieldConfig` also covers relationships, rich text, repeaters and field groups — none a sensible dashboard setting, each dragging real editing UI. A label, a count, a toggle and a choice cover what a card wants, and widening later is additive where narrowing would not be.

## Shape on write, meaning on read

The layout writer already refuses a config that is not a plain object, nests too deeply, or makes the payload too large. That stays. The **declaration** is applied when the value is read:

- a key no setting declares is **ignored, and kept**;
- a declared key that is absent takes its default;
- a wrongly-typed value takes its default too.

Rejecting unknown keys at write time would make a saved layout unwritable the moment a plugin renames a setting or is uninstalled — and plugins version independently of core, so the strict reading punishes exactly the upgrade it is meant to survive. Keeping the key rather than stripping it means reinstalling the plugin restores its settings.

**A function default is refused at declaration.** `defaultValue` may be a thunk on a collection field, evaluated by the server that holds it; a widget definition is serialized to the admin as JSON, where a function disappears — so the setting would silently have no default at all.

## Which settings drive the query

A closed set, matched by name **and** type. `limit` typed `number` sets the row count; a `text` setting of that name drives nothing rather than putting a string where a count goes. Stated rather than inferred, because the alternative is a mapping DSL to learn, document and validate for a set that currently has one member.

**Nothing is clamped here.** `clampLimit` already bounds every query the endpoint accepts, and re-checking would be a second implementation of a rule this module cannot see — the mistake `executeWidgetQuery` warns about for filters.

Applied in `WidgetGrid`, the last place a card and the placement that put it there are both in scope: the batch takes widgets, and a widget does not know which placement it is drawn for, since the same widget can sit on a dashboard twice with different settings.

## Evidence

Each break is a wrong implementation, caught by its own named test:

| break | caught by |
| --- | --- |
| duplicate setting names allowed | `refuses a duplicate name` |
| function defaults accepted | `refuses a function default, which could not cross the wire` |
| wrong-typed stored value trusted | `falls back to the default...` + `rejects a non-finite number` |
| knob matched on name only | `ignores a setting whose name matches but whose type does not` |
| mutate the caller's query | `does not mutate the query it was given` |
| setting incompatible with `FieldConfig` | the compat type test, on all four variants |

Every break was re-run after the `validateOneSetting` extraction; the count assertion caught one that no longer applied at its old indentation rather than reporting a false green.

`pnpm check-types` clean, 364 widget tests in core, 314 in admin, lint clean, fallow `pass` with 0 introduced findings.

## Why the UI is separate

The interface between the halves is real: this one declares, resolves and applies; the sheet edits `WidgetPlacement.config`. Splitting on that boundary is the discipline that took the migration work from eight review rounds bundled to zero findings apart.

This half is reachable and testable on its own — a config stored through the layout API changes what a card asks today.

## Known limit

A stored setting drives the query only for the `limit` knob. `status` and `sort` are the obvious next members of that set and are deliberately not added until something needs them, since each is a decision about what a reader may change rather than a mechanical addition.