### PR TITLE
ci: move the form builder's integration suites into the integration lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,14 @@ jobs:
         if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: pnpm check:docs-claims
 
+      # The integration jobs select packages with a hand-written filter list, so
+      # a package that gains the task and is not added to it runs NOWHERE: the
+      # unit job no longer includes those files and no leg selects them, and
+      # every job stays green because what would have been reported is absent.
+      - name: Integration lane covers every package that declares it
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
+        run: pnpm check:integration-lane
+
       # The About line and topic list are repository settings, not files, so every
       # check that reads git's index is blind to them. Reports unverifiable rather
       # than failing when the API cannot be reached.

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -248,17 +248,20 @@ jobs:
       # Builds all three adapters for the same reason the database job does:
       # nextly's database/factory.ts references them as optional peers, and
       # turbo's `^build` does not traverse peerDependencies.
-      # `plugin-seo` runs on THIS leg only, unlike the packages beside it. Its
-      # suites call `createTestNextly`, which boots on in-memory SQLite and
-      # names no dialect, so the postgres and mysql legs would run byte-identical
-      # work — three times the runtime for one answer. They are here rather than
-      # in the unit `Test` step because each case boots a real instance, and
-      # doing that while seventeen other suites run in parallel is what took one
-      # past a 30s budget on CI while it finishes in about 1.5s alone.
+      # `plugin-seo` and `plugin-form-builder` run on THIS leg only, unlike the
+      # packages beside them. Their suites call `createTestNextly` and name no
+      # dialect, so it boots on in-memory SQLite and the postgres and mysql legs
+      # would run byte-identical work — three times the runtime for one answer.
+      # `plugin-page-builder` is in all three because its suites DO take a
+      # dialect, which is the property that decides this rather than the kind of
+      # package it is. They are here rather than in the unit `Test` step because
+      # each case boots a real instance, and doing that while every other
+      # package's suite runs in parallel is what took one past a 30s budget on
+      # CI while it finishes in about 1.5s alone.
       - name: Run integration tests (sqlite)
         run: |
-          pnpm turbo build --filter=nextly --filter=@nextlyhq/adapter-postgres --filter=@nextlyhq/adapter-mysql --filter=@nextlyhq/adapter-sqlite --filter=@nextlyhq/plugin-page-builder --filter=@nextlyhq/plugin-seo
-          pnpm turbo test:integration --filter=@nextlyhq/adapter-sqlite --filter=nextly --filter=@nextlyhq/plugin-page-builder --filter=@nextlyhq/plugin-seo
+          pnpm turbo build --filter=nextly --filter=@nextlyhq/adapter-postgres --filter=@nextlyhq/adapter-mysql --filter=@nextlyhq/adapter-sqlite --filter=@nextlyhq/plugin-page-builder --filter=@nextlyhq/plugin-seo --filter=@nextlyhq/plugin-form-builder
+          pnpm turbo test:integration --filter=@nextlyhq/adapter-sqlite --filter=nextly --filter=@nextlyhq/plugin-page-builder --filter=@nextlyhq/plugin-seo --filter=@nextlyhq/plugin-form-builder
         env:
           TURBO_CACHE_DIR: .turbo
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "check:drizzle-v1-legacy": "node scripts/check-drizzle-v1-legacy.cjs",
     "check:storage-format-literals": "node scripts/check-storage-format-literals.cjs",
     "check:dev-concurrency": "node scripts/check-dev-concurrency.mjs",
+    "check:integration-lane": "node scripts/check-integration-lane.mjs",
     "check:comments": "node scripts/check-comment-convention.mjs",
     "check:docs-claims": "node scripts/check-docs-claims.mjs",
     "docs:fix": "node scripts/check-docs-claims.mjs --fix",

