### PR TITLE
feat(blocks-engine): detach a component instance, keeping the author's own content linked

### DIFF
--- a/.changeset/detach-a-component-instance.md
+++ b/.changeset/detach-a-component-instance.md
@@ -1,0 +1,41 @@
+---
+"@nextlyhq/blocks-engine": patch
+---
+
+Detach a component instance: inline what it was drawing, and stop tracking it.
+
+The instance is replaced, where it stands, by the nodes it rendered — the
+definition's tree with this instance's overrides, variant and slot content
+already applied. Afterwards the author owns those nodes and an edit to the
+definition no longer reaches them, which is the point: detach is how a page
+keeps what a component gave it without staying bound to it.
+
+The inlined content comes from the renderer's own resolver rather than a second
+traversal of the definition, so what an author gets is what they were looking
+at. A planner that re-applied overrides and slots itself would agree with the
+page until one of the two moved, and the difference would be silent.
+
+**A component the author dropped INTO the instance stays a component.** That is
+their content, not the definition's, and detaching its host says nothing about
+it. It cannot be had from the resolver's depth cap: that bounds nesting inside a
+DEFINITION, while supplied slot content is composed in the host's own scope
+where the depth never advances — measured, a nested instance was fully inlined
+and lost its link. So supplied content never reaches the resolver at all; it is
+lifted out, stood in for, and put back.
+
+**Two halves, two rules.** Supplied slot content MOVES: same node ids, same
+authored DOM ids, because it is the same content in a new parent and the
+instance holding it goes in the same edit. The definition's contribution is a
+COPY: fresh node ids, and its authored DOM ids kept except where the page really
+holds that name.
+
+Nothing the resolver mints for rendering is stored. It scopes a DOM id per
+composed node so two instances cannot collide, and `resolveComponentInstances`
+now reports what each scoped id was derived from — without that, detaching wrote
+a render-time digest into the database as though an author had typed it, and it
+went stale the moment the definition renamed its own anchor.
+
+Provenance goes on the existing `origin` record's `component` arm, which the
+format already describes as "detached from a component, severing the link
+deliberately" — no digest, because detaching is the act of declining further
+change.

--- a/.changeset/detach-a-component-instance.md
+++ b/.changeset/detach-a-component-instance.md
@@ -72,3 +72,19 @@ classification and a closed list of reasons — out of the renderer and the
 preview as much as out of detaching. Such a definition is now reported
 `unreadable`, which is what that reason already meant: a value that IS supplied
 and cannot be read.
+
+The containment reaches the definition's NODES, not only its envelope. A field
+that computes itself is read later too — by the clone that builds the inlined
+tree — and it threw out of the resolver and out of detaching alike. It is now
+contained at the expansion of ONE instance, the unit the resolver's savepoint
+already covers, so a definition that fails halfway gives back the ids and budget
+it had begun to claim, exactly as a refusal for the node budget does.
+
+A component whose definition nests an instance of ITSELF detaches. The nested
+one is refused as a cycle and carries the same component id, so reading the
+component name refused a detach that had already succeeded.
+
+A gated instance keeps its authored DOM ids. Collisions are decided after the
+gate is applied, because a condition-gated subtree renders nothing and collides
+with no one — and a rename made for a conflict that does not exist outlives the
+gate that excused it.

--- a/.changeset/detach-a-component-instance.md
+++ b/.changeset/detach-a-component-instance.md
@@ -88,3 +88,10 @@ A gated instance keeps its authored DOM ids. Collisions are decided after the
 gate is applied, because a condition-gated subtree renders nothing and collides
 with no one — and a rename made for a conflict that does not exist outlives the
 gate that excused it.
+
+`resolveComponentInstances` also refuses a definition written in a format this
+build cannot read. It checked only that `nodes` was an array and `kind` was
+`component`, so a definition from a future or corrupt writer was inlined and,
+for a surface that persists what it inlines, written into a page under rules
+this build does not implement. `unreadable` already meant "an envelope this
+build does not understand"; nothing had asked the question.

--- a/.changeset/detach-a-component-instance.md
+++ b/.changeset/detach-a-component-instance.md
@@ -63,3 +63,12 @@ Provenance goes on the existing `origin` record's `component` arm, which the
 format already describes as "detached from a component, severing the link
 deliberately" — no digest, because detaching is the act of declining further
 change.
+
+`resolveComponentInstances` also stops letting a supplied definition's own
+accessors escape. It reads a definition's `kind` to tell a component from a page
+and its `nodes` to tell a document from anything else, and a field that computes
+itself and throws took the caller's error out of a function that promises a
+classification and a closed list of reasons — out of the renderer and the
+preview as much as out of detaching. Such a definition is now reported
+`unreadable`, which is what that reason already meant: a value that IS supplied
+and cannot be read.

--- a/.changeset/detach-a-component-instance.md
+++ b/.changeset/detach-a-component-instance.md
@@ -1,5 +1,29 @@
 ---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
 "@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
 ---
 
 Detach a component instance: inline what it was drawing, and stop tracking it.

