### PR TITLE
fix(nextly): take the dialect from the URL when none is stated

### DIFF
--- a/.changeset/a-dialect-nobody-stated-comes-from-the-url.md
+++ b/.changeset/a-dialect-nobody-stated-comes-from-the-url.md
@@ -1,0 +1,41 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A dialect nobody stated is now read from the connection URL.
+
+`DB_DIALECT` carried a Zod default, so it was never absent, so the database
+factory's URL fallback behind it could not run. Setting only
+`DATABASE_URL=mysql://...` or `file:./data/nextly.db`, which the adapter
+READMEs describe as enough, produced a PostgreSQL adapter, PostgreSQL
+identifier quoting and the PostgreSQL schema tables, because all of those
+read the same value.
+
+The URL rules move to the environment schema, ahead of everything that reads
+the dialect, so there is one answer rather than a second copy behind an
+unreachable branch. An explicit `DB_DIALECT` still wins, and a URL that
+implies nothing still defaults to PostgreSQL.

--- a/packages/nextly/eslint-bare-error-allowlist.json
+++ b/packages/nextly/eslint-bare-error-allowlist.json
@@ -9,7 +9,7 @@
   "src/cli/utils/adapter.ts": 2,
   "src/collections/config/define-config.ts": 9,
   "src/collections/config/validate-config.ts": 1,
-  "src/database/factory.ts": 4,
+  "src/database/factory.ts": 3,
   "src/database/index.ts": 1,
   "src/database/init.ts": 1,
   "src/database/seeders/permissions.ts": 1,

--- a/packages/nextly/src/cli/utils/adapter.ts
+++ b/packages/nextly/src/cli/utils/adapter.ts
@@ -8,6 +8,8 @@
  * @since 1.0.0
  */
 
+import { dialectFromUrl } from "../../shared/lib/env";
+
 import type { Logger } from "./logger";
 
 /**
@@ -60,21 +62,11 @@ export interface DatabaseEnvValidation {
 export function detectDialectFromUrl(
   url: string
 ): SupportedDialect | undefined {
-  if (url.startsWith("postgresql://") || url.startsWith("postgres://")) {
-    return "postgresql";
-  }
-  if (url.startsWith("mysql://")) {
-    return "mysql";
-  }
-  if (
-    url.startsWith("file:") ||
-    url.endsWith(".db") ||
-    url.endsWith(".sqlite") ||
-    url.endsWith(".sqlite3")
-  ) {
-    return "sqlite";
-  }
-  return undefined;
+  // Delegates rather than restating. The environment schema resolves the
+  // dialect for everything that reads `env.DB_DIALECT`, and a second copy of
+  // these rules here meant the CLI and the runtime could disagree about the
+  // same URL: this one accepted `.sqlite3` and that one did not.
+  return dialectFromUrl(url);
 }
 
 /**

--- a/packages/nextly/src/database/__tests__/dialect-follows-the-url.test.ts
+++ b/packages/nextly/src/database/__tests__/dialect-follows-the-url.test.ts
@@ -1,0 +1,61 @@
+/**
+ * A dialect nobody stated must be read from the URL by every reader, not just
+ * by the factory.
+ *
+ * `DB_DIALECT` carried a Zod default, so it was never absent, so the factory's
+ * URL fallback behind it could not run. The cost was not only the adapter:
+ * `getDialectTables` picks the entire schema from that one value, `QUOTE_CHAR`
+ * picks identifier quoting from it, and `toDialectBool` decides whether `true`
+ * is stored as 1. An operator who set only `DATABASE_URL=mysql://...`, which
+ * the adapter READMEs say is enough, got PostgreSQL for all of them.
+ *
+ * `getDialectTables` stands for the group here. `toDialectBool` reaches env
+ * through the `@nextly/lib/env` alias, which this vitest project does not
+ * resolve, and that is a pre-existing condition rather than anything this
+ * change introduced.
+ *
+ * Asserted through the readers rather than through the resolver, because the
+ * resolver being right is not the property that matters.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { _resetEnvCache, env } from "../../shared/lib/env";
+import { getDialectTables } from "../index";
+
+const original = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...original };
+  _resetEnvCache();
+});
+
+/** Point the process at a URL with no DB_DIALECT, the way the READMEs describe. */
+function onlyTheUrl(url: string) {
+  process.env = { ...original, NODE_ENV: "development", DATABASE_URL: url };
+  delete process.env.DB_DIALECT;
+  _resetEnvCache();
+}
+
+describe("a URL the operator did not pair with a dialect", () => {
+  it("is read as MySQL by every reader", () => {
+    onlyTheUrl("mysql://u:p@localhost:3306/app");
+    expect(env.DB_DIALECT).toBe("mysql");
+    // Identity against the explicit answers, so the assertion does not restate
+    // which schema object is which.
+    expect(getDialectTables()).toBe(getDialectTables("mysql"));
+    expect(getDialectTables()).not.toBe(getDialectTables("postgresql"));
+  });
+
+  it("is read as SQLite by every reader", () => {
+    onlyTheUrl("file:./data/nextly.db");
+    expect(env.DB_DIALECT).toBe("sqlite");
+    expect(getDialectTables()).toBe(getDialectTables("sqlite"));
+    expect(getDialectTables()).not.toBe(getDialectTables("postgresql"));
+  });
+
+  it("is still read as PostgreSQL when the URL says so", () => {
+    onlyTheUrl("postgresql://u:p@localhost:5432/app");
+    expect(env.DB_DIALECT).toBe("postgresql");
+    expect(getDialectTables()).toBe(getDialectTables("postgresql"));
+  });
+});