--- a/packages/plugin-form-builder/package.json
+++ b/packages/plugin-form-builder/package.json
@@ -30,6 +30,7 @@
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
     "test": "vitest run",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:watch": "vitest"
   },
   "dependencies": {

--- a/packages/plugin-form-builder/vitest.config.ts
+++ b/packages/plugin-form-builder/vitest.config.ts
@@ -1,21 +1,25 @@
 import { defineConfig } from "vitest/config";
 
-// Several suites here (`*.integration.test.ts`) boot a full Nextly instance
-// per test via `createTestNextly` (DI container + schema registry + an
-// in-memory SQLite DB). A single boot is ~700ms, but when the whole package
-// runs in parallel with the rest of the monorepo's `Test` step the CI runner
-// saturates and individual tests occasionally exceed Vitest's 5s default —
-// an intermittent, environment-only timeout (each suite passes in isolation).
-// Give these integration tests the headroom they legitimately need; fast unit
-// tests finishing in milliseconds are unaffected.
+// Unit suites only. The `*.integration.test.ts` files boot a real Nextly
+// instance per test via `createTestNextly` (DI container + schema registry +
+// in-memory SQLite), which is not what the `test` task is sized for: turbo runs
+// it across every package at once, and a boot competing with the rest of the
+// monorepo took a case to 30556ms on CI while the same file finishes in about
+// 1.6s in isolation. Raising the budget was the previous answer here, and it
+// has now been exceeded, so the suites move to their own task instead — the
+// split `nextly`, the three adapters, `plugin-page-builder` and `plugin-seo`
+// already use.
 export default defineConfig({
   test: {
-    testTimeout: 30000,
-    hookTimeout: 30000,
+    include: ["src/**/*.{test,spec}.{ts,tsx}"],
+    exclude: [
+      "**/node_modules/**",
+      "**/dist/**",
+      "src/**/*.integration.test.ts",
+    ],
     // Component suites request jsdom per file (`@vitest-environment jsdom`)
-    // rather than switching it on globally, so the integration suites above
-    // keep the node environment they actually need. This setup only fills in
-    // globals jsdom lacks, so it is inert for the node ones.
+    // rather than switching it on globally. This setup only fills in globals
+    // jsdom lacks, so it is inert for the node ones.
     setupFiles: ["./src/__tests__/setup.ts"],
   },
 });

--- a/packages/plugin-form-builder/vitest.integration.config.ts
+++ b/packages/plugin-form-builder/vitest.integration.config.ts
@@ -1,0 +1,26 @@
+// Integration config for the form-builder plugin. Runs only
+// `*.integration.test.ts`.
+//
+// Mirrors the split in `nextly`, `plugin-page-builder` and `plugin-seo`: these
+// boot a real Nextly instance per test and exercise the plugin's own
+// collections against it, so they need a budget a unit default cannot give them
+// and they must not compete with the parallel unit step for the runner.
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    name: "plugin-form-builder-integration",
+    environment: "node",
+    include: ["src/**/*.integration.test.ts"],
+    exclude: ["**/node_modules/**", "**/dist/**"],
+    // A real instance boot per test, so the unit default is far too tight.
+    // Kept at the value the unit config used to carry, which was sized for this
+    // work — what changes is that it is no longer paid while every other
+    // package's suite runs beside it.
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+    // Each test boots its own instance against a shared in-memory database, so
+    // the files cannot safely interleave.
+    fileParallelism: false,
+  },
+});

--- a/scripts/check-integration-lane.mjs
+++ b/scripts/check-integration-lane.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+
+/**
+ * Every package with a `test:integration` task must be named by a workflow leg
+ * that runs one, and every leg's filters must name a package that has one.
+ *
+ * The integration jobs select what to run with a hand-written `--filter` list,
+ * repeated once per dialect leg. Nothing connects that list to the packages
+ * that actually declare the task, so the two drift in both directions and each
+ * drift is silent:
+ *
+ *   - a package gains `test:integration` and nobody edits the workflow. Its
+ *     suites run NOWHERE. The unit job no longer includes them and no
+ *     integration leg selects them, so the coverage leaves and every job stays
+ *     green — the shape a check cannot notice, because what it would have
+ *     reported is simply absent.
+ *   - a filter keeps naming a package that no longer has the task. Turbo
+ *     matches no task and moves on, so the leg reports success while the entry
+ *     stands as a record of coverage nobody is getting.
+ *
+ * Both sides are DERIVED rather than restated. The packages come from reading
+ * the manifests git tracks, and the legs come from parsing the commands the
+ * workflow actually runs, so neither is a list kept in step by hand.
+ *
+ * Usage:
+ *   node scripts/check-integration-lane.mjs
+ */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+const WORKFLOW = ".github/workflows/integration.yml";
+
+/**
+ * A `turbo test:integration` invocation and the packages it selects.
+ *
+ * Matched on the command rather than on a step name, because the name is prose
+ * somebody can reword while the command is what runs. One invocation per line:
+ * the workflow writes each as a single command inside a `run:` block, and a
+ * filter split across a continuation would be a different shape than any leg
+ * currently uses — so this reports what it can see and the population check
+ * below refuses when it sees none.
+ */
+export function integrationInvocations(workflow) {
+  const invocations = [];
+  for (const line of workflow.split(/\r?\n/)) {
+    if (!/\bturbo\s+test:integration\b/.test(line)) continue;
+    const filters = [...line.matchAll(/--filter=(\S+)/g)].map(m => m[1]);
+    invocations.push({ line: line.trim(), filters });
+  }
+  return invocations;
+}
+
+/** Every tracked manifest that declares the task, by package name. */
+export function packagesWithIntegrationTask(readManifest, manifestPaths) {
+  const named = [];
+  for (const path of manifestPaths) {
+    let manifest;
+    try {
+      manifest = JSON.parse(readManifest(path));
+    } catch {
+      continue; // an unreadable manifest is reported by the workspace linter
+    }
+    if (typeof manifest?.name !== "string") continue;
+    if (typeof manifest?.scripts?.["test:integration"] === "string") {
+      named.push(manifest.name);
+    }
+  }
+  return named.sort();
+}
+
+/** What the two sides disagree about, in both directions. */
+export function laneDrift(declared, selected) {
+  const selectedSet = new Set(selected);
+  const declaredSet = new Set(declared);
+  return {
+    unrun: declared.filter(name => !selectedSet.has(name)),
+    stale: selected.filter(name => !declaredSet.has(name)),
+  };
+}
+
+const invokedDirectly =
+  process.argv[1] && process.argv[1].endsWith("check-integration-lane.mjs");
+
+if (invokedDirectly) {
+  let manifestPaths;
+  try {
+    manifestPaths = execFileSync(
+      "git",
+      ["ls-files", "packages/*/package.json", "apps/*/package.json"],
+      { cwd: root, encoding: "utf8" }
+    )
+      .split("\n")
+      .filter(Boolean);
+  } catch {
+    console.error(
+      "check-integration-lane: cannot list tracked manifests; this reads git's " +
+        "index rather than the filesystem, so it has nothing to judge."
+    );
+    process.exit(2);
+  }
+
+  let workflow;
+  try {
+    workflow = readFileSync(join(root, WORKFLOW), "utf8");
+  } catch {
+    console.error(
+      `check-integration-lane: ${WORKFLOW} could not be read, so the legs have ` +
+        "nothing to be compared against."
+    );
+    process.exit(2);
+  }
+
+  const invocations = integrationInvocations(workflow);
+  const declared = packagesWithIntegrationTask(
+    path => readFileSync(join(root, path), "utf8"),
+    manifestPaths
+  );
+  const selected = [
+    ...new Set(invocations.flatMap(invocation => invocation.filters)),
+  ].sort();
+
+  // The population, before the verdict. An empty side is satisfied by every
+  // comparison below, so each of these would report a clean lane having
+  // examined nothing.
+  if (manifestPaths.length === 0) {
+    console.error(
+      "check-integration-lane: no tracked package manifests were found, so no " +
+        "package could have been judged."
+    );
+    process.exit(2);
+  }
+  if (invocations.length === 0) {
+    console.error(
+      `check-integration-lane: ${WORKFLOW} runs no \`turbo test:integration\`. ` +
+        "Either the legs were rewritten and this check needs teaching, or the " +
+        "integration lane has stopped running and every package would read as " +
+        "covered."
+    );
+    process.exit(2);
+  }
+  if (declared.length === 0) {
+    console.error(
+      "check-integration-lane: no package declares a `test:integration` script, " +
+        "which would make every filter below stale rather than the lane clean."
+    );
+    process.exit(2);
+  }
+
+  const { unrun, stale } = laneDrift(declared, selected);
+
+  if (unrun.length > 0 || stale.length > 0) {
+    console.error("check-integration-lane: FAILED\n");
+    for (const name of unrun) {
+      console.error(
+        `  - ${name} declares \`test:integration\` and no leg selects it, so its ` +
+          "suites run nowhere. Add `--filter=" +
+          name +
+          `\` to a leg in ${WORKFLOW}.`
+      );
+    }
+    for (const name of stale) {
+      console.error(
+        `  - ${WORKFLOW} filters for ${name}, which declares no ` +
+          "`test:integration`. Turbo matches no task and the leg passes without " +
+          "running it; drop the filter or add the script."
+      );
+    }
+    console.error(`\ndeclared (${declared.length}): ${declared.join(", ")}`);
+    console.error(`selected (${selected.length}): ${selected.join(", ")}`);
+    process.exit(1);
+  }
+
+  console.log(
+    `check-integration-lane: ok — ${declared.length} package(s) declare ` +
+      `\`test:integration\` and every one is selected by a leg, across ` +
+      `${invocations.length} invocation(s).`
+  );
+}

