### PR TITLE
feat(admin): let a custom edit view claim the document it is editing

### DIFF
--- a/.changeset/custom-edit-views-claim-the-document.md
+++ b/.changeset/custom-edit-views-claim-the-document.md
@@ -41,6 +41,18 @@ scheduled-release banner already there, which the page renders on that branch fo
 the same reason: a custom view replaces the form, not the facts about the
 document.
 
+The view is also handed what the claim withholds, through the props every custom
+edit view already receives rather than an admin-internal hook it cannot import.
+The banner says in words that unsaved changes cannot be saved while a colleague
+holds the document, and a view that wrote anyway would make that sentence false
+and would overwrite the holder's row. The bundled form builder reads it, so its
+save is withheld and its Save button says so.
+
+The claim is taken only once the document is actually on screen. Taken while the
+entry is still loading, or after it failed to load, it would heartbeat a document
+the editor is not looking at, and colleagues would be told this person is editing
+a page that never appeared for them.
+
 Only that branch claims. The form still claims for the default editor, and
 claiming in both places would put two claims on one document under one author.
 The condition is the resolved component rather than the registered path, because

--- a/.changeset/custom-edit-views-claim-the-document.md
+++ b/.changeset/custom-edit-views-claim-the-document.md
@@ -1,0 +1,48 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Give a custom collection edit view the same document claim the default editor
+takes.
+
+A collection registering `admin.components.views.Edit.Component` returns its own
+view before the entry form mounts, and the form is where the default editor
+claims. So those views announced nothing to the lock: a colleague opening the
+same document was told nobody held it, and the editor was shown no holder and
+offered no takeover, on precisely the documents a project cared enough about to
+build a bespoke editor for.
+
+The claim is now taken above the branch, and the lock banner renders beside the
+scheduled-release banner already there, which the page renders on that branch for
+the same reason: a custom view replaces the form, not the facts about the
+document.
+
+Only that branch claims. The form still claims for the default editor, and
+claiming in both places would put two claims on one document under one author.
+The condition is the resolved component rather than the registered path, because
+a path that resolves to nothing falls through to the form, which has its own
+claim.

--- a/.changeset/custom-edit-views-claim-the-document.md
+++ b/.changeset/custom-edit-views-claim-the-document.md
@@ -48,6 +48,14 @@ holds the document, and a view that wrote anyway would make that sentence false
 and would overwrite the holder's row. The bundled form builder reads it, so its
 save is withheld and its Save button says so.
 
+Both halves of the claim, not only the save. The strip says the editor may read
+this document and not change it, so the builder's state withholds every action
+that would change it while a colleague holds it, and keeps the ones that only
+move around: selecting a field, switching tabs. The refusal sits once at the
+state every control reaches rather than at each of the dozens of controls, and it
+withholds every action except the ones named, so one added later is covered
+without anyone remembering.
+
 The claim is taken only once the document is actually on screen. Taken while the
 entry is still loading, or after it failed to load, it would heartbeat a document
 the editor is not looking at, and colleagues would be told this person is editing

--- a/packages/admin/src/components/features/entries/EntryForm/index.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/index.ts
@@ -70,6 +70,19 @@ export {
   type AutoSaveIndicatorProps,
 } from "./AutoSaveIndicator";
 
+// Document lock: the banner and the claim behind it, for every editor of a
+// document rather than only this form. A custom edit view replaces the FORM,
+// not the facts about the document, and it reaches these through the same
+// barrel the form does.
+export {
+  DocumentLockBanner,
+  type DocumentLockBannerProps,
+} from "./DocumentLockBanner";
+export {
+  useDocumentLockSurface,
+  type DocumentLockSurface,
+} from "./useDocumentLockSurface";
+
 // Show JSON dialog
 export { ShowJSONDialog, type ShowJSONDialogProps } from "./ShowJSONDialog";
 

