### PR TITLE
fix(nextly): claim a document only when the caller may update that row

### DIFF
--- a/.changeset/claim-only-what-you-may-update.md
+++ b/.changeset/claim-only-what-you-may-update.md
@@ -1,0 +1,42 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Claim a document only when the caller may actually update that row.
+
+`/api/document-lock` authorized writes on `update-<slug>`, which is the coarse
+route permission: it says a caller may update documents of this kind, not that
+they may update THIS one. A collection carrying an owner-only or role-based
+stored rule refuses the row while that permission still stands, so a non-owner
+could take a claim on a document every real update denies them, and the
+legitimate owner was then shown a false holder and pushed to take over their own
+row.
+
+The gate the version routes already run for the same reason now runs here too. It
+was named `assertVersionDocumentUpdatable` and is renamed to
+`assertDocumentUpdatable`, since it was never about versions: its own docblock
+describes the document's update rules, and it now has two callers.

--- a/packages/nextly/src/api/__tests__/document-lock-route.test.ts
+++ b/packages/nextly/src/api/__tests__/document-lock-route.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
+import { NextlyError } from "../../errors/nextly-error";
+
 const service = {
   read: vi.fn(),
   acquire: vi.fn(),
@@ -27,14 +29,23 @@ vi.mock("../../auth/middleware", () => ({
 const canReadEntity = vi.fn();
 const callerHoldsPermission = vi.fn();
 vi.mock("../../auth/entity-read-access", () => ({
-  readAccessCaller: (caller: unknown) => caller,
+  readAccessCaller: (caller: { user: unknown }) => caller.user,
   canReadEntity: (slug: string, caller: unknown) =>
     canReadEntity(slug, caller) as unknown,
   callerHoldsPermission: (slug: string, caller: unknown) =>
     callerHoldsPermission(slug, caller) as unknown,
 }));
+// The stored per-document update rules, which the coarse permission above does
+// not run. Spied rather than executed: what this file establishes is that the
+// route asks, and with which document.
+const assertDocumentUpdatable = vi.fn();
+vi.mock("../versions-access", () => ({
+  assertDocumentUpdatable: (...args: unknown[]) =>
+    assertDocumentUpdatable(...args) as unknown,
+}));
+
 vi.mock("../authenticated-read", () => ({
-  readCaller: (auth: unknown) => Promise.resolve(auth),
+  readCaller: (auth: unknown) => Promise.resolve({ user: auth }),
   PRIVATE_NO_STORE_HEADERS: {
     "Cache-Control": "private, no-store",
     Vary: "Cookie",
@@ -57,6 +68,7 @@ beforeEach(() => {
   requireAuthentication.mockResolvedValue(auth);
   canReadEntity.mockResolvedValue(true);
   callerHoldsPermission.mockResolvedValue(true);
+  assertDocumentUpdatable.mockResolvedValue(undefined);
 });
 
 describe("document lock route", () => {
@@ -242,5 +254,54 @@ describe("document lock route", () => {
 
     expect(body).toHaveProperty("message");
     expect(body.item).toMatchObject({ status: "acquired" });
+  });
+
+  it("asks whether THIS document may be updated, not documents of its kind", async () => {
+    // 🔴 `update-<slug>` is the coarse route permission and says only the latter.
+    // A collection carrying an owner-only stored rule refuses the row while that
+    // permission still stands, so without this a non-owner claims a document
+    // every real update denies them - and the owner is shown a false holder and
+    // pushed to take over their own row.
+    service.acquire.mockResolvedValue({ status: "acquired", claimToken: "t" });
+
+    await acquireLock(post({ ...ref }));
+
+    expect(assertDocumentUpdatable).toHaveBeenCalledWith(
+      ref.scopeKind,
+      ref.slug,
+      ref.entryId,
+      auth,
+      undefined
+    );
+  });
+
+  it("refuses the claim when the stored rules refuse the row", async () => {
+    // The real refusal, not a stand-in: the handler branches on what a
+    // `NextlyError` is, and a look-alike is reported as a 500 while the
+    // assertion below still reads "the claim did not happen".
+    assertDocumentUpdatable.mockRejectedValue(
+      NextlyError.forbidden({
+        logContext: { reason: "document-not-updatable" },
+      })
+    );
+
+    const response = await acquireLock(post({ ...ref }));
+
+    expect(response.status).toBe(403);
+    expect(service.acquire).not.toHaveBeenCalled();
+  });
+
+  it("does not ask it of a read", async () => {
+    // Reading who holds a document is not updating it, and running an update
+    // gate here would hide the holder from everyone who may only read.
+    service.read.mockResolvedValue(null);
+
+    await readLock(
+      new Request(
+        "https://x.test/api/document-lock?scopeKind=collection&slug=posts&entryId=42"
+      )
+    );
+
+    expect(assertDocumentUpdatable).not.toHaveBeenCalled();
   });
 });

--- a/packages/nextly/src/api/document-lock.ts
+++ b/packages/nextly/src/api/document-lock.ts
@@ -37,6 +37,7 @@ import { getCachedNextly } from "../init";
 
 import { PRIVATE_NO_STORE_HEADERS, readCaller } from "./authenticated-read";
 import { respondData, respondMutation } from "./response-shapes";
+import { assertDocumentUpdatable } from "./versions-access";
 import { withErrorHandler } from "./with-error-handler";
 
 async function getDocumentLockService(): Promise<DocumentLockService> {
@@ -95,6 +96,14 @@ function readRef(source: {
  * renewing and releasing need UPDATE, because a lock is a statement that you
  * are editing, and someone who cannot edit is not.
  *
+ * 🔴 UPDATE means THIS document, not documents of this kind. `update-<slug>` is
+ * the coarse route permission and says only the latter, so a collection carrying
+ * an owner-only stored rule refuses the row while that permission still stands.
+ * Without the second gate a non-owner claims a document every real update denies
+ * them, and the owner is then shown a false holder and pushed to take over their
+ * own row. The gate the version routes already use runs here, for the reason its
+ * own docblock gives.
+ *
  * Both helpers are entity-generic and read the collection and single maps
  * alike, so a Single needs no branch here, and both delegate to the canonical
  * machinery rather than reproducing the API-key and super-admin rules that
@@ -105,7 +114,8 @@ async function authorize(
   ref: DocumentRef,
   intent: "read" | "write"
 ): Promise<void> {
-  const caller = readAccessCaller(await readCaller(auth));
+  const authenticated = await readCaller(auth);
+  const caller = readAccessCaller(authenticated);
   const allowed =
     intent === "read"
       ? await canReadEntity(ref.slug, caller)
@@ -117,6 +127,18 @@ async function authorize(
     throw NextlyError.forbidden({
       logContext: { slug: ref.slug, scopeKind: ref.scopeKind, intent },
     });
+  }
+
+  if (intent === "write") {
+    // Route authorization has just run, so the coarse re-check is skipped and
+    // what runs here is the stored per-document rules this gate exists for.
+    await assertDocumentUpdatable(
+      ref.scopeKind,
+      ref.slug,
+      ref.entryId,
+      authenticated.user,
+      authenticated.authenticatedScope
+    );
   }
 }
 

--- a/packages/nextly/src/api/versions-access.ts
+++ b/packages/nextly/src/api/versions-access.ts
@@ -164,7 +164,7 @@ export async function assertVersionDocumentReadable(
  * Both entity kinds are covered deliberately. A gate that reached only one
  * would read as complete and would not be.
  */
-export async function assertVersionDocumentUpdatable(
+export async function assertDocumentUpdatable(
   scopeKind: VersionScopeKind,
   slug: string,
   entryId: string,
@@ -191,7 +191,7 @@ export async function assertVersionDocumentUpdatable(
   if (!allowed) {
     throw NextlyError.forbidden({
       logContext: {
-        reason: "version-document-not-updatable",
+        reason: "document-not-updatable",
         scopeKind,
         scopeSlug: slug,
         entryId,

--- a/packages/nextly/src/dispatcher/handlers/__tests__/autosave-policy.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/autosave-policy.test.ts
@@ -14,7 +14,7 @@ const autosaveSpy = vi.fn();
 
 vi.mock("../../../api/versions-access", () => ({
   assertVersionDocumentReadable: vi.fn(),
-  assertVersionDocumentUpdatable: vi.fn(),
+  assertDocumentUpdatable: vi.fn(),
   resolveVersionsPolicy: (...a: unknown[]) => policySpy(...a),
   tryResolveCurrentFields: vi.fn(async () => []),
   redactSnapshotForUser: vi.fn(),

--- a/packages/nextly/src/dispatcher/handlers/__tests__/discard-working-draft-access.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/discard-working-draft-access.test.ts
@@ -22,7 +22,7 @@ vi.mock("../../../domains/versions/discard-working-draft", () => ({
 
 vi.mock("../../../api/versions-access", () => ({
   assertVersionDocumentReadable: readableSpy,
-  assertVersionDocumentUpdatable: updatableSpy,
+  assertDocumentUpdatable: updatableSpy,
 }));
 
 vi.mock("../../../auth/entity-read-access", () => ({

--- a/packages/nextly/src/dispatcher/handlers/__tests__/versions-label.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/versions-label.test.ts
@@ -21,7 +21,7 @@ vi.mock("../../../di", () => ({
 
 vi.mock("../../../api/versions-access", () => ({
   assertVersionDocumentReadable: readableSpy,
-  assertVersionDocumentUpdatable: updatableSpy,
+  assertDocumentUpdatable: updatableSpy,
   redactSnapshotForUser: vi.fn(),
   resolveSingleDocumentId: vi.fn(),
 }));

--- a/packages/nextly/src/dispatcher/handlers/versions-methods.ts
+++ b/packages/nextly/src/dispatcher/handlers/versions-methods.ts
@@ -13,7 +13,7 @@ import type { PaginationMeta } from "../../api/response-shapes";
 import {
   assertDiffVersionPair,
   assertVersionDocumentReadable,
-  assertVersionDocumentUpdatable,
+  assertDocumentUpdatable,
   diffDocumentVersions,
   hydrateVersionSnapshot,
   redactSnapshotForUser,
@@ -507,7 +507,7 @@ export async function setVersionLabelForDocument(
   // route earned. Applied even when the request turns out to write nothing:
   // this is a write endpoint, and gating only the writing case would let the
   // no-op be used to discover what the caller is allowed to change.
-  await assertVersionDocumentUpdatable(
+  await assertDocumentUpdatable(
     args.scopeKind,
     args.slug,
     args.entryId,
@@ -670,7 +670,7 @@ export async function discardWorkingDraftForDocument(
     args.user,
     authenticatedScope
   );
-  await assertVersionDocumentUpdatable(
+  await assertDocumentUpdatable(
     args.scopeKind,
     args.slug,
     args.entryId,
@@ -739,7 +739,7 @@ export async function autosaveForDocument(
     args.user,
     authenticatedScope
   );
-  await assertVersionDocumentUpdatable(
+  await assertDocumentUpdatable(
     args.scopeKind,
     args.slug,
     args.entryId,

--- a/packages/nextly/src/domains/collections/__tests__/api-key-scope-coverage.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/api-key-scope-coverage.integration.test.ts
@@ -9,7 +9,7 @@
  * `checkCollectionAccess`:
  *   - `deleteEntry`
  *   - the version-label update gate (`canUpdateEntry`, used by
- *     `assertVersionDocumentUpdatable`)
+ *     `assertDocumentUpdatable`)
  *
  * Each uses a collection whose code-defined rule refuses the operation. A
  * super-admin caller WITHOUT a scope bypasses the rule; the same super-admin
@@ -98,7 +98,7 @@ describe("API-key scope coverage on delete + version-label gates", () => {
     );
     const id = (created.data as { id: string }).id;
 
-    // `canUpdateEntry` is the gate `assertVersionDocumentUpdatable` runs before a
+    // `canUpdateEntry` is the gate `assertDocumentUpdatable` runs before a
     // version-label edit. A super-admin owning an update-scoped key: the scope
     // reaches the gate, the super-admin bypass is skipped, and the refusing rule
     // applies — the key may NOT edit labels.


### PR DESCRIPTION
## Summary

The last of the review findings from #1593, which merged with two open.

`/api/document-lock` authorized writes on `update-<slug>` — the **coarse** route permission. It says a caller may update documents of this *kind*, not that they may update *this one*. A collection carrying an owner-only or role-based stored rule refuses the row while that permission still stands.

So a non-owner could take a claim on a document every real update denies them, and the legitimate owner was then shown a false holder and pushed to take over their own row.

## Derived, not duplicated

The version routes already run exactly this gate, and its docblock already states the problem: *"The route-level `update-<slug>` permission is coarse: it says the caller may update documents of this kind, not that they may update THIS one."*

So this calls that gate rather than writing a second copy of the decision — `.claude/rules/derived-checks.md` is explicit that a narrower view must be derived from the richer one.

It was named `assertVersionDocumentUpdatable`, which was never accurate: nothing in it is about versions, and it now has two callers. Renamed to `assertDocumentUpdatable` across its 3 call sites and 3 test mocks, and its log reason generalises with it.

**Read is deliberately untouched.** Seeing who holds a document is not updating it, and running an update gate there would hide the holder from everyone who may only read.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

Follows #1593. One finding from that review remains and is **not** in this PR: custom collection edit views (`admin.components.views.Edit.Component`) return before `EntryForm` mounts, so they never claim. That needs a supported plugin surface for the lock rather than a patch, so it is its own piece of work.

## Changeset

- [x] I added a changeset
- [x] I selected the correct semver bump (patch)

## Test plan

- [x] `pnpm build` 19/19 · `pnpm check-types` 42/42 · `pnpm lint` 24/24 · `pnpm test` 38/38
- [x] `fallow audit --gate new-only` — `complexity_introduced: 0`
- [x] Three route tests: the gate is asked with this document's identity, a refusal stops the claim reaching the service, and a read never asks it
- [x] **Mutation-tested** — removing the gate, and extending it to reads, both fail the suite

## Notes for reviewers

One consequence worth weighing: a caller who may read but not update now gets a 403 on claim, which the admin surfaces as `unavailable` ("we could not check whether anyone else is editing"). That wording is imprecise for "this is not yours to claim". It is not wrong to refuse them, and the document is not editable for them regardless, but a distinct state would say it better. I left that out rather than widen this PR.
