### PR TITLE
fix(blocks-engine): stop reading a document the survey could not read

### DIFF
--- a/.changeset/validate-gated-on-unreadable.md
+++ b/.changeset/validate-gated-on-unreadable.md
@@ -1,0 +1,54 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A document the size survey could not READ is no longer read anyway.
+
+`surveyDocument` refuses to invoke an accessor — it reports the document
+`document-unreadable` rather than run a getter it was handed — and the node walk
+then reached those same fields by ordinary property access, invoking exactly
+what the survey had declined to. Ten node fields did it: `id`, `type`,
+`version`, `props`, `slots`, `attributes`, `cssId`, `styles`, `bindings` and
+`visibility`, each taking a caller's error out of `validate()` as a native throw
+instead of the issue list it promises.
+
+This is the root of a class that produced roughly twenty-three of thirty review
+findings across three pull requests — a value read before it has been
+established as data — and two of those findings were introduced by a fix for
+another. Guarding each read is what kept failing; the verdict was already
+computed and simply never consulted.
+
+**A document that merely exceeds a limit is unaffected.** Only `unreadable`
+stops the walk. An oversized document was read perfectly well, its nodes are
+still checked under the cap, and every per-node issue it produced before is
+still produced.
+
+**The trade, stated plainly:** an unreadable document now reports one verdict
+rather than several. A duplicate DOM id inside one is no longer named
+separately. Those documents come from an import or a script rather than from the
+editor, and the same duplicate on an ordinary document is reported exactly as
+before.

--- a/.changeset/validate-gated-on-unreadable.md
+++ b/.changeset/validate-gated-on-unreadable.md
@@ -36,11 +36,10 @@ what the survey had declined to. Ten node fields did it: `id`, `type`,
 `visibility`, each taking a caller's error out of `validate()` as a native throw
 instead of the issue list it promises.
 
-This is the root of a class that produced roughly twenty-three of thirty review
-findings across three pull requests — a value read before it has been
-established as data — and two of those findings were introduced by a fix for
-another. Guarding each read is what kept failing; the verdict was already
-computed and simply never consulted.
+The document's own `formatVersion`, `kind` and `nodes` did it too, which is why
+the check sits ahead of the envelope rather than after it: the envelope is
+reached before any node is, and it reads those three to decide whether the value
+is a document at all.
 
 **A document that merely exceeds a limit is unaffected.** Only `unreadable`
 stops the walk. An oversized document was read perfectly well, its nodes are

--- a/packages/blocks-engine/src/validation.test.ts
+++ b/packages/blocks-engine/src/validation.test.ts
@@ -2719,12 +2719,14 @@ describe("an unstorable document does not have its values parsed", () => {
       )
     ).toBe(false);
 
-    // What this does NOT do, stated rather than implied: the property is still
-    // READ, so the getter still runs. Skipping the read entirely would mean not
-    // validating the node's shape at all, and a document is refused on its
-    // shape long before its style values matter. The exposure that closes is
-    // the parsing of whatever the getter returns, not the single invocation.
-    expect(reads).toBeGreaterThan(0);
+    // And the getter is never invoked AT ALL, which is stronger than this
+    // originally promised. It used to read the property and skip only the
+    // parsing, on the reasoning that a node still had to be checked for shape;
+    // the walk now stops for a document the survey could not read, so the
+    // document's own code is not executed inside the check deciding whether to
+    // trust it. Nothing about a document nobody can read is worth learning by
+    // running it.
+    expect(reads).toBe(0);
   });
 });
 
@@ -2946,16 +2948,21 @@ describe("a node's provenance record is checked on both roads to storage", () =>
       }
 
       expect(escaped).toBeUndefined();
-      // Reported, NOT deferred. See the case below for why the survey cannot be
-      // relied on to have covered it.
+      // The SURVEY's verdict, and WHICH verdict depends on where the trap
+      // bites. `getPrototypeOf` stops the survey from reading the document, so
+      // it is `document-unreadable` and the walk no longer runs at all.
+      // `ownKeys` and `getOwnPropertyDescriptor` stop it SERIALIZING one, which
+      // is `document-unwritable` — a different fact, and one the walk is not
+      // gated on, so those two still reach the per-record guard.
       //
