### PR TITLE
test(blocks-engine): make the format boundary a boundary, not a scan for crossings

### DIFF
--- a/.changeset/format-boundary-reads-the-build-graph.md
+++ b/.changeset/format-boundary-reads-the-build-graph.md
@@ -1,0 +1,33 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The build writes esbuild's module graph beside the bundles, so the format entry point's boundary can be checked against every edge rather than the ones initialisation happens to follow.
+
+A graph observed by importing an entry point contains only what loading it resolved. A dynamic import behind a function is a real edge to a real dependency, and nothing asks the resolver for it until it is called — so the entry could reach a runtime dependency and every check still report a clean boundary. The metafile records every edge with its kind, deferred ones included, from the tool that emitted the code.
+
+It is written to `dist` and excluded from the published package: it describes a build rather than shipping with one.

--- a/packages/blocks-engine/package.json
+++ b/packages/blocks-engine/package.json
@@ -30,7 +30,8 @@
   },
   "files": [
     "dist",
-    "docs"
+    "docs",
+    "!dist/metafile-*.json"
   ],
   "scripts": {
     "build": "tsup",

--- a/packages/blocks-engine/src/format-boundary.test.ts
+++ b/packages/blocks-engine/src/format-boundary.test.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import {
   cpSync,
   existsSync,
+  readdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
@@ -41,20 +42,39 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
  * exist. Both directions were wrong, and the first is the dangerous one,
  * because a scan that sees less reports a healthier boundary.
  *
- * So the question is put to the module resolver instead, in the two forms that
- * cannot be under-read:
+ * Two instruments replace it, each complete in a dimension the other is not.
  *
- * - the entry is imported from a directory with NO `node_modules` above it, so
- *   anything reaching a runtime dependency fails to resolve. Complete by
- *   construction rather than a pattern to keep extending.
- * - the entry is imported again under a resolution hook, which reports every
- *   specifier Node actually resolved. That is the module graph itself, not a
- *   reading of what the text appears to say.
+ * **The build's own module graph.** `tsup` writes esbuild's metafile beside the
+ * bundles, recording every import edge with its KIND — including the ones
+ * nothing executes. A `import("css-tree/parser")` behind a function is a real
+ * edge to a real dependency, and no amount of loading the entry point asks the
+ * resolver for it. Authoritative because it comes from the tool that emitted
+ * the code.
+ *
+ * **The resolver.** The entry is imported from a directory with NO
+ * `node_modules` above it, so anything reaching a runtime dependency fails to
+ * resolve. That says nothing about deferred edges, and it is the only one of
+ * the two that judges the FILE rather than a record about it.
+ *
+ * Neither alone is enough, and the pairing is the point: a metafile can
+ * describe a build the files on disk are no longer from, and an import passes
+ * over every dependency it never reaches. So the metafile is checked against
+ * the bytes actually on disk, and the import is run against the real files.
  *
  * @module format-boundary.test
  */
 
 const DIST = resolve(dirname(fileURLToPath(import.meta.url)), "..", "dist");
+const PACKAGE = dirname(DIST);
+const METAFILE = join(DIST, "metafile-esm.json");
+
+/**
+ * How long a child gets to import one entry point before it is a hang.
+ *
+ * Loading two files is milliseconds of work; a minute is the point past which
+ * no plausible amount of runner contention explains it.
+ */
+const CHILD_TIMEOUT_MS = 60_000;
 const FORMAT_ENTRY = "format.mjs";
 const ROOT_ENTRY = "index.mjs";
 
@@ -151,8 +171,22 @@ function runEntry(
       // directory holding the entry rather than from wherever vitest was run.
       cwd: from,
       env: { ...process.env, NEXTLY_RESOLVE_RECORD: record },
+      // A ceiling, because this call is SYNCHRONOUS: an entry point that opens
+      // a handle or deadlocks while initialising would otherwise block the
+      // vitest worker itself, and vitest's own per-test timeout cannot fire on
+      // a thread that is not yielding — the suite hangs where it should report.
+      // Generous, so a cold start on a loaded runner is never the cause.
+      timeout: CHILD_TIMEOUT_MS,
     }
   );
+
+  // `spawnSync` reports a timeout or a failure to start through `error` and
+  // leaves `status` null, which reads as "did not exit 0" — the right verdict
+  // for the boundary and the wrong REASON to show. Carried into the message so
+  // a hang is reported as a hang.
+  const stderr = [result.stderr ?? "", result.error?.message ?? ""]
+    .filter(part => part !== "")
+    .join("\n");
 
   const resolved = !instrumented
     ? []
@@ -161,7 +195,7 @@ function runEntry(
         .filter(line => line !== "")
         .map(line => JSON.parse(line) as { specifier: string; url: string });
 
-  return { ok: result.status === 0, stderr: result.stderr ?? "", resolved };
+  return { ok: result.status === 0, stderr, resolved };
 }
 
 const isRelative = (specifier: string) => specifier.startsWith(".");
@@ -246,31 +280,216 @@ describe("the format entry point's boundary", () => {
   });
 });
 
