### PR TITLE
feat(admin): tell an editor who has the document, and let them take it over

### DIFF
--- a/.changeset/an-editor-is-told-who-has-the-document.md
+++ b/.changeset/an-editor-is-told-who-has-the-document.md
@@ -34,22 +34,34 @@ uneditable while somebody else has it. Both are needed: rendered read-only the
 fields are legible but ambiguous, since a tinted uneditable form reads equally as
 a document this account lacks permission to change.
 
-The claim is advisory throughout, and the four decisions that follow from it are
-derived in one place so the collection editor and the single editor cannot
-disagree about them.
+The claim is advisory throughout, and what follows from it is derived in one
+place so the collection editor and the single editor cannot disagree.
 
+- **Every write passes one gate.** Save, Publish, Unpublish, Delete, discarding a
+  working draft, the keyboard shortcut, a native form submit and the quick-edit
+  modal all reach the same handlers, so the refusal lives there. The controls are
+  disabled as well, because nothing should offer what it cannot do, but disabling
+  affordances one at a time is a list the next write path gets added without.
+- **The title and the slug are writes too**, and the same claim withholds them.
+  The title also drives the slug, so leaving it editable contradicted the strip
+  above it.
 - **Asking does not block editing.** Gating every document open on a round trip
   would cost every author on every open, to guard against a case that is rare,
   and a refusal loses nothing since the form is never cleared.
-- **A lock that cannot be checked does not stop work.** The claim exists to tell
-  two people about each other, not to be a permission, so a server that cannot be
-  reached leaves the editor working with a note rather than an outage.
+- **A failure to re-check a KNOWN claim does not unlock the document.** Every beat
+  re-asks, so a transient rejection arrives long after a holder was reported;
+  treating that as "free" hands the document to a second editor while the last
+  confirmed fact is that a colleague holds an unexpired lease. Only a first check
+  that never succeeded leaves the editor working.
 - **A displaced editor keeps what they typed.** Their unsaved work stays on
-  screen and stays theirs; what stops is writing, until they take the document
-  back.
-- **Autosave stops wherever saving stops.** A recovery point is a write to the
-  same row, so leaving it running under someone else's claim is the overwrite the
-  feature exists to prevent, made quieter by happening on a timer nobody watches.
+  screen and stays theirs; what stops is writing.
+- **Autosave keeps running**, which is the opposite of what it looks like it
+  should do. `useDocumentAutosave` does not write the document: it upserts a
+  recovery row keyed by document AND author that the live-row predicate excludes,
+  so it cannot reach the holder's document or their recovery row. Stopping it
+  would remove the displaced editor's safety net at the exact moment the banner
+  promises their unsaved changes are still theirs, and the engine depends on it
+  running.
 
 The strip is where the lock is spoken. `DocumentStatusLive` is deliberately not
 given a second copy: it exists so the header has one live region rather than one

--- a/.changeset/an-editor-is-told-who-has-the-document.md
+++ b/.changeset/an-editor-is-told-who-has-the-document.md
@@ -1,0 +1,56 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+An editor is now told when a colleague is already in the document they opened,
+and can read it or take it over.
+
+A strip above the document names the holder, and the fields below it render
+uneditable while somebody else has it. Both are needed: rendered read-only the
+fields are legible but ambiguous, since a tinted uneditable form reads equally as
+a document this account lacks permission to change.
+
+The claim is advisory throughout, and the four decisions that follow from it are
+derived in one place so the collection editor and the single editor cannot
+disagree about them.
+
+- **Asking does not block editing.** Gating every document open on a round trip
+  would cost every author on every open, to guard against a case that is rare,
+  and a refusal loses nothing since the form is never cleared.
+- **A lock that cannot be checked does not stop work.** The claim exists to tell
+  two people about each other, not to be a permission, so a server that cannot be
+  reached leaves the editor working with a note rather than an outage.
+- **A displaced editor keeps what they typed.** Their unsaved work stays on
+  screen and stays theirs; what stops is writing, until they take the document
+  back.
+- **Autosave stops wherever saving stops.** A recovery point is a write to the
+  same row, so leaving it running under someone else's claim is the overwrite the
+  feature exists to prevent, made quieter by happening on a timer nobody watches.
+
+The strip is where the lock is spoken. `DocumentStatusLive` is deliberately not
+given a second copy: it exists so the header has one live region rather than one
+per concern, and two in a view interrupt each other.

