### PR TITLE
fix(deps): version the fast-uri bump, which reaches published output

### DIFF
--- a/.changeset/published-fast-uri-range.md
+++ b/.changeset/published-fast-uri-range.md
@@ -1,0 +1,44 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Version the `fast-uri` bump, which reaches published output rather than only
+this repository's tooling.
+
+`@nextlyhq/telemetry` bundles every one of its dependencies into its build
+(`noExternal` matches everything), so `conf` -> `ajv` -> `fast-uri` is inlined
+into the emitted file rather than resolved by a consumer, and that file is
+incorporated into the published `nextly` and `create-nextly-app` CLIs. Raising
+the override floor from `^3.1.5` to `^3.1.6` therefore changed what those
+artifacts contain: 3.1.7 replaces a 3.1.5 carrying four advisories, the highest
+being server-side request forgery through malformed IPv6 normalization and host
+confusion through skipped IDN canonicalization on scheme-relative references.
+
+The telemetry client validates its own configuration schema and never parses a
+URI a user supplies, so this closes no reachable hole. It is a patched release of
+code that genuinely ships, which is why it needs a version rather than only a
+lockfile entry.


### PR DESCRIPTION
## Summary

#1584 raised the `fast-uri` override floor and shipped with no changeset, on my claim that all four bumped packages were tooling-only. That claim was wrong for `fast-uri`, and this is the version it needed.

`packages/telemetry/tsup.config.ts` sets `noExternal: [/(.*)/]`, so every dependency is **inlined into the emitted file** rather than resolved by a consumer. `conf` → `ajv` → `fast-uri` therefore lands inside the built artifact, and that artifact is incorporated into the published `nextly` and `create-nextly-app` CLIs.

Confirmed by reading the artifact rather than reasoning from the manifest: the built `packages/telemetry/dist/index.mjs` is 581KB and carries the ajv and fast-uri code directly. A manifest describes what gets *resolved*; `noExternal` is precisely where that stops being the same question as what gets *shipped*.

So the floor moving `^3.1.5` → `^3.1.6` changed published bytes: 3.1.7 replaces a 3.1.5 carrying four advisories, the highest being SSRF via malformed IPv6 normalization and host confusion via skipped IDN canonicalization on scheme-relative references.

The telemetry client validates its own configuration schema and never parses a user-supplied URI, so no reachable hole closes. It is a patched release of code that genuinely ships, which is the reason it needs a version and not just a lockfile line.

## Scope

**This PR previously also raised `@arethetypeswrong/cli`.** That has been removed: #1586 does exactly the same bump, was opened a minute earlier, and is the focused change. Rebased onto current `main` so the two cannot collide. #1586 is the one to merge for the red `main`; this one is only the changeset.

## Type of change

- [x] Refactor / chore (no user-facing change)

## Related issues

Follows #1584. Companion to #1586. The two remaining advisories are `mysql2`, carried by #1497.

## Changeset

- [x] I added a changeset
- [x] I selected the correct semver bump (patch)

Names all 25 lockstep packages, generated from `.changeset/config.json` rather than copied. `scripts/release/check-changesets.mjs` accepts it.

## Test plan

- [x] `node scripts/release/check-changesets.mjs` — covers the group
- [x] Verified the bundling claim in the built artifact, not the manifest

This PR adds one file under `.changeset/`, which the CI scope filter treats as inert for build and test.