-describe("what the format entry point actually loads", () => {
-  it("resolves no runtime dependency", () => {
-    // The same claim asked a second way, in a place where dependencies ARE
-    // resolvable. The isolated import proves nothing external could load; this
-    // proves nothing external was even asked for, which is what would still
-    // hold if the sandbox ever stopped being isolated.
-    const run = runEntry(DIST, FORMAT_ENTRY, { instrumented: true });
+/**
+ * One output file as the build recorded it: what it weighs, and what it
+ * imports.
+ *
+ * `external` distinguishes a bare package from another emitted chunk, so
+ * following the second and collecting the first is the whole graph walk — over
+ * data the bundler produced, rather than over the text it produced.
+ */
+interface BuildOutput {
+  readonly bytes: number;
+  readonly imports?: readonly {
+    readonly path: string;
+    readonly kind: string;
+    readonly external?: boolean;
+  }[];
+}
 
-    expect(run.ok, run.stderr).toBe(true);
-    expect(externals(run)).toEqual([]);
+function buildGraph(): Record<string, BuildOutput> {
+  const raw: unknown = JSON.parse(readFileSync(METAFILE, "utf8"));
+  const outputs = (raw as { outputs?: Record<string, BuildOutput> }).outputs;
+  if (outputs === undefined) {
+    throw new Error(`${METAFILE} has no outputs; the build did not write it`);
+  }
+  return outputs;
+}
+
+/**
+ * Every emitted file an entry reaches, chunks included.
+ *
+ * The one traversal both questions below are asked of. They differ only in what
+ * they read off each file — its externals, or its bytes — and walking twice is
+ * two answers to "what does this entry reach", which drift the first time a
+ * kind of edge is treated differently in one of them.
+ */
+function reachableOutputs(
+  outputs: Record<string, BuildOutput>,
+  entry: string
+): string[] {
+  const seen = new Set<string>();
+  const queue = [entry];
+  while (queue.length > 0) {
+    const file = queue.pop();
+    // An emitted chunk can reference another in a cycle, so a walk without this
+    // does not return.
+    if (file === undefined || seen.has(file)) continue;
+    seen.add(file);
+    for (const edge of outputs[file]?.imports ?? []) {
+      if (edge.external !== true) queue.push(edge.path);
+    }
+  }
+  return [...seen];
+}
+
+/**
+ * Every bare package an emitted entry reaches.
+ *
+ * Every KIND of edge counts, and that is the point of reading this rather than
+ * observing an import: `kind` is `dynamic-import` for the deferred ones, and a
+ * deferred edge to a runtime dependency is exactly as much of a dependency as
+ * an eager one — it is simply one nothing asks for until it is called.
+ */
+function buildExternals(
+  outputs: Record<string, BuildOutput>,
+  entry: string
+): string[] {
+  const externals = new Set<string>();
+  for (const file of reachableOutputs(outputs, entry)) {
+    for (const edge of outputs[file]?.imports ?? []) {
+      if (edge.external === true) externals.add(edge.path);
+    }
+  }
+  return [...externals].sort();
+}
+
+/** The bytes of every emitted file an entry reaches, chunks included. */
+function buildBytes(
+  outputs: Record<string, BuildOutput>,
+  entry: string
+): number {
+  return reachableOutputs(outputs, entry).reduce(
+    (total, file) => total + (outputs[file]?.bytes ?? 0),
+    0
+  );
+}
+
+/** The metafile's own name for an emitted file: a path from the package root. */
+const emitted = (file: string) => `dist/${file}`;
+
+describe("the walk over that graph", () => {
+  /**
+   * A graph with the three shapes the real one does not currently have.
+   *
+   * The build emits no dynamic import today and reaches its dependency
+   * straight from the entry, so every property below is invisible when asserted
+   * against `dist`: a walk that ignored deferred edges, or never followed a
+   * chunk, or summed only the entry, agrees with the correct one on this
+   * build. They would start disagreeing the day the bundle changed shape,
+   * which is the day the walk stops being watched.
+   */
+  const FIXTURE: Record<string, BuildOutput> = {
+    "dist/entry.mjs": {
+      bytes: 10,
+      imports: [
+        { path: "dist/chunk.mjs", kind: "import-statement" },
+        { path: "eager-pkg", kind: "import-statement", external: true },
+      ],
+    },
+    "dist/chunk.mjs": {
+      bytes: 100,
+      imports: [
+        { path: "deferred-pkg", kind: "dynamic-import", external: true },
+        // Back to the entry: emitted chunks do reference each other in cycles,
+        // and a walk without a seen-set does not return from this.
+        { path: "dist/entry.mjs", kind: "import-statement" },
+      ],
+    },
+  };
+
+  it("follows chunk edges to the dependencies behind them", () => {
+    expect(buildExternals(FIXTURE, "dist/entry.mjs")).toContain("deferred-pkg");
   });
 
-  it("CONTROL: the same instrument sees the root's dependency", () => {
-    // A hook that recorded nothing would report an empty external set for every
-    // entry point, including one that demonstrably pulls a parser. Matched by
-    // package rather than by exact specifier: the compiler imports
-    // `css-tree/parser` and `css-tree/walker` by subpath, so an equality check
-    // against the bare name finds nothing and the control passes for the wrong
-    // reason.
-    const run = runEntry(DIST, ROOT_ENTRY, { instrumented: true });
+  it("counts a DEFERRED edge as a dependency", () => {
+    // The property this file was rebuilt for. An import behind a function is a
+    // real edge to a real package; nothing asks the resolver for it until it is
+    // called, which is exactly why observing an import cannot see it.
+    const deferredOnly: Record<string, BuildOutput> = {
+      "dist/only.mjs": {
+        bytes: 1,
+        imports: [{ path: "lazy-pkg", kind: "dynamic-import", external: true }],
+      },
+    };
 
-    expect(run.ok, run.stderr).toBe(true);
-    expect(externals(run).map(specifier => specifier.split("/")[0])).toContain(
-      "css-tree"
+    expect(buildExternals(deferredOnly, "dist/only.mjs")).toEqual(["lazy-pkg"]);
+  });
+
+  it("sums the bytes of every chunk an entry reaches", () => {
+    expect(buildBytes(FIXTURE, "dist/entry.mjs")).toBe(110);
+  });
+
+  it("does not treat a chunk as a dependency", () => {
+    // The other direction: a relative edge is code this package emitted, and
+    // reporting it as an external would make every entry point look like it
+    // reaches something.
+    expect(buildExternals(FIXTURE, "dist/entry.mjs")).toEqual([
+      "deferred-pkg",
+      "eager-pkg",
+    ]);
+  });
+});
+
+describe("the module graph the build recorded", () => {
+  it("describes the files that are actually on disk", () => {
+    // The metafile is a RECORD of a build, and every assertion below trusts it
+    // to describe this one. A `dist` rebuilt by some path that did not write it
+    // leaves a stale graph saying whatever it said last time — which is the
+    // flattering direction, because the boundary was intact then.
+    //
+    // NOT by comparing recorded sizes against the files. Measured, they do not
+    // agree and are not meant to: esbuild records what IT emitted, and tsup
+    // rewrites both the module and its map afterwards — `dist/format.mjs` is
+    // 890 bytes in the record and 490 on disk. A guard built on that would fail
+    // on every correct build, and be removed.
+    //
+    // Two things that do hold. The record names exactly the modules that exist,
+    // so an entry point added or dropped without rewriting it is caught; and no
+    // module is NEWER than the record, so a `dist` rebuilt by some path that
+    // did not write one is caught. That second case is the one worth having,
+    // because a stale graph says whatever it said last time — which is the
+    // flattering direction, since the boundary was intact then.
+    const outputs = buildGraph();
+    const recorded = Object.keys(outputs)
+      .filter(file => file.endsWith(".mjs"))
+      .sort();
+    const onDisk = readdirSync(DIST)
+      .filter(file => file.endsWith(".mjs"))
+      .map(emitted)
+      .sort();
+
+    expect(recorded.length).toBeGreaterThan(0);
+    expect(recorded).toEqual(onDisk);
+
+    const writtenAt = statSync(METAFILE).mtimeMs;
+    for (const file of recorded) {
+      expect(statSync(join(PACKAGE, file)).mtimeMs, file).toBeLessThanOrEqual(
+        writtenAt
+      );
+    }
+  });
+
+  it("gives the format entry no runtime dependency, deferred ones included", () => {
+    // The claim the whole entry point exists for, asked of every edge rather
+    // than of the ones initialisation happens to follow.
+    const outputs = buildGraph();
+
+    expect(buildExternals(outputs, emitted(FORMAT_ENTRY))).toEqual([]);
+  });
+
+  it("CONTROL: the same walk finds the root's dependency", () => {
+    // A walk that followed nothing would report an empty external set for every
+    // entry point, including one that demonstrably bundles a parser. Matched by
+    // package, because the compiler imports `css-tree/parser` and
+    // `css-tree/walker` by subpath and an equality check against the bare name
+    // finds neither.
+    const outputs = buildGraph();
+    const packages = buildExternals(outputs, emitted(ROOT_ENTRY)).map(
+      specifier => specifier.split("/")[0]
     );
+
+    expect(packages).toContain("css-tree");
   });
 
   it("stays a small fraction of the package root", () => {
@@ -279,13 +498,9 @@ describe("what the format entry point actually loads", () => {
     // be raised until it meant nothing. What must stay true is that this entry
     // costs a small fraction of the root, which is the property consumers rely
     // on.
-    //
-    // Measured over the files the resolver REPORTED loading, so the two sides
-    // are the graphs Node built rather than two readings of the text.
-    const format = bytesOf(
-      runEntry(DIST, FORMAT_ENTRY, { instrumented: true })
-    );
-    const root = bytesOf(runEntry(DIST, ROOT_ENTRY, { instrumented: true }));
+    const outputs = buildGraph();
+    const format = buildBytes(outputs, emitted(FORMAT_ENTRY));
+    const root = buildBytes(outputs, emitted(ROOT_ENTRY));
 
     expect(format).toBeGreaterThan(0);
     expect(root).toBeGreaterThan(format * 10);

--- a/packages/blocks-engine/src/format-boundary.test.ts
+++ b/packages/blocks-engine/src/format-boundary.test.ts
@@ -6,6 +6,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  realpathSync,
   statSync,
   writeFileSync,
 } from "node:fs";
@@ -105,15 +106,48 @@ function lookupChain(from: string): string[] {
   }
 }
 
+/**
+ * A directory to build the sandbox under whose ancestors hold no
+ * `node_modules`.
+ *
+ * `os.tmpdir()` is the obvious answer and is not always the right one: it reads
+ * `TMPDIR`, which a hermetic or project-local test setup can point INSIDE the
+ * checkout — and then the sandbox sits under the workspace, every runtime
+ * dependency resolves by the ordinary upward lookup, and the boundary passes by
+ * not being one. The precondition below catches that, so the failure is honest;
+ * it is still a red for a reason that has nothing to do with the bundle.
+ *
+ * So the location is CHOSEN rather than assumed. Candidates are tried in order
+ * and the first with a clean ancestor chain wins.
+ *
+ * Refuses rather than falling back to a dirty directory. A sandbox that
+ * resolves is not a sandbox, and a suite that quietly went on using one would
+ * report the boundary intact whatever the bundle imports.
+ */
+function isolatedRoot(): string {
+  // The runner's own temp first where CI provides one, then the platform's,
+  // then the POSIX default — which is deliberately last, because it is the one
+  // an environment variable cannot redirect and so the one least likely to have
+  // been pointed anywhere.
+  const candidates = [process.env.RUNNER_TEMP, tmpdir(), "/tmp"];
+  const tried: string[] = [];
+  for (const candidate of candidates) {
+    if (candidate === undefined || !existsSync(candidate)) continue;
+    const reachable = lookupChain(realpathSync(candidate)).filter(existsSync);
+    if (reachable.length === 0) return candidate;
+    tried.push(`${candidate} (reaches ${reachable[0] ?? ""})`);
+  }
+  throw new Error(
+    `no dependency-free directory to sandbox in; tried ${tried.join(", ")}`
+  );
+}
+
 let sandbox = "";
 let hooks = "";
 let record = "";
 
 beforeAll(() => {
-  // OUTSIDE the workspace, which is the whole point: a copy under the package
-  // would find the workspace's `node_modules` by the ordinary upward lookup and
-  // resolve every runtime dependency exactly as the real build does.
-  sandbox = mkdtempSync(join(tmpdir(), "nextly-format-boundary-"));
+  sandbox = mkdtempSync(join(isolatedRoot(), "nextly-format-boundary-"));
   cpSync(DIST, join(sandbox, "dist"), { recursive: true });
 
   record = join(sandbox, "resolved.jsonl");
@@ -249,7 +283,11 @@ describe("the format entry point's boundary", () => {
     // in the flattering direction if it is wrong: a `node_modules` anywhere
     // above the sandbox resolves every runtime dependency, the isolated import
     // succeeds for the wrong reason, and the control below stops controlling.
-    const reachable = lookupChain(sandbox).filter(existsSync);
+    //
+    // `isolatedRoot` chose a clean root, so this asserts that creating the
+    // sandbox inside it introduced nothing — and that the choice was made at
+    // all, which is the part a later edit could drop.
+    const reachable = lookupChain(realpathSync(sandbox)).filter(existsSync);
     expect(reachable, `resolvable from ${sandbox}`).toEqual([]);
   });
 

--- a/packages/blocks-engine/src/format-boundary.test.ts
+++ b/packages/blocks-engine/src/format-boundary.test.ts
@@ -1,8 +1,18 @@
-import { existsSync, readFileSync, statSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import {
+  cpSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, parse, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 /**
  * The `./format` entry point's whole value is what it does NOT reach.
@@ -21,192 +31,263 @@ import { describe, expect, it } from "vitest";
  * the compiler compiles, type-checks, and passes every source-level guard while
  * silently restoring the regression this entry point was added to remove.
  *
- * A comment saying "import nothing heavy here" is the version of this that does
- * not work: the correct path and the easy path differ, so the rule gets broken
- * by someone who knows it.
+ * ## Why nothing here reads the bundle as text
+ *
+ * The boundary used to be checked by matching import syntax with a regular
+ * expression, and a scan over syntax has an unbounded surface: measured, an
+ * `import` written with a comment between the keyword and its parenthesis
+ * matched nothing — certifying the entry while omitting a module it reaches —
+ * and a keyword inside a longer string was read as an import that does not
+ * exist. Both directions were wrong, and the first is the dangerous one,
+ * because a scan that sees less reports a healthier boundary.
+ *
+ * So the question is put to the module resolver instead, in the two forms that
+ * cannot be under-read:
+ *
+ * - the entry is imported from a directory with NO `node_modules` above it, so
+ *   anything reaching a runtime dependency fails to resolve. Complete by
+ *   construction rather than a pattern to keep extending.
+ * - the entry is imported again under a resolution hook, which reports every
+ *   specifier Node actually resolved. That is the module graph itself, not a
+ *   reading of what the text appears to say.
+ *
+ * @module format-boundary.test
  */
 
 const DIST = resolve(dirname(fileURLToPath(import.meta.url)), "..", "dist");
+const FORMAT_ENTRY = "format.mjs";
+const ROOT_ENTRY = "index.mjs";
+
+/** What running one entry point in a child process reported. */
+interface EntryRun {
+  readonly ok: boolean;
+  readonly stderr: string;
+  /** Each specifier the resolver was asked for, with what it answered. */
+  readonly resolved: readonly { specifier: string; url: string }[];
+}
 
 /**
- * Every module specifier a source file imports, in any of the forms the bundler
- * emits.
+ * The directories a bare specifier would be looked up in, from `from` upwards.
  *
- * Four forms, all of which a bundle can contain:
- *
- * - `import x from "y"` and `export … from "y"` — the `from` clause.
- * - `import "y"` — a side-effect import, which has no `from` clause and is how
- *   a parser is pulled in for its registration behaviour alone.
- * - `import("y")` — a dynamic import, which defers loading without avoiding it.
- * - both quote styles, since the bundler emits single quotes.
- *
- * A form this misses is not reported as a gap. The graph simply comes back
- * smaller and the external set emptier, which is what a healthy boundary looks
- * like, so every assertion below passes over a dependency it never saw.
- * `specifiersIn` is therefore exported and asserted directly on input whose
- * answer is known, rather than trusted because the boundary looks intact.
+ * Node walks parents until the filesystem root, so isolation is a property of
+ * the whole chain rather than of the directory chosen. Asserted rather than
+ * assumed: a `node_modules` anywhere above would make every import below
+ * resolve, and the boundary test would pass by not being a boundary.
  */
-export function specifiersIn(source: string): string[] {
-  const found: string[] = [];
-  // `from "x"` covers import and export alike; the second alternative is a bare
-  // `import "x"` with no binding, which the first cannot see.
-  // `import(` is matched with its parenthesis so a dynamic import is seen; the
-  // bare `import "x"` alternative would not reach it, because the quote does
-  // not follow the keyword directly.
-  //
-  // The capture excludes a NEWLINE because a module specifier cannot contain
-  // one, and without that this reads a false import out of ordinary code: the
-  // literal `"from"` ends with a quote, so the keyword pattern matches the word
-  // inside the string and captures everything up to the next quote — which for
-  // `ownEntry(value, "from")` followed by a comparison is a fragment of the
-  // next two lines. Excluding the newline cannot hide a real specifier and does
-  // refuse that.
-  for (const match of source.matchAll(
-    /(?:from|import)\s*\(?\s*['"]([^'"\n]+)['"]/g
-  )) {
-    found.push(match[1]!);
+function lookupChain(from: string): string[] {
+  const chain: string[] = [];
+  let current = from;
+  for (;;) {
+    chain.push(join(current, "node_modules"));
+    const parent = dirname(current);
+    if (parent === current || current === parse(current).root) return chain;
+    current = parent;
   }
-  return found;
+}
+
+let sandbox = "";
+let hooks = "";
+let record = "";
+
+beforeAll(() => {
+  // OUTSIDE the workspace, which is the whole point: a copy under the package
+  // would find the workspace's `node_modules` by the ordinary upward lookup and
+  // resolve every runtime dependency exactly as the real build does.
+  sandbox = mkdtempSync(join(tmpdir(), "nextly-format-boundary-"));
+  cpSync(DIST, join(sandbox, "dist"), { recursive: true });
+
+  record = join(sandbox, "resolved.jsonl");
+  hooks = join(sandbox, "hooks.mjs");
+  // A resolution hook rather than a reading of the emitted text. It records
+  // what the resolver was ASKED and what it ANSWERED, so a specifier written in
+  // a form no pattern anticipates is still seen — there is no form to miss.
+  writeFileSync(
+    hooks,
+    [
+      `import { appendFileSync } from "node:fs";`,
+      `export async function resolve(specifier, context, next) {`,
+      `  const result = await next(specifier, context);`,
+      `  appendFileSync(process.env.NEXTLY_RESOLVE_RECORD, JSON.stringify({ specifier, url: result.url }) + "\\n");`,
+      `  return result;`,
+      `}`,
+    ].join("\n")
+  );
+});
+
+afterAll(() => {
+  if (sandbox !== "") rmSync(sandbox, { recursive: true, force: true });
+});
+
+/**
+ * Import one entry point in a child process, optionally recording what the
+ * resolver did.
+ *
+ * A child rather than this process, because the question is what happens on a
+ * fresh resolution from a particular directory — and the test runner has
+ * already loaded this package, its dependencies and its own graph.
+ */
+function runEntry(
+  from: string,
+  entry: string,
+  { instrumented }: { instrumented: boolean }
+): EntryRun {
+  const url = pathToFileURL(join(from, entry)).href;
+  const bootstrap = instrumented
+    ? [
+        `import { register } from "node:module";`,
+        `import { pathToFileURL } from "node:url";`,
+        `register(pathToFileURL(${JSON.stringify(hooks)}));`,
+        `await import(${JSON.stringify(url)});`,
+      ].join("\n")
+    : `await import(${JSON.stringify(url)});`;
+
+  if (instrumented) writeFileSync(record, "");
+  const result = spawnSync(
+    process.execPath,
+    ["--input-type=module", "--eval", bootstrap],
+    {
+      encoding: "utf8",
+      // The child's own cwd, so a bare specifier is looked up from the
+      // directory holding the entry rather than from wherever vitest was run.
+      cwd: from,
+      env: { ...process.env, NEXTLY_RESOLVE_RECORD: record },
+    }
+  );
+
+  const resolved = !instrumented
+    ? []
+    : readFileSync(record, "utf8")
+        .split("\n")
+        .filter(line => line !== "")
+        .map(line => JSON.parse(line) as { specifier: string; url: string });
+
+  return { ok: result.status === 0, stderr: result.stderr ?? "", resolved };
 }
 
 const isRelative = (specifier: string) => specifier.startsWith(".");
 
-/** Every emitted file an entry point reaches, following relative specifiers. */
-function bundleGraph(entry: string): string[] {
-  const seen = new Set<string>();
-  const queue = [entry];
-
-  while (queue.length > 0) {
-    const file = queue.pop();
-    if (file === undefined || seen.has(file) || !existsSync(file)) continue;
-    seen.add(file);
-
-    for (const specifier of specifiersIn(readFileSync(file, "utf8"))) {
-      if (isRelative(specifier)) queue.push(resolve(dirname(file), specifier));
-    }
+/**
+ * The bare package specifiers a run actually resolved.
+ *
+ * A specifier carrying a SCHEME is not one of them, and excluding it is not
+ * cosmetic: the bootstrap imports the entry by its own `file:` URL, so a run
+ * that resolved nothing at all would otherwise report one external and every
+ * empty-set assertion below would fail on the harness rather than on the
+ * boundary. Built-ins are excluded for the reason the boundary is about
+ * bundle weight: `node:path` costs a consumer nothing to load.
+ */
+function externals(run: EntryRun): string[] {
+  const found = new Set<string>();
+  for (const { specifier } of run.resolved) {
+    if (isRelative(specifier) || URL.canParse(specifier)) continue;
+    if (specifier.startsWith("node:")) continue;
+    found.add(specifier);
   }
-
-  return [...seen];
+  return [...found].sort();
 }
 
-/** Bare package specifiers an entry point's graph imports at runtime. */
-function externalImports(files: string[]): Set<string> {
-  const externals = new Set<string>();
-  for (const file of files) {
-    for (const specifier of specifiersIn(readFileSync(file, "utf8"))) {
-      if (!isRelative(specifier)) externals.add(specifier);
-    }
+/** The bytes of every emitted file a run loaded from `dist`. */
+function bytesOf(run: EntryRun): number {
+  const files = new Set<string>();
+  for (const { url } of run.resolved) {
+    if (!url.startsWith("file:")) continue;
+    const file = fileURLToPath(url);
+    if (file.startsWith(DIST)) files.add(file);
   }
-  return externals;
+  let total = 0;
+  for (const file of files) total += statSync(file).size;
+  return total;
 }
 
-function bytesOf(files: string[]): number {
-  return files.reduce((total, file) => total + statSync(file).size, 0);
-}
-
-describe("the import scanner", () => {
-  it("does not read an import out of a string literal named like the keyword", () => {
-    // `"from"` ends in a quote, so a keyword match that allowed a newline in
-    // the specifier captured the next two lines of ordinary code and reported
-    // it as an external dependency. A module specifier has no newline in it.
-    const source = [
-      'const from = ownEntry(value, "from");',
-      'if (from === "component") return true;',
-    ].join("\n");
-
-    expect(specifiersIn(source)).toEqual([]);
+describe("the format entry point's boundary", () => {
+  it("has been built", () => {
+    // Every assertion below reads these files. A missing one makes the
+    // isolated import fail for a reason that has nothing to do with the
+    // boundary, and an unbuilt tree would otherwise read as a broken one.
+    for (const entry of [FORMAT_ENTRY, ROOT_ENTRY]) {
+      const file = join(DIST, entry);
+      expect(existsSync(file), `${file} is missing`).toBe(true);
+    }
   });
 
-  it("still sees every real specifier shape", () => {
-    // The control: the narrowing must not cost a form the walk depends on.
-    const source = [
-      'import { a } from "./a";',
-      'export { b } from "./b";',
-      'import "./side-effect";',
-      'const c = await import("./c");',
-    ].join("\n");
+  it("is asked from a directory nothing can be resolved out of", () => {
+    // The precondition the two assertions below rest on, and the one that fails
+    // in the flattering direction if it is wrong: a `node_modules` anywhere
+    // above the sandbox resolves every runtime dependency, the isolated import
+    // succeeds for the wrong reason, and the control below stops controlling.
+    const reachable = lookupChain(sandbox).filter(existsSync);
+    expect(reachable, `resolvable from ${sandbox}`).toEqual([]);
+  });
 
-    expect(specifiersIn(source)).toEqual([
-      "./a",
-      "./b",
-      "./side-effect",
-      "./c",
-    ]);
+  it("imports with no node_modules in reach", () => {
+    // The boundary itself. Not "no import matched a pattern" — the resolver was
+    // given the entry with nothing to resolve a bare specifier from, and it
+    // loaded. Anything reaching a runtime dependency cannot.
+    const run = runEntry(join(sandbox, "dist"), FORMAT_ENTRY, {
+      instrumented: false,
+    });
+
+    expect(run.ok, run.stderr).toBe(true);
+  });
+
+  it("CONTROL: the package root cannot, in that same directory", () => {
+    // Without this the test above passes on an isolation that isolates
+    // nothing — a sandbox that could still see a `node_modules`, a child that
+    // silently exited 0, an entry file that does not exist. The root reaches
+    // the CSS parser, so it must fail here, and its failure is what proves the
+    // format entry's success means something.
+    const run = runEntry(join(sandbox, "dist"), ROOT_ENTRY, {
+      instrumented: false,
+    });
+
+    expect(run.ok).toBe(false);
+    expect(run.stderr).toContain("ERR_MODULE_NOT_FOUND");
+    expect(run.stderr).toContain("css-tree");
   });
 });
 
-describe("the format entry point's boundary", () => {
-  const formatEntry = join(DIST, "format.mjs");
-  const rootEntry = join(DIST, "index.mjs");
+describe("what the format entry point actually loads", () => {
+  it("resolves no runtime dependency", () => {
+    // The same claim asked a second way, in a place where dependencies ARE
+    // resolvable. The isolated import proves nothing external could load; this
+    // proves nothing external was even asked for, which is what would still
+    // hold if the sandbox ever stopped being isolated.
+    const run = runEntry(DIST, FORMAT_ENTRY, { instrumented: true });
 
-  it("has been built", () => {
-    // Every assertion below reads these files. Missing ones would make each
-    // graph empty, every external set empty, and every expectation trivially
-    // satisfied — a suite reporting that nothing heavy is reachable because
-    // nothing at all is.
-    expect(existsSync(formatEntry), `${formatEntry} is missing`).toBe(true);
-    expect(existsSync(rootEntry), `${rootEntry} is missing`).toBe(true);
+    expect(run.ok, run.stderr).toBe(true);
+    expect(externals(run)).toEqual([]);
   });
 
-  it("reaches no runtime dependency", () => {
-    const externals = externalImports(bundleGraph(formatEntry));
-    expect([...externals].sort()).toEqual([]);
+  it("CONTROL: the same instrument sees the root's dependency", () => {
+    // A hook that recorded nothing would report an empty external set for every
+    // entry point, including one that demonstrably pulls a parser. Matched by
+    // package rather than by exact specifier: the compiler imports
+    // `css-tree/parser` and `css-tree/walker` by subpath, so an equality check
+    // against the bare name finds nothing and the control passes for the wrong
+    // reason.
+    const run = runEntry(DIST, ROOT_ENTRY, { instrumented: true });
+
+    expect(run.ok, run.stderr).toBe(true);
+    expect(externals(run).map(specifier => specifier.split("/")[0])).toContain(
+      "css-tree"
+    );
   });
 
   it("stays a small fraction of the package root", () => {
-    const format = bytesOf(bundleGraph(formatEntry));
-    const root = bytesOf(bundleGraph(rootEntry));
-
     // A ratio rather than a byte ceiling: the absolute size moves whenever the
     // engine grows, and a fixed number would either fail on unrelated work or
     // be raised until it meant nothing. What must stay true is that this entry
     // costs a small fraction of the root, which is the property consumers rely
-    // on. Measured at roughly 1.5% when written.
+    // on.
+    //
+    // Measured over the files the resolver REPORTED loading, so the two sides
+    // are the graphs Node built rather than two readings of the text.
+    const format = bytesOf(
+      runEntry(DIST, FORMAT_ENTRY, { instrumented: true })
+    );
+    const root = bytesOf(runEntry(DIST, ROOT_ENTRY, { instrumented: true }));
+
     expect(format).toBeGreaterThan(0);
     expect(root).toBeGreaterThan(format * 10);
-  });
-
-  it("is measured by a walk that can actually see the difference", () => {
-    // The positive control, and the reason the two assertions above mean
-    // anything. A traversal that silently followed nothing would report an
-    // empty external set and a tiny size for EVERY entry point, including one
-    // that demonstrably pulls a parser. Requiring the root to reach a real
-    // dependency proves the walk resolves specifiers and reads what it finds.
-    const rootFiles = bundleGraph(rootEntry);
-    expect(rootFiles.length).toBeGreaterThan(1);
-    // Matched by package rather than by exact specifier: the compiler imports
-    // `css-tree/parser` and `css-tree/walker` by subpath, so an equality check
-    // against the bare name finds nothing and the control passes for the wrong
-    // reason — reporting a healthy boundary because it could not see the
-    // dependency it was pointed at.
-    const rootPackages = [...externalImports(rootFiles)].map(
-      specifier => specifier.split("/")[0]
-    );
-    expect(rootPackages).toContain("css-tree");
-  });
-
-  it("sees every import form the bundler emits", () => {
-    // The control for the SCANNER rather than for the boundary, on input whose
-    // answer is known. It is the only assertion in this file that can fail when
-    // the scanner narrows: the four above read real bundles, where a form that
-    // goes unmatched produces a smaller graph and an emptier external set —
-    // indistinguishable from the boundary being intact.
-    const emitted = [
-      `import { a } from './rel.mjs';`,
-      `import "css-tree/parser";`,
-      `export { b } from "./other.mjs";`,
-      `import c from 'some-pkg';`,
-      `const lazy = () => import("lazy-pkg/sub");`,
-      `await import('./deferred.mjs');`,
-    ].join("\n");
-
-    expect(specifiersIn(emitted).sort()).toEqual([
-      "./deferred.mjs",
-      "./other.mjs",
-      "./rel.mjs",
-      "css-tree/parser",
-      "lazy-pkg/sub",
-      "some-pkg",
-    ]);
   });
 });

--- a/packages/blocks-engine/tsup.config.ts
+++ b/packages/blocks-engine/tsup.config.ts
@@ -10,6 +10,17 @@ export default defineConfig({
   clean: true,
   sourcemap: true,
   treeshake: true,
+  // The module graph esbuild actually built, written beside the bundles.
+  //
+  // `format-boundary.test.ts` reads it because a graph OBSERVED by importing an
+  // entry point only contains what initialisation resolved: a dynamic import
+  // behind a function is a real edge to a real dependency that nothing asks the
+  // resolver for until it is called. The metafile records every edge with its
+  // kind, deferred ones included, from the tool that emitted the code.
+  //
+  // Kept out of the published package by the `files` negation in package.json:
+  // it describes a build rather than shipping with one.
+  metafile: true,
   outExtension() {
     return { js: ".mjs" };
   },


### PR DESCRIPTION
Raised as a P1 by Codex on #1576 and independently by CodeRabbit. AGENTS.md: *prefer a boundary the system cannot cross to a check that looks for crossings.*

## What was wrong

The `./format` entry point's whole value is what it does **not** reach, and that was checked by matching import syntax with a regular expression. A scan over syntax has an unbounded surface, and two holes were measured on `main`:

1. an `import` written with a comment between the keyword and its parenthesis matched **nothing** — the walk certified the entry while omitting a module it reaches. **A false pass**, which is the dangerous direction: a scan that sees less reports a healthier boundary.
2. a keyword inside a longer string was read as an import, reporting a dependency that does not exist.

A third instance is what surfaced it: an array literal of field names in `document.ts` made the scan report the format entry reaching a module called `', '`. The response to each was another patch to the pattern, which is the shape AGENTS.md says cannot be finished.

## What replaces it

The question now goes to **the module resolver**, in two forms that cannot be under-read.

**The entry is imported from a directory with no `node_modules` above it.** `dist` is copied to a sandbox under the OS temp directory and `format.mjs` is imported there in a child process. Anything reaching a runtime dependency fails to resolve. Complete by construction — there is no import form to miss, because nothing is being read.

**The entry is imported again under a resolution hook**, which records every specifier Node actually resolved and what it answered. That is the module graph itself rather than a reading of what the text appears to say, and it is what the size ratio is now measured over.

## Every instrument is controlled

This file replaces the instrument three assertions depended on, so each new one has a control that must move:

| instrument | its control |
|---|---|
| the sandbox is isolated | the lookup chain from the sandbox to the filesystem root is asserted to contain no `node_modules` — one above it would make the boundary pass by not being one |
| the isolated import means something | **the package root must FAIL in that same directory**, with `ERR_MODULE_NOT_FOUND` naming `css-tree` |
| the resolution hook records | the root's externals must contain `css-tree`, matched by package because the compiler imports it by subpath |

## Break-verification

Against **the regression itself**, not a mutation: `import "css-tree/parser"` prepended to the built `format.mjs` fails both mechanisms —

```
killed 2
  - imports with no node_modules in reach
  - resolves no runtime dependency
```

And three breaks of the harness, each caught by a control:

| harness break | what failed |
|---|---|
| sandbox inside the package, where `node_modules` IS reachable | the isolation precondition, and the root's must-fail control stopped failing |
| the resolution hook records nothing | the `css-tree` control, and the size ratio |
| a run reported ok whatever the child did | the root's must-fail control |

## Notes

`specifiersIn` goes with the scan. It had no caller outside this file; the identically named helper in `packages/ui/scripts` is its own implementation and is untouched.

**Test-only, so no changeset** — per AGENTS.md.

Suite 2332 across 52 files, unchanged from the baseline: seven assertions before, seven after.

## Gates

`fallow audit --base origin/main` **pass**, `complexity_introduced` 0, `dead_code_introduced` 0, `duplication_introduced` 0 · `check:comments` 0 · `lint:design` 0 · `turbo run check-types` 0 across 42 tasks.
