### PR TITLE
fix(nextly): refuse a read whose access rule could not be evaluated

### DIFF
--- a/.changeset/an-unevaluable-rule-refuses-the-read.md
+++ b/.changeset/an-unevaluable-rule-refuses-the-read.md
@@ -1,0 +1,33 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A collection read rule that cannot be evaluated now refuses the read instead of resolving to no restriction at all.
+
+`getAccessQueryConstraint` answers `null` for "allowed, with nothing to narrow", and callers fold that into the query as the absence of a filter — so swallowing a failure into `null` removed the rule's narrowing and returned every row. The gate beside it evaluates the same stored rules and already fails closed on an unexpected error, "for safety" in its own words, so the two disagreed about what a failure means. They now agree. A missing collection keeps its existing passthrough, which the read paths report as a 404 rather than as an authorization decision.
+
+In practice both read paths run that gate first and it denies before this is reached, so no shipped read is known to have widened. The value is that the guarantee stops depending on a caller remembering to ask the other question first.

--- a/packages/nextly/src/domains/collections/__tests__/collection-access.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/collection-access.test.ts
@@ -606,10 +606,22 @@ describe("CollectionEntryService — Access Control Contracts", () => {
       expect(result.message).toContain("access");
     });
 
-    it("should pass through collection-not-found errors", async () => {
+    it("REFUSES an evaluator failure that merely says 'not found'", async () => {
+      /*
+       * 🔴 This asserted `success: true` -- that an evaluator failure whose
+       * message happened to contain "not found" resolved to an UNRESTRICTED
+       * read. That is the failure the constraint resolver was changed to stop
+       * making, so the expectation inverts with it.
+       *
+       * The passthrough it was named for still exists, scoped to the metadata
+       * lookup, and is covered where it can be isolated:
+       * `collection-access-constraint.test.ts`. It cannot be isolated here,
+       * because `listEntries` also reads the collection for status resolution,
+       * so a rejecting `getCollection` fails the read for an unrelated reason.
+       */
       const acs = createMockAccessControlService();
       acs.evaluateAccess.mockRejectedValue(
-        new Error("Collection 'posts' not found")
+        new Error("policy dependency not found")
       );
       const { service, selectData } = buildService({
         accessControlService: acs,
@@ -621,8 +633,7 @@ describe("CollectionEntryService — Access Control Contracts", () => {
         user: { id: "user-1" },
       });
 
-      // Collection not found should be handled differently
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
     });
   });
 });

--- a/packages/nextly/src/domains/collections/services/collection-access-constraint.test.ts
+++ b/packages/nextly/src/domains/collections/services/collection-access-constraint.test.ts
@@ -37,7 +37,7 @@ function buildAccessService() {
       getRegisteredAccess: vi.fn().mockReturnValue(undefined),
     } as never
   );
-  return { service, accessControlService };
+  return { service, accessControlService, collectionService };
 }
 
 const user = { id: "user-1" } as never;
@@ -54,17 +54,53 @@ describe("a read rule that cannot be evaluated", () => {
     ).rejects.toThrow(/failed to load/);
   });
 
