### PR TITLE
docs: stop calling Nextly a framework, and import what the package exports

### DIFF
--- a/docs/admin/index.mdx
+++ b/docs/admin/index.mdx
@@ -62,8 +62,8 @@ The Users section groups three pages:
 
 The Settings inner sidebar is split into sub-groups:
 
-- **System** — General (site-wide settings) and API Keys.
-- **Email** — Email Providers (Resend, SMTP, etc.), Email Templates, and Email Layout.
+- **System.** General (site-wide settings) and API Keys.
+- **Email.** Email Providers (Resend, SMTP, etc.), Email Templates, and Email Layout.
 
 Image-size presets and the (programmatic) Permissions page also live under settings.
 

--- a/docs/configuration/collections.mdx
+++ b/docs/configuration/collections.mdx
@@ -121,17 +121,17 @@ Every collection row has these. Never declare them yourself.
 - `title`
 - `slug`
 
-If your `fields` array includes a field named `title` or `slug`, your definition replaces the auto-inject - same column, your shape. If you don't declare them, the framework adds bare-bones columns with no validation, no uniqueness, no admin form input.
+If your `fields` array includes a field named `title` or `slug`, your definition replaces the auto-inject - same column, your shape. If you don't declare them, Nextly adds bare-bones columns with no validation, no uniqueness, no admin form input.
 
 ### Should you redeclare `title` and `slug`?
 
-Almost always **yes**, even though the framework will inject them anyway. Five reasons:
+Almost always **yes**, even though Nextly will inject them anyway. Five reasons:
 
 1. **Uniqueness on `slug`** - the auto-injected `slug` is a plain `text NOT NULL` column with no unique constraint. To require unique slugs (the typical case for URL-routed content), declare your own field with `unique: true`.
 2. **Admin form visibility** - Nextly's admin builds the create/edit form from your `fields` array. The auto-injected columns are database-only and don't appear in the form. If you don't declare `title`, the admin shows no title input.
 3. **Validation and hooks** - auto-injected columns have no field config. Declared fields can attach `required`, `minLength`, `beforeChange` hooks (e.g. `auto-slug` to derive slug from title), defaults, and so on.
 4. **Custom UI** - placeholders, descriptions, field ordering, `admin: { readOnly: true }` all live on the field declaration.
-5. **Self-documentation** - a contributor reading the collection file sees the full surface in one place, without having to know the framework's reserved-column behavior.
+5. **Self-documentation** - a contributor reading the collection file sees the full surface in one place, without having to know Nextly's reserved-column behavior.
 
 You can legitimately skip declaring them when the collection is internal-only (e.g. an `audit-log`) and you don't need form visibility, validation, or unique slugs.
 

--- a/docs/configuration/field-groups.mdx
+++ b/docs/configuration/field-groups.mdx
@@ -11,11 +11,11 @@ Field groups are reusable field structures. Define a set of fields once as a fie
 
 Key characteristics:
 
-- **Templates, not documents** — field groups define a field structure; each embed creates its own data row.
-- **Own database table** — each field group gets a table derived from its slug and prefixed with `comp_` (e.g. `comp_seo`). The name is always derived; it cannot be overridden.
-- **Nesting** — a field group's fields can include `component` fields referencing other field groups (max depth: 3 levels).
-- **Slug uniqueness** — field group slugs must be unique across field groups, collections, **and** singles.
-- **Dual creation** — define in code with `defineFieldGroup()` or visually in the Visual Schema Builder.
+- **Templates, not documents.** Field groups define a field structure; each embed creates its own data row.
+- **Own database table.** Each field group gets a table derived from its slug and prefixed with `comp_` (e.g. `comp_seo`). The name is always derived; it cannot be overridden.
+- **Nesting.** A field group's fields can include `component` fields referencing other field groups (max depth: 3 levels).
+- **Slug uniqueness.** Field group slugs must be unique across field groups, collections, **and** singles.
+- **Dual creation.** Define in code with `defineFieldGroup()` or visually in the Visual Schema Builder.
 
 <Tabs items={["Code-first", "Visual Schema Builder"]}>
 <Tab value="Code-first">