--- a/packages/blocks-engine/src/composition-planners.ts
+++ b/packages/blocks-engine/src/composition-planners.ts
@@ -26,6 +26,7 @@
 import {
   COMPONENT_INSTANCE_TYPE,
   isComponentDocument,
+  isComponentInstance,
   renderedDomId,
 } from "./document";
 import type {
@@ -62,8 +63,12 @@ import {
 } from "./ops";
 import { patternDigest } from "./pattern-digest";
 import { isPlainRecord } from "./plain-record";
-import { componentIdsIn } from "./resolve-instances";
-import { boundedOwnKeys, defineEntry } from "./safe-record";
+import {
+  componentIdsIn,
+  resolveComponentInstances,
+  type DefinitionsById,
+} from "./resolve-instances";
+import { boundedOwnKeys, defineEntry, ownKeys } from "./safe-record";
 import { contiguousRun, type RunProblem } from "./sibling-run";
 import {
   findNode,
@@ -2293,6 +2298,408 @@ function walkRenderedIds(
     if (hidden.has(node)) return;
     const id = renderedDomId(node);
     if (id !== undefined) fn(id);
+  });
+}
+
+/**
+ * Detach a component instance: inline what it renders, and stop tracking it.
+ *
+ * The instance is replaced, where it stands, by the nodes it was drawing —
+ * the definition's tree with this instance's overrides, variant and slot
+ * content already applied. Afterwards the author owns those nodes outright and
+ * an edit to the definition no longer reaches them, which is the whole point:
+ * detach is how a page escapes a component without losing what it looked like.
+ *
+ * One way, and undoable only through history. Every builder that ships this
+ * ships it that way — Webflow's `unlinkComponent`, Gutenberg's unsynced
+ * pattern, Figma's detached instance — and the reason is that the inverse is
+ * not well defined: once the nodes are edited there is no telling which of them
+ * the definition would still claim.
+ *
+ * ## What it renders, through the renderer's own resolver
+ *
+ * The inlined nodes come from {@link resolveComponentInstances}, not from a
+ * second traversal of the definition. Overrides, variant selection, exposed
+ * slots and their defaults are a body of rules that already exists and is
+ * already tested; a planner that re-applied them would agree with the page
+ * until one of the two moved, and the failure would be silent — a detach that
+ * produces subtly different content from what the author was looking at.
+ *
+ * ## Nested instances stay linked, by construction
+ *
+ * A component the author dropped INTO this instance's slot is their content,
+ * not this component's, and detaching their host says nothing about it. That
+ * rule cannot be had from the resolver's depth cap: `maxComposedDepth` bounds
+ * DEFINITION-internal nesting, and supplied slot content is composed in the
+ * host's own scope where the depth never advances — measured, a nested instance
+ * in supplied content is fully inlined at depth 1, losing its link.
+ *
+ * So the content never reaches the resolver. Each supplied slot is swapped for
+ * a placeholder, the definition is resolved around those, and the author's own
+ * nodes are put back afterwards untouched. Nothing has to detect a nested
+ * instance because nothing was ever in a position to inline one.
+ *
+ * ## The author's content moves; the definition's is copied
+ *
+ * Two different things happen to two different halves, and conflating them is
+ * the defect this shape avoids. Supplied slot content MOVES: it keeps its node
+ * ids and its authored DOM ids, because it is the same content in a new parent
+ * and the instance that held it is removed in the same group. The definition's
+ * contribution is a COPY: it takes fresh node ids, and it may keep its authored
+ * DOM ids only where the page has none to collide with.
+ *
+ * The resolver's own ids are never persisted either way. It mints a `cx-`
+ * scoped id per composed node — a render-time digest, deliberately not a stored
+ * id shape — and re-minting DOM ids unconditionally is the defect
+ * `planInsertPattern` was fixed for: an id renamed on a page that had no
+ * conflict grows a suffix every cycle.
+ */
+export function planDetach(
+  document: BlockDocument,
+  instanceId: string,
+  definitions: DefinitionsById,
+  nesting: NestingSource,
+  limits: DocumentLimits = DEFAULT_LIMITS
+): PlanResult<never> {
+  // Everything `applyOp` asks before it looks at an op, asked exactly as the
+  // other planners ask it: the envelope, then the whole forest, because a
+  // malformed node the author never touched refuses the first op of a group.
+  if (
+    documentRefusal(document) !== undefined ||
+    forestRefusal(document.nodes) !== undefined
+  ) {
+    return { problem: "unusable-document" };
+  }
+
+  const located = locatedInstance(document, instanceId);
+  if (located.problem !== undefined) return located;
+
+  const position = replacementPosition(located.at);
+  if (position.problem !== undefined) return position;
+
+  // The page as it will BE, taken from the op layer rather than derived: the
+  // remove has to succeed for anything else to matter, and its result is also
+  // the only honest answer to "which DOM ids are still taken". The instance's
+  // own subtree is not among them — that content is moving, not being copied
+  // beside itself, and treating it as taken renames the author's own anchors.
+  const locked =
+    lockRefusal([located.node]) ?? removableRefusal(document, [located.node]);
+  if (locked !== undefined) return locked;
+
+  const removal: BuilderOp = { kind: "remove", id: located.node.id };
+  let remaining: BlockDocument;
+  try {
+    remaining = applyOps(document, [removal], limits).document;
+  } catch {
+    return { problem: "unusable-document" };
+  }
+
+  const inlined = detachedRoots(
+    document,
+    located.node,
+    definitions,
+    domIdsIn(remaining.nodes),
+    limits
+  );
+  if (inlined.problem !== undefined) return inlined;
+
+  const destination = destinationOf(document, position.at);
+  if (destination.problem !== undefined) return destination;
+
+  // Asked of the nodes GOING IN, not of the instance they replace. A slot that
+  // accepted a component instance need not accept what the component draws.
+  const refusal =
+    placementRefusal(inlined.roots, destination.place.where, nesting) ??
+    internalNestingRefusal(inlined.roots, nesting);
+  if (refusal !== undefined) return refusal;
+
+  const ops: BuilderOp[] = [
+    removal,
+    ...inlined.roots.map(
+      (node, offset): BuilderOp => ({
+        kind: "insert",
+        node,
+        at: { ...position.at, index: position.at.index + offset },
+      })
+    ),
+  ];
+
+  // The byte cap, asked of the apply because the apply is the only thing that
+  // can answer it: a definition larger than the instance it replaces can push a
+  // page over a ceiling it was inside. Run on a copy, since `applyOps` is pure.
+  try {
+    applyOps(document, ops, limits);
+  } catch {
+    return { problem: "exceeds-limits" };
+  }
+
+  return { pageOps: ops };
+}
+
+/** An instance found on the page, with the position it holds. */
+interface LocatedInstance {
+  readonly node: BlockNode;
+  readonly at: RunPlacement;
+  readonly problem?: undefined;
+  readonly permitted?: undefined;
+}
+
+/**
+ * The one instance being detached, and where it sits.
+ *
+ * Through {@link contiguousRun}, which is how every other planner asks a
+ * document where a selection is — so the index a detach inserts at is computed
+ * by the same code that computes it for a save, rather than by a second search
+ * that can answer differently.
+ *
+ * Not through `savableRun`: that one also asks whether the selection could be
+ * lifted to a document ROOT, which is a question about saving. An instance that
+ * may not be a root is still perfectly detachable where it stands.
+ */
+function locatedInstance(
+  document: BlockDocument,
+  instanceId: string
+): LocatedInstance | PlanRefusal {
+  const result = contiguousRun(document.nodes, [instanceId]);
+  if (result.run === undefined) return { problem: result.problem };
+  const place = result.run.places[0];
+  if (place === undefined) return { problem: "unknown" };
+
+  const shape = shapeRefusal([place.node]);
+  if (shape !== undefined) return shape;
+  // A node that is not an instance has nothing to detach FROM, and inlining
+  // whatever it is would replace it with itself under a provenance record that
+  // is not true.
+  if (!isComponentInstance(place.node)) return { problem: "not-a-component" };
+
+  const { parentId, slot } = result.run;
+  return {
+    node: place.node,
+    at: {
+      ...(parentId === undefined ? {} : { parentId }),
+      ...(slot === undefined ? {} : { slot }),
+      index: place.index,
+    },
+  };
+}
+
+/** The nodes an instance was drawing, ready to stand on the page themselves. */
+interface DetachedRoots {
+  readonly roots: readonly BlockNode[];
+  readonly problem?: undefined;
+  readonly permitted?: undefined;
+}
+
+/**
+ * Resolve one instance into the nodes it renders, keeping its slot content out.
+ *
+ * The supplied slots are lifted off before the resolver sees them and put back
+ * after, which is what makes "a nested instance stays linked" true by
+ * construction rather than by a pass that hunts for one afterwards.
+ *
+ * Content the resolver does NOT place is content the page does not render —
+ * a slot the definition does not expose, say — and it is not carried over. The
+ * page showed the author what detaching would leave them, and this produces
+ * exactly that.
+ */
+function detachedRoots(
+  document: BlockDocument,
+  instance: BlockNode,
+  definitions: DefinitionsById,
+  taken: ReadonlySet<string>,
+  limits: DocumentLimits
+): DetachedRoots | PlanRefusal {
+  const componentId = instance.props?.componentId;
+  if (typeof componentId !== "string" || componentId === "") {
+    return { problem: "invalid-source" };
+  }
+
+  const held = suppliedSlots(instance);
+  // The page's OWN envelope, with only this instance in it. Built from the
+  // document rather than assembled, so the resolver reads the format version
+  // and settings the page actually carries.
+  const probe: BlockDocument = {
+    ...document,
+    nodes: [{ ...instance, slots: held.slots }],
+  };
+  const resolved = resolveComponentInstances(probe, definitions, {
+    maxComposedDepth: 1,
+    limits,
+  });
+  // The instance itself left standing means there is nothing to inline: the
+  // definition is missing, unpublished, or refused. Detaching to nothing would
+  // delete the author's section.
+  if (resolved.unresolved.some(one => one.componentId === componentId)) {
+    return { problem: "not-a-component" };
+  }
+
+  // TWO passes of the one copier, because two different things are being
+  // undone and each has its own policy.
+  //
+  // First the resolver's own scoping. It mints a `cx-` suffixed DOM id per
+  // composed node so two instances of a component do not collide on the page —
+  // a render-time digest, and `resolveComponentInstances` now says what each
+  // one came from. Persisting it would store a machine id where the author
+  // wrote `card-anchor`, and it would go stale the moment the definition
+  // renamed its own anchor.
+  //
+  // Then the page. With the authored ids back, `{avoid}` renames one only where
+  // the page really holds that name — the rule `planInsertPattern` was fixed to
+  // follow, after unconditional re-minting was found to grow a suffix on every
+  // cycle. Asking both of a single policy would need a fifth `DomIdPolicy` arm;
+  // asking the same published copier twice needs none.
+  const authored = reidForestWithMap(
+    withoutResolverMarkers(resolved.document.nodes),
+    { restore: resolved.renamedDomIds }
+  );
+  const copied = reidForestWithMap(authored.nodes, { avoid: taken });
+  const roots = restoreSuppliedSlots(
+    copied.nodes,
+    held.byId,
+    composed(authored.nodeIds, copied.nodeIds)
+  );
+  return {
+    roots: roots.map(root => ({
+      ...root,
+      origin: { from: "component" as const, id: componentId },
+    })),
+  };
+}
+
+/**
+ * Two id maps read as one, so a caller that copied twice can still say where a
+ * node it started with ended up.
+ */
+function composed(
+  first: ReadonlyMap<string, string>,
+  second: ReadonlyMap<string, string>
+): ReadonlyMap<string, string> {
+  const through = new Map<string, string>();
+  for (const [from, middle] of first) {
+    const to = second.get(middle);
+    if (to !== undefined) through.set(from, to);
+  }
+  return through;
+}
+
+/** The slot content an author supplied, lifted out and stood in for. */
+interface SuppliedSlots {
+  /** The instance's slots, each supplied one holding a single placeholder. */
+  readonly slots: Record<string, BlockNode[]>;
+  /** Placeholder id → the nodes it stands in for. */
+  readonly byId: ReadonlyMap<string, readonly BlockNode[]>;
+}
+
+/**
+ * Swap each supplied slot for a placeholder, keeping what it held.
+ *
+ * A placeholder rather than nothing, because WHERE the content goes is the
+ * resolver's answer to give: an exposed slot names a node deep in the
+ * definition's tree, and a planner that put the content back by finding that
+ * node itself would be a second implementation of the mapping — one that agrees
+ * until an exposed slot moves.
+ *
+ * An empty or unreadable slot is dropped rather than stood in for. Supplying
+ * nothing is how an author asks for the definition's own default content, and a
+ * placeholder there would suppress it.
+ */
+function suppliedSlots(instance: BlockNode): SuppliedSlots {
+  const source = instance.slots;
+  const byId = new Map<string, readonly BlockNode[]>();
+  const slots: Record<string, BlockNode[]> = {};
+  if (!isPlainRecord(source)) return { slots, byId };
+  for (const name of ownKeys(source)) {
+    const content: unknown = source[name];
+    if (!Array.isArray(content) || content.length === 0) continue;
+    const placeholder: BlockNode = {
+      id: newId(),
+      type: "core/box",
+      version: 1,
+      props: {},
+    };
+    byId.set(placeholder.id, content as readonly BlockNode[]);
+    slots[name] = [placeholder];
+  }
+  return { slots, byId };
+}
+
+/**
+ * Put the author's own nodes back where their placeholders landed.
+ *
+ * Located through the id map the copier returns, not by searching for the
+ * placeholder again: the copy re-identified it, and `nodeIds` is the record of
+ * where every id went. A placeholder the resolver did not place has no entry
+ * and its content is not carried — see {@link detachedRoots}.
+ */
+function restoreSuppliedSlots(
+  nodes: readonly BlockNode[],
+  byId: ReadonlyMap<string, readonly BlockNode[]>,
+  nodeIds: ReadonlyMap<string, string>
+): BlockNode[] {
+  if (byId.size === 0) return [...nodes];
+  const placed = new Map<string, readonly BlockNode[]>();
+  for (const [original, content] of byId) {
+    const landed = nodeIds.get(original);
+    if (landed !== undefined) placed.set(landed, content);
+  }
+  return placed.size === 0 ? [...nodes] : splicedForest(nodes, placed);
+}
+
+/** One forest, with each placed id replaced by the nodes it stands in for. */
+function splicedForest(
+  nodes: readonly BlockNode[],
+  placed: ReadonlyMap<string, readonly BlockNode[]>
+): BlockNode[] {
+  const out: BlockNode[] = [];
+  for (const node of nodes) {
+    const content = placed.get(node.id);
+    if (content !== undefined) {
+      out.push(...content);
+      continue;
+    }
+    out.push(splicedNode(node, placed));
+  }
+  return out;
+}
+
+/** The same, one level down. Bounded by the depth the resolver already capped. */
+function splicedNode(
+  node: BlockNode,
+  placed: ReadonlyMap<string, readonly BlockNode[]>
+): BlockNode {
+  const source = node.slots;
+  if (!isPlainRecord(source)) return node;
+  const slots: Record<string, BlockNode[]> = {};
+  for (const name of ownKeys(source)) {
+    const content: unknown = source[name];
+    slots[name] = Array.isArray(content)
+      ? splicedForest(content as readonly BlockNode[], placed)
+      : (content as BlockNode[]);
+  }
+  return { ...node, slots };
+}
+
+/**
+ * The resolved tree with the resolver's own fields taken off.
+ *
+ * `instanceOf` and `unresolvedComponent` are render-time facts —
+ * `ResolvedBlockNode` says so, and `BlockNode`'s key set is the stored format.
+ * Persisting either would put a field into the database that no reader of a
+ * stored document expects and that strict validation does not describe.
+ */
+function withoutResolverMarkers(nodes: readonly BlockNode[]): BlockNode[] {
+  return mapForest([...nodes], node => {
+    const marked = node as BlockNode & Record<string, unknown>;
+    if (
+      marked.instanceOf === undefined &&
+      marked.unresolvedComponent === undefined
+    ) {
+      return node;
+    }
+    const copy: Record<string, unknown> = { ...marked };
+    delete copy.instanceOf;
+    delete copy.unresolvedComponent;
+    return copy as unknown as BlockNode;
   });
 }
 

--- a/packages/blocks-engine/src/composition-planners.ts
+++ b/packages/blocks-engine/src/composition-planners.ts
@@ -2863,9 +2863,16 @@ function suppliedSlots(instance: BlockNode): SuppliedSlots {
     byId.set(placeholder.id, content as readonly BlockNode[]);
     // `defineEntry`, never assignment. A slot literally named `__proto__` is a
     // key a stored document may carry, and `slots[name] = …` sets the object's
-    // PROTOTYPE instead of creating that key — so the placeholder was never
-    // written, the resolver placed nothing, and the author's content was
-    // dropped without a word.
+    // PROTOTYPE instead of creating that key — so the placeholder would never
+    // be written, the resolver would place nothing, and the author's content
+    // would be dropped without a word.
+    //
+    // No document reaches here carrying that key today: `documentRefusal`
+    // rejects one, because an own `__proto__` does not survive the round trip
+    // this format is stored through. That makes the guard CHEAP rather than
+    // unnecessary — reachability is a property of the call graph, and the call
+    // graph moves. The cost is one function call on a path that already builds
+    // an object.
     defineEntry(slots, name, [placeholder]);
   }
   return { slots, byId };

--- a/packages/blocks-engine/src/composition-planners.ts
+++ b/packages/blocks-engine/src/composition-planners.ts
@@ -2481,10 +2481,17 @@ function resolvedDefinition(
     maxComposedDepth: 1,
     limits,
   });
-  // The instance itself left standing means there is nothing to inline: the
+  // THIS instance left standing means there is nothing to inline: the
   // definition is missing, unpublished, or refused. Detaching to nothing would
   // delete the author's section.