--- a/scripts/check-integration-lane.mjs
+++ b/scripts/check-integration-lane.mjs
@@ -36,43 +36,83 @@ const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const WORKFLOW = ".github/workflows/integration.yml";
 
 /**
- * Every shell command the workflow actually RUNS, in order.
+ * Whether a step's `if:` disables it no matter what the run decides.
+ *
+ * Only a LITERAL false, because that is the whole set this can answer. A matrix
+ * condition is the workflow selecting a leg rather than disabling one, and
+ * whether it holds depends on a run that has not happened - so treating an
+ * expression as disabled would report a lane uncovered while it runs perfectly,
+ * which for this check is the more expensive direction.
+ */
+export function staticallyDisabled(condition) {
+  if (typeof condition !== "string") return false;
+  const bare = condition.trim().replace(/^\$\{\{(.*)\}\}$/s, "$1").trim();
+  return bare === "false";
+}
+
+/**
+ * Each step in the workflow, with the condition on it and the commands it runs.
  *
  * 🔴 Reading `run:` rather than scanning every line is the load-bearing part.
  * The workflow's prose explains what each leg does, so a paragraph naming a
- * command reads identically to the command — and a line scan counts an
- * invocation that was commented out while the lane it described has stopped
- * running. That is this check reporting a covered lane it never had.
+ * command reads identically to the command - and a line scan counts an
+ * invocation that was commented out, or one belonging to a step that is turned
+ * off, while the lane it described has stopped running. That is this check
+ * reporting a covered lane it never had.
  *
- * Both YAML forms the file uses: a block scalar (`run: |`), whose body is every
- * following line indented past the key, and the one-line form. A block's body is
- * a shell script, so a line opening with `#` there is a comment for the same
- * reason a YAML one is, and neither executes.
+ * Steps are block-sequence items (`- name:` / `- uses:` / `- run:`), and their
+ * keys sit one level in. Both `run:` forms the file uses are read: a block
+ * scalar, whose body is every following line indented past the key, and the
+ * one-line form. A block's body is a shell script, so a line opening with `#`
+ * there is a comment for the same reason a YAML one is, and neither executes.
  *
- * The boundary, stated rather than covered badly: this reads indentation, not
- * YAML. A quoted `#`, a folded scalar carrying a continuation, or a command
- * assembled across lines would need a parser, and none is a form this workflow
- * uses. What it will not do is mistake prose or a disabled line for a command.
+ * ⚠️ The boundary, stated rather than covered badly. This reads indentation,
+ * not YAML, so what it CANNOT see is: a condition on the JOB rather than the
+ * step, a step disabled by an expression only the run can evaluate, a `#`
+ * inside quotes, and a command assembled across lines. Each would need a
+ * parser, and none is a form this workflow uses. The check names that limit in
+ * its own output rather than leaving it implicit, which is the call
+ * `check-comment-convention.mjs` already made for its own YAML reader.
  */
