### PR TITLE
fix(blocks-engine): refuse a malformed root before reading the site settings

### DIFF
--- a/.changeset/malformed-root-before-settings.md
+++ b/.changeset/malformed-root-before-settings.md
@@ -33,7 +33,12 @@ malformed-root refusal too, so a `null`, a primitive or an array — a value tha
 was never going to be validated — still caused the caller's breakpoint settings
 to be read, and an adversarial set escaped as a native error.
 
-The coarse root test asks nothing that can throw: `typeof`, a null comparison
-and `Array.isArray` run no user code, where asking for a prototype is something
-a hostile root can refuse. So the coarse question is settled first and the
-precise one stays where it was, after the survey has had its say.
+The coarse root test runs no user code: `typeof`, a null comparison and
+`Array.isArray` invoke no trap, where asking for a prototype is something a
+hostile root can refuse. So the coarse question is settled first and the precise
+one stays where it was, after the survey has had its say.
+
+`Array.isArray` can still throw even though it runs nothing — a revoked proxy
+refuses the array brand rather than answering it — so it is wrapped, and a root
+that cannot answer reaches the survey's readability verdict instead of being
+refused on a question nothing answered.

--- a/.changeset/malformed-root-before-settings.md
+++ b/.changeset/malformed-root-before-settings.md
@@ -1,0 +1,39 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A wholly malformed document is refused before the site's settings are read.
+
+Moving the breakpoint scan ahead of the readability gate put it ahead of the
+malformed-root refusal too, so a `null`, a primitive or an array — a value that
+was never going to be validated — still caused the caller's breakpoint settings
+to be read, and an adversarial set escaped as a native error.
+
+The coarse root test asks nothing that can throw: `typeof`, a null comparison
+and `Array.isArray` run no user code, where asking for a prototype is something
+a hostile root can refuse. So the coarse question is settled first and the
+precise one stays where it was, after the survey has had its say.

--- a/.changeset/malformed-root-before-settings.md
+++ b/.changeset/malformed-root-before-settings.md
@@ -42,3 +42,9 @@ one stays where it was, after the survey has had its say.
 refuses the array brand rather than answering it — so it is wrapped, and a root
 that cannot answer reaches the survey's readability verdict instead of being
 refused on a question nothing answered.
+
+Both readings now live beside each other as `isPlainRecord` and
+`definitelyNotARecord`, sharing the clause they agree on and reporting one
+issue. The throw-free reading refuses only what the full one would refuse, so
+asking it early can never disagree with asking the full one late — a property
+asserted over a shared table of root shapes rather than left as a convention.