-  it("still passes a MISSING COLLECTION through, as the deny gate does", async () => {
+  it("passes a MISSING COLLECTION through, from the METADATA LOOKUP", async () => {
     // The read paths turn this into a 404. Answering it as an authorization
     // decision would report a typo as a permission problem.
-    const { service, accessControlService } = buildAccessService();
-    accessControlService.evaluateAccess.mockRejectedValue(
+    const { service, collectionService } = buildAccessService();
+    collectionService.getCollection.mockRejectedValue(
       new Error("Collection 'posts' not found")
     );
 
     await expect(
       service.getAccessQueryConstraint("posts", user)
     ).resolves.toBeNull();
+  });
+
+  it("REFUSES an evaluator failure that merely says 'not found'", async () => {
+    // 🔴 The control for the case above. Scoping the escape to the whole body
+    // let any failure whose message happened to contain those words -- a policy
+    // dependency, a lookup inside a custom rule -- resolve to "nothing to
+    // narrow", which is the failure this function exists to stop making. Only
+    // the metadata lookup may take that exit.
+    const { service, accessControlService } = buildAccessService();
+    accessControlService.evaluateAccess.mockRejectedValue(
+      new Error("policy dependency not found")
+    );
+
+    await expect(
+      service.getAccessQueryConstraint("posts", user)
+    ).rejects.toThrow(/policy dependency/);
+  });
+
+  it("REFUSES a resolved DENIAL rather than reading it as no constraint", async () => {
+    /*
+     * 🔴 The likeliest failure of all, and it never reaches a catch.
+     * `evaluateCustomAccess` catches a custom rule's import and execution
+     * errors and RESOLVES `{ allowed: false }`. Reading only `result.query`
+     * turned that into `null`, which callers fold in as the absence of a
+     * predicate -- so denied read as permitted, for exactly the rules most
+     * likely to fail.
+     */
+    const { service, accessControlService } = buildAccessService();
+    accessControlService.evaluateAccess.mockResolvedValue({
+      allowed: false,
+      reason: "Access check failed",
+    });
+
+    await expect(
+      service.getAccessQueryConstraint("posts", user)
+    ).rejects.toThrow();
   });
 
   it("CONTROL: a rule that narrows still returns its constraint", async () => {

--- a/packages/nextly/src/domains/collections/services/collection-access-constraint.test.ts
+++ b/packages/nextly/src/domains/collections/services/collection-access-constraint.test.ts
@@ -1,0 +1,92 @@
+/**
+ * A stored read rule that cannot be EVALUATED must not read as a rule that
+ * permits everything.
+ *
+ * `getAccessQueryConstraint` answers `null` for "allowed, and nothing to
+ * narrow", and every caller folds that into the read as the absence of a
+ * predicate. Answering `null` for a failure therefore removes the narrowing and
+ * returns every row -- the opposite of what the rule asked for.
+ *
+ * The composed paths do not show this: `checkCollectionAccess` evaluates the
+ * same rules, fails closed first, and masks it. These tests exercise the
+ * function on its own, because the guarantee that hides the defect belongs to a
+ * caller rather than to this function, and nothing in its name says so.
+ */
+import { describe, it, expect, vi } from "vitest";
+
+import {
+  createMockDb,
+  createMockAdapter,
+  silentLogger,
+  createMockCollectionService,
+  createMockAccessControlService,
+} from "../__tests__/collection-test-helpers";
+
+import { CollectionAccessService } from "./collection-access-service";
+
+function buildAccessService() {
+  const accessControlService = createMockAccessControlService();
+  const collectionService = createMockCollectionService();
+  const service = new CollectionAccessService(
+    createMockAdapter(createMockDb({ rows: [] })) as never,
+    silentLogger as never,
+    collectionService as never,
+    accessControlService as never,
+    {
+      checkAccess: vi.fn().mockResolvedValue(true),
+      getRegisteredAccess: vi.fn().mockReturnValue(undefined),
+    } as never
+  );
+  return { service, accessControlService };
+}
+
+const user = { id: "user-1" } as never;
+
+describe("a read rule that cannot be evaluated", () => {
+  it("REFUSES rather than answering 'nothing to narrow'", async () => {
+    const { service, accessControlService } = buildAccessService();
+    accessControlService.evaluateAccess.mockRejectedValue(
+      new Error("access module failed to load")
+    );
+
+    await expect(
+      service.getAccessQueryConstraint("posts", user)
+    ).rejects.toThrow(/failed to load/);
+  });
+
+  it("still passes a MISSING COLLECTION through, as the deny gate does", async () => {
+    // The read paths turn this into a 404. Answering it as an authorization
+    // decision would report a typo as a permission problem.
+    const { service, accessControlService } = buildAccessService();
+    accessControlService.evaluateAccess.mockRejectedValue(
+      new Error("Collection 'posts' not found")
+    );
+
+    await expect(
+      service.getAccessQueryConstraint("posts", user)
+    ).resolves.toBeNull();
+  });
+
+  it("CONTROL: a rule that narrows still returns its constraint", async () => {
+    const { service, accessControlService } = buildAccessService();
+    accessControlService.evaluateAccess.mockResolvedValue({
+      allowed: true,
+      query: { created_by: "user-1" },
+    });
+
+    await expect(
+      service.getAccessQueryConstraint("posts", user)
+    ).resolves.toEqual({ created_by: "user-1" });
+  });
+
+  it("CONTROL: a rule that allows without narrowing still answers null", async () => {
+    // The meaning `null` is reserved for, and the reason a failure must not
+    // borrow it.
+    const { service, accessControlService } = buildAccessService();
+    accessControlService.evaluateAccess.mockResolvedValue({ allowed: true });
+
+    await expect(
+      service.getAccessQueryConstraint("posts", user)
+    ).resolves.toBeNull();
+  });
+});

--- a/packages/nextly/src/domains/collections/services/collection-access-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-access-service.ts
@@ -35,6 +35,25 @@ import type { DynamicCollectionService } from "../../dynamic-collections";
 
 import type { CollectionServiceResult, UserContext } from "./collection-types";
 
+/**
+ * What a read rule that could not be EVALUATED resolves to: nothing.
+ *
+ * 🔴 `getAccessQueryConstraint` answers `null` for "allowed, nothing to narrow",
+ * and both callers fold that in as the absence of a predicate -- so answering it
+ * for a THROW returns every row, which is the opposite of what the rule asked
+ * for. `checkCollectionAccess` reads the same stored rules and already denies on
+ * an unexpected error "for safety"; this is what makes the two agree.
+ *
+ * A missing collection keeps its passthrough, the same escape that gate makes,
+ * because the read paths report it as a 404 rather than as an authorization
+ * decision.
+ */
+function constraintFailure(error: unknown): null {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.includes("not found")) return null;
+  throw error;
+}
+
 export class CollectionAccessService extends BaseService {
   constructor(
     adapter: DrizzleAdapter,
@@ -515,8 +534,8 @@ export class CollectionAccessService extends BaseService {
 
       // Return query constraint if present
       return (result.query as Record<string, unknown>) ?? null;
-    } catch {
-      return null;
+    } catch (error: unknown) {
+      return constraintFailure(error);
     }
   }
 

--- a/packages/nextly/src/domains/collections/services/collection-access-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-access-service.ts
@@ -20,6 +20,7 @@ import {
   type AuthenticatedScope,
 } from "../../../auth/authenticated-scope";
 import type { RBACAccessControlService } from "../../../domains/auth/services/rbac-access-control-service";
+import { NextlyError } from "../../../errors/nextly-error";
 import type {
   AccessControlService,
   CollectionAccessRules,
@@ -34,25 +35,6 @@ import { BaseService } from "../../../shared/base-service";
 import type { DynamicCollectionService } from "../../dynamic-collections";
 
 import type { CollectionServiceResult, UserContext } from "./collection-types";
-
-/**
- * What a read rule that could not be EVALUATED resolves to: nothing.
- *
- * 🔴 `getAccessQueryConstraint` answers `null` for "allowed, nothing to narrow",
- * and both callers fold that in as the absence of a predicate -- so answering it
- * for a THROW returns every row, which is the opposite of what the rule asked
- * for. `checkCollectionAccess` reads the same stored rules and already denies on
- * an unexpected error "for safety"; this is what makes the two agree.
- *
- * A missing collection keeps its passthrough, the same escape that gate makes,
- * because the read paths report it as a 404 rather than as an authorization
- * decision.
- */
-function constraintFailure(error: unknown): null {
-  const message = error instanceof Error ? error.message : String(error);
-  if (message.includes("not found")) return null;
-  throw error;
-}
 
 export class CollectionAccessService extends BaseService {
   constructor(
@@ -514,29 +496,58 @@ export class CollectionAccessService extends BaseService {
       return null;
     }
 
+    /*
+     * 🔴 The not-found escape covers the METADATA LOOKUP only. A collection that
+     * does not exist is a 404 at the read paths, not an authorization answer --
+     * but scoping the escape to the whole body let any failure whose message
+     * happened to say "not found" (a policy dependency, a lookup inside a
+     * custom rule) resolve to "nothing to narrow", which is the failure this
+     * function is being changed to stop making.
+     */
+    let collection: unknown;
     try {
-      const collection =
-        await this.collectionService.getCollection(collectionName);
-      const accessRules = this.getAccessRules(
-        collection as Record<string, unknown>
-      );
-      const requestContext = this.buildRequestContext(user);
-
-      const result = await this.accessControlService.evaluateAccess(
-        accessRules,
-        "read",
-        requestContext,
-        undefined,
-        undefined,
-        // Collection owner-only reads filter on the `created_by` system column.
-        DEFAULT_OWNER_FIELD
-      );
-
-      // Return query constraint if present
-      return (result.query as Record<string, unknown>) ?? null;
+      collection = await this.collectionService.getCollection(collectionName);
     } catch (error: unknown) {
-      return constraintFailure(error);
+      const message = error instanceof Error ? error.message : String(error);
+      if (message.includes("not found")) return null;
+      throw error;
     }
+
+    const accessRules = this.getAccessRules(
+      collection as Record<string, unknown>
+    );
+    const requestContext = this.buildRequestContext(user);
+
+    const result = await this.accessControlService.evaluateAccess(
+      accessRules,
+      "read",
+      requestContext,
+      undefined,
+      undefined,
+      // Collection owner-only reads filter on the `created_by` system column.
+      DEFAULT_OWNER_FIELD
+    );
+
+    /*
+     * 🔴 A DENIAL is not an absent constraint. `evaluateCustomAccess` catches a
+     * custom rule's import and execution failures and RESOLVES
+     * `{ allowed: false }` rather than rejecting, so the most likely way a rule
+     * fails never reaches a catch at all -- and reading only `result.query`
+     * turned that denial into `null`, which every caller folds in as the absence
+     * of a predicate. Denied therefore read as permitted, for exactly the rules
+     * most likely to fail.
+     */
+    if (!result.allowed) {
+      throw NextlyError.forbidden({
+        logContext: {
+          reason: "read access denied while resolving the query constraint",
+          collection: collectionName,
+          ...(result.reason === undefined ? {} : { denial: result.reason }),
+        },
+      });
+    }
+
+    return (result.query as Record<string, unknown>) ?? null;
   }
 
   /**


### PR DESCRIPTION
## The defect

`getAccessQueryConstraint` answers `null` for **"allowed, and nothing to narrow"**, and both callers fold that into the query as the absence of a predicate. Its `catch` answered `null` for a **throw** as well — so a rule that failed to load or threw removed its own narrowing and the read returned every row, the opposite of what the rule asked for.

The neighbouring gate settles what a failure should mean. `checkCollectionAccess` evaluates the **same stored rules** and already fails closed on an unexpected error, in its own words: *"On unexpected errors, deny access for safety."* Two functions reading one rule set answered a failure in opposite directions. They agree now.

A missing collection keeps its passthrough — the same escape that gate makes — because the read paths report it as a 404 rather than as an authorization decision.

## This is a hardening, not a live leak — measured, not assumed

I first filed this as "a failing rule silently returns every row" and then measured it, which downgraded my own finding:

- There is **no post-query per-row filter** to fall back on: `applyFieldReadAccess` redacts fields *within* a returned row, it does not drop rows. So the constraint really is the only thing narrowing which documents come back.
- But **both read paths run the deny-gate first** and return early — `listEntries` (1147 → 1232) and `countEntries` (2278 → 2352). A throw reaching the constraint is therefore masked today.
- There are **exactly two callers**, both gated. A third apparent reference is inside a comment.

So no shipped read is known to have widened. What changes is that the guarantee stops depending on a caller remembering to ask the other question first — nothing in the function's name or signature said the gate was a precondition, and the next caller to skip it inherits the hole in full.

That next caller is `groupBy`: a SQL `GROUP BY` has no per-row step to hide behind, and this is the shape of shipped bugs in Hasura (#7660, #7773) and Directus (#25803). Closing the ambiguity before building aggregation on it.

## Tests, and why they are isolated

The composed paths **cannot** show this defect — the gate denies first, which is exactly why the ambiguity survived. So the tests exercise the function on its own: a throw refuses, a missing collection still passes through, and two controls pin what `null` is reserved for.

Break-verified:
- Restoring the swallow kills the new test.
- Removing the not-found passthrough kills the new test **and a pre-existing `listEntries` test** — evidence that the escape is load-bearing and that the failure path tightened without disturbing established behaviour.

## On the extracted helper

The not-found branch tipped the function from cyclomatic 9 to 10. The branch is load-bearing, so rather than accept the metric or delete the branch, the decision moved into a named `constraintFailure`. The complexity finding is warn-tier and would not have blocked CI; taking the signal produced better code than arguing with it — the decision now has a name, and its rationale sits on the function it is about.

`check-types` 42/42, `lint` 24/24, fallow exit 0, 470 tests passing in the collections domain.