-      // `ownKeys` is the exception the rule produces rather than an oversight:
-      // nothing enumerates the record's own keys any more, so that trap never
-      // fires for this check and the record reads as whole. The survey still
-      // meets it — it has to serialize the document — and refuses the document
-      // as unwritable, which is the verdict that covers it.
+      // That is worth stating because it is what keeps the guard necessary. It
+      // is not made redundant by the gate: two of these three traps get past
+      // it, and so does the case below — a trap that fires only for an ABSENT
+      // field, which the survey never asks for and therefore never meets.
       expect(codes).toContain(
-        trap === "ownKeys" ? "document-unwritable" : "invalid-origin"
+        trap === "getPrototypeOf"
+          ? "document-unreadable"
+          : "document-unwritable"
       );
     }
   );
@@ -3270,18 +3277,83 @@ describe("a bag validation has already refused is never enumerated", () => {
       })
     ).not.toThrow();
     expect(ran).toBe(false);
-    // And it is still REPORTED, rather than quietly skipped.
+    // And it is still REPORTED, rather than quietly skipped — as
+    // `document-unreadable` rather than `invalid-attributes`. The survey met
+    // this accessor too and refused the whole document, and the walk that would
+    // have named the field no longer runs on a document nobody can read.
     expect(
       validateDocument(doc, {
         breakpoints: FIXTURE_BREAKPOINTS,
         mode: "strict",
-      }).issues.some(issue => issue.code === "invalid-attributes")
+      }).issues.some(issue => issue.code === "document-unreadable")
     ).toBe(true);
   });
 
-  it("still registers the cssId of a node whose bag it refused", () => {
-    // The control for the fallback. With the bag unreadable `cssId` is the only
-    // place an id can come from, and dropping it would lose a real duplicate.
+  it.each([
+    "id",
+    "type",
+    "version",
+    "props",
+    "slots",
+    "attributes",
+    "cssId",
+    "styles",
+    "bindings",
+    "visibility",
+  ])(
+    "does not read a node's %s off a document the survey could not read",
+    field => {
+      // The whole point of the gate, measured field by field. `surveyDocument`
+      // refuses to invoke an accessor and reports the document unreadable; the
+      // walk then reached the same field by ordinary property access and
+      // invoked exactly what the survey declined to. Every one of these ten
+      // took the caller's error out of `validate()` as a native throw instead
+      // of the issue list it promises.
+      const node: Record<string, unknown> = {
+        id: "n1",
+        type: "core/text",
+        version: 1,
+        props: {},
+      };
+      Object.defineProperty(node, field, {
+        enumerable: true,
+        configurable: true,
+        get() {
+          throw new Error("a document should not get to run this");
+        },
+      });
+
+      let escaped: unknown;
+      let codes: string[] = [];
+      try {
+        codes = validate(
+          {
+            formatVersion: DOCUMENT_FORMAT_VERSION,
+            kind: "page",
+            nodes: [node],
+          } as unknown as BlockDocument,
+          { breakpoints: FIXTURE_BREAKPOINTS, mode: "strict" }
+        ).map(issue => issue.code);
+      } catch (error) {
+        escaped = error;
+      }
+
+      expect(escaped).toBeUndefined();
+      expect(codes).toContain("document-unreadable");
+    }
+  );
+
+  it("reports one verdict for the unreadable document, and the duplicate for a readable one", () => {
+    // The cost of stopping at the survey's verdict, stated rather than hidden:
+    // a document carrying an accessor is refused as a whole, so the duplicate
+    // DOM id inside it is not named separately. That is the trade — one honest
+    // verdict, and none of the document's own code run — and it is bounded to
+    // documents the survey could not read, which come from an import or a
+    // script rather than from the editor.
+    //
+    // The second half is what makes the first safe to accept: the same
+    // duplicate on an ORDINARY document is still reported, so the capability is
+    // intact rather than lost.
     const bag = Object.create({}, { id: { enumerable: true, get: () => "x" } });
     const doc = {
       formatVersion: DOCUMENT_FORMAT_VERSION,
@@ -3299,12 +3371,27 @@ describe("a bag validation has already refused is never enumerated", () => {
       ],
     } as unknown as BlockDocument;
 
+    const codes = validateDocument(doc, {
+      breakpoints: FIXTURE_BREAKPOINTS,
+      mode: "strict",
+    }).issues.map(issue => issue.code);
+    expect(codes).toContain("document-unreadable");
+    expect(codes).not.toContain("duplicate-dom-id");
+
+    const readable = {
+      formatVersion: DOCUMENT_FORMAT_VERSION,
+      kind: "page",
+      nodes: [
+        { id: "n1", type: "core/text", version: 1, props: {}, cssId: "hero" },
+        { id: "n2", type: "core/text", version: 1, props: {}, cssId: "hero" },
+      ],
+    } as unknown as BlockDocument;
     expect(
-      validateDocument(doc, {
+      validateDocument(readable, {
         breakpoints: FIXTURE_BREAKPOINTS,
         mode: "strict",
-      }).issues.some(issue => issue.code === "duplicate-dom-id")
-    ).toBe(true);
+      }).issues.map(issue => issue.code)
+    ).toContain("duplicate-dom-id");
   });
 });
 

