### PR TITLE
test(plugin-form-builder): restore the jsdom budget the split removed

### DIFF
--- a/packages/plugin-form-builder/vitest.config.ts
+++ b/packages/plugin-form-builder/vitest.config.ts
@@ -17,6 +17,15 @@ export default defineConfig({
       "**/dist/**",
       "src/**/*.integration.test.ts",
     ],
+    // The component suites here render React under jsdom, which is heavier than
+    // the node unit tests vitest's 5s default is sized for. This package
+    // carried a 30s budget until the integration suites moved out, and that
+    // budget was covering these too: without it `ConditionalLogicEditor` took
+    // 5399ms on a loaded CI runner and failed on the default, turning `main`
+    // red. Set to the value `@nextlyhq/admin` already uses for the same class
+    // of test rather than a number picked here, and kept apart from the 30s the
+    // integration config carries, which is sized for an instance boot.
+    testTimeout: 10_000,
     // Component suites request jsdom per file (`@vitest-environment jsdom`)
     // rather than switching it on globally. This setup only fills in globals
     // jsdom lacks, so it is inert for the node ones.


### PR DESCRIPTION
`main` is red, and this is the one-line cause.

## What is broken

`Lint / Typecheck / Test / Build` fails on `02483d8b2`:

```
× writes back the comparison key, not the row's operator key  5399ms
  FAIL src/admin/components/builder/ConditionalLogicEditor.test.tsx
  Error: Test timed out in 5000ms.

Tasks: 28 successful, 31 total
Failed: @nextlyhq/plugin-form-builder#test
```

## Why

#1609 moved this package's `*.integration.test.ts` files into the integration
lane, and took `testTimeout: 30000` out of the unit config with them. The
reading was that the budget existed for the `createTestNextly` boots. It did
not exist only for those — the React-under-jsdom component suites in the same
package were relying on it too. Without it they fall back to vitest's 5s
default, which is sized for node unit tests, not for rendering a component
tree under jsdom on a shared runner.

## The value

`10_000`, which is what `packages/admin/vitest.config.ts` already carries for
the same class of test (`environment: "jsdom"`), rather than a number chosen
here. Deliberately **not** the 30s the integration config keeps: that budget is
sized for an instance boot, and reusing it here would put the two back under
one number after this PR's own history showed why they are different.

Observed worst case is 5399ms, so this is about 1.85x headroom. It is the only
case in the package over 5s — the suite is not generally slow, one render is.

## Evidence

- Mutation test: with the config set to `testTimeout: 1`, the file fails with
  `Test timed out in 1ms` — so the value is read and applied, not merely
  present.
- Restored and run from the repository root with the package's own script:
  `pnpm --filter @nextlyhq/plugin-form-builder run test` → **29 files, 342
  tests, all passing**, exit 0.

## Scope

Test configuration only. No changeset — this ships nothing, matching #1609,
which changed the same file and carried none.

Separately open: #1612 also restores this budget, as part of the much larger
change that gates `nextly` and `@nextlyhq/admin`. This PR carries it alone so
`main` and the release PR are not waiting on that review.
