### PR TITLE
fix(admin): close four ways a claim could outlive what the server holds

### DIFF
--- a/.changeset/document-lock-late-and-stalled-claims.md
+++ b/.changeset/document-lock-late-and-stalled-claims.md
@@ -26,35 +26,32 @@
 "@nextlyhq/module-specifiers": patch
 ---
 
-Close five ways a document claim could report one thing while the server held
-another, and widen the reader the client-bundle boundary depends on.
+Close five more ways a document claim could report one thing while the server
+held another, and stop aborting claims.
 
-**A claim is credited from when it was sent, not when the reply arrived.** The
-lease starts when the server processes a claim, so timing it from receipt credits
-the editor with however long the reply spent in transit. A reply delayed past the
-margin left the hook reporting a claim that had already expired server-side,
-while a colleague could take the row.
+**Nothing is aborted any more.** A claim is not idempotent, so cancelling one
+makes its outcome unknowable: it may still commit, and an aborted fetch can never
+hand back the token it was given. The editor would then hold a token the server
+had replaced with one it could never learn. Only the hold on the one-at-a-time
+slot expires now; the reply still arrives, and a claim whose slot has moved on is
+released as the duplicate it is. That converges without the server needing to know
+anything about client retries.
 
-**A request that never settles is now bounded.** Nothing cleared the
-one-at-a-time slot for a pending request, so every later beat returned at the
-serialisation guard and the editor sat in `acquiring` for the whole session with
-a take-over queued behind a request that was never coming back. Claims carry an
-abort signal bounded by one heartbeat.
+**Intent survives the wait.** Whatever waits on the slot is remembered as an
+intent rather than a flag, and a take-over whose request outlives its slot is
+re-asked as a take-over. Retried as a plain claim it politely declines to displace
+anyone, and the colleague keeps the document despite the click.
 
-**A failed poll forgets the holder it had cached.** A colleague renewing on the
-same cadence reports identical fields, so the quiet-poll comparison suppressed
-the update and stranded the editor on `unavailable` while the server was
-answering perfectly well.
+**A repair is queued, not dropped.** The signal that a late duplicate displaced
+the live claim is an acquisition like any other, so it meets the same slot. It is
+kept separately from a queued claim, because a claim is satisfied by winning the
+document and a repair is not: what a repair reports is that the token just
+installed may already be dead.
 
-**A late reply from a replaced effect run repairs what it broke.** The server
-treats a claim from the same owner as takeable, so a request still in flight when
-its effect was cleaned up displaced the run that replaced it. Handing that claim
-back left the live run holding a token the server had already forgotten. The run
-that got displaced is now told to claim again.
+**A repair names the document it is for.** Two claims on different documents use
+different lock keys, so a late reply for one cannot have displaced the other, and
+waking it would start a claim nobody asked for.
 
-**`module.require` counts as loading a module.** It is the documented CommonJS
-method and resolves exactly as the free function does, so
-`@nextlyhq/module-specifiers` reported a file loading nothing while it loaded a
-driver, and the client-bundle boundary that reads it would have certified such a
-graph as clean. `loader.require` still does not count: it is a method on somebody
-else's object.
+**The confirmation timestamp never moves backwards.** Renewal replies can arrive
+out of order, and an older one landing after a newer one shortened a lease the
+newer one had already extended, firing the loss deadline several beats early.

--- a/.changeset/document-lock-late-and-stalled-claims.md
+++ b/.changeset/document-lock-late-and-stalled-claims.md
@@ -1,0 +1,60 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Close five ways a document claim could report one thing while the server held
+another, and widen the reader the client-bundle boundary depends on.
+
+**A claim is credited from when it was sent, not when the reply arrived.** The
+lease starts when the server processes a claim, so timing it from receipt credits
+the editor with however long the reply spent in transit. A reply delayed past the
+margin left the hook reporting a claim that had already expired server-side,
+while a colleague could take the row.
+
+**A request that never settles is now bounded.** Nothing cleared the
+one-at-a-time slot for a pending request, so every later beat returned at the
+serialisation guard and the editor sat in `acquiring` for the whole session with
+a take-over queued behind a request that was never coming back. Claims carry an
+abort signal bounded by one heartbeat.
+
+**A failed poll forgets the holder it had cached.** A colleague renewing on the
+same cadence reports identical fields, so the quiet-poll comparison suppressed
+the update and stranded the editor on `unavailable` while the server was
+answering perfectly well.
+
+**A late reply from a replaced effect run repairs what it broke.** The server
+treats a claim from the same owner as takeable, so a request still in flight when
+its effect was cleaned up displaced the run that replaced it. Handing that claim
+back left the live run holding a token the server had already forgotten. The run
+that got displaced is now told to claim again.
+
+**`module.require` counts as loading a module.** It is the documented CommonJS
+method and resolves exactly as the free function does, so
+`@nextlyhq/module-specifiers` reported a file loading nothing while it loaded a
+driver, and the client-bundle boundary that reads it would have certified such a
+graph as clean. `loader.require` still does not count: it is a method on somebody
+else's object.

--- a/.changeset/document-lock-late-and-stalled-claims.md
+++ b/.changeset/document-lock-late-and-stalled-claims.md
@@ -55,3 +55,19 @@ waking it would start a claim nobody asked for.
 **The confirmation timestamp never moves backwards.** Renewal replies can arrive
 out of order, and an older one landing after a newer one shortened a lease the
 newer one had already extended, firing the loss deadline several beats early.
+**A rejection from a superseded claim is ignored.** A retry can win and the
+original then fail; reporting that replaced a good claim with `unavailable` and
+left it there, since renewals only move the confirmation forward. It also
+requeued a take-over the retry had already satisfied, which later displaced a
+colleague with no second click.
+
+**A queued take-over survives a repair.** A win only spends the click if it
+actually established possession, and a repair says the token just installed may
+already be the dead one.
+
+**`module.require` is read through the wrappers around it** — parentheses, a
+cast, a non-null assertion, `satisfies` — since each reads the same binding and a
+check on the receiver as written is a bypass anyone can reach by accident. And it
+claims nothing when the file declares a `module` of its own, because reporting a
+dependency the file never loads is the direction that makes a rule stop being
+read.

