### PR TITLE
docs(nextly): separate the two access layers a missing user acts on

### DIFF
--- a/packages/nextly/AGENTS.md
+++ b/packages/nextly/AGENTS.md
@@ -20,10 +20,17 @@ inside `packages/nextly`.
 
 - Direct API lists return `{ items, meta }`; mutations return a result with
   `.item`. There is no `docs`/`totalDocs` shape anywhere.
-- `overrideAccess` defaults to `true` (trusted server context). Enforcing
-  COLLECTION and DOCUMENT access requires `overrideAccess: false` plus a
-  `user` — a stored owner rule has nobody to compare against otherwise, so it
-  is skipped rather than failed.
+- `overrideAccess` defaults to `true` (trusted server context) and returns
+  before any check. Under `overrideAccess: false` there are TWO layers and a
+  missing `user` does opposite things to them. The coarse RBAC permission gate
+  needs a user to have permissions, so without one it does not run. The STORED
+  rules run either way, and an `owner-only` rule with no user is DENIED
+  (`Authentication required`), not skipped. So an anonymous caller is refused
+  by the rule rather than waved past the gate.
+- A collection with NO rule for an operation is public: `evaluateAccess`
+  returns `allowed: true` when `rules?.[operation]` is absent. Two exceptions
+  fail closed instead — `publish`/`unpublish` with no user and no explicit
+  rule, and `routeAuthorized` with no user.
 - FIELD-level rules are different: they run whenever `overrideAccess` is
   false, user or not. "Which fields may this writer set" has a perfectly good
   answer for nobody, and treating absence of a user as trust let an anonymous