-export function runCommands(workflow) {
-  const commands = [];
+export function workflowSteps(workflow) {
   const lines = workflow.split(/\r?\n/);
+  const steps = [];
+  let step;
   for (let index = 0; index < lines.length; index++) {
-    const block = /^(\s*)(?:-\s+)?run:[ \t]*[|>][-+]?[ \t]*$/.exec(lines[index]);
-    if (block) {
-      const keyIndent = block[1].length;
+    const line = lines[index];
+    const item = /^(\s*)-\s+\S/.exec(line);
+    if (item) {
+      step = { indent: item[1].length, condition: undefined, commands: [] };
+      steps.push(step);
+    }
+    if (step === undefined) continue;
+    // A key of THIS step sits one level in from its dash. Deeper belongs to
+    // another mapping, and shallower has ended the step.
+    const keyIndent = step.indent + 2;
+    // Either spelling of the same position: the first key sits ON the dash
+    // line (`- run: ...`), and the rest are indented to where that key began.
+    const own = new RegExp(
+      `^(?:\\s{${step.indent}}-\\s+|\\s{${keyIndent}})(\\w[\\w-]*):(.*)$`
+    ).exec(line);
+    if (own === null) continue;
+    const [, key, rest] = own;
+    if (key === "if") {
+      step.condition = rest.trim();
+      continue;
+    }
+    if (key !== "run") continue;
+    if (/^[ \t]*[|>][-+]?[ \t]*$/.test(rest)) {
       for (let body = index + 1; body < lines.length; body++) {
-        const line = lines[body];
-        if (line.trim() === "") continue;
-        if (line.length - line.trimStart().length <= keyIndent) break;
-        commands.push(line.trim());
+        const bodyLine = lines[body];
+        if (bodyLine.trim() === "") continue;
+        if (bodyLine.length - bodyLine.trimStart().length <= keyIndent) break;
+        step.commands.push(bodyLine.trim());
       }
       continue;
     }
-    const inline = /^\s*(?:-\s+)?run:[ \t]+([^|>\s].*)$/.exec(lines[index]);
-    if (inline) commands.push(inline[1].trim());
+    if (rest.trim() !== "") step.commands.push(rest.trim());
   }
-  return commands;
+  return steps;
 }
 
 /**
@@ -83,16 +123,22 @@ export function runCommands(workflow) {
  */
 export function integrationInvocations(workflow) {
   const invocations = [];
-  for (const command of runCommands(workflow)) {
-    // A disabled command is not an invocation, however completely it describes
-    // one. Anchored at the start, so a `#` cannot precede what it disables.
-    if (command.startsWith("#")) continue;
-    // A trailing comment is not part of the command either, and one naming a
-    // package would otherwise be read as coverage.
-    const executable = command.split(/\s+#\s/)[0];
-    if (!/\bturbo\s+test:integration\b/.test(executable)) continue;
-    const filters = [...executable.matchAll(/--filter=(\S+)/g)].map(m => m[1]);
-    invocations.push({ line: executable.trim(), filters });
+  for (const step of workflowSteps(workflow)) {
+    // A step that cannot run covers nothing, however completely its command
+    // describes the lane.
+    if (staticallyDisabled(step.condition)) continue;
+    for (const command of step.commands) {
+      // A disabled command is not an invocation either. Anchored at the start,
+      // so a `#` cannot precede what it disables.
+      if (command.startsWith("#")) continue;
+      // Everything from an unquoted `#` is a comment to the shell, with or
+      // without a space after it: `cmd #--filter=x` runs `cmd`. Splitting on
+      // `#` alone is what keeps a commented flag from reading as coverage.
+      const executable = command.split(/\s+#/)[0];
+      if (!/\bturbo\s+test:integration\b/.test(executable)) continue;
+      const filters = [...executable.matchAll(/--filter=(\S+)/g)].map(m => m[1]);
+      invocations.push({ line: executable.trim(), filters });
+    }
   }
   return invocations;
 }
@@ -221,5 +267,11 @@ if (invokedDirectly) {
     `check-integration-lane: ok — ${declared.length} package(s) declare ` +
       `\`test:integration\` and every one is selected by a leg, across ` +
       `${invocations.length} invocation(s).`
+  );
+  // Said on the way past rather than only in the source, so a reader taking
+  // this as proof of coverage knows which shapes it did not judge.
+  console.log(
+    "  reads step `run:` by indentation, not YAML: a job-level condition, a " +
+      "step disabled by an expression, or a `#` inside quotes are not seen."
   );
 }

--- a/scripts/check-integration-lane.mjs
+++ b/scripts/check-integration-lane.mjs
@@ -36,21 +36,63 @@ const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const WORKFLOW = ".github/workflows/integration.yml";
 
 /**
+ * Every shell command the workflow actually RUNS, in order.
+ *
+ * 🔴 Reading `run:` rather than scanning every line is the load-bearing part.
+ * The workflow's prose explains what each leg does, so a paragraph naming a
+ * command reads identically to the command — and a line scan counts an
+ * invocation that was commented out while the lane it described has stopped
+ * running. That is this check reporting a covered lane it never had.
+ *
+ * Both YAML forms the file uses: a block scalar (`run: |`), whose body is every
+ * following line indented past the key, and the one-line form. A block's body is
+ * a shell script, so a line opening with `#` there is a comment for the same
+ * reason a YAML one is, and neither executes.
+ *
+ * The boundary, stated rather than covered badly: this reads indentation, not
+ * YAML. A quoted `#`, a folded scalar carrying a continuation, or a command
+ * assembled across lines would need a parser, and none is a form this workflow
+ * uses. What it will not do is mistake prose or a disabled line for a command.
+ */
+export function runCommands(workflow) {
+  const commands = [];
+  const lines = workflow.split(/\r?\n/);
+  for (let index = 0; index < lines.length; index++) {
+    const block = /^(\s*)(?:-\s+)?run:[ \t]*[|>][-+]?[ \t]*$/.exec(lines[index]);
+    if (block) {
+      const keyIndent = block[1].length;
+      for (let body = index + 1; body < lines.length; body++) {
+        const line = lines[body];
+        if (line.trim() === "") continue;
+        if (line.length - line.trimStart().length <= keyIndent) break;
+        commands.push(line.trim());
+      }
+      continue;
+    }
+    const inline = /^\s*(?:-\s+)?run:[ \t]+([^|>\s].*)$/.exec(lines[index]);
+    if (inline) commands.push(inline[1].trim());
+  }
+  return commands;
+}
+
+/**
  * A `turbo test:integration` invocation and the packages it selects.
  *
  * Matched on the command rather than on a step name, because the name is prose
- * somebody can reword while the command is what runs. One invocation per line:
- * the workflow writes each as a single command inside a `run:` block, and a
- * filter split across a continuation would be a different shape than any leg
- * currently uses — so this reports what it can see and the population check
- * below refuses when it sees none.
+ * somebody can reword while the command is what runs.
  */
 export function integrationInvocations(workflow) {
   const invocations = [];
-  for (const line of workflow.split(/\r?\n/)) {
-    if (!/\bturbo\s+test:integration\b/.test(line)) continue;
-    const filters = [...line.matchAll(/--filter=(\S+)/g)].map(m => m[1]);
-    invocations.push({ line: line.trim(), filters });
+  for (const command of runCommands(workflow)) {
+    // A disabled command is not an invocation, however completely it describes
+    // one. Anchored at the start, so a `#` cannot precede what it disables.
+    if (command.startsWith("#")) continue;
+    // A trailing comment is not part of the command either, and one naming a
+    // package would otherwise be read as coverage.
+    const executable = command.split(/\s+#\s/)[0];
+    if (!/\bturbo\s+test:integration\b/.test(executable)) continue;
+    const filters = [...executable.matchAll(/--filter=(\S+)/g)].map(m => m[1]);
+    invocations.push({ line: executable.trim(), filters });
   }
   return invocations;
 }

--- a/scripts/check-integration-lane.test.mjs
+++ b/scripts/check-integration-lane.test.mjs
@@ -8,7 +8,8 @@ import {
   integrationInvocations,
   laneDrift,
   packagesWithIntegrationTask,
-  runCommands,
+  staticallyDisabled,
+  workflowSteps,
 } from "./check-integration-lane.mjs";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -16,7 +17,7 @@ const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const manifest = (name, extra = {}) =>
   JSON.stringify({ name, scripts: { test: "vitest run", ...extra } });
 
-describe("runCommands", () => {
+describe("workflowSteps", () => {
   it("reads a block scalar's body and stops at the next key", () => {
     const workflow = [
       "      - name: Run integration tests",
@@ -27,16 +28,32 @@ describe("runCommands", () => {
       "          TURBO_CACHE_DIR: .turbo",
     ].join("\n");
 
-    expect(runCommands(workflow)).toEqual([
-      "pnpm turbo build --filter=nextly",
-      "pnpm turbo test:integration --filter=nextly",
+    expect(workflowSteps(workflow)).toEqual([
+      {
+        indent: 6,
+        condition: undefined,
+        commands: [
+          "pnpm turbo build --filter=nextly",
+          "pnpm turbo test:integration --filter=nextly",
+        ],
+      },
     ]);
   });
 
   it("reads the one-line form too", () => {
-    expect(runCommands("        run: pnpm install --frozen-lockfile")).toEqual([
-      "pnpm install --frozen-lockfile",
+    expect(workflowSteps("      - run: pnpm install --frozen-lockfile")).toEqual([
+      { indent: 6, condition: undefined, commands: ["pnpm install --frozen-lockfile"] },
     ]);
+  });
+
+  it("keeps the condition with the step it guards", () => {
+    const workflow = [
+      "      - name: Run integration tests (mysql)",
+      "        if: matrix.dialect == 'mysql'",
+      "        run: pnpm turbo test:integration --filter=nextly",
+    ].join("\n");
+
+    expect(workflowSteps(workflow)[0].condition).toBe("matrix.dialect == 'mysql'");
   });
 
   it("does not read the prose that explains the workflow", () => {
@@ -49,9 +66,25 @@ describe("runCommands", () => {
       "        run: pnpm turbo test:integration --filter=nextly",
     ].join("\n");
 
-    expect(runCommands(workflow)).toEqual([
+    expect(workflowSteps(workflow).flatMap(s => s.commands)).toEqual([
       "pnpm turbo test:integration --filter=nextly",
     ]);
+  });
+});
+
+describe("staticallyDisabled", () => {
+  it("is true only for a literal false", () => {
+    expect(staticallyDisabled("false")).toBe(true);
+    expect(staticallyDisabled("${{ false }}")).toBe(true);
+  });
+
+  it("leaves a condition the run decides alone", () => {
+    // 🔴 The control that keeps this from over-reporting: a matrix condition is
+    // the workflow SELECTING a leg, not disabling one. Reading it as disabled
+    // would report the postgres and mysql legs as covering nothing.
+    expect(staticallyDisabled("matrix.dialect == 'mysql'")).toBe(false);
+    expect(staticallyDisabled("success()")).toBe(false);
+    expect(staticallyDisabled(undefined)).toBe(false);
   });
 });
 
@@ -61,6 +94,7 @@ describe("integrationInvocations", () => {
     // by a `#` still describes its filters perfectly. Counting them reports a
     // covered lane while nothing runs, which is the one answer worse than none.
     const workflow = [
+      "      - name: Run integration tests",
       "        run: |",
       "          # pnpm turbo test:integration --filter=nextly --filter=@scope/a",
     ].join("\n");
@@ -68,8 +102,46 @@ describe("integrationInvocations", () => {
     expect(integrationInvocations(workflow)).toEqual([]);
   });
 
+  it("does not count a step that cannot run", () => {
+    // 🔴 A step turned off still describes its filters perfectly, so counting
+    // them reports a lane covered by something that never executes.
+    const workflow = [
+      "      - name: Run integration tests",
+      "        if: ${{ false }}",
+      "        run: pnpm turbo test:integration --filter=nextly",
+    ].join("\n");
+
+    expect(integrationInvocations(workflow)).toEqual([]);
+  });
+
+  it("still counts a step whose condition the run decides", () => {
+    // The control for the case above.
+    const workflow = [
+      "      - name: Run integration tests (mysql)",
+      "        if: matrix.dialect == 'mysql'",
+      "        run: pnpm turbo test:integration --filter=nextly",
+    ].join("\n");
+
+    expect(integrationInvocations(workflow)).toHaveLength(1);
+  });
+
+  it("treats a comment with no space after the hash as a comment", () => {
+    // `cmd #--filter=x` runs `cmd`; the shell needs no space after the hash.
+    // Splitting on `# ` alone read the commented flag as coverage.
+    const workflow = [
+      "      - name: Run integration tests",
+      "        run: |",
+      "          pnpm turbo test:integration --filter=nextly #--filter=@scope/a",
+    ].join("\n");
+
+    expect(integrationInvocations(workflow)).toEqual([
+      { line: "pnpm turbo test:integration --filter=nextly", filters: ["nextly"] },
+    ]);
+  });
+
   it("stops at a trailing comment rather than reading its filters", () => {
     const workflow = [
+      "      - name: Run integration tests",
       "        run: |",
       "          pnpm turbo test:integration --filter=nextly # later --filter=@scope/a",
     ].join("\n");

--- a/scripts/check-integration-lane.test.mjs
+++ b/scripts/check-integration-lane.test.mjs
@@ -8,6 +8,7 @@ import {
   integrationInvocations,
   laneDrift,
   packagesWithIntegrationTask,
+  runCommands,
 } from "./check-integration-lane.mjs";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -15,7 +16,69 @@ const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const manifest = (name, extra = {}) =>
   JSON.stringify({ name, scripts: { test: "vitest run", ...extra } });
 
+describe("runCommands", () => {
+  it("reads a block scalar's body and stops at the next key", () => {
+    const workflow = [
+      "      - name: Run integration tests",
+      "        run: |",
+      "          pnpm turbo build --filter=nextly",
+      "          pnpm turbo test:integration --filter=nextly",
+      "        env:",
+      "          TURBO_CACHE_DIR: .turbo",
+    ].join("\n");
+
+    expect(runCommands(workflow)).toEqual([
+      "pnpm turbo build --filter=nextly",
+      "pnpm turbo test:integration --filter=nextly",
+    ]);
+  });
+
+  it("reads the one-line form too", () => {
+    expect(runCommands("        run: pnpm install --frozen-lockfile")).toEqual([
+      "pnpm install --frozen-lockfile",
+    ]);
+  });
+
+  it("does not read the prose that explains the workflow", () => {
+    // 🔴 The comments here describe what each leg runs, so a paragraph naming a
+    // command is written exactly like the command. Only `run:` executes.
+    const workflow = [
+      "      # `plugin-seo` runs on THIS leg only. The others would run",
+      "      # pnpm turbo test:integration --filter=@nextlyhq/plugin-seo twice.",
+      "      - name: Something",
+      "        run: pnpm turbo test:integration --filter=nextly",
+    ].join("\n");
+
+    expect(runCommands(workflow)).toEqual([
+      "pnpm turbo test:integration --filter=nextly",
+    ]);
+  });
+});
+
 describe("integrationInvocations", () => {
+  it("does not count an invocation that was commented out", () => {
+    // 🔴 The defect this exists to prevent, in the check itself: a leg disabled
+    // by a `#` still describes its filters perfectly. Counting them reports a
+    // covered lane while nothing runs, which is the one answer worse than none.
+    const workflow = [
+      "        run: |",
+      "          # pnpm turbo test:integration --filter=nextly --filter=@scope/a",
+    ].join("\n");
+
+    expect(integrationInvocations(workflow)).toEqual([]);
+  });
+
+  it("stops at a trailing comment rather than reading its filters", () => {
+    const workflow = [
+      "        run: |",
+      "          pnpm turbo test:integration --filter=nextly # later --filter=@scope/a",
+    ].join("\n");
+
+    expect(integrationInvocations(workflow)).toEqual([
+      { line: "pnpm turbo test:integration --filter=nextly", filters: ["nextly"] },
+    ]);
+  });
+
   it("reads the filters off the command, not off the step name", () => {
     // The name is prose somebody can reword; the command is what runs.
     const workflow = [

--- a/scripts/check-integration-lane.test.mjs
+++ b/scripts/check-integration-lane.test.mjs
@@ -1,0 +1,122 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+  integrationInvocations,
+  laneDrift,
+  packagesWithIntegrationTask,
+} from "./check-integration-lane.mjs";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+const manifest = (name, extra = {}) =>
+  JSON.stringify({ name, scripts: { test: "vitest run", ...extra } });
+
+describe("integrationInvocations", () => {
+  it("reads the filters off the command, not off the step name", () => {
+    // The name is prose somebody can reword; the command is what runs.
+    const workflow = [
+      "      - name: Something else entirely",
+      "        run: |",
+      "          pnpm turbo build --filter=@nextlyhq/adapter-sqlite",
+      "          pnpm turbo test:integration --filter=nextly --filter=@nextlyhq/plugin-seo",
+    ].join("\n");
+
+    expect(integrationInvocations(workflow)).toEqual([
+      {
+        line: "pnpm turbo test:integration --filter=nextly --filter=@nextlyhq/plugin-seo",
+        filters: ["nextly", "@nextlyhq/plugin-seo"],
+      },
+    ]);
+  });
+
+  it("ignores a build that filters the same packages", () => {
+    // 🔴 The control that matters: a `turbo build` line carries an identical
+    // filter list, so a reader matching only `--filter=` would count packages
+    // as covered because they were BUILT.
+    const workflow =
+      "          pnpm turbo build --filter=nextly --filter=@nextlyhq/plugin-seo";
+
+    expect(integrationInvocations(workflow)).toEqual([]);
+  });
+
+  it("finds nothing when the task is not run", () => {
+    expect(integrationInvocations("          pnpm turbo test --filter=nextly")).toEqual(
+      []
+    );
+  });
+});
+
+describe("packagesWithIntegrationTask", () => {
+  const files = {
+    "packages/a/package.json": manifest("@scope/a", {
+      "test:integration": "vitest run --config vitest.integration.config.ts",
+    }),
+    "packages/b/package.json": manifest("@scope/b"),
+    "packages/c/package.json": "{ not json",
+    "packages/d/package.json": JSON.stringify({ scripts: {} }),
+  };
+
+  it("names only the packages that declare the task", () => {
+    expect(
+      packagesWithIntegrationTask(path => files[path], Object.keys(files))
+    ).toEqual(["@scope/a"]);
+  });
+
+  it("skips a manifest it cannot read rather than throwing", () => {
+    // An unreadable manifest is the workspace linter's finding, not this one,
+    // and crashing here would take the real answer with it.
+    expect(() =>
+      packagesWithIntegrationTask(path => files[path], Object.keys(files))
+    ).not.toThrow();
+  });
+});
+
+describe("laneDrift", () => {
+  it("reports a package no leg selects", () => {
+    expect(laneDrift(["a", "b"], ["a"])).toEqual({ unrun: ["b"], stale: [] });
+  });
+
+  it("reports a filter for a package that has no such task", () => {
+    expect(laneDrift(["a"], ["a", "gone"])).toEqual({
+      unrun: [],
+      stale: ["gone"],
+    });
+  });
+
+  it("is silent when the two agree", () => {
+    expect(laneDrift(["a", "b"], ["b", "a"])).toEqual({ unrun: [], stale: [] });
+  });
+});
+
+describe("this repository", () => {
+  it("runs every package that declares the task", () => {
+    // Against the real tree, not a fixture: a guard proved only on fixtures has
+    // not been shown to agree with the thing it guards.
+    const manifests = execFileSync(
+      "git",
+      ["ls-files", "packages/*/package.json", "apps/*/package.json"],
+      { cwd: root, encoding: "utf8" }
+    )
+      .split("\n")
+      .filter(Boolean);
+    const declared = packagesWithIntegrationTask(
+      path => readFileSync(join(root, path), "utf8"),
+      manifests
+    );
+    const invocations = integrationInvocations(
+      readFileSync(join(root, ".github/workflows/integration.yml"), "utf8")
+    );
+    const selected = [...new Set(invocations.flatMap(i => i.filters))];
+
+    // The population before the verdict: an empty side agrees with anything.
+    expect(manifests.length).toBeGreaterThan(10);
+    expect(invocations.length).toBeGreaterThan(0);
+    expect(declared.length).toBeGreaterThan(0);
+
+    expect(laneDrift(declared, selected)).toEqual({ unrun: [], stale: [] });
+  });
+});


### PR DESCRIPTION
Main went red on `748840abf` with `plugin-form-builder`'s
`submit-form.integration.test.ts` timing out at **30556ms against a 30000ms
budget**. This is the structural fix rather than a third raise of that number.

## The mechanism, measured

| | |
|---|---|
| The failing test, in isolation | **1619ms** |
| Its ten siblings in the same file | **35–52ms** |
| The same test on CI | **30556ms** — an **18.9× blowup** |

The blowup lands on the one test that does real work and never touches the 45ms
ones, which is what separates contention from a hang: a hang stalls regardless
of input, and load scales with the work there is to be slow at.

**Not caused by the commit it failed on.** `748840abf` is #1598 (blocks-engine)
and touches **zero** files in `plugin-form-builder` — unreachability, not a green
re-run. The next commit passed 72/72.

**Rate: 1 in 23 main runs.** Of the other three reds in that window, two were an
`attw` break already fixed and one was a `Post Checkout` infrastructure step.

## Why not raise the timeout

That was already the answer here once — the unit config carries `testTimeout:
30000` added for exactly these files, up from the 5s default. Raising it again
would be the third tuning of a number nothing derives.

`plugin-seo` hit the identical defect and moved its suites instead. Its config
says so:

> Raising the budget was the previous answer and it has now been exceeded twice,
> so the suites move to their own task instead — the split `nextly`, the three
> adapters and `plugin-page-builder` already use.

`plugin-form-builder` is the package that was missed. This applies the decision
the repository already made.

## The sqlite leg only, and why that is a property rather than a preference

Every call in these seven files is `createTestNextly({ plugins })` naming **no
dialect**, so it boots in-memory SQLite and the postgres and mysql legs would run
byte-identical work — three times the runtime for one answer.

`plugin-page-builder` sits in all three legs because its suites genuinely take
one (`createTestNextly({ dialect, ... })` in
`site-style-section-write.integration.test.ts`). So placement follows whether the
suites exercise the dialect matrix, not what kind of package it is. The workflow
comment now says that, since the previous wording read as a fact about `plugin-seo`
rather than about its tests.

## Nothing dropped, and the arithmetic says so

The unit config narrows `include`, which is exactly how coverage leaves silently.
It reconciles:

| | files | tests |
|---|---|---|
| before | 36 | 401 |
| unit, after | 29 | 342 |
| integration, after | 7 | 59 |
| **sum** | **36** ✓ | **401** ✓ |

The exact CI invocation was run, not just the local script:
`pnpm turbo test:integration --filter=@nextlyhq/plugin-form-builder` → 7 files,
59 tests, 11 turbo tasks.

## The guard, which is the part that outlives this PR

The integration jobs select packages with a **hand-written `--filter` list,
repeated once per leg**. A package that gains `test:integration` and is not added
to it runs **nowhere**: the unit job no longer includes those files and no leg
selects them, and every job stays green, because what would have been reported is
simply absent. That is the failure mode nothing can notice.

`scripts/check-integration-lane.mjs` reads **both sides** — the manifests git
tracks and the commands the workflow runs — and refuses in either direction:

- a package declares the task and no leg selects it → its suites run nowhere;
- a leg filters a package with no such task → turbo matches nothing and the leg
  passes without running it.

It asserts the **population before the verdict** and exits `2` rather than `0`
when it finds no invocation, no manifest or no declaring package — an empty side
agrees with any comparison, so each of those would otherwise report a clean lane
it never examined.

### Proved by making it fail

| mutation | expected | result |
|---|---|---|
| the new package left out of every leg | exit 1, names it | ✅ |
| a filter naming a package with no task | exit 1, names it | ✅ |
| the package drops the script, filter stands | exit 1, names it | ✅ |
| the legs stop running the task at all | **exit 2**, refuses | ✅ |

The fourth is the one worth having: a check that reported "clean" when the lane
had stopped running would be worse than no check.

Its test also runs against the **real tree**, not only fixtures, and one case
pins that a `turbo build` line carrying an identical `--filter` list is not
counted as coverage.

## Verification

- `plugin-form-builder`: unit **29 files / 342 tests**, integration **7 / 59**,
  both exit 0. `lint` (`--max-warnings 0`) and `check-types` clean.
- `pnpm test:scripts`: **28 files, 951 tests** (was 27/942 — exactly the 9 added).
- From the root: `check:comments`, `check:dev-concurrency`, `check:docs-claims`,
  `lint:workspace`, `lint:design` all exit 0.
- `fallow audit --changed-since origin/main --gate new-only --workspace
  '!playground' --config .fallowrc.jsonc` → **pass**, nothing introduced.

No changeset: test configuration, CI and a guard script. Nothing that ships
changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added dedicated integration testing for the form-builder plugin using an in-memory database.
  - Separated unit and integration test suites for clearer, more reliable test execution.
  - Expanded automated coverage for integration workflow validation and package selection.

- **Chores**
  - Added automated checks to ensure all integration-enabled packages are included in the appropriate CI test lane.
  - Updated CI to build and test the form-builder plugin alongside existing SQLite integration coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->