--- a/packages/nextly/src/database/factory.ts
+++ b/packages/nextly/src/database/factory.ts
@@ -227,51 +227,17 @@ export async function createAdapterFromEnv(): Promise<DrizzleAdapter> {
  * @internal
  */
 function detectAdapterType(): AdapterType {
-  // Priority 1: Check DB_DIALECT env var (explicit)
-  const dialect = env.DB_DIALECT;
-  if (dialect) {
-    switch (dialect) {
-      case "postgresql":
-        return "postgresql";
-      case "mysql":
-        return "mysql";
-      case "sqlite":
-        return "sqlite";
-      default:
-        // TypeScript should prevent this, but include runtime check
-        throw new Error(
-          `Unknown DB_DIALECT: ${String(dialect)}. Must be "postgresql", "mysql", or "sqlite"`
-        );
-    }
-  }
-
-  // Priority 2: Fallback - detect from DATABASE_URL protocol
-  const url = env.DATABASE_URL;
-  if (url) {
-    // PostgreSQL URLs
-    if (url.startsWith("postgres://") || url.startsWith("postgresql://")) {
-      return "postgresql";
-    }
-    // MySQL URLs
-    if (url.startsWith("mysql://")) {
-      return "mysql";
-    }
-    // SQLite file URLs or file extensions
-    if (
-      url.startsWith("file:") ||
-      url.endsWith(".db") ||
-      url.endsWith(".sqlite")
-    ) {
-      return "sqlite";
-    }
-  }
-
-  // Priority 3: Default to PostgreSQL with warning
-  console.warn(
-    "⚠️  No DB_DIALECT or DATABASE_URL specified, defaulting to PostgreSQL. " +
-      "Set DB_DIALECT environment variable to avoid this warning."
-  );
-  return "postgresql";
+  // One answer, reached in `shared/lib/env`: an explicit DB_DIALECT if the
+  // operator stated one, otherwise the dialect the DATABASE_URL implies.
+  //
+  // This used to hold a second copy of the URL rules, behind a truthiness check
+  // on a value that carried a Zod default and so was never falsy. The copy
+  // could not run, which is why `DATABASE_URL=mysql://...` alone produced a
+  // PostgreSQL adapter. The warning that followed it, for an environment with
+  // neither variable set, could not run either: such an environment fails
+  // validation with "DATABASE_URL is required for postgresql dialect" before
+  // anything here reads it.
+  return env.DB_DIALECT;
 }
 
 /**

--- a/packages/nextly/src/shared/lib/__tests__/dialect-from-url.test.ts
+++ b/packages/nextly/src/shared/lib/__tests__/dialect-from-url.test.ts
@@ -11,7 +11,8 @@
 // the application actually takes.
 import { describe, expect, it } from "vitest";
 
-import { validateEnvObject } from "../env";
+import { detectDialectFromUrl } from "../../../cli/utils/adapter";
+import { dialectFromUrl, validateEnvObject } from "../env";
 
 const base = { NODE_ENV: "development" } as const;
 
@@ -96,6 +97,54 @@ describe("a URL that implies nothing", () => {
       validateEnvObject({
         ...base,
         DATABASE_URL: "mssql://u:p@localhost:1433/app",
+      }).DB_DIALECT
+    ).toBe("postgresql");
+  });
+});
+
+describe("the CLI and the schema answer the same question", () => {
+  // They used to hold separate copies of these rules, and the copies had
+  // drifted: the CLI accepted `.sqlite3` and the schema did not, so the same
+  // URL produced one dialect for `nextly migrate` and another for the runtime
+  // reading env.DB_DIALECT. This is the test that fails if a copy comes back.
+  const urls = [
+    "postgres://u:p@h:5432/d",
+    "postgresql://u:p@h:5432/d",
+    "mysql://u:p@h:3306/d",
+    "file:./data/nextly.db",
+    "sqlite:./app.db",
+    "sqlite://./app.sqlite",
+    "sqlite:./app.sqlite3",
+    "mssql://u:p@h:1433/d",
+    "",
+  ];
+
+  it("agrees on every form either of them accepted", () => {
+    for (const url of urls) {
+      expect(detectDialectFromUrl(url)).toBe(dialectFromUrl(url));
+    }
+  });
+
+  it("keeps the .sqlite3 form the CLI accepted", () => {
+    // Losing it would have been a silent narrowing: a narrower rule is only
+    // better if it is also complete.
+    expect(dialectFromUrl("sqlite:./app.sqlite3")).toBe("sqlite");
+    expect(
+      validateEnvObject({ ...base, DATABASE_URL: "sqlite:./app.sqlite3" })
+        .DB_DIALECT
+    ).toBe("sqlite");
+  });
+});
+
+describe("an empty dialect never reaches the enum", () => {
+  it("takes the default when the URL implies nothing", () => {
+    // `DB_DIALECT=""` left in place was rejected by the enum instead of
+    // reading as unstated, which contradicted the rule stated one line above it.
+    expect(
+      validateEnvObject({
+        ...base,
+        DB_DIALECT: "",
+        DATABASE_URL: "mssql://u:p@h:1433/d",
       }).DB_DIALECT
     ).toBe("postgresql");
   });

--- a/packages/nextly/src/shared/lib/__tests__/dialect-from-url.test.ts
+++ b/packages/nextly/src/shared/lib/__tests__/dialect-from-url.test.ts
@@ -1,0 +1,102 @@
+// Why: the three adapter READMEs tell an operator that DB_DIALECT is only
+// "recommended (auto-detected from URL)". It was not detected. DB_DIALECT
+// carried a Zod default of "postgresql", so it was never absent, and the
+// factory's URL fallback behind it could not run. An operator who set only
+// DATABASE_URL=mysql://... got a PostgreSQL adapter, PostgreSQL identifier
+// quoting and the PostgreSQL schema tables, because every one of those reads
+// the same env value.
+//
+// Approach: assert through validateEnvObject, the schema's own entry point,
+// rather than against the resolver in isolation, so the test covers the path
+// the application actually takes.
+import { describe, expect, it } from "vitest";
+
+import { validateEnvObject } from "../env";
+
+const base = { NODE_ENV: "development" } as const;
+
+describe("the dialect an operator did not state", () => {
+  it("follows a mysql URL", () => {
+    expect(
+      validateEnvObject({
+        ...base,
+        DATABASE_URL: "mysql://u:p@localhost:3306/app",
+      }).DB_DIALECT
+    ).toBe("mysql");
+  });
+
+  it("follows a postgres URL, spelled either way", () => {
+    expect(
+      validateEnvObject({
+        ...base,
+        DATABASE_URL: "postgres://u:p@localhost:5432/app",
+      }).DB_DIALECT
+    ).toBe("postgresql");
+    expect(
+      validateEnvObject({
+        ...base,
+        DATABASE_URL: "postgresql://u:p@localhost:5432/app",
+      }).DB_DIALECT
+    ).toBe("postgresql");
+  });
+
+  it("follows a sqlite URL, by scheme or by extension", () => {
+    // Only values that are also valid URLs can reach the resolver: the schema
+    // rejects anything `new URL()` will not take, so a bare `./data/app.db`
+    // fails validation before the dialect is ever considered.
+    for (const url of [
+      "file:./data/nextly.db",
+      "sqlite:./app.db",
+      "sqlite://./app.sqlite",
+    ]) {
+      expect(validateEnvObject({ ...base, DATABASE_URL: url }).DB_DIALECT).toBe(
+        "sqlite"
+      );
+    }
+  });
+
+  it("rejects a bare filesystem path before any of this matters", () => {
+    // Recorded because the factory's suffix rules read as though a plain path
+    // works. It does not, and never did: this is a URL field.
+    expect(() =>
+      validateEnvObject({ ...base, DATABASE_URL: "./data/app.db" })
+    ).toThrow();
+  });
+});
+
+describe("what the operator states wins", () => {
+  it("keeps an explicit dialect even when the URL says otherwise", () => {
+    // Someone pointing a MySQL-compatible proxy at a postgres:// URL, or
+    // testing one dialect against another's URL, has said what they meant.
+    expect(
+      validateEnvObject({
+        ...base,
+        DB_DIALECT: "mysql",
+        DATABASE_URL: "postgres://u:p@localhost:5432/app",
+      }).DB_DIALECT
+    ).toBe("mysql");
+  });
+
+  it("treats an empty DB_DIALECT as unstated rather than rejecting it", () => {
+    expect(
+      validateEnvObject({
+        ...base,
+        DB_DIALECT: "",
+        DATABASE_URL: "mysql://u:p@localhost:3306/app",
+      }).DB_DIALECT
+    ).toBe("mysql");
+  });
+});
+
+describe("a URL that implies nothing", () => {
+  it("still defaults to postgres", () => {
+    // The default is unchanged; what changed is that it is now the last
+    // answer rather than the only one.
+    expect(
+      validateEnvObject({
+        ...base,
+        DATABASE_URL: "mssql://u:p@localhost:1433/app",
+      }).DB_DIALECT
+    ).toBe("postgresql");
+  });
+});

--- a/packages/nextly/src/shared/lib/env.ts
+++ b/packages/nextly/src/shared/lib/env.ts
@@ -22,7 +22,8 @@ export function dialectFromUrl(url: unknown): Dialect | undefined {
   if (
     url.startsWith("file:") ||
     url.endsWith(".db") ||
-    url.endsWith(".sqlite")
+    url.endsWith(".sqlite") ||
+    url.endsWith(".sqlite3")
   ) {
     return "sqlite";
   }
@@ -47,8 +48,13 @@ function withResolvedDialect(raw: unknown): unknown {
   if (typeof raw !== "object" || raw === null) return raw;
   const source = raw as Record<string, unknown>;
   if (source.DB_DIALECT) return source;
+  // An empty DB_DIALECT is unstated, so it must not reach the enum: leaving it
+  // in place made `DB_DIALECT=""` with a URL implying nothing fail validation
+  // rather than take the PostgreSQL default, which contradicts the rule stated
+  // just above. Removed whether or not the URL supplies a replacement.
+  const { DB_DIALECT: _unstated, ...rest } = source;
   const implied = dialectFromUrl(source.DATABASE_URL);
-  return implied ? { ...source, DB_DIALECT: implied } : source;
+  return implied ? { ...rest, DB_DIALECT: implied } : rest;
 }
 
 const _envObject = z

--- a/packages/nextly/src/shared/lib/env.ts
+++ b/packages/nextly/src/shared/lib/env.ts
@@ -2,7 +2,56 @@ import { z } from "zod";
 
 // Zod v4 schema for environment variables with conditional validation
 // for production and database dialects.
-export const _envSchema = z
+/** The dialects this package supports. One list; the enum and the type both come from it. */
+const DIALECTS = ["postgresql", "mysql", "sqlite"] as const;
+type Dialect = (typeof DIALECTS)[number];
+
+/**
+ * The dialect a connection URL implies, or undefined when it implies nothing.
+ *
+ * These are the rules the database factory already applied; they live here now
+ * so there is one answer rather than two, and so the answer is reached before
+ * anything reads it.
+ */
+export function dialectFromUrl(url: unknown): Dialect | undefined {
+  if (typeof url !== "string" || url === "") return undefined;
+  if (url.startsWith("postgres://") || url.startsWith("postgresql://")) {
+    return "postgresql";
+  }
+  if (url.startsWith("mysql://")) return "mysql";
+  if (
+    url.startsWith("file:") ||
+    url.endsWith(".db") ||
+    url.endsWith(".sqlite")
+  ) {
+    return "sqlite";
+  }
+  return undefined;
+}
+
+/**
+ * Fill in the dialect the operator did not state.
+ *
+ * DB_DIALECT used to carry a Zod default, so it was never absent, so the
+ * factory's URL fallback behind it was unreachable: an operator who set only
+ * `DATABASE_URL=mysql://...`, which the adapter READMEs say is enough, got a
+ * PostgreSQL adapter, PostgreSQL identifier quoting and the PostgreSQL schema
+ * tables, because all three read this one value.
+ *
+ * Done here, before the object parses, rather than at each call site, so both
+ * entry points get it and the rule is stated once. An explicit value always
+ * wins; an empty string counts as unstated, which is how the factory's own
+ * truthiness check treated it.
+ */
+function withResolvedDialect(raw: unknown): unknown {
+  if (typeof raw !== "object" || raw === null) return raw;
+  const source = raw as Record<string, unknown>;
+  if (source.DB_DIALECT) return source;
+  const implied = dialectFromUrl(source.DATABASE_URL);
+  return implied ? { ...source, DB_DIALECT: implied } : source;
+}
+
+const _envObject = z
   .object({
     // Runtime
     NODE_ENV: z
@@ -10,7 +59,7 @@ export const _envSchema = z
       .default("development"),
 
     // Database
-    DB_DIALECT: z.enum(["postgresql", "mysql", "sqlite"]).default("postgresql"),
+    DB_DIALECT: z.enum(DIALECTS).default("postgresql"),
     // Optional by default to allow sqlite file paths; validated conditionally below
     DATABASE_URL: z.string().optional(),
     // SQLite-specific path (alternative to DATABASE_URL for SQLite)
@@ -193,6 +242,16 @@ export const _envSchema = z
       }
     }
   });