--- a/packages/admin/src/lib/plugins/component-registry.ts
+++ b/packages/admin/src/lib/plugins/component-registry.ts
@@ -75,6 +75,24 @@ export interface CustomEditViewProps {
   onCancel?: () => void;
   /** Callback to duplicate entry */
   onDuplicate?: () => void;
+  /**
+   * What a colleague's claim on this document withholds.
+   *
+   * A custom view replaces the FORM, not the facts about the document, and the
+   * strip above it says in words that unsaved changes cannot be saved while
+   * someone else holds the claim. A view that writes anyway makes that sentence
+   * false, so the two decisions travel together and reach the view through the
+   * props it already receives rather than an admin-internal hook it cannot
+   * import.
+   *
+   * Absent while creating, which has no document to claim.
+   */
+  documentLock?: {
+    /** Fields should render uneditable: the document is someone else's. */
+    readOnly: boolean;
+    /** Save, delete and every other write should be withheld. */
+    actionsDisabled: boolean;
+  };
 }
 
 /**

--- a/packages/admin/src/pages/dashboard/entries/[slug]/[id]/custom-edit-view-lock.test.tsx
+++ b/packages/admin/src/pages/dashboard/entries/[slug]/[id]/custom-edit-view-lock.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * A custom edit view takes the same claim the default editor takes.
+ *
+ * The page returns its custom-view branch before `EntryForm` mounts, and
+ * `EntryForm` is where the default editor claims. Everything here is about
+ * which branch does the claiming, so `EntryForm` is replaced by a marker and
+ * the lock hook is the real one, observed through the request it makes.
+ *
+ * @module pages/dashboard/entries/[slug]/[id]/custom-edit-view-lock.test
+ */
+
+import { screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  clearRegistry,
+  registerComponent,
+} from "@admin/lib/plugins/component-registry";
+
+import { renderWithProviders } from "../../../../../__tests__/utils";
+
+const useDocumentLock = vi.fn();
+vi.mock("@admin/hooks/queries/useDocumentLock", () => ({
+  useDocumentLock: (options: unknown) => useDocumentLock(options) as unknown,
+}));
+
+// Replaced, not mocked away: the barrel also exports the banner and the surface
+// hook this page now uses, and those are the code under test.
+vi.mock(
+  "@admin/components/features/entries/EntryForm",
+  async importOriginal => {
+    const actual =
+      await importOriginal<
+        typeof import("@admin/components/features/entries/EntryForm")
+      >();
+    return { ...actual, EntryForm: () => <div>default entry form</div> };
+  }
+);
+
+vi.mock("@admin/components/features/releases/ScheduledReleaseBanner", () => ({
+  ScheduledReleaseBanner: () => null,
+}));
+vi.mock("@admin/components/features/releases/AddToReleaseAction", () => ({
+  useAddToReleaseAction: () => ({ dialog: null, contributed: null }),
+}));
+
+let collectionSchema: Record<string, unknown> = {};
+vi.mock("@admin/hooks/queries/useCollections", () => ({
+  useCollectionSchema: () => ({
+    data: collectionSchema,
+    isLoading: false,
+    error: null,
+  }),
+}));
+vi.mock("@admin/hooks/queries/useEntry", () => ({
+  useEntry: () => ({
+    data: { id: "42", title: "A post" },
+    isLoading: false,
+    error: null,
+  }),
+}));
+vi.mock("@admin/hooks/useLocalization", () => ({
+  useLocalization: () => ({ defaultLocale: undefined, enabled: false }),
+}));
+vi.mock("@admin/hooks/useEditorLocale", () => ({
+  useEditorLocale: () => ({
+    locale: undefined,
+    changeLocale: vi.fn(),
+    resetLocale: vi.fn(),
+    seedFromLocale: vi.fn(),
+    clearSeed: vi.fn(),
+  }),
+}));
+vi.mock("@admin/hooks/useTranslationMode", () => ({
+  useTranslationMode: () => ({
+    translateFrom: undefined,
+    enterTranslationMode: vi.fn(),
+    exitTranslationMode: vi.fn(),
+  }),
+}));
+vi.mock("@admin/hooks/usePluginAutoRegistration", () => ({
+  usePluginAutoRegistration: () => undefined,
+}));
+
+import EditEntryPage from "./index";
+
+const CUSTOM_VIEW = "@acme/shop/admin#ProductEditor";
+const takeOver = vi.fn();
+
+/** The claim the page asked for, whichever branch asked. */
+function claimRequest(): Record<string, unknown> {
+  const last = useDocumentLock.mock.calls.at(-1);
+  if (last === undefined) throw new Error("the lock hook was never called");
+  return last[0] as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useDocumentLock.mockReturnValue({
+    state: { status: "held-by-me" },
+    takeOver,
+  });
+  collectionSchema = { name: "posts", label: "Posts", slug: "posts" };
+});
+
+afterEach(() => {
+  clearRegistry();
+});
+
+describe("a custom collection edit view", () => {
+  it("claims the document it is editing", () => {
+    registerComponent(CUSTOM_VIEW, () => <div>bespoke product editor</div>);
+    collectionSchema = {
+      ...collectionSchema,
+      admin: { components: { views: { Edit: { Component: CUSTOM_VIEW } } } },
+    };
+
+    renderWithProviders(<EditEntryPage params={{ slug: "posts", id: "42" }} />);
+
+    expect(screen.getByText("bespoke product editor")).toBeInTheDocument();
+    expect(claimRequest()).toMatchObject({
+      scopeKind: "collection",
+      slug: "posts",
+      entryId: "42",
+      enabled: true,
+    });
+  });
+
+  it("names the colleague who has it, and offers to take it over", () => {
+    registerComponent(CUSTOM_VIEW, () => <div>bespoke product editor</div>);
+    collectionSchema = {
+      ...collectionSchema,
+      admin: { components: { views: { Edit: { Component: CUSTOM_VIEW } } } },
+    };
+    useDocumentLock.mockReturnValue({
+      state: {
+        status: "held-by-other",
+        holder: { ownerId: "u2", ownerLabel: "Ada", expiresInSeconds: 90 },
+      },
+      takeOver,
+    });
+
+    renderWithProviders(<EditEntryPage params={{ slug: "posts", id: "42" }} />);
+
+    const banner = screen.getByTestId("document-lock-banner");
+    expect(banner).toHaveTextContent("Ada");
+  });
+
+  it("leaves the claim to the form when there is no custom view", () => {
+    // 🔴 The page must not claim on this branch. `EntryForm` claims for the
+    // default editor, and a second claim here would put two on one document
+    // under one author, which the repository keys and releases separately.
+    renderWithProviders(<EditEntryPage params={{ slug: "posts", id: "42" }} />);
+
+    expect(screen.getByText("default entry form")).toBeInTheDocument();
+    expect(claimRequest()).toMatchObject({ enabled: false });
+  });
+
+  it("leaves it to the form when a registered view resolves to nothing", () => {
+    // The path is declared but the component never registered, so the page
+    // falls through to `EntryForm` - and the claim has to follow the branch
+    // that actually renders, not the one the schema advertises.
+    collectionSchema = {
+      ...collectionSchema,
+      admin: { components: { views: { Edit: { Component: CUSTOM_VIEW } } } },
+    };
+
+    renderWithProviders(<EditEntryPage params={{ slug: "posts", id: "42" }} />);
+
+    expect(screen.getByText("default entry form")).toBeInTheDocument();
+    expect(claimRequest()).toMatchObject({ enabled: false });
+  });
+});

