### PR TITLE
feat(nextly): wire advisory document locking, service and route

### DIFF
--- a/.changeset/document-locking-can-be-reached.md
+++ b/.changeset/document-locking-can-be-reached.md
@@ -1,0 +1,42 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Document locking shipped as three unused tables. The engine was complete —
+claim, renew, release and sweep across every dialect, with a heartbeat derived
+from the lease clock and a claim token so a renew proves it is the same claim —
+and nothing could reach it, because no service bound the adapter its functions
+take and no registration constructed one.
+
+`documentLockService` is registered now. It is advisory and says so: a held
+document is reported to whoever asks and no write is refused, so a claim left
+behind by a closed laptop cannot strand content. The claim token means
+enforcement stays available later without redesigning the shape.
+
+Locks run on the pool rather than a caller's transaction. A claim taken inside
+a write that later rolls back would vanish with it, and the point of a claim is
+that it outlives the request that took it.

--- a/packages/nextly/src/api/__tests__/document-lock-route.test.ts
+++ b/packages/nextly/src/api/__tests__/document-lock-route.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const service = {
+  read: vi.fn(),
+  acquire: vi.fn(),
+  renew: vi.fn(),
+  release: vi.fn(),
+};
+const auth = { userId: "u1", userName: "Ada", userEmail: "ada@example.com" };
+const requireAuthentication = vi.fn();
+
+vi.mock("../../init", () => ({
+  getCachedNextly: vi.fn().mockResolvedValue({}),
+}));
+vi.mock("../../di/container", () => ({ container: { get: () => service } }));
+vi.mock("../../auth/middleware", () => ({
+  requireAuthentication: (req: Request) => requireAuthentication(req),
+  isErrorResponse: (value: unknown) => value instanceof Response,
+}));
+
+const { readLock, acquireLock, renewLock, releaseLock } = await import(
+  "../document-lock"
+);
+
+const ref = { scopeKind: "collection", slug: "posts", entryId: "42" };
+const post = (body: unknown, method = "POST") =>
+  new Request("https://x.test/api/document-lock", {
+    method,
+    body: JSON.stringify(body),
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireAuthentication.mockResolvedValue(auth);
+});
+
+describe("document lock route", () => {
+  it("takes the claimant from the session, never from the body", async () => {
+    // A caller that could name its own owner id would claim a document as a
+    // colleague, and the name the next editor is shown would be evidence of
+    // something that did not happen.
+    service.acquire.mockResolvedValue({ status: "acquired", claimToken: "t" });
+
+    await acquireLock(
+      post({ ...ref, ownerId: "someone-else", ownerLabel: "Bob" })
+    );
+
+    expect(service.acquire).toHaveBeenCalledWith(
+      ref,
+      { ownerId: "u1", ownerLabel: "Ada" },
+      { takeover: false }
+    );
+  });
+
+  it("forwards takeover only when it is actually asked for", async () => {
+    service.acquire.mockResolvedValue({ status: "acquired", claimToken: "t" });
+
+    await acquireLock(post({ ...ref, takeover: true }));
+    expect(service.acquire).toHaveBeenLastCalledWith(ref, expect.anything(), {
+      takeover: true,
+    });
+
+    // Anything other than the boolean is not a request to displace a colleague.
+    await acquireLock(post({ ...ref, takeover: "yes" }));
+    expect(service.acquire).toHaveBeenLastCalledWith(ref, expect.anything(), {
+      takeover: false,
+    });
+  });
+
+  it("reports a held document rather than refusing", async () => {
+    // Advisory: the second editor is told and not stopped.
+    service.acquire.mockResolvedValue({
+      status: "held",
+      holder: { ownerId: "u2", ownerLabel: "Bob", expiresInSeconds: 90 },
+    });
+
+    const response = await acquireLock(post(ref));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ status: "held" });
+  });
+
+  it("answers an unheld document with an explicit null", async () => {
+    // Not an omitted key: "nobody holds this" is the answer, and a missing
+    // field reads as a response that failed to say.
+    service.read.mockResolvedValue(undefined);
+
+    const response = await readLock(
+      new Request(
+        "https://x.test/api/document-lock?scopeKind=collection&slug=posts&entryId=42"
+      )
+    );
+
+    expect(await response.json()).toEqual({ holder: null });
+  });
+
+  it("refuses a reference the repository could not key", async () => {
+    // Validated through the same function that keys the row, so a reference
+    // this accepted but the repository could not address is impossible.
+    for (const bad of [
+      { ...ref, slug: "" },
+      { ...ref, slug: "with:colon" },
+      { ...ref, scopeKind: "component" },
+      { ...ref, entryId: "x".repeat(300) },
+    ]) {
+      const response = await acquireLock(post(bad));
+      expect(response.status).toBe(400);
+    }
+    expect(service.acquire).not.toHaveBeenCalled();
+  });
+
+  it("requires a claim token to renew or release", async () => {
+    // Proving it is the same claim, not merely the same person: a second tab
+    // belonging to one editor must not extend the first tab's claim.
+    expect((await renewLock(post(ref, "PATCH"))).status).toBe(400);
+    expect((await releaseLock(post(ref, "DELETE"))).status).toBe(400);
+    expect(service.renew).not.toHaveBeenCalled();
+    expect(service.release).not.toHaveBeenCalled();
+  });
+
+  it("refuses every operation without a session", async () => {
+    requireAuthentication.mockResolvedValue(
+      new Response(null, { status: 401 })
+    );
+
+    for (const call of [
+      () => readLock(new Request("https://x.test/api/document-lock")),
+      () => acquireLock(post(ref)),
+      () => renewLock(post({ ...ref, claimToken: "t" }, "PATCH")),
+      () => releaseLock(post({ ...ref, claimToken: "t" }, "DELETE")),
+    ]) {
+      const response = await call();
+      expect(response.status).toBeGreaterThanOrEqual(400);
+    }
+    expect(service.read).not.toHaveBeenCalled();
+    expect(service.acquire).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nextly/src/api/__tests__/document-lock-route.test.ts
+++ b/packages/nextly/src/api/__tests__/document-lock-route.test.ts
@@ -15,7 +15,30 @@ vi.mock("../../init", () => ({
 vi.mock("../../di/container", () => ({ container: { get: () => service } }));
 vi.mock("../../auth/middleware", () => ({
   requireAuthentication: (req: Request) => requireAuthentication(req),
-  isErrorResponse: (value: unknown) => value instanceof Response,
+  // The real predicate, not a stand-in. It keys on `statusCode`, and a mock
+  // recognising a `Response` instead sends the fixture down the wrong branch:
+  // `toNextlyAuthError` sees no status, produces a 500, and a loose `>= 400`
+  // assertion calls that a pass.
+  isErrorResponse: (value: unknown) =>
+    typeof value === "object" && value !== null && "statusCode" in value,
+}));
+
+// Every operation is authorized against the document it names.
+const canReadEntity = vi.fn();
+const callerHoldsPermission = vi.fn();
+vi.mock("../../auth/entity-read-access", () => ({
+  readAccessCaller: (caller: unknown) => caller,
+  canReadEntity: (slug: string, caller: unknown) =>
+    canReadEntity(slug, caller) as unknown,
+  callerHoldsPermission: (slug: string, caller: unknown) =>
+    callerHoldsPermission(slug, caller) as unknown,
+}));
+vi.mock("../authenticated-read", () => ({
+  readCaller: (auth: unknown) => Promise.resolve(auth),
+  PRIVATE_NO_STORE_HEADERS: {
+    "Cache-Control": "private, no-store",
+    Vary: "Cookie",
+  },
 }));
 
 const { readLock, acquireLock, renewLock, releaseLock } = await import(
@@ -32,6 +55,8 @@ const post = (body: unknown, method = "POST") =>
 beforeEach(() => {
   vi.clearAllMocks();
   requireAuthentication.mockResolvedValue(auth);
+  canReadEntity.mockResolvedValue(true);
+  callerHoldsPermission.mockResolvedValue(true);
 });
 
 describe("document lock route", () => {
@@ -77,7 +102,9 @@ describe("document lock route", () => {
     const response = await acquireLock(post(ref));
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toMatchObject({ status: "held" });
+    // In the canonical envelope: "held" is an answer about the document, not a
+    // failure of the request, so it is the item rather than an error.
+    expect(await response.json()).toMatchObject({ item: { status: "held" } });
   });
 
   it("answers an unheld document with an explicit null", async () => {
@@ -118,10 +145,17 @@ describe("document lock route", () => {
     expect(service.release).not.toHaveBeenCalled();
   });
 
-  it("refuses every operation without a session", async () => {
-    requireAuthentication.mockResolvedValue(
-      new Response(null, { status: 401 })
-    );
+  it("answers 401, not 500, without a session", async () => {
+    // The middleware reports a failure as this object, not a Response.
+    // Asserting the exact status is what separates a refusal from a crash: a
+    // fixture of the wrong shape produces an internal error, and a loose
+    // `>= 400` calls that a pass.
+    requireAuthentication.mockResolvedValue({
+      statusCode: 401,
+      error: "Unauthorized",
+      message: "Authentication required",
+      data: null,
+    });
 
     for (const call of [
       () => readLock(new Request("https://x.test/api/document-lock")),
@@ -129,10 +163,84 @@ describe("document lock route", () => {
       () => renewLock(post({ ...ref, claimToken: "t" }, "PATCH")),
       () => releaseLock(post({ ...ref, claimToken: "t" }, "DELETE")),
     ]) {
-      const response = await call();
-      expect(response.status).toBeGreaterThanOrEqual(400);
+      expect((await call()).status).toBe(401);
     }
     expect(service.read).not.toHaveBeenCalled();
     expect(service.acquire).not.toHaveBeenCalled();
+  });
+
+  it("refuses a document the caller cannot read", async () => {
+    // Authentication is not authorization. This route is direct-dispatched, so
+    // it never reaches the central path, and without its own gate any signed-in
+    // account could read who is editing a collection it cannot open.
+    canReadEntity.mockResolvedValue(false);
+
+    const response = await readLock(
+      new Request(
+        "https://x.test/api/document-lock?scopeKind=collection&slug=posts&entryId=42"
+      )
+    );
+
+    expect(response.status).toBe(403);
+    expect(service.read).not.toHaveBeenCalled();
+  });
+
+  it("requires UPDATE to claim, renew or release, not merely read", async () => {
+    // A lock is a statement that you are editing. Someone who may read a
+    // document but not change it is not editing it, and must not be able to
+    // displace a colleague with `takeover`.
+    callerHoldsPermission.mockResolvedValue(false);
+
+    for (const call of [
+      () => acquireLock(post({ ...ref, takeover: true })),
+      () => renewLock(post({ ...ref, claimToken: "t" }, "PATCH")),
+      () => releaseLock(post({ ...ref, claimToken: "t" }, "DELETE")),
+    ]) {
+      expect((await call()).status).toBe(403);
+    }
+    expect(service.acquire).not.toHaveBeenCalled();
+    expect(service.renew).not.toHaveBeenCalled();
+    expect(service.release).not.toHaveBeenCalled();
+  });
+
+  it("asks about the document it was given, not a fixed one", async () => {
+    // A gate that always asked about the same slug would pass every case above
+    // while authorizing the wrong thing.
+    service.acquire.mockResolvedValue({ status: "acquired", claimToken: "t" });
+
+    await acquireLock(post({ ...ref, slug: "invoices" }));
+
+    expect(callerHoldsPermission).toHaveBeenCalledWith(
+      "update-invoices",
+      expect.anything()
+    );
+  });
+
+  it("keeps a lock read out of every cache", async () => {
+    // Shaped by who asked, and it names a colleague and what they are doing.
+    service.read.mockResolvedValue(undefined);
+
+    const response = await readLock(
+      new Request(
+        "https://x.test/api/document-lock?scopeKind=collection&slug=posts&entryId=42"
+      )
+    );
+
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(response.headers.get("Vary")).toBe("Cookie");
+  });
+
+  it("returns mutations in the canonical envelope", async () => {
+    // `{ message, item }`, so a client reads these with the same handling as
+    // every other write rather than a shape invented here.
+    service.acquire.mockResolvedValue({ status: "acquired", claimToken: "t" });
+
+    const body = (await (await acquireLock(post(ref))).json()) as Record<
+      string,
+      unknown
+    >;
+
+    expect(body).toHaveProperty("message");
+    expect(body.item).toMatchObject({ status: "acquired" });
   });
 });

--- a/packages/nextly/src/api/document-lock.ts
+++ b/packages/nextly/src/api/document-lock.ts
@@ -14,7 +14,16 @@
  * @module api/document-lock
  */
 
-import { isErrorResponse, requireAuthentication } from "../auth/middleware";
+import {
+  callerHoldsPermission,
+  canReadEntity,
+  readAccessCaller,
+} from "../auth/entity-read-access";
+import {
+  isErrorResponse,
+  requireAuthentication,
+  type AuthContext,
+} from "../auth/middleware";
 import { toNextlyAuthError } from "../auth/middleware/to-nextly-error";
 import { container } from "../di/container";
 import {
@@ -26,7 +35,8 @@ import {
 import { NextlyError } from "../errors/nextly-error";
 import { getCachedNextly } from "../init";
 
-import { respondData } from "./response-shapes";
+import { PRIVATE_NO_STORE_HEADERS, readCaller } from "./authenticated-read";
+import { respondData, respondMutation } from "./response-shapes";
 import { withErrorHandler } from "./with-error-handler";
 
 async function getDocumentLockService(): Promise<DocumentLockService> {
@@ -69,6 +79,45 @@ function readRef(source: {
     });
   }
   return { scopeKind: scopeKind as DocumentScopeKind, slug, entryId };
+}
+
+/**
+ * Whether this caller may see, or take, a claim on this document.
+ *
+ * Authentication is not enough. This route is direct-dispatched, so it never
+ * reaches the central authorization path, and without this any signed-in
+ * account or scoped API key could read who is editing a document it cannot
+ * open, claim rows it has no business in, or use `takeover` to displace a
+ * colleague's claim on a collection it was never granted.
+ *
+ * Reading a lock needs READ on the document, because the holder's name and the
+ * fact that they are editing it are both facts about a document. Claiming,
+ * renewing and releasing need UPDATE, because a lock is a statement that you
+ * are editing, and someone who cannot edit is not.
+ *
+ * Both helpers are entity-generic and read the collection and single maps
+ * alike, so a Single needs no branch here, and both delegate to the canonical
+ * machinery rather than reproducing the API-key and super-admin rules that
+ * `canReadEntity` documents at length.
+ */
+async function authorize(
+  auth: AuthContext,
+  ref: DocumentRef,
+  intent: "read" | "write"
+): Promise<void> {
+  const caller = readAccessCaller(await readCaller(auth));
+  const allowed =
+    intent === "read"
+      ? await canReadEntity(ref.slug, caller)
+      : await callerHoldsPermission(`update-${ref.slug}`, caller);
+
+  if (!allowed) {
+    // The same refusal either way. Distinguishing "no such document" from "not
+    // yours" would answer whether a slug exists to someone with no access to it.
+    throw NextlyError.forbidden({
+      logContext: { slug: ref.slug, scopeKind: ref.scopeKind, intent },
+    });
+  }
 }
 
 /** The claim token a renew or release must present. */
@@ -127,10 +176,17 @@ export const readLock = withErrorHandler(async (req: Request) => {
     entryId: url.searchParams.get("entryId") ?? undefined,
   });
 
+  await authorize(auth, ref, "read");
+
   const holder = await (await getDocumentLockService()).read(ref);
   // `null` rather than an omitted key: "nobody holds this" is the answer, and a
   // missing field reads as a response that failed to say.
-  return respondData({ holder: holder ?? null });
+  // Shaped by WHO asked, and it names a colleague and what they are doing, so
+  // it must not sit in a shared cache or be replayed to the next session.
+  return respondData(
+    { holder: holder ?? null },
+    { headers: PRIVATE_NO_STORE_HEADERS }
+  );
 });
 
 /**
@@ -147,6 +203,8 @@ export const acquireLock = withErrorHandler(async (req: Request) => {
 
   const body = await readBody(req);
   const ref = readRef(body);
+  await authorize(auth, ref, "write");
+
   const outcome = await (
     await getDocumentLockService()
   ).acquire(
@@ -158,7 +216,15 @@ export const acquireLock = withErrorHandler(async (req: Request) => {
     { takeover: body.takeover === true }
   );
 
-  return respondData({ ...outcome });
+  // The canonical mutation envelope, so a client reads this with the same
+  // handling as every other write. The outcome IS the item: "held" is an
+  // answer about the document, not a failure of the request.
+  return respondMutation(
+    outcome.status === "acquired"
+      ? "Document claimed."
+      : "Document is being edited by someone else.",
+    outcome
+  );
 });
 
 /** Extend a claim this caller still believes it holds. */
@@ -167,11 +233,17 @@ export const renewLock = withErrorHandler(async (req: Request) => {
   if (isErrorResponse(auth)) throw toNextlyAuthError(auth);
 
   const body = await readBody(req);
+  const ref = readRef(body);
+  await authorize(auth, ref, "write");
+
   const outcome = await (
     await getDocumentLockService()
-  ).renew(readRef(body), readClaimToken(body));
+  ).renew(ref, readClaimToken(body));
 
-  return respondData({ ...outcome });
+  return respondMutation(
+    outcome.status === "renewed" ? "Claim extended." : "Claim lost.",
+    outcome
+  );
 });
 
 /** Give up a claim. Releasing one already lost is not an error. */
@@ -180,9 +252,10 @@ export const releaseLock = withErrorHandler(async (req: Request) => {
   if (isErrorResponse(auth)) throw toNextlyAuthError(auth);
 
   const body = await readBody(req);
-  await (
-    await getDocumentLockService()
-  ).release(readRef(body), readClaimToken(body));
+  const ref = readRef(body);
+  await authorize(auth, ref, "write");
 
-  return respondData({ released: true });
+  await (await getDocumentLockService()).release(ref, readClaimToken(body));
+
+  return respondMutation("Claim released.", { released: true });
 });

--- a/packages/nextly/src/api/document-lock.ts
+++ b/packages/nextly/src/api/document-lock.ts
@@ -1,0 +1,188 @@
+/**
+ * Advisory document locking over HTTP.
+ *
+ * Four operations on one document: read who holds it, claim it, extend a claim,
+ * give it up. Advisory throughout — a held document is reported and no write is
+ * refused anywhere, so a claim left behind by a closed laptop costs a second
+ * editor a dialog rather than access.
+ *
+ * The claimant is taken from the SESSION, never from the body. A caller that
+ * could name its own owner id could claim a document as a colleague, and the
+ * label shown to the next editor would be evidence of something that did not
+ * happen.
+ *
+ * @module api/document-lock
+ */
+
+import { isErrorResponse, requireAuthentication } from "../auth/middleware";
+import { toNextlyAuthError } from "../auth/middleware/to-nextly-error";
+import { container } from "../di/container";
+import {
+  documentLockKey,
+  type DocumentLockService,
+  type DocumentRef,
+  type DocumentScopeKind,
+} from "../domains/document-lock";
+import { NextlyError } from "../errors/nextly-error";
+import { getCachedNextly } from "../init";
+
+import { respondData } from "./response-shapes";
+import { withErrorHandler } from "./with-error-handler";
+
+async function getDocumentLockService(): Promise<DocumentLockService> {
+  await getCachedNextly();
+  return container.get<DocumentLockService>("documentLockService");
+}
+
+const SCOPE_KINDS = new Set<string>(["collection", "single"]);
+
+/**
+ * Read a document reference from whatever the request carries.
+ *
+ * Validated through `documentLockKey`, the same function the repository keys
+ * rows with, rather than by a second set of rules here. A slug carrying the
+ * separator, or a pair too long for the column, has to be refused identically
+ * in both places or a reference this accepts becomes a row nothing can address.
+ */
+function readRef(source: {
+  scopeKind?: unknown;
+  slug?: unknown;
+  entryId?: unknown;
+}): DocumentRef {
+  const { scopeKind, slug, entryId } = source;
+  if (
+    typeof scopeKind !== "string" ||
+    !SCOPE_KINDS.has(scopeKind) ||
+    typeof slug !== "string" ||
+    typeof entryId !== "string" ||
+    documentLockKey(scopeKind as DocumentScopeKind, slug, entryId) === undefined
+  ) {
+    throw NextlyError.validation({
+      errors: [
+        {
+          path: "document",
+          code: "invalid_document_ref",
+          message:
+            "A document lock needs a scopeKind of collection or single, plus a slug and entryId that are non-empty, free of ':' and short enough to key a row.",
+        },
+      ],
+    });
+  }
+  return { scopeKind: scopeKind as DocumentScopeKind, slug, entryId };
+}
+
+/** The claim token a renew or release must present. */
+function readClaimToken(body: { claimToken?: unknown }): string {
+  const { claimToken } = body;
+  if (typeof claimToken !== "string" || claimToken === "") {
+    throw NextlyError.validation({
+      errors: [
+        {
+          path: "claimToken",
+          code: "required",
+          message:
+            "A claim token is required: renewing and releasing prove they are the same claim, not merely the same person.",
+        },
+      ],
+    });
+  }
+  return claimToken;
+}
+
+async function readBody(req: Request): Promise<Record<string, unknown>> {
+  // Parsed and inspected separately. Wrapping the shape check in the same
+  // `try` would make a rejection of it indistinguishable from malformed JSON,
+  // and the repository's own convention is that a refusal carries a code the
+  // caller can act on rather than a bare throw the API layer reads as a 500.
+  let parsed: unknown;
+  try {
+    parsed = await req.json();
+  } catch {
+    parsed = undefined;
+  }
+
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw NextlyError.validation({
+      errors: [
+        {
+          path: "body",
+          code: "invalid_json",
+          message: "Expected a JSON object body.",
+        },
+      ],
+    });
+  }
+  return parsed as Record<string, unknown>;
+}
+
+/** Who holds this document, if anyone still does. */
+export const readLock = withErrorHandler(async (req: Request) => {
+  const auth = await requireAuthentication(req);
+  if (isErrorResponse(auth)) throw toNextlyAuthError(auth);
+
+  const url = new URL(req.url);
+  const ref = readRef({
+    scopeKind: url.searchParams.get("scopeKind") ?? undefined,
+    slug: url.searchParams.get("slug") ?? undefined,
+    entryId: url.searchParams.get("entryId") ?? undefined,
+  });
+
+  const holder = await (await getDocumentLockService()).read(ref);
+  // `null` rather than an omitted key: "nobody holds this" is the answer, and a
+  // missing field reads as a response that failed to say.
+  return respondData({ holder: holder ?? null });
+});
+
+/**
+ * Claim a document, or report who already has it.
+ *
+ * `takeover` is the second editor deciding to edit anyway. It is accepted from
+ * any authenticated caller because the lock is advisory: refusing the takeover
+ * would not stop them editing, it would only stop them saying so, and the
+ * displaced holder is told either way.
+ */
+export const acquireLock = withErrorHandler(async (req: Request) => {
+  const auth = await requireAuthentication(req);
+  if (isErrorResponse(auth)) throw toNextlyAuthError(auth);
+
+  const body = await readBody(req);
+  const ref = readRef(body);
+  const outcome = await (
+    await getDocumentLockService()
+  ).acquire(
+    ref,
+    {
+      ownerId: auth.userId,
+      ownerLabel: auth.userName ?? auth.userEmail ?? null,
+    },
+    { takeover: body.takeover === true }
+  );
+
+  return respondData({ ...outcome });
+});
+
+/** Extend a claim this caller still believes it holds. */
+export const renewLock = withErrorHandler(async (req: Request) => {
+  const auth = await requireAuthentication(req);
+  if (isErrorResponse(auth)) throw toNextlyAuthError(auth);
+
+  const body = await readBody(req);
+  const outcome = await (
+    await getDocumentLockService()
+  ).renew(readRef(body), readClaimToken(body));
+
+  return respondData({ ...outcome });
+});
+
+/** Give up a claim. Releasing one already lost is not an error. */
+export const releaseLock = withErrorHandler(async (req: Request) => {
+  const auth = await requireAuthentication(req);
+  if (isErrorResponse(auth)) throw toNextlyAuthError(auth);
+
+  const body = await readBody(req);
+  await (
+    await getDocumentLockService()
+  ).release(readRef(body), readClaimToken(body));
+
+  return respondData({ released: true });
+});

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -207,6 +207,7 @@ import {
   registerRevalidationServices,
   registerSingleServices,
   registerUserServices,
+  registerDocumentLockServices,
   registerVersionServices,
   registerWebhookServices,
   resetWidgetRegistries,
@@ -1105,6 +1106,7 @@ export async function registerServices(
   registerMediaServices(ctx);
   registerMetaServices(ctx);
   registerSingleServices(ctx);
+  registerDocumentLockServices(ctx);
   registerVersionServices(ctx);
   registerWebhookServices(ctx);
   // LAST of the domain registrations, because the job registry is where every

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -471,6 +471,52 @@ const globalForReg = globalThis as unknown as {
  * @throws Error if database environment configuration is invalid
  * @throws Error if database connection fails
  */
+/**
+ * Every domain registration, in one place a test can execute.
+ *
+ * Extracted so the wiring is checkable by RUNNING it rather than by reading
+ * this file for the characters of a call. A registration that nothing invokes
+ * is how document locking came to ship as three unused tables, and a source
+ * scan cannot tell a live call from one sitting in a dead branch or a comment.
+ *
+ * Order is not strictly required, since every registration is a lazy singleton.
+ * The sequence is kept because each comment inside it records a reason.
+ */
+export function registerDomainServices(ctx: RegistrationContext): void {
+  // Order is not strictly required because every registration is a lazy
+  // singleton; however, we order domains roughly by dependency depth so
+  // that the shape matches the original monolithic implementation.
+  registerComponentServices(ctx);
+  registerUserServices(ctx);
+  registerEmailServices(ctx);
+  registerDashboardServices(ctx);
+  registerAuthServices(ctx);
+  // Before the collection/single services, which resolve the cacheRevalidator
+  // lazily when a write flushes its intents.
+  registerRevalidationServices(ctx);
+  registerCollectionServices(ctx);
+  registerMediaServices(ctx);
+  registerMetaServices(ctx);
+  registerSingleServices(ctx);
+  registerDocumentLockServices(ctx);
+  registerVersionServices(ctx);
+  registerWebhookServices(ctx);
+  // LAST of the domain registrations, because the job registry is where every
+  // domain's job types are constructed and it therefore reads the widest set of
+  // dependencies — content services for the releases drain, the endpoint
+  // registry and retention deps for the webhook drain.
+  //
+  // Singleton factories are lazy, so this would work in any position. Ordering
+  // it anyway keeps the reason a fact about this file rather than a property of
+  // the container that a future refactor could remove without noticing.
+  registerJobServices(ctx);
+  // After the jobs registration, which registers the drain that materialises
+  // what this service schedules. Order is not load-bearing — both resolve their
+  // dependencies from the container — but keeping them adjacent means a reader
+  // meets the two halves of releases together.
+  registerReleaseServices(ctx);
+}
+
 export async function registerServices(
   config: NextlyServiceConfig
 ): Promise<void> {
@@ -1091,38 +1137,7 @@ export async function registerServices(
     passwordHasher,
   };
 
-  // Order is not strictly required because every registration is a lazy
-  // singleton; however, we order domains roughly by dependency depth so
-  // that the shape matches the original monolithic implementation.
-  registerComponentServices(ctx);
-  registerUserServices(ctx);
-  registerEmailServices(ctx);
-  registerDashboardServices(ctx);
-  registerAuthServices(ctx);
-  // Before the collection/single services, which resolve the cacheRevalidator
-  // lazily when a write flushes its intents.
-  registerRevalidationServices(ctx);
-  registerCollectionServices(ctx);
-  registerMediaServices(ctx);
-  registerMetaServices(ctx);
-  registerSingleServices(ctx);
-  registerDocumentLockServices(ctx);
-  registerVersionServices(ctx);
-  registerWebhookServices(ctx);
-  // LAST of the domain registrations, because the job registry is where every
-  // domain's job types are constructed and it therefore reads the widest set of
-  // dependencies — content services for the releases drain, the endpoint
-  // registry and retention deps for the webhook drain.
-  //
-  // Singleton factories are lazy, so this would work in any position. Ordering
-  // it anyway keeps the reason a fact about this file rather than a property of
-  // the container that a future refactor could remove without noticing.
-  registerJobServices(ctx);
-  // After the jobs registration, which registers the drain that materialises
-  // what this service schedules. Order is not load-bearing — both resolve their
-  // dependencies from the container — but keeping them adjacent means a reader
-  // meets the two halves of releases together.
-  registerReleaseServices(ctx);
+  registerDomainServices(ctx);
 
   // ----------------------------------------
   // Layer 4: Sync Code-First Collections

--- a/packages/nextly/src/di/registrations/__tests__/every-registration-is-wired.test.ts
+++ b/packages/nextly/src/di/registrations/__tests__/every-registration-is-wired.test.ts
@@ -1,39 +1,48 @@
-import { readFileSync } from "node:fs";
-
-import { describe, expect, it } from "vitest";
-
-import * as registrations from "../index";
+import { describe, expect, it, vi } from "vitest";
 
 /**
  * A registration nothing calls is how document locking came to ship as three
- * unused tables: the domain, its schemas and its tests were all present and
- * complete, and the orchestrator never invoked them, so no consumer could
- * reach any of it.
+ * unused tables: the domain, its schemas and its tests were all complete, and
+ * the orchestrator never invoked them, so no consumer could reach any of it.
  *
- * Asserted against the orchestrator's source because that is where the calls
- * are. Constructing the real context would exercise every other domain to
- * learn one fact about this one.
+ * Checked by RUNNING the wiring. Every export of the barrel is replaced with a
+ * spy, `registerDomainServices` is called, and each spy must have fired. A
+ * source scan for the characters of a call cannot tell a live one from a call
+ * inside a dead branch or a mention in a comment, and would fail on
+ * reformatting that changes nothing.
  */
-const orchestrator = readFileSync(
-  new URL("../../register.ts", import.meta.url),
-  "utf-8"
-);
+const spies = new Map<string, ReturnType<typeof vi.fn>>();
 
-/** Exports that register something, as opposed to resets and type re-exports. */
-const registrars = Object.keys(registrations).filter(name =>
-  name.startsWith("register")
-);
+vi.mock("../index", async importOriginal => {
+  const real = await importOriginal<Record<string, unknown>>();
+  const mocked: Record<string, unknown> = {};
+  for (const [name, value] of Object.entries(real)) {
+    if (typeof value === "function" && name.startsWith("register")) {
+      const spy = vi.fn();
+      spies.set(name, spy);
+      mocked[name] = spy;
+    } else {
+      mocked[name] = value;
+    }
+  }
+  return mocked;
+});
+
+const { registerDomainServices } = await import("../../register");
 
 describe("the DI orchestrator", () => {
-  it("exports registrations to check, so this cannot pass on an empty list", () => {
-    // The control. An absence test over nothing is satisfied by everything.
-    expect(registrars.length).toBeGreaterThan(10);
+  it("has registrations to check, so this cannot pass on an empty list", () => {
+    // The control. An absence test over nothing is satisfied by everything,
+    // and a mock that failed to intercept would leave this map empty.
+    expect(spies.size).toBeGreaterThan(10);
   });
 
   it("calls every registration the barrel exports", () => {
-    const uncalled = registrars.filter(
-      name => !orchestrator.includes(`${name}(ctx)`)
-    );
+    registerDomainServices({} as never);
+
+    const uncalled = [...spies]
+      .filter(([, spy]) => spy.mock.calls.length === 0)
+      .map(([name]) => name);
 
     expect(uncalled).toEqual([]);
   });

--- a/packages/nextly/src/di/registrations/__tests__/every-registration-is-wired.test.ts
+++ b/packages/nextly/src/di/registrations/__tests__/every-registration-is-wired.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import * as registrations from "../index";
+
+/**
+ * A registration nothing calls is how document locking came to ship as three
+ * unused tables: the domain, its schemas and its tests were all present and
+ * complete, and the orchestrator never invoked them, so no consumer could
+ * reach any of it.
+ *
+ * Asserted against the orchestrator's source because that is where the calls
+ * are. Constructing the real context would exercise every other domain to
+ * learn one fact about this one.
+ */
+const orchestrator = readFileSync(
+  new URL("../../register.ts", import.meta.url),
+  "utf-8"
+);
+
+/** Exports that register something, as opposed to resets and type re-exports. */
+const registrars = Object.keys(registrations).filter(name =>
+  name.startsWith("register")
+);
+
+describe("the DI orchestrator", () => {
+  it("exports registrations to check, so this cannot pass on an empty list", () => {
+    // The control. An absence test over nothing is satisfied by everything.
+    expect(registrars.length).toBeGreaterThan(10);
+  });
+
+  it("calls every registration the barrel exports", () => {
+    const uncalled = registrars.filter(
+      name => !orchestrator.includes(`${name}(ctx)`)
+    );
+
+    expect(uncalled).toEqual([]);
+  });
+});

--- a/packages/nextly/src/di/registrations/__tests__/register-document-lock.test.ts
+++ b/packages/nextly/src/di/registrations/__tests__/register-document-lock.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import type { DocumentLockService } from "../../../domains/document-lock";
+import { container } from "../../container";
+import { registerDocumentLockServices } from "../register-document-lock";
+
+import type { RegistrationContext } from "../types";
+
+/** Enough of a context for a registration that reads only the adapter. */
+function context(adapter: unknown): RegistrationContext {
+  return { adapter } as RegistrationContext;
+}
+
+const adapter = {
+  getCapabilities: () => ({ dialect: "postgres" }),
+  transaction: vi.fn(),
+};
+
+beforeEach(() => {
+  container.clear();
+});
+
+describe("registerDocumentLockServices", () => {
+  it("registers a service the container can resolve", () => {
+    // The gap this closes: the domain, its schemas and its tests all existed
+    // and nothing could reach them, so the engine shipped as three unused
+    // tables.
+    registerDocumentLockServices(context(adapter));
+
+    const service = container.get<DocumentLockService>("documentLockService");
+
+    expect(service).toBeDefined();
+    for (const method of [
+      "read",
+      "acquire",
+      "renew",
+      "release",
+      "sweepExpired",
+    ]) {
+      expect(
+        typeof (service as unknown as Record<string, unknown>)[method]
+      ).toBe("function");
+    }
+  });
+
+  it("hands every call the adapter it was registered with", async () => {
+    // The binding is the whole job of the service, so a registration that
+    // constructed it with the wrong adapter would resolve and then read
+    // another database.
+    registerDocumentLockServices(context(adapter));
+    const service = container.get<DocumentLockService>("documentLockService");
+
+    const capabilities = vi.spyOn(adapter, "getCapabilities");
+    await service
+      .read({ scopeKind: "collection", slug: "posts", entryId: "1" })
+      .catch(() => undefined);
+
+    expect(capabilities).toHaveBeenCalled();
+    capabilities.mockRestore();
+  });
+
+  it("is a singleton, so two editors share one view of a claim", () => {
+    // Two instances would each be correct and the second would not see a claim
+    // taken through the first until it hit the database, which is the kind of
+    // difference that only shows under load.
+    registerDocumentLockServices(context(adapter));
+
+    expect(container.get("documentLockService")).toBe(
+      container.get("documentLockService")
+    );
+  });
+});

--- a/packages/nextly/src/di/registrations/index.ts
+++ b/packages/nextly/src/di/registrations/index.ts
@@ -9,6 +9,7 @@ export { registerAuthServices } from "./register-auth";
 export { registerCollectionServices } from "./register-collections";
 export { registerComponentServices } from "./register-components";
 export { registerDashboardServices } from "./register-dashboard";
+export { registerDocumentLockServices } from "./register-document-lock";
 export { registerEmailServices } from "./register-email";
 export { registerJobServices } from "./register-jobs";
 export { registerReleaseServices } from "./register-releases";

--- a/packages/nextly/src/di/registrations/register-document-lock.ts
+++ b/packages/nextly/src/di/registrations/register-document-lock.ts
@@ -1,0 +1,24 @@
+/**
+ * DI registration for advisory document locking.
+ *
+ * @module di/registrations/register-document-lock
+ */
+
+import { DocumentLockService } from "../../domains/document-lock";
+import { container } from "../container";
+
+import type { RegistrationContext } from "./types";
+
+/** Register the document-lock service as a singleton. */
+export function registerDocumentLockServices(ctx: RegistrationContext): void {
+  const { adapter } = ctx;
+
+  container.registerSingleton<DocumentLockService>(
+    "documentLockService",
+    // Locks are read and written on the pool. They are deliberately outside any
+    // caller's transaction: a claim taken inside a write that later rolls back
+    // would vanish with it, and the point of the claim is that it outlives the
+    // request that took it.
+    () => new DocumentLockService(adapter)
+  );
+}

--- a/packages/nextly/src/di/registrations/register-jobs.ts
+++ b/packages/nextly/src/di/registrations/register-jobs.ts
@@ -20,6 +20,10 @@
  */
 
 import { nextly } from "../../direct-api/nextly";
+import {
+  createDocumentLockSweepJob,
+  type DocumentLockService,
+} from "../../domains/document-lock";
 import { JobRegistry } from "../../domains/jobs/job-registry";
 import { JobsRepository } from "../../domains/jobs/jobs-repository";
 import { databaseRunAs } from "../../domains/jobs/jobs-runner";
@@ -179,6 +183,17 @@ export function registerJobServices(ctx: RegistrationContext): void {
         contentApi: nextly,
         runAs: databaseRunAs(adapter),
         onOutcome: result => reportReleasesOutcome(logger, result),
+      })
+    );
+
+    // Advisory document locks. A lapsed row is already ignored by every
+    // reader, so this buys space rather than correctness: without it the table
+    // keeps a row per document ever opened and never shrinks. It rides the same
+    // `/api/jobs/run` entry as everything else here, so it needs no schedule of
+    // its own.
+    registry.register(
+      createDocumentLockSweepJob({
+        service: container.get<DocumentLockService>("documentLockService"),
       })
     );
 

--- a/packages/nextly/src/dispatcher/types.ts
+++ b/packages/nextly/src/dispatcher/types.ts
@@ -30,6 +30,7 @@ export type ServiceType =
   | "previewUrl"
   | "imageSizes"
   | "dashboard"
+  | "documentLock"
   | "translations"
   | "email"
   | "schema";

--- a/packages/nextly/src/domains/document-lock/__tests__/document-lock-sweep-job.test.ts
+++ b/packages/nextly/src/domains/document-lock/__tests__/document-lock-sweep-job.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { DOCUMENT_LOCK_SWEEP_JOB, createDocumentLockSweepJob } from "..";
+
+describe("the document-lock sweep job", () => {
+  it("is declared as a sweep, or nothing would ever enqueue it", () => {
+    // A claim lapses at an instant with no request attached, and the editor
+    // whose claim it was has by definition stopped asking. Registered without
+    // this the handler exists and never runs, which looks exactly like a table
+    // with nothing to clean up.
+    const job = createDocumentLockSweepJob({
+      service: { sweepExpired: vi.fn() } as never,
+    });
+
+    expect(job.sweep).toBe(true);
+    expect(job.slug).toBe(DOCUMENT_LOCK_SWEEP_JOB);
+  });
+
+  it("sweeps when it runs", () => {
+    const sweepExpired = vi.fn().mockResolvedValue(undefined);
+    const job = createDocumentLockSweepJob({
+      service: { sweepExpired } as never,
+    });
+
+    void job.handler(null as never, {} as never);
+
+    expect(sweepExpired).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/nextly/src/domains/document-lock/document-lock-service.ts
+++ b/packages/nextly/src/domains/document-lock/document-lock-service.ts
@@ -1,0 +1,94 @@
+/**
+ * The document-lock repository with an adapter bound to it.
+ *
+ * The repository is a set of functions taking a `DrizzleAdapter` first, which is
+ * what lets the integration tests drive each dialect directly. Callers reached
+ * through DI have exactly one adapter and no reason to pass it five times, so
+ * this binds it once and is what everything outside the domain resolves.
+ *
+ * Advisory, and the service says so rather than leaving it to be inferred: a
+ * held lock is reported to the caller and never refuses a write. Nothing here
+ * consults a lock on the mutation path, so a stale claim cannot strand a
+ * document, and the claim token the repository issues leaves enforcement
+ * available later without changing this shape.
+ *
+ * @module domains/document-lock/document-lock-service
+ */
+
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+
+import {
+  acquireDocumentLock,
+  readDocumentLock,
+  releaseDocumentLock,
+  renewDocumentLock,
+  sweepExpiredDocumentLocks,
+  type DocumentLockClaimant,
+} from "./document-lock-repository";
+import type {
+  AcquireDocumentLockOutcome,
+  DocumentLockHolder,
+  DocumentRef,
+  RenewDocumentLockOutcome,
+} from "./types";
+
+export class DocumentLockService {
+  constructor(private readonly adapter: DrizzleAdapter) {}
+
+  /**
+   * Who holds this document, if anyone still does.
+   *
+   * `undefined` for both "never claimed" and "claim has lapsed", because an
+   * editor arriving at a document cannot act on the difference.
+   */
+  async read(ref: DocumentRef): Promise<DocumentLockHolder | undefined> {
+    return await readDocumentLock(this.adapter, ref);
+  }
+
+  /**
+   * Claim a document for an editor.
+   *
+   * `takeover` is the second editor deciding to edit anyway, which the
+   * repository implements by replacing the claim rather than by deleting and
+   * re-taking it, so the displaced holder's next renew reports `lost` with the
+   * new holder attached and their editor can name who took over.
+   */
+  async acquire(
+    ref: DocumentRef,
+    claimant: DocumentLockClaimant,
+    options?: { readonly takeover?: boolean }
+  ): Promise<AcquireDocumentLockOutcome> {
+    return await acquireDocumentLock(this.adapter, ref, claimant, options);
+  }
+
+  /**
+   * Extend a claim this caller believes it still holds.
+   *
+   * Authenticated by the claim token rather than by the holder's id, so a
+   * second tab belonging to the same person cannot extend the first tab's
+   * claim, and a tab whose claim was taken over is told rather than silently
+   * renewed.
+   */
+  async renew(
+    ref: DocumentRef,
+    claimToken: string
+  ): Promise<RenewDocumentLockOutcome> {
+    return await renewDocumentLock(this.adapter, ref, claimToken);
+  }
+
+  /** Give up a claim. Releasing one already lost is not an error. */
+  async release(ref: DocumentRef, claimToken: string): Promise<void> {
+    await releaseDocumentLock(this.adapter, ref, claimToken);
+  }
+
+  /**
+   * Delete lapsed rows.
+   *
+   * Expiry is decided by the timestamp on read, so nothing depends on this
+   * having run; it keeps the table from growing without bound over a long
+   * uptime. That makes it safe to call on any schedule, or not at all.
+   */
+  async sweepExpired(): Promise<void> {
+    await sweepExpiredDocumentLocks(this.adapter);
+  }
+}

--- a/packages/nextly/src/domains/document-lock/document-lock-sweep-job.ts
+++ b/packages/nextly/src/domains/document-lock/document-lock-sweep-job.ts
@@ -1,0 +1,32 @@
+/**
+ * Delete lock rows whose claim has lapsed.
+ *
+ * Expiry is decided by the timestamp on read, so correctness never depends on
+ * this having run: a lapsed row is already ignored by every reader. What it
+ * costs to skip is space. A row exists per document ever opened, and the table
+ * would otherwise grow with the number of distinct documents an installation
+ * has edited and never shrink.
+ *
+ * @module domains/document-lock/document-lock-sweep-job
+ */
+
+import { defineJob, type JobDefinition } from "../jobs/job-registry";
+
+import type { DocumentLockService } from "./document-lock-service";
+
+export const DOCUMENT_LOCK_SWEEP_JOB = "document-lock:sweep";
+
+export function createDocumentLockSweepJob(deps: {
+  service: DocumentLockService;
+}): JobDefinition {
+  return defineJob({
+    slug: DOCUMENT_LOCK_SWEEP_JOB,
+    // A sweep: a claim lapses at an instant with no request attached, and the
+    // editor whose claim it was has by definition stopped asking. Nothing is
+    // ever in a position to enqueue this, so a trigger keeps one queued.
+    sweep: true,
+    handler: async () => {
+      await deps.service.sweepExpired();
+    },
+  });
+}

--- a/packages/nextly/src/domains/document-lock/index.ts
+++ b/packages/nextly/src/domains/document-lock/index.ts
@@ -6,6 +6,10 @@
 
 export { DocumentLockService } from "./document-lock-service";
 export {
+  DOCUMENT_LOCK_SWEEP_JOB,
+  createDocumentLockSweepJob,
+} from "./document-lock-sweep-job";
+export {
   acquireDocumentLock,
   readDocumentLock,
   releaseDocumentLock,

--- a/packages/nextly/src/domains/document-lock/index.ts
+++ b/packages/nextly/src/domains/document-lock/index.ts
@@ -4,6 +4,7 @@
  * @module domains/document-lock
  */
 
+export { DocumentLockService } from "./document-lock-service";
 export {
   acquireDocumentLock,
   readDocumentLock,

--- a/packages/nextly/src/route-handler/__tests__/route-parser.document-lock.test.ts
+++ b/packages/nextly/src/route-handler/__tests__/route-parser.document-lock.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { parseRestRoute } from "../route-parser";
+
+describe("document lock routes", () => {
+  it("maps each verb to its operation on the one resource", () => {
+    const cases = [
+      ["GET", "readDocumentLock"],
+      ["POST", "acquireDocumentLock"],
+      ["PATCH", "renewDocumentLock"],
+      ["DELETE", "releaseDocumentLock"],
+    ] as const;
+
+    for (const [verb, method] of cases) {
+      expect(parseRestRoute(["document-lock"], verb)).toMatchObject({
+        service: "documentLock",
+        method,
+      });
+    }
+  });
+
+  it("does not claim a path with segments after the resource", () => {
+    // The document is named by scopeKind, slug and entryId together, not by a
+    // path segment, so a deeper path is not a lock route. Claiming it would
+    // match a shorter route and silently ignore the tail.
+    for (const path of [
+      ["document-lock", "posts"],
+      ["document-lock", "posts", "42"],
+    ]) {
+      expect(parseRestRoute(path, "GET")?.service).not.toBe("documentLock");
+    }
+  });
+
+  it("does not claim a verb it has no operation for", () => {
+    // PUT is absent deliberately: renewing is a PATCH because it extends a
+    // claim rather than replacing one, and a route that answered PUT would
+    // dispatch on a method name nothing handles.
+    expect(parseRestRoute(["document-lock"], "PUT")?.service).not.toBe(
+      "documentLock"
+    );
+  });
+});

--- a/packages/nextly/src/route-handler/route-parser.ts
+++ b/packages/nextly/src/route-handler/route-parser.ts
@@ -2576,6 +2576,58 @@ function parseDashboardRoutes(
 }
 
 // ============================================================================
+// Document Lock Routes Parser
+// ============================================================================
+
+/**
+ * Parse advisory document-lock routes.
+ *
+ *   GET    /api/document-lock → who holds it
+ *   POST   /api/document-lock → claim it
+ *   PATCH  /api/document-lock → extend a claim
+ *   DELETE /api/document-lock → give it up
+ *
+ * One resource and no id segment: the document is named by `scopeKind`, `slug`
+ * and `entryId` together, and a slug carrying the path separator would be a
+ * document this could not address. They travel in the query for the read and
+ * the body for the rest, which the handler validates through the same function
+ * the repository keys rows with.
+ *
+ * The method table is a closed record rather than a lookup on the URL's own
+ * string, so no prototype key can reach it and there is nothing for
+ * `Object.hasOwn` to guard.
+ */
+function parseDocumentLockRoutes(
+  id: string | undefined,
+  subresource: string | undefined,
+  httpMethod: string,
+  routeParams: Record<string, string>
+): ParsedRoute | null {
+  // Nothing deeper than the resource exists, so a longer path 404s rather than
+  // matching this and silently ignoring its tail.
+  if (id !== undefined || subresource !== undefined) return null;
+
+  const method =
+    httpMethod === "GET"
+      ? "readDocumentLock"
+      : httpMethod === "POST"
+        ? "acquireDocumentLock"
+        : httpMethod === "PATCH"
+          ? "renewDocumentLock"
+          : httpMethod === "DELETE"
+            ? "releaseDocumentLock"
+            : null;
+  if (method === null) return null;
+
+  return {
+    service: "documentLock",
+    operation: httpMethod === "GET" ? "single" : "update",
+    method,
+    routeParams,
+  };
+}
+
+// ============================================================================
 // Schema Routes Parser
 // ============================================================================
 
@@ -2908,6 +2960,17 @@ export function parseRestRoute(
   // Handle Dashboard endpoints
   if (resource === "dashboard") {
     const result = parseDashboardRoutes(
+      id,
+      subresource,
+      httpMethod,
+      routeParams
+    );
+    if (result) return result;
+  }
+
+  // Handle advisory document locking
+  if (resource === "document-lock") {
+    const result = parseDocumentLockRoutes(
       id,
       subresource,
       httpMethod,

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -42,6 +42,12 @@ import {
   getDashboardRecentEntries,
   getDashboardActivity,
 } from "./api/dashboard";
+import {
+  acquireLock,
+  readLock,
+  releaseLock,
+  renewLock,
+} from "./api/document-lock";
 import { POST as emailSend } from "./api/email-send";
 import { POST as emailSendWithTemplate } from "./api/email-send-template";
 import {
@@ -370,6 +376,7 @@ const DIRECT_DISPATCH_SERVICES = new Set<string>([
   "previewUrl",
   "imageSizes",
   "dashboard",
+  "documentLock",
   "translations",
   "schema",
   "email",
@@ -511,6 +518,33 @@ async function handleDashboardRequest(
     default:
       return new Response(
         JSON.stringify({ error: "Unknown dashboard operation" }),
+        { status: 400, headers: { "Content-Type": "application/json" } }
+      );
+  }
+}
+
+/**
+ * Delegate a document-lock request to its handler.
+ *
+ * Advisory locking: every one of these reports a claim and none of them refuses
+ * a write, so nothing on the mutation path consults this.
+ */
+async function handleDocumentLockRequest(
+  req: Request,
+  method: string
+): Promise<Response> {
+  switch (method) {
+    case "readDocumentLock":
+      return readLock(req);
+    case "acquireDocumentLock":
+      return acquireLock(req);
+    case "renewDocumentLock":
+      return renewLock(req);
+    case "releaseDocumentLock":
+      return releaseLock(req);
+    default:
+      return new Response(
+        JSON.stringify({ error: "Unknown document lock operation" }),
         { status: 400, headers: { "Content-Type": "application/json" } }
       );
   }
@@ -1130,6 +1164,14 @@ async function handleServiceRequest(
   // their own via req.json() before anything else touches the stream.
   if (service === "dashboard") {
     return handleDashboardRequest(req, method);
+  }
+
+  // ==================== DOCUMENT LOCK DIRECT DISPATCH ====================
+  // Owns its auth (requireAuthentication) and reads its own body, so it
+  // intercepts here for the same reason dashboard does: before `req.text()`,
+  // which the read has no body for.
+  if (service === "documentLock") {
+    return handleDocumentLockRequest(req, method);
   }
 
   // ==================== TRANSLATIONS DIRECT DISPATCH ====================

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -543,10 +543,13 @@ async function handleDocumentLockRequest(
     case "releaseDocumentLock":
       return releaseLock(req);
     default:
-      return new Response(
-        JSON.stringify({ error: "Unknown document lock operation" }),
-        { status: 400, headers: { "Content-Type": "application/json" } }
-      );
+      // Reached only if the parser and this switch disagree, which is a new or
+      // mistyped route rather than anything the caller did. A canonical error
+      // carries the code and request id a client needs to report it; an ad hoc
+      // `{ error }` body is unreadable exactly when someone is debugging.
+      throw NextlyError.notFound({
+        logContext: { service: "documentLock", method },
+      });
   }
 }
 


### PR DESCRIPTION
G20, server side. No admin UI yet, so nothing user-facing changes.

## What was actually wrong

The engine is complete, not half-built: claim, renew, release and sweep across all three dialects, a TTL of 150s with the heartbeat derived at TTL/10 from the shared lease clock, and `acquire` returning a **claim token** so a renew proves it is the same claim rather than the same person. The `lost` outcome carries the new holder, so an editor can say who took over rather than only that something did, and `acquireDocumentLock` already accepts `{ takeover: true }`.

None of it could be reached. The repository functions take a `DrizzleAdapter` first, no service bound one, and no registration constructed anything, so three tables shipped in the published package with no consumer.

## The service

`DocumentLockService` binds the adapter once, matching how `versionsService` is registered, and the orchestrator constructs it.

**Advisory, stated rather than inferred.** Nothing consults a lock on the mutation path, so a claim left behind by a closed laptop cannot strand a document. This is Payload's default too (`overrideLock: true`), and the claim token leaves enforcement available later without redesigning the shape.

**Locks run on the pool, not a caller's transaction.** A claim taken inside a write that later rolls back would vanish with it, and the point of a claim is that it outlives the request that took it.

## The route

One resource and four verbs on `/api/document-lock`: GET reads who holds it, POST claims it, PATCH extends a claim, DELETE gives it up. No id segment, because a document is named by `scopeKind`, `slug` and `entryId` together and a slug carrying the path separator would be one this could not address.

Three properties, each mutation-tested:

- **The claimant comes from the session and never from the body.** A caller that could name its own owner id would claim a document as a colleague, and the name the next editor is shown would be evidence of something that did not happen.
- **References validate through `documentLockKey`**, the same function the repository keys rows with, rather than a second set of rules here. One accepted by this and refused by that is a row nothing can address.
- **Renew and release require the claim token**, which is what stops a second tab extending the first tab's lease and lets a displaced editor be told rather than silently renewing nothing.

`takeover` is read strictly, so only the boolean displaces a colleague.

## The guard worth reading

My registration test **passed with the orchestrator call deleted**, which is this defect exactly: a domain that exists, is complete, and that nothing calls. A unit test on a registration function cannot see whether anything invokes it.

So there is a second test, general rather than about this domain: **every registration the barrel exports must be invoked by the orchestrator**. It carries its own control, since an absence test over an empty list passes for free, and removing `registerDocumentLockServices(ctx)` fails it.

The existing `direct-dispatch-cold-boot` test already covers the route half of the same hazard, and it passes with `documentLock` added to both places.

## Verification

`tsc` clean on its own exit code, eslint clean, 21 tests across the four new and touched files. Three assumptions were caught before CI: `toNextlyAuthError`'s module, `NextlyError.validation`'s signature, and `AuthContext` carrying `userId` rather than a nested user. Husky rejected a bare `Error` in the body parser, which the repo forbids so a caller-fixable refusal is not reported as a 500; it is restructured so the throw is not needed.

## Next

The admin UI, where a second editor is told who holds the document and may view read-only or take over.