### PR TITLE
feat(root): let the docs check repair the key prefix it verifies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "check:dev-concurrency": "node scripts/check-dev-concurrency.mjs",
     "check:comments": "node scripts/check-comment-convention.mjs",
     "check:docs-claims": "node scripts/check-docs-claims.mjs",
+    "docs:fix": "node scripts/check-docs-claims.mjs --fix",
     "check:repo-metadata": "node scripts/check-repo-metadata.mjs",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "lint": "turbo run lint",

--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -20,7 +20,12 @@
 
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { readFileSync, readdirSync, existsSync } from "node:fs";
+import {
+  readFileSync,
+  readdirSync,
+  existsSync,
+  writeFileSync,
+} from "node:fs";
 import { basename, dirname, extname, join, relative, sep } from "node:path";
 
 /**
@@ -1121,7 +1126,14 @@ const blankSourceComments = text => partitionSource(text, "code");
 /** The file with its code padded out, leaving what a reader is shown of it. */
 const sourceComments = text => partitionSource(text, "comments");
 
-function documentedKeyPrefix(repoRoot, tracked, packages, findings, isExempt) {
+function documentedKeyPrefix(
+  repoRoot,
+  tracked,
+  packages,
+  findings,
+  isExempt,
+  repairs
+) {
   if (!tracked.includes(KEY_PREFIX_SOURCE)) {
     findings.push({
       check: "key-prefix-source-missing",
@@ -1289,6 +1301,19 @@ function documentedKeyPrefix(repoRoot, tracked, packages, findings, isExempt) {
         line,
         message: `documents \`${match[0].trim()}\`; keys are issued with the prefix "${prefix}"`,
       });
+      // The repair is recorded HERE, where the wrong example was found, rather
+      // than searched for again by something else. A second pass would be a
+      // second answer to "which tokens are key examples", and this one already
+      // carries the exemptions, the file scope and the placeholder rules.
+      //
+      // Only a token that HAS a prefix is repairable: swapping one prefix for
+      // another is a rewrite of what the example claims, while `Bearer abc123`
+      // states no format and inventing one for it would be writing the
+      // documentation rather than correcting it. Those stay findings.
+      const documented = DOCUMENTED_PREFIX.exec(token)?.[0];
+      if (repairs !== undefined && documented !== undefined) {
+        repairs.push({ file: rel, start, from: documented, to: prefix });
+      }
     }
   }
 
@@ -1336,6 +1361,9 @@ export async function runChecks({
   remoteRefs,
   hasLocalCommit,
   files,
+  // Present only when a caller intends to repair. Absent, every check behaves
+  // exactly as it did, so reporting is never changed by the ability to fix.
+  repairs,
 }) {
   const findings = [];
   const unverifiable = [];
@@ -1594,11 +1622,64 @@ export async function runChecks({
 
   readmeSkeleton(repoRoot, packages, findings);
   retiredKeywords(repoRoot, packages, findings);
-  documentedKeyPrefix(repoRoot, tracked, packages, findings, exemption("documented-key-prefix"));
+  documentedKeyPrefix(
+    repoRoot,
+    tracked,
+    packages,
+    findings,
+    exemption("documented-key-prefix"),
+    repairs
+  );
   internalLinks(repoRoot, tracked, findings);
   metaReachability(repoRoot, tracked, findings);
 
   return { findings, unverifiable };
+}
+
+/**
+ * Write the repairs a check recorded, and say what was rewritten.
+ *
+ * Applied back to front within each file, because a repair is addressed by the
+ * offset the check read it at and rewriting an earlier one first would move
+ * every later offset in that file by the difference in prefix lengths.
+ *
+ * Each write is checked against the text it claims to replace before it lands.
+ * The offsets come from the reading the checks scan, which pads comments rather
+ * than deleting them so that a match's offset still names its real position; if
+ * that ever stopped holding, this would silently corrupt a page. Refusing on a
+ * mismatch turns that into a stop rather than a rewrite of the wrong bytes.
+ *
+ * @param {string} repoRoot
+ * @param {{file: string, start: number, from: string, to: string}[]} repairs
+ * @returns {Map<string, number>} how many examples were rewritten per file
+ */
+export function applyRepairs(repoRoot, repairs) {
+  const byFile = new Map();
+  for (const repair of repairs) {
+    if (!byFile.has(repair.file)) byFile.set(repair.file, []);
+    byFile.get(repair.file).push(repair);
+  }
+
+  const counts = new Map();
+  for (const [rel, edits] of byFile) {
+    const absolute = join(repoRoot, rel);
+    let text = readFileSync(absolute, "utf-8");
+    for (const edit of [...edits].sort((a, b) => b.start - a.start)) {
+      const found = text.slice(edit.start, edit.start + edit.from.length);
+      if (found !== edit.from) {
+        throw new Error(
+          `${rel}: expected "${edit.from}" at ${String(edit.start)} and found "${found}"; refusing to rewrite`
+        );
+      }
+      text =
+        text.slice(0, edit.start) +
+        edit.to +
+        text.slice(edit.start + edit.from.length);
+    }
+    writeFileSync(absolute, text);
+    counts.set(rel, edits.length);
+  }
+  return counts;
 }
 
 const invokedDirectly =
@@ -1611,7 +1692,32 @@ if (invokedDirectly) {
     ? JSON.parse(readFileSync(allowlistPath, "utf-8"))
     : {};
 
-  const { findings, unverifiable } = await runChecks({ repoRoot, allowlist });
+  // Repairs are always COLLECTED and only written when asked for. Collecting
+  // costs an array the run already had the answers for, and it is what lets a
+  // plain run say how many of its findings a rewrite would settle instead of
+  // leaving the reader to guess.
+  const fix = process.argv.includes("--fix");
+  const repairs = [];
+  let { findings, unverifiable } = await runChecks({
+    repoRoot,
+    allowlist,
+    repairs,
+  });
+
+  if (fix && repairs.length > 0) {
+    const counts = applyRepairs(repoRoot, repairs);
+    const total = [...counts.values()].reduce((sum, n) => sum + n, 0);
+    console.log(
+      `docs claims: rewrote ${String(total)} key example(s) in ${String(counts.size)} file(s).`
+    );
+    for (const [rel, count] of counts) {
+      console.log(`  ${rel} (${String(count)})`);
+    }
+    // Re-read from disk. What is reported now is the state a reviewer will see,
+    // not the state that was found before the rewrite - and anything the repair
+    // could not settle is still a finding.
+    ({ findings, unverifiable } = await runChecks({ repoRoot, allowlist }));
+  }
 
   if (unverifiable.length > 0) {
     console.warn(
@@ -1636,5 +1742,13 @@ if (invokedDirectly) {
     }
   }
   console.error(`\n${findings.length} finding(s).`);
+  // Said where the failure is read, so it reaches a local run as well as CI.
+  // Only the examples whose prefix is merely wrong can be rewritten; the rest
+  // state no format and need someone to decide what they should say.
+  if (!fix && repairs.length > 0) {
+    console.error(
+      `${String(repairs.length)} of these name${repairs.length === 1 ? "s" : ""} a prefix that \`pnpm docs:fix\` can rewrite.`
+    );
+  }
   process.exit(1);
 }

--- a/scripts/check-docs-claims.test.mjs
+++ b/scripts/check-docs-claims.test.mjs
@@ -1,9 +1,10 @@
-import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, writeFile, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
+  applyRepairs,
   digestLine,
   namesRetiredCategory,
   packageKeywords,
@@ -2207,5 +2208,148 @@ describe("packageKeywords", () => {
       "cms",
       "framework",
     ]);
+  });
+});
+
+describe("documented-key-prefix repair", () => {
+  const SOURCE = "packages/nextly/src/domains/auth/services/api-key-service.ts";
+  const tree = (docs, declaration = 'const KEY_PREFIX = "nx_live_";') => ({
+    "README.md": "# nextly\n\n@nextlyhq/thing\n",
+    [SOURCE]: `${declaration}\nexport function make() { return KEY_PREFIX; }\n`,
+    ...docs,
+  });
+
+  /** Runs the checks in repairing mode and hands back both halves. */
+  async function repairsFor(spec) {
+    const { root, files } = await fixture(spec);
+    const repairs = [];
+    const { findings } = await runChecks({
+      repoRoot: root,
+      files,
+      remoteRefs: REFS,
+      hasLocalCommit: () => true,
+      repairs,
+    });
+    return { root, files, repairs, checks: findings.map(f => f.check) };
+  }
+
+  it("records the swap the finding already knows how to make", async () => {
+    const { repairs } = await repairsFor(
+      tree({
+        "docs/guides/authentication.mdx":
+          "Use `Authorization: Bearer sk_live_EXAMPLE`\n",
+      })
+    );
+
+    expect(repairs).toEqual([
+      {
+        file: "docs/guides/authentication.mdx",
+        start: expect.any(Number),
+        from: "sk_live_",
+        to: "nx_live_",
+      },
+    ]);
+  });
+
+  it("records nothing when the page already agrees with the source", async () => {
+    // The negative case the repair needs most: a fixer that offered an edit on
+    // a correct page would rewrite the tree on every run.
+    const { repairs, checks } = await repairsFor(
+      tree({
+        "docs/guides/authentication.mdx":
+          "Use `Authorization: Bearer nx_live_EXAMPLE`\n",
+      })
+    );
+
+    expect(checks).not.toContain("documented-key-prefix");
+    expect(repairs).toEqual([]);
+  });
+
+  it("leaves an example that states no format as a finding", async () => {
+    // 🔴 `Bearer abc123` claims no prefix, so there is nothing to swap. Giving
+    // it one would be writing the documentation rather than correcting it, so
+    // it stays reported and unrepaired.
+    const { repairs, checks } = await repairsFor(
+      tree({
+        "docs/guides/authentication.mdx":
+          "Use `Authorization: Bearer abc123`\n",
+      })
+    );
+
+    expect(checks).toContain("documented-key-prefix");
+    expect(repairs).toEqual([]);
+  });
+
+  it("rewrites the page, and the re-read reports clean", async () => {
+    const spec = tree({
+      "docs/guides/authentication.mdx":
+        "Use `Authorization: Bearer sk_live_EXAMPLE`\n",
+    });
+    const { root, files, repairs } = await repairsFor(spec);
+
+    applyRepairs(root, repairs);
+
+    expect(
+      await readFile(join(root, "docs/guides/authentication.mdx"), "utf-8")
+    ).toBe("Use `Authorization: Bearer nx_live_EXAMPLE`\n");
+
+    const { findings } = await runChecks({
+      repoRoot: root,
+      files,
+      remoteRefs: REFS,
+      hasLocalCommit: () => true,
+    });
+    expect(findings.map(f => f.check)).not.toContain("documented-key-prefix");
+  });
+
+  it("rewrites every example in one file, whatever the prefixes measure", async () => {
+    // 🔴 The prefixes here are DIFFERENT LENGTHS from the one replacing them, so
+    // an edit applied front to back would move every later offset in the file
+    // and corrupt the ones after the first. Two examples in one page is the
+    // smallest tree that can catch it, and the real docs have eleven.
+    const page =
+      "First `Authorization: Bearer sk_EXAMPLE`\n\n" +
+      "Then `Authorization: Bearer stripe_live_key_EXAMPLE`\n";
+    const { root, files, repairs } = await repairsFor(
+      tree({ "docs/guides/authentication.mdx": page })
+    );
+
+    expect(repairs).toHaveLength(2);
+    applyRepairs(root, repairs);
+
+    expect(
+      await readFile(join(root, "docs/guides/authentication.mdx"), "utf-8")
+    ).toBe(
+      "First `Authorization: Bearer nx_live_EXAMPLE`\n\n" +
+        "Then `Authorization: Bearer nx_live_EXAMPLE`\n"
+    );
+
+    const { findings } = await runChecks({
+      repoRoot: root,
+      files,
+      remoteRefs: REFS,
+      hasLocalCommit: () => true,
+    });
+    expect(findings.map(f => f.check)).not.toContain("documented-key-prefix");
+  });
+
+  it("refuses rather than rewriting bytes it cannot recognise", async () => {
+    // The offsets rest on the readers padding comments instead of deleting
+    // them. If that ever stopped holding, a silent rewrite would corrupt a
+    // page, so the write checks what it is replacing and stops instead.
+    const { root } = await fixture(
+      tree({ "docs/guides/authentication.mdx": "Use `Bearer sk_live_EXAMPLE`\n" })
+    );
+
+    expect(() =>
+      applyRepairs(root, [
+        {
+          file: "docs/guides/authentication.mdx",
+          start: 0,
+          from: "sk_live_",
+          to: "nx_live_",
+        },
+      ])
+    ).toThrow(/refusing to rewrite/);
   });
 });


### PR DESCRIPTION
The docs said API keys look like `sk_`; the service issues `nx_live_`. A reader
following the docs built a header that could never authenticate and got a generic
authentication failure with no hint the format was the problem. That was #1566,
and it took 30 findings over 10 rounds because checking prose for drift has an
unbounded surface: the same mistake can appear in any sentence, fence or doc
comment across 65 pages, three of which carry **16 key examples** between them.

This lets the check that finds the drift also repair it.

## Why it lives in the check rather than beside it

The check already computes everything a repair needs: the prefix read from the
one file that declares it, the exact set of files that publish prose (which
includes `ARCHITECTURE.md` and JSDoc that ships in package declarations, not just
`docs/`), the exemptions, the placeholder rules, and the precise offset of every
example that disagrees.

A separate generator would be a **second answer to "which tokens are key
examples"**, and it would drift from the first — which is the failure this whole
check exists to prevent. `.claude/rules/derived-checks.md` is the rule. So the
repair is recorded where the finding is raised, and nothing searches twice.

## What it will and will not touch

**Only an example that already states a prefix is repaired.** `Bearer abc123`
claims no format, so there is nothing to swap, and inventing one would be writing
the documentation rather than correcting it. Those stay findings.

**Writes are applied back to front within each file**, because a repair is
addressed by the offset the check read it at, and rewriting an earlier one first
would move every later offset in that file by the difference in prefix lengths.

**Each write is checked against the text it claims to replace.** The offsets rest
on the readers padding comments rather than deleting them; measured across
**3422 files** (66 markdown, 3356 TypeScript), zero length mismatches, with a
control proving the probe could fail. If that ever stopped holding, refusing is a
stop rather than a silent rewrite of the wrong bytes.

**Repairs are always collected and only written when `--fix` asks**, so a plain
run still changes nothing. CI's `pnpm check:docs-claims` is untouched.

## DX

    $ pnpm check:docs-claims
    documented-key-prefix (2):
      docs/guides/authentication.mdx:10 — documents `Bearer sk_live_EXAMPLE`; keys are issued with the prefix "nx_live_"
      docs/guides/authentication.mdx:303 — documents `Bearer abc123def`; keys are issued with the prefix "nx_live_"
    2 finding(s).
    1 of these names a prefix that `pnpm docs:fix` can rewrite.

The hint is printed by the script, so it reaches a local run as well as CI.

## Verification

- End to end: broke all **16** occurrences across the 3 real doc files to a
  foreign prefix, ran `--fix`, and the result is **byte-identical to the
  original**. Detection found 16; repair fixed 16.
- `pnpm test:scripts`: **27 files, 942 tests, exit 0.** 6 new.
- `pnpm check:docs-claims` exit 0; `pnpm docs:fix` on a correct tree is a no-op.
- `pnpm check:comments` exit 0.
- `fallow audit --changed-since origin/main --gate new-only --workspace '!playground' --config .fallowrc.jsonc`: **pass**, `complexity_introduced: 0`.
- Mutation-tested, each asserted applied and each killed by the test that names it:
  - repairs applied front to back → the multi-example case fails;
  - the write stops checking what it replaces → the refusal case fails;
  - a token stating no format is repaired anyway → that case fails.

## Two notes for review

`scripts/*.mjs` is not covered by lint-staged (its globs are `*.{js,jsx,ts,tsx}`
and `*.{json,css,scss,md}`) nor by `pnpm format` (`ts,tsx,md`), so this file has
never been prettier-formatted. I formatted it once by habit, which rewrote 300
lines of untouched code; that is reverted and the diff is only the change.

`documentedKeyPrefix` was already long and this adds ~10 lines to it. The gate
passes with nothing introduced, but a reviewer who wants it split should say so
rather than assume it was considered and dismissed.