--- a/packages/blocks-engine/src/plain-record.test.ts
+++ b/packages/blocks-engine/src/plain-record.test.ts
@@ -1,0 +1,97 @@
+/**
+ * The two readings of "is this a record", and the relationship between them.
+ *
+ * @module plain-record.test
+ */
+import { describe, expect, it } from "vitest";
+
+import { definitelyNotARecord, isPlainRecord } from "./plain-record";
+
+/**
+ * Every root shape either reading has an opinion about.
+ *
+ * One table, shared, so the property below is asserted over the same
+ * population both functions are asked about — a second list per test would let
+ * a shape be added to one and not the other, which is the drift the property
+ * exists to catch.
+ */
+function roots(): { name: string; value: unknown }[] {
+  const { proxy, revoke } = Proxy.revocable({} as Record<string, unknown>, {});
+  revoke();
+  return [
+    { name: "null", value: null },
+    { name: "undefined", value: undefined },
+    { name: "a number", value: 7 },
+    { name: "a string", value: "{}" },
+    { name: "a boolean", value: false },
+    { name: "a symbol", value: Symbol("root") },
+    { name: "a function", value: () => undefined },
+    { name: "an array", value: [] },
+    { name: "an object literal", value: {} },
+    { name: "a null-prototype object", value: Object.create(null) },
+    { name: "a Date", value: new Date() },
+    { name: "a Map", value: new Map() },
+    { name: "a class instance", value: new (class {})() },
+    { name: "a revoked proxy", value: proxy },
+  ];
+}
+
+describe("the throw-free reading never accepts what the full one refuses", () => {
+  it.each(roots())("holds for $name", ({ value }) => {
+    // The property that makes two readings of one question safe: refusing early
+    // can only ever agree with refusing late. A reading that answered `true`
+    // for something `isPlainRecord` accepts would refuse a valid document
+    // before the caller's settings were even read.
+    if (!definitelyNotARecord(value)) return;
+
+    let full: boolean;
+    try {
+      full = isPlainRecord(value);
+    } catch {
+      // A value whose prototype cannot be read is not one the full reading
+      // accepts either, which is what the property claims.
+      return;
+    }
+    expect(full).toBe(false);
+  });
+
+  it("is not vacuous: the table contains values it refuses AND values it does not", () => {
+    // Without this the property above passes on a table of nothing but records,
+    // and on an implementation that answers `false` to everything.
+    const refused = roots().filter(root => definitelyNotARecord(root.value));
+    const undecided = roots().filter(root => !definitelyNotARecord(root.value));
+
+    expect(refused.length).toBeGreaterThan(0);
+    expect(undecided.length).toBeGreaterThan(0);
+  });
+});
+
+describe("the throw-free reading answers where the full one throws", () => {
+  it("declines to refuse a revoked proxy rather than throwing", () => {
+    const { proxy, revoke } = Proxy.revocable(
+      {} as Record<string, unknown>,
+      {}
+    );
+    revoke();
+
+    // It cannot say, so it does not refuse — and the caller's later, fuller
+    // reading is what decides. The control is the full reading on the same
+    // value, which throws.
+    expect(definitelyNotARecord(proxy)).toBe(false);
+    expect(() => isPlainRecord(proxy)).toThrow(TypeError);
+  });
+
+  it("declines to refuse an object whose prototype trap throws", () => {
+    const hostile = new Proxy(
+      {},
+      {
+        getPrototypeOf() {
+          throw new Error("the prototype is not for reading");
+        },
+      }
+    );
+
+    expect(definitelyNotARecord(hostile)).toBe(false);
+    expect(() => isPlainRecord(hostile)).toThrow();
+  });
+});