--- a/packages/admin/src/pages/dashboard/entries/[slug]/[id]/custom-edit-view-lock.test.tsx
+++ b/packages/admin/src/pages/dashboard/entries/[slug]/[id]/custom-edit-view-lock.test.tsx
@@ -52,12 +52,9 @@ vi.mock("@admin/hooks/queries/useCollections", () => ({
     error: null,
   }),
 }));
+let entryQuery: Record<string, unknown> = {};
 vi.mock("@admin/hooks/queries/useEntry", () => ({
-  useEntry: () => ({
-    data: { id: "42", title: "A post" },
-    isLoading: false,
-    error: null,
-  }),
+  useEntry: () => entryQuery,
 }));
 vi.mock("@admin/hooks/useLocalization", () => ({
   useLocalization: () => ({ defaultLocale: undefined, enabled: false }),
@@ -86,6 +83,7 @@ import EditEntryPage from "./index";
 
 const CUSTOM_VIEW = "@acme/shop/admin#ProductEditor";
 const takeOver = vi.fn();
+let customViewProps: Record<string, unknown> | undefined;
 
 /** The claim the page asked for, whichever branch asked. */
 function claimRequest(): Record<string, unknown> {
@@ -101,7 +99,26 @@ beforeEach(() => {
     takeOver,
   });
   collectionSchema = { name: "posts", label: "Posts", slug: "posts" };
+  entryQuery = {
+    data: { id: "42", title: "A post" },
+    isLoading: false,
+    error: null,
+  };
+  // Cleared, so a case reading these cannot pass on the previous case's render.
+  customViewProps = undefined;
 });
+
+/** Registers a custom view and points the collection at it. */
+function withCustomView(body = "bespoke product editor") {
+  registerComponent(CUSTOM_VIEW, (props: Record<string, unknown>) => {
+    customViewProps = props;
+    return <div>{body}</div>;
+  });
+  collectionSchema = {
+    ...collectionSchema,
+    admin: { components: { views: { Edit: { Component: CUSTOM_VIEW } } } },
+  };
+}
 
 afterEach(() => {
   clearRegistry();
@@ -144,6 +161,66 @@ describe("a custom collection edit view", () => {
 
     const banner = screen.getByTestId("document-lock-banner");
     expect(banner).toHaveTextContent("Ada");
+  });
+
+  it("hands it what the claim withholds, so its own writes can honour it", () => {
+    // 🔴 The banner this page renders says in words that unsaved changes cannot
+    // be saved while a colleague holds the document. A view that writes anyway
+    // makes that sentence false, so the same decision the banner was derived
+    // from travels to the view through the props it already receives.
+    withCustomView();
+    useDocumentLock.mockReturnValue({
+      state: {
+        status: "held-by-other",
+        holder: { ownerId: "u2", ownerLabel: "Ada", expiresInSeconds: 90 },
+      },
+      takeOver,
+    });
+
+    renderWithProviders(<EditEntryPage params={{ slug: "posts", id: "42" }} />);
+
+    expect(customViewProps?.documentLock).toEqual({
+      readOnly: true,
+      actionsDisabled: true,
+    });
+  });
+
+  it("withholds nothing while the claim is this editor's own", () => {
+    withCustomView();
+
+    renderWithProviders(<EditEntryPage params={{ slug: "posts", id: "42" }} />);
+
+    expect(customViewProps?.documentLock).toEqual({
+      readOnly: false,
+      actionsDisabled: false,
+    });
+  });
+
+  it("does not claim while the document is still loading", () => {
+    // 🔴 A claim taken here heartbeats a document the editor is only seeing a
+    // skeleton of, and colleagues are told this person is editing it.
+    withCustomView();
+    entryQuery = { data: undefined, isLoading: true, error: null };
+
+    renderWithProviders(<EditEntryPage params={{ slug: "posts", id: "42" }} />);
+
+    expect(claimRequest()).toMatchObject({ enabled: false });
+  });
+
+  it("does not claim when the document failed to load", () => {
+    // The worse half of the same case: a persistent failure leaves colleagues
+    // told this person is editing a page that never appeared, for as long as
+    // they stay on the route.
+    withCustomView();
+    entryQuery = {
+      data: undefined,
+      isLoading: false,
+      error: new Error("nope"),
+    };
+
+    renderWithProviders(<EditEntryPage params={{ slug: "posts", id: "42" }} />);
+
+    expect(claimRequest()).toMatchObject({ enabled: false });
   });
 
   it("leaves the claim to the form when there is no custom view", () => {

--- a/packages/admin/src/pages/dashboard/entries/[slug]/[id]/index.tsx
+++ b/packages/admin/src/pages/dashboard/entries/[slug]/[id]/index.tsx
@@ -317,6 +317,9 @@ export default function EditEntryPage({
   );
   usePluginAutoRegistration(collectionsForRegistration);
 
+  const isLoading = isLoadingCollection || isLoadingEntry;
+  const error = collectionError || entryError;
+
   // Resolved here, above this component's loading and error returns, for the
   // reason the hooks above give: whether a custom view renders decides whether
   // THIS page claims the document, and a hook cannot be asked that after a
@@ -346,11 +349,21 @@ export default function EditEntryPage({
     scopeKind: "collection",
     slug: slug ?? "",
     entryId: id,
-    enabled: Boolean(CustomEditView && slug && id),
+    // 🔴 The same prerequisites the custom branch renders under, not merely a
+    // resolved component. A claim taken while the entry is still loading, or
+    // after it failed, heartbeats a document the editor is not looking at - and
+    // on a load failure that leaves the lock endpoint reachable, colleagues are
+    // told this person is editing a page that never appeared for them.
+    enabled: Boolean(
+      CustomEditView &&
+        slug &&
+        id &&
+        !isLoading &&
+        !error &&
+        collection &&
+        entry
+    ),
   });
-
-  const isLoading = isLoadingCollection || isLoadingEntry;
-  const error = collectionError || entryError;
 
   /**
    * The page's measure, on every branch.
@@ -506,6 +519,13 @@ export default function EditEntryPage({
       onSuccess: handleSuccess,
       onDelete: handleDelete,
       onCancel: handleCancel,
+      // The banner above says in words that changes cannot be saved while a
+      // colleague holds this. Passing the same decision the banner was derived
+      // from is what keeps that sentence true.
+      documentLock: {
+        readOnly: customViewLock.readOnly,
+        actionsDisabled: customViewLock.actionsDisabled,
+      },
     };
 
     return (

--- a/packages/admin/src/pages/dashboard/entries/[slug]/[id]/index.tsx
+++ b/packages/admin/src/pages/dashboard/entries/[slug]/[id]/index.tsx
@@ -17,7 +17,9 @@ import { useMemo } from "react";
 
 import { entryTitleValue } from "@admin/components/features/entries/entry-title";
 import {
+  DocumentLockBanner,
   EntryForm,
+  useDocumentLockSurface,
   type EntryFormCollection,
 } from "@admin/components/features/entries/EntryForm";
 import { useAddToReleaseAction } from "@admin/components/features/releases/AddToReleaseAction";
@@ -315,6 +317,38 @@ export default function EditEntryPage({
   );
   usePluginAutoRegistration(collectionsForRegistration);
 
+  // Resolved here, above this component's loading and error returns, for the
+  // reason the hooks above give: whether a custom view renders decides whether
+  // THIS page claims the document, and a hook cannot be asked that after a
+  // return. The registration hook has run, so the registry can answer.
+  const customEditViewPath =
+    collection?.admin?.components?.views?.Edit?.Component;
+  const CustomEditView = customEditViewPath
+    ? getComponent<CustomEditViewProps>(customEditViewPath)
+    : undefined;
+
+  /*
+   * A custom edit view replaces the FORM, not the facts about the document, so
+   * it takes the same claim the default editor takes. Without one it never
+   * announces itself to the lock, so a colleague opening the same document is
+   * told nobody holds it, and the editor is shown no holder and offered no
+   * takeover — on precisely the documents a project cared enough about to build
+   * a bespoke editor for.
+   *
+   * 🔴 Enabled ONLY on that branch. `EntryForm` claims for the default editor,
+   * and claiming in both places would put two claims on one document under one
+   * author, which the repository keys and releases separately. The condition is
+   * the resolved component rather than the registered path, because a path that
+   * resolves to nothing falls through to `EntryForm` and that branch has its
+   * own claim.
+   */
+  const customViewLock = useDocumentLockSurface({
+    scopeKind: "collection",
+    slug: slug ?? "",
+    entryId: id,
+    enabled: Boolean(CustomEditView && slug && id),
+  });
+
   const isLoading = isLoadingCollection || isLoadingEntry;
   const error = collectionError || entryError;
 
@@ -447,13 +481,6 @@ export default function EditEntryPage({
   const entryData = entry as unknown as Record<string, unknown>;
   const entryTitle = getEntryTitle(entryData, id, collection.admin?.useAsTitle);
 
-  // Check for custom Edit view component from plugins
-  const customEditViewPath =
-    collection.admin?.components?.views?.Edit?.Component;
-  const CustomEditView = customEditViewPath
-    ? getComponent<CustomEditViewProps>(customEditViewPath)
-    : undefined;
-
   // Shared callbacks for both default and custom views
   const handleSuccess = () => {
     // Stay on edit page - success toast is shown by mutation hook
@@ -500,6 +527,13 @@ export default function EditEntryPage({
           <ScheduledReleaseBanner
             document={{ scopeKind: "collection", scopeSlug: slug, entryId: id }}
             onDefaultLocale={!isNonDefaultLocale}
+          />
+          {/* Said for the same reason, about the other fact a second editor
+              needs: who has this document open. The strip renders nothing while
+              the claim is this editor's own. */}
+          <DocumentLockBanner
+            notice={customViewLock.notice}
+            onTakeOver={customViewLock.takeOver}
           />
           {/* Boxed for the same reason the injection slots are: under the
               measured frame this is a direct child of a CSS grid, and the rule

--- a/packages/plugin-form-builder/src/admin/FormBuilderView.tsx
+++ b/packages/plugin-form-builder/src/admin/FormBuilderView.tsx
@@ -732,6 +732,7 @@ export function FormBuilderView({
   return (
     <FormBuilderProvider
       key={providerKey}
+      readOnly={documentLock?.readOnly === true}
       initialData={{
         id: resolvedEntryId,
         name: initialData?.name,

--- a/packages/plugin-form-builder/src/admin/FormBuilderView.tsx
+++ b/packages/plugin-form-builder/src/admin/FormBuilderView.tsx
@@ -79,6 +79,16 @@ export interface FormBuilderViewProps {
   onSave?: (data: unknown) => void;
   onSuccess?: (entry?: Record<string, unknown>) => void;
   onCancel?: () => void;
+  /**
+   * What a colleague's claim on this form withholds, handed over by the admin
+   * page that renders this view.
+   *
+   * The strip above this builder says in words that unsaved changes cannot be
+   * saved while someone else holds the document. Committing anyway would make
+   * that sentence false and would overwrite the holder's row, so the save reads
+   * it too.
+   */
+  documentLock?: { readOnly: boolean; actionsDisabled: boolean };
 }
 
 // ============================================================================
@@ -105,6 +115,7 @@ function FormBuilderViewInner({
   onSave,
   onSuccess,
   onCancel,
+  documentLock,
 }: Pick<
   FormBuilderViewProps,
   | "isCreating"
@@ -113,6 +124,7 @@ function FormBuilderViewInner({
   | "onSave"
   | "onSuccess"
   | "onCancel"
+  | "documentLock"
 >) {
   const {
     fields,
@@ -257,6 +269,16 @@ function FormBuilderViewInner({
 
   // ── Save / Cancel ─────────────────────────────────────────────────────────
   const handleSave = useCallback(async () => {
+    // The commit is where the refusal lives, following the rule the entry
+    // editor sets: a write passes one gate rather than each control being
+    // disabled separately. The button below reads the same fact, so the
+    // interface does not offer what this would refuse.
+    //
+    // Today that button is this callback's only caller, so the two cannot be
+    // told apart by a test. What the gate is for is the next caller - a
+    // shortcut, a second action bar - arriving without one.
+    if (documentLock?.actionsDisabled === true) return;
+
     // Check if there are fields
     if (fields.length === 0) {
       toast.error("Please add at least one field to the form");
@@ -347,6 +369,10 @@ function FormBuilderViewInner({
     entryId,
     queryClient,
     markAsSaved,
+    // Read inside, so it belongs here. Without it the callback closes over the
+    // claim as it stood when the form mounted, and a colleague taking the
+    // document over mid-session would leave this still committing.
+    documentLock?.actionsDisabled,
   ]);
 
   const handleCancel = useCallback(() => {
@@ -616,7 +642,7 @@ function FormBuilderViewInner({
           onClick={() => {
             void handleSave();
           }}
-          disabled={isSaving}
+          disabled={isSaving || documentLock?.actionsDisabled === true}
           className="flex items-center gap-1.5"
         >
           {isSaving ? (
@@ -696,6 +722,7 @@ export function FormBuilderView({
   onSave,
   onSuccess,
   onCancel,
+  documentLock,
 }: FormBuilderViewProps) {
   const resolvedEntryId = entryId || id || initialData?.id;
   const resolvedCollectionSlug = collectionSlug || collection || "forms";
@@ -724,6 +751,7 @@ export function FormBuilderView({
         onSave={onSave}
         onSuccess={onSuccess}
         onCancel={onCancel}
+        documentLock={documentLock}
       />
     </FormBuilderProvider>
   );

--- a/packages/plugin-form-builder/src/admin/context/FormBuilderContext.tsx
+++ b/packages/plugin-form-builder/src/admin/context/FormBuilderContext.tsx
@@ -131,7 +131,28 @@ export interface FormBuilderProviderProps {
   };
   /** Child components */
   children: ReactNode;
+  /**
+   * The document belongs to someone else right now, so nothing here may change
+   * it.
+   *
+   * Held here rather than at each control because the builder has dozens of
+   * them across four tabs, and a rule spelled at every one is a rule one new
+   * control forgets. Reading is untouched: the editor still browses fields,
+   * switches tabs and opens settings, which is exactly what the strip above
+   * offers them.
+   */
+  readOnly?: boolean;
 }
+
+/**
+ * The actions that survive a read-only document.
+ *
+ * Everything else on the context changes the form, and every one of those marks
+ * it dirty - the same question asked twice, so this is the complement of it
+ * rather than a second list of what to block. `markAsSaved` is the save's own
+ * bookkeeping and cannot run while the save is withheld anyway.
+ */
+const READS_ONLY = new Set(["selectField", "setActiveTab", "markAsSaved"]);
 
 /** Default form settings (the canonical defaults from the settings reader) */
 export const DEFAULT_SETTINGS: FormSettings = DEFAULT_FORM_SETTINGS;
@@ -300,6 +321,7 @@ export function createFieldFromType(
 export function FormBuilderProvider({
   initialData,
   children,
+  readOnly = false,
 }: FormBuilderProviderProps) {
   // State
   const [fields, setFieldsState] = useState<AnyFormField[]>(
@@ -546,8 +568,30 @@ export function FormBuilderProvider({
     ]
   );
 
+  /**
+   * The same value with every document-changing action withheld.
+   *
+   * 🔴 Fail-closed, and deliberately so: it withholds every function EXCEPT the
+   * ones named, rather than naming the ones to withhold. An action added here
+   * later is inert under a colleague's claim without anyone remembering this
+   * exists, which is the opposite of how a list of things-to-disable ages.
+   *
+   * What stays is navigation and the save's own bookkeeping. Neither changes
+   * the document, and both are what "you can read it" has to mean.
+   */
+  const guarded = useMemo<FormBuilderContextValue>(() => {
+    if (!readOnly) return value;
+    return Object.fromEntries(
+      Object.entries(value).map(([name, member]) =>
+        typeof member === "function" && !READS_ONLY.has(name)
+          ? [name, () => undefined]
+          : [name, member]
+      )
+    ) as FormBuilderContextValue;
+  }, [value, readOnly]);
+
   return (
-    <FormBuilderContext.Provider value={value}>
+    <FormBuilderContext.Provider value={guarded}>
       {children}
     </FormBuilderContext.Provider>
   );

--- a/packages/plugin-form-builder/src/admin/context/read-only.test.tsx
+++ b/packages/plugin-form-builder/src/admin/context/read-only.test.tsx
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+
+/**
+ * What the builder's state refuses while a colleague holds the document.
+ *
+ * The page above renders a strip saying the editor may read this document and
+ * not change it. The builder has dozens of controls across four tabs, so the
+ * refusal lives once at the state they all reach rather than at each of them.
+ *
+ * @module admin/context/read-only.test
+ */
+import "@testing-library/jest-dom/vitest";
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  FormBuilderProvider,
+  useFormBuilder,
+  createNotification,
+  type FormBuilderContextValue,
+} from "./FormBuilderContext";
+
+afterEach(cleanup);
+
+const FIELD = {
+  id: "f2",
+  name: "phone",
+  label: "Phone",
+  type: "text",
+} as never;
+
+/**
+ * One representative call per action that changes the document.
+ *
+ * Every action the context publishes is either here or named as one that reads.
+ * The completeness case below derives that from the context's own keys, so an
+ * action added later fails this file rather than slipping through untested.
+ */
+const CHANGES_THE_DOCUMENT: Record<
+  string,
+  (ctx: FormBuilderContextValue) => void
+> = {
+  setFields: c => c.setFields([FIELD]),
+  addField: c => c.addField(FIELD),
+  updateField: c => c.updateField("email", { label: "Changed" }),
+  deleteField: c => c.deleteField("email"),
+  moveField: c => c.moveField(0, 1),
+  duplicateField: c => c.duplicateField("email"),
+  updateFormData: c => c.updateFormData({ name: "Changed" }),
+  updateSettings: c => c.updateSettings({ submitButtonText: "Changed" }),
+  addNotification: c => c.addNotification(createNotification()),
+  duplicateNotification: c => c.duplicateNotification("n1"),
+  updateNotification: c => c.updateNotification("n1", { subject: "Changed" }),
+  deleteNotification: c => c.deleteNotification("n1"),
+  seedNotifications: c => c.seedNotifications([createNotification()]),
+};
+
+/** The actions that are navigation or bookkeeping rather than an edit. */
+const READS = ["selectField", "setActiveTab", "markAsSaved"];
+
+function mount(readOnly: boolean) {
+  let ctx!: FormBuilderContextValue;
+  function Probe() {
+    ctx = useFormBuilder();
+    return null;
+  }
+  render(
+    <FormBuilderProvider
+      readOnly={readOnly}
+      initialData={{
+        name: "Contact",
+        slug: "contact",
+        fields: [
+          { id: "f1", name: "email", label: "Email", type: "email" } as never,
+        ],
+      }}
+    >
+      <Probe />
+    </FormBuilderProvider>
+  );
+  return () => ctx;
+}
+
+/** Everything about the document, as one comparable value. */
+const document = (c: FormBuilderContextValue) =>
+  JSON.stringify({
+    fields: c.fields,
+    formData: c.formData,
+    settings: c.settings,
+    notifications: c.notifications,
+    isDirty: c.isDirty,
+  });
+
+describe("the form builder's state under a colleague's claim", () => {
+  it("covers every action the context publishes", () => {
+    // 🔴 Derived from the context itself, not from a list written once. An
+    // action added later is in neither table, and this is where that is said.
+    const ctx = mount(false)();
+    const published = Object.entries(ctx)
+      .filter(([, member]) => typeof member === "function")
+      .map(([name]) => name);
+
+    expect(published.length).toBeGreaterThan(10);
+    expect(
+      published.filter(
+        name => !(name in CHANGES_THE_DOCUMENT) && !READS.includes(name)
+      )
+    ).toEqual([]);
+  });
+
+  for (const [name, call] of Object.entries(CHANGES_THE_DOCUMENT)) {
+    it(`withholds ${name}`, () => {
+      const read = mount(true);
+      const before = document(read());
+
+      act(() => {
+        call(read());
+      });
+
+      expect(document(read())).toBe(before);
+    });
+
+    it(`allows ${name} when nobody else holds the document`, () => {
+      // The control for the case above. Without it "nothing changed" is
+      // satisfied by a call that never does anything, and every refusal here
+      // would pass against a builder that cannot edit at all.
+      const write = mount(false);
+      const before = document(write());
+
+      act(() => {
+        call(write());
+      });
+
+      expect(document(write())).not.toBe(before);
+    });
+  }
+
+  it("still lets the editor move around the document", () => {
+    const read = mount(true);
+
+    act(() => {
+      read().selectField("email");
+      read().setActiveTab("settings");
+    });
+
+    expect(read().selectedFieldId).toBe("email");
+    expect(read().activeTab).toBe("settings");
+  });
+});

--- a/packages/plugin-form-builder/src/admin/document-lock.test.tsx
+++ b/packages/plugin-form-builder/src/admin/document-lock.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+
+/**
+ * What a colleague's claim withholds from the form builder.
+ *
+ * This view replaces the entry FORM, not the facts about the document, and the
+ * page that renders it puts a strip above saying in words that unsaved changes
+ * cannot be saved while someone else holds the claim. A builder that committed
+ * anyway would make that sentence false and would overwrite the holder's row.
+ *
+ * Run against the real view rather than a mocked one, because the defect was
+ * that the decision never crossed into it.
+ *
+ * @module admin/document-lock.test
+ */
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { FormBuilderView } from "./FormBuilderView";
+
+beforeAll(() => {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => undefined;
+  Element.prototype.releasePointerCapture = () => undefined;
+  Element.prototype.scrollIntoView = () => undefined;
+});
+
+afterEach(cleanup);
+
+function builder(
+  documentLock: { readOnly: boolean; actionsDisabled: boolean } | undefined,
+  onSave: ReturnType<typeof vi.fn>
+) {
+  return (
+    <QueryClientProvider client={new QueryClient()}>
+      <FormBuilderView
+        entryId="form-1"
+        initialData={{
+          name: "Contact",
+          slug: "contact",
+          // A form with no fields refuses to save for its own reason, which
+          // would pass this test without the lock doing anything.
+          fields: [{ id: "f1", name: "email", label: "Email", type: "email" }],
+        }}
+        onSave={onSave}
+        documentLock={documentLock}
+      />
+    </QueryClientProvider>
+  );
+}
+
+function view(documentLock?: { readOnly: boolean; actionsDisabled: boolean }) {
+  const onSave = vi.fn();
+  const { rerender } = render(builder(documentLock, onSave));
+  return {
+    onSave,
+    /** Re-render as the page does when the claim changes under the editor. */
+    claimChangesTo: (next: { readOnly: boolean; actionsDisabled: boolean }) =>
+      rerender(builder(next, onSave)),
+  };
+}
+
+const save = () => screen.getByRole("button", { name: /save/i });
+
+describe("the form builder under a colleague's claim", () => {
+  it("saves normally when nobody else holds the document", async () => {
+    // The control. Without it "did not save" is satisfied by a builder that
+    // never saves, and every assertion below would pass on a broken view.
+    const { onSave } = view({ readOnly: false, actionsDisabled: false });
+
+    expect(save()).toBeEnabled();
+    await userEvent.setup().click(save());
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+
+  it("saves normally when the page passes no claim at all", async () => {
+    // Creating has no document to claim, and a view rendered outside the entry
+    // page is handed nothing. Neither is a reason to refuse a save.
+    const { onSave } = view(undefined);
+
+    expect(save()).toBeEnabled();
+    await userEvent.setup().click(save());
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+
+  it("withholds the save while a colleague holds it", async () => {
+    const { onSave } = view({ readOnly: true, actionsDisabled: true });
+
+    expect(save()).toBeDisabled();
+    await userEvent.setup().click(save());
+
+    expect(onSave).not.toHaveBeenCalled();
+  });
+  it("withholds it after a colleague takes the document mid-session", async () => {
+    // The transition, not the mount: an editor who HELD the document when they
+    // opened it, and lost it while they worked.
+    //
+    // This does not distinguish the commit gate from the disabled button, and
+    // it does not pin the callback's dependency on the claim either - the
+    // button's disabled state is computed on every render, so it withholds the
+    // click whether or not the callback went stale. Removing that dependency
+    // leaves this passing. It is here for the scenario, not as evidence.
+    const { onSave, claimChangesTo } = view({
+      readOnly: false,
+      actionsDisabled: false,
+    });
+
+    claimChangesTo({ readOnly: true, actionsDisabled: true });
+    await userEvent.setup().click(save());
+
+    expect(onSave).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes the one document-lock finding that was fixed nowhere.

## The gap

A collection registering `admin.components.views.Edit.Component` gets its own
edit view, and the page returns that branch *before* `EntryForm` mounts.
`EntryForm` is where the default editor claims the document.

So a custom edit view announced nothing to the lock. A colleague opening the same
document was told nobody held it. The editor using the custom view was shown no
holder and offered no takeover. That happened on precisely the documents a
project cared enough about to build a bespoke editor for.

## The fix, and why it is shaped this way

The page already answers this question for the other fact a second editor needs.
Three lines above the gap, the custom-view branch renders `ScheduledReleaseBanner`
with this reasoning:

> A custom edit view replaces the FORM, not the facts about the document. Its
> editor is as able to save changes into a scheduled release as any other, and
> omitting the banner here would withhold the warning from precisely the
> documents a project cared enough about to build a bespoke editor for.

The lock is the same kind of fact, so it gets the same treatment: the claim is
taken above the branch, and `DocumentLockBanner` renders beside the release one.

No new plugin API. The lock is advisory by design — `document-lock.ts` says
"a held document is reported and no write is refused anywhere" — so claiming,
naming the holder and offering takeover *is* the protocol. A plugin author has to
do nothing to participate.

**Only that branch claims.** `EntryForm` still claims for the default editor, and
claiming in both places would put two claims on one document under one author,
which the repository keys and releases separately. The condition is the resolved
component rather than the registered path, because a path that resolves to
nothing falls through to `EntryForm` and its own claim.

The hook is called above the page's six early returns, which is the pattern this
file already states twice — `useAddToReleaseAction` carries the same note.

## Verification

- `packages/admin` full suite: **407 files, 4056 tests, exit 0.** No regressions
  from adding the two barrel exports.
- New page test, 4 cases: the custom view claims; the holder is named and
  takeover offered; the default branch does not claim; a registered path that
  resolves to nothing does not claim.
- `lint` (`--max-warnings 0`), `check-types`, `check:comments`, `lint:design`
  all exit 0. `fallow audit --gate new-only`: no issues in 4 changed files.
- Mutation-tested, each mutation asserted applied and each killed by the tests
  that name it:
  - claim on both branches → the two "leaves it to the form" cases fail;
  - never claim → the "claims the document" case fails;
  - banner removed → the "names the colleague" case fails.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Custom entry edit views now receive document-lock status, including read-only and disabled-action states.
  - Added document-lock notifications and takeover actions to custom editing experiences.
  - Form Builder prevents saving and disables the Save button when another user holds the document.
  - Document-lock information is available for custom edit views that replace the standard entry form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->