### PR TITLE
build(deps): move arethetypeswrong past the fflate floor that broke it

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "check:gate-scope": "node scripts/gate-scope.mjs"
   },
   "devDependencies": {
-    "@arethetypeswrong/cli": "^0.18.2",
+    "@arethetypeswrong/cli": "^0.18.5",
     "@aws-sdk/client-s3": "^3.1090.0",
     "@aws-sdk/lib-storage": "^3.1090.0",
     "@changesets/changelog-github": "^0.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,8 +65,8 @@ importers:
         version: 4.1.12
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.18.2
-        version: 0.18.2
+        specifier: ^0.18.5
+        version: 0.18.5
       '@aws-sdk/client-s3':
         specifier: ^3.1090.0
         version: 3.1090.0
@@ -1847,13 +1847,13 @@ packages:
   '@andrewbranch/untar.js@1.0.3':
     resolution: {integrity: sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==}
 
-  '@arethetypeswrong/cli@0.18.2':
-    resolution: {integrity: sha512-PcFM20JNlevEDKBg4Re29Rtv2xvjvQZzg7ENnrWFSS0PHgdP2njibVFw+dRUhNkPgNfac9iUqO0ohAXqQL4hbw==}
+  '@arethetypeswrong/cli@0.18.5':
+    resolution: {integrity: sha512-gM+8vRsQOD/Uc7EnBedUhkG5OCsDWE4uoak5QvomGpMpaky0Eh41p04nIMgrWb8EOmqZUJGc6zz9hsP6E56R7g==}
     engines: {node: '>=20'}
     hasBin: true
 
-  '@arethetypeswrong/core@0.18.2':
-    resolution: {integrity: sha512-GiwTmBFOU1/+UVNqqCGzFJYfBXEytUkiI+iRZ6Qx7KmUVtLm00sYySkfe203C9QtPG11yOz1ZaMek8dT/xnlgg==}
+  '@arethetypeswrong/core@0.18.5':
+    resolution: {integrity: sha512-9ytjzGwxjm9Uz7I9avfbt5vlQt6uk9uRRESzJjqrznl6WKvI6dwYTo+vJ3U02Wrq/mR3iql/PzhvHhKdJIAjDQ==}
     engines: {node: '>=20'}
 
   '@asamuzakjp/css-color@4.0.5':
@@ -9014,9 +9014,9 @@ snapshots:
 
   '@andrewbranch/untar.js@1.0.3': {}
 
-  '@arethetypeswrong/cli@0.18.2':
+  '@arethetypeswrong/cli@0.18.5':
     dependencies:
-      '@arethetypeswrong/core': 0.18.2
+      '@arethetypeswrong/core': 0.18.5
       chalk: 4.1.2
       cli-table3: 0.6.5
       commander: 10.0.1
@@ -9024,13 +9024,13 @@ snapshots:
       marked-terminal: 7.3.0(marked@9.1.6)
       semver: 7.8.5
 
-  '@arethetypeswrong/core@0.18.2':
+  '@arethetypeswrong/core@0.18.5':
     dependencies:
       '@andrewbranch/untar.js': 1.0.3
       '@loaderkit/resolve': 1.0.4
       cjs-module-lexer: 1.4.3
       fflate: 0.8.3
-      lru-cache: 11.2.2
+      lru-cache: 11.3.5
       semver: 7.8.5
       typescript: 5.6.1-rc
       validate-npm-package-name: 5.0.1


### PR DESCRIPTION
**`main` is red, and has been since #1584.** This is the fix.

## What broke

#1584 raised the `fflate` override floor to `^0.8.3` for a security advisory. That floor is satisfiable by `@arethetypeswrong/core@0.18.2`, which declares `fflate: ^0.8.2` and cannot read a tarball unpacked by 0.8.3. The package check dies on `packages/prettier-config` with:

```
error while checking file:
Cannot read properties of undefined (reading 'filename')
```

and takes the whole **Lint / Typecheck / Test / Build** job with it.

It is not the blocks-engine merge that followed it — I checked the six most recent commits on main, and the job goes red at `5102a9bcb` (#1584) and stays red.

## Measured, one variable at a time

In a throwaway project outside the repo, against a real tarball packed from `packages/prettier-config`:

| attw | fflate | result |
|---|---|---|
| 0.18.2 | 0.8.2 | passes |
| 0.18.2 | **0.8.3** | **the exact error CI reports** |
| **0.18.5** | 0.8.3 | passes |

## Why forward rather than back

Upstream adapted rather than regressed: `@arethetypeswrong/core@0.18.5` declares `fflate: ^0.8.3`. So the tool moves and **#1584's security floor stays exactly where it put it** — the only direction that keeps both. Rolling `fflate` back would unbreak the gate by reopening the advisory that PR was written to close.

## Why the floor moves, not just the lockfile

`^0.18.2` already admitted 0.18.5; the lockfile pinned 0.18.2, and CI installs frozen — which is why it kept choosing the broken one. Raising the floor is the same reasoning #1584 gives for its own: *"a caret floor that still admits a vulnerable version lets the next lockfile refresh land back on one."* Here it is a broken version rather than a vulnerable one, and the argument is identical.

## Verified in the repo, not only in the probe

`@arethetypeswrong/core@0.18.5` now resolves `fflate@0.8.3` — the failing combination — and the workflow's own command over every published package exits **0** with no failure markers. `turbo check-types` 42/42 and blocks-engine 2255 passing after the lockfile change.

No changeset: tooling only, no published package source changed — the same shape as #1584, which shipped none.