--- a/packages/blocks-engine/src/validation.test.ts
+++ b/packages/blocks-engine/src/validation.test.ts
@@ -2948,17 +2948,18 @@ describe("a node's provenance record is checked on both roads to storage", () =>
       }
 
       expect(escaped).toBeUndefined();
-      // The SURVEY's verdict, and WHICH verdict depends on where the trap
-      // bites. `getPrototypeOf` stops the survey from reading the document, so
-      // it is `document-unreadable` and the walk no longer runs at all.
-      // `ownKeys` and `getOwnPropertyDescriptor` stop it SERIALIZING one, which
-      // is `document-unwritable` — a different fact, and one the walk is not
-      // gated on, so those two still reach the per-record guard.
+      // A SURVEY-classification test, and only that. All three traps make the
+      // survey call the document unreadable, so validation stops at that
+      // verdict and none of them reaches the per-record guard — this would
+      // stay green with that guard deleted, and says nothing about it.
       //
-      // That is worth stating because it is what keeps the guard necessary. It
-      // is not made redundant by the gate: two of these three traps get past
-      // it, and so does the case below — a trap that fires only for an ABSENT
-      // field, which the survey never asks for and therefore never meets.
+      // Which verdict is reported depends on where the trap bites first:
+      // `ownKeys` and `getOwnPropertyDescriptor` also stop the document being
+      // SERIALIZED, and `checkLimits` reports unwritable ahead of unreadable.
+      //
+      // What keeps the guard necessary is the case below — a trap that fires
+      // only for an ABSENT field, which the survey never asks for and therefore
+      // never meets, so the walk runs and the record is judged.
       expect(codes).toContain(
         trap === "getPrototypeOf"
           ? "document-unreadable"
@@ -3287,6 +3288,46 @@ describe("a bag validation has already refused is never enumerated", () => {
         mode: "strict",
       }).issues.some(issue => issue.code === "document-unreadable")
     ).toBe(true);
+  });
+
+  it("still reports a fault in the site's own breakpoints", () => {
+    // `collectBreakpointIds` judges the CALLER's settings, not the document, so
+    // a duplicate id among them is true whatever the document turns out to be.
+    // Collecting it inside the envelope meant an unreadable document silently
+    // swallowed a fault in the site's configuration — one the author would fix
+    // in a different screen entirely.
+    const node: Record<string, unknown> = {
+      id: "n1",
+      type: "core/text",
+      version: 1,
+      props: {},
+    };
+    Object.defineProperty(node, "props", {
+      enumerable: true,
+      configurable: true,
+      get() {
+        throw new Error("a document should not get to run this");
+      },
+    });
+    const duplicated = {
+      viewport: [
+        { id: "base", label: "Desktop" },
+        { id: "base", label: "Again" },
+      ],
+      container: [],
+    } as unknown as typeof FIXTURE_BREAKPOINTS;
+
+    const codes = validate(
+      {
+        formatVersion: DOCUMENT_FORMAT_VERSION,
+        kind: "page",
+        nodes: [node],
+      } as unknown as BlockDocument,
+      { breakpoints: duplicated, mode: "strict" }
+    ).map(issue => issue.code);
+
+    expect(codes).toContain("breakpoint-id-not-unique");
+    expect(codes).toContain("document-unreadable");
   });
 
   it.each(["formatVersion", "kind", "nodes"])(

--- a/packages/blocks-engine/src/validation.test.ts
+++ b/packages/blocks-engine/src/validation.test.ts
@@ -3289,6 +3289,68 @@ describe("a bag validation has already refused is never enumerated", () => {
     ).toBe(true);
   });
 
