### PR TITLE
fix(nextly): ask whether a collection is missing by type, not by wording

### DIFF
--- a/.changeset/a-missing-collection-is-a-typed-answer.md
+++ b/.changeset/a-missing-collection-is-a-typed-answer.md
@@ -29,3 +29,5 @@
 A read against a collection that does not exist answers "not found" again, instead of a server error.
 
 Both halves of the collection access check decided whether an error meant "this collection does not exist" by looking for the words "not found" in its message. The error the registry actually raises carries the text "Not found.", so neither comparison ever matched the one error it was written for — a genuinely missing collection produced a 500 from the permission gate, and, since a recent change, a rejected read from the constraint resolver. Both now ask the error what it is rather than reading its prose, so the case they were written for is the case they catch, and an unrelated failure whose wording happens to contain those words no longer takes the exit.
+
+The registry that raises it now says so by type as well as in words. It threw a bare error, so every caller had to read its wording to learn what had happened, and a guard that asked by type instead missed it entirely. It now carries a not-found code alongside the same message, so a caller may ask either way and neither answer changes.

--- a/.changeset/a-missing-collection-is-a-typed-answer.md
+++ b/.changeset/a-missing-collection-is-a-typed-answer.md
@@ -1,0 +1,31 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A read against a collection that does not exist answers "not found" again, instead of a server error.
+
+Both halves of the collection access check decided whether an error meant "this collection does not exist" by looking for the words "not found" in its message. The error the registry actually raises carries the text "Not found.", so neither comparison ever matched the one error it was written for — a genuinely missing collection produced a 500 from the permission gate, and, since a recent change, a rejected read from the constraint resolver. Both now ask the error what it is rather than reading its prose, so the case they were written for is the case they catch, and an unrelated failure whose wording happens to contain those words no longer takes the exit.

--- a/packages/nextly/eslint-bare-error-allowlist.json
+++ b/packages/nextly/eslint-bare-error-allowlist.json
@@ -31,7 +31,7 @@
   "src/domains/auth/services/role-inheritance-service.ts": 2,
   "src/domains/auth/services/role/utils.ts": 2,
   "src/domains/collections/services/collection-relationship-service.ts": 1,
-  "src/domains/dynamic-collections/services/dynamic-collection-registry-service.ts": 4,
+  "src/domains/dynamic-collections/services/dynamic-collection-registry-service.ts": 2,
   "src/domains/dynamic-collections/services/dynamic-collection-service.ts": 1,
   "src/domains/dynamic-collections/services/dynamic-collection-validation-service.ts": 14,
   "src/domains/email/services/email-provider-registry.ts": 1,

--- a/packages/nextly/src/domains/collections/services/collection-access-constraint.test.ts
+++ b/packages/nextly/src/domains/collections/services/collection-access-constraint.test.ts
@@ -22,6 +22,8 @@ import {
   createMockAccessControlService,
 } from "../__tests__/collection-test-helpers";
 