--- a/packages/blocks-engine/src/plain-record.ts
+++ b/packages/blocks-engine/src/plain-record.ts
@@ -17,7 +17,49 @@
 export function isPlainRecord(
   value: unknown
 ): value is Record<string, unknown> {
-  if (typeof value !== "object" || value === null) return false;
+  if (notAnObject(value)) return false;
   const prototype = Object.getPrototypeOf(value) as unknown;
   return prototype === Object.prototype || prototype === null;
+}
+
+/**
+ * The part of {@link isPlainRecord} that runs no user code, for callers that
+ * cannot afford to run any yet.
+ *
+ * It answers `true` only when the value is a record under NO reading — a
+ * primitive, `null`, an array — and `false` for everything whose record-ness
+ * only the prototype can settle. So it can refuse earlier than
+ * {@link isPlainRecord} and can never ACCEPT something that would go on to be
+ * refused: `definitelyNotARecord(v)` implies `!isPlainRecord(v)`, which is the
+ * property that makes two readings of one question safe to have.
+ *
+ * Here rather than at the caller, beside the answer it under-approximates.
+ * Both readings share {@link notAnObject}, so the clause they agree on has one
+ * implementation and cannot drift; a copy at the call site would agree until
+ * one of them learned about a shape the other did not.
+ *
+ * `Array.isArray` runs no trap, but it reads the array brand THROUGH a proxy
+ * and a revoked one throws rather than answering. A value that cannot say
+ * whether it is an array cannot be refused on the strength of the question, so
+ * the throw resolves to "not certainly a non-record" and the caller's later,
+ * fuller reading decides.
+ */
+export function definitelyNotARecord(value: unknown): boolean {
+  if (notAnObject(value)) return true;
+  try {
+    return Array.isArray(value);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The cheap half of both readings: a value that is not an object at all cannot
+ * be a record, and finding that out runs nothing.
+ *
+ * Separate so the two readings above state it once. `typeof null` is
+ * `"object"`, which is why the null test is not redundant.
+ */
+function notAnObject(value: unknown): boolean {
+  return typeof value !== "object" || value === null;
 }

--- a/packages/blocks-engine/src/validation.test.ts
+++ b/packages/blocks-engine/src/validation.test.ts
@@ -3327,6 +3327,46 @@ describe("a bag validation has already refused is never enumerated", () => {
     }
   );
 
+  it("sends a root that cannot answer the array question to the survey", () => {
+    // `Array.isArray` runs no trap, but it reads the array brand THROUGH a
+    // proxy and a revoked one throws rather than answering. Asking it bare took
+    // `validate()` out as a native `TypeError` on a root every other release
+    // reported as an issue list.
+    //
+    // A root that cannot answer that question is not thereby a non-record, so
+    // the refusal above is NOT the answer: it is unreadable, which is the
+    // survey's verdict to give, and it reaches the readability gate — which is
+    // also why the site's own duplicate id is still reported for it.
+    const { proxy, revoke } = Proxy.revocable(
+      {} as Record<string, unknown>,
+      {}
+    );
+    revoke();
+    const duplicated = {
+      viewport: [
+        { id: "base", label: "Desktop" },
+        { id: "base", label: "Again" },
+      ],
+      container: [],
+    } as unknown as typeof FIXTURE_BREAKPOINTS;
+
+    let escaped: unknown;
+    let codes: string[] = [];
+    try {
+      codes = validate(proxy as unknown as BlockDocument, {
+        breakpoints: duplicated,
+        mode: "strict",
+      }).map(issue => issue.code);
+    } catch (error) {
+      escaped = error;
+    }
+
+    expect(escaped).toBeUndefined();
+    expect(codes).toContain("document-unwritable");
+    expect(codes).toContain("breakpoint-id-not-unique");
+    expect(codes).not.toContain("invalid-document");
+  });
+
   it("still reports a fault in the site's own breakpoints", () => {
     // `collectBreakpointIds` judges the CALLER's settings, not the document, so
     // a duplicate id among them is true whatever the document turns out to be.

--- a/packages/blocks-engine/src/validation.test.ts
+++ b/packages/blocks-engine/src/validation.test.ts
@@ -3290,6 +3290,43 @@ describe("a bag validation has already refused is never enumerated", () => {
     ).toBe(true);
   });
 
+  it.each([
+    ["null", null],
+    ["a primitive", 7],
+    ["an array", []],
+  ])(
+    "refuses %s as a document without touching the site settings",
+    (_name, root) => {
+      // Hoisting the breakpoint scan ahead of the readability gate put it ahead
+      // of the malformed-root refusal too, so a document that was never going to
+      // be validated still ran the caller's settings — and an adversarial set
+      // escaped as a native error. The coarse root test asks nothing that can
+      // throw, so it can safely come first.
+      const hostile = new Proxy(
+        { viewport: [], container: [] },
+        {
+          getPrototypeOf() {
+            throw new Error("settings should not be read for this document");
+          },
+        }
+      ) as unknown as typeof FIXTURE_BREAKPOINTS;
+
+      let escaped: unknown;
+      let codes: string[] = [];
+      try {
+        codes = validate(root as unknown as BlockDocument, {
+          breakpoints: hostile,
+          mode: "strict",
+        }).map(issue => issue.code);
+      } catch (error) {
+        escaped = error;
+      }
+
+      expect(escaped).toBeUndefined();
+      expect(codes).toEqual(["invalid-document"]);
+    }
+  );
+
   it("still reports a fault in the site's own breakpoints", () => {
     // `collectBreakpointIds` judges the CALLER's settings, not the document, so
     // a duplicate id among them is true whatever the document turns out to be.

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -350,6 +350,32 @@ export interface ValidationResult {
 }
 
 /**
+ * The coarse root question: is this value even a CANDIDATE for a record?
+ *
+ * `typeof` and the null comparison run no code at all. `Array.isArray` runs no
+ * trap either, but it reads the array brand THROUGH a proxy, and a revoked one
+ * throws rather than answering — `TypeError: Cannot perform 'IsArray' on a
+ * proxy that has been revoked`, which leaves a native error where an issue list
+ * is owed. `surveyDocument` wraps the same call for the same reason.
+ *
+ * A root that cannot answer the brand question is NOT thereby a non-record. It
+ * is unreadable, and that verdict belongs to the survey, which has already
+ * recorded it, and to the readability gate that reports it — so the throw
+ * resolves to "not an array" and the value falls through to them. Answering
+ * `true` instead would relabel as `invalid-document` a root the readability
+ * gate reports as `document-unwritable`, and would refuse it on the strength of
+ * a question that was never answered.
+ */
+function malformedRoot(doc: unknown): boolean {
+  if (typeof doc !== "object" || doc === null) return true;
+  try {
+    return Array.isArray(doc);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Issues only — the narrow view, DERIVED from {@link validateDocument} rather
  * than computed beside it.
  *
@@ -389,12 +415,11 @@ export function validateDocument(
   // document that was never going to be validated runs unrelated hostile input
   // for nothing.
   //
-  // Asked with tests that cannot themselves throw. `typeof`, a null comparison
-  // and `Array.isArray` run no user code; `isPlainRecord` asks for the
-  // prototype, and a root that refuses to answer that is exactly the case the
-  // readability gate below exists for. So the coarse question is asked here and
-  // the precise one stays in the envelope, after the survey has had its say.
-  if (typeof doc !== "object" || doc === null || Array.isArray(doc)) {
+  // Coarse, and deliberately so: `isPlainRecord` asks for the prototype, and a
+  // root that refuses to answer that is exactly the case the readability gate
+  // below exists for. So the blunt question is settled here and the precise one
+  // stays in the envelope, after the survey has had its say.
+  if (malformedRoot(doc)) {
     issues.push({
       path: "",
       code: "invalid-document",

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -383,6 +383,27 @@ export function validateDocument(
   const unknownSeverity: IssueSeverity =
     ctx.mode === "strict" ? "error" : "warning";
 
+  // A root that is not even a candidate for a record — `null`, a primitive, an
+  // array — is refused before ANYTHING else is inspected, the caller's own
+  // settings included. Reading an adversarial breakpoint set on behalf of a
+  // document that was never going to be validated runs unrelated hostile input
+  // for nothing.
+  //
+  // Asked with tests that cannot themselves throw. `typeof`, a null comparison
+  // and `Array.isArray` run no user code; `isPlainRecord` asks for the
+  // prototype, and a root that refuses to answer that is exactly the case the
+  // readability gate below exists for. So the coarse question is asked here and
+  // the precise one stays in the envelope, after the survey has had its say.
+  if (typeof doc !== "object" || doc === null || Array.isArray(doc)) {
+    issues.push({
+      path: "",
+      code: "invalid-document",
+      severity: "error",
+      message: "The document must be an object.",
+    });
+    return { issues, survey };
+  }
+
   // The SITE's own breakpoints, before anything about the document is decided.
   // They come from the caller's settings rather than from the document, so a
   // duplicate id among them is true whatever the document turns out to be —

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -34,7 +34,7 @@ import { boundedLimit, surveyDocument } from "./measure-bytes";
 import type { DocumentSurvey } from "./measure-bytes";
 import { canBeRoot, canNest, canNestInSlot } from "./nesting";
 import type { NestingSource } from "./nesting";
-import { isPlainRecord } from "./plain-record";
+import { definitelyNotARecord, isPlainRecord } from "./plain-record";
 import { boundedOwnKeys } from "./safe-record";
 import type { TokenKind } from "./style/catalog-types";
 import { breakpointContexts } from "./style/compile-page";
@@ -350,32 +350,6 @@ export interface ValidationResult {
 }
 
 /**
- * The coarse root question: is this value even a CANDIDATE for a record?
- *
- * `typeof` and the null comparison run no code at all. `Array.isArray` runs no
- * trap either, but it reads the array brand THROUGH a proxy, and a revoked one
- * throws rather than answering — `TypeError: Cannot perform 'IsArray' on a
- * proxy that has been revoked`, which leaves a native error where an issue list
- * is owed. `surveyDocument` wraps the same call for the same reason.
- *
- * A root that cannot answer the brand question is NOT thereby a non-record. It
- * is unreadable, and that verdict belongs to the survey, which has already
- * recorded it, and to the readability gate that reports it — so the throw
- * resolves to "not an array" and the value falls through to them. Answering
- * `true` instead would relabel as `invalid-document` a root the readability
- * gate reports as `document-unwritable`, and would refuse it on the strength of
- * a question that was never answered.
- */
-function malformedRoot(doc: unknown): boolean {
-  if (typeof doc !== "object" || doc === null) return true;
-  try {
-    return Array.isArray(doc);
-  } catch {
-    return false;
-  }
-}
-
-/**
  * Issues only — the narrow view, DERIVED from {@link validateDocument} rather
  * than computed beside it.
  *
@@ -388,6 +362,25 @@ export function validate(
   ctx: ValidationContext
 ): ValidationIssue[] {
   return validateDocument(doc, ctx).issues;
+}
+
+/**
+ * The one issue both root readings report.
+ *
+ * Two places decide a root is not a document — the coarse test before the
+ * caller's settings are read, and the envelope's fuller reading after the
+ * survey — and they say the same thing for the same reason. Written twice, the
+ * two copies agree until someone improves the sentence in one of them, and an
+ * author then reads a different message depending on which shape their document
+ * happens to be broken in.
+ */
+function invalidDocumentIssue(): ValidationIssue {
+  return {
+    path: "",
+    code: "invalid-document",
+    severity: "error",
+    message: "The document must be an object.",
+  };
 }
 
 export function validateDocument(
@@ -415,17 +408,14 @@ export function validateDocument(
   // document that was never going to be validated runs unrelated hostile input
   // for nothing.
   //
-  // Coarse, and deliberately so: `isPlainRecord` asks for the prototype, and a
-  // root that refuses to answer that is exactly the case the readability gate
-  // below exists for. So the blunt question is settled here and the precise one
-  // stays in the envelope, after the survey has had its say.
-  if (malformedRoot(doc)) {
-    issues.push({
-      path: "",
-      code: "invalid-document",
-      severity: "error",
-      message: "The document must be an object.",
-    });
+  // The THROW-FREE reading of the same question the envelope asks in full.
+  // `isPlainRecord` settles it by asking for the prototype, which a hostile root
+  // refuses — exactly the case the readability gate below exists for — so it
+  // cannot run before the survey has had its say. `definitelyNotARecord` never
+  // accepts what its fuller half would refuse, so refusing early here can only
+  // ever agree with the envelope, and the two cannot drift apart.
+  if (definitelyNotARecord(doc)) {
+    issues.push(invalidDocumentIssue());
     return { issues, survey };
   }
 
@@ -569,12 +559,7 @@ function documentEnvelope(
   // untrusted, while `doc` keeps its declared type for the typed helper calls.
   const rawDoc: unknown = doc;
   if (!isPlainRecord(rawDoc)) {
-    issues.push({
-      path: "",
-      code: "invalid-document",
-      severity: "error",
-      message: "The document must be an object.",
-    });
+    issues.push(invalidDocumentIssue());
     return { stop: true };
   }
 


### PR DESCRIPTION
Follow-up to #1589, which merged before this could be folded in. **The regression is on `main` now**, which is why this is its own PR.

## What broke

#1589 moved the breakpoint scan ahead of the readability gate, so that a fault in the site's own settings would still be reported for an unreadable document. That also moved it ahead of the **malformed-root** refusal.

So a `null`, a primitive, or an array — a value that was never going to be validated — still caused the caller's breakpoint settings to be read. With an adversarial set, that escaped `validate()` as a native error:

```
validate(null, { breakpoints: new Proxy(…, { getPrototypeOf() { throw } }), mode: "strict" })
```

Reproduced on all three roots. Each threw `boom` and returned no issues.

## The fix

Refuse the malformed root first, using tests that **cannot themselves throw**: `typeof`, a null comparison, and `Array.isArray` run no user code.

That matters for the ordering. The precise check — `isPlainRecord` — asks for the prototype, and a root that refuses to answer that is exactly what the readability gate exists to catch. So the coarse question is settled here and the precise one stays in the envelope, after the survey has had its say. A hostile root proxy still reaches the gate rather than this line.

## What is preserved

Both behaviours #1589 added still hold, and both are still asserted:

- an **unreadable** document still reports a duplicate breakpoint id, because that scan still runs before the readability gate;
- an unreadable document still stops before any of its own fields are read.

## Evidence

Three tests, one per malformed root, asserting no escape and exactly `["invalid-document"]`. All three fail against `main`.

blocks-engine 2314 passing, 0 typecheck errors. fallow `pass` / 0 introduced, `check:comments` and `check-changesets.mjs` clean.

One note on the local `turbo check-types`: `@nextlyhq/admin` fails in my worktree with `Cannot find module '@nextlyhq/module-specifiers'`. I ran the control — it fails identically on clean `main` with my changes stashed — so it is an unbuilt package in this checkout, not something this PR introduces.
