### PR TITLE
fix(nextly): let a departing editor release a claim the rules now refuse

### DIFF
--- a/.changeset/release-a-claim-the-rules-refuse.md
+++ b/.changeset/release-a-claim-the-rules-refuse.md
@@ -1,0 +1,43 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Let a departing editor give up a document claim the stored rules have stopped
+permitting.
+
+The per-document update gate ran on every write intent, and releasing a claim
+routes through the same branch. Those rules read the document, so a holder's own
+save could flip them mid-claim by changing an owner or a status the rule reads,
+and from then on the editor's own release was refused. The claim stood until its
+150-second lease lapsed, showing colleagues a holder who had already left and
+pushing them to take over a document nobody was editing.
+
+The intent now names the operation rather than grouping every write together.
+Claiming and renewing both assert that this editor is editing this document, so
+both ask the stored rules. Releasing asserts the opposite and stops at the
+collection's update permission, resting on the claim token that names the one
+acquisition being given up and fences the delete itself.

--- a/packages/nextly/src/api/__tests__/document-lock-route.test.ts
+++ b/packages/nextly/src/api/__tests__/document-lock-route.test.ts
@@ -291,6 +291,45 @@ describe("document lock route", () => {
     expect(service.acquire).not.toHaveBeenCalled();
   });
 