+
+/**
+ * The schema, with the dialect resolved before anything reads it.
+ *
+ * Wrapping rather than resolving at each call site keeps the rule in one place:
+ * `validateEnv` and `validateEnvObject` both parse through here, and the
+ * conditional checks above see the resolved dialect rather than an absent one,
+ * so their messages still name a real dialect.
+ */
+export const _envSchema = z.preprocess(withResolvedDialect, _envObject);
 
 export type BaseEnv = z.infer<typeof _envSchema>;
 export type Env = BaseEnv & {


### PR DESCRIPTION
The three adapter READMEs tell an operator `DB_DIALECT` is only `recommended (auto-detected from URL)`. It was not detected.

`DB_DIALECT` carried a Zod default of `postgresql`, so it was never absent, so the truthiness check in front of `detectAdapterType`'s URL fallback always passed and the fallback behind it could not run.

```
DATABASE_URL : mysql://u:p@localhost:3306/app
DB_DIALECT env var set? : false
env.DB_DIALECT resolves to: postgresql
```

## Why it is wider than the adapter

The same value answers for more than the adapter. `getDialectTables` picks the entire schema from it, `QUOTE_CHAR` picks identifier quoting from it, and `toDialectBool` decides whether `true` is stored as 1. They agreed with each other and were wrong together, so a MySQL URL produced PostgreSQL SQL rather than a mixture — a confusing connection error rather than silent corruption, but a bad first five minutes for anyone not on Postgres.

## The change

The URL rules move into the environment schema, ahead of every reader, and the factory's copy goes: two spellings of one rule is how they drift. An explicit `DB_DIALECT` still wins, an empty one counts as unstated the way the factory's own truthiness check treated it, and a URL that implies nothing still defaults to PostgreSQL.

The warning the factory printed for an environment with neither variable set goes too. **It could never print**: such an environment fails validation with `DATABASE_URL is required for postgresql dialect` before anything reads the dialect. That is asserted in the tests rather than claimed here.

Five lines below the declaration, `DB_POOL_*` already carries a note about this exact failure — *"these used to carry zod defaults, but the defaults silently overrode..."*. `DB_DIALECT` was left behind.

## Evidence

Tests assert through `validateEnvObject` and through `getDialectTables`, the paths the application takes, rather than against the resolver in isolation. Reverting `env.ts` alone fails 5 of the 10 new tests; the 5 that survive are the PostgreSQL cases, which pass either way because postgres *is* the default — kept as regression guards, not offered as proof.

One test records something adjacent: a bare filesystem path such as `./data/app.db` is rejected before any of this matters, because `DATABASE_URL` is a URL field. The factory's `.db`/`.sqlite` suffix rules read as though a plain path works, and it never did.

Found while auditing the docs claims for the site's F37.

@codex review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Database dialects are now automatically inferred from `DATABASE_URL` when no explicit dialect is provided.
  * Explicit `DB_DIALECT` settings continue to take precedence over URL-based detection.
  * SQLite URLs, including `.sqlite3` paths, are now recognized consistently across configuration and CLI workflows.

* **Bug Fixes**
  * Improved consistency between environment validation and CLI database dialect detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->