+import { NextlyError } from "../../../errors/nextly-error";
+
 import { CollectionAccessService } from "./collection-access-service";
 
 function buildAccessService() {
@@ -58,9 +60,10 @@ describe("a read rule that cannot be evaluated", () => {
     // The read paths turn this into a 404. Answering it as an authorization
     // decision would report a typo as a permission problem.
     const { service, collectionService } = buildAccessService();
-    collectionService.getCollection.mockRejectedValue(
-      new Error("Collection 'posts' not found")
-    );
+    // The CANONICAL error the registry raises: `NextlyError.notFound()` with
+    // no message override, so its text is "Not found." A hand-written lowercase
+    // Error passed a message check that the real one does not.
+    collectionService.getCollection.mockRejectedValue(NextlyError.notFound());
 
     await expect(
       service.getAccessQueryConstraint("posts", user)

--- a/packages/nextly/src/domains/collections/services/collection-access-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-access-service.ts
@@ -359,8 +359,16 @@ export class CollectionAccessService extends BaseService {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
 
-      // If collection not found, let other code handle it
-      if (errorMessage?.includes("not found")) {
+      /*
+       * If the collection is not found, let other code handle it -- asked by
+       * TYPE. `getRecordOrThrow` raises `NextlyError.notFound()` with no
+       * message override, so its text is "Not found." and this lowercase
+       * comparison never matched the error it was written for: a genuinely
+       * missing collection took the branch below and answered 500 instead of
+       * the 404 the read paths give it. The message check also caught any
+       * unrelated failure whose wording happened to contain those words.
+       */
+      if (NextlyError.isNotFound(error)) {
         return null;
       }
 
@@ -508,8 +516,15 @@ export class CollectionAccessService extends BaseService {
     try {
       collection = await this.collectionService.getCollection(collectionName);
     } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
-      if (message.includes("not found")) return null;
+      /*
+       * 🔴 The TYPED answer, not the message. `getRecordOrThrow` raises
+       * `NextlyError.notFound()` with no message override, so the text is
+       * "Not found." -- capital N -- and a lowercase `includes("not found")`
+       * misses the only error this branch exists for, while still catching any
+       * unrelated failure whose wording happens to match. Matching on prose is
+       * wrong in both directions at once.
+       */
+      if (NextlyError.isNotFound(error)) return null;
       throw error;
     }
 

--- a/packages/nextly/src/domains/dynamic-collections/__tests__/dynamic-collection-registry-service.not-found.integration.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/__tests__/dynamic-collection-registry-service.not-found.integration.test.ts
@@ -1,0 +1,106 @@
+/**
+ * What the registry raises when a collection does not exist.
+ *
+ * 🔴 Pinned against the REAL producer, because a consumer guard was written
+ * against the wrong one. `getAccessQueryConstraint` decides "does this
+ * collection exist" from this error, and a typed guard asking
+ * `NextlyError.isNotFound` silently missed a bare `Error` here -- turning a
+ * missing collection into a 500 rather than the 404 the read paths give it. A
+ * unit test that mocked the error shape could not see that; only asking the
+ * producer can.
+ *
+ * The MESSAGE is asserted beside the code on purpose: an older caller still
+ * matches on that wording, so it is part of the contract until that caller
+ * changes too.
+ */
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { describe, expect, it, afterEach, beforeEach } from "vitest";
+
+import { sqliteTableDdl } from "../../../__tests__/fixtures/sqlite-table-ddl";
+import { NextlyError } from "../../../errors/nextly-error";
+import { dynamicCollectionsSqlite } from "../../../schemas/dynamic-collections/sqlite";
+import { DynamicCollectionRegistryService } from "../services/dynamic-collection-registry-service";
+
+type RegistryLogger = ConstructorParameters<
+  typeof DynamicCollectionRegistryService
+>[1];
+
+const noopLogger: RegistryLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+} as unknown as RegistryLogger;
+
+describe("DynamicCollectionRegistryService — a collection that is not there", () => {
+  let sqlite: Database.Database;
+  let registry: DynamicCollectionRegistryService;
+
+  beforeEach(() => {
+    sqlite = new Database(":memory:");
+    sqlite.pragma("foreign_keys = OFF");
+    for (const statement of sqliteTableDdl(dynamicCollectionsSqlite)) {
+      sqlite.exec(statement);
+    }
+
+    const db = drizzle({ client: sqlite });
+    const adapter = {
+      getDrizzle: <T>() => db as T,
+      getCapabilities: () => ({
+        dialect: "sqlite" as const,
+        supportsJsonb: false,
+        supportsJson: true,
+        supportsArrays: false,
+        supportsGeneratedColumns: true,
+        supportsFts: true,
+        supportsIlike: false,
+        supportsReturning: true,
+        supportsSavepoints: true,
+        supportsOnConflict: true,
+        maxParamsPerQuery: 999,
+        maxIdentifierLength: 128,
+      }),
+    } satisfies Pick<DrizzleAdapter, "getDrizzle" | "getCapabilities">;
+
+    registry = new DynamicCollectionRegistryService(
+      adapter as unknown as DrizzleAdapter,
+      noopLogger
+    );
+  });
+
+  afterEach(() => {
+    sqlite.close();
+  });
+
+  it("raises a TYPED not-found, so a guard can ask what it is", async () => {
+    await expect(registry.getCollection("ghosts")).rejects.toSatisfy(
+      (error: unknown) => NextlyError.isNotFound(error)
+    );
+  });
+
+  it("keeps the wording an older caller still matches on", async () => {
+    // `collection-query-service` maps a read failure to 404 by reading this
+    // text. Changing the message while adding the code would have moved the
+    // break rather than closed it.
+    await expect(registry.getCollection("ghosts")).rejects.toThrow(
+      /Collection "ghosts" not found/
+    );
+  });
+
+  it("CONTROL: a collection that IS there does not raise", async () => {
+    sqlite
+      .prepare(
+        `INSERT INTO dynamic_collections
+           (id, slug, table_name, labels, fields, timestamps, status, localized,
+            source, locked, schema_hash, schema_version, migration_status,
+            created_at, updated_at)
+         VALUES ('id-real', 'real', 'dc_real', @labels, '[]', 1, 0, 0,
+            'ui', 0, 'h1', 1, 'pending', 1700000000, 1700000000)`
+      )
+      .run({ labels: JSON.stringify({ singular: "real", plural: "reals" }) });
+
+    await expect(registry.getCollection("real")).resolves.toBeDefined();
+  });
+});

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-registry-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-registry-service.ts
@@ -308,7 +308,19 @@ export class DynamicCollectionRegistryService extends BaseService {
       .limit(1);
 
     if (existing.length === 0) {
-      throw new Error(`Collection "${collectionSlug}" not found`);
+      /*
+       * 🔴 TYPED, and the message is unchanged on purpose. Callers decide
+       * "does this collection exist" from this error; a bare `Error` forced
+       * them to read its prose, and one of them then missed the branded
+       * `NextlyError.notFound()` the OTHER registry raises. Carrying both a
+       * `NOT_FOUND` code and the wording every existing caller already matches
+       * lets a guard ask by type without breaking one that still asks by text.
+       * Product code here throws `NextlyError`, never a bare `Error`.
+       */
+      throw NextlyError.notFound({
+        message: `Collection "${collectionSlug}" not found`,
+        logContext: { collection: collectionSlug },
+      });
     }
 
     const targetSlug = updates.slug ?? existing[0].slug;
@@ -503,7 +515,11 @@ export class DynamicCollectionRegistryService extends BaseService {
       .limit(1);
 
     if (result.length === 0) {
-      throw new Error(`Collection "${slug}" not found`);
+      // Typed for the same reason as above, with the wording preserved.
+      throw NextlyError.notFound({
+        message: `Collection "${slug}" not found`,
+        logContext: { collection: slug },
+      });
     }
 
     const row = result[0] as Record<string, unknown>;


### PR DESCRIPTION
Follow-up to #1610, fixing a regression it introduced and a pre-existing bug of the same shape beside it.

## The defect

Both halves of the collection access check asked "does this collection exist?" by looking for the words `"not found"` in an error message:

```ts
if (errorMessage?.includes("not found")) return null;
```

`getRecordOrThrow` raises `NextlyError.notFound()` with **no message override**, so the text is `"Not found."` — capital N. The lowercase comparison never matched the one error it was written for.

- **The permission gate** has carried this since it was written: a genuinely missing collection fell past the passthrough and answered **500** instead of the 404 the read paths give it.
- **The constraint resolver** inherited the same comparison in #1610, which made a missing collection **reject** rather than resolve to no constraint. That regression is mine.

Matching on prose was wrong in both directions at once: it missed the error it targeted, **and** it would catch any unrelated failure whose wording happened to contain those words — the fragility that made the resolver's escape too broad in the first place, raised on #1610.

Both now ask `NextlyError.isNotFound(error)`.

## The test hid it

The resolver's test injected a hand-written `new Error("Collection 'posts' not found")` — lowercase, so it passed a check the real error fails. The fixture agreed with the code and both disagreed with production.

It now rejects with the canonical `NextlyError.notFound()`.

**Break-verified:** restoring the message comparison kills that test. The previous version of the test could not have caught this, which is the point.

## Verification

`check-types` 42/42, `lint` 24/24, fallow exit 0, changeset valid, 472 tests passing in the collections domain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of missing collections across collection access and dynamic collection operations.
  - Missing collections are now identified consistently, while unrelated errors are no longer incorrectly treated as missing data.
  - Existing “Collection not found” messages remain available for compatibility.

- **Tests**
  - Added coverage for missing and existing collection scenarios using a real in-memory database.
  - Updated access-control tests to use the standard not-found error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->