+  it("asks it of a renewal too, which restates the same claim", async () => {
+    // A renewal says the holder is STILL editing, so it has to answer the same
+    // question a claim does. Gating only the claim would let a lock outlive the
+    // rules that permitted it, for as long as the holder kept renewing.
+    service.renew.mockResolvedValue({ status: "renewed" });
+
+    await renewLock(post({ ...ref, claimToken: "t" }, "PATCH"));
+
+    expect(assertDocumentUpdatable).toHaveBeenCalledWith(
+      ref.scopeKind,
+      ref.slug,
+      ref.entryId,
+      auth,
+      undefined
+    );
+  });
+
+  it("does not ask it of a release, so a refused row can still be given up", async () => {
+    // Releasing is the opposite statement: this editor has STOPPED editing. The
+    // stored rules read the document, so the holder's own save can flip them
+    // mid-claim, and asking them here would refuse the departing editor's own
+    // DELETE and strand the claim until its lease lapsed - leaving colleagues a
+    // holder who has already left. The claim token names the one acquisition
+    // being given up, and the DELETE is fenced on it.
+    assertDocumentUpdatable.mockRejectedValue(
+      NextlyError.forbidden({
+        logContext: { reason: "document-not-updatable" },
+      })
+    );
+
+    const response = await releaseLock(
+      post({ ...ref, claimToken: "t" }, "DELETE")
+    );
+
+    expect(response.status).toBe(200);
+    expect(assertDocumentUpdatable).not.toHaveBeenCalled();
+    expect(service.release).toHaveBeenCalledWith(ref, "t");
+  });
+
   it("does not ask it of a read", async () => {
     // Reading who holds a document is not updating it, and running an update
     // gate here would hide the holder from everyone who may only read.

--- a/packages/nextly/src/api/document-lock.ts
+++ b/packages/nextly/src/api/document-lock.ts
@@ -92,9 +92,9 @@ function readRef(source: {
  * colleague's claim on a collection it was never granted.
  *
  * Reading a lock needs READ on the document, because the holder's name and the
- * fact that they are editing it are both facts about a document. Claiming,
- * renewing and releasing need UPDATE, because a lock is a statement that you
- * are editing, and someone who cannot edit is not.
+ * fact that they are editing it are both facts about a document. Claiming and
+ * renewing need UPDATE, because a lock is a statement that you are editing, and
+ * someone who cannot edit is not.
  *
  * 🔴 UPDATE means THIS document, not documents of this kind. `update-<slug>` is
  * the coarse route permission and says only the latter, so a collection carrying
@@ -104,6 +104,14 @@ function readRef(source: {
  * own row. The gate the version routes already use runs here, for the reason its
  * own docblock gives.
  *
+ * A release stops at the coarse permission, because it is the opposite
+ * statement: that this editor has STOPPED editing. The stored rules read the
+ * document, so the holder's own save can flip them mid-claim, and asking them on
+ * the way out would refuse the departing editor's own DELETE and strand the
+ * claim until its lease lapsed, leaving colleagues a holder who has already
+ * left. What a release actually rests on is the claim token, which names the one
+ * acquisition being given up and fences the DELETE itself.
+ *
  * Both helpers are entity-generic and read the collection and single maps
  * alike, so a Single needs no branch here, and both delegate to the canonical
  * machinery rather than reproducing the API-key and super-admin rules that
@@ -112,7 +120,7 @@ function readRef(source: {
 async function authorize(
   auth: AuthContext,
   ref: DocumentRef,
-  intent: "read" | "write"
+  intent: "read" | "claim" | "release"
 ): Promise<void> {
   const authenticated = await readCaller(auth);
   const caller = readAccessCaller(authenticated);
@@ -129,7 +137,7 @@ async function authorize(
     });
   }
 
-  if (intent === "write") {
+  if (intent === "claim") {
     // Route authorization has just run, so the coarse re-check is skipped and
     // what runs here is the stored per-document rules this gate exists for.
     await assertDocumentUpdatable(
@@ -225,7 +233,7 @@ export const acquireLock = withErrorHandler(async (req: Request) => {
 
   const body = await readBody(req);
   const ref = readRef(body);
-  await authorize(auth, ref, "write");
+  await authorize(auth, ref, "claim");
 
   const outcome = await (
     await getDocumentLockService()
@@ -256,7 +264,7 @@ export const renewLock = withErrorHandler(async (req: Request) => {
 
   const body = await readBody(req);
   const ref = readRef(body);
-  await authorize(auth, ref, "write");
+  await authorize(auth, ref, "claim");
 
   const outcome = await (
     await getDocumentLockService()
@@ -275,7 +283,7 @@ export const releaseLock = withErrorHandler(async (req: Request) => {
 
   const body = await readBody(req);
   const ref = readRef(body);
-  await authorize(auth, ref, "write");
+  await authorize(auth, ref, "release");
 
   await (await getDocumentLockService()).release(ref, readClaimToken(body));
 


### PR DESCRIPTION
Follow-up to #1599, which had already merged when the review finding landed.

## The defect

#1599 added the per-document update gate to `/api/document-lock`, so a caller can
only claim a document the stored rules would actually let it update. That gate
ran on `intent === "write"`, and `releaseLock` routes through the same branch.

So releasing a claim asked the same question as taking one. Those rules read the
document, which means the holder's own save can flip them mid-claim by changing
an owner or a status the rule reads. From that moment the editor's own
best-effort DELETE is refused, and the claim stands until its 150-second lease
lapses. Colleagues see a holder who has already left, and are pushed to take over
a document nobody is editing.

A role change does the same thing, but the save is the case that happens in
ordinary editing.

## The fix

The intent now names the operation instead of grouping every write together:
`"read" | "claim" | "release"`.

- **Claiming and renewing** both assert that this editor is editing this
  document, so both ask the stored rules. A renewal restating a claim the rules
  no longer permit is the case that makes gating renew worth stating explicitly,
  and it now has its own test.
- **Releasing** asserts the opposite, that this editor has stopped. It stops at
  the collection's `update-<slug>` permission and rests on the claim token, which
  names the one acquisition being given up and fences the `DELETE` itself
  (`releaseDocumentLock` deletes `WHERE id = ? AND claim_token = ?`, and the
  token is a server-minted `randomUUID`).

The coarse permission stays on release deliberately rather than dropping
authorization altogether. It is role-shaped, so it changes only by an
administrator's action and does not strand a claim in normal editing, and keeping
it leaves the route's authenticated-editor boundary where it was.

## Verification

- `packages/nextly` `src/api/__tests__` — 186 pass, 20 files.
- `lint` (`--max-warnings 0`) and `check-types` (both tsconfigs) exit 0.
- `check:comments` exit 0; `fallow audit --gate new-only` exit 0, nothing introduced.
- Mutation-tested, each mutation asserted applied and each killed by the test
  that names it:
  - gate restored to every non-read intent → the release test fails;
  - release relabelled as a claim → the release test fails;
  - renew's gate removed → the renew test fails.

The release test both mocks the gate to reject and asserts it was never called,
so it fails in two ways if the gate returns to that path.
