### PR TITLE
test(nextly): give the drain-bounds fixture one clock read

### DIFF
--- a/packages/nextly/src/domains/webhooks/__tests__/webhook-drain-job-bounds.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/webhook-drain-job-bounds.test.ts
@@ -76,12 +76,23 @@ describe("the drain job's bounds", () => {
     );
 
     const REMAINING_MS = 3_000;
+    /*
+     * 🔴 ONE clock read, with the deadline derived from it. Written as two --
+     * `new Date()` for `now` and a separate `Date.now()` for the deadline --
+     * any scheduling delay BETWEEN those two adjacent property initialisers
+     * lands inside what the handler computes: `remainingPassMs` is
+     * `deadline - now`, so a 1ms gap makes it 3001, the budget split gives
+     * 1500 + 1501, and the assertion below compares that against the constant
+     * 3000 and fails. The production arithmetic is correct at every step; the
+     * fixture was asserting against a number it had not actually handed over.
+     */
+    const now = new Date();
     const job = create({} as never, {} as never);
     await job.handler(null, {
       user: null,
-      now: new Date(),
+      now,
       content: {} as never,
-      deadline: new Date(Date.now() + REMAINING_MS),
+      deadline: new Date(now.getTime() + REMAINING_MS),
     });
 
     const [, , options] = runWebhookDrain.mock.calls[0] as unknown as [


### PR DESCRIPTION
## What

`webhook-drain-job-bounds.test.ts` > "derives its budget from what is LEFT of the pass" fails intermittently with `expected 3001 to be less than or equal to 3000`. It runs in `nextly:test`, so it reddens the **pre-push hook** and CI for changes that have nothing to do with webhooks — it blocked a push on an unrelated widget branch, which is how it was found.

## Why it happens

`remainingPassMs` is `deadline.getTime() - now.getTime()`. The fixture built those two from **separate clock reads** in adjacent property initialisers:

```ts
now: new Date(),                              // T1
deadline: new Date(Date.now() + REMAINING_MS) // T2 + 3000
```

Initialisers evaluate in order, so what the handler receives is `3000 + (T2 - T1)`. A scheduling delay of ≥1ms makes the remainder 3001; the split then gives `requestTimeoutMs = floor(3001/2) = 1500` and `maxDurationMs = 3001 - 1500 = 1501`, summing to 3001 — which the assertion compares against the **constant** 3000.

**The production arithmetic is correct at every step.** The fixture was asserting against a number it had not handed over.

Rare when the file runs alone; likely under the pre-push hook, which runs the whole monorepo's lint, build and test concurrently.

## The change

One clock read, with the deadline derived from it, so the remainder is exactly the value the assertion names whatever the machine is doing. One file, test only.

## Verification

Two breaks, because the fix and the diagnosis are separate claims:

- **The test still catches its own subject.** Replacing `remainingPassMs(context)` with the constant bound fails it: `expected 12000 to be less than or equal to 3000`. So this is not a test weakened into always passing.
- **The diagnosis is right.** Restoring the two clock reads *and forcing a 2ms gap* reproduces the failure exactly: `expected 3002 to be less than or equal to 3000` — the same shape as the observed 3001 at 1ms.

Full `nextly` suite: 895 files, 11422 passed. `check-types`, `lint` and `fallow audit` clean.

No changeset: test-only.