-  if (resolved.unresolved.some(one => one.componentId === componentId)) {
+  //
+  // Matched on the instance, not the component. A definition that nests an
+  // instance of ITSELF reports that nested one as a cycle — carrying the same
+  // `componentId` — while the outer expansion succeeded, and reading the
+  // component name refused a detach that had already worked. `instanceId` is
+  // the node as it appears in the returned document, which for the one being
+  // detached is the id it was selected by.
+  if (resolved.unresolved.some(one => one.instanceId === instance.id)) {
     return { problem: "not-a-component" };
   }
 
@@ -2645,8 +2652,25 @@ function detachedRoots(
   // expose is dropped by the resolver and never reaches the page, so counting
   // its ids renamed a definition's authored anchor to avoid something that will
   // not be there — breaking a fragment link or a selector for no collision.
+  if (gate !== undefined && authored.nodes.some(isConditionGated)) {
+    return { problem: "condition-gated" };
+  }
+  // The gate goes on BEFORE the ids are judged, not after. `domIdsIn` counts
+  // only what RENDERS, and a condition-gated subtree renders nothing — so a
+  // hidden variant's authored anchor collides with no one. Reminting it anyway
+  // gave the detached copy a permanent rename for a conflict that does not
+  // exist, and one that outlives the gate: remove the condition later and the
+  // fragment the author wrote is still pointing at a suffixed id.
+  //
+  // Applying it here also means the copier's own hidden-subtree rule is the
+  // thing deciding, rather than this planner reproducing it.
+  const gated = authored.nodes.map(root => ({
+    ...root,
+    ...gatedWith(root, gate),
+  }));
+
   const placed = placedContent(held, authored.nodeIds);
-  const copied = reidForestWithMap(authored.nodes, {
+  const copied = reidForestWithMap(gated, {
     avoid: domIdsIn([...remaining, ...placed]),
   });
   const roots = restoreSuppliedSlots(
@@ -2654,9 +2678,6 @@ function detachedRoots(
     held.byId,
     composed(authored.nodeIds, copied.nodeIds)
   );
-  if (gate !== undefined && roots.some(isConditionGated)) {
-    return { problem: "condition-gated" };
-  }
   // Two nodes rendering ONE id. Resolution scoped both to one runtime id, and
   // putting the authored one back gives the page a duplicate — which `applyOps`
   // does not police and strict validation, the gate this predicts, refuses. The
@@ -2664,7 +2685,6 @@ function detachedRoots(
   // succeeding into a page that cannot be published.
   const stamped = roots.map(root => ({
     ...root,
-    ...gatedWith(root, gate),
     origin: { from: "component" as const, id: componentId },
   }));
   return duplicateDomIdRefusal(stamped) ?? { roots: stamped };

--- a/packages/blocks-engine/src/composition-planners.ts
+++ b/packages/blocks-engine/src/composition-planners.ts
@@ -33,6 +33,7 @@ import type {
   BlockDocument,
   BlockNode,
   BlockOrigin,
+  Condition,
   ComponentDocument,
   ExposedProperty,
   ExposedPropertyType,
@@ -81,6 +82,7 @@ import {
 } from "./tree";
 import { componentEnvelopeIssues } from "./validation";
 import type { ValidationIssue } from "./validation";
+import { isConditionGated } from "./visibility";
 
 /** A library row a planner asks the caller to create. */
 export interface PlannedCreate<TFields> {
@@ -2403,17 +2405,11 @@ export function planDetach(
     return { problem: "unusable-document" };
   }
 
-  // What the page will hold when this lands: everything outside the instance,
-  // AND the supplied slot content, which is restored into the result rather
-  // than copied and so keeps the ids it already has. Leaving it out let a
-  // definition id collide with one of the author's own after restoration —
-  // legal on the page today, because the definition's is rendered scoped — and
-  // the group was then refused with a cause about size.
   const inlined = detachedRoots(
     document,
     located.node,
     definitions,
-    domIdsIn([...remaining.nodes, ...suppliedContent(located.node)]),
+    remaining.nodes,
     limits
   );
   if (inlined.problem !== undefined) return inlined;
@@ -2450,6 +2446,80 @@ export function planDetach(
   }
 
   return { pageOps: ops };
+}
+
+/** One instance resolved into the nodes it renders, or why it could not be. */
+interface ResolvedDefinition {
+  readonly nodes: BlockNode[];
+  readonly renamedDomIds: ReadonlyMap<string, string>;
+  readonly problem?: undefined;
+  readonly permitted?: undefined;
+}
+
+/**
+ * Inline ONE instance through the renderer's own resolver, and judge the result.
+ *
+ * Its own function so the caller stays inside the complexity the gate allows,
+ * and because everything here is about getting a trustworthy forest OUT of the
+ * resolver — what happens to its ids afterwards is a separate question.
+ */
+function resolvedDefinition(
+  document: BlockDocument,
+  instance: BlockNode,
+  componentId: string,
+  definitions: DefinitionsById,
+  limits: DocumentLimits
+): ResolvedDefinition | PlanRefusal {
+  // The page's OWN envelope, with only this instance in it. Built from the
+  // document rather than assembled, so the resolver reads the format version
+  // and settings the page actually carries.
+  const probe: BlockDocument = {
+    ...document,
+    nodes: [instance],
+  };
+  const resolved = resolveComponentInstances(probe, definitions, {
+    maxComposedDepth: 1,
+    limits,
+  });
+  // The instance itself left standing means there is nothing to inline: the
+  // definition is missing, unpublished, or refused. Detaching to nothing would
+  // delete the author's section.
+  if (resolved.unresolved.some(one => one.componentId === componentId)) {
+    return { problem: "not-a-component" };
+  }
+
+  // TWO passes of the one copier, because two different things are being
+  // undone and each has its own policy.
+  //
+  // First the resolver's own scoping. It mints a `cx-` suffixed DOM id per
+  // composed node so two instances of a component do not collide on the page —
+  // a render-time digest, and `resolveComponentInstances` now says what each
+  // one came from. Persisting it would store a machine id where the author
+  // wrote `card-anchor`, and it would go stale the moment the definition
+  // renamed its own anchor.
+  //
+  // Then the page. With the authored ids back, `{avoid}` renames one only where
+  // the page really holds that name — the rule `planInsertPattern` was fixed to
+  // follow, after unconditional re-minting was found to grow a suffix on every
+  // cycle. Asking both of a single policy would need a fifth `DomIdPolicy` arm;
+  // asking the same published copier twice needs none.
+  // Before the copy, because copying is itself a step that can fail: a stored
+  // definition reaching this module from an in-process caller can hold a value
+  // JSON cannot carry — a function in `props` — and `structuredClone` throws a
+  // native `DataCloneError` out of a function that promises a refusal. The
+  // shape rule catches the same node and turns the crash into a cause, which is
+  // what `storedRefusal` does for the pattern paths.
+  const inlinedNodes = withoutResolverMarkers(resolved.document.nodes);
+  if (forestRefusal(inlinedNodes) !== undefined) {
+    return { problem: "unusable-document" };
+  }
+  // The NODE contract separately, and reported as itself: a forest of plain
+  // storable records is not yet a forest of nodes this engine would carry, and
+  // `"invalid-node"` is what every other planner calls that — an author whose
+  // definition holds a legacy node gets the same cause whichever road they took.
+  const shape = shapeRefusal(inlinedNodes);
+  if (shape !== undefined) return shape;
+  return { nodes: inlinedNodes, renamedDomIds: resolved.renamedDomIds };
 }
 
 /** An instance found on the page, with the position it holds. */
@@ -2522,7 +2592,7 @@ function detachedRoots(
   document: BlockDocument,
   instance: BlockNode,
   definitions: DefinitionsById,
-  taken: ReadonlySet<string>,
+  remaining: readonly BlockNode[],
   limits: DocumentLimits
 ): DetachedRoots | PlanRefusal {
   const componentId = instance.props?.componentId;
@@ -2545,61 +2615,59 @@ function detachedRoots(
   // than merged: two condition sets combine as a cross product of their groups,
   // and quietly rewriting an author's visibility rules is not something a
   // detach should do.
-  const gate = instance.visibility;
+  //
+  // The CONDITIONS only. `devices` lives in the same envelope and is explicitly
+  // NOT a gate — per-breakpoint hiding is CSS on a node that is always served —
+  // and the resolver already carries it onto the roots itself, under a rule
+  // about which direction may propagate. Lifting the whole envelope threw that
+  // merge away and then refused every responsive instance whose definition
+  // styled its own breakpoints.
+  const gate = conditionGate(instance);
   const held = suppliedSlots(instance);
-  // The page's OWN envelope, with only this instance in it. Built from the
-  // document rather than assembled, so the resolver reads the format version
-  // and settings the page actually carries.
-  const probe: BlockDocument = {
-    ...document,
-    nodes: [ungated({ ...instance, slots: held.slots })],
-  };
-  const resolved = resolveComponentInstances(probe, definitions, {
-    maxComposedDepth: 1,
-    limits,
-  });
-  // The instance itself left standing means there is nothing to inline: the
-  // definition is missing, unpublished, or refused. Detaching to nothing would
-  // delete the author's section.
-  if (resolved.unresolved.some(one => one.componentId === componentId)) {
-    return { problem: "not-a-component" };
-  }
-
-  // TWO passes of the one copier, because two different things are being
-  // undone and each has its own policy.
-  //
-  // First the resolver's own scoping. It mints a `cx-` suffixed DOM id per
-  // composed node so two instances of a component do not collide on the page —
-  // a render-time digest, and `resolveComponentInstances` now says what each
-  // one came from. Persisting it would store a machine id where the author
-  // wrote `card-anchor`, and it would go stale the moment the definition
-  // renamed its own anchor.
-  //
-  // Then the page. With the authored ids back, `{avoid}` renames one only where
-  // the page really holds that name — the rule `planInsertPattern` was fixed to
-  // follow, after unconditional re-minting was found to grow a suffix on every
-  // cycle. Asking both of a single policy would need a fifth `DomIdPolicy` arm;
-  // asking the same published copier twice needs none.
-  const authored = reidForestWithMap(
-    withoutResolverMarkers(resolved.document.nodes),
-    { restore: resolved.renamedDomIds }
+  const inlined = resolvedDefinition(
+    document,
+    withoutConditions({ ...instance, slots: held.slots }),
+    componentId,
+    definitions,
+    limits
   );
-  const copied = reidForestWithMap(authored.nodes, { avoid: taken });
+  if (inlined.problem !== undefined) return inlined;
+  const { nodes: inlinedNodes, renamedDomIds } = inlined;
+
+  const authored = reidForestWithMap(inlinedNodes, {
+    restore: renamedDomIds,
+  });
+  // What the page will actually hold: everything outside the instance, AND the
+  // supplied content resolution PLACED — restored rather than copied, so it
+  // keeps the ids it already has.
+  //
+  // Placed, not merely supplied. Content for a slot the definition does not
+  // expose is dropped by the resolver and never reaches the page, so counting
+  // its ids renamed a definition's authored anchor to avoid something that will
+  // not be there — breaking a fragment link or a selector for no collision.
+  const placed = placedContent(held, authored.nodeIds);
+  const copied = reidForestWithMap(authored.nodes, {
+    avoid: domIdsIn([...remaining, ...placed]),
+  });
   const roots = restoreSuppliedSlots(
     copied.nodes,
     held.byId,
     composed(authored.nodeIds, copied.nodeIds)
   );
-  if (gate !== undefined && roots.some(root => root.visibility !== undefined)) {
+  if (gate !== undefined && roots.some(isConditionGated)) {
     return { problem: "condition-gated" };
   }
-  return {
-    roots: roots.map(root => ({
-      ...root,
-      ...(gate === undefined ? {} : { visibility: gate }),
-      origin: { from: "component" as const, id: componentId },
-    })),
-  };
+  // Two nodes rendering ONE id. Resolution scoped both to one runtime id, and
+  // putting the authored one back gives the page a duplicate — which `applyOps`
+  // does not police and strict validation, the gate this predicts, refuses. The
+  // pattern paths already ask this; asking it here is what keeps a plan from
+  // succeeding into a page that cannot be published.
+  const stamped = roots.map(root => ({
+    ...root,
+    ...gatedWith(root, gate),
+    origin: { from: "component" as const, id: componentId },
+  }));
+  return duplicateDomIdRefusal(stamped) ?? { roots: stamped };
 }
 
 /**
@@ -2618,28 +2686,62 @@ function composed(
   return through;
 }
 
-/** The same node with any condition gate taken off. */
-function ungated(instance: BlockNode): BlockNode {
-  if (instance.visibility === undefined) return instance;
-  const copy: Record<string, unknown> = { ...instance };
-  delete copy.visibility;
-  return copy as unknown as BlockNode;
+/** The condition groups an instance is gated by, when it is gated at all. */
+function conditionGate(instance: BlockNode): Condition[][] | undefined {
+  if (!isConditionGated(instance)) return undefined;
+  const envelope = instance.visibility;
+  return isPlainRecord(envelope)
+    ? (envelope.conditions as Condition[][] | undefined)
+    : undefined;
 }
 
 /**
- * Every node an author supplied to this instance's slots, flattened.
+ * The same node with its CONDITIONS removed and the rest of its envelope kept.
  *
- * The roots only — {@link domIdsIn} walks what it is given — and read through
- * the same guards {@link suppliedSlots} reads, so the ids counted as taken are
- * exactly the nodes that will be restored.
+ * `devices` stays: it is not a gate, and the resolver merges it onto the roots
+ * under a rule of its own about which direction may propagate.
  */
-function suppliedContent(instance: BlockNode): BlockNode[] {
-  const source = instance.slots;
-  if (!isPlainRecord(source)) return [];
+function withoutConditions(instance: BlockNode): BlockNode {
+  const envelope = instance.visibility;
+  if (!isPlainRecord(envelope)) return instance;
+  const kept: Record<string, unknown> = { ...envelope };
+  delete kept.conditions;
+  return { ...instance, visibility: kept };
+}
+
+/**
+ * A root's visibility with the instance's conditions added, keeping its own.
+ *
+ * MERGED rather than assigned, because the resolver may already have put device
+ * flags here — overwriting the envelope would drop the per-breakpoint hiding it
+ * just carried over. Only reached when no root is condition-gated, so there are
+ * no conditions of its own to lose.
+ */
+function gatedWith(
+  root: BlockNode,
+  gate: Condition[][] | undefined
+): { visibility?: BlockNode["visibility"] } {
+  if (gate === undefined) return {};
+  const envelope = isPlainRecord(root.visibility) ? root.visibility : {};
+  return { visibility: { ...envelope, conditions: gate } };
+}
+
+/**
+ * The supplied content resolution actually PLACED, flattened.
+ *
+ * Keyed on the placeholder ids the copier reports landing, so this is exactly
+ * the set {@link restoreSuppliedSlots} will put back. Content for a slot the
+ * definition does not expose has no entry: the resolver dropped it, it will not
+ * reach the page, and counting its ids as taken renames an authored anchor to
+ * avoid a collision that cannot happen.
+ */
+function placedContent(
+  held: SuppliedSlots,
+  nodeIds: ReadonlyMap<string, string>
+): BlockNode[] {
   const all: BlockNode[] = [];
-  for (const name of ownKeys(source)) {
-    const content: unknown = source[name];
-    if (Array.isArray(content)) all.push(...(content as BlockNode[]));
+  for (const [placeholder, content] of held.byId) {
+    if (nodeIds.has(placeholder)) all.push(...content);
   }
   return all;
 }
@@ -2680,7 +2782,12 @@ function suppliedSlots(instance: BlockNode): SuppliedSlots {
       props: {},
     };
     byId.set(placeholder.id, content as readonly BlockNode[]);
-    slots[name] = [placeholder];
+    // `defineEntry`, never assignment. A slot literally named `__proto__` is a
+    // key a stored document may carry, and `slots[name] = …` sets the object's
+    // PROTOTYPE instead of creating that key — so the placeholder was never
+    // written, the resolver placed nothing, and the author's content was
+    // dropped without a word.
+    defineEntry(slots, name, [placeholder]);
   }
   return { slots, byId };
 }
@@ -2734,9 +2841,13 @@ function splicedNode(
   const slots: Record<string, BlockNode[]> = {};
   for (const name of ownKeys(source)) {
     const content: unknown = source[name];
-    slots[name] = Array.isArray(content)
-      ? splicedForest(content as readonly BlockNode[], placed)
-      : (content as BlockNode[]);
+    defineEntry(
+      slots,
+      name,
+      Array.isArray(content)
+        ? splicedForest(content as readonly BlockNode[], placed)
+        : (content as BlockNode[])
+    );
   }
   return { ...node, slots };
 }

--- a/packages/blocks-engine/src/composition-planners.ts
+++ b/packages/blocks-engine/src/composition-planners.ts
@@ -67,6 +67,7 @@ import { isPlainRecord } from "./plain-record";
 import {
   componentIdsIn,
   resolveComponentInstances,
+  type ComponentUnresolvedReason,
   type DefinitionsById,
 } from "./resolve-instances";
 import { boundedOwnKeys, defineEntry, ownKeys } from "./safe-record";
@@ -2164,6 +2165,15 @@ interface FreshCopy {
    */
   readonly renamed: ReadonlyMap<string, string>;
   readonly nodes: BlockNode[];
+  /**
+   * Each node's id BEFORE the copy → the id it was given.
+   *
+   * Published because a caller may have put something into the forest it needs
+   * to find again afterwards — detaching stands a placeholder in for the
+   * author's slot content and has to know where it landed — and the copy is the
+   * only thing that knows.
+   */
+  readonly nodeIds: ReadonlyMap<string, string>;
   readonly problem?: undefined;
 }
 
@@ -2218,7 +2228,13 @@ function freshCopy(
     const clash =
       [...minted.domIds.values()].some(id => taken.has(id)) ||
       duplicateDomIdRefusal(minted.nodes) !== undefined;
-    if (!clash) return { nodes: minted.nodes, renamed: minted.domIds };
+    if (!clash) {
+      return {
+        nodes: minted.nodes,
+        renamed: minted.domIds,
+        nodeIds: minted.nodeIds,
+      };
+    }
   }
   return { problem: "dom-id-collision" };
 }
@@ -2448,6 +2464,30 @@ export function planDetach(
   return { pageOps: ops };
 }
 
+/**
+ * What each way of failing to inline an instance means to whoever asked.
+ *
+ * A RECORD over the reason type, not a condition, so the compiler asks for an
+ * answer the day a reason is added rather than letting it fall into whichever
+ * branch happens to be last. Collapsing them all to `"not-a-component"` told an
+ * author to publish or repair a component that was neither missing nor broken —
+ * only bigger than the limits this call was given.
+ *
+ * `budget` and `node-depth` are the page's ceilings, and `composed-depth` is
+ * the nesting one; all three are the size answer. The rest are faults in the
+ * component or in the instance naming it, which is a different screen and a
+ * different remedy.
+ */
+const DETACH_REFUSALS: Record<ComponentUnresolvedReason, PlanProblem> = {
+  budget: "exceeds-limits",
+  "node-depth": "exceeds-limits",
+  "composed-depth": "exceeds-limits",
+  missing: "not-a-component",
+  unreadable: "not-a-component",
+  cycle: "not-a-component",
+  malformed: "invalid-source",
+};
+
 /** One instance resolved into the nodes it renders, or why it could not be. */
 interface ResolvedDefinition {
   readonly nodes: BlockNode[];
@@ -2491,9 +2531,11 @@ function resolvedDefinition(
   // component name refused a detach that had already worked. `instanceId` is
   // the node as it appears in the returned document, which for the one being
   // detached is the id it was selected by.
-  if (resolved.unresolved.some(one => one.instanceId === instance.id)) {
-    return { problem: "not-a-component" };
-  }
+  const refused = resolved.unresolved.find(
+    one => one.instanceId === instance.id
+  );
+  if (refused !== undefined)
+    return { problem: DETACH_REFUSALS[refused.reason] };
 
   // TWO passes of the one copier, because two different things are being
   // undone and each has its own policy.
@@ -2669,10 +2711,26 @@ function detachedRoots(
     ...gatedWith(root, gate),
   }));
 
+  // The DEFINITION's own fault, asked before the copy and reported as itself.
+  // Two of its nodes rendering one id is a fault in the component, and
+  // `freshCopy` below would report it as `dom-id-collision` — which names the
+  // destination and sends an author to look at the page they are detaching
+  // ONTO rather than at the component. Asked of the authored form, since that
+  // is where two nodes sharing an id become visible: resolution had scoped them
+  // to one runtime id apiece.
+  const duplicated = duplicateDomIdRefusal(authored.nodes);
+  if (duplicated !== undefined) return duplicated;
+
+  // Through the CHECKED copier, not a second call to the raw one. `{avoid}`
+  // mints against the ids the destination holds, but a minted `hero-<suffix>`
+  // can itself land on an id the page already carries — `freshCopy` compares
+  // what was minted against that set, re-mints from fresh node ids when it
+  // clashes, and refuses as `dom-id-collision` rather than producing a page
+  // with two of one id. It also asks `duplicateDomIdRefusal` of the copy, which
+  // is the collision entirely inside the forest.
   const placed = placedContent(held, authored.nodeIds);
-  const copied = reidForestWithMap(gated, {
-    avoid: domIdsIn([...remaining, ...placed]),
-  });
+  const copied = freshCopy(gated, domIdsIn([...remaining, ...placed]));
+  if (copied.problem !== undefined) return copied;
   const roots = restoreSuppliedSlots(
     copied.nodes,
     held.byId,
@@ -2683,11 +2741,12 @@ function detachedRoots(
   // does not police and strict validation, the gate this predicts, refuses. The
   // pattern paths already ask this; asking it here is what keeps a plan from
   // succeeding into a page that cannot be published.
-  const stamped = roots.map(root => ({
-    ...root,
-    origin: { from: "component" as const, id: componentId },
-  }));
-  return duplicateDomIdRefusal(stamped) ?? { roots: stamped };
+  return {
+    roots: roots.map(root => ({
+      ...root,
+      origin: { from: "component" as const, id: componentId },
+    })),
+  };
 }
 
 /**

--- a/packages/blocks-engine/src/composition-planners.ts
+++ b/packages/blocks-engine/src/composition-planners.ts
@@ -242,7 +242,16 @@ export type PlanProblem =
    */
   | "self-reference"
   /** The document handed over is not a component definition. */
-  | "not-a-component";
+  | "not-a-component"
+  /**
+   * A gated instance whose content carries gates of its own.
+   *
+   * Its own cause because nothing is malformed and the remedy is the author's:
+   * the instance is shown conditionally and so is something the component
+   * draws, and the two sets of conditions cannot be combined into one without
+   * rewriting rules nobody asked to change.
+   */
+  | "condition-gated";
 
 /** A refusal, with whatever the surface needs to phrase it. */
 export interface PlanRefusal {
@@ -2394,11 +2403,17 @@ export function planDetach(
     return { problem: "unusable-document" };
   }
 
+  // What the page will hold when this lands: everything outside the instance,
+  // AND the supplied slot content, which is restored into the result rather
+  // than copied and so keeps the ids it already has. Leaving it out let a
+  // definition id collide with one of the author's own after restoration —
+  // legal on the page today, because the definition's is rendered scoped — and
+  // the group was then refused with a cause about size.
   const inlined = detachedRoots(
     document,
     located.node,
     definitions,
-    domIdsIn(remaining.nodes),
+    domIdsIn([...remaining.nodes, ...suppliedContent(located.node)]),
     limits
   );
   if (inlined.problem !== undefined) return inlined;
@@ -2413,15 +2428,16 @@ export function planDetach(
     internalNestingRefusal(inlined.roots, nesting);
   if (refusal !== undefined) return refusal;
 
+  // Through the SHARED builder, not a second insert path. It takes the locks
+  // off on the way in and puts them back once the nodes have landed, because
+  // `applyOp` refuses an insert whose subtree arrives locked — the inverse of
+  // an insert is a remove, and a remove refuses a locked subtree, so such an
+  // insert could never be undone. A definition holding a locked block is
+  // ordinary, and building the ops by hand refused every one of them, reported
+  // as a byte-cap failure.
   const ops: BuilderOp[] = [
     removal,
-    ...inlined.roots.map(
-      (node, offset): BuilderOp => ({
-        kind: "insert",
-        node,
-        at: { ...position.at, index: position.at.index + offset },
-      })
-    ),
+    ...insertOps(inlined.roots, destination.place, document, position.at),
   ];
 
   // The byte cap, asked of the apply because the apply is the only thing that
@@ -2514,13 +2530,29 @@ function detachedRoots(
     return { problem: "invalid-source" };
   }
 
+  // A CONDITION-GATED instance is refused by the resolver on purpose: inlining
+  // it would replace it with roots that inherit no gate, and content shown to a
+  // reader it was withheld from cannot be taken back. It says so by returning
+  // the instance untouched — and, unlike every other refusal, WITHOUT an
+  // `unresolved` entry, so a planner reading only that list saw a clean
+  // resolution and planned to replace the instance with itself: an op group
+  // that reported success, stayed linked to the definition, and stamped a
+  // provenance record saying it had been detached.
+  //
+  // The gate is lifted for the resolution and put back on the roots, which
+  // preserves it exactly — gating is inherited, so a gate on each root gates
+  // everything beneath it. A root carrying a gate of its OWN is refused rather
+  // than merged: two condition sets combine as a cross product of their groups,
+  // and quietly rewriting an author's visibility rules is not something a
+  // detach should do.
+  const gate = instance.visibility;
   const held = suppliedSlots(instance);
   // The page's OWN envelope, with only this instance in it. Built from the
   // document rather than assembled, so the resolver reads the format version
   // and settings the page actually carries.
   const probe: BlockDocument = {
     ...document,
-    nodes: [{ ...instance, slots: held.slots }],
+    nodes: [ungated({ ...instance, slots: held.slots })],
   };
   const resolved = resolveComponentInstances(probe, definitions, {
     maxComposedDepth: 1,
@@ -2558,9 +2590,13 @@ function detachedRoots(
     held.byId,
     composed(authored.nodeIds, copied.nodeIds)
   );
+  if (gate !== undefined && roots.some(root => root.visibility !== undefined)) {
+    return { problem: "condition-gated" };
+  }
   return {
     roots: roots.map(root => ({
       ...root,
+      ...(gate === undefined ? {} : { visibility: gate }),
       origin: { from: "component" as const, id: componentId },
     })),
   };
@@ -2580,6 +2616,32 @@ function composed(
     if (to !== undefined) through.set(from, to);
   }
   return through;
+}
+
+/** The same node with any condition gate taken off. */
+function ungated(instance: BlockNode): BlockNode {
+  if (instance.visibility === undefined) return instance;
+  const copy: Record<string, unknown> = { ...instance };
+  delete copy.visibility;
+  return copy as unknown as BlockNode;
+}
+
+/**
+ * Every node an author supplied to this instance's slots, flattened.
+ *
+ * The roots only — {@link domIdsIn} walks what it is given — and read through
+ * the same guards {@link suppliedSlots} reads, so the ids counted as taken are
+ * exactly the nodes that will be restored.
+ */
+function suppliedContent(instance: BlockNode): BlockNode[] {
+  const source = instance.slots;
+  if (!isPlainRecord(source)) return [];
+  const all: BlockNode[] = [];
+  for (const name of ownKeys(source)) {
+    const content: unknown = source[name];
+    if (Array.isArray(content)) all.push(...(content as BlockNode[]));
+  }
+  return all;
 }
 
 /** The slot content an author supplied, lifted out and stood in for. */

--- a/packages/blocks-engine/src/detach.test.ts
+++ b/packages/blocks-engine/src/detach.test.ts
@@ -394,6 +394,136 @@ describe("what the op group has to survive", () => {
   });
 });
 
+describe("responsive visibility is not a gate", () => {
+  it("detaches, and keeps the resolver's device merge", () => {
+    // `devices` shares the visibility envelope with `conditions` but is
+    // explicitly NOT a gate — per-breakpoint hiding is CSS on a node that is
+    // always served — and the resolver already carries it onto the roots under
+    // a rule of its own about which direction may propagate. Lifting the WHOLE
+    // envelope for the resolution threw that merge away and then refused every
+    // responsive instance whose definition styled its own breakpoints.
+    const definitions = defs({
+      card: component([
+        node("d1", {
+          props: { mark: "body" },
+          visibility: { devices: { desktop: true } },
+        }),
+      ]),
+    });
+    const doc = page([
+      instance("i1", "card", { visibility: { devices: { mobile: false } } }),
+    ]);
+
+    const result = applied(doc, planDetach(doc, "i1", definitions, anyParent));
+
+    expect(result.nodes[0]?.visibility).toEqual({
+      devices: { desktop: true, mobile: false },
+    });
+  });
+});
+
+describe("what the copy must not do to ids", () => {
+  it("keeps an authored id when only DISCARDED content would collide", () => {
+    // Content for a slot the definition does not expose is dropped by the
+    // resolver and never reaches the page. Counting its ids as taken renamed a
+    // definition's authored anchor to avoid something that will not be there,
+    // breaking a fragment link or a selector for no collision at all.
+    const definitions = defs({
+      card: component([
+        node("d1", { cssId: "anchor", props: { mark: "body" } }),
+      ]),
+    });
+    const doc = page([
+      instance("i1", "card", {
+        slots: { body: [node("orphan", { cssId: "anchor" })] },
+      }),
+    ]);
+
+    const result = applied(doc, planDetach(doc, "i1", definitions, anyParent));
+
+    expect(marked(result.nodes, "body").cssId).toBe("anchor");
+  });
+
+  it("refuses a definition that renders one id on two nodes", () => {
+    // Resolution scopes both to one runtime id; putting the authored one back
+    // gives the page a duplicate. `applyOps` does not police DOM-id uniqueness
+    // and strict validation — the gate this predicts — refuses it, so the plan
+    // would succeed into a page that can never be published.
+    const definitions = defs({
+      card: component([
+        node("d1", { cssId: "same" }),
+        node("d2", { cssId: "same" }),
+      ]),
+    });
+    const doc = page([instance("i1", "card")]);
+
+    expect(planDetach(doc, "i1", definitions, anyParent).problem).toBe(
+      "duplicate-dom-id"
+    );
+  });
+});
+
+describe("a slot name the format allows and JavaScript does not", () => {
+  const exposing = (key: string): DefinitionsById => {
+    const envelope: Record<string, unknown> = {};
+    Object.defineProperty(envelope, key, {
+      value: { label: "B", nodeId: "s1", slot: "children" },
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
+    return defs({
+      card: component([box("s1", [])], {
+        slots: envelope as ComponentDocument["slots"],
+      }),
+    });
+  };
+
+  const supplying = (key: string): BlockDocument => {
+    const supplied: Record<string, BlockNode[]> = {};
+    Object.defineProperty(supplied, key, {
+      value: [node("mine", { props: { mark: "m" } })],
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
+    return page([instance("i1", "card", { slots: supplied })]);
+  };
+
+  it("restores content from an ordinary slot", () => {
+    // The control. Without it the assertion below passes for a planner that
+    // restores nothing at all.
+    const doc = supplying("body");
+
+    const result = applied(
+      doc,
+      planDetach(doc, "i1", exposing("body"), anyParent)
+    );
+
+    expect(marked(result.nodes, "m").id).toBe("mine");
+  });
+
+  it("refuses a `__proto__` slot rather than dropping it silently", () => {
+    // Locks the OUTCOME, and it does not discriminate: such a document is
+    // refused upstream today whichever way the slots were written, so this
+    // passes with or without the fix beside it. Kept because the failure it
+    // guards against is a silent one — a future change that let this document
+    // through would produce a plan reporting success with the author's content
+    // quietly gone, and nothing else here would notice.
+    //
+    // The write itself goes through `defineEntry` regardless: `slots[name] = …`
+    // with this name sets the object's PROTOTYPE instead of creating the key,
+    // so the placeholder is never written and the resolver places nothing.
+    // `validate` calls such a document `document-lossy` and the pattern paths
+    // call it `invalid-node`.
+    const doc = supplying("__proto__");
+
+    expect(
+      planDetach(doc, "i1", exposing("__proto__"), anyParent).problem
+    ).toBe("unusable-document");
+  });
+});
+
 describe("what detach refuses", () => {
   const definitions = defs({ card: component([node("d1")]) });
 

--- a/packages/blocks-engine/src/detach.test.ts
+++ b/packages/blocks-engine/src/detach.test.ts
@@ -505,19 +505,18 @@ describe("a slot name the format allows and JavaScript does not", () => {
     expect(marked(result.nodes, "m").id).toBe("mine");
   });
 
-  it("refuses a `__proto__` slot rather than dropping it silently", () => {
-    // Locks the OUTCOME, and it does not discriminate: such a document is
-    // refused upstream today whichever way the slots were written, so this
-    // passes with or without the fix beside it. Kept because the failure it
-    // guards against is a silent one — a future change that let this document
-    // through would produce a plan reporting success with the author's content
-    // quietly gone, and nothing else here would notice.
+  it("refuses a document whose slot key JSON cannot carry", () => {
+    // What this asserts, and what it does NOT. It asserts the outcome: such a
+    // document is refused, so the author's content is never quietly dropped on
+    // the floor. It is NOT coverage of the placeholder write — `documentRefusal`
+    // rejects this document before `suppliedSlots` is reached, so it passes
+    // whether that write uses `defineEntry` or a plain assignment. The reason
+    // `defineEntry` is used there anyway is stated where the code is, not
+    // implied by a test that cannot see it.
     //
-    // The write itself goes through `defineEntry` regardless: `slots[name] = …`
-    // with this name sets the object's PROTOTYPE instead of creating the key,
-    // so the placeholder is never written and the resolver places nothing.
     // `validate` calls such a document `document-lossy` and the pattern paths
-    // call it `invalid-node`.
+    // call it `invalid-node`; this path calls it `unusable-document`. All three
+    // agree it does not round-trip.
     const doc = supplying("__proto__");
 
     expect(
@@ -628,6 +627,24 @@ describe("what detach refuses", () => {
 
     expect(escaped).toBeUndefined();
     expect(problem).toBe("not-a-component");
+  });
+
+  it("refuses a definition written in a format this build cannot read", () => {
+    // The resolver checked only that `nodes` is an array and `kind` is
+    // `component`, so a definition from a future or corrupt writer was inlined
+    // and its content persisted into the page under rules this build does not
+    // implement. `unreadable` already meant "an envelope this build does not
+    // understand"; nothing asked the question.
+    const definition = {
+      formatVersion: 999,
+      kind: "component",
+      nodes: [node("d1")],
+    } as unknown as BlockDocument;
+    const doc = page([instance("i1", "card")]);
+
+    expect(
+      planDetach(doc, "i1", defs({ card: definition }), anyParent).problem
+    ).toBe("not-a-component");
   });
 
   it.each(["id", "type", "props", "slots", "visibility", "cssId"])(

--- a/packages/blocks-engine/src/detach.test.ts
+++ b/packages/blocks-engine/src/detach.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Detaching a component instance: inlining what it drew, and letting it go.
+ *
+ * The two halves are asserted apart throughout, because they are governed by
+ * different rules and conflating them is the defect this planner is shaped to
+ * avoid. The DEFINITION's contribution is a copy — fresh node ids, authored DOM
+ * ids kept unless the page collides. The author's SUPPLIED SLOT CONTENT moves —
+ * same node ids, same DOM ids, and a component instance inside it stays an
+ * instance.
+ */
+import { describe, expect, it } from "vitest";
+
+import { planDetach } from "./composition-planners";
+import type { DefinitionsById } from "./resolve-instances";
+import { applyOps } from "./ops";
+import { COMPONENT_INSTANCE_TYPE, DOCUMENT_FORMAT_VERSION } from "./document";
+import type { BlockDocument, BlockNode, ComponentDocument } from "./document";
+import { mintDomId, walkNodes } from "./tree";
+
+const node = (id: string, extra: Partial<BlockNode> = {}): BlockNode => ({
+  id,
+  type: "core/text",
+  version: 1,
+  props: {},
+  ...extra,
+});
+
+const box = (id: string, children: BlockNode[]): BlockNode =>
+  node(id, { type: "core/box", slots: { children } });
+
+const instance = (
+  id: string,
+  componentId: string,
+  extra: Partial<BlockNode> = {}
+): BlockNode => ({
+  id,
+  type: COMPONENT_INSTANCE_TYPE,
+  version: 1,
+  props: { componentId },
+  ...extra,
+});
+
+const page = (nodes: BlockNode[]): BlockDocument => ({
+  formatVersion: DOCUMENT_FORMAT_VERSION,
+  kind: "page",
+  nodes,
+});
+
+const component = (
+  nodes: BlockNode[],
+  envelope: Partial<ComponentDocument> = {}
+): ComponentDocument => ({
+  formatVersion: DOCUMENT_FORMAT_VERSION,
+  kind: "component",
+  nodes,
+  ...envelope,
+});
+
+const defs = (entries: Record<string, BlockDocument>): DefinitionsById =>
+  new Map(Object.entries(entries));
+
+const anyParent = { parentsOf: () => undefined };
+
+/**
+ * The prefix the resolver puts on every node id it composes.
+ *
+ * Spelled here rather than imported because it is deliberately not published:
+ * the point of the assertion is that nothing wearing it reaches storage, and a
+ * test that imported the constant would still pass if the resolver stopped
+ * using it and started leaking something else.
+ */
+const SCOPED_MARKER = "cx-";
+
+/** The document a plan produces, as the op layer would build it. */
+function applied(doc: BlockDocument, plan: ReturnType<typeof planDetach>) {
+  if (plan.pageOps === undefined) {
+    throw new Error(`refused: ${String(plan.problem)}`);
+  }
+  return applyOps(doc, plan.pageOps).document;
+}
+
+function flatten(nodes: readonly BlockNode[]): BlockNode[] {
+  const out: BlockNode[] = [];
+  walkNodes([...nodes], n => {
+    out.push(n);
+  });
+  return out;
+}
+
+const marked = (nodes: readonly BlockNode[], mark: string): BlockNode => {
+  const found = flatten(nodes).find(n => n.props?.mark === mark);
+  if (found === undefined) throw new Error(`no node marked ${mark}`);
+  return found;
+};
+
+describe("what detach puts on the page", () => {
+  const definitions = defs({
+    card: component([
+      node("d1", { props: { mark: "body" }, cssId: "card-anchor" }),
+    ]),
+  });
+
+  it("replaces the instance with what it was drawing", () => {
+    const doc = page([node("before"), instance("i1", "card"), node("after")]);
+
+    const result = applied(doc, planDetach(doc, "i1", definitions, anyParent));
+
+    // In place: the run reads before → the inlined body → after.
+    expect(result.nodes.map(n => n.props?.mark ?? n.id)).toEqual([
+      "before",
+      "body",
+      "after",
+    ]);
+    // And the instance is gone, so nothing still points at the definition.
+    expect(flatten(result.nodes).map(n => n.type)).not.toContain(
+      COMPONENT_INSTANCE_TYPE
+    );
+  });
+
+  it("records the component it came from, and no digest", () => {
+    // The `component` arm of the existing provenance record, not a field of its
+    // own: a detached subtree declines further change, so it has nothing a
+    // digest would answer — which is what that arm's docblock says it is for.
+    const doc = page([instance("i1", "card")]);
+
+    const result = applied(doc, planDetach(doc, "i1", definitions, anyParent));
+    const origin = result.nodes[0]?.origin;
+
+    expect(origin).toEqual({ from: "component", id: "card" });
+  });
+
+  it("gives the definition's nodes fresh ids", () => {
+    // They are a COPY. Keeping the definition's own ids would put the same id
+    // on the page twice the moment a second instance of it is detached.
+    const doc = page([instance("i1", "card"), instance("i2", "card")]);
+
+    const once = applied(doc, planDetach(doc, "i1", definitions, anyParent));
+    const twice = applied(once, planDetach(once, "i2", definitions, anyParent));
+    const ids = flatten(twice.nodes).map(n => n.id);
+
+    expect(ids).not.toContain("d1");
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("keeps the definition's authored DOM id when the page has none", () => {
+    // The resolver mints a scoped `cx-` id per composed node for rendering.
+    // Persisting that would put a render-time digest into the database and grow
+    // a suffix on every cycle — the defect `planInsertPattern` was fixed for.
+    const doc = page([instance("i1", "card")]);
+
+    const result = applied(doc, planDetach(doc, "i1", definitions, anyParent));
+
+    expect(marked(result.nodes, "body").cssId).toBe("card-anchor");
+  });
+
+  it("renames it only when the page really holds that id", () => {
+    const doc = page([
+      node("held", { cssId: "card-anchor" }),
+      instance("i1", "card"),
+    ]);
+
+    const result = applied(doc, planDetach(doc, "i1", definitions, anyParent));
+    const body = marked(result.nodes, "body");
+
+    // Exactly what the engine's own rule mints from the AUTHORED id and this
+    // node's OWN id. Asserting only "different, but contains card-anchor" is
+    // equally satisfied by persisting the resolver's scoped form, which is
+    // derived from an id this node no longer has — the thing to avoid.
+    expect(body.cssId).toBe(mintDomId("card-anchor", body.id));
+  });
+
+  it("persists none of the resolver's render-time ids", () => {
+    // The invariant behind the two tests above, stated once over the whole
+    // output. Composed node ids wear a `cx-` prefix precisely so a reader can
+    // tell them from stored ones, and a scoped DOM id carries the same marker.
+    // Either one in the database is a render artefact an author now owns.
+    const doc = page([
+      node("held", { cssId: "card-anchor" }),
+      instance("i1", "card"),
+    ]);
+
+    const result = applied(doc, planDetach(doc, "i1", definitions, anyParent));
+
+    for (const one of flatten(result.nodes)) {
+      expect(one.id.startsWith(SCOPED_MARKER)).toBe(false);
+    }
+  });
+
+  it("strips the resolver's own render-time fields", () => {
+    // `instanceOf` and `unresolvedComponent` are facts about a render, and
+    // `BlockNode`'s key set is the stored format.
+    const doc = page([instance("i1", "card")]);
+
+    const result = applied(doc, planDetach(doc, "i1", definitions, anyParent));
+
+    for (const one of flatten(result.nodes)) {
+      const stored = one as BlockNode & Record<string, unknown>;
+      expect(stored.instanceOf).toBeUndefined();
+      expect(stored.unresolvedComponent).toBeUndefined();
+    }
+  });
+});
+
+describe("the author's own slot content moves through untouched", () => {
+  const definitions = defs({
+    shell: component([box("s1", [node("default-body")])], {
+      slots: { body: { label: "Body", nodeId: "s1", slot: "children" } },
+    }),
+    leafy: component([node("l1", { props: { mark: "leaf" } })]),
+  });
+
+  it("KEEPS a nested component instance linked", () => {
+    // The rule the design states, and the one the resolver's depth cap does not
+    // deliver on its own: `maxComposedDepth` bounds DEFINITION-internal
+    // nesting, while supplied slot content composes in the host's scope where
+    // the depth never advances. Measured before this planner existed: a nested
+    // instance at depth 1 was fully inlined, losing its link.
+    //
+    // A component the author dropped into this instance is THEIR content.
+    // Detaching its host says nothing about it.
+    const doc = page([
+      instance("i1", "shell", { slots: { body: [instance("i2", "leafy")] } }),
+    ]);
+
+    const result = applied(doc, planDetach(doc, "i1", definitions, anyParent));
+    const nested = flatten(result.nodes).filter(
+      n => n.type === COMPONENT_INSTANCE_TYPE
+    );
+
+    expect(nested).toHaveLength(1);
+    expect(nested[0]?.id).toBe("i2");
+    expect(nested[0]?.props?.componentId).toBe("leafy");
+    // Still an instance, so it never drew the definition's content.
+    expect(flatten(result.nodes).find(n => n.props?.mark === "leaf")).toBe(
+      undefined
+    );
+  });
+
+  it("keeps the author's node ids and DOM ids", () => {
+    // It MOVES rather than being copied: the instance holding it is removed in
+    // the same group, so its ids are free, and re-minting them would rename an
+    // author's anchor for a collision that does not exist.
+    const doc = page([
+      instance("i1", "shell", {
+        slots: {
+          body: [
+            node("mine", { cssId: "author-anchor", props: { mark: "a" } }),
+          ],
+        },
+      }),
+    ]);
+
+    const result = applied(doc, planDetach(doc, "i1", definitions, anyParent));
+    const mine = marked(result.nodes, "a");
+
+    expect(mine.id).toBe("mine");
+    expect(mine.cssId).toBe("author-anchor");
+  });
+
+  it("lands it where the definition exposes the slot", () => {
+    const doc = page([
+      instance("i1", "shell", {
+        slots: { body: [node("mine", { props: { mark: "a" } })] },
+      }),
+    ]);
+
+    const result = applied(doc, planDetach(doc, "i1", definitions, anyParent));
+
+    // Inside the definition's own box, replacing its default content.
+    const root = result.nodes[0];
+    expect(root?.type).toBe("core/box");
+    expect(root?.slots?.children?.map(n => n.id)).toEqual(["mine"]);
+  });
+
+  it("shows the definition's default when the author supplied nothing", () => {
+    // The control for the test above: an empty slot is how an author asks for
+    // the default, so a placeholder there would suppress it.
+    const doc = page([instance("i1", "shell", { slots: { body: [] } })]);
+
+    const result = applied(doc, planDetach(doc, "i1", definitions, anyParent));
+
+    expect(result.nodes[0]?.slots?.children).toHaveLength(1);
+    expect(result.nodes[0]?.slots?.children?.[0]?.id).not.toBe("default-body");
+  });
+});
+
+describe("what detach refuses", () => {
+  const definitions = defs({ card: component([node("d1")]) });
+
+  it("refuses a node that is not a component instance", () => {
+    const doc = page([node("plain")]);
+
+    expect(planDetach(doc, "plain", definitions, anyParent).problem).toBe(
+      "not-a-component"
+    );
+  });
+
+  it("refuses an id the document does not hold", () => {
+    const doc = page([instance("i1", "card")]);
+
+    expect(planDetach(doc, "nope", definitions, anyParent).problem).toBe(
+      "unknown"
+    );
+  });
+
+  it("refuses an instance whose definition is missing", () => {
+    // Inlining nothing would silently delete the author's section.
+    const doc = page([instance("i1", "gone")]);
+
+    expect(planDetach(doc, "i1", definitions, anyParent).problem).toBe(
+      "not-a-component"
+    );
+  });
+
+  it("refuses an instance naming no component at all", () => {
+    const doc = page([
+      { id: "i1", type: COMPONENT_INSTANCE_TYPE, version: 1, props: {} },
+    ]);
+
+    expect(planDetach(doc, "i1", definitions, anyParent).problem).toBe(
+      "invalid-source"
+    );
+  });
+
+  it("refuses when the page is at its byte ceiling", () => {
+    const doc = page([instance("i1", "card")]);
+    const limits = {
+      maxNodes: 100,
+      maxDepth: 10,
+      maxBytes: JSON.stringify(doc).length,
+    };
+
+    expect(planDetach(doc, "i1", definitions, anyParent, limits).problem).toBe(
+      "exceeds-limits"
+    );
+  });
+});

--- a/packages/blocks-engine/src/detach.test.ts
+++ b/packages/blocks-engine/src/detach.test.ts
@@ -524,6 +524,56 @@ describe("a slot name the format allows and JavaScript does not", () => {
   });
 });
 
+describe("a definition that nests an instance of itself", () => {
+  it("detaches the outer one, and leaves the nested one standing", () => {
+    // The nested instance is refused as a cycle and carries the SAME
+    // `componentId` as the one being detached, so a check reading the component
+    // name saw a refusal that belonged to a different node and rejected a
+    // detach that had in fact succeeded. The instance id is what tells them
+    // apart: it is the node as it appears in the returned document.
+    const definitions = defs({
+      card: component([
+        node("d1", { props: { mark: "body" } }),
+        instance("dn", "card"),
+      ]),
+    });
+    const doc = page([instance("i1", "card")]);
+
+    const result = applied(doc, planDetach(doc, "i1", definitions, anyParent));
+
+    expect(marked(result.nodes, "body").props?.mark).toBe("body");
+    // The nested one is still an instance: refused, not inlined, not dropped.
+    expect(
+      flatten(result.nodes).filter(n => n.type === COMPONENT_INSTANCE_TYPE)
+    ).toHaveLength(1);
+  });
+});
+
+describe("a gated instance keeps its authored ids", () => {
+  it("does not remint an id that renders nowhere", () => {
+    // `domIdsIn` counts only what RENDERS, and a condition-gated subtree
+    // renders nothing — so a hidden variant's anchor collides with no one.
+    // Deciding collisions before the gate was applied renamed it anyway, and
+    // the rename outlives the gate: remove the condition later and the author's
+    // fragment is still pointing at a suffixed id.
+    const definitions = defs({
+      card: component([node("d1", { cssId: "hero", props: { mark: "body" } })]),
+    });
+    const doc = page([
+      node("onpage", { cssId: "hero" }),
+      instance("i1", "card", {
+        visibility: {
+          conditions: [[{ field: "tier", op: "eq", value: "pro" }]],
+        },
+      }),
+    ]);
+
+    const result = applied(doc, planDetach(doc, "i1", definitions, anyParent));
+
+    expect(marked(result.nodes, "body").cssId).toBe("hero");
+  });
+});
+
 describe("what detach refuses", () => {
   const definitions = defs({ card: component([node("d1")]) });
 
@@ -577,6 +627,47 @@ describe("what detach refuses", () => {
     expect(escaped).toBeUndefined();
     expect(problem).toBe("not-a-component");
   });
+
+  it.each(["id", "type", "props", "slots", "visibility", "cssId"])(
+    "refuses a definition whose node computes its %s",
+    field => {
+      // One level past the envelope guard: the definition's NODES are read
+      // later, by the clone that builds the inlined tree, and a field computing
+      // itself there threw out of both the resolver and this planner. Contained
+      // at the expansion of one instance, which is the unit the resolver's
+      // savepoint already covers.
+      const bad: Record<string, unknown> = {
+        id: "d1",
+        type: "core/text",
+        version: 1,
+        props: {},
+      };
+      Object.defineProperty(bad, field, {
+        enumerable: true,
+        configurable: true,
+        get() {
+          throw new Error("boom");
+        },
+      });
+      const doc = page([instance("i1", "card")]);
+
+      let escaped: unknown;
+      let problem: string | undefined;
+      try {
+        problem = planDetach(
+          doc,
+          "i1",
+          defs({ card: component([bad as unknown as BlockNode]) }),
+          anyParent
+        ).problem;
+      } catch (error) {
+        escaped = error;
+      }
+
+      expect(escaped).toBeUndefined();
+      expect(problem).toBe("not-a-component");
+    }
+  );
 
   it("refuses an instance whose definition is missing", () => {
     // Inlining nothing would silently delete the author's section.

--- a/packages/blocks-engine/src/detach.test.ts
+++ b/packages/blocks-engine/src/detach.test.ts
@@ -284,6 +284,116 @@ describe("the author's own slot content moves through untouched", () => {
   });
 });
 
+describe("a condition-gated instance", () => {
+  const gate = {
+    conditions: [[{ field: "tier", op: "eq", value: "pro" }]],
+  } as BlockNode["visibility"];
+  const definitions = defs({
+    card: component([node("d1", { props: { mark: "body" } })]),
+    gatedInside: component([
+      node("g1", {
+        props: { mark: "body" },
+        visibility: {
+          conditions: [[{ field: "locale", op: "eq", value: "fr" }]],
+        },
+      }),
+    ]),
+  });
+
+  it("really detaches it, carrying the gate onto what replaces it", () => {
+    // The resolver declines to inline a gated instance — replacing it with
+    // roots that inherit no gate would show a reader content withheld from
+    // them — and it says so by returning the instance UNTOUCHED, with no
+    // `unresolved` entry. A planner reading only that list saw a clean
+    // resolution and planned to replace the instance with itself: success
+    // reported, still linked to the definition, and stamped with a provenance
+    // record claiming it had been detached.
+    //
+    // Gating is inherited, so the gate on each root gates everything beneath
+    // it and the page renders exactly as before.
+    const doc = page([instance("i1", "card", { visibility: gate })]);
+
+    const result = applied(doc, planDetach(doc, "i1", definitions, anyParent));
+
+    expect(flatten(result.nodes).map(n => n.type)).not.toContain(
+      COMPONENT_INSTANCE_TYPE
+    );
+    expect(result.nodes[0]?.visibility).toEqual(gate);
+    expect(marked(result.nodes, "body").props?.mark).toBe("body");
+  });
+
+  it("refuses when the content carries a gate of its own", () => {
+    // Two condition sets combine as a cross product of their groups, and
+    // quietly rewriting an author's visibility rules is not a detach's to make.
+    const doc = page([instance("i1", "gatedInside", { visibility: gate })]);
+
+    expect(planDetach(doc, "i1", definitions, anyParent).problem).toBe(
+      "condition-gated"
+    );
+  });
+
+  it("leaves ungated content alone", () => {
+    // The control: without a gate on the instance, nothing is stamped.
+    const doc = page([instance("i1", "card")]);
+
+    const result = applied(doc, planDetach(doc, "i1", definitions, anyParent));
+
+    expect(result.nodes[0]?.visibility).toBeUndefined();
+  });
+});
+
+describe("what the op group has to survive", () => {
+  it("unlocks a locked block for the insert and locks it again after", () => {
+    // `applyOp` refuses an insert whose subtree arrives locked: the inverse of
+    // an insert is a remove, and a remove refuses a locked subtree, so such an
+    // insert could never be undone. Building the ops by hand refused every
+    // definition holding a locked block, reported as a byte-cap failure.
+    const definitions = defs({
+      card: component([node("d1", { locked: true, props: { mark: "body" } })]),
+    });
+    const doc = page([instance("i1", "card")]);
+
+    const plan = planDetach(doc, "i1", definitions, anyParent);
+    const result = applied(doc, plan);
+
+    // It arrives unlocked and is locked where it landed.
+    expect(plan.pageOps?.some(op => op.kind === "update")).toBe(true);
+    expect(marked(result.nodes, "body").locked).toBe(true);
+  });
+
+  it("avoids a DOM id the author's own slot content will bring back", () => {
+    // The supplied content is RESTORED rather than copied, so it keeps the id
+    // it already has. Counting only the page outside the instance let the
+    // definition's id land on top of the author's — legal on the page today,
+    // because the definition's is rendered scoped — and the group was refused
+    // with a cause about size.
+    const definitions = defs({
+      shell: component(
+        [
+          node("s1", {
+            type: "core/box",
+            cssId: "shared",
+            slots: { children: [] },
+          }),
+        ],
+        { slots: { body: { label: "Body", nodeId: "s1", slot: "children" } } }
+      ),
+    });
+    const doc = page([
+      instance("i1", "shell", {
+        slots: { body: [node("mine", { cssId: "shared" })] },
+      }),
+    ]);
+
+    const result = applied(doc, planDetach(doc, "i1", definitions, anyParent));
+    const root = result.nodes[0];
+
+    // The author keeps theirs; the definition's copy moves aside.
+    expect(root?.slots?.children?.[0]?.cssId).toBe("shared");
+    expect(root?.cssId).toBe(mintDomId("shared", root!.id));
+  });
+});
+
 describe("what detach refuses", () => {
   const definitions = defs({ card: component([node("d1")]) });
 

--- a/packages/blocks-engine/src/detach.test.ts
+++ b/packages/blocks-engine/src/detach.test.ts
@@ -16,6 +16,8 @@ import { applyOps } from "./ops";
 import { COMPONENT_INSTANCE_TYPE, DOCUMENT_FORMAT_VERSION } from "./document";
 import type { BlockDocument, BlockNode, ComponentDocument } from "./document";
 import { mintDomId, walkNodes } from "./tree";
+import { DEFAULT_LIMITS } from "./limits";
+import type { DocumentLimits } from "./limits";
 
 const node = (id: string, extra: Partial<BlockNode> = {}): BlockNode => ({
   id,
@@ -687,6 +689,39 @@ describe("what detach refuses", () => {
       "invalid-source"
     );
   });
+
+  const overSized: [string, Partial<DocumentLimits>, "wide" | "deep"][] = [
+    ["a definition larger than the node budget", { maxNodes: 3 }, "wide"],
+    ["a definition deeper than the depth cap", { maxDepth: 3 }, "deep"],
+  ];
+
+  it.each(overSized)(
+    "says %s is too big, not that the component is wrong",
+    (_name, caps, shape) => {
+      // Collapsing every refusal of the selected instance to
+      // `not-a-component` told an author to publish or repair a component that
+      // was neither missing nor broken — only bigger than the limits this call
+      // was given. The remedy for a size is the page or the ceiling; the remedy
+      // for a bad component is a different screen entirely.
+      const big: BlockNode[] = [];
+      for (let i = 0; i < 8; i += 1) big.push(node(`b${String(i)}`));
+      let deep: BlockNode = node("leaf");
+      for (let i = 0; i < 8; i += 1) {
+        deep = box(`w${String(i)}`, [deep]);
+      }
+      const definitions = defs({
+        card: component(shape === "wide" ? big : [deep]),
+      });
+      const doc = page([instance("i1", "card")]);
+
+      expect(
+        planDetach(doc, "i1", definitions, anyParent, {
+          ...DEFAULT_LIMITS,
+          ...caps,
+        }).problem
+      ).toBe("exceeds-limits");
+    }
+  );
 
   it("refuses when the page is at its byte ceiling", () => {
     const doc = page([instance("i1", "card")]);

--- a/packages/blocks-engine/src/detach.test.ts
+++ b/packages/blocks-engine/src/detach.test.ts
@@ -543,6 +543,41 @@ describe("what detach refuses", () => {
     );
   });
 
+  it("refuses a definition whose fields compute themselves", () => {
+    // The resolver reads a supplied definition's `kind` to tell a component
+    // from a page, and an accessor there threw straight out of this planner,
+    // which promises a refusal. Contained where the read happens, so every
+    // caller of the resolver gets the classification rather than the error.
+    const definition: Record<string, unknown> = {
+      formatVersion: DOCUMENT_FORMAT_VERSION,
+      nodes: [node("d1")],
+    };
+    Object.defineProperty(definition, "kind", {
+      enumerable: true,
+      configurable: true,
+      get() {
+        throw new Error("boom");
+      },
+    });
+    const doc = page([instance("i1", "card")]);
+
+    let escaped: unknown;
+    let problem: string | undefined;
+    try {
+      problem = planDetach(
+        doc,
+        "i1",
+        defs({ card: definition as unknown as BlockDocument }),
+        anyParent
+      ).problem;
+    } catch (error) {
+      escaped = error;
+    }
+
+    expect(escaped).toBeUndefined();
+    expect(problem).toBe("not-a-component");
+  });
+
   it("refuses an instance whose definition is missing", () => {
     // Inlining nothing would silently delete the author's section.
     const doc = page([instance("i1", "gone")]);

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -194,6 +194,7 @@ export type {
 export { patternDigest } from "./pattern-digest";
 export {
   planConvertToComponent,
+  planDetach,
   planDuplicateComponent,
   planInsertPattern,
   planSaveAsComponent,

--- a/packages/blocks-engine/src/resolve-instances.test.ts
+++ b/packages/blocks-engine/src/resolve-instances.test.ts
@@ -569,6 +569,49 @@ describe("resolveComponentInstances refusals", () => {
     expect(result.document.nodes[1]!.id).not.toBe("i2");
   });
 
+  it.each(["kind", "nodes"])(
+    "classifies a definition whose %s computes itself, rather than throwing",
+    field => {
+      // The lookup is an object this module was handed, and the document it
+      // returns came from an import, a script or a database. A field that
+      // computes itself and throws took the caller's error out of a function
+      // that promises a classification and a closed list of reasons — and out
+      // of every planner built on it.
+      //
+      // `unreadable` is what this already calls a supplied document it cannot
+      // read; the reason existed and was simply unreachable.
+      const definition: Record<string, unknown> = {
+        formatVersion: DOCUMENT_FORMAT_VERSION,
+        kind: "component",
+        nodes: [node("d1")],
+      };
+      Object.defineProperty(definition, field, {
+        enumerable: true,
+        configurable: true,
+        get() {
+          throw new Error("boom");
+        },
+      });
+      const doc = page([instance("i1", "card")]);
+
+      let escaped: unknown;
+      let result: ReturnType<typeof resolveComponentInstances> | undefined;
+      try {
+        result = resolveComponentInstances(
+          doc,
+          defs({ card: definition as unknown as BlockDocument })
+        );
+      } catch (error) {
+        escaped = error;
+      }
+
+      expect(escaped).toBeUndefined();
+      expect(result?.unresolved).toEqual([
+        { instanceId: "i1", componentId: "card", reason: "unreadable" },
+      ]);
+    }
+  );
+
   it("gives back the rename records of an abandoned expansion", () => {
     // The claim and the record of what it came from are released together. An
     // expansion that scopes a DOM id and then runs out of budget leaves the

--- a/packages/blocks-engine/src/resolve-instances.test.ts
+++ b/packages/blocks-engine/src/resolve-instances.test.ts
@@ -569,6 +569,31 @@ describe("resolveComponentInstances refusals", () => {
     expect(result.document.nodes[1]!.id).not.toBe("i2");
   });
 
+  it("gives back the rename records of an abandoned expansion", () => {
+    // The claim and the record of what it came from are released together. An
+    // expansion that scopes a DOM id and then runs out of budget leaves the
+    // ORIGINAL instance standing, so a rename it had begun to make describes
+    // nothing in the returned document — and a consumer reversing the map to
+    // recover authored ids would rewrite a reference using a mapping for an id
+    // nothing renders.
+    const doc = page([instance("i1", "big")]);
+    const definitions = defs({
+      big: component([node("b1", { cssId: "anchor" }), node("b2"), node("b3")]),
+    });
+
+    const result = resolveComponentInstances(doc, definitions, {
+      limits: { ...DEFAULT_LIMITS, maxNodes: 2 },
+    });
+
+    // The control: it really did abandon the expansion, so the assertion below
+    // is about the record being released rather than never made.
+    expect(result.unresolved).toEqual([
+      { instanceId: "i1", componentId: "big", reason: "budget" },
+    ]);
+    expect([...result.renamedDomIds.values()]).not.toContain("anchor");
+    expect(result.renamedDomIds.size).toBe(0);
+  });
+
   it("keeps a refused instance's own slot content untouched", () => {
     const doc = page([
       instance("i1", "gone", {}, { slots: { body: [node("mine")] } }),

--- a/packages/blocks-engine/src/resolve-instances.ts
+++ b/packages/blocks-engine/src/resolve-instances.ts
@@ -841,6 +841,42 @@ function hideEach(
  * longer exists is ignored in silence: the element simply loses its name,
  * visibly to nobody who is not using assistive technology.
  */
+/** The three optional fields a relink can rewrite, plus the one it always does. */
+interface RelinkedFields {
+  attributes: ResolvedBlockNode["attributes"];
+  props: Record<string, unknown>;
+  bindings: ResolvedBlockNode["bindings"];
+  slots: ResolvedBlockNode["slots"];
+}
+
+/**
+ * One node with its rewritten fields, leaving ABSENT ones absent.
+ *
+ * Spread conditionally, the way `relinkOne` does for the same three fields.
+ * `{ ...node, bindings }` writes the key even when the value is `undefined`,
+ * and a key holding `undefined` is a value JSON cannot carry — `applyOp`
+ * refuses a whole insert for one. That went unnoticed while this output was
+ * only ever rendered; a resolved tree is now also what a detached instance is
+ * stored from, and an ordinary node with no attributes came out of here
+ * carrying `attributes: undefined`.
+ *
+ * Its own function so the walk that calls it stays inside the complexity the
+ * gate allows.
+ */
+function relinked(
+  node: ResolvedBlockNode,
+  fields: RelinkedFields
+): ResolvedBlockNode {
+  const { attributes, props, bindings, slots } = fields;
+  return {
+    ...node,
+    props,
+    ...(attributes === undefined ? {} : { attributes }),
+    ...(bindings === undefined ? {} : { bindings }),
+    ...(slots === undefined ? {} : { slots }),
+  };
+}
+
 function withRemappedIdReferences(
   roots: ResolvedBlockNode[] | null,
   ctx: InlineContext
@@ -881,7 +917,7 @@ function withRemappedIdReferences(
       ) {
         return node;
       }
-      return { ...node, attributes, props, bindings, slots };
+      return relinked(node, { attributes, props, bindings, slots });
     });
   const rewriteSlots = (
     slots: Record<string, ResolvedBlockNode[]>
@@ -945,7 +981,16 @@ function rollback(run: ResolveRun, mark: Savepoint): void {
   }
   run.minted.length = mark.minted;
   for (let i = run.mintedDomIds.length - 1; i >= mark.mintedDomIds; i -= 1) {
-    run.takenDomIds.delete(run.mintedDomIds[i]);
+    const id = run.mintedDomIds[i];
+    run.takenDomIds.delete(id);
+    // The record of what it was derived from goes back with the claim itself.
+    // An abandoned expansion leaves the ORIGINAL instance standing, so a rename
+    // it had begun to make describes nothing in the returned document — and a
+    // consumer reversing the map would rewrite a reference using a mapping for
+    // an id nothing renders. Released here rather than in a pass of its own,
+    // keyed on the same list, so the two cannot come to disagree about what was
+    // given back.
+    run.renamedDomIds.delete(id);
   }
   run.mintedDomIds.length = mark.mintedDomIds;
 }

--- a/packages/blocks-engine/src/resolve-instances.ts
+++ b/packages/blocks-engine/src/resolve-instances.ts
@@ -665,6 +665,63 @@ function expandInstance(
   // slots — so a mark taken after it would leave a refused instance having
   // permanently charged the page for a tree nobody receives.
   const mark = savepoint(run);
+  let inlined: ResolvedBlockNode[] | null;
+  try {
+    inlined = inlinedDefinition(instance, definition, componentId, {
+      run,
+      scope,
+      depth,
+      presupplied,
+      owner,
+    });
+  } catch {
+    // Everything that follows CONSUMES the definition — its nodes, their props,
+    // their slots — and all of it is a caller's data. A field that computes
+    // itself and throws took that error out of a function promising a
+    // classification and a closed list of reasons. Guarding the envelope read
+    // was not enough: a NODE's fields are read later, by the clone.
+    //
+    // Contained at the expansion of ONE instance, which is the unit the
+    // savepoint already covers, so a definition that fails halfway gives back
+    // the ids and budget it had begun to claim — exactly as a refusal for the
+    // node budget does. `unreadable` is the reason this module already
+    // publishes for a supplied document it cannot read.
+    run.abort = undefined;
+    rollback(run, mark);
+    return [refuse(run, instance, componentId, "unreadable")];
+  }
+  if (inlined === null) {
+    const reason = run.abort ?? "budget";
+    run.abort = undefined;
+    rollback(run, mark);
+    return [refuse(run, instance, componentId, reason)];
+  }
+  return inlined;
+}
+
+/** Where an expansion sits, and what the host already composed for it. */
+interface InstancePlacement {
+  run: ResolveRun;
+  scope: ComposedScope;
+  depth: number;
+  presupplied?: Record<string, ResolvedBlockNode[]>;
+  owner?: string;
+}
+
+/**
+ * The definition's tree, inlined for one instance — the speculative half.
+ *
+ * Split from the refusal handling above so that everything which READS a
+ * caller's definition sits inside one boundary, and so the savepoint that pays
+ * for it is taken in exactly one place.
+ */
+function inlinedDefinition(
+  instance: ResolvedBlockNode,
+  definition: ComponentDocument,
+  componentId: string,
+  placement: InstancePlacement
+): ResolvedBlockNode[] | null {
+  const { run, scope, depth, presupplied, owner } = placement;
   // The instance node is REPLACED, so its own slot under the cap is freed for
   // what replaces it. Credited before the clone rather than after, or a
   // definition that exactly fills the remaining room is refused for needing
@@ -701,12 +758,7 @@ function expandInstance(
     cloneDefinitionForest(definition.nodes, ctx, 1),
     ctx
   );
-  if (inlined === null) {
-    const reason = run.abort ?? "budget";
-    run.abort = undefined;
-    rollback(run, mark);
-    return [refuse(run, instance, componentId, reason)];
-  }
+  if (inlined === null) return null;
   return withInstanceDevices(inlined, instance);
 }
 

--- a/packages/blocks-engine/src/resolve-instances.ts
+++ b/packages/blocks-engine/src/resolve-instances.ts
@@ -234,6 +234,13 @@ export interface ResolvedComposition {
   referenced: readonly string[];
   /** Every instance that could not be inlined. Empty on a clean resolution. */
   unresolved: readonly UnresolvedInstance[];
+  /**
+   * Every DOM id this resolution minted, mapped back to what it came from.
+   *
+   * Empty when nothing was scoped, which is also what a document holding no
+   * instances returns — the two say the same thing to every reader.
+   */
+  renamedDomIds: ReadonlyMap<string, string>;
 }
 
 /**
@@ -290,6 +297,7 @@ export function resolveComponentInstances(
     document,
     referenced: [],
     unresolved: [],
+    renamedDomIds: new Map<string, string>(),
   };
   if (!isPlainRecord(document) || !Array.isArray(document.nodes)) {
     return unchanged;
@@ -324,6 +332,7 @@ export function resolveComponentInstances(
     budget: limits.maxNodes - survey.count,
     taken: survey.ids,
     takenDomIds: survey.domIds,
+    renamedDomIds: new Map<string, string>(),
     minted: [],
     mintedDomIds: [],
     abort: undefined,
@@ -340,6 +349,7 @@ export function resolveComponentInstances(
     document: nodes === document.nodes ? document : { ...document, nodes },
     referenced: run.referenced,
     unresolved: run.unresolved,
+    renamedDomIds: run.renamedDomIds,
   };
 }
 
@@ -364,6 +374,22 @@ interface ResolveRun {
   taken: Set<string>;
   /** The same, for the ids that reach the DOM rather than the document. */
   takenDomIds: Set<string>;
+  /**
+   * Every DOM id this run MINTED, mapped back to the one it was derived from.
+   *
+   * Minted → original, not the other way round, and the direction is forced:
+   * one definition id becomes a different scoped id in every instance of that
+   * component, so keying on the original would keep only the last. A minted id
+   * is unique to its instance, so this direction stays injective however many
+   * instances a page holds.
+   *
+   * Published because the resolver is the only thing that knows it. A surface
+   * that turns composed content back into stored content — detaching an
+   * instance does exactly that — otherwise has to persist a render-time digest
+   * as though an author had typed it, or invert the mint by taking the string
+   * apart. This is the same gap `origin.renamed` closed for pattern inserts.
+   */
+  renamedDomIds: Map<string, string>;
   /**
    * The ids this run minted, in order, so a refused instance can give them
    * back. Host ids are not in it: they were never this run's to release.
@@ -1921,6 +1947,7 @@ function scopedDomId(
   if (existing !== undefined) return existing;
   const minted = claimDomId(ctx.run, mintDomId(value, nodeId));
   ctx.domIds.set(value, minted);
+  ctx.run.renamedDomIds.set(minted, value);
   return minted;
 }
 

--- a/packages/blocks-engine/src/resolve-instances.ts
+++ b/packages/blocks-engine/src/resolve-instances.ts
@@ -1035,6 +1035,27 @@ function readDefinition(
   // document fault, so it takes `unreadable`: offering the publish remedy for
   // corrupt component data sends an author to the wrong screen, which is the
   // whole reason these reasons are a closed list rather than a message.
+  // Every read below is a caller's: the lookup is an object this module was
+  // handed, and the document it returns came from an import, a script or a
+  // database. A `kind` that computes itself and throws took the caller's error
+  // out of `resolveComponentInstances`, which promises a classification and a
+  // closed list of reasons — and out of every planner built on it.
+  //
+  // `unreadable` is the answer this function already declares for exactly this:
+  // "a value that IS supplied and cannot be read is a document fault". Nothing
+  // new is being invented, only made reachable.
+  try {
+    return readSuppliedDefinition(componentId, run);
+  } catch {
+    return "unreadable";
+  }
+}
+
+/** The lookup's answer for one component, read as the caller supplied it. */
+function readSuppliedDefinition(
+  componentId: string,
+  run: ResolveRun
+): ComponentDocument | ComponentUnresolvedReason {
   if (!run.definitions.has(componentId)) return "missing";
   // Read ONCE and carried out, so expansion never asks again.
   const definition = run.definitions.get(componentId);

--- a/packages/blocks-engine/src/resolve-instances.ts
+++ b/packages/blocks-engine/src/resolve-instances.ts
@@ -46,6 +46,7 @@
  */
 import {
   COMPONENT_INSTANCE_TYPE,
+  DOCUMENT_FORMAT_VERSION,
   isComponentDocument,
   isUnsetOverride,
   renderedDomId,
@@ -1121,6 +1122,17 @@ function readSuppliedDefinition(
   // and slots meaning nothing. The kind is what the engine already publishes
   // an answer for.
   if (!isComponentDocument(definition)) return "unreadable";
+  // The FORMAT, on the same read. `unreadable` already means "an envelope this
+  // build does not understand" — the reason existed and nothing asked the
+  // question. A definition written in a format this build cannot interpret was
+  // inlined regardless, so a surface that persists what it inlines wrote
+  // content read under the wrong rules into a page.
+  //
+  // Asked HERE rather than by the caller, because the lookup is a caller's
+  // object and nothing in its contract makes it pure: validating one `get` and
+  // expanding a second means the document that was checked is not the document
+  // that is used.
+  if (definition.formatVersion !== DOCUMENT_FORMAT_VERSION) return "unreadable";
   return definition;
 }
 


### PR DESCRIPTION
Plan 06 T-2's last planner. Detach replaces a component instance, where it stands, with the nodes it was rendering — the definition's tree with this instance's overrides, variant and slot content already applied — and stops tracking the definition.

## The research corrected the design's one-liner

The design says "inline the RESOLVED subtree through `resolveComponentInstances`, keep nested instances linked", and a prior handoff assumed `maxComposedDepth: 1` delivers that. **It delivers half**, measured before any code was written:

| nesting | at depth 1 |
|---|---|
| a component nested inside the **definition's** own tree | left standing as an instance ✅ |
| a component the author dropped into the instance's **slot** | fully inlined, link lost ❌ |

Supplied slot content is composed in the *host's* scope, where the depth never advances, so the cap never applies to it. That is the common authoring case.

A second measurement made the fix small: **plain** supplied slot content already passes through the resolver untouched — own node id, unscoped `cssId`, no marker. The resolver already treats supplied content as page content; only an instance inside it gets resolved.

## So the content never reaches the resolver

Each supplied slot is lifted out and stood in for by a placeholder, the definition is resolved around those, and the author's nodes are put back untouched. Nothing has to *detect* a nested instance because nothing is ever in a position to inline one — a boundary rather than a check for crossings.

The placeholder is what keeps the resolver in charge of *where* content goes: an exposed slot names a node deep in the definition's tree, and a planner that re-derived that mapping would be a second implementation of it.

## Two halves, two rules

- **Supplied slot content MOVES** — same node ids, same authored DOM ids. It is the same content in a new parent, and the instance holding it is removed in the same op group, so its ids are free. Re-minting them would rename an author's anchor for a collision that does not exist.
- **The definition's contribution is a COPY** — fresh node ids, authored DOM ids kept except where the page really holds that name (the `{avoid}` rule `planInsertPattern` was fixed to follow).

## One change outside the planner

`resolveComponentInstances` now reports the DOM ids it minted and what each was derived from. It scopes them so two instances cannot collide on a page, and **only it knows the mapping** — without it, detach persisted a render-time digest as though an author had typed `card-anchor-cx1j4trk`, and it would go stale the moment the definition renamed its own anchor. This is the same gap `origin.renamed` closed for pattern inserts.

Keyed minted → original, because one definition id becomes a different scoped id in every instance, so the other direction keeps only the last.

Provenance uses the `origin` record's existing `component` arm, which the format already describes as *"detached from a component, severing the link deliberately"* — so no new field, and no digest, because detaching declines further change.

## Evidence

- 16 tests. Every design decision break-verified by writing the **wrong** implementation, not a mutation: letting slot content reach the resolver kills 4; dropping the DOM-id restore kills 2; not stripping the resolver's markers kills 1.
- One test was found passing for the wrong reason during that pass — a scoped id also "contains" the authored one — and now asserts the engine's own `mintDomId` rule exactly.
- blocks-engine 2271, blocks-react 1162, plugin-page-builder 642. fallow `pass` / 0 introduced, `check:comments`, `lint:design`, `changeset status`, `turbo check-types` 42/42.

Prior art checked: Webflow `unlinkComponent` and Gutenberg's unsynced pattern corroborate the one-way, undoable, per-instance shape; neither documents nested-instance behaviour. Figma cascades to *ancestors*, not descendants. No shipped tool documents the nested case, so the rule here is this design's own and is enforced by the planner.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to detach component instances, replacing them with editable inline content while preserving authored slot content and applicable conditions.
  - Detached content preserves author-defined identifiers where possible and safely renames conflicts.
  - The detach capability is now available through the public blocks engine API.

- **Bug Fixes**
  - Improved cleanup after unsuccessful component expansion attempts.
  - Prevented unnecessary empty properties from appearing during component composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->