--- a/docs/configuration/nextly-config.mdx
+++ b/docs/configuration/nextly-config.mdx
@@ -553,11 +553,11 @@ admin: {
 
 `defineConfig()` performs these checks at startup:
 
-- **Duplicate slugs** — collection, single, and field group slugs must be unique across all three.
-- **Cross-type conflicts** — a single cannot share a slug with a collection or field group.
-- **Field group nesting** — circular field group references and excessive nesting (max depth 3) are rejected.
-- **User config** — only the allowed scalar field types are accepted.
-- **API-key bounds** — `apiKeys.rateLimit.requestsPerHour` and `apiKeys.rateLimit.windowMs` must be positive.
+- **Duplicate slugs.** Collection, single, and field group slugs must be unique across all three.
+- **Cross-type conflicts.** A single cannot share a slug with a collection or field group.
+- **Field group nesting.** Circular field group references and excessive nesting (max depth 3) are rejected.
+- **User config.** Only the allowed scalar field types are accepted.
+- **API-key bounds.** `apiKeys.rateLimit.requestsPerHour` and `apiKeys.rateLimit.windowMs` must be positive.
 
 Validation failures throw a descriptive error at startup so misconfigurations surface immediately.
 

--- a/docs/guides/authentication.mdx
+++ b/docs/guides/authentication.mdx
@@ -29,10 +29,9 @@ Cookies are scoped to `/admin/*` so Nextly auth never collides with frontend app
 ```typescript
 // app/api/my-route/route.ts
 import { getSession } from "nextly/auth";
-import { env } from "nextly/lib/env";
 
 export async function GET(req: Request) {
-  const result = await getSession(req, env.NEXTLY_SECRET ?? "");
+  const result = await getSession(req, process.env.NEXTLY_SECRET ?? "");
 
   if (!result.authenticated) {
     return Response.json({ error: "Not authenticated" }, { status: 401 });
@@ -63,11 +62,10 @@ Custom user fields defined via `defineConfig({ users: { fields } })` are also su
 
 ```typescript
 import { requireAuth } from "nextly/auth";
-import { env } from "nextly/lib/env";
 
 export async function GET(req: Request) {
   // Throws AuthenticationError if no valid session.
-  const user = await requireAuth(req, env.NEXTLY_SECRET ?? "");
+  const user = await requireAuth(req, process.env.NEXTLY_SECRET ?? "");
   return Response.json({ email: user.email });
 }
 ```
@@ -98,10 +96,9 @@ import {
   hasAnyRole,
   hasAllRoles,
 } from "nextly/auth";
-import { env } from "nextly/lib/env";
 
 export async function GET(req: Request) {
-  const result = await getSession(req, env.NEXTLY_SECRET ?? "");
+  const result = await getSession(req, process.env.NEXTLY_SECRET ?? "");
   if (!result.authenticated) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/docs/guides/draft-published-status.mdx
+++ b/docs/guides/draft-published-status.mdx
@@ -5,7 +5,7 @@ description: Enable a Draft / Published lifecycle on collections and singles, wi
 
 Nextly supports an opt-in Draft / Published lifecycle for collections and singles. When enabled, every record carries a `status` system column (`'draft'` or `'published'`); the admin entry create/edit page splits its primary action into **Save Draft** + **Publish** (or **Update**), and public-facing API queries can filter unpublished records out by default.
 
-This is a meta-level toggle on the collection or single -- you do not declare a `status` field yourself. The framework injects the column at schema-generation time when you opt in.
+This is a meta-level toggle on the collection or single -- you do not declare a `status` field yourself. Nextly injects the column at schema-generation time when you opt in.
 
 ## Enabling on a collection
 

--- a/docs/page-builder/index.mdx
+++ b/docs/page-builder/index.mdx
@@ -15,7 +15,7 @@ plugin uses.
 
 ## What you get
 
-- **20 blocks out of the box** — layout (section, box, columns, column, card, accordion,
+- **20 blocks out of the box.** Layout (section, box, columns, column, card, accordion,
   accordion item, spacer, divider), content (heading, paragraph, rich text, list, quote,
   image, gallery, button, embed, form), and one that reads from your content
   ([collection loop](#reading-content-into-a-page)).

--- a/docs/plugins/admin-ui.mdx
+++ b/docs/plugins/admin-ui.mdx
@@ -5,7 +5,7 @@ description: Contribute admin menu items, pages, settings, and collection-view o
 
 A plugin can extend the Nextly admin in two complementary ways:
 
-- **`contributes.admin`** — the *declarative* surface: menu entries, custom pages,
+- **`contributes.admin`.** The *declarative* surface: menu entries, custom pages,
   a settings panel, and per-collection view overrides (D19–D23).
 - **`admin`** (on the plugin definition) — *placement & appearance*: where the
   plugin's items sit in the sidebar and how they look (D20).

--- a/docs/plugins/auth.mdx
+++ b/docs/plugins/auth.mdx
@@ -168,7 +168,7 @@ WordPress draw the line.
 
 ## Security notes
 
-- **Strategies are app-opt-in** — installing a plugin never silently lets it
+- **Strategies are app-opt-in.** Installing a plugin never silently lets it
   authenticate users.
 - An enabled strategy/hook runs with **full trust** (D34, no sandbox in v1) — vet auth
   plugins like any dependency.

--- a/docs/plugins/distribution.mdx
+++ b/docs/plugins/distribution.mdx
@@ -58,11 +58,11 @@ secrets in config or commit them.
 
 In v1, plugins are found through:
 
-- **npm** — search the **`nextly-plugin`** keyword.
-- **The Nextly docs** — first-party and notable community plugins are listed on the
+- **npm.** Search the **`nextly-plugin`** keyword.
+- **The Nextly docs.** First-party and notable community plugins are listed on the
   [plugins index](/docs/plugins). To get a community plugin listed, see
   [Contributing a plugin](/docs/plugins/contributing).
-- **GitHub** — the `nextly-plugin` topic.
+- **GitHub.** The `nextly-plugin` topic.
 
 There is intentionally no in-app gallery or one-click install yet.
 

--- a/docs/plugins/lifecycle.mdx
+++ b/docs/plugins/lifecycle.mdx
@@ -74,10 +74,10 @@ definePlugin({
 });
 ```
 
-- **`dependsOn`** — a missing dependency, or one whose installed version is outside the
+- **`dependsOn`.** A missing dependency, or one whose installed version is outside the
   range, is a fail-fast boot error (`reason: "missing-dependency"` /
   `"version-incompatible"`).
-- **`optionalDependsOn`** — an **absent** optional dependency is fine; a **present but
+- **`optionalDependsOn`.** An **absent** optional dependency is fine; a **present but
   out-of-range** one fails fast (`reason: "optional-version-incompatible"`). Use
   `ctx.nextlyVersion` or feature checks to branch on whether an optional dep is active.
 

--- a/docs/schema-builder/index.mdx
+++ b/docs/schema-builder/index.mdx
@@ -20,7 +20,7 @@ Create a new entity from any of the three list pages above. Edit an existing ent
 Each Schema Builder uses a two-column layout:
 
 - **Canvas** (main area) — a sortable list of the fields in your schema. Each row shows an icon, the field name, the type badge, and a "Required" indicator. Drag the grip handle to reorder. Click a row to edit it. Container types (Repeater, Group) display their child fields inline with indentation and dedicated drop zones.
-- **Right panel** — the field palette and the field editor. Use the toolbar at the top of the canvas to open the Settings dialog (entity-level config like description, sidebar icon, admin group) or to preview/save changes.
+- **Right panel.** The field palette and the field editor. Use the toolbar at the top of the canvas to open the Settings dialog (entity-level config like description, sidebar icon, admin group) or to preview/save changes.
 
 ### Field palette
 

--- a/docs/webhooks/retention.mdx
+++ b/docs/webhooks/retention.mdx
@@ -5,8 +5,8 @@ description: How Nextly prunes the webhook event ledger and delivery log, plus P
 
 Nextly records outbound webhook activity in two high-churn tables:
 
-- **`nextly_events`** — the event ledger (the outbox). A content change writes a row here **only when recording is active**: an enabled webhook endpoint exists, or the `webhooks.audit` seam is on. An install with no enabled endpoint and audit off records nothing, so the table does not grow.
-- **`nextly_webhook_deliveries`** — **one row per (endpoint, event)**, carrying the retry state. Each retry is appended to that row's in-row attempt log, not added as a new row, so more matching endpoints add rows while retries enlarge existing ones.
+- **`nextly_events`.** The event ledger (the outbox). A content change writes a row here **only when recording is active**: an enabled webhook endpoint exists, or the `webhooks.audit` seam is on. An install with no enabled endpoint and audit off records nothing, so the table does not grow.
+- **`nextly_webhook_deliveries`.** **One row per (endpoint, event)**, carrying the retry state. Each retry is appended to that row's in-row attempt log, not added as a new row, so more matching endpoints add rows while retries enlarge existing ones.
 
 When recording is active these tables fill continuously and are pruned automatically. This page explains the retention policy, the manual `nextly webhooks:prune` command, and how to keep the underlying tables from bloating on Postgres and SQLite.
 
@@ -70,7 +70,7 @@ The command reports how many webhook events, audit events, and terminal delivery
 
 **`webhooks:prune` is cleanup, not delivery.** It does not fan out or deliver anything. Its behaviour splits on whether an enabled endpoint exists:
 
-- **With an enabled endpoint,** an event that was never fanned out is **kept** — it may still be delivered — so prune only reclaims already-fanned-out events plus terminal (`delivered`/`failed`) deliveries. You still need the **drain running** to fan out and deliver; `webhooks:prune` supplements it with scheduled cleanup, it does not replace it.
+- **With an enabled endpoint,** an event that was never fanned out is **kept**. It may still be delivered, so prune only reclaims already-fanned-out events plus terminal (`delivered`/`failed`) deliveries. You still need the **drain running** to fan out and deliver; `webhooks:prune` supplements it with scheduled cleanup, it does not replace it.
 - **With no enabled endpoint** (an audit-only install, `webhooks.audit` on), there is nothing to deliver to, so aged un-fanned events are reclaimable and `webhooks:prune` is all you need to keep the ledger bounded.
 
 A daily cron is a good baseline where you want scheduled cleanup:


### PR DESCRIPTION
Two of the F37 items measured from nextly-site, fixed at the source. `content/docs` is gitignored there and refetched every build, so this is the only repository that can.

## "the framework"

Four places called Nextly "the framework" while describing what it does to a collection:

- `docs/configuration/collections.mdx` (3)
- `docs/guides/draft-published-status.mdx` (1)

The category is a CMS and content platform. "Framework" is the word the positioning retired, and a reader learning the product from these pages learns the wrong thing about it. `check:docs-claims` did not catch them because it guards the category *claim*, not casual reference.

## An import that cannot work

The authentication guide imported `env` from `nextly/lib/env` three times. That subpath is not in the package's exports map, which declares **51 keys and no wildcard**, so a reader following the guide gets `ERR_PACKAGE_PATH_NOT_EXPORTED`.

The snippets only needed the secret, so they read `process.env.NEXTLY_SECRET` directly and the import is gone. I deliberately did **not** publish the subpath: exporting an internal module to make a documentation page true is the wrong direction, and this one carries the validated environment, which is not a public surface.

## Checked rather than assumed

`getSession`, `requireAuth`, `hasAnyRole` and `hasAllRoles` are all genuinely exported from `nextly/auth`, and `getSession(request, secret)` takes the secret as a **required** second argument, so nothing here now relies on a default that does not exist. My first check of those exports used a grep that missed re-export blocks and reported all four missing; the second parsed the export statements. Worth mentioning because the first answer was wrong in the direction that would have caused a bad "fix".

`pnpm check:docs-claims` passes.

## Also here: the mechanical em dashes

Second commit. The house rule is that copy carries no em dashes and the docs carried 695. This takes the **24** that are the `- **Term** — Description` list form, which has a settled rewrite: the term takes the full stop, the description starts a sentence.

Only that form. The description is capitalised only where it begins with a plain lowercase letter, so a leading code span or identifier is left as written, and the 42 inside code fences are not copy and are untouched.

**Two the pass got wrong**, found by reading its output rather than trusting the regex: one description began with bold text and so was not capitalised, and one line was not a term-and-description item at all but a sentence with bold emphasis — which put the full stop inside the bold *and* left a second em dash further along the same line. Both corrected in the same commit.

I had reported 58 as mechanical earlier. Re-measuring, only 24 are; the other 34 are bold mid-paragraph and need judgement.

## Not in this PR

**628 em dashes remain**, across 48 files, top-heavy: `configuration/fields.mdx` alone has 104 and the top 12 hold 376. They sit mid-sentence and each needs a choice between a comma, a colon and a sentence break. A sweep would produce worse prose than what is there — the two defects above are the small version of that argument — so they are a writing pass, separately.
