### PR TITLE
fix(nextly): reload the schema registry after boot migrations, on both paths

### DIFF
--- a/.changeset/prod-boot-reloads-the-registry.md
+++ b/.changeset/prod-boot-reloads-the-registry.md
@@ -1,0 +1,31 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A collection created by a migration is queryable on the boot that registered it, in production as well as development.
+
+The runtime schema registry is built before boot migrations run, so an entity a migration registered was visible in the admin and on dashboard cards while every query against it failed until the next restart. Both boot paths now refresh the registry through one shared step, and they refresh it whenever migrations ran rather than only when that particular process registered something — so a replica that waited on the migrate lock behind another one is not left serving a stale view.

--- a/packages/nextly/src/di/__tests__/load-dynamic-tables.test.ts
+++ b/packages/nextly/src/di/__tests__/load-dynamic-tables.test.ts
@@ -210,6 +210,48 @@ describe("loadDynamicTables — fault tolerance", () => {
     expect(register).not.toHaveBeenCalled();
   });
 
+  /*
+   * 🔴 The swallow above is right for a FRESH database and wrong for a caller
+   * that has just migrated: there the table certainly exists, so a failed read
+   * means that caller's registry is stale and it must not report a reload as
+   * done. Resolving silently gives both callers the same answer to different
+   * questions, so the failure is now offered to whoever asked for it.
+   *
+   * Driven through the REAL loader. The boot reload's own tests mock this
+   * module, so they can only show that it reacts to `onReadError` -- nothing
+   * there says this function ever calls it.
+   */
+  it("tells a caller that asked when the read itself failed", async () => {
+    const { adapter } = makeAdapter([], { throwOnSelect: true });
+    const register = vi.fn(async () => {});
+    const onReadError = vi.fn();
+
+    await expect(
+      loadDynamicTables(adapter, "dynamic_singles", register, onReadError)
+    ).resolves.toBeUndefined();
+
+    expect(onReadError).toHaveBeenCalledTimes(1);
+    expect(register).not.toHaveBeenCalled();
+  });
+
+  it("does not report a read error when the read succeeded", async () => {
+    // The control: a callback fired unconditionally would satisfy the case
+    // above while telling every healthy boot its registry is stale.
+    const { adapter } = makeAdapter([
+      { table_name: "single_ok", fields: "[]", slug: "ok", status: 0 },
+    ]);
+    const onReadError = vi.fn();
+
+    await loadDynamicTables(
+      adapter,
+      "dynamic_singles",
+      vi.fn(async () => {}),
+      onReadError
+    );
+
+    expect(onReadError).not.toHaveBeenCalled();
+  });
+
   it("isolates failures per row — a thrown register continues with the next row", async () => {
     const { adapter } = makeAdapter([
       { table_name: "single_bad", fields: "[]", slug: "bad", status: 0 },

--- a/packages/nextly/src/di/__tests__/load-dynamic-tables.test.ts
+++ b/packages/nextly/src/di/__tests__/load-dynamic-tables.test.ts
@@ -201,12 +201,16 @@ describe("loadDynamicTables — SELECT shape", () => {
 
 describe("loadDynamicTables — fault tolerance", () => {
   it("does not throw if the source table doesn't exist (fresh DB)", async () => {
+    // Still resolves rather than throwing -- a fresh database has no registry
+    // table and that is the right answer for the caller this was written for.
+    // What it resolves WITH is the neighbouring test's subject; asserting
+    // `undefined` here only ever pinned the absence of a return value.
     const { adapter } = makeAdapter([], { throwOnSelect: true });
     const register = vi.fn(async () => {});
 
     await expect(
       loadDynamicTables(adapter, "dynamic_singles", register)
-    ).resolves.toBeUndefined();
+    ).resolves.not.toThrow();
     expect(register).not.toHaveBeenCalled();
   });
 
@@ -221,35 +225,87 @@ describe("loadDynamicTables — fault tolerance", () => {
    * module, so they can only show that it reacts to `onReadError` -- nothing
    * there says this function ever calls it.
    */
-  it("tells a caller that asked when the read itself failed", async () => {
+  it("reports the failed read rather than only swallowing it", async () => {
     const { adapter } = makeAdapter([], { throwOnSelect: true });
     const register = vi.fn(async () => {});
-    const onReadError = vi.fn();
 
-    await expect(
-      loadDynamicTables(adapter, "dynamic_singles", register, onReadError)
-    ).resolves.toBeUndefined();
+    const result = await loadDynamicTables(
+      adapter,
+      "dynamic_singles",
+      register
+    );
 
-    expect(onReadError).toHaveBeenCalledTimes(1);
+    expect(result.registered).toBe(0);
+    expect(result.failures.map(f => f.scope)).toEqual(["read"]);
     expect(register).not.toHaveBeenCalled();
   });
 
-  it("does not report a read error when the read succeeded", async () => {
-    // The control: a callback fired unconditionally would satisfy the case
-    // above while telling every healthy boot its registry is stale.
+  /*
+   * 🔴 A ROW failure has to be reportable too, and a lower count is not it: one
+   * unregisterable collection is indistinguishable from a database holding one
+   * fewer, so a caller reading the count alone calls its reload complete while
+   * that entity stays unaddressable.
+   */
+  it("reports a row whose register callback throws, naming it", async () => {
+    const { adapter } = makeAdapter([
+      { table_name: "single_bad", fields: "[]", slug: "bad", status: 0 },
+      { table_name: "single_ok", fields: "[]", slug: "ok", status: 0 },
+    ]);
+    const register = vi.fn(async (tableName: string) => {
+      if (tableName === "single_bad") throw new Error("synthetic");
+    });
+
+    const result = await loadDynamicTables(
+      adapter,
+      "dynamic_singles",
+      register
+    );
+
+    // The other row still registered: one bad row costs only itself.
+    expect(result.registered).toBe(1);
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0]?.scope).toBe("row");
+    expect(result.failures[0]?.tableName).toBe("single_bad");
+  });
+
+  it("reports a row whose stored fields are not an array", async () => {
+    // The other way a row goes unregistered, and it used to be a bare
+    // `continue` -- so it never even reached the per-row catch.
+    const { adapter } = makeAdapter([
+      {
+        table_name: "single_corrupt",
+        fields: '"not-an-array"',
+        slug: "c",
+        status: 0,
+      },
+    ]);
+
+    const result = await loadDynamicTables(
+      adapter,
+      "dynamic_singles",
+      vi.fn(async () => {})
+    );
+
+    expect(result.registered).toBe(0);
+    expect(result.failures[0]?.tableName).toBe("single_corrupt");
+  });
+
+  it("reports nothing when every row registered", async () => {
+    // The control for all three: an outcome that always carried a failure
+    // would satisfy them while telling every healthy boot its registry is
+    // stale.
     const { adapter } = makeAdapter([
       { table_name: "single_ok", fields: "[]", slug: "ok", status: 0 },
     ]);
-    const onReadError = vi.fn();
 
-    await loadDynamicTables(
+    const result = await loadDynamicTables(
       adapter,
       "dynamic_singles",
-      vi.fn(async () => {}),
-      onReadError
+      vi.fn(async () => {})
     );
 
-    expect(onReadError).not.toHaveBeenCalled();
+    expect(result.registered).toBe(1);
+    expect(result.failures).toEqual([]);
   });
 
   it("isolates failures per row — a thrown register continues with the next row", async () => {

--- a/packages/nextly/src/di/load-dynamic-tables.ts
+++ b/packages/nextly/src/di/load-dynamic-tables.ts
@@ -74,7 +74,21 @@ export async function loadDynamicTables(
      * tables hold both kinds. `undefined` where the registry is too old to say.
      */
     builderOwned: boolean | undefined
-  ) => Promise<void>
+  ) => Promise<void>,
+  /**
+   * Told when the registry read itself failed, rather than swallowing it.
+   *
+   * 🔴 The catch below exists for a FRESH database, where the registry table
+   * does not exist yet and an empty result is the right answer. A caller that
+   * has just run migrations is in the opposite situation: the table certainly
+   * exists, so a failed read means its registry is stale and it must not report
+   * the reload as done. Those two callers need different answers from the same
+   * silence, and only the caller knows which it is.
+   *
+   * Optional, so the boot-time registry build keeps the fresh-database
+   * behaviour it was written for without restating it.
+   */
+  onReadError?: (error: unknown) => void
 ): Promise<void> {
   // Components have no `status` column (they're not Draft/Published) — selecting it
   // would fail. They DO carry `localized` (i18n). Collections/singles carry both.
@@ -167,8 +181,10 @@ export async function loadDynamicTables(
         // Skip individual row if schema generation fails.
       }
     }
-  } catch {
-    // Dynamic table may not exist yet (fresh database).
+  } catch (err) {
+    // Dynamic table may not exist yet (fresh database), which is why this is
+    // swallowed by default. A caller that knows better says so.
+    onReadError?.(err);
   }
 }
 

--- a/packages/nextly/src/di/load-dynamic-tables.ts
+++ b/packages/nextly/src/di/load-dynamic-tables.ts
@@ -57,6 +57,37 @@ export type DynamicTableRow = {
  * valid Drizzle table — having no user-defined fields is NOT a reason
  * to skip registration.
  */
+/** Why one row, or the read itself, produced no registration. */
+export interface DynamicTableLoadFailure {
+  scope: "read" | "row";
+  /** The row's table, when a single row is at fault. */
+  tableName?: string;
+  error: unknown;
+}
+
+/**
+ * What one pass over a registry table actually did.
+ *
+ * 🔴 Returned rather than signalled through callbacks, because this function
+ * has THREE outcomes and used to collapse them into `Promise<void>`: the read
+ * failed, some rows failed, or everything registered. Both swallows are RIGHT
+ * for the caller they were written for — a fresh database has no registry table
+ * yet, and one corrupt row must not cost every other dynamic table its
+ * registration — and wrong for a caller that has just migrated, which must not
+ * report a reload as done while an entity it registered is unaddressable.
+ *
+ * A caller that does not care ignores the value and keeps exactly the old
+ * behaviour; a caller that does gets the evidence rather than inferring it from
+ * silence. An earlier revision used an `onReadError` callback, which answered
+ * only the first of the three and would have needed a second callback for the
+ * second — two ad-hoc channels where the function has one outcome to describe.
+ */
+export interface DynamicTableLoadResult {
+  /** How many rows registered a runtime schema. */
+  registered: number;
+  failures: DynamicTableLoadFailure[];
+}
+
 export async function loadDynamicTables(
   adapter: DrizzleAdapter,
   sourceTable:
@@ -74,22 +105,8 @@ export async function loadDynamicTables(
      * tables hold both kinds. `undefined` where the registry is too old to say.
      */
     builderOwned: boolean | undefined
-  ) => Promise<void>,
-  /**
-   * Told when the registry read itself failed, rather than swallowing it.
-   *
-   * 🔴 The catch below exists for a FRESH database, where the registry table
-   * does not exist yet and an empty result is the right answer. A caller that
-   * has just run migrations is in the opposite situation: the table certainly
-   * exists, so a failed read means its registry is stale and it must not report
-   * the reload as done. Those two callers need different answers from the same
-   * silence, and only the caller knows which it is.
-   *
-   * Optional, so the boot-time registry build keeps the fresh-database
-   * behaviour it was written for without restating it.
-   */
-  onReadError?: (error: unknown) => void
-): Promise<void> {
+  ) => Promise<void>
+): Promise<DynamicTableLoadResult> {
   // Components have no `status` column (they're not Draft/Published) — selecting it
   // would fail. They DO carry `localized` (i18n). Collections/singles carry both.
   // Asked under both registry spellings: the storage migration renames this
@@ -145,6 +162,8 @@ export async function loadDynamicTables(
     throw lastError;
   };
 
+  const result: DynamicTableLoadResult = { registered: 0, failures: [] };
+
   try {
     const rows = await readRows();
 
@@ -153,7 +172,17 @@ export async function loadDynamicTables(
         const fields =
           typeof row.fields === "string" ? JSON.parse(row.fields) : row.fields;
 
-        if (!Array.isArray(fields)) continue;
+        if (!Array.isArray(fields)) {
+          // Recorded rather than skipped in silence: the entity ends up
+          // unregistered either way, and a caller that has just migrated must
+          // not call that a completed reload.
+          result.failures.push({
+            scope: "row",
+            tableName: String(row.table_name),
+            error: new Error("stored `fields` is not an array"),
+          });
+          continue;
+        }
 
         // Coerce dialect-specific representations into a JS boolean.
         // sqlite returns 0/1, postgres returns booleans, mysql may return
@@ -177,15 +206,25 @@ export async function loadDynamicTables(
           localized,
           builderOwned
         );
-      } catch {
-        // Skip individual row if schema generation fails.
+        result.registered += 1;
+      } catch (err) {
+        // Still skipped rather than thrown: one row that cannot generate a
+        // schema must not cost every other dynamic table its registration.
+        // Recorded, so a caller that needs to know can ask.
+        result.failures.push({
+          scope: "row",
+          tableName: String(row.table_name),
+          error: err,
+        });
       }
     }
   } catch (err) {
     // Dynamic table may not exist yet (fresh database), which is why this is
-    // swallowed by default. A caller that knows better says so.
-    onReadError?.(err);
+    // still swallowed rather than thrown.
+    result.failures.push({ scope: "read", error: err });
   }
+
+  return result;
 }
 
 /** Slug sets for the dynamic (Builder/UI + previously-synced) entities. */

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -1442,112 +1442,50 @@ async function initializeSchemaRegistry(
       );
     }
 
-    // Step 2: Dynamic collections.
+    // Step 2: Dynamic collections. Main table and, for a localized one, its
+    // `_locales` companion — one registration through the shared registrar, so
+    // singles below and the boot-time reload cannot register a different half.
     await loadDynamicTables(
       adapter,
       "dynamic_collections",
       async (tableName, fields, hasStatus, localized, builderOwned) => {
-        const { generateRuntimeSchema } = await import(
-          "../domains/schema/services/runtime-schema-generator"
+        const { registerDynamicEntitySchema } = await import(
+          "../domains/schema/services/register-dynamic-entity"
         );
-        // Localized collections omit their translatable columns from the main
-        // runtime table (they live in the companion) — mirror the migration.
-        const { table } = generateRuntimeSchema(
-          tableName,
-          fields as FieldDefinition[],
+        await registerDynamicEntitySchema({
+          adapter,
+          registry,
           dialect,
-          { status: hasStatus === true, localized }
-        );
-        registry.registerDynamicSchema(tableName, table);
-        // Register the companion `_locales` table so queries can reach it (M4).
-        if (localized) {
-          // i18n: create the companion on boot/db:sync if a migration hasn't already
-          // (idempotent) so code-first localized entities work without a manual migrate.
-          const { ensureCompanionTable } = await import(
-            "../domains/i18n/runtime/companion-io"
-          );
-          await ensureCompanionTable(adapter, {
-            // These registries hold code-first and plugin rows as well as Builder ones, and their
-            // creators size a text column differently, so the row's own ownership decides.
-            builtBy: builtByFor("collection", builderOwned),
-            slug: tableName,
-            tableName,
-            fields: fields as { name: string; type: string }[],
-            dialect,
-            status: hasStatus === true,
-          });
-          const { buildCompanionRuntimeTable } = await import(
-            "../domains/i18n/runtime/companion-registration"
-          );
-          const companion = buildCompanionRuntimeTable({
-            slug: tableName,
-            tableName,
-            fields: fields as { name: string; type: string }[],
-            dialect,
-            localized: true,
-            // Carry `_status` so a Draft/Published localized collection's
-            // DI-registered companion matches loadCompanionSchema.
-            status: hasStatus === true,
-          });
-          if (companion) {
-            registry.registerDynamicSchema(
-              companion.companionTableName,
-              companion.table
-            );
-          }
-        }
+          kind: "collection",
+          tableName,
+          fields: fields as FieldDefinition[],
+          status: hasStatus === true,
+          localized,
+          builderOwned,
+        });
       }
     );
 
-    // Step 3: Dynamic singles. Localized singles omit their translatable columns
-    // from the main runtime table and register the companion `single_<slug>_locales`
-    // table for reads/writes — mirrors collections (Step 2).
+    // Step 3: Dynamic singles — the same registration as collections above,
+    // asked about a different owner.
     await loadDynamicTables(
       adapter,
       "dynamic_singles",
       async (tableName, fields, hasStatus, localized, builderOwned) => {
-        const { generateRuntimeSchema } = await import(
-          "../domains/schema/services/runtime-schema-generator"
+        const { registerDynamicEntitySchema } = await import(
+          "../domains/schema/services/register-dynamic-entity"
         );
-        const { table } = generateRuntimeSchema(
-          tableName,
-          fields as FieldDefinition[],
+        await registerDynamicEntitySchema({
+          adapter,
+          registry,
           dialect,
-          { status: hasStatus === true, localized }
-        );
-        registry.registerDynamicSchema(tableName, table);
-        if (localized) {
-          const { ensureCompanionTable } = await import(
-            "../domains/i18n/runtime/companion-io"
-          );
-          await ensureCompanionTable(adapter, {
-            // A single is built by the same service as a collection, but only when the Builder owns
-            // it — this registry carries code-first singles too, and those came from the pipeline.
-            builtBy: builtByFor("single", builderOwned),
-            slug: tableName,
-            tableName,
-            fields: fields as { name: string; type: string }[],
-            dialect,
-            status: hasStatus === true,
-          });
-          const { buildCompanionRuntimeTable } = await import(
-            "../domains/i18n/runtime/companion-registration"
-          );
-          const companion = buildCompanionRuntimeTable({
-            slug: tableName,
-            tableName,
-            fields: fields as { name: string; type: string }[],
-            dialect,
-            localized: true,
-            status: hasStatus === true,
-          });
-          if (companion) {
-            registry.registerDynamicSchema(
-              companion.companionTableName,
-              companion.table
-            );
-          }
-        }
+          kind: "single",
+          tableName,
+          fields: fields as FieldDefinition[],
+          status: hasStatus === true,
+          localized,
+          builderOwned,
+        });
       }
     );
 

--- a/packages/nextly/src/domains/schema/services/__tests__/register-dynamic-entity.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/register-dynamic-entity.test.ts
@@ -1,0 +1,104 @@
+/**
+ * A localized entity is TWO Drizzle tables, and registering one is not
+ * registering it.
+ *
+ * The main table omits the translatable columns — they live in
+ * `<table>_locales` — so a caller that registers only the main one leaves every
+ * localized read and write addressing a table without the columns it needs. And
+ * nothing downstream repairs that: `ensureSingleRuntimeTable` ADOPTS an existing
+ * registration when both tables are present rather than rebuilding it.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { registerDynamicEntitySchema } from "../register-dynamic-entity";
+
+vi.mock("../runtime-schema-generator", () => ({
+  generateRuntimeSchema: () => ({ table: { __main: true } }),
+}));
+
+const ensureCompanionTable = vi.hoisted(() => vi.fn(async () => undefined));
+vi.mock("../../../i18n/runtime/companion-io", () => ({ ensureCompanionTable }));
+
+vi.mock("../../../i18n/runtime/companion-registration", () => ({
+  buildCompanionRuntimeTable: ({ tableName }: { tableName: string }) => ({
+    companionTableName: `${tableName}_locales`,
+    table: { __companion: true },
+  }),
+}));
+
+function registryStub() {
+  const registered: string[] = [];
+  return {
+    registered,
+    registry: {
+      registerDynamicSchema: (name: string) => registered.push(name),
+    } as never,
+  };
+}
+
+const base = {
+  adapter: {} as never,
+  dialect: "postgresql" as const,
+  tableName: "ds_settings",
+  fields: [],
+  status: false,
+  builderOwned: undefined,
+};
+
+describe("registerDynamicEntitySchema", () => {
+  // Cleared per case: the mock is module-scoped, so one test's calls would
+  // otherwise satisfy the next one's "was not called" assertion.
+  beforeEach(() => ensureCompanionTable.mockClear());
+
+  it("registers the main table AND the companion for a localized entity", async () => {
+    const { registry, registered } = registryStub();
+
+    await registerDynamicEntitySchema({
+      ...base,
+      registry,
+      kind: "single",
+      localized: true,
+    });
+
+    expect(registered).toEqual(["ds_settings", "ds_settings_locales"]);
+  });
+
+  it("registers only the main table when the entity is not localized", async () => {
+    // The control. Registering a companion unconditionally would satisfy the
+    // case above while creating a `_locales` table for every entity that has
+    // no translations to put in one.
+    const { registry, registered } = registryStub();
+
+    await registerDynamicEntitySchema({
+      ...base,
+      registry,
+      kind: "single",
+      localized: false,
+    });
+
+    expect(registered).toEqual(["ds_settings"]);
+    expect(ensureCompanionTable).not.toHaveBeenCalled();
+  });
+
+  it("asks about the owner its OWN kind implies", async () => {
+    // A single and a collection are built by different services when the
+    // Builder owns them, and their creators size a text column differently --
+    // so the companion's DDL depends on this being the row's real kind.
+    const { registry } = registryStub();
+
+    await registerDynamicEntitySchema({
+      ...base,
+      registry,
+      kind: "collection",
+      tableName: "dc_posts",
+      localized: true,
+    });
+
+    const [, opts] = ensureCompanionTable.mock.calls[0] as unknown as [
+      unknown,
+      { builtBy: string; tableName: string },
+    ];
+    expect(opts.tableName).toBe("dc_posts");
+    expect(opts.builtBy).toBeDefined();
+  });
+});

--- a/packages/nextly/src/domains/schema/services/register-dynamic-entity.ts
+++ b/packages/nextly/src/domains/schema/services/register-dynamic-entity.ts
@@ -1,0 +1,100 @@
+/**
+ * Register one dynamic entity's runtime schema — main table AND companion.
+ *
+ * 🔴 A localized collection or single is TWO Drizzle tables. The main table
+ * omits the translatable columns, which live in `<table>_locales`, so a caller
+ * that registers only the main one leaves every localized read and write
+ * addressing a table without the columns it needs. The two are one
+ * registration, and this is the only place that says so.
+ *
+ * Extracted because it had two copies and needed a third. `registerServices`
+ * spelled it once for `dynamic_collections` and again for `dynamic_singles`,
+ * differing only in which owner `builtByFor` is asked about — and the boot-time
+ * reload that refreshes those registries after a migration had a narrower
+ * version again, which registered the main table and silently left a stale
+ * companion behind. Three spellings of one rule is how the third came to be
+ * missing half of it.
+ *
+ * The field-group equivalent already lives beside it as
+ * `domains/field-groups/services/register-field-group-schemas`.
+ *
+ * @module domains/schema/services/register-dynamic-entity
+ */
+
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+
+import type { SchemaRegistry } from "../../../database/schema-registry";
+import type { FieldDefinition } from "../../../schemas/dynamic-collections/legacy-types";
+import { builtByFor } from "../pipeline/registered-collections";
+
+export interface RegisterDynamicEntityArgs {
+  adapter: DrizzleAdapter;
+  registry: SchemaRegistry;
+  dialect: SupportedDialect;
+  /** Which registry the row came from, which decides whose sizing rules apply. */
+  kind: "collection" | "single";
+  tableName: string;
+  fields: FieldDefinition[];
+  status: boolean;
+  localized: boolean;
+  /**
+   * Ownership as the registry reported it; `undefined` where it is too old to
+   * say. These registries hold code-first and plugin rows as well as Builder
+   * ones, and their creators size a text column differently, so the row's own
+   * ownership decides rather than the caller.
+   */
+  builderOwned: boolean | undefined;
+}
+
+export async function registerDynamicEntitySchema(
+  args: RegisterDynamicEntityArgs
+): Promise<void> {
+  const { adapter, registry, dialect, tableName, fields, status, localized } =
+    args;
+
+  const { generateRuntimeSchema } = await import("./runtime-schema-generator");
+  // A localized entity omits its translatable columns from the main runtime
+  // table -- they live in the companion -- which mirrors what the migration did.
+  const { table } = generateRuntimeSchema(tableName, fields, dialect, {
+    status,
+    localized,
+  });
+  registry.registerDynamicSchema(tableName, table);
+
+  if (!localized) return;
+
+  // Created here if a migration has not already (idempotent), so a code-first
+  // localized entity works without a manual migrate.
+  const { ensureCompanionTable } = await import(
+    "../../i18n/runtime/companion-io"
+  );
+  await ensureCompanionTable(adapter, {
+    builtBy: builtByFor(args.kind, args.builderOwned),
+    slug: tableName,
+    tableName,
+    fields,
+    dialect,
+    status,
+  });
+
+  const { buildCompanionRuntimeTable } = await import(
+    "../../i18n/runtime/companion-registration"
+  );
+  const companion = buildCompanionRuntimeTable({
+    slug: tableName,
+    tableName,
+    fields,
+    dialect,
+    localized: true,
+    // Carries `_status`, so a Draft/Published localized entity's registered
+    // companion matches what `loadCompanionSchema` expects.
+    status,
+  });
+  if (companion) {
+    registry.registerDynamicSchema(
+      companion.companionTableName,
+      companion.table
+    );
+  }
+}

--- a/packages/nextly/src/init/__tests__/prod-migrations.test.ts
+++ b/packages/nextly/src/init/__tests__/prod-migrations.test.ts
@@ -8,6 +8,17 @@ import {
 
 const shutdownServices = vi.fn();
 vi.mock("../../di", () => ({ shutdownServices: () => shutdownServices() }));
+
+/*
+ * The registry reload is observed through its OWN module rather than through
+ * the container, because what this file is about is WHEN the production path
+ * asks for a reload -- and the container would let a reload that never happened
+ * look the same as one that found nothing to do.
+ */
+const reloadDynamicTables = vi.fn(async () => undefined);
+vi.mock("../reload-dynamic-tables", () => ({
+  reloadDynamicTables: (label: string) => reloadDynamicTables(label),
+}));
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -326,5 +337,111 @@ describe("runProdMigrationsIfEnabled", () => {
       runProdMigrationsIfEnabled(a as never)
     ).resolves.toBeUndefined();
     expect(a.logger.error).toHaveBeenCalled();
+  });
+});
+
+/*
+ * `registerServices` builds the runtime schema registry BEFORE this path runs,
+ * so a migration that registers an entity leaves the process holding a registry
+ * that predates it -- the collection is addressable in metadata and drawn on a
+ * dashboard card while every query against it fails.
+ */
+describe("the schema registry is reloaded before the gate opens", () => {
+  beforeEach(() => {
+    reloadDynamicTables.mockClear();
+    _resetBootMigrationsGateForTest();
+  });
+
+  it("reloads after migrations ran", async () => {
+    await runProdMigrationsIfEnabled(args() as never);
+    expect(reloadDynamicTables).toHaveBeenCalledTimes(1);
+  });
+
+  /*
+   * 🔴 The case that decides the CONDITION, and the reason it is not the
+   * registration counts. On a rolling deploy a second replica waits on the
+   * migrate lock, acquires it once the first has finished, and runs against a
+   * settled database: `ran` is true while `applied` and the registration counts
+   * are 0. Its registry is exactly as stale as the migrating replica's was.
+   * Gated on "did I register anything", this replica never reloads and serves
+   * entities it can see but cannot query.
+   */
+  it("reloads on a replica that applied and registered nothing", async () => {
+    await runProdMigrationsIfEnabled(
+      args({
+        migrateCore: vi.fn(async () => ({
+          applied: 0,
+          coreChanged: false,
+          ran: true,
+          collectionsRegistered: 0,
+          singlesRegistered: 0,
+        })),
+      }) as never
+    );
+    expect(reloadDynamicTables).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT reload when migrations did not run", async () => {
+    // `ran: false` means the lock stayed held, and this path refuses to serve
+    // rather than reloading anything -- a registry refreshed for a process
+    // that is about to throw is work spent on a boot nobody will use.
+    await expect(
+      runProdMigrationsIfEnabled(
+        args({
+          migrateCore: vi.fn(async () => ({
+            applied: 0,
+            coreChanged: false,
+            ran: false,
+          })),
+        }) as never
+      )
+    ).rejects.toThrow();
+    expect(reloadDynamicTables).not.toHaveBeenCalled();
+  });
+
+  it("does not reload outside production", async () => {
+    // The control for the three above: a rule that reloaded unconditionally
+    // would satisfy the first two while doing it on every dev boot as well.
+    process.env.NODE_ENV = "development";
+    await runProdMigrationsIfEnabled(args() as never);
+    expect(reloadDynamicTables).not.toHaveBeenCalled();
+  });
+
+  /*
+   * 🔴 The reload runs BEFORE `allowBootMigrations`, so nothing waiting on that
+   * gate is released onto a registry this boot already knows is behind. The
+   * ordering is only safe because the reload cannot throw; asserted here so a
+   * later move of either line fails rather than silently reopening the window.
+   */
+  it("opens the boot gate only after the reload has finished", async () => {
+    // 🔴 The gate is OPENED first, because `awaitBootMigrations` resolves
+    // immediately when nothing is pending -- so without this the assertion
+    // below is satisfied by there being no gate at all rather than by the
+    // ordering it names.
+    openBootMigrationsGate(true);
+
+    // The control for exactly that: the gate must be genuinely pending before
+    // the run, or "not yet open during the reload" means nothing.
+    let openedEarly = false;
+    void awaitBootMigrations().then(() => {
+      openedEarly = true;
+    });
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(openedEarly).toBe(false);
+
+    let gateOpenDuringReload: boolean | undefined;
+    reloadDynamicTables.mockImplementationOnce(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0));
+      gateOpenDuringReload = openedEarly;
+      return undefined;
+    });
+
+    await runProdMigrationsIfEnabled(args() as never);
+
+    expect(gateOpenDuringReload).toBe(false);
+    // And it DID open afterwards, or the assertion above would pass on a path
+    // that simply never opens the gate.
+    await expect(awaitBootMigrations()).resolves.toBeUndefined();
+    expect(openedEarly).toBe(true);
   });
 });

--- a/packages/nextly/src/init/__tests__/prod-migrations.test.ts
+++ b/packages/nextly/src/init/__tests__/prod-migrations.test.ts
@@ -399,6 +399,44 @@ describe("the schema registry is reloaded before the gate opens", () => {
     expect(reloadDynamicTables).not.toHaveBeenCalled();
   });
 
+  /*
+   * 🔴 `runFileMigrations` commits and records each migration file
+   * independently before propagating a later file's error, so a batch that
+   * failed part-way has already written whatever metadata its earlier files
+   * carried. This path swallows that error and goes on to SERVE, so skipping
+   * the reload here served exactly those entities against the pre-migration
+   * registry -- the defect reached through the error branch rather than the
+   * happy one.
+   */
+  it("reloads when a partly-applied batch fails and the app continues", async () => {
+    await runProdMigrationsIfEnabled(
+      args({
+        migrateCore: vi.fn(async () => {
+          throw new Error("0003_later.sql failed after 0002 committed");
+        }),
+      }) as never
+    );
+    expect(reloadDynamicTables).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT reload when the process refuses to serve", async () => {
+    // The control, and the distinction that makes the case above right: a
+    // refusal throws and the process wants restarting, so refreshing a registry
+    // nobody will read is work spent on a boot that is over.
+    await expect(
+      runProdMigrationsIfEnabled(
+        args({
+          migrateCore: vi.fn(async () => ({
+            applied: 0,
+            coreChanged: false,
+            ran: false,
+          })),
+        }) as never
+      )
+    ).rejects.toThrow();
+    expect(reloadDynamicTables).not.toHaveBeenCalled();
+  });
+
   it("does not reload outside production", async () => {
     // The control for the three above: a rule that reloaded unconditionally
     // would satisfy the first two while doing it on every dev boot as well.

--- a/packages/nextly/src/init/__tests__/reload-dynamic-tables.test.ts
+++ b/packages/nextly/src/init/__tests__/reload-dynamic-tables.test.ts
@@ -24,6 +24,12 @@ vi.mock("../../domains/schema/services/runtime-schema-generator", () => ({
   generateRuntimeSchema: () => ({ table: {} }),
 }));
 
+const registerComponentSchemas = vi.hoisted(() => vi.fn(async () => 0));
+vi.mock(
+  "../../domains/field-groups/services/register-field-group-schemas",
+  () => ({ registerComponentSchemas })
+);
+
 // The in-flight and queued runs are pinned to `globalThis`, so one test's
 // leftovers would otherwise be answered to the next test's callers.
 const reloadGlobals = globalThis as unknown as {
@@ -59,6 +65,8 @@ afterEach(() => {
   vi.restoreAllMocks();
   containerGet.mockReset();
   loadDynamicTables.mockReset();
+  registerComponentSchemas.mockReset();
+  registerComponentSchemas.mockResolvedValue(0);
 });
 
 describe("reloadDynamicTables", () => {
@@ -122,14 +130,78 @@ describe("reloadDynamicTables", () => {
   });
 
   /*
-   * 🔴 Never throws, and the production caller depends on it: it reloads before
-   * `allowBootMigrations()`, so an exception escaping here would leave that gate
-   * closed and hang every consumer waiting on it.
+   * 🔴 `loadDynamicTables` RESOLVES when the registry read fails -- it swallows
+   * that for the fresh database it was written for -- so a test that mocks it
+   * to REJECT asserts a behaviour the real dependency never produces, and the
+   * silence this path has to notice would go unnoticed. The loader now tells
+   * its caller, and this drives that channel rather than a rejection.
    */
-  it("does not throw when the load fails", async () => {
+  it("reports a swallowed read failure instead of claiming success", async () => {
     ready();
-    loadDynamicTables.mockRejectedValue(new Error("table is gone"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    // The real loader's shape: resolve, having told the caller it read nothing.
+    loadDynamicTables.mockImplementation(
+      async (
+        _adapter: unknown,
+        _table: unknown,
+        _register: unknown,
+        onReadError?: (e: unknown) => void
+      ) => {
+        onReadError?.(new Error("relation does not exist"));
+      }
+    );
+
+    await reloadDynamicTables("[t]");
+
+    expect(warn.mock.calls.flat().join(" ")).toMatch(/INCOMPLETE/);
+    // And it did NOT also claim the reload finished.
+    expect(log.mock.calls.flat().join(" ")).not.toMatch(/reloaded:/);
+  });
+
+  it("still reports success when nothing failed", async () => {
+    // The control: a rule that warned unconditionally would satisfy the case
+    // above while never reporting a healthy reload.
+    ready();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    loadDynamicTables.mockResolvedValue(undefined);
+
+    await reloadDynamicTables("[t]");
+
+    expect(log.mock.calls.flat().join(" ")).toMatch(/reloaded:/);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  /*
+   * 🔴 A migration generated from a UI manifest writes `dynamic_components`
+   * rows beside the collection and single ones, and a `comp_` table missing
+   * from the registry is unaddressable exactly as a collection would be.
+   * Through `registerComponentSchemas` rather than a third read, because that
+   * path also resolves the storage rename's type column per table and
+   * registers the `_locales` companion for a localized group.
+   */
+  it("registers field groups through the component path", async () => {
+    ready();
+    loadDynamicTables.mockResolvedValue(undefined);
+    registerComponentSchemas.mockResolvedValue(2);
+
+    await reloadDynamicTables("[t]");
+
+    expect(registerComponentSchemas).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the entity reload when field groups cannot be registered", async () => {
+    // One unregisterable group must not cost the collections and singles their
+    // reload -- and the caller must still not see a throw, because it reloads
+    // before the boot gate opens.
+    ready();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    loadDynamicTables.mockResolvedValue(undefined);
+    registerComponentSchemas.mockRejectedValue(new Error("comp registry gone"));
+
     await expect(reloadDynamicTables("[t]")).resolves.toBeUndefined();
+    expect(warn.mock.calls.flat().join(" ")).toMatch(/field groups/);
   });
 
   it("does not throw when the registry is not in the container", async () => {

--- a/packages/nextly/src/init/__tests__/reload-dynamic-tables.test.ts
+++ b/packages/nextly/src/init/__tests__/reload-dynamic-tables.test.ts
@@ -14,6 +14,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { reloadDynamicTables } from "../reload-dynamic-tables";
 
+/**
+ * The loader's real return shape.
+ *
+ * Spelled once, because a mock that resolves something the real function never
+ * returns is the defect these tests exist to catch, one layer up.
+ */
+const ok = (registered = 0) => ({ registered, failures: [] });
+
 const containerGet = vi.hoisted(() => vi.fn());
 vi.mock("../../di/container", () => ({ container: { get: containerGet } }));
 
@@ -72,7 +80,7 @@ afterEach(() => {
 describe("reloadDynamicTables", () => {
   it("reads both metadata tables", () => {
     ready();
-    loadDynamicTables.mockResolvedValue(undefined);
+    loadDynamicTables.mockResolvedValue(ok());
     return reloadDynamicTables("[t]").then(() => {
       expect(loadDynamicTables.mock.calls.map(c => c[1])).toEqual([
         "dynamic_collections",
@@ -86,11 +94,11 @@ describe("reloadDynamicTables", () => {
     let release: (() => void) | undefined;
     loadDynamicTables.mockImplementationOnce(
       () =>
-        new Promise<void>(resolve => {
-          release = resolve;
+        new Promise(resolve => {
+          release = () => resolve(ok());
         })
     );
-    loadDynamicTables.mockResolvedValue(undefined);
+    loadDynamicTables.mockResolvedValue(ok());
 
     const first = reloadDynamicTables("[a]");
     // Arrives while the first is still reading, which is the boot whose rows
@@ -111,11 +119,11 @@ describe("reloadDynamicTables", () => {
     let release: (() => void) | undefined;
     loadDynamicTables.mockImplementationOnce(
       () =>
-        new Promise<void>(resolve => {
-          release = resolve;
+        new Promise(resolve => {
+          release = () => resolve(ok());
         })
     );
-    loadDynamicTables.mockResolvedValue(undefined);
+    loadDynamicTables.mockResolvedValue(ok());
 
     const first = reloadDynamicTables("[a]");
     const second = reloadDynamicTables("[b]");
@@ -140,22 +148,52 @@ describe("reloadDynamicTables", () => {
     ready();
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
-    // The real loader's shape: resolve, having told the caller it read nothing.
-    loadDynamicTables.mockImplementation(
-      async (
-        _adapter: unknown,
-        _table: unknown,
-        _register: unknown,
-        onReadError?: (e: unknown) => void
-      ) => {
-        onReadError?.(new Error("relation does not exist"));
-      }
-    );
+    // The real loader's shape: RESOLVE, carrying the failure it swallowed.
+    loadDynamicTables.mockResolvedValue({
+      registered: 0,
+      failures: [
+        { scope: "read", error: new Error("relation does not exist") },
+      ],
+    });
 
     await reloadDynamicTables("[t]");
 
     expect(warn.mock.calls.flat().join(" ")).toMatch(/INCOMPLETE/);
     // And it did NOT also claim the reload finished.
+    expect(log.mock.calls.flat().join(" ")).not.toMatch(/reloaded:/);
+  });
+
+  /*
+   * 🔴 A ROW failure must reach the same warning a read failure does. The
+   * loader skips a row whose stored `fields` will not parse or whose schema
+   * will not generate, and the count merely comes back lower -- which is
+   * indistinguishable from a database holding one fewer entity. Reported off
+   * the count alone, the boot called the reload complete and opened the gate
+   * while that collection stayed unqueryable.
+   */
+  it("reports a row that could not be registered, naming it", async () => {
+    ready();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    loadDynamicTables.mockResolvedValue({
+      registered: 2,
+      failures: [
+        {
+          scope: "row",
+          tableName: "dc_posts",
+          error: new Error("stored `fields` is not an array"),
+        },
+      ],
+    });
+
+    await reloadDynamicTables("[t]");
+
+    const warned = warn.mock.calls.flat().join(" ");
+    expect(warned).toMatch(/INCOMPLETE/);
+    // Names the entity, so an operator knows WHICH one is unqueryable rather
+    // than that something is.
+    expect(warned).toMatch(/dc_posts/);
+    // And it did not also claim the reload finished, despite 2 registering.
     expect(log.mock.calls.flat().join(" ")).not.toMatch(/reloaded:/);
   });
 
@@ -165,7 +203,7 @@ describe("reloadDynamicTables", () => {
     ready();
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
-    loadDynamicTables.mockResolvedValue(undefined);
+    loadDynamicTables.mockResolvedValue(ok());
 
     await reloadDynamicTables("[t]");
 
@@ -183,7 +221,7 @@ describe("reloadDynamicTables", () => {
    */
   it("registers field groups through the component path", async () => {
     ready();
-    loadDynamicTables.mockResolvedValue(undefined);
+    loadDynamicTables.mockResolvedValue(ok());
     registerComponentSchemas.mockResolvedValue(2);
 
     await reloadDynamicTables("[t]");
@@ -197,7 +235,7 @@ describe("reloadDynamicTables", () => {
     // before the boot gate opens.
     ready();
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    loadDynamicTables.mockResolvedValue(undefined);
+    loadDynamicTables.mockResolvedValue(ok());
     registerComponentSchemas.mockRejectedValue(new Error("comp registry gone"));
 
     await expect(reloadDynamicTables("[t]")).resolves.toBeUndefined();
@@ -220,7 +258,7 @@ describe("reloadDynamicTables", () => {
     loadDynamicTables.mockRejectedValueOnce(new Error("transient"));
     await reloadDynamicTables("[t]");
 
-    loadDynamicTables.mockResolvedValue(undefined);
+    loadDynamicTables.mockResolvedValue(ok());
     await reloadDynamicTables("[t]");
     expect(loadDynamicTables.mock.calls.map(c => c[1])).toContain(
       "dynamic_singles"

--- a/packages/nextly/src/init/__tests__/reload-dynamic-tables.test.ts
+++ b/packages/nextly/src/init/__tests__/reload-dynamic-tables.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Registry reloads are serialized, and a boot arriving mid-reload still gets
+ * its own rows read.
+ *
+ * Both boot paths call this, and in a Next.js dev server several workers reach
+ * it at once. Two reloads overlapping would let one register schemas from a
+ * read the other has already superseded; handing a mid-reload caller the
+ * running promise would serialize them and lose that caller's entities, since
+ * the run already going may have read the metadata tables before those rows
+ * were committed — which is the defect this module exists to close, arriving
+ * through the fix for it.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { reloadDynamicTables } from "../reload-dynamic-tables";
+
+const containerGet = vi.hoisted(() => vi.fn());
+vi.mock("../../di/container", () => ({ container: { get: containerGet } }));
+
+const loadDynamicTables = vi.hoisted(() => vi.fn());
+vi.mock("../../di/load-dynamic-tables", () => ({ loadDynamicTables }));
+
+vi.mock("../../domains/schema/services/runtime-schema-generator", () => ({
+  generateRuntimeSchema: () => ({ table: {} }),
+}));
+
+// The in-flight and queued runs are pinned to `globalThis`, so one test's
+// leftovers would otherwise be answered to the next test's callers.
+const reloadGlobals = globalThis as unknown as {
+  __nextly_registryReloadInFlight?: Promise<void>;
+  __nextly_registryReloadQueued?: Promise<void>;
+};
+
+/** A container holding both services, so the reload reaches the loader. */
+function ready(): void {
+  containerGet.mockImplementation((name: string) =>
+    name === "adapter"
+      ? { getCapabilities: () => ({ dialect: "postgresql" as const }) }
+      : { registerDynamicSchema: vi.fn() }
+  );
+}
+
+/** Waits until the paused load has actually started, then releases it. */
+async function releaseWhenStarted(get: () => (() => void) | undefined) {
+  for (let i = 0; i < 200 && !get(); i += 1) {
+    await new Promise(resolve => setTimeout(resolve, 5));
+  }
+  const release = get();
+  // 🔴 Refuses rather than returning: `release?.()` on an unset value is a
+  // no-op, and the awaits below would then hang until the suite timed out --
+  // reporting a fixture that never armed as a product defect.
+  if (!release) throw new Error("the paused load never started");
+  release();
+}
+
+afterEach(() => {
+  delete reloadGlobals.__nextly_registryReloadInFlight;
+  delete reloadGlobals.__nextly_registryReloadQueued;
+  vi.restoreAllMocks();
+  containerGet.mockReset();
+  loadDynamicTables.mockReset();
+});
+
+describe("reloadDynamicTables", () => {
+  it("reads both metadata tables", () => {
+    ready();
+    loadDynamicTables.mockResolvedValue(undefined);
+    return reloadDynamicTables("[t]").then(() => {
+      expect(loadDynamicTables.mock.calls.map(c => c[1])).toEqual([
+        "dynamic_collections",
+        "dynamic_singles",
+      ]);
+    });
+  });
+
+  it("gives a caller arriving mid-reload a run of its OWN", async () => {
+    ready();
+    let release: (() => void) | undefined;
+    loadDynamicTables.mockImplementationOnce(
+      () =>
+        new Promise<void>(resolve => {
+          release = resolve;
+        })
+    );
+    loadDynamicTables.mockResolvedValue(undefined);
+
+    const first = reloadDynamicTables("[a]");
+    // Arrives while the first is still reading, which is the boot whose rows
+    // that read may have been too early to see.
+    const second = reloadDynamicTables("[b]");
+    void first;
+    expect(second).not.toBe(first);
+
+    await releaseWhenStarted(() => release);
+    await Promise.all([first, second]);
+
+    // Two passes over two tables: the first run, then the trailing one.
+    expect(loadDynamicTables).toHaveBeenCalledTimes(4);
+  });
+
+  it("coalesces every further caller onto the ONE trailing run", async () => {
+    ready();
+    let release: (() => void) | undefined;
+    loadDynamicTables.mockImplementationOnce(
+      () =>
+        new Promise<void>(resolve => {
+          release = resolve;
+        })
+    );
+    loadDynamicTables.mockResolvedValue(undefined);
+
+    const first = reloadDynamicTables("[a]");
+    const second = reloadDynamicTables("[b]");
+    const third = reloadDynamicTables("[c]");
+    // They all want the state after the last of them, so one trailing run
+    // serves them both -- otherwise a busy dev server queues a run per worker.
+    expect(third).toBe(second);
+
+    await releaseWhenStarted(() => release);
+    await Promise.all([first, second, third]);
+    expect(loadDynamicTables).toHaveBeenCalledTimes(4);
+  });
+
+  /*
+   * 🔴 Never throws, and the production caller depends on it: it reloads before
+   * `allowBootMigrations()`, so an exception escaping here would leave that gate
+   * closed and hang every consumer waiting on it.
+   */
+  it("does not throw when the load fails", async () => {
+    ready();
+    loadDynamicTables.mockRejectedValue(new Error("table is gone"));
+    await expect(reloadDynamicTables("[t]")).resolves.toBeUndefined();
+  });
+
+  it("does not throw when the registry is not in the container", async () => {
+    containerGet.mockImplementation((name: string) =>
+      name === "adapter" ? {} : undefined
+    );
+    await expect(reloadDynamicTables("[t]")).resolves.toBeUndefined();
+    // And it stopped rather than reading with a registry it could not write to.
+    expect(loadDynamicTables).not.toHaveBeenCalled();
+  });
+
+  it("recovers after a failed reload rather than wedging", async () => {
+    // The control for the two above: swallowing a failure must not leave the
+    // in-flight latch set, or every later boot would be handed a dead promise.
+    ready();
+    loadDynamicTables.mockRejectedValueOnce(new Error("transient"));
+    await reloadDynamicTables("[t]");
+
+    loadDynamicTables.mockResolvedValue(undefined);
+    await reloadDynamicTables("[t]");
+    expect(loadDynamicTables.mock.calls.map(c => c[1])).toContain(
+      "dynamic_singles"
+    );
+  });
+});

--- a/packages/nextly/src/init/__tests__/reload-dynamic-tables.test.ts
+++ b/packages/nextly/src/init/__tests__/reload-dynamic-tables.test.ts
@@ -32,6 +32,14 @@ vi.mock("../../domains/schema/services/runtime-schema-generator", () => ({
   generateRuntimeSchema: () => ({ table: {} }),
 }));
 
+/** Typed with its argument, so the recorded calls carry one to assert on. */
+const registerDynamicEntitySchema = vi.hoisted(() =>
+  vi.fn(async (_args: { kind: string; localized: boolean }) => undefined)
+);
+vi.mock("../../domains/schema/services/register-dynamic-entity", () => ({
+  registerDynamicEntitySchema,
+}));
+
 const registerComponentSchemas = vi.hoisted(() => vi.fn(async () => 0));
 vi.mock(
   "../../domains/field-groups/services/register-field-group-schemas",
@@ -75,6 +83,8 @@ afterEach(() => {
   loadDynamicTables.mockReset();
   registerComponentSchemas.mockReset();
   registerComponentSchemas.mockResolvedValue(0);
+  registerDynamicEntitySchema.mockReset();
+  registerDynamicEntitySchema.mockResolvedValue(undefined);
 });
 
 describe("reloadDynamicTables", () => {
@@ -219,6 +229,39 @@ describe("reloadDynamicTables", () => {
    * path also resolves the storage rename's type column per table and
    * registers the `_locales` companion for a localized group.
    */
+  /*
+   * 🔴 Registered through the SAME registrar `registerServices` uses, so a
+   * localized entity's `<table>_locales` companion is refreshed with its main
+   * table. Building a runtime schema here instead registered only the main one,
+   * and nothing downstream repaired it: `ensureSingleRuntimeTable` ADOPTS an
+   * existing registration when both tables are present rather than rebuilding,
+   * so every read and write of a newly migrated localized field addressed a
+   * table without those columns until the next restart.
+   */
+  it("registers each entity through the shared registrar, with its kind", async () => {
+    ready();
+    loadDynamicTables.mockImplementation(
+      async (_adapter: unknown, table: string, register: never) => {
+        await (register as unknown as (...a: unknown[]) => Promise<void>)(
+          table === "dynamic_collections" ? "dc_posts" : "ds_settings",
+          [],
+          false,
+          true,
+          undefined
+        );
+        return ok(1);
+      }
+    );
+
+    await reloadDynamicTables("[t]");
+
+    const kinds = registerDynamicEntitySchema.mock.calls.map(c => c[0].kind);
+    expect(kinds).toEqual(["collection", "single"]);
+    // And the localization flag is carried, which is what decides whether the
+    // companion is registered at all.
+    expect(registerDynamicEntitySchema.mock.calls[0]?.[0].localized).toBe(true);
+  });
+
   it("registers field groups through the component path", async () => {
     ready();
     loadDynamicTables.mockResolvedValue(ok());

--- a/packages/nextly/src/init/boot-apply.ts
+++ b/packages/nextly/src/init/boot-apply.ts
@@ -33,6 +33,8 @@
 // runs first. Both need the same boot-apply behavior, so the logic
 // is centralized here and called from both.
 
+import { reloadDynamicTables } from "./reload-dynamic-tables";
+
 const callerLabel = (caller?: string): string =>
   caller ? `[Nextly:${caller}]` : "[Nextly]";
 
@@ -56,11 +58,11 @@ export async function runBootTimeApplyIfDev(opts?: {
     // Any metadata-table-to-physical-table mismatch self-heals on next boot.
     await registerMigrationMetadata(label);
 
-    // Step 1.6: Reload dynamic tables into schema registry
-    // After migration metadata is registered, we need to reload the dynamic
-    // tables so the schema registry picks up the newly registered collections.
-    // Without this, queries against migration-created collections fail because
-    // the registry was loaded before the metadata was inserted.
+    // Step 1.6: Reload dynamic tables into the schema registry.
+    // The registry was built by `registerServices` before any of the above ran,
+    // so without this a migration-created collection is addressable in metadata
+    // and unqueryable. Shared with the production path, which needs the same
+    // step for the same reason.
     await reloadDynamicTables(label);
 
     // Step 2: Apply code-first schema changes
@@ -85,102 +87,6 @@ export async function runBootTimeApplyIfDev(opts?: {
         `but code-first edits won't be applied until next restart, ` +
         `HMR fires, or you run \`nextly db:sync\`. ` +
         `Set NEXTLY_BOOT_APPLY_FAIL_LOUDLY=1 for full error details.`
-    );
-  }
-}
-
-/**
- * Reload dynamic tables into the schema registry after migration metadata registration.
- *
- * After registerMigrationMetadata() inserts rows into dynamic_collections/dynamic_singles,
- * the schema registry needs to be reloaded so those collections become queryable.
- *
- * This is called AFTER migration metadata is registered because the initial schema
- * registry load (during registerServices) happens before migration metadata exists.
- */
-async function reloadDynamicTables(label: string): Promise<void> {
-  try {
-    const { container } = await import("../di/container");
-    const { loadDynamicTables } = await import("../di/load-dynamic-tables");
-    const { generateRuntimeSchema } = await import(
-      "../domains/schema/services/runtime-schema-generator"
-    );
-
-    // Get services from container
-    const adapter = container.get("adapter");
-    const schemaRegistry = container.get("schemaRegistry");
-
-    if (!schemaRegistry) {
-      console.warn(
-        `${label} Schema registry not available for reload. Collections from migrations may not be queryable.`
-      );
-      return;
-    }
-
-    if (!adapter) {
-      console.warn(
-        `${label} Adapter not available for reload. Collections from migrations may not be queryable.`
-      );
-      return;
-    }
-
-    // Get dialect using adapter's getCapabilities method
-    const getCapabilities = (
-      adapter as {
-        getCapabilities: () => { dialect: "postgresql" | "mysql" | "sqlite" };
-      }
-    ).getCapabilities;
-    const dialect = getCapabilities().dialect;
-
-    // Reload collections
-    await loadDynamicTables(
-      adapter as Parameters<typeof loadDynamicTables>[0],
-      "dynamic_collections",
-      (tableName, fields, hasStatus, localized) => {
-        const { table } = generateRuntimeSchema(
-          tableName,
-          fields as Parameters<typeof generateRuntimeSchema>[1],
-          dialect,
-          { status: hasStatus === true, localized: localized === true }
-        );
-        (
-          schemaRegistry as {
-            registerDynamicSchema: (tableName: string, table: unknown) => void;
-          }
-        ).registerDynamicSchema(tableName, table);
-        return Promise.resolve();
-      }
-    );
-
-    // Reload singles
-    await loadDynamicTables(
-      adapter as Parameters<typeof loadDynamicTables>[0],
-      "dynamic_singles",
-      (tableName, fields, hasStatus, localized) => {
-        const { table } = generateRuntimeSchema(
-          tableName,
-          fields as Parameters<typeof generateRuntimeSchema>[1],
-          dialect,
-          { status: hasStatus === true, localized: localized === true }
-        );
-        (
-          schemaRegistry as {
-            registerDynamicSchema: (tableName: string, table: unknown) => void;
-          }
-        ).registerDynamicSchema(tableName, table);
-        return Promise.resolve();
-      }
-    );
-
-    console.log(
-      `${label} ✅ Schema registry reloaded with migration collections`
-    );
-  } catch (err) {
-    // Schema registry reload failed - log but don't block startup
-    const msg = err instanceof Error ? err.message : String(err);
-    console.warn(
-      `${label} Schema registry reload failed: ${msg}. ` +
-        `Collections from migrations may not be queryable.`
     );
   }
 }

--- a/packages/nextly/src/init/prod-migrations.ts
+++ b/packages/nextly/src/init/prod-migrations.ts
@@ -291,6 +291,23 @@ export async function runProdMigrationsIfEnabled(
         err instanceof Error ? err.message : String(err)
       }. The app will continue; run \`nextly migrate\` to resolve.`
     );
+
+    /*
+     * 🔴 Reloaded on the FAILING path too, because this process goes on to
+     * serve. `runFileMigrations` commits and records each migration file
+     * independently before propagating a later file's error, so a batch that
+     * failed part-way has already written whatever metadata its earlier files
+     * carried — and skipping the reload here served exactly those entities
+     * against the pre-migration registry, which is the defect this whole path
+     * exists to close, reached through the error branch instead of the happy
+     * one.
+     *
+     * Before `allowBootMigrations` for the same reason as the success path, and
+     * safe there for the same reason: the reload cannot throw.
+     */
+    const { reloadDynamicTables } = await import("./reload-dynamic-tables");
+    await reloadDynamicTables("[Nextly]");
+
     // The app continues on this path, so the gate must open — a swallowed
     // failure that left it pending would hang every consumer forever, turning a
     // recoverable error into a worse outage than the one being tolerated.

--- a/packages/nextly/src/init/prod-migrations.ts
+++ b/packages/nextly/src/init/prod-migrations.ts
@@ -215,6 +215,32 @@ export async function runProdMigrationsIfEnabled(
       throw bootMigrationsNotRun(adapter.dialect);
     }
     logger.info(`[Nextly] Boot migrations complete (${applied} applied).`);
+
+    /*
+     * 🔴 Reloaded whenever migrations RAN, never on how many entities this
+     * process registered. `registerServices` built this registry before the
+     * lock was ever taken, so it predates the rows regardless of who wrote
+     * them — and `migrateCore` reports `collectionsRegistered` for the work
+     * THIS process did, not for whether its own view is current.
+     *
+     * The two differ on a rolling deploy, which is the case that matters. A
+     * replica that waits on the lock and acquires it after another replica has
+     * already migrated runs `migrateCore` against a settled database: `ran` is
+     * true, `applied` and the registration counts are 0, and its registry is
+     * exactly as stale as the migrating replica's was. Gated on those counts it
+     * would never reload, and would serve the entities it can see but not
+     * query. `ran === true` is the condition every replica that goes on to
+     * SERVE satisfies — the ones that do not throw a few lines above rather
+     * than reaching here.
+     *
+     * Before `allowBootMigrations`, so nothing waiting on that gate is released
+     * onto a registry this boot already knows is behind. It cannot throw, which
+     * is what makes that ordering safe: an exception here would leave the gate
+     * closed and hang every consumer of it.
+     */
+    const { reloadDynamicTables } = await import("./reload-dynamic-tables");
+    await reloadDynamicTables("[Nextly]");
+
     allowBootMigrations();
   } catch (err) {
     // A refusal is not a failure to swallow. Every other error here is

--- a/packages/nextly/src/init/reload-dynamic-tables.ts
+++ b/packages/nextly/src/init/reload-dynamic-tables.ts
@@ -20,6 +20,7 @@
 // A TYPE-only import, so naming the loader's parameter costs nothing at
 // runtime: the specifier is erased, and the loader itself is still imported
 // dynamically below to keep it off the boot path until a reload actually runs.
+import type { SchemaRegistry } from "../database/schema-registry";
 import type { loadDynamicTables } from "../di/load-dynamic-tables";
 
 /**
@@ -77,7 +78,14 @@ function startReload(label: string): Promise<void> {
 /** What a registry reload needs from the container, once both are present. */
 interface ReloadDeps {
   adapter: Parameters<typeof loadDynamicTables>[0];
-  registerDynamicSchema: (tableName: string, table: unknown) => void;
+  /**
+   * The registry itself, not a bound method off it.
+   *
+   * The container hands both services back untyped, so they are narrowed ONCE
+   * where they are read; carrying the registry whole lets the field-group path
+   * register into the same object rather than being handed a second view of it.
+   */
+  registry: SchemaRegistry;
   dialect: "postgresql" | "mysql" | "sqlite";
 }
 
@@ -101,19 +109,87 @@ async function runReload(label: string): Promise<void> {
     const deps = await resolveDeps(label);
     if (!deps) return;
 
-    // Both registries, one pass each, through one loader. They differ only in
-    // the table read; spelling the body twice is how the two would drift.
+    // Both entity registries, one pass each, through one loader. They differ
+    // only in the table read; spelling the body twice is how the two drift.
+    let registered = 0;
+    const failures: string[] = [];
     for (const table of ["dynamic_collections", "dynamic_singles"] as const) {
-      await loadInto(deps, table);
+      registered += await loadInto(deps, table, err => {
+        failures.push(
+          `${table}: ${err instanceof Error ? err.message : String(err)}`
+        );
+      });
     }
 
-    console.log(`${label} Schema registry reloaded from migration metadata.`);
+    /*
+     * 🔴 Field groups go through `registerComponentSchemas`, not a third turn
+     * of the loop above. A migration generated from a UI manifest writes
+     * `dynamic_components` rows alongside the collection and single ones, and
+     * a `comp_` table that is not in the registry is unaddressable exactly as a
+     * collection would be. The registration is more than a runtime schema —
+     * it resolves the storage rename's type column per table and registers the
+     * `_locales` companion for a localized group — and that logic already
+     * exists here. Restating the parts of it this module happens to need is
+     * how the two would come to disagree.
+     */
+    const components = await registerComponents(deps, label, failures);
+
+    if (failures.length > 0) {
+      console.warn(
+        `${label} Schema registry reload INCOMPLETE (${failures.join("; ")}). ` +
+          `Entities this boot registered may not be queryable until a restart.`
+      );
+      return;
+    }
+
+    console.log(
+      `${label} Schema registry reloaded: ${registered} entities, ` +
+        `${components} field groups.`
+    );
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.warn(
       `${label} Schema registry reload failed: ${msg}. ` +
-        `Collections this boot registered are not queryable until a restart.`
+        `Entities this boot registered are not queryable until a restart.`
     );
+  }
+}
+
+/**
+ * Register every field group's runtime schema, or record why it could not be.
+ *
+ * Separated because it is the one part of a reload that is NOT a read of a
+ * metadata table: it is a whole registration path with its own dependencies,
+ * and inlining it put a second subject inside the loop above.
+ */
+async function registerComponents(
+  deps: ReloadDeps,
+  label: string,
+  failures: string[]
+): Promise<number> {
+  try {
+    const { registerComponentSchemas } = await import(
+      "../domains/field-groups/services/register-field-group-schemas"
+    );
+    return await registerComponentSchemas({
+      adapter: deps.adapter,
+      registry: deps.registry,
+      dialect: deps.dialect,
+      logger: {
+        debug: (m: string) => console.debug(`${label} ${m}`),
+        info: (m: string) => console.log(`${label} ${m}`),
+        warn: (m: string) => console.warn(`${label} ${m}`),
+        error: (m: string) => console.error(`${label} ${m}`),
+      },
+    });
+  } catch (err) {
+    // Recorded rather than thrown: one unregisterable group must not cost the
+    // collections and singles their reload, and this function's caller must
+    // never throw.
+    failures.push(
+      `field groups: ${err instanceof Error ? err.message : String(err)}`
+    );
+    return 0;
   }
 }
 
@@ -134,29 +210,34 @@ async function resolveDeps(label: string): Promise<ReloadDeps | undefined> {
   const { getCapabilities } = adapter as {
     getCapabilities: () => { dialect: "postgresql" | "mysql" | "sqlite" };
   };
-  const { registerDynamicSchema } = schemaRegistry as {
-    registerDynamicSchema: (tableName: string, table: unknown) => void;
-  };
 
   return {
     adapter: adapter as ReloadDeps["adapter"],
-    // Bound to the registry, because both are read off the container as
-    // untyped services and a bare method reference would lose its receiver.
-    registerDynamicSchema: registerDynamicSchema.bind(schemaRegistry),
+    registry: schemaRegistry as SchemaRegistry,
     dialect: getCapabilities.call(adapter).dialect,
   };
 }
 
-/** Read one metadata table and register a runtime schema for each row. */
+/**
+ * Read one metadata table, register a runtime schema per row, and say how many.
+ *
+ * 🔴 Returns a COUNT rather than nothing, because `loadDynamicTables` resolves
+ * whether or not it read anything — it swallows a failed read for the fresh
+ * database it was written for. Reporting "reloaded" off its resolution alone
+ * claimed a repair that may not have happened; the number is what this pass
+ * actually did, and `onReadError` is what separates zero rows from no read.
+ */
 async function loadInto(
   deps: ReloadDeps,
-  table: "dynamic_collections" | "dynamic_singles"
-): Promise<void> {
+  table: "dynamic_collections" | "dynamic_singles",
+  onReadError: (error: unknown) => void
+): Promise<number> {
   const { loadDynamicTables } = await import("../di/load-dynamic-tables");
   const { generateRuntimeSchema } = await import(
     "../domains/schema/services/runtime-schema-generator"
   );
 
+  let registered = 0;
   await loadDynamicTables(
     deps.adapter,
     table,
@@ -167,8 +248,11 @@ async function loadInto(
         deps.dialect,
         { status: hasStatus === true, localized: localized === true }
       );
-      deps.registerDynamicSchema(tableName, runtime);
+      deps.registry.registerDynamicSchema(tableName, runtime);
+      registered += 1;
       return Promise.resolve();
-    }
+    },
+    onReadError
   );
+  return registered;
 }

--- a/packages/nextly/src/init/reload-dynamic-tables.ts
+++ b/packages/nextly/src/init/reload-dynamic-tables.ts
@@ -21,7 +21,10 @@
 // runtime: the specifier is erased, and the loader itself is still imported
 // dynamically below to keep it off the boot path until a reload actually runs.
 import type { SchemaRegistry } from "../database/schema-registry";
-import type { loadDynamicTables } from "../di/load-dynamic-tables";
+import type {
+  DynamicTableLoadResult,
+  loadDynamicTables,
+} from "../di/load-dynamic-tables";
 
 /**
  * The in-flight reload and the one queued behind it.
@@ -114,11 +117,29 @@ async function runReload(label: string): Promise<void> {
     let registered = 0;
     const failures: string[] = [];
     for (const table of ["dynamic_collections", "dynamic_singles"] as const) {
-      registered += await loadInto(deps, table, err => {
-        failures.push(
-          `${table}: ${err instanceof Error ? err.message : String(err)}`
-        );
-      });
+      const outcome = await loadInto(deps, table);
+      registered += outcome.registered;
+      for (const failure of outcome.failures) {
+        /*
+         * 🔴 A ROW failure counts as much as a read failure. The loader skips a
+         * row whose stored `fields` will not parse or whose schema will not
+         * generate -- right, because one corrupt row must not cost every other
+         * dynamic table its registration -- and the count merely comes back
+         * lower. Read off the count alone, one unregisterable collection looks
+         * exactly like a database holding one fewer, so the boot logged a
+         * completed reload and opened the gate while that entity stayed
+         * unqueryable: the defect this module exists to close, one level down
+         * from where it was first fixed.
+         */
+        const where = failure.tableName
+          ? `${table}.${failure.tableName}`
+          : table;
+        const why =
+          failure.error instanceof Error
+            ? failure.error.message
+            : String(failure.error);
+        failures.push(`${where}: ${why}`);
+      }
     }
 
     /*
@@ -219,26 +240,23 @@ async function resolveDeps(label: string): Promise<ReloadDeps | undefined> {
 }
 
 /**
- * Read one metadata table, register a runtime schema per row, and say how many.
+ * Read one metadata table and register a runtime schema per row.
  *
- * 🔴 Returns a COUNT rather than nothing, because `loadDynamicTables` resolves
- * whether or not it read anything — it swallows a failed read for the fresh
- * database it was written for. Reporting "reloaded" off its resolution alone
- * claimed a repair that may not have happened; the number is what this pass
- * actually did, and `onReadError` is what separates zero rows from no read.
+ * Hands the loader's own outcome straight back rather than reducing it here:
+ * what this pass registered and what it could not are one answer, and the
+ * CALLER is the party that decides whether a failure means the reload is
+ * incomplete.
  */
 async function loadInto(
   deps: ReloadDeps,
-  table: "dynamic_collections" | "dynamic_singles",
-  onReadError: (error: unknown) => void
-): Promise<number> {
+  table: "dynamic_collections" | "dynamic_singles"
+): Promise<DynamicTableLoadResult> {
   const { loadDynamicTables } = await import("../di/load-dynamic-tables");
   const { generateRuntimeSchema } = await import(
     "../domains/schema/services/runtime-schema-generator"
   );
 
-  let registered = 0;
-  await loadDynamicTables(
+  return loadDynamicTables(
     deps.adapter,
     table,
     (tableName, fields, hasStatus, localized) => {
@@ -249,10 +267,7 @@ async function loadInto(
         { status: hasStatus === true, localized: localized === true }
       );
       deps.registry.registerDynamicSchema(tableName, runtime);
-      registered += 1;
       return Promise.resolve();
-    },
-    onReadError
+    }
   );
-  return registered;
 }

--- a/packages/nextly/src/init/reload-dynamic-tables.ts
+++ b/packages/nextly/src/init/reload-dynamic-tables.ts
@@ -252,22 +252,39 @@ async function loadInto(
   table: "dynamic_collections" | "dynamic_singles"
 ): Promise<DynamicTableLoadResult> {
   const { loadDynamicTables } = await import("../di/load-dynamic-tables");
-  const { generateRuntimeSchema } = await import(
-    "../domains/schema/services/runtime-schema-generator"
+  const { registerDynamicEntitySchema } = await import(
+    "../domains/schema/services/register-dynamic-entity"
   );
+
+  /*
+   * 🔴 Through the SAME registrar `registerServices` uses, not a runtime schema
+   * built here. A localized entity is two Drizzle tables -- the main one omits
+   * the translatable columns, which live in `<table>_locales` -- and this
+   * registered only the first. `ensureSingleRuntimeTable` adopts an existing
+   * registration when both tables are present rather than rebuilding it, so
+   * nothing downstream repaired the stale companion: every read and write of a
+   * newly migrated localized field addressed a table without those columns
+   * until the next restart.
+   */
+  const kind = table === "dynamic_collections" ? "collection" : "single";
 
   return loadDynamicTables(
     deps.adapter,
     table,
-    (tableName, fields, hasStatus, localized) => {
-      const { table: runtime } = generateRuntimeSchema(
+    async (tableName, fields, hasStatus, localized, builderOwned) => {
+      await registerDynamicEntitySchema({
+        adapter: deps.adapter,
+        registry: deps.registry,
+        dialect: deps.dialect,
+        kind,
         tableName,
-        fields as Parameters<typeof generateRuntimeSchema>[1],
-        deps.dialect,
-        { status: hasStatus === true, localized: localized === true }
-      );
-      deps.registry.registerDynamicSchema(tableName, runtime);
-      return Promise.resolve();
+        fields: fields as Parameters<
+          typeof registerDynamicEntitySchema
+        >[0]["fields"],
+        status: hasStatus === true,
+        localized,
+        builderOwned,
+      });
     }
   );
 }

--- a/packages/nextly/src/init/reload-dynamic-tables.ts
+++ b/packages/nextly/src/init/reload-dynamic-tables.ts
@@ -1,0 +1,174 @@
+/**
+ * Re-read the tables a migration registered, so they become queryable.
+ *
+ * `registerServices` builds the runtime schema registry from
+ * `dynamic_collections` / `dynamic_singles` BEFORE either boot path applies
+ * migrations, so a migration that registers an entity leaves this process
+ * holding a registry that predates it. Such a collection is addressable in the
+ * workspace metadata and drawn on a dashboard card while every query against it
+ * fails — which is worse than not registering it, because the reader can see it.
+ *
+ * 🔴 Shared by BOTH boot paths rather than living on the dev one. The dev path
+ * has reloaded since it was written; production has never reloaded at all, and
+ * the two are the same lifecycle — apply, register, reload — reached from
+ * different entry points. Two implementations of it would agree on the day the
+ * second was written.
+ *
+ * @module init/reload-dynamic-tables
+ */
+
+// A TYPE-only import, so naming the loader's parameter costs nothing at
+// runtime: the specifier is erased, and the loader itself is still imported
+// dynamically below to keep it off the boot path until a reload actually runs.
+import type { loadDynamicTables } from "../di/load-dynamic-tables";
+
+/**
+ * The in-flight reload and the one queued behind it.
+ *
+ * 🔴 One trailing run rather than handing a late caller the run already going.
+ * A caller arriving mid-reload is a boot path that has just committed rows the
+ * running pass may have read the tables too early to see — so returning the
+ * in-flight promise would leave that caller's own entities missing until a
+ * restart, which is the defect this module exists to close. Whoever arrives
+ * during a run wants the state after the last of them, and one trailing run
+ * delivers that however many arrive.
+ *
+ * On `globalThis` for the reason the config reload's queue is: a Next.js dev
+ * server holds several module registries, and a guard scoped to this module
+ * would be several guards.
+ */
+const globalForReload = globalThis as unknown as {
+  __nextly_registryReloadInFlight?: Promise<void>;
+  __nextly_registryReloadQueued?: Promise<void>;
+};
+
+export function reloadDynamicTables(label: string): Promise<void> {
+  // Checked before the running one: the queued run clears itself inside its own
+  // continuation, a microtask later than the running one's cleanup, so a caller
+  // landing between the two would otherwise start a second concurrent run
+  // alongside the queued one.
+  const queued = globalForReload.__nextly_registryReloadQueued;
+  if (queued) return queued;
+
+  const running = globalForReload.__nextly_registryReloadInFlight;
+  if (running) {
+    globalForReload.__nextly_registryReloadQueued = running
+      // A failed reload must not swallow the rows that landed during it: the
+      // tables are read either way, and this caller sees its own outcome.
+      .catch(() => undefined)
+      .then(() => {
+        delete globalForReload.__nextly_registryReloadQueued;
+        return startReload(label);
+      });
+    return globalForReload.__nextly_registryReloadQueued;
+  }
+
+  return startReload(label);
+}
+
+function startReload(label: string): Promise<void> {
+  const started = runReload(label).finally(() => {
+    delete globalForReload.__nextly_registryReloadInFlight;
+  });
+  globalForReload.__nextly_registryReloadInFlight = started;
+  return started;
+}
+
+/** What a registry reload needs from the container, once both are present. */
+interface ReloadDeps {
+  adapter: Parameters<typeof loadDynamicTables>[0];
+  registerDynamicSchema: (tableName: string, table: unknown) => void;
+  dialect: "postgresql" | "mysql" | "sqlite";
+}
+
+/**
+ * Never throws.
+ *
+ * 🔴 A failed reload degrades rather than refusing, which is the opposite of
+ * how this boot treats a migration it could not establish — and the asymmetry
+ * is deliberate. An unverified migration means the process does not know what
+ * schema it is serving, so it must not serve. A stale registry means it knows
+ * exactly what it is serving and is missing the entities this migration added:
+ * every collection that existed before still answers. Refusing to start would
+ * turn a bounded, restart-recoverable gap into a total outage.
+ *
+ * It must also never throw for a mechanical reason: `runProdMigrationsIfEnabled`
+ * calls this before `allowBootMigrations()`, and an exception escaping here
+ * would leave that gate closed — hanging every consumer waiting on it.
+ */
+async function runReload(label: string): Promise<void> {
+  try {
+    const deps = await resolveDeps(label);
+    if (!deps) return;
+
+    // Both registries, one pass each, through one loader. They differ only in
+    // the table read; spelling the body twice is how the two would drift.
+    for (const table of ["dynamic_collections", "dynamic_singles"] as const) {
+      await loadInto(deps, table);
+    }
+
+    console.log(`${label} Schema registry reloaded from migration metadata.`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(
+      `${label} Schema registry reload failed: ${msg}. ` +
+        `Collections this boot registered are not queryable until a restart.`
+    );
+  }
+}
+
+/** The container's adapter and registry, or `undefined` with a reason logged. */
+async function resolveDeps(label: string): Promise<ReloadDeps | undefined> {
+  const { container } = await import("../di/container");
+  const adapter = container.get("adapter");
+  const schemaRegistry = container.get("schemaRegistry");
+
+  if (!schemaRegistry || !adapter) {
+    console.warn(
+      `${label} ${!schemaRegistry ? "Schema registry" : "Adapter"} not available for reload. ` +
+        `Collections this boot registered are not queryable until a restart.`
+    );
+    return undefined;
+  }
+
+  const { getCapabilities } = adapter as {
+    getCapabilities: () => { dialect: "postgresql" | "mysql" | "sqlite" };
+  };
+  const { registerDynamicSchema } = schemaRegistry as {
+    registerDynamicSchema: (tableName: string, table: unknown) => void;
+  };
+
+  return {
+    adapter: adapter as ReloadDeps["adapter"],
+    // Bound to the registry, because both are read off the container as
+    // untyped services and a bare method reference would lose its receiver.
+    registerDynamicSchema: registerDynamicSchema.bind(schemaRegistry),
+    dialect: getCapabilities.call(adapter).dialect,
+  };
+}
+
+/** Read one metadata table and register a runtime schema for each row. */
+async function loadInto(
+  deps: ReloadDeps,
+  table: "dynamic_collections" | "dynamic_singles"
+): Promise<void> {
+  const { loadDynamicTables } = await import("../di/load-dynamic-tables");
+  const { generateRuntimeSchema } = await import(
+    "../domains/schema/services/runtime-schema-generator"
+  );
+
+  await loadDynamicTables(
+    deps.adapter,
+    table,
+    (tableName, fields, hasStatus, localized) => {
+      const { table: runtime } = generateRuntimeSchema(
+        tableName,
+        fields as Parameters<typeof generateRuntimeSchema>[1],
+        deps.dialect,
+        { status: hasStatus === true, localized: localized === true }
+      );
+      deps.registerDynamicSchema(tableName, runtime);
+      return Promise.resolve();
+    }
+  );
+}


### PR DESCRIPTION
## What

A collection created by a migration was not queryable on the boot that registered it, in **production**.

`registerServices` builds the runtime schema registry before either boot path applies migrations (`init.ts:328` vs `:375`/`:385`), so a migration that registers an entity leaves the process holding a registry that predates it. The collection is addressable in the workspace metadata and drawn on a dashboard card while every query against it fails — which is worse than not registering it at all, because the reader can see it.

The dev path has reloaded since it was written (`boot-apply.ts`); production never has. The reload is now **one implementation both paths call**, rather than a private function on the dev side.

## The condition is `ran`, not the registration counts

The task this came from proposed gating on `collectionsRegistered` / `singlesRegistered`. **Research showed that hook is unsound**, and I verified the mechanism in `withMigrateLock` rather than take it on trust:

- A replica that waits on the migrate lock and acquires it *after* another replica has already migrated runs `migrateCore` against a settled database.
- `locks.ts:179` returns `{ ran: true }` for it; `applied` and both registration counts are `0`.
- Its registry was built at `registerServices`, before it ever touched the lock — **exactly as stale as the migrating replica's was.**

Gated on those counts, that replica never reloads and serves entities it can see but cannot query. `ran === true` is the condition every replica that goes on to *serve* satisfies; the ones that do not throw a few lines above rather than reaching here.

## Ordering and failure posture

It runs **before `allowBootMigrations()`**, so nothing waiting on that gate is released onto a registry this boot already knows is behind.

That ordering is safe only because the reload **cannot throw** — an exception there would leave the gate closed and hang every consumer. So a failed reload degrades and says so, which is deliberately the opposite of how this path treats a migration it could not establish: an unverified migration means the process does not know what schema it is serving, so it must not serve; a stale registry means it knows exactly what it is serving and is missing what this migration added. Refusing to start would turn a bounded, restart-recoverable gap into a total outage.

Concurrent callers get **one trailing run** rather than the run already going, following the queue `reload-config.ts` already uses: a caller arriving mid-reload is a boot that has just committed rows the running pass may have read the tables too early to see.

## What I did NOT do, and why

Prior art (Payload) migrates *before* completing initialization, which removes the reload step entirely. That is the better architecture and it is **not a reorder here**: `runProdMigrationsIfEnabled` takes the adapter from `getService("adapter")`, and the registry is built inside `registerServices` (`register.ts:750`) after it. Doing it properly means splitting service registration into connect → migrate → build-registry, against a boot path carrying a refusal latch, a coalescing gate and a documented connection-storm hazard. That deserves its own change and its own review rather than riding along with a bug fix. Research node: `research:prod-boot-registry-reload-ordering`.

## Verification

Seven break-verifications, each killing a test whose name matches what broke:

| break | test that died |
| --- | --- |
| production path never reloads | reloads after migrations ran |
| **gated on registration counts** (the proposed hook) | reloads on a replica that applied and registered nothing |
| reload moved after the gate opens | opens the boot gate only after the reload has finished |
| mid-run caller handed the running promise | gives a caller arriving mid-reload a run of its OWN |
| no single-flight | coalesces every further caller onto the ONE trailing run |
| a failed reload throws | does not throw when the load fails |
| only the collections table read | reads both metadata tables |

One of my own tests was initially satisfied by absence — `awaitBootMigrations()` resolves immediately when no gate is pending, so "gate not open during reload" was true because there was no gate. It now opens one first and asserts it is genuinely pending before measuring.

Full `nextly` suite: 902 files, 11,495 passed. `check-types`, `lint`, `fallow audit` and `changeset status` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Dynamic collections, singletons, and field groups are now refreshed after successful migrations, making newly migrated schemas available without restarting the application.
  - Production replicas also refresh their schema information after waiting for migrations completed elsewhere.

- **Bug Fixes**
  - Schema reload failures are now surfaced through warnings instead of being silently treated as empty databases.
  - Reload operations are coordinated to avoid overlapping refreshes while ensuring subsequent requests are processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->