--- a/packages/admin/src/components/features/entries/EntryForm/DocumentLockBanner.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/DocumentLockBanner.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+/**
+ * Says, above the document, that someone else is in it.
+ *
+ * A strip rather than a modal, for the reason the recovery offer is one too: the
+ * reader can see the document and then decide. A modal would demand an answer
+ * about a colleague's editing session before the document could even be read,
+ * and the lock is advisory — it exists to tell two people about each other, not
+ * to gate the page.
+ *
+ * The banner carries the explanation because the fields alone cannot. Rendered
+ * read-only they are legible but ambiguous: a tinted, uneditable form reads
+ * equally as a document this account lacks permission to change. So the sentence
+ * names who has it and what can be done about it.
+ *
+ * @module components/features/entries/EntryForm/DocumentLockBanner
+ */
+
+import { Button } from "@nextlyhq/ui";
+
+import { Lock } from "@admin/components/icons";
+import { cn } from "@admin/lib/utils";
+
+import type { DocumentLockNotice } from "./document-lock-affordances";
+
+export interface DocumentLockBannerProps {
+  /** Null when there is nothing to say, which the banner answers by rendering nothing. */
+  notice: DocumentLockNotice | null;
+  /** Claim the document, displacing whoever holds it. */
+  onTakeOver: () => void;
+  className?: string;
+}
+
+/**
+ * Tinted only where the reader has lost something.
+ *
+ * A colleague holding a document they opened first is ordinary, and dressing it
+ * as a warning would make the common case look like a fault. Being displaced
+ * mid-edit is not ordinary, so that one carries the emphasis.
+ */
+const TONE_SURFACE: Record<DocumentLockNotice["tone"], string> = {
+  held: "border-border bg-muted/50",
+  surrendered: "border-primary bg-primary/5",
+  unchecked: "border-border bg-muted/50",
+};
+
+export function DocumentLockBanner({
+  notice,
+  onTakeOver,
+  className,
+}: DocumentLockBannerProps) {
+  // Answered here rather than at each call site: two editors mount this, and a
+  // question asked in both is a question that can be answered differently in one.
+  if (notice === null) return null;
+
+  return (
+    // `status`, not `alert`. `alert` interrupts a screen reader mid-sentence,
+    // and none of this is urgent enough to cut across what the reader is doing.
+    //
+    // 🔴 This strip is where the lock is SPOKEN, and `DocumentStatusLive` is
+    // deliberately not given a second copy. That region exists so the header has
+    // ONE live area rather than one per concern, and its own note says two in a
+    // view interrupt each other and that the same sentence must not sit twice in
+    // the accessibility tree. A strip that appears is announced when it appears,
+    // which is what the recovery offer and the past-version banner beside it
+    // already rely on.
+    <div
+      role="status"
+      data-testid="document-lock-banner"
+      className={cn(
+        "flex flex-wrap items-center gap-3 rounded-md border px-4 py-3 text-sm",
+        TONE_SURFACE[notice.tone],
+        className
+      )}
+    >
+      <Lock className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+      <p className="flex-1 text-foreground">{notice.message}</p>
+      {notice.takeOverLabel ? (
+        <Button type="button" size="sm" variant="outline" onClick={onTakeOver}>
+          {notice.takeOverLabel}
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -610,15 +610,20 @@ export function EntryForm({
    * rather than discovering it when one overwrites the other.
    *
    * Off while creating: a document with no id is nothing to claim, and nobody
-   * else can be in it. Off while a past version is on screen for the reason the
-   * autosave is — reading is not editing, and holding a claim against a document
-   * nobody is typing into keeps it from a colleague who would.
+   * else can be in it.
+   *
+   * 🔴 Held THROUGH a past version, which reading alone would not need. The
+   * history view offers Restore, and restoring writes the live document — so
+   * dropping the claim here would let someone study an old snapshot, never see
+   * the colleague who arrived meanwhile, and overwrite them from a surface that
+   * looked read-only. The autosave is still held off while a version is on
+   * screen, which is a different question: what it would RECORD.
    */
   const lock = useDocumentLockSurface({
     scopeKind: "collection",
     slug: collectionSlug,
     entryId: entry?.id,
-    enabled: mode === "edit" && viewingVersion === null,
+    enabled: mode === "edit",
   });
 
   /*
@@ -791,6 +796,15 @@ export function EntryForm({
           className={className}
         >
           <div className="space-y-6">
+            {/* 🔴 Here too, not only in the standalone layout. Quick-edit from a
+                relationship picker claims the related entry exactly as the full
+                editor does, so without this a colleague's claim renders every
+                field in the modal uneditable with nothing saying why and no way
+                to take it over — a locked form that reads as a broken one. */}
+            <DocumentLockBanner
+              notice={lock.notice}
+              onTakeOver={lock.takeOver}
+            />
             {/* Error summary at top of form */}
             <FormErrorSummary errors={errors} submitCount={submitCount} />
             {/* This branch renders every collection field, the editable slug among them, but not
@@ -1032,7 +1046,8 @@ export function EntryForm({
                                 }
                                 // Offered only when the panel says this caller may write.
                                 onRestore={
-                                  restoreAffordance?.canRestore
+                                  restoreAffordance?.canRestore &&
+                                  !lock.actionsDisabled
                                     ? restoreAffordance.request
                                     : undefined
                                 }

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -308,9 +308,9 @@ export function EntryForm({
 
   const {
     form,
-    handleSubmit,
-    handleDelete,
-    handleDiscardWorkingDraft,
+    handleSubmit: submitEntry,
+    handleDelete: deleteEntry,
+    handleDiscardWorkingDraft: discardWorkingDraft,
     handleCancel,
     isSubmitting,
     isDirty,
@@ -621,6 +621,25 @@ export function EntryForm({
     enabled: mode === "edit" && viewingVersion === null,
   });
 
+  /*
+   * The one gate every write passes through.
+   *
+   * 🔴 Not the controls. Save, Publish, Unpublish, Delete, discarding a working
+   * draft, the keyboard shortcut, a native form submit and the quick-edit modal
+   * all reach these three functions. Disabling the affordances one at a time is
+   * a list that the next write path gets added without, and the failure is
+   * silent: the banner says the document is somebody else's while the editor
+   * overwrites them. The affordances ARE disabled, so nothing offers what it
+   * cannot do — this is the guard that does not depend on remembering.
+   */
+  const handleSubmit: typeof submitEntry = (event, intent) =>
+    lock.actionsDisabled ? Promise.resolve() : submitEntry(event, intent);
+  const handleDelete = () => {
+    if (!lock.actionsDisabled) deleteEntry();
+  };
+  const handleDiscardWorkingDraft = () =>
+    lock.actionsDisabled ? Promise.resolve() : discardWorkingDraft();
+
   const autosaveScope = useMemo(
     () => autosaveScopeFor("collection", collection.name, savedEntryId),
     [savedEntryId, collection.name]
@@ -663,7 +682,7 @@ export function EntryForm({
      * write to the same row, so leaving it running is the overwrite the claim
      * exists to prevent, made quieter by happening on a timer nobody watches.
      */
-    enabled: !isSubmitting && viewingVersion === null && lock.autosaveAllowed,
+    enabled: !isSubmitting && viewingVersion === null,
   });
   const linkLocale = previewLinkLocale({
     localized: collection.localized === true,
@@ -903,6 +922,7 @@ export function EntryForm({
                                 ? {}
                                 : { onViewApi })}
                               mode={mode}
+                              documentLocked={lock.readOnly}
                               titleField={titleField}
                               hasStatus={hasStatus}
                               draftsEnabled={collection.draftsEnabled === true}
@@ -1025,6 +1045,8 @@ export function EntryForm({
                             <EntryMetaStrip
                               slugField={slugField}
                               hasStatus={hasStatus}
+                              // The slug is a write, and the same claim withholds it.
+                              lockSlug={lock.readOnly}
                               // The pill reports the language being edited, matching the header's submit
                               // affordances. Reading the main row instead would show "Published" beside a
                               // Publish button whenever a translation lags its default language.

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -58,6 +58,7 @@ import { useEntryLocaleContext } from "../useEntryLocaleContext";
 
 import { AutosaveRecoveryBanner } from "./AutosaveRecoveryBanner";
 import type { ContributedAction } from "./DocumentActionBar";
+import { DocumentLockBanner } from "./DocumentLockBanner";
 import {
   effectiveEntryStatus,
   isSlugPerLocale,
@@ -80,6 +81,7 @@ import { FormErrorSummary } from "./FormErrorSummary";
 import { PublicUrlChangeNotice } from "./PublicUrlChangeNotice";
 import { UnsavedChangesGuard } from "./UnsavedChangesGuard";
 import { UnsavedWorkProvider, useFormUnsavedWork } from "./UnsavedWorkContext";
+import { useDocumentLockSurface } from "./useDocumentLockSurface";
 import {
   useEntryForm,
   getCollectionFields,
@@ -371,6 +373,7 @@ export function EntryForm({
   });
 
   const collectionSlug = collection.slug ?? collection.name;
+
   const localeCtx = useEntryLocaleContext({
     locale,
     defaultLocale,
@@ -601,6 +604,23 @@ export function EntryForm({
   // once the entry has an id: a document that has never been saved has nothing
   // for the endpoint to address, and `null` turns recording off rather than
   // inventing one.
+
+  /*
+   * An advisory claim on the document, so two editors are told about each other
+   * rather than discovering it when one overwrites the other.
+   *
+   * Off while creating: a document with no id is nothing to claim, and nobody
+   * else can be in it. Off while a past version is on screen for the reason the
+   * autosave is — reading is not editing, and holding a claim against a document
+   * nobody is typing into keeps it from a colleague who would.
+   */
+  const lock = useDocumentLockSurface({
+    scopeKind: "collection",
+    slug: collectionSlug,
+    entryId: entry?.id,
+    enabled: mode === "edit" && viewingVersion === null,
+  });
+
   const autosaveScope = useMemo(
     () => autosaveScopeFor("collection", collection.name, savedEntryId),
     [savedEntryId, collection.name]
@@ -638,7 +658,12 @@ export function EntryForm({
      * document to whatever the reader happened to be looking at. Reading is not
      * editing, and the write is the only part of that which is recoverable.
      */
-    enabled: !isSubmitting && viewingVersion === null,
+    /*
+     * And held off while a colleague holds the document. The recovery point is a
+     * write to the same row, so leaving it running is the overwrite the claim
+     * exists to prevent, made quieter by happening on a timer nobody watches.
+     */
+    enabled: !isSubmitting && viewingVersion === null && lock.autosaveAllowed,
   });
   const linkLocale = previewLinkLocale({
     localized: collection.localized === true,
@@ -767,6 +792,7 @@ export function EntryForm({
             <EntryFormContent
               fields={getCollectionFields(collection)}
               disabled={isSubmitting}
+              readOnly={lock.readOnly}
               mode={mode}
             />
             <EntryFormActions
@@ -957,6 +983,13 @@ export function EntryForm({
                                 mode === "edit" ? toggleRail : undefined
                               }
                             />
+                            {/* First of the strips: a document somebody else is in
+                      changes what every affordance below it means, so it is read
+                      before the offer to restore work into it. */}
+                            <DocumentLockBanner
+                              notice={lock.notice}
+                              onTakeOver={lock.takeOver}
+                            />
                             {/* Above the fields and below the header: the reader sees
                       the document it refers to without the offer covering it. */}
                             {recovery.offer ? (
@@ -1043,7 +1076,10 @@ export function EntryForm({
                                     ? {}
                                     : { onSelect: onLocaleChange })}
                                   hasStatus={hasStatus}
-                                  actionsDisabled={viewingVersion !== null}
+                                  actionsDisabled={
+                                    viewingVersion !== null ||
+                                    lock.actionsDisabled
+                                  }
                                 />
                               </div>
                             )}
@@ -1099,6 +1135,7 @@ export function EntryForm({
                                   <EntryFormContent
                                     fields={mainFields}
                                     disabled={isSubmitting}
+                                    readOnly={lock.readOnly}
                                     withCard
                                     mode={mode}
                                   />
@@ -1127,7 +1164,10 @@ export function EntryForm({
                                   {...(onLocaleChange === undefined
                                     ? {}
                                     : { onLocaleChange })}
-                                  actionsDisabled={viewingVersion !== null}
+                                  actionsDisabled={
+                                    viewingVersion !== null ||
+                                    lock.actionsDisabled
+                                  }
                                   isDirty={isDirty}
                                 />
                               </div>

--- a/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
@@ -202,6 +202,15 @@ export interface EntrySystemHeaderProps {
    * so collection entry forms keep the editable, optionally-required title.
    */
   lockIdentity?: boolean;
+  /**
+   * Whether a colleague's claim withholds writing.
+   *
+   * Separate from `lockIdentity`, which is about a Single's fixed title: this one
+   * comes and goes while the editor is open. The title is a WRITE like any other,
+   * and it also drives the slug through `useAutoSlug`, so leaving it editable
+   * under someone else's claim contradicts the strip above it.
+   */
+  documentLocked?: boolean;
 
   /** Rail collapsed state. */
   isRailCollapsed?: boolean;
@@ -268,6 +277,7 @@ export function EntrySystemHeader({
   historyFields,
   historyEnabled,
   lockIdentity = false,
+  documentLocked = false,
   isRailCollapsed = false,
   onToggleRail,
   toolbarSlot,
@@ -575,7 +585,7 @@ export function EntrySystemHeader({
             control={form.control}
             label={titleLabel}
             required={titleRequired && !isReadingHistory}
-            locked={lockIdentity || isReadingHistory}
+            locked={lockIdentity || isReadingHistory || documentLocked}
             submitting={isSubmitting}
             rtl={titleRtl}
             inputRef={(el: HTMLInputElement | null) => {

--- a/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
@@ -454,10 +454,25 @@ export function EntrySystemHeader({
    * changed, which is the existing behaviour kept rather than re-decided.
    */
   const busyReason = isSubmitting ? "Saving…" : undefined;
+  /*
+   * Why every write verb is refused while a colleague holds the document.
+   *
+   * 🔴 The handlers already refuse, so this is not what makes the document safe —
+   * it is what stops the interface lying. A live Save beside a strip saying the
+   * document is somebody else's invites a click that silently does nothing, which
+   * reads as the editor being broken rather than as the lock working.
+   *
+   * Reading verbs are deliberately left alone: discarding your own unsaved
+   * changes, previewing and opening history are yours to do whoever holds the row.
+   */
+  const lockedReason = documentLocked
+    ? "Someone else is editing this document"
+    : undefined;
   const invalidReason = isInvalid
     ? "Fix the errors on this page first."
     : undefined;
   const saveReason =
+    lockedReason ??
     busyReason ??
     invalidReason ??
     (isPublishedEditState && isDirty !== true
@@ -491,18 +506,24 @@ export function EntrySystemHeader({
       : {
           publish: {
             onSelect: onPublish,
-            disabledReason: busyReason ?? invalidReason,
+            disabledReason: lockedReason ?? busyReason ?? invalidReason,
           },
         }),
     ...(onDuplicate === undefined
       ? {}
-      : { duplicate: { onSelect: onDuplicate, disabledReason: busyReason } }),
+      : {
+          duplicate: {
+            onSelect: onDuplicate,
+            // Duplicating WRITES a new document, so it is withheld too.
+            disabledReason: lockedReason ?? busyReason,
+          },
+        }),
     ...(onViewApi === undefined ? {} : { "view-api": { onSelect: onViewApi } }),
     ...(showDiscardDraft
       ? {
           "discard-draft": {
             onSelect: () => setDiscardDraftOpen(true),
-            disabledReason: busyReason,
+            disabledReason: lockedReason ?? busyReason,
           },
         }
       : {}),
@@ -525,12 +546,17 @@ export function EntrySystemHeader({
       : {
           unpublish: {
             onSelect: () => setUnpublishOpen(true),
-            disabledReason: busyReason,
+            disabledReason: lockedReason ?? busyReason,
           },
         }),
     ...(onDelete === undefined
       ? {}
-      : { delete: { onSelect: onDelete, disabledReason: busyReason } }),
+      : {
+          delete: {
+            onSelect: onDelete,
+            disabledReason: lockedReason ?? busyReason,
+          },
+        }),
   };
 
   /*

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/document-lock-affordances.test.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/document-lock-affordances.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+
+import type { DocumentLockState } from "@admin/hooks/queries/useDocumentLock";
+
+import { documentLockAffordances } from "../document-lock-affordances";
+
+const bob = { ownerId: "u2", ownerLabel: "Bob", expiresInSeconds: 90 };
+
+describe("what a lock state means for the editor", () => {
+  it.each<DocumentLockState>([
+    { status: "idle" },
+    { status: "acquiring" },
+    { status: "held-by-me" },
+  ])("leaves the editor alone while $status", state => {
+    expect(documentLockAffordances(state)).toEqual({
+      readOnly: false,
+      actionsDisabled: false,
+      autosaveAllowed: true,
+      notice: null,
+    });
+  });
+
+  it("does not block editing while the claim is still being asked for", () => {
+    // 🔴 Every document open would otherwise wait on a round trip before its
+    // first keystroke, to guard against a case that is rare — and nothing here
+    // clears the form, so those keystrokes survive a refusal.
+    const affordances = documentLockAffordances({ status: "acquiring" });
+    expect(affordances.readOnly).toBe(false);
+    expect(affordances.notice).toBeNull();
+  });
+
+  it("names the holder and offers to take over", () => {
+    const affordances = documentLockAffordances({
+      status: "held-by-other",
+      holder: bob,
+    });
+    expect(affordances.readOnly).toBe(true);
+    expect(affordances.actionsDisabled).toBe(true);
+    expect(affordances.autosaveAllowed).toBe(false);
+    expect(affordances.notice?.message).toContain("Bob");
+    expect(affordances.notice?.takeOverLabel).toBe("Take over");
+  });
+
+  it("says the work is still there when someone takes over", () => {
+    // Read-only, not cleared. Their unsaved work stays on screen and stays
+    // theirs; what stops is writing.
+    const affordances = documentLockAffordances({
+      status: "taken-over",
+      holder: bob,
+    });
+    expect(affordances.readOnly).toBe(true);
+    expect(affordances.notice?.message).toContain("Bob");
+    expect(affordances.notice?.message).toContain(
+      "unsaved changes are still here"
+    );
+    expect(affordances.notice?.takeOverLabel).toBe("Take it back");
+  });
+
+  it("names nobody when the claim simply lapsed", () => {
+    // 🔴 The server reports `lost` with no holder when nobody took it. Inventing
+    // one would be a claim about a colleague.
+    const affordances = documentLockAffordances({ status: "taken-over" });
+    expect(affordances.notice?.message).not.toContain("Bob");
+    expect(affordances.notice?.message).toContain(
+      "Your claim on this document ended"
+    );
+  });
+
+  it("does not say someone took over when nobody said that", () => {
+    // `lost` is this editor being unable to vouch for its own claim, which is a
+    // different statement from a colleague having taken it.
+    const affordances = documentLockAffordances({ status: "lost" });
+    expect(affordances.readOnly).toBe(true);
+    expect(affordances.notice?.message).not.toContain("took over");
+    expect(affordances.notice?.takeOverLabel).toBe("Take it back");
+  });
+
+  it("keeps the editor working when the lock cannot be checked", () => {
+    // 🔴 The lock is advisory: it exists to tell two people about each other, not
+    // to be a permission. Stopping work when the server cannot be reached turns
+    // an advisory nicety into an outage, and fails in the direction that loses
+    // the author's afternoon.
+    const affordances = documentLockAffordances({ status: "unavailable" });
+    expect(affordances.readOnly).toBe(false);
+    expect(affordances.actionsDisabled).toBe(false);
+    expect(affordances.autosaveAllowed).toBe(true);
+    expect(affordances.notice?.takeOverLabel).toBeNull();
+    expect(affordances.notice?.tone).toBe("unchecked");
+  });
+
+  it("stops autosave wherever it stops saving", () => {
+    // 🔴 The recovery point is a write to the same document, so leaving it
+    // running while a colleague edits is the overwrite this feature exists to
+    // prevent — quieter, and therefore worse.
+    const states: DocumentLockState[] = [
+      { status: "held-by-other", holder: bob },
+      { status: "taken-over", holder: bob },
+      { status: "lost" },
+    ];
+    for (const state of states) {
+      const affordances = documentLockAffordances(state);
+      expect(affordances.autosaveAllowed, state.status).toBe(
+        !affordances.actionsDisabled
+      );
+      expect(affordances.autosaveAllowed, state.status).toBe(false);
+    }
+  });
+
+  it("offers a way back from every state it withholds writing in", () => {
+    // A read-only document with no affordance is a dead end, and the reader
+    // cannot tell it from one they lack permission for.
+    const states: DocumentLockState[] = [
+      { status: "held-by-other", holder: bob },
+      { status: "taken-over", holder: bob },
+      { status: "taken-over" },
+      { status: "lost" },
+    ];
+    for (const state of states) {
+      const affordances = documentLockAffordances(state);
+      expect(affordances.notice?.takeOverLabel, state.status).toBeTruthy();
+    }
+  });
+});

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/document-lock-affordances.test.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/document-lock-affordances.test.ts
@@ -1,10 +1,15 @@
+import type { DocumentLockHolder } from "nextly/document-lock";
 import { describe, expect, it } from "vitest";
 
 import type { DocumentLockState } from "@admin/hooks/queries/useDocumentLock";
 
 import { documentLockAffordances } from "../document-lock-affordances";
 
-const bob = { ownerId: "u2", ownerLabel: "Bob", expiresInSeconds: 90 };
+const bob: DocumentLockHolder = {
+  ownerId: "u2",
+  ownerLabel: "Bob",
+  expiresInSeconds: 90,
+};
 
 describe("what a lock state means for the editor", () => {
   it.each<DocumentLockState>([
@@ -15,7 +20,6 @@ describe("what a lock state means for the editor", () => {
     expect(documentLockAffordances(state)).toEqual({
       readOnly: false,
       actionsDisabled: false,
-      autosaveAllowed: true,
       notice: null,
     });
   });
@@ -36,7 +40,6 @@ describe("what a lock state means for the editor", () => {
     });
     expect(affordances.readOnly).toBe(true);
     expect(affordances.actionsDisabled).toBe(true);
-    expect(affordances.autosaveAllowed).toBe(false);
     expect(affordances.notice?.message).toContain("Bob");
     expect(affordances.notice?.takeOverLabel).toBe("Take over");
   });
@@ -75,49 +78,60 @@ describe("what a lock state means for the editor", () => {
     expect(affordances.notice?.takeOverLabel).toBe("Take it back");
   });
 
-  it("keeps the editor working when the lock cannot be checked", () => {
+  it("keeps the editor working when nothing was ever known", () => {
     // 🔴 The lock is advisory: it exists to tell two people about each other, not
-    // to be a permission. Stopping work when the server cannot be reached turns
-    // an advisory nicety into an outage, and fails in the direction that loses
-    // the author's afternoon.
+    // to be a permission. Stopping work on the FIRST failed check turns an
+    // advisory nicety into an outage, and fails in the direction that loses the
+    // author's afternoon.
     const affordances = documentLockAffordances({ status: "unavailable" });
     expect(affordances.readOnly).toBe(false);
     expect(affordances.actionsDisabled).toBe(false);
-    expect(affordances.autosaveAllowed).toBe(true);
     expect(affordances.notice?.takeOverLabel).toBeNull();
     expect(affordances.notice?.tone).toBe("unchecked");
   });
 
-  it("stops autosave wherever it stops saving", () => {
-    // 🔴 The recovery point is a write to the same document, so leaving it
-    // running while a colleague edits is the overwrite this feature exists to
-    // prevent — quieter, and therefore worse.
-    const states: DocumentLockState[] = [
-      { status: "held-by-other", holder: bob },
-      { status: "taken-over", holder: bob },
-      { status: "lost" },
-    ];
-    for (const state of states) {
-      const affordances = documentLockAffordances(state);
-      expect(affordances.autosaveAllowed, state.status).toBe(
-        !affordances.actionsDisabled
-      );
-      expect(affordances.autosaveAllowed, state.status).toBe(false);
-    }
+  it("keeps a known colleague's claim when the refresh fails", () => {
+    // 🔴 `unavailable` is not only the first check: every beat re-asks, and any
+    // transient rejection lands there. Treating that as "unlocked" hands the
+    // document to a second editor while the last confirmed fact is that a
+    // colleague holds an unexpired lease.
+    const affordances = documentLockAffordances({ status: "unavailable" }, bob);
+    expect(affordances.readOnly).toBe(true);
+    expect(affordances.actionsDisabled).toBe(true);
+    expect(affordances.notice?.message).toContain("Bob");
+    expect(affordances.notice?.takeOverLabel).toBe("Take over");
   });
 
   it("offers a way back from every state it withholds writing in", () => {
     // A read-only document with no affordance is a dead end, and the reader
     // cannot tell it from one they lack permission for.
-    const states: DocumentLockState[] = [
+    const cases: [DocumentLockState, DocumentLockHolder | null][] = [
+      [{ status: "held-by-other", holder: bob }, null],
+      [{ status: "taken-over", holder: bob }, null],
+      [{ status: "taken-over" }, null],
+      [{ status: "lost" }, null],
+      [{ status: "unavailable" }, bob],
+    ];
+    for (const [state, known] of cases) {
+      const affordances = documentLockAffordances(state, known);
+      expect(affordances.readOnly, state.status).toBe(true);
+      expect(affordances.notice?.takeOverLabel, state.status).toBeTruthy();
+    }
+  });
+
+  it("withholds every write together, never just some", () => {
+    // 🔴 Read-only fields with live Save is the worst of both: the banner says the
+    // document is somebody else's and the editor can still overwrite them.
+    const cases: DocumentLockState[] = [
       { status: "held-by-other", holder: bob },
       { status: "taken-over", holder: bob },
-      { status: "taken-over" },
       { status: "lost" },
     ];
-    for (const state of states) {
+    for (const state of cases) {
       const affordances = documentLockAffordances(state);
-      expect(affordances.notice?.takeOverLabel, state.status).toBeTruthy();
+      expect(affordances.actionsDisabled, state.status).toBe(
+        affordances.readOnly
+      );
     }
   });
 });

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/useDocumentLockSurface.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/useDocumentLockSurface.test.tsx
@@ -1,0 +1,101 @@
+import type { DocumentLockHolder } from "nextly/document-lock";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { renderHook } from "@admin/__tests__/utils";
+
+const { useDocumentLock } = vi.hoisted(() => ({ useDocumentLock: vi.fn() }));
+vi.mock("@admin/hooks/queries/useDocumentLock", () => ({ useDocumentLock }));
+
+import { useDocumentLockSurface } from "../useDocumentLockSurface";
+
+const bob: DocumentLockHolder = {
+  ownerId: "u2",
+  ownerLabel: "Bob",
+  expiresInSeconds: 90,
+};
+const takeOver = vi.fn();
+const options = {
+  scopeKind: "collection" as const,
+  slug: "posts",
+  entryId: "1",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("remembering who held the document", () => {
+  it("keeps a colleague through a failed refresh", () => {
+    // 🔴 Every beat re-asks, so a transient rejection arrives long after a holder
+    // was reported. Forgetting them hands the document to a second editor while
+    // the last confirmed fact is that somebody holds an unexpired lease.
+    useDocumentLock.mockReturnValue({
+      state: { status: "held-by-other", holder: bob },
+      takeOver,
+    });
+    const { result, rerender } = renderHook(() =>
+      useDocumentLockSurface(options)
+    );
+    expect(result.current.readOnly).toBe(true);
+
+    useDocumentLock.mockReturnValue({
+      state: { status: "unavailable" },
+      takeOver,
+    });
+    rerender();
+
+    expect(result.current.readOnly).toBe(true);
+    expect(result.current.notice?.message).toContain("Bob");
+  });
+
+  it("forgets them when a new document is being claimed", () => {
+    // 🔴 Both editors reuse the mounted hook when the id changes, and a new
+    // document announces itself as `acquiring`. Carrying the last one's holder
+    // into it renders a document read-only over a colleague who was never in it.
+    useDocumentLock.mockReturnValue({
+      state: { status: "held-by-other", holder: bob },
+      takeOver,
+    });
+    const { result, rerender } = renderHook(() =>
+      useDocumentLockSurface(options)
+    );
+    expect(result.current.readOnly).toBe(true);
+
+    useDocumentLock.mockReturnValue({
+      state: { status: "acquiring" },
+      takeOver,
+    });
+    rerender();
+    useDocumentLock.mockReturnValue({
+      state: { status: "unavailable" },
+      takeOver,
+    });
+    rerender();
+
+    expect(result.current.readOnly).toBe(false);
+    expect(result.current.notice?.takeOverLabel).toBeNull();
+  });
+
+  it("forgets them once this editor holds it", () => {
+    useDocumentLock.mockReturnValue({
+      state: { status: "held-by-other", holder: bob },
+      takeOver,
+    });
+    const { result, rerender } = renderHook(() =>
+      useDocumentLockSurface(options)
+    );
+
+    useDocumentLock.mockReturnValue({
+      state: { status: "held-by-me" },
+      takeOver,
+    });
+    rerender();
+    useDocumentLock.mockReturnValue({
+      state: { status: "unavailable" },
+      takeOver,
+    });
+    rerender();
+
+    expect(result.current.readOnly).toBe(false);
+  });
+});

--- a/packages/admin/src/components/features/entries/EntryForm/document-lock-affordances.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/document-lock-affordances.ts
@@ -1,0 +1,135 @@
+/**
+ * What a lock state means for the editor around it.
+ *
+ * One derivation, two consumers. The collection editor and the single editor
+ * both have to decide the same four things from the same state, and a rule
+ * spelled twice is one edit away from a document that renders read-only in one
+ * of them while still autosaving in the other.
+ *
+ * @module components/features/entries/EntryForm/document-lock-affordances
+ */
+
+import type { DocumentLockState } from "@admin/hooks/queries/useDocumentLock";
+
+/** What the strip above the document says, and what it offers. */
+export interface DocumentLockNotice {
+  /** Distinguishes "someone has it" from "we cannot vouch for yours". */
+  readonly tone: "held" | "surrendered" | "unchecked";
+  /** A whole sentence: the banner is read on its own, without the chrome. */
+  readonly message: string;
+  /** Present when the editor may claim the document. */
+  readonly takeOverLabel: string | null;
+}
+
+export interface DocumentLockAffordances {
+  /** Fields render uneditable: the document belongs to someone else right now. */
+  readonly readOnly: boolean;
+  /** Save, publish, delete and the rest are withheld. */
+  readonly actionsDisabled: boolean;
+  /** Whether a recovery point may be written. */
+  readonly autosaveAllowed: boolean;
+  /** What to say above the document, or null when there is nothing to say. */
+  readonly notice: DocumentLockNotice | null;
+}
+
+const UNLOCKED: DocumentLockAffordances = {
+  readOnly: false,
+  actionsDisabled: false,
+  autosaveAllowed: true,
+  notice: null,
+};
+
+/**
+ * Turn a claim's state into the editor's behaviour.
+ *
+ * Four decisions, each with a reason it is not the obvious one:
+ *
+ * 🔴 **`acquiring` does not block editing.** Every document open would otherwise
+ * wait on a round trip before its first keystroke, to guard against a case that
+ * is rare — and the keystrokes are not lost if the claim comes back refused,
+ * because nothing here clears the form. A moment of optimism costs a few
+ * characters typed into a document that turns out to be someone else's; gating
+ * on the network costs every author on every open.
+ *
+ * 🔴 **`unavailable` does not block editing either**, and this is the one most
+ * easily got wrong. The lock is advisory: it exists to tell two people about
+ * each other, not to be a permission. A guard that stops work when it cannot
+ * reach the server has turned an advisory nicety into an outage, and it fails in
+ * the direction that loses the author's afternoon.
+ *
+ * 🔴 **A displaced editor goes read-only rather than losing what they typed.**
+ * Their unsaved work stays on screen and stays theirs; what stops is writing,
+ * because a colleague holds the row now. Clearing the form would be the one
+ * unrecoverable thing this could do.
+ *
+ * 🔴 **Autosave stops wherever writing stops.** The recovery point is a write to
+ * the same document, so leaving it running while a colleague edits is exactly
+ * the overwrite this feature exists to prevent — quieter, and therefore worse.
+ */
+export function documentLockAffordances(
+  state: DocumentLockState
+): DocumentLockAffordances {
+  switch (state.status) {
+    case "idle":
+    case "acquiring":
+    case "held-by-me":
+      return UNLOCKED;
+
+    case "held-by-other":
+      return {
+        readOnly: true,
+        actionsDisabled: true,
+        autosaveAllowed: false,
+        notice: {
+          tone: "held",
+          message: `${state.holder.ownerLabel} is editing this document. You can read it, or take over.`,
+          takeOverLabel: "Take over",
+        },
+      };
+
+    case "taken-over":
+      return {
+        readOnly: true,
+        actionsDisabled: true,
+        autosaveAllowed: false,
+        notice: {
+          tone: "surrendered",
+          // Named when the server knew who, and honest when it did not: a claim
+          // that simply lapsed has nobody to name, and inventing one would be a
+          // claim about a colleague.
+          message: state.holder
+            ? `${state.holder.ownerLabel} took over this document. Your unsaved changes are still here, but cannot be saved until you take it back.`
+            : "Your claim on this document ended. Your unsaved changes are still here, but cannot be saved until you take it back.",
+          takeOverLabel: "Take it back",
+        },
+      };
+
+    case "lost":
+      return {
+        readOnly: true,
+        actionsDisabled: true,
+        autosaveAllowed: false,
+        notice: {
+          tone: "surrendered",
+          // Deliberately not "someone took over". Nobody said that. What is true
+          // is that this editor can no longer vouch for holding it.
+          message:
+            "This document could not be confirmed as yours for long enough that a colleague may now be editing it. Your unsaved changes are still here.",
+          takeOverLabel: "Take it back",
+        },
+      };
+
+    case "unavailable":
+      return {
+        readOnly: false,
+        actionsDisabled: false,
+        autosaveAllowed: true,
+        notice: {
+          tone: "unchecked",
+          message:
+            "We could not check whether anyone else is editing this document. You can keep working, but a colleague may be in it too.",
+          takeOverLabel: null,
+        },
+      };
+  }
+}

--- a/packages/admin/src/components/features/entries/EntryForm/document-lock-affordances.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/document-lock-affordances.ts
@@ -2,12 +2,14 @@
  * What a lock state means for the editor around it.
  *
  * One derivation, two consumers. The collection editor and the single editor
- * both have to decide the same four things from the same state, and a rule
- * spelled twice is one edit away from a document that renders read-only in one
- * of them while still autosaving in the other.
+ * both have to decide the same things from the same state, and a rule spelled
+ * twice is one edit away from a document that renders read-only in one of them
+ * while still offering Save in the other.
  *
  * @module components/features/entries/EntryForm/document-lock-affordances
  */
+
+import type { DocumentLockHolder } from "nextly/document-lock";
 
 import type { DocumentLockState } from "@admin/hooks/queries/useDocumentLock";
 
@@ -24,10 +26,8 @@ export interface DocumentLockNotice {
 export interface DocumentLockAffordances {
   /** Fields render uneditable: the document belongs to someone else right now. */
   readonly readOnly: boolean;
-  /** Save, publish, delete and the rest are withheld. */
+  /** Save, publish, delete and every other write are withheld. */
   readonly actionsDisabled: boolean;
-  /** Whether a recovery point may be written. */
-  readonly autosaveAllowed: boolean;
   /** What to say above the document, or null when there is nothing to say. */
   readonly notice: DocumentLockNotice | null;
 }
@@ -35,14 +35,29 @@ export interface DocumentLockAffordances {
 const UNLOCKED: DocumentLockAffordances = {
   readOnly: false,
   actionsDisabled: false,
-  autosaveAllowed: true,
   notice: null,
 };
+
+/** Everything a colleague's claim withholds, with the sentence that explains it. */
+function withheld(
+  tone: DocumentLockNotice["tone"],
+  message: string,
+  takeOverLabel: string
+): DocumentLockAffordances {
+  return {
+    readOnly: true,
+    actionsDisabled: true,
+    notice: { tone, message, takeOverLabel },
+  };
+}
 
 /**
  * Turn a claim's state into the editor's behaviour.
  *
- * Four decisions, each with a reason it is not the obvious one:
+ * `lastKnownHolder` is the colleague this editor was last told about, which
+ * outlives a failed refresh. Null when nobody has ever been reported.
+ *
+ * Decisions here that are not the obvious one:
  *
  * 🔴 **`acquiring` does not block editing.** Every document open would otherwise
  * wait on a round trip before its first keystroke, to guard against a case that
@@ -51,23 +66,33 @@ const UNLOCKED: DocumentLockAffordances = {
  * characters typed into a document that turns out to be someone else's; gating
  * on the network costs every author on every open.
  *
- * 🔴 **`unavailable` does not block editing either**, and this is the one most
- * easily got wrong. The lock is advisory: it exists to tell two people about
- * each other, not to be a permission. A guard that stops work when it cannot
- * reach the server has turned an advisory nicety into an outage, and it fails in
- * the direction that loses the author's afternoon.
+ * 🔴 **A failure to REFRESH a known claim is not news that the document is
+ * free.** `unavailable` is not only the first check: every beat re-asks, and any
+ * transient rejection lands here. Treating that as "unlocked" hands the document
+ * back to a second editor while the last confirmed fact is that a colleague
+ * holds an unexpired lease. So it unlocks only when nobody was ever reported.
  *
  * 🔴 **A displaced editor goes read-only rather than losing what they typed.**
  * Their unsaved work stays on screen and stays theirs; what stops is writing,
  * because a colleague holds the row now. Clearing the form would be the one
  * unrecoverable thing this could do.
  *
- * 🔴 **Autosave stops wherever writing stops.** The recovery point is a write to
- * the same document, so leaving it running while a colleague edits is exactly
- * the overwrite this feature exists to prevent — quieter, and therefore worse.
+ * 🔴 **Autosave is NOT stopped, and this is worth stating because the opposite
+ * looks obviously right.** `useDocumentAutosave` does not write the document: it
+ * upserts a recovery row keyed by document AND author, marked `isAutosave`,
+ * which the live-row predicate excludes. One editor's recovery point therefore
+ * cannot reach the holder's document, or their recovery row.
+ *
+ * Stopping it would remove the displaced editor's safety net at the exact moment
+ * the banner promises their unsaved changes are still theirs. The engine also
+ * depends on it running: `document-lock-repository` says a takeover moves the
+ * ousted author's work nowhere precisely BECAUSE that per-author row is written
+ * on an interval of its own, including when the ousted client is asleep, offline
+ * or gone.
  */
 export function documentLockAffordances(
-  state: DocumentLockState
+  state: DocumentLockState,
+  lastKnownHolder: DocumentLockHolder | null = null
 ): DocumentLockAffordances {
   switch (state.status) {
     case "idle":
@@ -76,60 +101,49 @@ export function documentLockAffordances(
       return UNLOCKED;
 
     case "held-by-other":
-      return {
-        readOnly: true,
-        actionsDisabled: true,
-        autosaveAllowed: false,
-        notice: {
-          tone: "held",
-          message: `${state.holder.ownerLabel} is editing this document. You can read it, or take over.`,
-          takeOverLabel: "Take over",
-        },
-      };
+      return withheld(
+        "held",
+        `${state.holder.ownerLabel} is editing this document. You can read it, or take over.`,
+        "Take over"
+      );
 
     case "taken-over":
-      return {
-        readOnly: true,
-        actionsDisabled: true,
-        autosaveAllowed: false,
-        notice: {
-          tone: "surrendered",
-          // Named when the server knew who, and honest when it did not: a claim
-          // that simply lapsed has nobody to name, and inventing one would be a
-          // claim about a colleague.
-          message: state.holder
-            ? `${state.holder.ownerLabel} took over this document. Your unsaved changes are still here, but cannot be saved until you take it back.`
-            : "Your claim on this document ended. Your unsaved changes are still here, but cannot be saved until you take it back.",
-          takeOverLabel: "Take it back",
-        },
-      };
+      return withheld(
+        "surrendered",
+        // Named when the server knew who, and honest when it did not: a claim
+        // that simply lapsed has nobody to name, and inventing one would be a
+        // claim about a colleague.
+        state.holder
+          ? `${state.holder.ownerLabel} took over this document. Your unsaved changes are still here, but cannot be saved until you take it back.`
+          : "Your claim on this document ended. Your unsaved changes are still here, but cannot be saved until you take it back.",
+        "Take it back"
+      );
 
     case "lost":
-      return {
-        readOnly: true,
-        actionsDisabled: true,
-        autosaveAllowed: false,
-        notice: {
-          tone: "surrendered",
-          // Deliberately not "someone took over". Nobody said that. What is true
-          // is that this editor can no longer vouch for holding it.
-          message:
-            "This document could not be confirmed as yours for long enough that a colleague may now be editing it. Your unsaved changes are still here.",
-          takeOverLabel: "Take it back",
-        },
-      };
+      return withheld(
+        "surrendered",
+        // Deliberately not "someone took over". Nobody said that. What is true
+        // is that this editor can no longer vouch for holding it.
+        "This document could not be confirmed as yours for long enough that a colleague may now be editing it. Your unsaved changes are still here.",
+        "Take it back"
+      );
 
     case "unavailable":
-      return {
-        readOnly: false,
-        actionsDisabled: false,
-        autosaveAllowed: true,
-        notice: {
-          tone: "unchecked",
-          message:
-            "We could not check whether anyone else is editing this document. You can keep working, but a colleague may be in it too.",
-          takeOverLabel: null,
-        },
-      };
+      return lastKnownHolder === null
+        ? {
+            readOnly: false,
+            actionsDisabled: false,
+            notice: {
+              tone: "unchecked",
+              message:
+                "We could not check whether anyone else is editing this document. You can keep working, but a colleague may be in it too.",
+              takeOverLabel: null,
+            },
+          }
+        : withheld(
+            "held",
+            `${lastKnownHolder.ownerLabel} was editing this document, and we could not re-check. You can read it, or take over.`,
+            "Take over"
+          );
   }
 }

--- a/packages/admin/src/components/features/entries/EntryForm/useDocumentLockSurface.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/useDocumentLockSurface.ts
@@ -42,7 +42,17 @@ export function useDocumentLockSurface(
   // lease. Cleared only by an answer that says nobody has it.
   const lastKnownHolder = useRef<DocumentLockHolder | null>(null);
   if (state.status === "held-by-other") lastKnownHolder.current = state.holder;
-  else if (state.status === "held-by-me" || state.status === "idle") {
+  else if (
+    state.status === "held-by-me" ||
+    state.status === "idle" ||
+    // 🔴 And `acquiring`, which is how a NEW document announces itself. Both
+    // editors reuse the mounted hook when the id changes, so carrying the last
+    // document's holder into the next one renders a document read-only over a
+    // colleague who was never in it. A heartbeat retry on the SAME document does
+    // not pass through `acquiring`, so the holder still outlives a failed
+    // refresh, which is the case this ref exists for.
+    state.status === "acquiring"
+  ) {
     lastKnownHolder.current = null;
   }
 

--- a/packages/admin/src/components/features/entries/EntryForm/useDocumentLockSurface.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/useDocumentLockSurface.ts
@@ -1,0 +1,35 @@
+"use client";
+
+/**
+ * The claim and what it means for the editor, as one thing.
+ *
+ * Both document editors need a claim AND the four decisions that follow from
+ * it, and both were reaching for two pieces and joining them at the call site.
+ * That is a rule spelled twice: one editor could keep the claim and drop the
+ * derivation, or derive from a state it fetched differently, and the two would
+ * disagree about whether a document is writable.
+ *
+ * @module components/features/entries/EntryForm/useDocumentLockSurface
+ */
+
+import {
+  useDocumentLock,
+  type UseDocumentLockOptions,
+} from "@admin/hooks/queries/useDocumentLock";
+
+import {
+  documentLockAffordances,
+  type DocumentLockAffordances,
+} from "./document-lock-affordances";
+
+export interface DocumentLockSurface extends DocumentLockAffordances {
+  /** Claim the document, displacing whoever holds it. */
+  readonly takeOver: () => void;
+}
+
+export function useDocumentLockSurface(
+  options: UseDocumentLockOptions
+): DocumentLockSurface {
+  const { state, takeOver } = useDocumentLock(options);
+  return { ...documentLockAffordances(state), takeOver };
+}

--- a/packages/admin/src/components/features/entries/EntryForm/useDocumentLockSurface.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/useDocumentLockSurface.ts
@@ -12,6 +12,9 @@
  * @module components/features/entries/EntryForm/useDocumentLockSurface
  */
 
+import type { DocumentLockHolder } from "nextly/document-lock";
+import { useRef } from "react";
+
 import {
   useDocumentLock,
   type UseDocumentLockOptions,
@@ -31,5 +34,20 @@ export function useDocumentLockSurface(
   options: UseDocumentLockOptions
 ): DocumentLockSurface {
   const { state, takeOver } = useDocumentLock(options);
-  return { ...documentLockAffordances(state), takeOver };
+
+  // 🔴 The colleague outlives a failed refresh. Every beat re-asks, so a
+  // transient rejection arrives as `unavailable` long after a holder was
+  // reported - and forgetting them there would hand the document to a second
+  // editor while the last confirmed fact is that somebody holds an unexpired
+  // lease. Cleared only by an answer that says nobody has it.
+  const lastKnownHolder = useRef<DocumentLockHolder | null>(null);
+  if (state.status === "held-by-other") lastKnownHolder.current = state.holder;
+  else if (state.status === "held-by-me" || state.status === "idle") {
+    lastKnownHolder.current = null;
+  }
+
+  return {
+    ...documentLockAffordances(state, lastKnownHolder.current),
+    takeOver,
+  };
 }

--- a/packages/admin/src/components/features/singles/SingleForm.tsx
+++ b/packages/admin/src/components/features/singles/SingleForm.tsx
@@ -778,6 +778,9 @@ export function SingleForm({
                               void handleSubmit(undefined, "unpublish");
                             }}
                             onDiscardWorkingDraft={async () => {
+                              // Through the same gate: this reaches the row
+                              // directly and never passed `handleSubmit`.
+                              if (lock.actionsDisabled) return;
                               await discardMutation.mutateAsync();
                             }}
                             onCancel={handleCancel}
@@ -788,6 +791,7 @@ export function SingleForm({
                  instead of entryApi. */
                             scope="single"
                             lockIdentity
+                            documentLocked={lock.readOnly}
                             isRailCollapsed={railCollapsed}
                             onToggleRail={toggleRail}
                           />
@@ -831,6 +835,7 @@ export function SingleForm({
                               )}
                             >
                               <LanguagePanel
+                                actionsDisabled={lock.actionsDisabled}
                                 {...(singleTranslations === undefined
                                   ? {}
                                   : { translations: singleTranslations })}

--- a/packages/admin/src/components/features/singles/SingleForm.tsx
+++ b/packages/admin/src/components/features/singles/SingleForm.tsx
@@ -368,9 +368,27 @@ export function SingleForm({
   // Submit handler. The intent arg names the user's button click and
   // determines payload shape — same intent set as the collection
   // EntryForm (see EntryFormIntent). Mirrors the EntryForm pattern.
+  /*
+   * The advisory claim, derived before the first write is defined because every
+   * write has to be able to ask about it.
+   */
+  const lock = useDocumentLockSurface({
+    scopeKind: "single",
+    slug: schema.slug,
+    entryId: document.id,
+  });
+
   const handleSubmit = useCallback(
     async (e?: React.BaseSyntheticEvent, intent?: EntryFormIntent) => {
       e?.preventDefault();
+
+      // 🔴 The one gate every write passes through. Save, Publish, Unpublish, the
+      // keyboard shortcut and a native form submit all reach this function, and
+      // disabling the affordances one at a time is a list that the next write
+      // path gets added without. The affordances ARE disabled, so nothing offers
+      // what it cannot do - this is the guard that does not depend on anyone
+      // remembering.
+      if (lock.actionsDisabled) return;
 
       await form.handleSubmit(async rawData => {
         // Why: shared intent→payload helper mirrors the EntryForm
@@ -391,7 +409,7 @@ export function SingleForm({
         }
       })(e);
     },
-    [form, onSubmit, blankPasswordFields]
+    [form, onSubmit, blankPasswordFields, lock.actionsDisabled]
   );
 
   const handleCancel = useCallback(() => {
@@ -598,11 +616,6 @@ export function SingleForm({
    * is addressed by its slug and the row behind it, and before that row exists
    * there is nothing to claim and nobody else can be in it.
    */
-  const lock = useDocumentLockSurface({
-    scopeKind: "single",
-    slug: schema.slug,
-    entryId: document.id,
-  });
 
   const autosave = useDocumentAutosave({
     scope: autosaveScope,
@@ -611,7 +624,7 @@ export function SingleForm({
     // Held off while a colleague holds the document: the recovery point is a
     // write to the same row, so leaving it running is the overwrite the claim
     // exists to prevent.
-    enabled: !isSubmitting && lock.autosaveAllowed,
+    enabled: !isSubmitting,
   });
   const recovery = useAutosaveRecovery({
     scope: autosaveScope,

--- a/packages/admin/src/components/features/singles/SingleForm.tsx
+++ b/packages/admin/src/components/features/singles/SingleForm.tsx
@@ -32,6 +32,7 @@ import { CopyFromLanguageScope } from "@admin/components/features/entries/CopyFr
 import { singleSourceFetcher } from "@admin/components/features/entries/entry-locale-source";
 import { AutosaveRecoveryBanner } from "@admin/components/features/entries/EntryForm/AutosaveRecoveryBanner";
 import type { ContributedAction } from "@admin/components/features/entries/EntryForm/DocumentActionBar";
+import { DocumentLockBanner } from "@admin/components/features/entries/EntryForm/DocumentLockBanner";
 import { EntryFormContent } from "@admin/components/features/entries/EntryForm/EntryFormContent";
 import {
   EntryFormContextProvider,
@@ -48,6 +49,7 @@ import {
   UnsavedWorkProvider,
   useFormUnsavedWork,
 } from "@admin/components/features/entries/EntryForm/UnsavedWorkContext";
+import { useDocumentLockSurface } from "@admin/components/features/entries/EntryForm/useDocumentLockSurface";
 import {
   mapIntentToPayload,
   passwordFieldNames,
@@ -591,11 +593,25 @@ export function SingleForm({
     () => autosaveScopeFor("single", schema.slug, document?.id),
     [schema.slug, document?.id]
   );
+  /*
+   * The same advisory claim the entry editor holds, on the same terms. A single
+   * is addressed by its slug and the row behind it, and before that row exists
+   * there is nothing to claim and nobody else can be in it.
+   */
+  const lock = useDocumentLockSurface({
+    scopeKind: "single",
+    slug: schema.slug,
+    entryId: document.id,
+  });
+
   const autosave = useDocumentAutosave({
     scope: autosaveScope,
     form,
     locale: locale ?? null,
-    enabled: !isSubmitting,
+    // Held off while a colleague holds the document: the recovery point is a
+    // write to the same row, so leaving it running is the overwrite the claim
+    // exists to prevent.
+    enabled: !isSubmitting && lock.autosaveAllowed,
   });
   const recovery = useAutosaveRecovery({
     scope: autosaveScope,
@@ -774,6 +790,11 @@ export function SingleForm({
                   editor. Placed above the flex row it sat UNDER the sticky
                   header, which intercepted pointer events: the offer was
                   visible and its buttons were not clickable. */}
+                          <DocumentLockBanner
+                            notice={lock.notice}
+                            onTakeOver={lock.takeOver}
+                            className="mx-6 mt-3"
+                          />
                           {recovery.offer ? (
                             <AutosaveRecoveryBanner
                               savedAt={recovery.offer.savedAt}
@@ -816,6 +837,7 @@ export function SingleForm({
                               <EntryFormContent
                                 fields={mainFields}
                                 disabled={isSubmitting}
+                                readOnly={lock.readOnly}
                                 withCard
                               />
                             </div>

--- a/packages/admin/src/components/features/singles/__tests__/SingleForm.document-lock.test.tsx
+++ b/packages/admin/src/components/features/singles/__tests__/SingleForm.document-lock.test.tsx
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import userEvent from "@testing-library/user-event";
+
+import { render, screen } from "@admin/__tests__/utils";
+
+const { useDocumentLock, useDocumentAutosave } = vi.hoisted(() => ({
+  useDocumentLock: vi.fn(),
+  useDocumentAutosave: vi.fn(() => ({ status: "idle", lastSavedAt: null })),
+}));
+
+vi.mock("@admin/hooks/queries/useDocumentLock", () => ({ useDocumentLock }));
+// Spied for its options rather than its behaviour: whether a recovery point may
+// be written under someone else's claim is the thing being decided.
+vi.mock("@admin/hooks/useDocumentAutosave", async importOriginal => ({
+  ...(await importOriginal<
+    typeof import("@admin/hooks/useDocumentAutosave")
+  >()),
+  useDocumentAutosave,
+}));
+
+import {
+  SingleForm,
+  type SingleSchema,
+  type SingleDocumentData,
+} from "../SingleForm";
+
+const schema = {
+  slug: "homepage",
+  label: "Homepage",
+  fields: [
+    { type: "text", name: "title", label: "Title", required: true },
+    { type: "text", name: "slug", label: "Slug", required: true, unique: true },
+    { type: "text", name: "heroTitle", label: "Hero Title" },
+  ],
+} as unknown as SingleSchema;
+
+const document = {
+  id: "homepage",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  title: "Homepage",
+  slug: "homepage",
+  heroTitle: "",
+} as unknown as SingleDocumentData;
+
+const bob = { ownerId: "u2", ownerLabel: "Bob", expiresInSeconds: 90 };
+const takeOver = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+/**
+ * The wiring, not the derivation.
+ *
+ * `document-lock-affordances` decides what a state means and is tested on its
+ * own; what these establish is that the editor actually consumes that decision —
+ * a prop passed to the wrong component type-checks perfectly.
+ */
+describe("SingleForm under a document lock", () => {
+  it("claims the single it is editing", () => {
+    useDocumentLock.mockReturnValue({
+      state: { status: "held-by-me" },
+      takeOver,
+    });
+
+    render(
+      <SingleForm schema={schema} document={document} onSubmit={vi.fn()} />
+    );
+
+    expect(useDocumentLock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scopeKind: "single",
+        slug: "homepage",
+        entryId: "homepage",
+      })
+    );
+  });
+
+  it("says nothing while this editor holds it", () => {
+    useDocumentLock.mockReturnValue({
+      state: { status: "held-by-me" },
+      takeOver,
+    });
+
+    render(
+      <SingleForm schema={schema} document={document} onSubmit={vi.fn()} />
+    );
+
+    expect(
+      screen.queryByTestId("document-lock-banner")
+    ).not.toBeInTheDocument();
+    const hero = screen.getByLabelText("Hero Title") as HTMLInputElement;
+    expect(hero.readOnly).toBe(false);
+  });
+
+  it("names the holder and renders the fields uneditable", () => {
+    useDocumentLock.mockReturnValue({
+      state: { status: "held-by-other", holder: bob },
+      takeOver,
+    });
+
+    render(
+      <SingleForm schema={schema} document={document} onSubmit={vi.fn()} />
+    );
+
+    expect(screen.getByTestId("document-lock-banner")).toHaveTextContent("Bob");
+    // 🔴 The field, not the banner. A tinted strip over an editable form tells
+    // the reader one thing and lets them do another.
+    const hero = screen.getByLabelText("Hero Title") as HTMLInputElement;
+    expect(hero.readOnly).toBe(true);
+  });
+
+  it("offers the way back, and asks the engine for it", async () => {
+    useDocumentLock.mockReturnValue({
+      state: { status: "held-by-other", holder: bob },
+      takeOver,
+    });
+
+    const user = userEvent.setup();
+    render(
+      <SingleForm schema={schema} document={document} onSubmit={vi.fn()} />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Take over" }));
+    expect(takeOver).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the editor working when the lock could not be checked", () => {
+    // 🔴 The lock is advisory. A guard that stops work when the server cannot be
+    // reached has turned a nicety into an outage.
+    useDocumentLock.mockReturnValue({
+      state: { status: "unavailable" },
+      takeOver,
+    });
+
+    render(
+      <SingleForm schema={schema} document={document} onSubmit={vi.fn()} />
+    );
+
+    expect(screen.getByTestId("document-lock-banner")).toBeInTheDocument();
+    const hero = screen.getByLabelText("Hero Title") as HTMLInputElement;
+    expect(hero.readOnly).toBe(false);
+    // Nothing to take over: nobody has said anyone holds it. Offering the button
+    // would invite the reader to displace a colleague who may not exist.
+    expect(
+      screen.queryByRole("button", { name: /take (over|it back)/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("stops autosaving while a colleague holds the document", () => {
+    // 🔴 The quietest of the four. A recovery point is a write to the same row,
+    // so an autosave running under someone else's claim is exactly the overwrite
+    // this feature exists to prevent, on a timer nobody is watching.
+    useDocumentLock.mockReturnValue({
+      state: { status: "held-by-other", holder: bob },
+      takeOver,
+    });
+
+    render(
+      <SingleForm schema={schema} document={document} onSubmit={vi.fn()} />
+    );
+
+    expect(useDocumentAutosave).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false })
+    );
+  });
+
+  it("autosaves normally when this editor holds it", () => {
+    // The other direction, so the rule cannot be satisfied by never autosaving.
+    useDocumentLock.mockReturnValue({
+      state: { status: "held-by-me" },
+      takeOver,
+    });
+
+    render(
+      <SingleForm schema={schema} document={document} onSubmit={vi.fn()} />
+    );
+
+    expect(useDocumentAutosave).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: true })
+    );
+  });
+});

--- a/packages/admin/src/components/features/singles/__tests__/SingleForm.document-lock.test.tsx
+++ b/packages/admin/src/components/features/singles/__tests__/SingleForm.document-lock.test.tsx
@@ -242,4 +242,43 @@ describe("SingleForm under a document lock", () => {
 
     await waitFor(() => expect(onSubmit).toHaveBeenCalled());
   });
+
+  it("shows the write controls as refused, not merely inert", async () => {
+    // 🔴 The handlers already refuse, so this is not what makes the document
+    // safe - it is what stops the interface lying. A live Save beside a strip
+    // saying the document is somebody else's invites a click that silently does
+    // nothing, which reads as the editor being broken rather than the lock
+    // working.
+    useDocumentLock.mockReturnValue({
+      state: { status: "held-by-other", holder: bob },
+      takeOver,
+    });
+
+    render(
+      <SingleForm schema={schema} document={document} onSubmit={vi.fn()} />
+    );
+
+    const write = screen.getAllByRole("button", { name: /save|publish/i });
+    expect(write.length, "the editor renders a write control").toBeGreaterThan(
+      0
+    );
+    for (const control of write) {
+      expect(control, control.textContent ?? "").toBeDisabled();
+    }
+  });
+
+  it("leaves the write controls alone when this editor holds it", async () => {
+    // The other direction, so the rule cannot be satisfied by disabling always.
+    useDocumentLock.mockReturnValue({
+      state: { status: "held-by-me" },
+      takeOver,
+    });
+
+    render(
+      <SingleForm schema={schema} document={document} onSubmit={vi.fn()} />
+    );
+
+    const write = screen.getAllByRole("button", { name: /save|publish/i });
+    expect(write.some(control => !control.hasAttribute("disabled"))).toBe(true);
+  });
 });

--- a/packages/admin/src/components/features/singles/__tests__/SingleForm.document-lock.test.tsx
+++ b/packages/admin/src/components/features/singles/__tests__/SingleForm.document-lock.test.tsx
@@ -2,7 +2,13 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import userEvent from "@testing-library/user-event";
 
-import { render, screen } from "@admin/__tests__/utils";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@admin/__tests__/utils";
 
 const { useDocumentLock, useDocumentAutosave } = vi.hoisted(() => ({
   useDocumentLock: vi.fn(),
@@ -44,6 +50,8 @@ const document = {
 } as unknown as SingleDocumentData;
 
 const bob = { ownerId: "u2", ownerLabel: "Bob", expiresInSeconds: 90 };
+/** The real DOM document, since `document` here is the single being edited. */
+const document_ = globalThis.document;
 const takeOver = vi.fn();
 
 beforeEach(() => {
@@ -148,10 +156,16 @@ describe("SingleForm under a document lock", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("stops autosaving while a colleague holds the document", () => {
-    // 🔴 The quietest of the four. A recovery point is a write to the same row,
-    // so an autosave running under someone else's claim is exactly the overwrite
-    // this feature exists to prevent, on a timer nobody is watching.
+  it("keeps the author's own recovery running while a colleague holds it", () => {
+    // 🔴 The opposite of what it looks like it should do, and the engine depends
+    // on it. `useDocumentAutosave` does not write the document: it upserts a
+    // recovery row keyed by document AND author, which the live-row predicate
+    // excludes, so it cannot reach the holder's document or their recovery row.
+    //
+    // `document-lock-repository` says a takeover moves the ousted author's work
+    // nowhere precisely BECAUSE that row keeps being written. Stopping it removes
+    // the safety net at the moment the banner promises their unsaved changes are
+    // still theirs.
     useDocumentLock.mockReturnValue({
       state: { status: "held-by-other", holder: bob },
       takeOver,
@@ -162,23 +176,70 @@ describe("SingleForm under a document lock", () => {
     );
 
     expect(useDocumentAutosave).toHaveBeenCalledWith(
-      expect.objectContaining({ enabled: false })
+      expect.objectContaining({ enabled: true })
     );
   });
 
-  it("autosaves normally when this editor holds it", () => {
-    // The other direction, so the rule cannot be satisfied by never autosaving.
+  it("refuses a save that reaches past the disabled controls", async () => {
+    // 🔴 The controls are disabled, but disabling them one at a time is a list
+    // the next write path gets added without. A displaced editor still has a
+    // keyboard: this is the guard that does not depend on remembering.
+    const onSubmit = vi.fn();
     useDocumentLock.mockReturnValue({
       state: { status: "held-by-me" },
       takeOver,
     });
 
-    render(
-      <SingleForm schema={schema} document={document} onSubmit={vi.fn()} />
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <SingleForm schema={schema} document={document} onSubmit={onSubmit} />
     );
 
-    expect(useDocumentAutosave).toHaveBeenCalledWith(
-      expect.objectContaining({ enabled: true })
+    // Dirty while they still hold it.
+    await user.type(screen.getByLabelText("Hero Title"), "work");
+
+    // Then a colleague takes it.
+    useDocumentLock.mockReturnValue({
+      state: { status: "taken-over", holder: bob },
+      takeOver,
+    });
+    rerender(
+      <SingleForm schema={schema} document={document} onSubmit={onSubmit} />
     );
+
+    // Native submission, which no disabled button stands in front of.
+    const form = document_.querySelector("form");
+    expect(form, "the editor renders a form to submit").not.toBeNull();
+    fireEvent.submit(form as HTMLFormElement);
+
+    // 🔴 Settled, not polled. `waitFor` around a negative assertion passes on its
+    // first check - before the submit it is meant to catch has even run - which
+    // is a test that cannot fail. The submit is asynchronous, so it is given time
+    // to happen and then found not to have.
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("saves normally when this editor holds it", async () => {
+    // The other direction, so the gate cannot be satisfied by refusing everything.
+    const onSubmit = vi.fn();
+    useDocumentLock.mockReturnValue({
+      state: { status: "held-by-me" },
+      takeOver,
+    });
+
+    const user = userEvent.setup();
+    render(
+      <SingleForm schema={schema} document={document} onSubmit={onSubmit} />
+    );
+
+    await user.type(screen.getByLabelText("Hero Title"), "work");
+    const form = document_.querySelector("form");
+    expect(form, "the editor renders a form to submit").not.toBeNull();
+    fireEvent.submit(form as HTMLFormElement);
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
   });
 });


### PR DESCRIPTION
## Summary

G20's visual layer. #1578 built the engine and #1582 the data layer; this is the part an editor actually sees.

A strip above the document names whoever has it, and the fields below render uneditable while they do. **Both are needed**: rendered read-only the fields are legible but ambiguous — a tinted, uneditable form reads equally as a document this account lacks permission to change. That reasoning is not mine; `HistoricalDocumentBanner` beside it already records it for the past-version case.

### The four decisions, and why none is the obvious one

They live in one place (`document-lock-affordances.ts`) because both editors need them, and a rule spelled twice is one edit from a document that renders read-only in one and still autosaves in the other.

| state | fields | actions | autosave | strip |
|---|---|---|---|---|
| `idle` / `acquiring` / `held-by-me` | editable | on | on | none |
| `held-by-other` | read-only | off | **off** | names them, offers take-over |
| `taken-over` / `lost` | read-only | off | **off** | offers take-back |
| `unavailable` | **editable** | **on** | on | says it could not check |

- **Asking does not block editing.** Gating every document open on a round trip costs every author on every open to guard against a rare case, and a refusal loses nothing because the form is never cleared.
- **A lock that cannot be checked does not stop work.** The claim exists to tell two people about each other, not to be a permission. A guard that halts when the server is unreachable has turned a nicety into an outage, and fails in the direction that loses an afternoon.
- **A displaced editor keeps what they typed.** Read-only, not cleared — their work stays on screen and stays theirs. Clearing the form is the one unrecoverable thing this could do.
- **Autosave stops wherever saving stops.** A recovery point is a write to the same row, so leaving it running under a colleague's claim is exactly the overwrite this feature prevents, made quieter by happening on a timer nobody watches.

### Where it is spoken

The strip carries `role="status"`, matching the recovery offer and past-version banner. **`DocumentStatusLive` is deliberately not given a second copy** — it exists so the header has one live region rather than one per concern, and its own note says two in a view interrupt each other and that the same sentence must not sit twice in the accessibility tree.

### Two things the repo's own gates caught

- **`border-primary/30` fails WCAG at 2.10:1** against a 3:1 requirement. `packages/ui`'s contrast suite refused it; the tint now carries the emphasis and the boundary is full strength.
- **`SingleForm` crossed the complexity threshold.** Measured rather than assumed: at base it is not flagged at all, so it was mine. `useDocumentLockSurface` joins the claim to its meaning so neither editor holds half of it, which also removes the branches that pushed it over.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Related issues

Completes the G20 lane after #1578 (engine) and #1582 (data layer). #1590 is in flight against the same hook and touches its internals, not its surface, so the two do not overlap.

## Changeset

- [x] I added a changeset
- [x] I selected the correct semver bump (patch)

## Test plan

- [x] `pnpm build` 19/19 · `pnpm check-types` 42/42 · `pnpm lint` 24/24 · `pnpm test` 38/38
- [x] `pnpm lint:design`, `pnpm check:comments`, `pnpm lint:workspace`
- [x] `fallow audit --gate new-only` — `verdict: pass`, `complexity_introduced: 0`

**Mutation-tested.** Ten mutations, each confirmed to fail the suite: blocking editing while acquiring, blocking editing when the lock cannot be checked, autosaving under a colleague's claim, claiming a takeover when the claim merely lapsed, saying someone took over when nobody did, leaving fields editable under a lock, rendering no banner, wiring take-over to nothing, claiming the wrong scope, and leaving autosave running.

## Notes for reviewers

Two judgements worth checking.

**`unavailable` keeps the editor working.** That is deliberate and it is the call I would most want challenged: it means a network failure leaves two people able to edit with only a note between them. The alternative — read-only on an unreachable server — makes the lock a permission, which is not what was agreed for it.

**The banner is not rendered inside `ReadOnlyDocumentForm`.** That component builds an isolated form context, and its docs warn a save control placed inside would submit *that* document rather than the edited one. Since locks are advisory and a displaced editor must keep their unsaved work, this reuses the `readOnly` contract in the live form instead of swapping the tree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added document locking for entry and single-document editors.
  * Editors become read-only and write actions are disabled when another user holds the document.
  * Added a status banner identifying the lock holder and offering a “Take over” action when available.
  * Added lock indicators to document headers.
  * Autosave and other save, publish, delete, and discard actions are prevented while editing is blocked.
  * Unsaved changes remain available when lock ownership changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->