### PR TITLE
build(deps): raise the attw floor so it can read a tarball again

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "check:gate-scope": "node scripts/gate-scope.mjs"
   },
   "devDependencies": {
-    "@arethetypeswrong/cli": "^0.18.2",
+    "@arethetypeswrong/cli": "^0.18.5",
     "@aws-sdk/client-s3": "^3.1090.0",
     "@aws-sdk/lib-storage": "^3.1090.0",
     "@changesets/changelog-github": "^0.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,8 +65,8 @@ importers:
         version: 4.1.12
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.18.2
-        version: 0.18.2
+        specifier: ^0.18.5
+        version: 0.18.5
       '@aws-sdk/client-s3':
         specifier: ^3.1090.0
         version: 3.1090.0
@@ -1847,13 +1847,13 @@ packages:
   '@andrewbranch/untar.js@1.0.3':
     resolution: {integrity: sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==}
 
-  '@arethetypeswrong/cli@0.18.2':
-    resolution: {integrity: sha512-PcFM20JNlevEDKBg4Re29Rtv2xvjvQZzg7ENnrWFSS0PHgdP2njibVFw+dRUhNkPgNfac9iUqO0ohAXqQL4hbw==}
+  '@arethetypeswrong/cli@0.18.5':
+    resolution: {integrity: sha512-gM+8vRsQOD/Uc7EnBedUhkG5OCsDWE4uoak5QvomGpMpaky0Eh41p04nIMgrWb8EOmqZUJGc6zz9hsP6E56R7g==}
     engines: {node: '>=20'}
     hasBin: true
 
-  '@arethetypeswrong/core@0.18.2':
-    resolution: {integrity: sha512-GiwTmBFOU1/+UVNqqCGzFJYfBXEytUkiI+iRZ6Qx7KmUVtLm00sYySkfe203C9QtPG11yOz1ZaMek8dT/xnlgg==}
+  '@arethetypeswrong/core@0.18.5':
+    resolution: {integrity: sha512-9ytjzGwxjm9Uz7I9avfbt5vlQt6uk9uRRESzJjqrznl6WKvI6dwYTo+vJ3U02Wrq/mR3iql/PzhvHhKdJIAjDQ==}
     engines: {node: '>=20'}
 
   '@asamuzakjp/css-color@4.0.5':
@@ -6417,6 +6417,7 @@ packages:
   eslint@9.39.1:
     resolution: {integrity: sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -9014,9 +9015,9 @@ snapshots:
 
   '@andrewbranch/untar.js@1.0.3': {}
 
-  '@arethetypeswrong/cli@0.18.2':
+  '@arethetypeswrong/cli@0.18.5':
     dependencies:
-      '@arethetypeswrong/core': 0.18.2
+      '@arethetypeswrong/core': 0.18.5
       chalk: 4.1.2
       cli-table3: 0.6.5
       commander: 10.0.1
@@ -9024,13 +9025,13 @@ snapshots:
       marked-terminal: 7.3.0(marked@9.1.6)
       semver: 7.8.5
 
-  '@arethetypeswrong/core@0.18.2':
+  '@arethetypeswrong/core@0.18.5':
     dependencies:
       '@andrewbranch/untar.js': 1.0.3
       '@loaderkit/resolve': 1.0.4
       cjs-module-lexer: 1.4.3
       fflate: 0.8.3
-      lru-cache: 11.2.2
+      lru-cache: 11.3.5
       semver: 7.8.5
       typescript: 5.6.1-rc
       validate-npm-package-name: 5.0.1
@@ -14931,7 +14932,7 @@ snapshots:
 
   path-scurry@2.0.2:
     dependencies:
-      lru-cache: 11.2.2
+      lru-cache: 11.3.5
       minipass: 7.1.3
 
   path-type@4.0.0: {}


### PR DESCRIPTION
## main is red, and this is why

`Lint / Typecheck / Test / Build` fails on `main` at the `attw` step:

```
error while checking file:
Cannot read properties of undefined (reading 'filename')
/home/runner/work/nextly/nextly/packages/tsconfig:
 ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command failed with exit code 3
```

`pnpm -r ... exec` stops at the first failure, so every package after `packages/tsconfig` goes unchecked too — the job reports one crash and silently drops the rest of the type-surface check.

## Cause

`@arethetypeswrong/core@0.18.2` depends on `fflate: "^0.8.2"`. #1584 raised the `fflate` override floor to `^0.8.3` to close an advisory, which moved the lockfile onto a version that version of attw cannot unpack a tarball with.

**Not inferred from the log — reproduced.** Isolated project, same tarball, same flags, one variable at a time:

| attw | fflate | result |
| --- | --- | --- |
| 0.18.2 | 0.8.3 | **exit 3**, error identical to CI |
| 0.18.2 | 0.8.2 | exit 0 |
| 0.18.5 | 0.8.3 | exit 0 |

The third was re-run in a clean directory: three successive installs had left both attw cores and both fflate versions in the store, so the first attempt could not say which pair actually ran. With exactly one of each present, it passes.

The control that matters in the other direction: `Lint / Typecheck / Test / Build` was `completed/success` on `62671fd26`, the commit immediately before #1584, and #1584 changed only `package.json` and `pnpm-lock.yaml`.

## Fix

Raise the attw floor to `^0.18.5`. `@arethetypeswrong/core@0.18.5` declares `fflate: "^0.8.3"`, so upstream already supports it.

**Every advisory floor #1584 raised stays exactly where it is.** Pinning `fflate` back, or scoping an override so attw keeps 0.8.2, would both trade a security fix for a tooling one.

Worth noting the declared range was ALREADY `^0.18.2`, which permits 0.18.5 — the lockfile was holding it down. That is the same trap `dependency-audit.yml`'s own header describes for overrides: the caret does not rescue you because the lockfile freezes the resolution. Raising the floor states the requirement rather than leaving a future lockfile refresh free to resolve back onto a version that cannot read a tarball.

## Verification

The exact command CI runs, across the full filter:

```
pnpm -r --filter '@nextlyhq/*' --filter 'nextly' --filter 'create-nextly-app' exec attw --pack . --ignore-rules false-esm no-resolution cjs-resolves-to-esm
```

Exit 0, **26 packages checked** (asserted against the filter's own package count, since `exec` stopping early is exactly the failure mode here), zero `Cannot read properties` occurrences.

`pnpm build` clean, `fallow audit` clean. No changeset: root tooling only, and `changeset status` confirms no published package is affected.