+  it.each(["formatVersion", "kind", "nodes"])(
+    "does not read the document's own %s when it could not be read",
+    field => {
+      // The ENVELOPE is reached before any node is, so a check placed after it
+      // is placed too late: these three are read to decide whether the document
+      // is one at all, and each took a caller's error out of `validate()`.
+      const doc: Record<string, unknown> = {
+        formatVersion: DOCUMENT_FORMAT_VERSION,
+        kind: "page",
+        nodes: [],
+      };
+      Object.defineProperty(doc, field, {
+        enumerable: true,
+        configurable: true,
+        get() {
+          throw new Error("a document should not get to run this");
+        },
+      });
+
+      let escaped: unknown;
+      let codes: string[] = [];
+      try {
+        codes = validate(doc as unknown as BlockDocument, {
+          breakpoints: FIXTURE_BREAKPOINTS,
+          mode: "strict",
+        }).map(issue => issue.code);
+      } catch (error) {
+        escaped = error;
+      }
+
+      expect(escaped).toBeUndefined();
+      expect(codes).toContain("document-unreadable");
+    }
+  );
+
+  it("does not inspect a root whose prototype trap throws", () => {
+    // `isPlainRecord` asks for the prototype, so the very first thing the
+    // envelope does is something a hostile root can refuse.
+    const doc = new Proxy(
+      { formatVersion: DOCUMENT_FORMAT_VERSION, kind: "page", nodes: [] },
+      {
+        getPrototypeOf() {
+          throw new Error("a document should not get to run this");
+        },
+      }
+    );
+
+    let escaped: unknown;
+    let codes: string[] = [];
+    try {
+      codes = validate(doc as unknown as BlockDocument, {
+        breakpoints: FIXTURE_BREAKPOINTS,
+        mode: "strict",
+      }).map(issue => issue.code);
+    } catch (error) {
+      escaped = error;
+    }
+
+    expect(escaped).toBeUndefined();
+    expect(codes).toContain("document-unreadable");
+  });
+
   it.each([
     "id",
     "type",

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -414,6 +414,34 @@ export function validateDocument(
   // bounded, and that is exactly what `traversed` reports.
   const overLimits = !survey.traversed;
 
+  // A document the survey could not READ is not one to read.
+  //
+  // `surveyDocument` refuses to invoke an accessor — it reports the document
+  // `document-unreadable` rather than run a getter it was handed — and
+  // everything below reaches those same fields by ordinary property access,
+  // invoking exactly what the survey declined to. Measured on this file before
+  // the gate: ten node fields did it — `id`, `type`, `version`, `props`,
+  // `slots`, `attributes`, `cssId`, `styles`, `bindings` and `visibility` —
+  // each taking a caller's error out of `validate()` as a native throw instead
+  // of the issue list it promises.
+  //
+  // `unreadable`, and NOT `overLimits`. They are different facts and only one
+  // of them is about reading: a document that merely exceeds `maxNodes` was
+  // read perfectly well, and its nodes are still worth checking under the cap —
+  // measured, such a survey reports `traversed: false` with `unreadable: false`.
+  // Stopping on the broader fact would silently drop every per-node issue on an
+  // oversized document.
+  //
+  // Stopping HERE rather than guarding each read is the point. Guarding reads
+  // is what this file kept trying: roughly twenty-three of thirty review
+  // findings across three pull requests were one site or one level of that, and
+  // two of them were introduced BY a fix for another. The verdict was already
+  // computed and already trustworthy; it was simply never consulted.
+  //
+  // `checkLimits` has already recorded `document-unreadable`, so the caller is
+  // told why — and gets the survey, which says the same thing in a field.
+  if (survey.unreadable) return { issues, survey };
+
   // Per-kind rules. Only `component` has any today, and it is the kind whose
   // extra fields nothing else in the document can check: `exposed` and `slots`
   // are pointers INTO the node forest, so this is the first point at which

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -383,6 +383,31 @@ export function validateDocument(
   const unknownSeverity: IssueSeverity =
     ctx.mode === "strict" ? "error" : "warning";
 
+  // A document the survey could not READ is not one to read, and this is the
+  // first line after the measurement for that reason: everything below reaches
+  // the document's own fields by ordinary property access.
+  //
+  // `surveyDocument` refuses to invoke an accessor — it reports the document
+  // `document-unreadable` rather than run a getter it was handed. Reading on
+  // regardless invokes exactly what it declined to, and a throwing getter then
+  // leaves as a native error rather than the issue list this promises.
+  // Measured, every field of a node did that, and so did `formatVersion`,
+  // `kind` and `nodes` on the document itself — which is why the check sits
+  // ahead of the envelope rather than after it.
+  //
+  // `unreadable`, and NOT `overLimits`. They are different facts and only one
+  // is about reading: a document that merely exceeds `maxNodes` was read
+  // perfectly well and reports `traversed: false` with `unreadable: false`, and
+  // its nodes are still worth checking under the cap. Stopping on the broader
+  // fact would drop every per-node issue such a document earns.
+  //
+  // The verdict is still RECORDED before returning, or a caller gets an empty
+  // issue list for a document nothing could read.
+  if (survey.unreadable) {
+    checkLimits(survey, issues);
+    return { issues, survey };
+  }
+
   const envelope = documentEnvelope(doc, ctx, unknownSeverity, issues);
   if (envelope.stop) return { issues, survey };
 
@@ -413,34 +438,6 @@ export function validateDocument(
   // back changed. It is a measurement that STOPPED SHORT which leaves nothing
   // bounded, and that is exactly what `traversed` reports.
   const overLimits = !survey.traversed;
-
-  // A document the survey could not READ is not one to read.
-  //
-  // `surveyDocument` refuses to invoke an accessor — it reports the document
-  // `document-unreadable` rather than run a getter it was handed — and
-  // everything below reaches those same fields by ordinary property access,
-  // invoking exactly what the survey declined to. Measured on this file before
-  // the gate: ten node fields did it — `id`, `type`, `version`, `props`,
-  // `slots`, `attributes`, `cssId`, `styles`, `bindings` and `visibility` —
-  // each taking a caller's error out of `validate()` as a native throw instead
-  // of the issue list it promises.
-  //
-  // `unreadable`, and NOT `overLimits`. They are different facts and only one
-  // of them is about reading: a document that merely exceeds `maxNodes` was
-  // read perfectly well, and its nodes are still worth checking under the cap —
-  // measured, such a survey reports `traversed: false` with `unreadable: false`.
-  // Stopping on the broader fact would silently drop every per-node issue on an
-  // oversized document.
-  //
-  // Stopping HERE rather than guarding each read is the point. Guarding reads
-  // is what this file kept trying: roughly twenty-three of thirty review
-  // findings across three pull requests were one site or one level of that, and
-  // two of them were introduced BY a fix for another. The verdict was already
-  // computed and already trustworthy; it was simply never consulted.
-  //
-  // `checkLimits` has already recorded `document-unreadable`, so the caller is
-  // told why — and gets the survey, which says the same thing in a field.
-  if (survey.unreadable) return { issues, survey };
 
   // Per-kind rules. Only `component` has any today, and it is the kind whose
   // extra fields nothing else in the document can check: `exposed` and `slots`

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -383,6 +383,13 @@ export function validateDocument(
   const unknownSeverity: IssueSeverity =
     ctx.mode === "strict" ? "error" : "warning";
 
+  // The SITE's own breakpoints, before anything about the document is decided.
+  // They come from the caller's settings rather than from the document, so a
+  // duplicate id among them is true whatever the document turns out to be —
+  // and collecting them inside the envelope meant an unreadable document
+  // silently swallowed a fault in the site's configuration.
+  const knownBreakpoints = collectBreakpointIds(ctx.breakpoints, issues);
+
   // A document the survey could not READ is not one to read, and this is the
   // first line after the measurement for that reason: everything below reaches
   // the document's own fields by ordinary property access.
@@ -408,7 +415,7 @@ export function validateDocument(
     return { issues, survey };
   }
 
-  const envelope = documentEnvelope(doc, ctx, unknownSeverity, issues);
+  const envelope = documentEnvelope(doc, unknownSeverity, issues);
   if (envelope.stop) return { issues, survey };
 
   checkLimits(survey, issues);
@@ -463,7 +470,7 @@ export function validateDocument(
     );
   }
 
-  const state = nodeCheckState(ctx, issues, envelope, unknownSeverity, {
+  const state = nodeCheckState(ctx, issues, knownBreakpoints, unknownSeverity, {
     overLimits,
   });
 
@@ -503,12 +510,10 @@ type DocumentEnvelope =
       readonly nodes: BlockNode[];
       /** As stored — validated above, and read again for the per-kind rules. */
       readonly kind: unknown;
-      readonly knownBreakpoints: Set<string>;
     };
 
 function documentEnvelope(
   doc: BlockDocument,
-  ctx: ValidationContext,
   unknownSeverity: IssueSeverity,
   issues: ValidationIssue[]
 ): DocumentEnvelope {
@@ -526,8 +531,6 @@ function documentEnvelope(
     });
     return { stop: true };
   }
-
-  const knownBreakpoints = collectBreakpointIds(ctx.breakpoints, issues);
 
   const formatVersion = rawDoc.formatVersion;
   if (formatVersion !== DOCUMENT_FORMAT_VERSION) {
@@ -571,7 +574,6 @@ function documentEnvelope(
     doc: rawDoc,
     nodes: rawDoc.nodes as BlockNode[],
     kind,
-    knownBreakpoints,
   };
 }
 
@@ -585,7 +587,7 @@ function documentEnvelope(
 function nodeCheckState(
   ctx: ValidationContext,
   issues: ValidationIssue[],
-  envelope: Extract<DocumentEnvelope, { stop: false }>,
+  knownBreakpoints: Set<string>,
   unknownSeverity: IssueSeverity,
   bounds: { readonly overLimits: boolean }
 ): NodeCheckState {
@@ -602,7 +604,7 @@ function nodeCheckState(
       classes: memoizeClassLookup(ctx.classes, styleBudget),
     },
     issues,
-    knownBreakpoints: envelope.knownBreakpoints,
+    knownBreakpoints,
     unknownSeverity,
     seenIds: new Map<string, string>(),
     seenDomIds: new Map<string, string>(),


### PR DESCRIPTION
Step 2 of two, following #1585. This is the fix that whole decomposition existed to make reachable.

## What was wrong

`surveyDocument` **refuses to invoke an accessor** — it reports the document `document-unreadable` rather than run a getter it was handed. The node walk then reached those same fields by ordinary property access, invoking exactly what the survey had declined to.

Ten node fields did it, measured field by field: `id`, `type`, `version`, `props`, `slots`, `attributes`, `cssId`, `styles`, `bindings`, `visibility`. Each took a caller's error out of `validate()` as a **native throw** instead of the issue list it promises.

This is the root of a class that produced roughly **23 of 30** review findings across #1567, #1572 and #1574 — a value read before it has been established as data — and two of those findings were introduced *by* a fix for another. Guarding each read is what kept failing. The verdict was already computed; it was simply never consulted.

## I had to correct the recorded plan

The task and its finding both said: *gate the per-value work on `survey.unreadable` as it is already gated on `!survey.traversed`.* **That is not what was wrong**, and I only found out by measuring:

- `overLimits = !survey.traversed` was **already true** for these documents — the survey reports `traversed: false` for them too.
- `overLimits` only ever fed `skipValueParsing`, which skips style **parsing**, not field reads.

So adding the term was a no-op: I applied it and all ten still escaped. **The walk itself was never gated at all.** The gate belongs on the walk.

## And on `unreadable` alone

| document | `traversed` | `unreadable` | walk |
|---|---|---|---|
| exceeds `maxNodes` | false | **false** | still runs, bounded |
| carries an accessor | false | **true** | stops |

Gating on the broader `!traversed` would have silently dropped every per-node issue on a merely oversized document — which was read perfectly well.

## The trade, stated rather than buried

An unreadable document now reports **one** verdict instead of several, so a duplicate DOM id inside one is no longer named separately.

Two existing tests documented the opposite choice, including one that deliberately asserted *"the property is still READ, so the getter still runs"*. Both are updated, and the reasoning is now the other way: nothing about a document nobody can read is worth learning by running its code. That test's assertion is now `reads === 0`, which is strictly stronger than what it promised before.

The bound on the cost: such documents come from an import or a script, not the editor — and **the same duplicate on an ordinary document is still reported**, asserted directly beside it so the capability is shown intact rather than assumed.

## Why the per-record guards are still needed

Worth stating, since this could look like it makes them redundant. It does not: of three Proxy traps, only `getPrototypeOf` makes the survey call the document unreadable. `ownKeys` and `getOwnPropertyDescriptor` make it *unwritable* — a different fact the walk is not gated on — and a trap that fires only for an **absent** field is never met by the survey at all. All three still reach the per-record descriptor guard, and that is asserted.

## Evidence

12 tests fail against `main` and pass here. fallow `pass` / 0 introduced, blocks-engine 2265 passing, `turbo check-types` 42/42, `check:comments`, `lint:design`, `check-changesets.mjs` clean.