--- a/packages/nextly/src/domains/collections/services/collection-access-anonymous.test.ts
+++ b/packages/nextly/src/domains/collections/services/collection-access-anonymous.test.ts
@@ -1,0 +1,97 @@
+/**
+ * What a request with no user meets on the way through, at both layers.
+ *
+ * The coarse RBAC gate needs a user in order to have permissions to check, so
+ * it does not run for an anonymous caller. The stored rules run regardless, and
+ * that is where the caller is refused: an `owner-only` rule has nobody to
+ * compare against and denies. Skipping the gate is therefore not a way past the
+ * rules, and the two must not be confused for each other.
+ *
+ * Driven through `checkCollectionAccess` with the real leaf evaluator, because
+ * this is a claim about how the layers combine. Calling the evaluator directly
+ * proves only the leaf, and would stay green if this service ever stopped
+ * running the stored rules when a user is absent.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+import { AccessControlService } from "../../../services/access/access-control-service";
+
+import { CollectionAccessService } from "./collection-access-service";
+
+import {
+  createMockDb,
+  createMockAdapter,
+  silentLogger,
+  createMockCollection,
+  createMockCollectionService,
+} from "../__tests__/collection-test-helpers";
+
+function buildService(accessRules: Record<string, unknown>) {
+  // Spied rather than stubbed away: "was this consulted" is half of what these
+  // tests assert.
+  const rbac = {
+    checkAccess: vi.fn().mockResolvedValue(true),
+    getRegisteredAccess: vi.fn().mockReturnValue(undefined),
+  };
+  const service = new CollectionAccessService(
+    createMockAdapter(createMockDb({ rows: [] })) as never,
+    silentLogger as never,
+    createMockCollectionService(
+      createMockCollection({ accessRules }) as never
+    ) as never,
+    // The real one. A stub here would decide the outcome this test is about.
+    new AccessControlService() as never,
+    rbac as never
+  );
+  return { service, rbac };
+}
+
+describe("checkCollectionAccess with no user", () => {
+  it("denies an owner-only write through the stored rule", async () => {
+    const { service, rbac } = buildService({ update: { type: "owner-only" } });
+
+    const result = await service.checkCollectionAccess(
+      "posts",
+      "update",
+      undefined
+    );
+
+    expect(result?.success).toBe(false);
+    expect(result?.statusCode).toBe(403);
+    // The gate was never asked, and the refusal still happened. This is the
+    // pairing: what a missing user skips is the permission check, not the rule.
+    expect(rbac.checkAccess).not.toHaveBeenCalled();
+  });
+
+  it("allows an operation the collection states no rule for", async () => {
+    // The positive control, and the surprising half: absent means public. A
+    // service that denied every anonymous request would pass the case above
+    // while being wrong about this one.
+    const { service, rbac } = buildService({ read: { type: "owner-only" } });
+
+    const result = await service.checkCollectionAccess(
+      "posts",
+      "update",
+      undefined
+    );
+
+    expect(result).toBeNull();
+    expect(rbac.checkAccess).not.toHaveBeenCalled();
+  });
+
+  it("refuses publish with no user and no rule for it", async () => {
+    // The exception to that default, decided in this service rather than the
+    // leaf: publishing anonymously needs a rule that says so.
+    const { service } = buildService({ read: { type: "public" } });
+
+    const result = await service.checkCollectionAccess(
+      "posts",
+      "publish",
+      undefined
+    );
+
+    expect(result?.success).toBe(false);
+    expect(result?.statusCode).toBe(403);
+  });
+});

--- a/packages/nextly/src/services/access/access-control-service.test.ts
+++ b/packages/nextly/src/services/access/access-control-service.test.ts
@@ -57,16 +57,13 @@ describe("AccessControlService role-based access (OR-membership)", () => {
 });
 
 describe("AccessControlService without a user", () => {
-  // `packages/nextly/AGENTS.md` states these two outcomes as the thing agents get
-  // wrong about enforcement, so they are pinned here: the doc said an owner rule
-  // with no user was skipped, and the service denies it. A claim in that file is
-  // read before any work happens, so it is worth a test rather than a reading.
   const service = new AccessControlService();
 
-  it("DENIES an owner-only rule rather than skipping it", async () => {
+  it("denies an owner-only rule rather than skipping it", async () => {
     // Nobody to compare an owner against is a refusal, not an absence of
     // opinion. What a missing user skips is the coarse RBAC gate, one layer up,
-    // which needs a user in order to have permissions to check.
+    // which needs a user in order to have permissions to check; the pairing is
+    // exercised end to end in `collection-access-anonymous.test.ts`.
     const result = await service.evaluateAccess(
       { update: { type: "owner-only" } } as CollectionAccessRules,
       "update",
@@ -78,8 +75,8 @@ describe("AccessControlService without a user", () => {
 
   it("allows an operation that has no rule at all", async () => {
     // The other half, and the one that surprises: absent means public here.
-    // `collection-access-service.ts` is what fails publish and unpublish closed
-    // on top of this, so the default is not the whole answer for those.
+    // `collection-access-service.ts` fails publish and unpublish closed on top
+    // of this, so the default is not the whole answer for those.
     const result = await service.evaluateAccess(
       { read: { type: "owner-only" } } as CollectionAccessRules,
       "update",

--- a/packages/nextly/src/services/access/access-control-service.test.ts
+++ b/packages/nextly/src/services/access/access-control-service.test.ts
@@ -56,6 +56,39 @@ describe("AccessControlService role-based access (OR-membership)", () => {
   });
 });
 
+describe("AccessControlService without a user", () => {
+  // `packages/nextly/AGENTS.md` states these two outcomes as the thing agents get
+  // wrong about enforcement, so they are pinned here: the doc said an owner rule
+  // with no user was skipped, and the service denies it. A claim in that file is
+  // read before any work happens, so it is worth a test rather than a reading.
+  const service = new AccessControlService();
+
+  it("DENIES an owner-only rule rather than skipping it", async () => {
+    // Nobody to compare an owner against is a refusal, not an absence of
+    // opinion. What a missing user skips is the coarse RBAC gate, one layer up,
+    // which needs a user in order to have permissions to check.
+    const result = await service.evaluateAccess(
+      { update: { type: "owner-only" } } as CollectionAccessRules,
+      "update",
+      { user: undefined } as RequestContext
+    );
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe("Authentication required");
+  });
+
+  it("allows an operation that has no rule at all", async () => {
+    // The other half, and the one that surprises: absent means public here.
+    // `collection-access-service.ts` is what fails publish and unpublish closed
+    // on top of this, so the default is not the whole answer for those.
+    const result = await service.evaluateAccess(
+      { read: { type: "owner-only" } } as CollectionAccessRules,
+      "update",
+      { user: undefined } as RequestContext
+    );
+    expect(result.allowed).toBe(true);
+  });
+});
+
 describe("AccessControlService owner-only default field", () => {
   const service = new AccessControlService();
 


### PR DESCRIPTION
`packages/nextly/AGENTS.md` said that enforcing collection and document access needs `overrideAccess: false` plus a `user`, because *"a stored owner rule has nobody to compare against otherwise, so it is skipped rather than failed."*

Executed against the real service, an `owner-only` rule with no user returns:

```
{ "allowed": false, "reason": "Authentication required" }
```

It is **denied**, not skipped.

## Both behaviours are real, at different layers

The sentence attributed the skip to the layer that denies.

- The coarse **RBAC gate** in `collection-access-service.ts` needs a user in order to have permissions to check. Every branch is guarded on `user`, so without one it does not run. *This* is what a missing user skips.
- The **stored rules** run either way, and that is where an anonymous caller is refused.

So an anonymous caller is stopped by the rule rather than waved past the gate, which is the opposite of what a reader would conclude. This is the first file an agent session reads, so a wrong claim here is read as true and acted on.

## The rule-less default, added

It is the other half of the same question and it surprises: a collection with **no rule** for an operation is public, since `evaluateAccess` returns `allowed: true` when `rules?.[operation]` is absent. Two cases fail closed on top of that, both in `collection-access-service.ts`: `publish`/`unpublish` with no user and no explicit rule, and `routeAuthorized` with no user.

## Verification

Both clauses are pinned by tests rather than left as prose, because I established them by running the service rather than reading it. `AccessControlService without a user` covers the denial and the rule-less default; 15 tests pass in that file.

One limit worth stating plainly: these pin the **code**. If the behaviour changes they fail. Nothing stops the doc from drifting again on its own, and matching for phrases like "skipped rather than failed" would be the brittle kind of guard that has produced several false positives on #1566. Making AGENTS.md claims machine-checkable in general needs each load-bearing claim to carry a named test and a guard that fails when one has none, which is a design change rather than part of this fix.