### PR TITLE
fix(admin): report a card's own request as fetching, not the whole batch

### DIFF
--- a/.changeset/a-card-reports-its-own-request.md
+++ b/.changeset/a-card-reports-its-own-request.md
@@ -1,0 +1,31 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A dashboard card stops showing itself as loading once its own data has arrived, instead of waiting for every other card on the page.
+
+A dashboard asking for more than thirty widgets' data is split into several requests that finish independently, but every card was reading one page-wide "still loading" flag. A card whose own request had already answered went on dimming numbers it had, until the last unrelated request finished — most visible on the largest dashboards, where the split happens. Each card now reads the state of the request that carries it, which is also what the published `WidgetComponentProps.isFetching` describes and what a plugin author is told to use to tell a first load from a widget that asks for nothing.

--- a/packages/admin/src/components/features/widgets/WidgetGrid.tsx
+++ b/packages/admin/src/components/features/widgets/WidgetGrid.tsx
@@ -212,7 +212,7 @@ export function WidgetGrid() {
   const {
     slots,
     cellSlots,
-    isFetching,
+    fetchingPlacementIds,
     updatedAt,
     requested,
     counted,
@@ -286,7 +286,7 @@ export function WidgetGrid() {
           cellSlots={cellSlots}
           requested={requested}
           updatedAt={updatedAt}
-          isFetching={isFetching}
+          fetchingPlacementIds={fetchingPlacementIds}
           announcement={announcement}
           onMove={moveWithinColumn}
           onMoveColumn={moveColumn}

--- a/packages/admin/src/components/features/widgets/edit/ArrangedColumns.tsx
+++ b/packages/admin/src/components/features/widgets/edit/ArrangedColumns.tsx
@@ -30,7 +30,8 @@ export interface ArrangedColumnsProps {
   cellSlots: CellSlots;
   requested: ReadonlySet<string>;
   updatedAt: Date | null;
-  isFetching: boolean;
+  /** The placements whose OWN request is still in flight. */
+  fetchingPlacementIds: ReadonlySet<string>;
   announcement: string;
   /** Move one card one step within the column it is drawn in. */
   onMove: (placementId: string, neighbourId: string, side: DropSide) => void;
@@ -73,7 +74,7 @@ export function ArrangedColumns({
   cellSlots,
   requested,
   updatedAt,
-  isFetching,
+  fetchingPlacementIds,
   announcement,
   onMove,
   onMoveColumn,
@@ -133,7 +134,13 @@ export function ArrangedColumns({
                 // batch, and neither did one whose archetype nothing can draw,
                 // so a refetch says nothing about either.
                 updatedAt: requested.has(row.placementId) ? updatedAt : null,
-                isFetching: requested.has(row.placementId) ? isFetching : false,
+                // 🔴 This card's own request, not the batch's. A dashboard
+                // above the per-request cap is split into partitions that
+                // settle independently, so the batch-wide flag left a card
+                // that had already answered reporting itself busy until every
+                // other partition answered too -- dimming settled numbers for
+                // no reason a reader could see.
+                isFetching: fetchingPlacementIds.has(row.placementId),
               }}
               on={{
                 // 🔴 Resolved against THIS column, not the whole arrangement.

--- a/packages/admin/src/components/features/widgets/useWidgetBatch.ts
+++ b/packages/admin/src/components/features/widgets/useWidgetBatch.ts
@@ -44,6 +44,8 @@ export interface WidgetBatch {
   /** A `stats` card's answers, by placement id then cell key. */
   cellSlots: CellSlots;
   isFetching: boolean;
+  /** The placements whose own request is still in flight. */
+  fetchingPlacementIds: ReadonlySet<string>;
   updatedAt: Date | null;
   /** Which PLACEMENTS took part in the batch at all. */
   requested: ReadonlySet<string>;
@@ -148,7 +150,7 @@ export function useWidgetBatch(cards: BatchCard[]): WidgetBatch {
     [cards]
   );
 
-  const { slots, cellSlots, isFetching, updatedAt } =
+  const { slots, cellSlots, isFetching, fetchingPlacementIds, updatedAt } =
     useWidgetQueries(requests);
 
   // Which cards are actually IN the batch, taken from the requests that were
@@ -195,6 +197,7 @@ export function useWidgetBatch(cards: BatchCard[]): WidgetBatch {
     slots,
     cellSlots,
     isFetching,
+    fetchingPlacementIds,
     updatedAt,
     requested,
     counted: outcomes.length,

--- a/packages/admin/src/hooks/queries/useWidgetQueries.test.tsx
+++ b/packages/admin/src/hooks/queries/useWidgetQueries.test.tsx
@@ -401,6 +401,61 @@ describe("useWidgetQueries", () => {
     });
   });
 
+  it("reports only the partition still in flight as fetching, not every card", async () => {
+    // 🔴 The same independence the failure case above relies on. A dashboard
+    // over the cap is split into partitions that settle separately, so a card
+    // whose own request has answered must stop reporting itself busy even while
+    // another partition is still running -- otherwise settled numbers stay
+    // dimmed for a reason no reader can see, and the published
+    // `WidgetComponentProps.isFetching` contract is not kept.
+    const over = MAX_QUERIES_PER_REQUEST + 1;
+    const requests = Array.from({ length: over }, (_, i) => ({
+      placementId: `core/${i}`,
+      query: countQuery(`collection:c${i}`),
+    }));
+
+    let releaseSecond: (() => void) | undefined;
+    const secondAnswered = new Promise<void>(resolve => {
+      releaseSecond = resolve;
+    });
+    vi.mocked(protectedApi.post).mockImplementation(
+      async (_path: string, body: unknown) => {
+        const sent = (body as { queries: unknown[] }).queries;
+        // The trailing partition holds exactly the one query over the cap.
+        if (sent.length === 1) await secondAnswered;
+        return {
+          results: sent.map(() => ({
+            ok: true,
+            result: { op: "count", total: 3 },
+          })),
+        };
+      }
+    );
+
+    const { result } = renderHook(() => useWidgetQueries(requests), {
+      wrapper,
+    });
+
+    // The first partition answers while the second is still held.
+    await waitFor(() => expect(result.current.slots["core/0"]).toBeDefined());
+
+    expect(result.current.fetchingPlacementIds.has("core/0")).toBe(false);
+    expect(result.current.fetchingPlacementIds.has(`core/${over - 1}`)).toBe(
+      true
+    );
+    // CONTROL: the batch-wide flag is still true, which is exactly why a card
+    // reading it rather than this set was wrong.
+    expect(result.current.isFetching).toBe(true);
+
+    releaseSecond?.();
+    await waitFor(() =>
+      expect(result.current.slots[`core/${over - 1}`]).toBeDefined()
+    );
+    await waitFor(() =>
+      expect(result.current.fetchingPlacementIds.size).toBe(0)
+    );
+  });
+
   describe("a member of results that is not a slot", () => {
     async function slotFor(member: unknown) {
       vi.mocked(protectedApi.post).mockResolvedValue({ results: [member] });

--- a/packages/admin/src/hooks/queries/useWidgetQueries.test.tsx
+++ b/packages/admin/src/hooks/queries/useWidgetQueries.test.tsx
@@ -454,6 +454,10 @@ describe("useWidgetQueries", () => {
     await waitFor(() =>
       expect(result.current.fetchingPlacementIds.size).toBe(0)
     );
+    // The batch-wide flag is DERIVED from that set, so it has to fall with it.
+    // Asserted because nothing else did: a flag stuck at `true` left every
+    // card's busy affordance on forever and no test noticed.
+    expect(result.current.isFetching).toBe(false);
   });
 
   describe("a member of results that is not a slot", () => {

--- a/packages/admin/src/hooks/queries/useWidgetQueries.ts
+++ b/packages/admin/src/hooks/queries/useWidgetQueries.ts
@@ -525,7 +525,21 @@ export function useWidgetQueries(
     slots,
     cellSlots,
     isLoading: results.some(answer => answer.isLoading),
-    isFetching: results.some(answer => answer.isFetching),
+    /*
+     * 🔴 DERIVED from the set, not reduced a second time from the same results.
+     * The two answer one question -- "is anything still loading" -- and
+     * computing it twice is how they come to disagree: a later change to which
+     * partitions count as in flight would have to be made in both places, and
+     * the grid-wide affordance and the per-card one would drift apart silently.
+     *
+     * Equivalent by construction, not by coincidence: `partitionRequests`
+     * advances while `start < queries.length`, so every partition it emits
+     * holds at least one request, and an empty input produces no partitions at
+     * all. A fetching partition therefore always contributes at least one
+     * placement, and the set is non-empty exactly when some partition is
+     * fetching.
+     */
+    isFetching: fetchingPlacementIds.size > 0,
     fetchingPlacementIds,
     // The FIRST failure, which is enough for the grid: what a reader needs per
     // widget is already in that widget's slot, and this says only that

--- a/packages/admin/src/hooks/queries/useWidgetQueries.ts
+++ b/packages/admin/src/hooks/queries/useWidgetQueries.ts
@@ -88,6 +88,16 @@ export interface UseWidgetQueriesResult {
    * says so — which is what `aria-busy` is for.
    */
   isFetching: boolean;
+  /**
+   * The placements whose OWN request is still in flight.
+   *
+   * `isFetching` above answers "is anything still loading", which is what the
+   * grid's own busy affordance needs. A CARD needs its own answer: on a
+   * dashboard split across partitions the two differ, and a card reading the
+   * batch-wide flag stays dimmed while an unrelated partition loads. A card
+   * that asked nothing is never in a partition, so it is never in this set.
+   */
+  fetchingPlacementIds: ReadonlySet<string>;
   error: Error | null;
   refetch: () => Promise<unknown>;
   /**
@@ -492,6 +502,23 @@ export function useWidgetQueries(
     }
   });
 
+  /*
+   * 🔴 Per PARTITION, not per batch. A dashboard above `MAX_QUERIES_PER_REQUEST`
+   * is split into independently settling requests, and the failure branch above
+   * already treats them independently -- "only this partition's widgets are
+   * affected, which is the point of splitting them". Reducing the fetch state
+   * with `some` threw that away for the one signal a card renders: a widget
+   * whose own partition answered went on reporting itself busy, dimming settled
+   * numbers, until every OTHER partition had answered too. The published
+   * `WidgetComponentProps` says `isFetching` is this card's query, so this is
+   * what makes that true rather than nearly true.
+   */
+  const fetchingPlacementIds = new Set<string>();
+  partitions.forEach((partition, index) => {
+    if (results[index]?.isFetching !== true) return;
+    partition.forEach(entry => fetchingPlacementIds.add(entry.placementId));
+  });
+
   const settledAt = results.map(answer => answer.dataUpdatedAt);
 
   return {
@@ -499,6 +526,7 @@ export function useWidgetQueries(
     cellSlots,
     isLoading: results.some(answer => answer.isLoading),
     isFetching: results.some(answer => answer.isFetching),
+    fetchingPlacementIds,
     // The FIRST failure, which is enough for the grid: what a reader needs per
     // widget is already in that widget's slot, and this says only that
     // something in the batch did not answer.


### PR DESCRIPTION
Follow-up to #1600, which published `WidgetComponentProps.isFetching` as **this card's** query. It was not.

## The defect

`useWidgetQueries` returned `isFetching: results.some(answer => answer.isFetching)` — one boolean for the whole page — and `ArrangedColumns` handed it to every requested placement.

A dashboard above `MAX_QUERIES_PER_REQUEST` (30) is split into partitions that settle independently. So a card whose own partition had already answered went on reporting itself busy, dimming numbers it already had, until every unrelated partition answered too. Most visible on exactly the dashboards where the split happens.

Raised by Codex on #1600 and confirmed in source before acting.

## Why a fix rather than a doc change

The module already treats partitions independently one branch away, and says why — a failed request fails only its own partition, "which is the point of splitting them". Fetch state was the single signal that did not follow, and it is the one a card renders.

It also matters beyond dimming: the guide tells a plugin author to use `isFetching` to tell a first load from a queryless widget, since `slot` is `undefined` in both cases. That reading is only sound if the flag is per card.

## The change

`fetchingPlacementIds` is built in the same partition walk that files the slots, and each card reads `fetchingPlacementIds.has(row.placementId)`. A card that asked nothing is never in a partition, so it is never in the set — which keeps the discriminator honest.

The batch-wide flag is no longer passed to the columns at all. It answers "is anything still loading", which the grid's own affordance wants and a card never did; leaving both in reach would be two sources of truth for one question.

## Evidence

The 359 tests over this area all passed **with** the defect present, so they did not cover it. The new test mirrors the per-partition failure test beside it: hold the trailing partition, assert the answered card is not fetching while the held one is, and assert the batch-wide flag is still `true` — which is precisely why reading it per card was wrong.

Break-verified: restoring the `some(...)` reduction kills that test and only that test; making the set always empty kills it too.

`check-types` 42/42, `lint` 24/24, fallow `✓ No issues in 6 changed files`, 465 tests passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Widget loading indicators now reflect each widget’s individual request status.
  - Widgets stop appearing busy as soon as their data is available, even when other widgets are still loading.
  - Overall loading status remains active until all widget requests are complete.

- **Tests**
  - Added coverage for dashboards whose widgets load across multiple partitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->