--- a/packages/admin/src/client-bundle-boundary.test.ts
+++ b/packages/admin/src/client-bundle-boundary.test.ts
@@ -471,11 +471,13 @@ describe("the rule can fail", () => {
   });
 
   it("fails on a CommonJS load", () => {
-    // `require` and `import x = require` reach a module exactly as an import does, and a visitor
-    // written by hand forgets them.
+    // `require`, `import x = require` and `module.require` reach a module exactly as an import
+    // does, and a visitor written by hand forgets them.
     for (const form of [
       'const db = require("drizzle-orm");',
       'import db = require("drizzle-orm");',
+      'const db = module.require("drizzle-orm");',
+      'const db = module["require"]("drizzle-orm");',
     ]) {
       const { io, resolve } = build({
         "/repo/packages/admin/src/Entry.ts": `"use client";\n${form}`,

--- a/packages/admin/src/hooks/queries/__tests__/useDocumentLock.test.tsx
+++ b/packages/admin/src/hooks/queries/__tests__/useDocumentLock.test.tsx
@@ -1078,4 +1078,97 @@ describe("useDocumentLock", () => {
     );
     expect(result.current.state.status).toBe("held-by-me");
   });
+
+  it("ignores a rejection from a claim that no longer owns the slot", async () => {
+    // 🔴 A retry can succeed and the original then reject. Reporting that
+    // replaces a good claim with `unavailable` and leaves it there, since
+    // renewals only move the confirmation forward and never restore the status.
+    let rejectStalled: (reason: unknown) => void = () => {};
+    post.mockReturnValueOnce(
+      new Promise((_resolve, reject) => {
+        rejectStalled = reject;
+      })
+    );
+
+    const { result } = renderHook(() => useDocumentLock(ref));
+    expect(result.current.state.status).toBe("acquiring");
+
+    // The slot expires and the next beat wins.
+    post.mockResolvedValue({
+      message: "",
+      item: { status: "acquired", claimToken: "retry" },
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS);
+    });
+    await waitFor(() => expect(result.current.state.status).toBe("held-by-me"));
+
+    // Only now does the original fail.
+    await act(async () => {
+      rejectStalled(new Error("offline"));
+      await new Promise(resolve => setTimeout(resolve, 0));
+    });
+
+    expect(result.current.state.status).toBe("held-by-me");
+  });
+
+  it("keeps a take-over queued while a repair says the claim may be dead", async () => {
+    // 🔴 A win only satisfies a queued take-over if it actually established
+    // possession. With a repair outstanding, the token just installed may already
+    // be the dead one - so dropping the click means the following plain claim
+    // comes back `held` and the decision is lost for good.
+    let settleStale: (value: unknown) => void = () => {};
+    post.mockReturnValueOnce(
+      new Promise(resolve => {
+        settleStale = resolve;
+      })
+    );
+
+    const { result, rerender } = renderHook(
+      ({ on }: { on: boolean }) => useDocumentLock({ ...ref, enabled: on }),
+      { initialProps: { on: true } }
+    );
+    rerender({ on: false });
+
+    let settleLive: (value: unknown) => void = () => {};
+    post.mockReturnValueOnce(
+      new Promise(resolve => {
+        settleLive = resolve;
+      })
+    );
+    rerender({ on: true });
+
+    // A person decides to take over while the live claim is still open.
+    await act(async () => {
+      result.current.takeOver();
+    });
+
+    // The stale reply lands, raising the repair.
+    await act(async () => {
+      settleStale({
+        message: "",
+        item: { status: "acquired", claimToken: "stale" },
+      });
+    });
+
+    // The live claim then wins - but a repair is outstanding, so the click stands.
+    // The repair itself is refused, which is the case that loses the click when
+    // the intent was dropped a moment too early.
+    post.mockResolvedValueOnce(held);
+    post.mockResolvedValue(acquired);
+    await act(async () => {
+      settleLive({
+        message: "",
+        item: { status: "acquired", claimToken: "live" },
+      });
+    });
+
+    await waitFor(() =>
+      expect(
+        post.mock.calls.filter(call => call[1]?.takeover === true).length,
+        "the take-over survived the repair"
+      ).toBeGreaterThan(0)
+    );
+    await waitFor(() => expect(result.current.state.status).toBe("held-by-me"));
+  });
 });

--- a/packages/admin/src/hooks/queries/__tests__/useDocumentLock.test.tsx
+++ b/packages/admin/src/hooks/queries/__tests__/useDocumentLock.test.tsx
@@ -25,12 +25,6 @@ const ref = {
 };
 const other = { ownerId: "u2", ownerLabel: "Bob", expiresInSeconds: 90 };
 
-/**
- * Every claim is sent under an abort signal, so a request that never settles
- * cannot hold the one-at-a-time slot for the rest of the session.
- */
-const BOUNDED = { signal: expect.any(AbortSignal) };
-
 const acquired = {
   message: "",
   item: { status: "acquired", claimToken: "t1" },
@@ -54,14 +48,10 @@ describe("useDocumentLock", () => {
     const { result } = renderHook(() => useDocumentLock(ref));
 
     await waitFor(() => expect(result.current.state.status).toBe("held-by-me"));
-    expect(post).toHaveBeenCalledWith(
-      "/document-lock",
-      {
-        ...ref,
-        takeover: false,
-      },
-      BOUNDED
-    );
+    expect(post).toHaveBeenCalledWith("/document-lock", {
+      ...ref,
+      takeover: false,
+    });
   });
 
   it("claims once per document, not once per render", async () => {
@@ -209,14 +199,10 @@ describe("useDocumentLock", () => {
     });
 
     await waitFor(() => expect(result.current.state.status).toBe("held-by-me"));
-    expect(post).toHaveBeenLastCalledWith(
-      "/document-lock",
-      {
-        ...ref,
-        takeover: true,
-      },
-      BOUNDED
-    );
+    expect(post).toHaveBeenLastCalledWith("/document-lock", {
+      ...ref,
+      takeover: true,
+    });
   });
 
   it("reports the claim unavailable when it cannot be asked for, and retries", async () => {
@@ -344,14 +330,10 @@ describe("useDocumentLock", () => {
       result.current.takeOver();
     });
     await waitFor(() =>
-      expect(post).toHaveBeenLastCalledWith(
-        "/document-lock",
-        {
-          ...ref,
-          takeover: true,
-        },
-        BOUNDED
-      )
+      expect(post).toHaveBeenLastCalledWith("/document-lock", {
+        ...ref,
+        takeover: true,
+      })
     );
 
     await act(async () => {
@@ -377,19 +359,15 @@ describe("useDocumentLock", () => {
     });
 
     await waitFor(() => expect(result.current.state.status).toBe("held-by-me"));
-    expect(post).toHaveBeenLastCalledWith(
-      "/document-lock",
-      {
-        ...ref,
-        takeover: false,
-      },
-      BOUNDED
-    );
+    expect(post).toHaveBeenLastCalledWith("/document-lock", {
+      ...ref,
+      takeover: false,
+    });
   });
 
   it("does not re-render the editor while a colleague keeps holding it", async () => {
-    // The poll above runs every beat. A fresh state object each time would
-    // re-render the whole edit view for no news.
+    // The poll runs every beat. A fresh state object each time would re-render
+    // the whole edit view for no news.
     post.mockResolvedValue(held);
     const { result } = renderHook(() => useDocumentLock(ref));
     await waitFor(() =>
@@ -397,9 +375,14 @@ describe("useDocumentLock", () => {
     );
 
     const first = result.current.state;
-    await act(async () => {
-      vi.advanceTimersByTime(DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS * 2);
-    });
+    // One beat at a time, letting each poll answer. Advancing several at once
+    // holds a reply past the slot's own expiry, which is a different case and
+    // has its own test.
+    for (let beat = 0; beat < 2; beat += 1) {
+      await act(async () => {
+        vi.advanceTimersByTime(DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS);
+      });
+    }
 
     expect(result.current.state).toBe(first);
   });
@@ -423,32 +406,37 @@ describe("useDocumentLock", () => {
     expect(result.current.state.status).toBe("acquiring");
   });
 
-  it("never runs two acquisitions at once", async () => {
-    // 🔴 The server treats a live claim from the SAME owner as takeable, so a
-    // second acquire mints a fresh token and invalidates the one still in
-    // flight. Whichever reply lands second wins, and the editor can end up
-    // renewing a token the server already replaced - reported as a takeover
-    // naming the editor themselves.
-    let settle: (value: unknown) => void = () => {};
-    post.mockReturnValueOnce(
-      new Promise(resolve => {
-        settle = resolve;
-      })
-    );
+  it("never runs two acquisitions at once, and keeps the intent when one stalls", async () => {
+    // 🔴 Two claims outstanding at once is the shape that loses a token: the
+    // server treats a live claim from the SAME owner as takeable, so the later
+    // one to commit wins and the other's token is dead on arrival.
+    //
+    // 🔴 And the request is never aborted. A claim is not idempotent, so
+    // cancelling one makes its outcome unknowable - it may still commit, and an
+    // aborted fetch can never hand back the token it was given. Only the hold on
+    // the slot expires.
+    post.mockReturnValue(new Promise(() => {}));
 
     const { result } = renderHook(() => useDocumentLock(ref));
     expect(post).toHaveBeenCalledTimes(1);
 
+    // A person decides to take over while that claim is still open.
     await act(async () => {
-      vi.advanceTimersByTime(DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS * 3);
+      result.current.takeOver();
     });
-
     expect(post).toHaveBeenCalledTimes(1);
 
+    // The slot expires after a beat. The decision is re-asked as a decision.
     await act(async () => {
-      settle(acquired);
+      vi.advanceTimersByTime(DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS);
     });
-    await waitFor(() => expect(result.current.state.status).toBe("held-by-me"));
+
+    expect(result.current.state.status).toBe("unavailable");
+    expect(post).toHaveBeenCalledTimes(2);
+    expect(post).toHaveBeenLastCalledWith("/document-lock", {
+      ...ref,
+      takeover: true,
+    });
   });
 
   it("reaches the deadline even when no request ever settles", async () => {
@@ -549,14 +537,10 @@ describe("useDocumentLock", () => {
     });
 
     await waitFor(() => expect(result.current.state.status).toBe("held-by-me"));
-    expect(post).toHaveBeenLastCalledWith(
-      "/document-lock",
-      {
-        ...ref,
-        takeover: true,
-      },
-      BOUNDED
-    );
+    expect(post).toHaveBeenLastCalledWith("/document-lock", {
+      ...ref,
+      takeover: true,
+    });
   });
 
   it("does not re-take a claim the pending poll just won", async () => {
@@ -739,13 +723,13 @@ describe("useDocumentLock", () => {
     );
   });
 
-  it("repairs the live claim when a superseded run's reply displaces it", async () => {
+  it("repairs the live claim when an earlier run's reply displaces it", async () => {
     // 🔴 Two fences, not one. The token fence separates two claims inside a run;
-    // this is two RUNS. A run whose cleanup has happened can still have a request
-    // in flight, and the server treats a claim from the SAME owner as takeable,
-    // so that late reply takes the row out from under the run that replaced it.
-    // Releasing it then leaves the live run holding a token the server has
-    // forgotten, reporting `held-by-me` over nothing.
+    // this is two RUNS on the same document. A run whose cleanup has happened can
+    // still have a request in flight, and the server treats a claim from the SAME
+    // owner as takeable, so that late reply takes the row out from under the run
+    // that replaced it. Releasing it then leaves the live run holding a token the
+    // server has forgotten, reporting `held-by-me` over nothing.
     let settleFirst: (value: unknown) => void = () => {};
     post.mockReturnValueOnce(
       new Promise(resolve => {
@@ -754,20 +738,20 @@ describe("useDocumentLock", () => {
     );
 
     const { result, rerender } = renderHook(
-      ({ id }: { id: string }) => useDocumentLock({ ...ref, entryId: id }),
-      { initialProps: { id: "42" } }
+      ({ on }: { on: boolean }) => useDocumentLock({ ...ref, enabled: on }),
+      { initialProps: { on: true } }
     );
 
-    // A second run replaces the first while its claim is still open.
+    // Same document, a second run: the first is cleaned up with its claim open.
+    rerender({ on: false });
     post.mockResolvedValue({
       message: "",
       item: { status: "acquired", claimToken: "live" },
     });
-    rerender({ id: "43" });
+    rerender({ on: true });
     await waitFor(() => expect(result.current.state.status).toBe("held-by-me"));
     const afterLive = post.mock.calls.length;
 
-    // Now the superseded run is answered, having displaced the live claim.
     await act(async () => {
       settleFirst({
         message: "",
@@ -785,6 +769,48 @@ describe("useDocumentLock", () => {
     await waitFor(() =>
       expect(post.mock.calls.length).toBeGreaterThan(afterLive)
     );
+    expect(result.current.state.status).toBe("held-by-me");
+  });
+
+  it("does not wake a run that moved to another document", async () => {
+    // 🔴 Two claims on different documents use different lock keys, so a late
+    // reply for one cannot have displaced the other. Waking it would start a
+    // claim nobody asked for - and if THAT request fails it reports the document
+    // unavailable while the server still records it as held.
+    let settleFirst: (value: unknown) => void = () => {};
+    post.mockReturnValueOnce(
+      new Promise(resolve => {
+        settleFirst = resolve;
+      })
+    );
+
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string }) => useDocumentLock({ ...ref, entryId: id }),
+      { initialProps: { id: "42" } }
+    );
+
+    post.mockResolvedValue({
+      message: "",
+      item: { status: "acquired", claimToken: "live" },
+    });
+    rerender({ id: "43" });
+    await waitFor(() => expect(result.current.state.status).toBe("held-by-me"));
+    const afterLive = post.mock.calls.length;
+
+    await act(async () => {
+      settleFirst({
+        message: "",
+        item: { status: "acquired", claimToken: "stale" },
+      });
+    });
+
+    // The stale claim is still handed back - it belongs to nobody now.
+    expect(del).toHaveBeenCalledWith(
+      "/document-lock",
+      expect.objectContaining({ claimToken: "stale" })
+    );
+    // But the document on screen was never displaced, so nothing is re-asked.
+    expect(post.mock.calls.length).toBe(afterLive);
     expect(result.current.state.status).toBe("held-by-me");
   });
 
@@ -854,9 +880,8 @@ describe("useDocumentLock", () => {
     const { result } = renderHook(() => useDocumentLock(ref));
     expect(result.current.state.status).toBe("acquiring");
 
-    // Answered long after it was sent, but inside the deadline measured from it.
-    const answeredAt =
-      DOCUMENT_LOCK_LOSS_AFTER_MS - DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS;
+    // Answered slowly, but inside the slot's own expiry so it still installs.
+    const answeredAt = DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS - 1000;
     await act(async () => {
       vi.advanceTimersByTime(answeredAt);
     });
@@ -866,16 +891,191 @@ describe("useDocumentLock", () => {
     });
     await waitFor(() => expect(result.current.state.status).toBe("held-by-me"));
 
-    // Past the deadline as measured from the SEND. Timed from the reply this
-    // editor would still believe it held the document.
+    // The deadline as measured from the SEND lands on the beat at
+    // `DOCUMENT_LOCK_LOSS_AFTER_MS`; measured from the reply it would be a beat
+    // later, and this editor would still believe it held the document.
     await act(async () => {
-      vi.advanceTimersByTime(
-        DOCUMENT_LOCK_LOSS_AFTER_MS -
-          answeredAt +
-          DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS
-      );
+      vi.advanceTimersByTime(DOCUMENT_LOCK_LOSS_AFTER_MS - answeredAt);
     });
 
     await waitFor(() => expect(result.current.state.status).toBe("lost"));
+  });
+
+  it("does not let an older renewal shorten a lease a newer one extended", async () => {
+    // 🔴 Replies can arrive out of order. An older renewal landing after a newer
+    // one would move the confirmation backwards, firing the deadline several
+    // beats early against a lease the server had already extended.
+    const { result } = renderHook(() => useDocumentLock(ref));
+    await waitFor(() => expect(result.current.state.status).toBe("held-by-me"));
+
+    let settleFirst: (value: unknown) => void = () => {};
+    let settleSecond: (value: unknown) => void = () => {};
+    patch.mockReturnValueOnce(
+      new Promise(resolve => {
+        settleFirst = resolve;
+      })
+    );
+    patch.mockReturnValueOnce(
+      new Promise(resolve => {
+        settleSecond = resolve;
+      })
+    );
+    patch.mockReturnValue(new Promise(() => {}));
+
+    // Two renewals dispatched a beat apart.
+    await act(async () => {
+      vi.advanceTimersByTime(DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS);
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS);
+    });
+
+    // The newer one answers first, then the older one.
+    const renewed = { message: "", item: { status: "renewed" } };
+    await act(async () => {
+      settleSecond(renewed);
+    });
+    await act(async () => {
+      settleFirst(renewed);
+    });
+
+    // Just past the deadline measured from the OLDER renewal, and short of the
+    // one measured from the newer. Moved backwards, this reports `lost`.
+    await act(async () => {
+      vi.advanceTimersByTime(
+        DOCUMENT_LOCK_LOSS_AFTER_MS - DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS
+      );
+    });
+
+    expect(result.current.state.status).toBe("held-by-me");
+  });
+
+  it("queues a repair behind a claim the live run has not finished", async () => {
+    // 🔴 The repair is an acquire like any other, so it meets the same
+    // one-at-a-time slot. Dropping it there loses the whole point of it: the live
+    // run installs a token the stale reply has already invalidated and reports
+    // `held-by-me` over a claim the server has forgotten.
+    let settleStale: (value: unknown) => void = () => {};
+    post.mockReturnValueOnce(
+      new Promise(resolve => {
+        settleStale = resolve;
+      })
+    );
+
+    const { result, rerender } = renderHook(
+      ({ on }: { on: boolean }) => useDocumentLock({ ...ref, enabled: on }),
+      { initialProps: { on: true } }
+    );
+
+    rerender({ on: false });
+
+    // The replacement run's own claim is still open when the stale one lands.
+    let settleLive: (value: unknown) => void = () => {};
+    post.mockReturnValueOnce(
+      new Promise(resolve => {
+        settleLive = resolve;
+      })
+    );
+    rerender({ on: true });
+    const afterLiveSent = post.mock.calls.length;
+
+    await act(async () => {
+      settleStale({
+        message: "",
+        item: { status: "acquired", claimToken: "stale" },
+      });
+    });
+    // Nothing new asked yet: the slot is still held by the live claim.
+    expect(post.mock.calls.length).toBe(afterLiveSent);
+
+    post.mockResolvedValue({
+      message: "",
+      item: { status: "acquired", claimToken: "second" },
+    });
+    await act(async () => {
+      settleLive({
+        message: "",
+        item: { status: "acquired", claimToken: "live" },
+      });
+    });
+
+    // The repair was kept, and runs once the slot frees.
+    await waitFor(() =>
+      expect(post.mock.calls.length).toBeGreaterThan(afterLiveSent)
+    );
+    await waitFor(() => expect(result.current.state.status).toBe("held-by-me"));
+  });
+
+  it("re-asks a take-over as a take-over when its own request stalls", async () => {
+    // 🔴 Finding the intent again is not the same as never losing it. A person's
+    // decision that outlives its request must come back as a decision: retried as
+    // a plain claim it politely declines to displace anyone, and the colleague
+    // keeps the document despite the click.
+    post.mockResolvedValue(held);
+    const { result } = renderHook(() => useDocumentLock(ref));
+    await waitFor(() =>
+      expect(result.current.state.status).toBe("held-by-other")
+    );
+
+    post.mockReturnValue(new Promise(() => {}));
+    await act(async () => {
+      result.current.takeOver();
+    });
+    expect(post).toHaveBeenLastCalledWith("/document-lock", {
+      ...ref,
+      takeover: true,
+    });
+    const sent = post.mock.calls.length;
+
+    // The slot expires without an answer.
+    await act(async () => {
+      vi.advanceTimersByTime(DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS);
+    });
+
+    expect(post.mock.calls.length).toBeGreaterThan(sent);
+    expect(post).toHaveBeenLastCalledWith("/document-lock", {
+      ...ref,
+      takeover: true,
+    });
+  });
+
+  it("hands back a stalled claim that answers after its slot expired", async () => {
+    // 🔴 The reason nothing is aborted, and the reason a claim carries a
+    // sequence. The retry has already replaced this token server-side - the
+    // server treats the same owner as takeable - so installing the late one would
+    // report a claim the server has forgotten.
+    let settleStalled: (value: unknown) => void = () => {};
+    post.mockReturnValueOnce(
+      new Promise(resolve => {
+        settleStalled = resolve;
+      })
+    );
+
+    const { result } = renderHook(() => useDocumentLock(ref));
+    expect(result.current.state.status).toBe("acquiring");
+
+    // The slot expires, and the next beat claims again and wins.
+    post.mockResolvedValue({
+      message: "",
+      item: { status: "acquired", claimToken: "retry" },
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS);
+    });
+    await waitFor(() => expect(result.current.state.status).toBe("held-by-me"));
+
+    // Only now does the original answer.
+    await act(async () => {
+      settleStalled({
+        message: "",
+        item: { status: "acquired", claimToken: "stalled" },
+      });
+    });
+
+    expect(del).toHaveBeenCalledWith(
+      "/document-lock",
+      expect.objectContaining({ claimToken: "stalled" })
+    );
+    expect(result.current.state.status).toBe("held-by-me");
   });
 });

--- a/packages/admin/src/hooks/queries/__tests__/useDocumentLock.test.tsx
+++ b/packages/admin/src/hooks/queries/__tests__/useDocumentLock.test.tsx
@@ -25,6 +25,12 @@ const ref = {
 };
 const other = { ownerId: "u2", ownerLabel: "Bob", expiresInSeconds: 90 };
 
+/**
+ * Every claim is sent under an abort signal, so a request that never settles
+ * cannot hold the one-at-a-time slot for the rest of the session.
+ */
+const BOUNDED = { signal: expect.any(AbortSignal) };
+
 const acquired = {
   message: "",
   item: { status: "acquired", claimToken: "t1" },
@@ -48,10 +54,14 @@ describe("useDocumentLock", () => {
     const { result } = renderHook(() => useDocumentLock(ref));
 
     await waitFor(() => expect(result.current.state.status).toBe("held-by-me"));
-    expect(post).toHaveBeenCalledWith("/document-lock", {
-      ...ref,
-      takeover: false,
-    });
+    expect(post).toHaveBeenCalledWith(
+      "/document-lock",
+      {
+        ...ref,
+        takeover: false,
+      },
+      BOUNDED
+    );
   });
 
   it("claims once per document, not once per render", async () => {
@@ -199,10 +209,14 @@ describe("useDocumentLock", () => {
     });
 
     await waitFor(() => expect(result.current.state.status).toBe("held-by-me"));
-    expect(post).toHaveBeenLastCalledWith("/document-lock", {
-      ...ref,
-      takeover: true,
-    });
+    expect(post).toHaveBeenLastCalledWith(
+      "/document-lock",
+      {
+        ...ref,
+        takeover: true,
+      },
+      BOUNDED
+    );
   });
 
   it("reports the claim unavailable when it cannot be asked for, and retries", async () => {
@@ -330,10 +344,14 @@ describe("useDocumentLock", () => {
       result.current.takeOver();
     });
     await waitFor(() =>
-      expect(post).toHaveBeenLastCalledWith("/document-lock", {
-        ...ref,
-        takeover: true,
-      })
+      expect(post).toHaveBeenLastCalledWith(
+        "/document-lock",
+        {
+          ...ref,
+          takeover: true,
+        },
+        BOUNDED
+      )
     );
 
     await act(async () => {
@@ -359,10 +377,14 @@ describe("useDocumentLock", () => {
     });
 
     await waitFor(() => expect(result.current.state.status).toBe("held-by-me"));
-    expect(post).toHaveBeenLastCalledWith("/document-lock", {
-      ...ref,
-      takeover: false,
-    });
+    expect(post).toHaveBeenLastCalledWith(
+      "/document-lock",
+      {
+        ...ref,
+        takeover: false,
+      },
+      BOUNDED
+    );
   });
 
   it("does not re-render the editor while a colleague keeps holding it", async () => {
@@ -527,10 +549,14 @@ describe("useDocumentLock", () => {
     });
 
     await waitFor(() => expect(result.current.state.status).toBe("held-by-me"));
-    expect(post).toHaveBeenLastCalledWith("/document-lock", {
-      ...ref,
-      takeover: true,
-    });
+    expect(post).toHaveBeenLastCalledWith(
+      "/document-lock",
+      {
+        ...ref,
+        takeover: true,
+      },
+      BOUNDED
+    );
   });
 
   it("does not re-take a claim the pending poll just won", async () => {
@@ -643,5 +669,213 @@ describe("useDocumentLock", () => {
     );
 
     expect(post.mock.calls.length).toBe(before + 1);
+  });
+
+  it("gives up on a claim that never answers, and retries", async () => {
+    // 🔴 A pending request is not a failed one. Nothing clears the one-at-a-time
+    // slot, so without a bound every later beat returns at the serialisation
+    // guard and the editor sits in `acquiring` for the whole session with a
+    // take-over queued behind a request that is never coming back.
+    //
+    // The mock honours the signal the way `fetch` does, since that abort is the
+    // whole mechanism under test.
+    post.mockImplementation(
+      (_path: string, _body: unknown, options?: { signal?: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          options?.signal?.addEventListener("abort", () =>
+            reject(new Error("aborted"))
+          );
+        })
+    );
+
+    const { result } = renderHook(() => useDocumentLock(ref));
+    expect(result.current.state.status).toBe("acquiring");
+
+    await act(async () => {
+      vi.advanceTimersByTime(DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS);
+    });
+    await waitFor(() =>
+      expect(result.current.state.status).toBe("unavailable")
+    );
+
+    // The slot is free again, so the next beat asks.
+    post.mockResolvedValue(acquired);
+    await act(async () => {
+      vi.advanceTimersByTime(DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS);
+    });
+    await waitFor(() => expect(result.current.state.status).toBe("held-by-me"));
+  });
+
+  it("shows the holder again after a failed poll, even if nothing changed", async () => {
+    // 🔴 The quiet-poll comparison must not outlive the state it was quiet about.
+    // A holder renewing on this same cadence reports identical fields, so keeping
+    // the cached reading suppresses the update and strands the editor on
+    // `unavailable` while the server is answering perfectly well.
+    post.mockResolvedValue(held);
+    const { result } = renderHook(() => useDocumentLock(ref));
+    await waitFor(() =>
+      expect(result.current.state.status).toBe("held-by-other")
+    );
+
+    post.mockRejectedValueOnce(new Error("offline"));
+    await act(async () => {
+      vi.advanceTimersByTime(DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS);
+    });
+    await waitFor(() =>
+      expect(result.current.state.status).toBe("unavailable")
+    );
+
+    // Same holder, same expiry: nothing about the reading changed.
+    post.mockResolvedValue(held);
+    await act(async () => {
+      vi.advanceTimersByTime(DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS);
+    });
+
+    await waitFor(() =>
+      expect(result.current.state).toEqual({
+        status: "held-by-other",
+        holder: other,
+      })
+    );
+  });
+
+  it("repairs the live claim when a superseded run's reply displaces it", async () => {
+    // 🔴 Two fences, not one. The token fence separates two claims inside a run;
+    // this is two RUNS. A run whose cleanup has happened can still have a request
+    // in flight, and the server treats a claim from the SAME owner as takeable,
+    // so that late reply takes the row out from under the run that replaced it.
+    // Releasing it then leaves the live run holding a token the server has
+    // forgotten, reporting `held-by-me` over nothing.
+    let settleFirst: (value: unknown) => void = () => {};
+    post.mockReturnValueOnce(
+      new Promise(resolve => {
+        settleFirst = resolve;
+      })
+    );
+
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string }) => useDocumentLock({ ...ref, entryId: id }),
+      { initialProps: { id: "42" } }
+    );
+
+    // A second run replaces the first while its claim is still open.
+    post.mockResolvedValue({
+      message: "",
+      item: { status: "acquired", claimToken: "live" },
+    });
+    rerender({ id: "43" });
+    await waitFor(() => expect(result.current.state.status).toBe("held-by-me"));
+    const afterLive = post.mock.calls.length;
+
+    // Now the superseded run is answered, having displaced the live claim.
+    await act(async () => {
+      settleFirst({
+        message: "",
+        item: { status: "acquired", claimToken: "stale" },
+      });
+    });
+
+    // Handed back...
+    expect(del).toHaveBeenCalledWith(
+      "/document-lock",
+      expect.objectContaining({ claimToken: "stale" })
+    );
+    // ...and the live run told to claim again rather than trusting a token the
+    // server no longer has.
+    await waitFor(() =>
+      expect(post.mock.calls.length).toBeGreaterThan(afterLive)
+    );
+    expect(result.current.state.status).toBe("held-by-me");
+  });
+
+  it("credits a renewal from when it was sent, not when the reply arrived", async () => {
+    // 🔴 The lease starts when the SERVER processes a renewal. Timing it from
+    // receipt credits this editor with however long the reply spent in transit,
+    // so a reply delayed past the margin has the hook reporting a claim that
+    // expired server-side while a colleague can already take the row.
+    //
+    // The timeline below separates the two readings: the renewal is sent at one
+    // beat and answered much later, and the deadline that follows is reached
+    // only if the send time is what counted.
+    const { result } = renderHook(() => useDocumentLock(ref));
+    await waitFor(() => expect(result.current.state.status).toBe("held-by-me"));
+
+    let settleRenew: (value: unknown) => void = () => {};
+    patch.mockReturnValueOnce(
+      new Promise(resolve => {
+        settleRenew = resolve;
+      })
+    );
+    // Every later beat is left open, so nothing else can move the deadline.
+    patch.mockReturnValue(new Promise(() => {}));
+
+    // The renewal is dispatched on this beat.
+    await act(async () => {
+      vi.advanceTimersByTime(DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS);
+    });
+    const sentAt = DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS;
+
+    // It is answered a long time later, but still inside the deadline measured
+    // from the last thing this editor knew.
+    const answeredAt =
+      DOCUMENT_LOCK_LOSS_AFTER_MS - DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS;
+    await act(async () => {
+      vi.advanceTimersByTime(answeredAt - sentAt);
+    });
+    await act(async () => {
+      settleRenew({ message: "", item: { status: "renewed" } });
+    });
+    expect(result.current.state.status).toBe("held-by-me");
+
+    // Now pass the deadline as measured from the SEND. Timed from the reply this
+    // editor would still believe it held the document.
+    await act(async () => {
+      vi.advanceTimersByTime(
+        sentAt +
+          DOCUMENT_LOCK_LOSS_AFTER_MS -
+          answeredAt +
+          DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS
+      );
+    });
+
+    await waitFor(() => expect(result.current.state.status).toBe("lost"));
+  });
+
+  it("credits a claim from when it was sent, not when the reply arrived", async () => {
+    // The same rule on the acquisition path. A claim answered slowly has already
+    // spent part of its lease by the time this editor hears about it.
+    let settleClaim: (value: unknown) => void = () => {};
+    post.mockReturnValueOnce(
+      new Promise(resolve => {
+        settleClaim = resolve;
+      })
+    );
+
+    const { result } = renderHook(() => useDocumentLock(ref));
+    expect(result.current.state.status).toBe("acquiring");
+
+    // Answered long after it was sent, but inside the deadline measured from it.
+    const answeredAt =
+      DOCUMENT_LOCK_LOSS_AFTER_MS - DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS;
+    await act(async () => {
+      vi.advanceTimersByTime(answeredAt);
+    });
+    patch.mockReturnValue(new Promise(() => {}));
+    await act(async () => {
+      settleClaim(acquired);
+    });
+    await waitFor(() => expect(result.current.state.status).toBe("held-by-me"));
+
+    // Past the deadline as measured from the SEND. Timed from the reply this
+    // editor would still believe it held the document.
+    await act(async () => {
+      vi.advanceTimersByTime(
+        DOCUMENT_LOCK_LOSS_AFTER_MS -
+          answeredAt +
+          DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS
+      );
+    });
+
+    await waitFor(() => expect(result.current.state.status).toBe("lost"));
   });
 });

--- a/packages/admin/src/hooks/queries/useDocumentLock.ts
+++ b/packages/admin/src/hooks/queries/useDocumentLock.ts
@@ -245,12 +245,14 @@ export function useDocumentLock({
       confirmedAt = sentAt;
       holder = null;
       surrendered = false;
-      // 🔴 Whatever a person or a poll was waiting for has already been got. A
-      // take-over queued behind a poll that then WON must not be carried into a
-      // later claim and spent displacing a colleague nobody asked to displace.
-      // `repairNeeded` is deliberately untouched: winning is exactly what a
-      // repair is about, since the token just installed may be the dead one.
-      pending = null;
+      // 🔴 Whatever a person or a poll was waiting for has been got -- but only
+      // if this claim actually established possession. A take-over queued behind
+      // a poll that then WON must not be carried into a later claim and spent
+      // displacing a colleague nobody asked to displace; a take-over queued while
+      // a repair is outstanding must NOT be dropped, because the repair says this
+      // very token may already be dead and the following plain claim would come
+      // back `held`, losing the click for good.
+      if (!repairNeeded) pending = null;
       setState({ status: "held-by-me" });
     };
 
@@ -296,7 +298,14 @@ export function useDocumentLock({
 
     /** Report a claim that could not be sent, keeping a decision for the beat. */
     const failClaim = (seq: number, intent: ClaimIntent) => {
-      if (inFlight === seq) inFlight = null;
+      // 🔴 A rejection from a claim that no longer owns the slot says nothing
+      // about the document. A retry can succeed and then the original finally
+      // rejects: reporting that would replace a good claim with `unavailable`
+      // and leave it there, since renewals only move `confirmedAt`. It would also
+      // requeue a take-over the retry has already satisfied, which later displaces
+      // a colleague with no second click.
+      if (inFlight !== seq) return;
+      inFlight = null;
       installUnavailable();
       // Kept for the beat rather than retried here, which would spin against a
       // server that is down. A take-over is kept because it was a decision.

--- a/packages/admin/src/hooks/queries/useDocumentLock.ts
+++ b/packages/admin/src/hooks/queries/useDocumentLock.ts
@@ -137,6 +137,14 @@ export function useDocumentLock({
   const takeOverRef = useRef<() => void>(() => {});
   const takeOver = useCallback(() => takeOverRef.current(), []);
 
+  // 🔴 The cross-RUN half of the fencing, which the token fence cannot cover. A
+  // run whose cleanup has already happened can still have a request in flight,
+  // and the server treats a claim from the same owner as takeable, so that late
+  // reply displaces the run that replaced it. This is how the run that got
+  // displaced hears about it; a run that has itself been cleaned up refuses the
+  // call, so an unmounted editor wakes nobody.
+  const reacquireRef = useRef<() => void>(() => {});
+
   const active = enabled && Boolean(entryId);
   // Memoised on the three primitives that identify the document. Rebuilt every
   // render it would be a new object each time, so the effect below would claim,
@@ -178,10 +186,18 @@ export function useDocumentLock({
         .delete("/document-lock", { ...ref, claimToken })
         .catch(() => undefined);
 
-    /** Store a claim this editor now holds. */
-    const installAcquired = (claimToken: string) => {
+    /**
+     * Store a claim this editor now holds.
+     *
+     * 🔴 `sentAt` is when the request was DISPATCHED, not when its reply arrived.
+     * The lease starts when the server processes the claim, so timing it from
+     * receipt credits this editor with however long the reply spent in transit —
+     * and a reply delayed past the margin has the hook reporting a claim that
+     * expired server-side while a colleague can already take the row.
+     */
+    const installAcquired = (claimToken: string, sentAt: number) => {
       token = claimToken;
-      confirmedAt = Date.now();
+      confirmedAt = sentAt;
       holder = null;
       surrendered = false;
       // Already holding it: a queued take-over would only displace ourselves.
@@ -206,33 +222,67 @@ export function useDocumentLock({
         return;
       }
       acquiring = true;
+      // 🔴 Bounded, because a request that never settles is not the same as one
+      // that fails. Nothing here would ever clear `acquiring`, so every later
+      // beat would return at the serialisation guard and the editor would sit in
+      // `acquiring` for the whole session with a take-over queued behind a
+      // request that is never coming back. One heartbeat is the bound: a claim
+      // that has not answered within a beat cannot help this beat.
+      const bound = new AbortController();
+      const boundTimer = setTimeout(
+        () => bound.abort(),
+        DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS
+      );
+      const sentAt = Date.now();
       let item: AcquireDocumentLockOutcome;
       try {
         ({ item } = await protectedApi.post<
           MutationResponse<AcquireDocumentLockOutcome>
-        >("/document-lock", { ...ref, takeover }));
+        >("/document-lock", { ...ref, takeover }, { signal: bound.signal }));
       } catch {
+        clearTimeout(boundTimer);
         // 🔴 Reported, not swallowed. A rejected acquire leaves no token, and
         // every later beat would exit at its token guard, so an editor would
         // spend the whole session silently unprotected. The beat retries.
         acquiring = false;
-        if (!cancelled) setState({ status: "unavailable" });
+        if (!cancelled) {
+          // 🔴 Forget the holder as well as the state. Kept, an identical reading
+          // on the next successful poll is suppressed as "nothing changed" and
+          // the editor stays on `unavailable` while the server is answering
+          // perfectly well — which is plausible whenever the holder renews on
+          // this same cadence.
+          holder = null;
+          setState({ status: "unavailable" });
+        }
         drainQueuedTakeover();
         return;
       }
+      clearTimeout(boundTimer);
       acquiring = false;
 
       if (cancelled) {
-        // 🔴 The claim outlived the editor that asked for it: this reply landed
+        // 🔴 The claim outlived the run that asked for it: this reply landed
         // after cleanup, which found no token to release. Releasing it here is
         // the difference between a colleague waiting one request and waiting a
         // whole lease.
-        if (item.status === "acquired") release(item.claimToken);
+        if (item.status === "acquired") {
+          release(item.claimToken);
+          // 🔴 And repair what winning it broke. The server treats a claim from
+          // the same owner as takeable, so this late reply DISPLACED whichever
+          // run replaced this one: releasing it now would leave that run holding
+          // a token the server has already forgotten, believing it is safe until
+          // a heartbeat says otherwise.
+          //
+          // Safe to call unconditionally. The signal is published by whichever
+          // run is live, and a run that has been cleaned up refuses it, so after
+          // an unmount there is nobody to wake and this does nothing.
+          reacquireRef.current();
+        }
         return;
       }
 
       if (item.status === "acquired") {
-        installAcquired(item.claimToken);
+        installAcquired(item.claimToken, sentAt);
         return;
       }
 
@@ -265,6 +315,11 @@ export function useDocumentLock({
     };
 
     takeOverRef.current = () => void acquire(true);
+    reacquireRef.current = () => {
+      if (cancelled) return;
+      surrendered = false;
+      void acquire(false);
+    };
     void acquire(false);
 
     const heartbeat = setInterval(() => {
@@ -293,6 +348,9 @@ export function useDocumentLock({
       }
 
       const sent = token;
+      // Timed from dispatch for the same reason a claim is: the lease the server
+      // grants starts when it processes this, not when the answer gets back.
+      const renewSentAt = Date.now();
       void protectedApi
         .patch<MutationResponse<RenewDocumentLockOutcome>>("/document-lock", {
           ...ref,
@@ -301,7 +359,7 @@ export function useDocumentLock({
         .then(({ item }) => {
           if (cancelled || sent !== token) return;
           if (item.status === "renewed") {
-            confirmedAt = Date.now();
+            confirmedAt = renewSentAt;
             return;
           }
           surrender({ status: "taken-over", holder: item.holder });
@@ -314,6 +372,8 @@ export function useDocumentLock({
     return () => {
       cancelled = true;
       takeOverRef.current = () => {};
+      // Left for the run that replaces this one to overwrite. Clearing it would
+      // drop the repair signal in exactly the window it exists for.
       clearInterval(heartbeat);
       if (token !== null) release(token);
     };

--- a/packages/admin/src/hooks/queries/useDocumentLock.ts
+++ b/packages/admin/src/hooks/queries/useDocumentLock.ts
@@ -17,28 +17,41 @@
  * ## One claim, owned by one effect
  *
  * Every mutable thing about a claim — the token, when it was last confirmed,
- * whether a request is in flight, and whether the editor is still mounted —
- * lives in the effect that created it, not in a ref shared across runs. That is
- * what makes the awkward cases fall out rather than needing to be handled one at
- * a time: a reply belonging to a superseded run closes over a `cancelled` that is
- * already true, and a reply belonging to a superseded CLAIM closes over a token
- * that no longer matches. React Strict Mode's double mount, a document switch
- * and an unmount are then the same case rather than three.
+ * what is in flight, and whether the editor is still mounted — lives in the
+ * effect that created it, not in a ref shared across runs. React Strict Mode's
+ * double mount, a document switch and an unmount are then the same case rather
+ * than three: each closes over a `cancelled` that is already true.
  *
- * ## Every reply is fenced on the token that produced it
+ * ## Every reply is fenced on what produced it
  *
- * 🔴 Not on the effect run. A takeover replaces the token WITHIN a run, so two
- * heartbeats can overlap across it: a `lost` answer belonging to the token that
- * was displaced would otherwise clear the claim the takeover just won, telling
- * an editor who holds the document that they do not.
+ * 🔴 A renewal is fenced on its TOKEN, not on the effect run. A takeover
+ * replaces the token WITHIN a run, so two heartbeats can overlap across it: a
+ * `lost` answer belonging to the displaced token would otherwise clear the claim
+ * the takeover just won.
  *
- * ## One acquire at a time
+ * 🔴 A claim is fenced on its SEQUENCE. Two acquisitions can be outstanding at
+ * once, and the server treats a live claim from the same owner as takeable, so
+ * the later one to commit wins and the other's token is already dead.
  *
- * 🔴 A second acquire cannot start while one is pending. The server treats a
- * live claim from the SAME owner as takeable, so a duplicate acquire mints a
- * fresh token and invalidates the one still in flight; whichever reply lands
- * second wins, and the editor can be left holding a token the server has already
- * replaced — renewing into a takeover that names the editor themselves.
+ * ## Nothing is aborted
+ *
+ * 🔴 A claim is not idempotent, so aborting one makes its outcome UNKNOWABLE:
+ * the request may still commit, and an aborted fetch can never hand back the
+ * token it was given. The editor would then hold a token the server has
+ * replaced with one it can never learn.
+ *
+ * So a slow claim is not cancelled — only its hold on the slot expires. The
+ * reply still arrives, and if the slot has moved on the token it carries is
+ * released as the duplicate it is. That converges without the server needing to
+ * know anything about client retries.
+ *
+ * ## Intent survives the wait
+ *
+ * 🔴 A person pressing "take over" is a decision, and a poll is not. Whatever is
+ * waiting on the slot is remembered as an intent rather than a boolean, a
+ * take-over outranks a queued claim, and a take-over whose request outlives the
+ * slot is re-asked as a take-over. Losing it turns the decision into a poll that
+ * politely declines to displace anyone.
  *
  * ## The beat outlives the claim
  *
@@ -114,6 +127,9 @@ export interface UseDocumentLockOptions {
   enabled?: boolean;
 }
 
+/** What is waiting for the acquisition slot. A decision outranks a poll. */
+type ClaimIntent = "takeover" | "claim";
+
 /** Whether two holder readings say the same thing, so a poll can stay quiet. */
 function sameHolder(a: DocumentLockHolder, b: DocumentLockHolder): boolean {
   return (
@@ -121,6 +137,15 @@ function sameHolder(a: DocumentLockHolder, b: DocumentLockHolder): boolean {
     a.ownerLabel === b.ownerLabel &&
     a.expiresInSeconds === b.expiresInSeconds
   );
+}
+
+/** Names one document, so a repair meant for it cannot land on another. */
+function documentKey(
+  scopeKind: DocumentScopeKind,
+  slug: string,
+  entryId: string
+): string {
+  return `${scopeKind}:${slug}:${entryId}`;
 }
 
 export function useDocumentLock({
@@ -141,9 +166,10 @@ export function useDocumentLock({
   // run whose cleanup has already happened can still have a request in flight,
   // and the server treats a claim from the same owner as takeable, so that late
   // reply displaces the run that replaced it. This is how the run that got
-  // displaced hears about it; a run that has itself been cleaned up refuses the
-  // call, so an unmounted editor wakes nobody.
-  const reacquireRef = useRef<() => void>(() => {});
+  // displaced hears about it. It carries the document the repair is FOR: a run
+  // editing another document was never displaced, since the two claims use
+  // different lock keys, and waking it would start a claim nobody asked for.
+  const reacquireRef = useRef<(forDocument: string) => void>(() => {});
 
   const active = enabled && Boolean(entryId);
   // Memoised on the three primitives that identify the document. Rebuilt every
@@ -160,15 +186,21 @@ export function useDocumentLock({
       return;
     }
 
+    const key = documentKey(ref.scopeKind, ref.slug, ref.entryId);
+
     let cancelled = false;
     let token: string | null = null;
     let confirmedAt = Date.now();
     let holder: DocumentLockHolder | null = null;
-    let acquiring = false;
-    // A person pressing "take over" while a poll is mid-flight must not lose the
-    // click. Serialising without this turns their decision into silence, and the
-    // poll that displaced it only ever asks politely.
-    let queuedTakeover = false;
+    // The acquisition holding the slot, and what waits behind it.
+    let claimSeq = 0;
+    let inFlight: number | null = null;
+    let pending: ClaimIntent | null = null;
+    // 🔴 A separate fact from `pending`, though both mean "ask again". A queued
+    // claim or take-over is SATISFIED by winning the document; a repair is not,
+    // because the very thing it reports is that the token just installed may
+    // already be dead. Collapsing them lets a win swallow the repair.
+    let repairNeeded = false;
     // Set when this editor stops being a contender: displaced by the server, or
     // past its own deadline. The beat then waits for the person rather than
     // re-taking a claim they were just told they had lost.
@@ -186,22 +218,39 @@ export function useDocumentLock({
         .delete("/document-lock", { ...ref, claimToken })
         .catch(() => undefined);
 
-    /**
-     * Store a claim this editor now holds.
-     *
-     * 🔴 `sentAt` is when the request was DISPATCHED, not when its reply arrived.
-     * The lease starts when the server processes the claim, so timing it from
-     * receipt credits this editor with however long the reply spent in transit —
-     * and a reply delayed past the margin has the hook reporting a claim that
-     * expired server-side while a colleague can already take the row.
-     */
+    /** Remember what still has to be asked. A decision outranks a poll. */
+    const remember = (intent: ClaimIntent) => {
+      if (intent === "takeover" || pending === null) pending = intent;
+    };
+
+    /** Ask for whatever was waiting, once the slot is free. */
+    const drain = () => {
+      if (cancelled || inFlight !== null) return;
+      if (repairNeeded) {
+        repairNeeded = false;
+        surrendered = false;
+        void acquire(false);
+        return;
+      }
+      if (pending === null) return;
+      const intent = pending;
+      pending = null;
+      void acquire(intent === "takeover");
+    };
+
+    /** Store a claim this editor now holds. */
     const installAcquired = (claimToken: string, sentAt: number) => {
       token = claimToken;
+      // A new claim is a new lease, timed from when it was asked for.
       confirmedAt = sentAt;
       holder = null;
       surrendered = false;
-      // Already holding it: a queued take-over would only displace ourselves.
-      queuedTakeover = false;
+      // 🔴 Whatever a person or a poll was waiting for has already been got. A
+      // take-over queued behind a poll that then WON must not be carried into a
+      // later claim and spent displacing a colleague nobody asked to displace.
+      // `repairNeeded` is deliberately untouched: winning is exactly what a
+      // repair is about, since the token just installed may be the dead one.
+      pending = null;
       setState({ status: "held-by-me" });
     };
 
@@ -216,90 +265,100 @@ export function useDocumentLock({
       }
     };
 
-    const acquire = async (takeover: boolean) => {
-      if (acquiring) {
-        if (takeover) queuedTakeover = true;
+    /** Report that the server could not be asked, and forget what it last said. */
+    const installUnavailable = () => {
+      if (cancelled) return;
+      // 🔴 Forget the holder as well as the state. Kept, an identical reading on
+      // the next successful poll is suppressed as "nothing changed" and the
+      // editor stays on `unavailable` while the server is answering perfectly
+      // well — which is plausible whenever the holder renews on this cadence.
+      holder = null;
+      setState({ status: "unavailable" });
+    };
+
+    /**
+     * Give up the SLOT without giving up the request.
+     *
+     * 🔴 Not an abort. A claim is not idempotent, so cancelling one makes its
+     * outcome unknowable: it may still commit, and an aborted fetch can never
+     * hand back the token it was given. Letting the slot go frees the beat while
+     * the answer is still coming.
+     */
+    const expireSlot = (seq: number, intent: ClaimIntent) => {
+      if (inFlight !== seq) return;
+      inFlight = null;
+      installUnavailable();
+      // The intent outlives its request: a person's take-over must not quietly
+      // become a poll that declines to displace anyone.
+      remember(intent);
+      drain();
+    };
+
+    /** Report a claim that could not be sent, keeping a decision for the beat. */
+    const failClaim = (seq: number, intent: ClaimIntent) => {
+      if (inFlight === seq) inFlight = null;
+      installUnavailable();
+      // Kept for the beat rather than retried here, which would spin against a
+      // server that is down. A take-over is kept because it was a decision.
+      if (intent === "takeover") remember("takeover");
+    };
+
+    /**
+     * Hand back a claim that arrived too late to be this editor's.
+     *
+     * 🔴 And say so. The server treats a claim from the same owner as takeable,
+     * so this reply displaced whatever holds the document now; releasing it
+     * quietly leaves that holder on a token the server has already forgotten.
+     */
+    const discardDuplicate = (item: AcquireDocumentLockOutcome) => {
+      if (item.status !== "acquired") return;
+      release(item.claimToken);
+      reacquireRef.current(key);
+    };
+
+    async function acquire(takeover: boolean): Promise<void> {
+      const intent: ClaimIntent = takeover ? "takeover" : "claim";
+      if (inFlight !== null) {
+        remember(intent);
         return;
       }
-      acquiring = true;
-      // 🔴 Bounded, because a request that never settles is not the same as one
-      // that fails. Nothing here would ever clear `acquiring`, so every later
-      // beat would return at the serialisation guard and the editor would sit in
-      // `acquiring` for the whole session with a take-over queued behind a
-      // request that is never coming back. One heartbeat is the bound: a claim
-      // that has not answered within a beat cannot help this beat.
-      const bound = new AbortController();
-      const boundTimer = setTimeout(
-        () => bound.abort(),
+
+      const seq = (claimSeq += 1);
+      inFlight = seq;
+      const sentAt = Date.now();
+      const slotExpiry = setTimeout(
+        () => expireSlot(seq, intent),
         DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS
       );
-      const sentAt = Date.now();
+
       let item: AcquireDocumentLockOutcome;
       try {
         ({ item } = await protectedApi.post<
           MutationResponse<AcquireDocumentLockOutcome>
-        >("/document-lock", { ...ref, takeover }, { signal: bound.signal }));
+        >("/document-lock", { ...ref, takeover }));
       } catch {
-        clearTimeout(boundTimer);
-        // 🔴 Reported, not swallowed. A rejected acquire leaves no token, and
-        // every later beat would exit at its token guard, so an editor would
-        // spend the whole session silently unprotected. The beat retries.
-        acquiring = false;
-        if (!cancelled) {
-          // 🔴 Forget the holder as well as the state. Kept, an identical reading
-          // on the next successful poll is suppressed as "nothing changed" and
-          // the editor stays on `unavailable` while the server is answering
-          // perfectly well — which is plausible whenever the holder renews on
-          // this same cadence.
-          holder = null;
-          setState({ status: "unavailable" });
-        }
-        drainQueuedTakeover();
+        clearTimeout(slotExpiry);
+        failClaim(seq, intent);
         return;
       }
-      clearTimeout(boundTimer);
-      acquiring = false;
+      clearTimeout(slotExpiry);
 
-      if (cancelled) {
-        // 🔴 The claim outlived the run that asked for it: this reply landed
-        // after cleanup, which found no token to release. Releasing it here is
-        // the difference between a colleague waiting one request and waiting a
-        // whole lease.
-        if (item.status === "acquired") {
-          release(item.claimToken);
-          // 🔴 And repair what winning it broke. The server treats a claim from
-          // the same owner as takeable, so this late reply DISPLACED whichever
-          // run replaced this one: releasing it now would leave that run holding
-          // a token the server has already forgotten, believing it is safe until
-          // a heartbeat says otherwise.
-          //
-          // Safe to call unconditionally. The signal is published by whichever
-          // run is live, and a run that has been cleaned up refuses it, so after
-          // an unmount there is nobody to wake and this does nothing.
-          reacquireRef.current();
-        }
+      // The slot moved on without this request, so whatever it won is a
+      // duplicate: a later acquisition has already replaced it server-side, or
+      // is about to.
+      const superseded = inFlight !== seq;
+      if (!superseded) inFlight = null;
+
+      if (cancelled || superseded) {
+        discardDuplicate(item);
+        if (superseded) drain();
         return;
       }
 
-      if (item.status === "acquired") {
-        installAcquired(item.claimToken, sentAt);
-        return;
-      }
-
-      installHeld(item.holder);
-      // 🔴 Only once the answer is stored, and only when it was a refusal.
-      // Draining first fires a second acquire against a claim this one may have
-      // just won, and if that one rejects it reports the claim unavailable over
-      // a token that is held and still renewing.
-      drainQueuedTakeover();
-    };
-
-    /** Run a take-over that arrived while another request held the slot. */
-    const drainQueuedTakeover = () => {
-      if (!queuedTakeover || cancelled) return;
-      queuedTakeover = false;
-      void acquire(true);
-    };
+      if (item.status === "acquired") installAcquired(item.claimToken, sentAt);
+      else installHeld(item.holder);
+      drain();
+    }
 
     /** Give the claim up, and hand back whatever the server may still be holding. */
     const surrender = (next: DocumentLockState) => {
@@ -315,10 +374,12 @@ export function useDocumentLock({
     };
 
     takeOverRef.current = () => void acquire(true);
-    reacquireRef.current = () => {
-      if (cancelled) return;
-      surrendered = false;
-      void acquire(false);
+    reacquireRef.current = (forDocument: string) => {
+      if (cancelled || forDocument !== key) return;
+      // Queued rather than asked directly: the live run may have a claim of its
+      // own still open, and the slot admits one at a time.
+      repairNeeded = true;
+      drain();
     };
     void acquire(false);
 
@@ -332,6 +393,14 @@ export function useDocumentLock({
         Date.now() - confirmedAt >= DOCUMENT_LOCK_LOSS_AFTER_MS
       ) {
         surrender({ status: "lost" });
+        return;
+      }
+
+      // A decision or a repair waiting on the slot is asked before anything
+      // else, so neither is overtaken by the poll below and turned into a
+      // polite request that declines to displace anyone.
+      if (pending !== null || repairNeeded) {
+        drain();
         return;
       }
 
@@ -359,7 +428,10 @@ export function useDocumentLock({
         .then(({ item }) => {
           if (cancelled || sent !== token) return;
           if (item.status === "renewed") {
-            confirmedAt = renewSentAt;
+            // 🔴 Never backwards. Replies can arrive out of order, and an older
+            // renewal landing after a newer one would shorten a lease the newer
+            // one already extended — firing the deadline several beats early.
+            confirmedAt = Math.max(confirmedAt, renewSentAt);
             return;
           }
           surrender({ status: "taken-over", holder: item.holder });
@@ -372,8 +444,9 @@ export function useDocumentLock({
     return () => {
       cancelled = true;
       takeOverRef.current = () => {};
-      // Left for the run that replaces this one to overwrite. Clearing it would
-      // drop the repair signal in exactly the window it exists for.
+      // `reacquireRef` is left for the run that replaces this one to overwrite,
+      // and refuses a document it does not own, so a late reply cannot wake an
+      // editor that has gone or one looking at something else.
       clearInterval(heartbeat);
       if (token !== null) release(token);
     };

--- a/packages/module-specifiers/src/index.test.ts
+++ b/packages/module-specifiers/src/index.test.ts
@@ -300,3 +300,47 @@ describe("module.require", () => {
     ).toEqual([]);
   });
 });
+
+/**
+ * The receiver, seen through what the language lets you write around it.
+ */
+describe("module.require through wrappers and shadows", () => {
+  it.each([
+    `const a = (module).require("pkg");`,
+    `const a = (module as NodeModule).require("pkg");`,
+    `const a = module!.require("pkg");`,
+    `const a = (module satisfies object).require("pkg");`,
+    `const a = ((module)).require("pkg");`,
+  ])("still reads it in %s", source => {
+    // 🔴 Each of these reads the same binding. A check on the receiver as
+    // written treats them as somebody else's property and reports the file as
+    // loading nothing, which is a bypass anyone can reach by accident.
+    expect(importedSpecifiers(source, "m.ts")).toEqual(["pkg"]);
+  });
+
+  it.each([
+    `function f(module: { require(id: string): unknown }) { return module.require("pkg"); }`,
+    `const module = { require: (id: string) => id };\nconst a = module.require("pkg");`,
+  ])(
+    "claims no dependency when the file declares its own module: %s",
+    source => {
+      // 🔴 The false direction for a guard. Renaming the identical receiver to
+      // `loader` already makes the report disappear, which is the tell that it was
+      // about the name rather than the thing.
+      expect(importedSpecifiers(source, "m.ts")).toEqual([]);
+    }
+  );
+
+  it("reports only the real import when module is a default binding", () => {
+    // The import itself is a specifier and stays one; what goes is the invented
+    // dependency on "pkg" that the file never loads.
+    const source = `import module from "elsewhere";\nconst a = module.require("pkg");`;
+    expect(importedSpecifiers(source, "m.ts")).toEqual(["elsewhere"]);
+  });
+
+  it("still sees a bare require in a file that shadows module", () => {
+    // The shadow is about the receiver, not about the file.
+    const source = `function f(module: unknown) { return module; }\nconst a = require("pkg");`;
+    expect(importedSpecifiers(source, "m.ts")).toEqual(["pkg"]);
+  });
+});

--- a/packages/module-specifiers/src/index.test.ts
+++ b/packages/module-specifiers/src/index.test.ts
@@ -258,3 +258,45 @@ describe("whether a reference survives to runtime", () => {
     );
   });
 });
+
+/**
+ * `module.require` is the documented CommonJS method and resolves exactly as the
+ * free function does, so a reader that sees only the bare identifier reports a
+ * file loading nothing while it loads a driver.
+ */
+describe("module.require", () => {
+  it("reads it as a runtime resolve", () => {
+    expect(
+      importedSpecifiers(`const a = module.require("pkg");`, "m.ts")
+    ).toEqual(["pkg"]);
+    expect(
+      moduleSpecifierRefs(`const a = module.require("pkg");`, "m.ts")
+    ).toEqual([{ specifier: "pkg", typeOnly: false }]);
+  });
+
+  it("reads the bracket spelling the same way", () => {
+    // `a.b` and `a["b"]` are the same read, and a rule for one is a rule the
+    // other walks around.
+    expect(
+      importedSpecifiers(`const a = module["require"]("pkg");`, "m.ts")
+    ).toEqual(["pkg"]);
+  });
+
+  it("keeps an unreadable target unreadable", () => {
+    expect(
+      importedSpecifiers(`const a = module.require(name);`, "m.ts")
+    ).toEqual([UNRESOLVABLE_SPECIFIER]);
+  });
+
+  it("leaves a require method on some other object alone", () => {
+    // 🔴 The negative control. Treating every `.require` as a resolve reports
+    // ordinary code as a dependency nobody has, and a rule that fires on correct
+    // code stops being read.
+    expect(
+      importedSpecifiers(`const a = loader.require("pkg");`, "m.ts")
+    ).toEqual([]);
+    expect(
+      importedSpecifiers(`const a = holder["require"]("pkg");`, "m.ts")
+    ).toEqual([]);
+  });
+});

--- a/packages/module-specifiers/src/index.ts
+++ b/packages/module-specifiers/src/index.ts
@@ -52,8 +52,9 @@ export const UNRESOLVABLE_SPECIFIER = "<unresolvable-specifier>";
  * - `import ... from` and `export ... from`, which carry a module specifier.
  * - `import "pkg"`, a bare side-effect import, which carries no bindings.
  * - `import("pkg")` and `require("pkg")`, which are call expressions. A bare
- *   `require` identifier only: `loader.require("x")` is a method on some object,
- *   not a module resolve.
+ *   `require` identifier, or `module.require` — the documented CommonJS method,
+ *   which resolves exactly as the free function does. `loader.require("x")` is a
+ *   method on some other object and is not a module resolve.
  * - `import x = require("pkg")`, the documented CommonJS-interop spelling, which
  *   is neither of the above.
  * - `typeof import("pkg")` in type position, which the parser gives as an
@@ -78,6 +79,37 @@ export const UNRESOLVABLE_SPECIFIER = "<unresolvable-specifier>";
  * over a file that was never read, and it was a live defect in two of the
  * readers this replaces. A default would let any caller reintroduce it silently.
  */
+/**
+ * Whether an expression is `module.require`, however it is spelled.
+ *
+ * `module.require` is the documented CommonJS method and resolves exactly as the
+ * free `require` does, so a reader that recognises only the bare identifier
+ * reports a file loading nothing while it loads a driver. `a.b` and `a["b"]` are
+ * the same read, and a rule for one is a rule the other walks around.
+ *
+ * Deliberately narrow: the receiver has to be `module` itself. `loader.require`
+ * is a method on somebody else's object, and treating every `.require` as a
+ * resolve would report ordinary code as a dependency nobody has.
+ */
+function readsModuleRequire(callee: ts.Expression): boolean {
+  const receiver = ts.isPropertyAccessExpression(callee)
+    ? callee.expression
+    : ts.isElementAccessExpression(callee)
+      ? callee.expression
+      : null;
+  if (
+    receiver === null ||
+    !ts.isIdentifier(receiver) ||
+    receiver.text !== "module"
+  ) {
+    return false;
+  }
+  if (ts.isPropertyAccessExpression(callee))
+    return callee.name.text === "require";
+  const key = (callee as ts.ElementAccessExpression).argumentExpression;
+  return ts.isStringLiteralLike(key) && key.text === "require";
+}
+
 export function importedSpecifiers(text: string, fileName: string): string[] {
   return moduleSpecifierRefs(text, fileName).map(ref => ref.specifier);
 }
@@ -183,7 +215,8 @@ export function moduleSpecifierRefs(
       const callee = node.expression;
       const resolvesAModule =
         callee.kind === ts.SyntaxKind.ImportKeyword ||
-        (ts.isIdentifier(callee) && callee.text === "require");
+        (ts.isIdentifier(callee) && callee.text === "require") ||
+        readsModuleRequire(callee);
       if (resolvesAModule) {
         const target = node.arguments[0];
         found.push({

--- a/packages/module-specifiers/src/index.ts
+++ b/packages/module-specifiers/src/index.ts
@@ -80,6 +80,75 @@ export const UNRESOLVABLE_SPECIFIER = "<unresolvable-specifier>";
  * readers this replaces. A default would let any caller reintroduce it silently.
  */
 /**
+ * See through wrappers that change the type or the grouping, never the object.
+ *
+ * `(module).require(...)`, `(module as NodeModule).require(...)` and
+ * `module!.require(...)` all read the same binding. A check on the receiver as
+ * written treats each as somebody else's property and reports the file as loading
+ * nothing, which is a bypass anyone can reach by accident.
+ */
+function unwrapReceiver(expression: ts.Expression): ts.Expression {
+  let current: ts.Expression = expression;
+  while (
+    ts.isParenthesizedExpression(current) ||
+    ts.isAsExpression(current) ||
+    ts.isNonNullExpression(current) ||
+    ts.isSatisfiesExpression(current)
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
+/**
+ * Whether the file introduces a binding of its own called `module`.
+ *
+ * 🔴 A file that declares `module` — a parameter, a variable, an import — is not
+ * talking about the CommonJS loader when it writes `module.require`, and
+ * reporting a dependency it never loads is the FALSE direction for a guard: a
+ * rule that fires on correct code stops being read. Renaming the identical
+ * receiver to `loader` already makes the report disappear, which is the tell that
+ * it was about the name rather than the thing.
+ *
+ * File-granular rather than scope-precise, and deliberately so: resolving a name
+ * to its declaration needs a program and a checker, which this reader exists to
+ * work without. The gap it leaves is a file that shadows `module` in one function
+ * and uses the real loader in another, where this reports neither.
+ */
+/** Every node kind that introduces a name a later expression can read. */
+const BINDING_KINDS: ReadonlySet<ts.SyntaxKind> = new Set([
+  ts.SyntaxKind.VariableDeclaration,
+  ts.SyntaxKind.Parameter,
+  ts.SyntaxKind.BindingElement,
+  ts.SyntaxKind.FunctionDeclaration,
+  ts.SyntaxKind.ClassDeclaration,
+  ts.SyntaxKind.ImportClause,
+  ts.SyntaxKind.ImportSpecifier,
+  ts.SyntaxKind.NamespaceImport,
+]);
+
+/** Whether one node binds the name `module`. */
+function bindsModule(node: ts.Node): boolean {
+  if (!BINDING_KINDS.has(node.kind)) return false;
+  const { name } = node as ts.NamedDeclaration;
+  return name !== undefined && ts.isIdentifier(name) && name.text === "module";
+}
+
+function declaresOwnModule(source: ts.SourceFile): boolean {
+  let declared = false;
+  const visit = (node: ts.Node): void => {
+    if (declared) return;
+    if (bindsModule(node)) {
+      declared = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  return declared;
+}
+
+/**
  * Whether an expression is `module.require`, however it is spelled.
  *
  * `module.require` is the documented CommonJS method and resolves exactly as the
@@ -87,15 +156,17 @@ export const UNRESOLVABLE_SPECIFIER = "<unresolvable-specifier>";
  * reports a file loading nothing while it loads a driver. `a.b` and `a["b"]` are
  * the same read, and a rule for one is a rule the other walks around.
  *
- * Deliberately narrow: the receiver has to be `module` itself. `loader.require`
- * is a method on somebody else's object, and treating every `.require` as a
- * resolve would report ordinary code as a dependency nobody has.
+ * Deliberately narrow: the receiver has to be `module` itself, seen through
+ * casts and grouping, and the file must not have introduced a `module` of its
+ * own. `loader.require` is a method on somebody else's object, and treating every
+ * `.require` as a resolve would report ordinary code as a dependency nobody has.
  */
-function readsModuleRequire(callee: ts.Expression): boolean {
-  const receiver = ts.isPropertyAccessExpression(callee)
-    ? callee.expression
-    : ts.isElementAccessExpression(callee)
-      ? callee.expression
+function readsModuleRequire(callee: ts.Expression, shadowed: boolean): boolean {
+  if (shadowed) return false;
+  const receiver =
+    ts.isPropertyAccessExpression(callee) ||
+    ts.isElementAccessExpression(callee)
+      ? unwrapReceiver(callee.expression)
       : null;
   if (
     receiver === null ||
@@ -158,6 +229,7 @@ export function moduleSpecifierRefs(
     true
   );
   const found: ModuleSpecifierRef[] = [];
+  const shadowsModule = declaresOwnModule(source);
   const seen = new Set<ts.Node>();
 
   const visit = (node: ts.Node): void => {
@@ -216,7 +288,7 @@ export function moduleSpecifierRefs(
       const resolvesAModule =
         callee.kind === ts.SyntaxKind.ImportKeyword ||
         (ts.isIdentifier(callee) && callee.text === "require") ||
-        readsModuleRequire(callee);
+        readsModuleRequire(callee, shadowsModule);
       if (resolvesAModule) {
         const target = node.arguments[0];
         found.push({


### PR DESCRIPTION
## Summary

#1582 merged with five review findings still open. All five were real; this closes them. Four are in the lock hook, one is in the reader the client-bundle boundary depends on.

### A claim is credited from when it was sent

The lease starts when the **server** processes a claim, so timing it from the reply credits the editor with however long that reply spent in transit. A reply delayed past the 30s margin left the hook reporting `held-by-me` for a claim that had already expired server-side, while a colleague could take the row.

Both the acquisition and the renewal now install the dispatch timestamp.

### A request that never settles is bounded

A pending request is not a failed one, and nothing cleared the one-at-a-time slot for it. Every later beat returned at the serialisation guard, so the editor sat in `acquiring` for the whole session — with a take-over queued behind a request that was never coming back. `fetcher` passes `RequestInit` through, so claims now carry an `AbortSignal` bounded by one heartbeat and the next beat retries.

The test mocks the signal the way `fetch` behaves, since that abort is the mechanism under test.

### A failed poll forgets its cached holder

The quiet-poll comparison exists so a colleague holding the document does not re-render the editor every 15s. Kept across a failure, an identical reading on the next successful poll is suppressed as "nothing changed" and the editor is stranded on `unavailable` while the server answers perfectly well — plausible precisely because the holder renews on this same cadence.

### A late reply repairs what winning it broke

The server treats a claim from the same owner as takeable, so a request still in flight when its effect was cleaned up **displaces the run that replaced it**. Handing that claim back then left the live run holding a token the server had already forgotten, reporting `held-by-me` over nothing until a heartbeat noticed.

The displaced run is now told to claim again. Worth noting what this did **not** need: a second generation counter beside the token fence. React runs a cleanup before the effect that replaces it, and the repair signal is refused by a run that has itself been cleaned up — so an unmounted editor wakes nobody. I wrote that extra check first, and removed it when a mutation showed nothing could fail on it.

### `module.require` counts as loading a module

It is the documented CommonJS method and resolves exactly as the free function does, so `@nextlyhq/module-specifiers` reported a file loading nothing while it loaded a driver — and the new client-bundle boundary that reads it would have certified such a graph as clean. The repository's own `packages/ui/src/layering.test.ts` already treats `module.require` as a runtime resolver, so the two readers disagreed.

Both spellings, since `a.b` and `a["b"]` are the same read. Deliberately narrow: the receiver must be `module` itself, because treating every `.require` as a resolve reports ordinary code as a dependency nobody has.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

Follows #1582, which merged with these five findings open.

## Changeset

- [x] I added a changeset
- [x] I selected the correct semver bump (patch)

Names all 25 lockstep packages, generated from `.changeset/config.json`.

## Test plan

Exit codes captured directly:

- [x] `pnpm build` — 19/19
- [x] `pnpm check-types` — 42/42
- [x] `pnpm lint` — 24/24
- [x] `pnpm test` — 38/38 (the lock hook alone is 31 cases; `module-specifiers` 37)
- [x] `pnpm test:scripts` — 936, run twice
- [x] `pnpm lint:design`, `pnpm check:comments`, `pnpm lint:workspace`
- [x] `fallow audit --gate new-only` — `verdict: pass`, `complexity_introduced: 0`

**Mutation-tested.** Every guard added here was broken on purpose and the suite confirmed to notice: crediting a renewal from its reply, crediting a claim from its reply, never aborting a stalled claim, keeping the cached holder through a failure, releasing a late claim without repairing, forgetting `module.require`, treating every `.require` as a resolve, and missing the bracket spelling. Two further mutations **survived** and were fixed by deleting the redundant code rather than by contriving a test for it.

## Notes for reviewers

The judgement worth checking is the abort bound. One heartbeat means a claim that has not answered within a beat is abandoned and retried — but an aborted request may still have been processed server-side, leaving a claim this editor does not know it holds. That is bounded by the lease and reclaimed by the next acquire, since the same owner is takeable, and it is stated in the code rather than left to be discovered.
