### PR TITLE
feat(nextly): refuse a GROUP BY on a field the caller may not read

### DIFF
--- a/.changeset/a-restricted-field-cannot-be-grouped-by.md
+++ b/.changeset/a-restricted-field-cannot-be-grouped-by.md
@@ -1,0 +1,31 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A field a caller may not read can no longer be used to group results.
+
+Filtering and sorting by such a field were already refused, because both reveal the hidden value: filtering through which rows come back, sorting through where they land. Grouping reveals it more directly than either — the distinct values become the buckets themselves, so the whole value set can be read off the labels while field redaction strips the column from rows nobody looks at. Selecting the field is not required for that, so guarding the selection would not have closed it. Grouping by a field that carries a read rule is now refused with its own reason, alongside the existing two.

--- a/packages/nextly/src/shared/lib/__tests__/groupable-fields.test.ts
+++ b/packages/nextly/src/shared/lib/__tests__/groupable-fields.test.ts
@@ -1,0 +1,93 @@
+/**
+ * A field a caller may not READ is a field it may not GROUP BY.
+ *
+ * 🔴 The third disclosure route, and the one the `where` and `sort` guards do
+ * not cover. Those leak a hidden value through which rows come back and through
+ * where they land. Grouping leaks it more directly than either: the distinct
+ * values BECOME the buckets, so a caller reads the whole value set off the
+ * labels while field redaction strips the column from every row it never sees.
+ *
+ * Selecting the field is not required for that, which is why guarding `select`
+ * would not help — the answer is the grouping, not the row.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  clearFieldFunctions,
+  registerFieldFunctions,
+} from "../field-level-registry";
+import { assertGroupableField } from "../filterable-fields";
+
+const SLUG = "vaults";
+
+/** A collection with one restricted field and one ordinary one. */
+function registerVaults(): void {
+  registerFieldFunctions("collection", SLUG, [
+    { name: "codename", type: "text", access: { read: () => false } },
+    { name: "region", type: "text" },
+  ]);
+}
+
+afterEach(() => {
+  clearFieldFunctions();
+});
+
+describe("grouping by a field that carries a read rule", () => {
+  it("is REFUSED, naming the field and why", () => {
+    // Asserted on the SERIALIZED error, not on `.message`:
+    // `NextlyError.validation` carries a generic public message and puts the
+    // per-field reason in its `errors` array, so a regex against the thrown
+    // message would pass or fail for reasons unrelated to this guard.
+    registerVaults();
+    try {
+      assertGroupableField("collection", SLUG, "codename");
+      expect.unreachable("should have refused");
+    } catch (error) {
+      expect(JSON.stringify(error)).toMatch(/cannot be used to group/i);
+      expect(JSON.stringify(error)).toContain("codename");
+    }
+  });
+
+  it("reports it as NOT_GROUPABLE, not as an unsortable or unfilterable field", () => {
+    // The three routes are different disclosures and a caller acting on the
+    // refusal needs to know which one they hit.
+    registerVaults();
+    try {
+      assertGroupableField("collection", SLUG, "codename");
+      expect.unreachable("should have refused");
+    } catch (error) {
+      expect(JSON.stringify(error)).toContain("FIELD_NOT_GROUPABLE");
+      expect(JSON.stringify(error)).toContain("groupBy.codename");
+    }
+  });
+
+  it("CONTROL: an ordinary field groups freely", () => {
+    registerVaults();
+    expect(() =>
+      assertGroupableField("collection", SLUG, "region")
+    ).not.toThrow();
+  });
+
+  it("CONTROL: no group key is nothing to judge", () => {
+    registerVaults();
+    expect(() =>
+      assertGroupableField("collection", SLUG, undefined)
+    ).not.toThrow();
+  });
+
+  it("judges the field that OWNS the rule for a nested path", () => {
+    registerVaults();
+    expect(() =>
+      assertGroupableField("collection", SLUG, "codename.inner")
+    ).toThrow();
+  });
+
+  it("a trusted caller has already decided who is asking", () => {
+    registerVaults();
+    expect(() =>
+      assertGroupableField("collection", SLUG, "codename", {
+        overrideAccess: true,
+      })
+    ).not.toThrow();
+  });
+});

--- a/packages/nextly/src/shared/lib/filterable-fields.ts
+++ b/packages/nextly/src/shared/lib/filterable-fields.ts
@@ -107,15 +107,42 @@ function protectedFields(
     .sort();
 }
 
-function refuse(fields: string[], at: "where" | "sort"): never {
+/** Where a field was named, and what naming it there would disclose. */
+type Position = "where" | "sort" | "groupBy";
+
+/**
+ * One row per position, rather than a ternary chain.
+ *
+ * A table because each position leaks the same hidden value by a DIFFERENT
+ * route, so each refusal has to say which route -- and a chain that grows a
+ * branch per position stops being readable at exactly the point a third one
+ * arrives.
+ */
+const REFUSALS: Record<Position, { code: string; because: string }> = {
+  where: {
+    code: "FIELD_NOT_FILTERABLE",
+    because:
+      "Filtering on a field you may not read would reveal its contents through the rows returned.",
+  },
+  sort: {
+    code: "FIELD_NOT_SORTABLE",
+    because:
+      "Ordering by a field you may not read reveals how its values compare across rows.",
+  },
+  groupBy: {
+    code: "FIELD_NOT_GROUPABLE",
+    because:
+      "Grouping by a field you may not read publishes its distinct values as the buckets themselves, which redaction never sees because the value is never rendered in a row.",
+  },
+};
+
+function refuse(fields: string[], at: Position): never {
+  const { code, because } = REFUSALS[at];
   throw NextlyError.validation({
     errors: fields.map(field => ({
       path: `${at}.${field}`,
-      code: at === "sort" ? "FIELD_NOT_SORTABLE" : "FIELD_NOT_FILTERABLE",
-      message:
-        at === "sort"
-          ? `The field "${field}" carries a read rule, so it cannot be used to sort. Ordering by a field you may not read reveals how its values compare across rows.`
-          : `The field "${field}" carries a read rule, so it cannot be used to filter. Filtering on a field you may not read would reveal its contents through the rows returned.`,
+      code,
+      message: `The field "${field}" carries a read rule, so it cannot be used to ${at === "groupBy" ? "group" : at === "sort" ? "sort" : "filter"}. ${because}`,
     })),
   });
 }
@@ -194,6 +221,34 @@ export function assertSortableField(
   const name = sort.replace(/^-/, "").split(".")[0];
   const denied = protectedFields(kind, slug, [name]);
   if (denied.length > 0) refuse(denied, "sort");
+}
+
+/**
+ * Refuse a GROUP BY that names a field carrying a read rule.
+ *
+ * 🔴 A third disclosure route, and the one the other two guards do not cover.
+ * `where` leaks a hidden value through which rows come back and `sort` through
+ * where they land; grouping leaks it MORE directly than either, because the
+ * distinct values become the buckets. A caller never sees the column -- field
+ * redaction strips it from every row -- and reads the whole value set off the
+ * labels instead. Selecting the field is not required, and refusing it does not
+ * help: the answer is the grouping, not the row.
+ *
+ * Conservative for the reason the module states: a field read rule is a
+ * function of the ROW, there is no row at query time, and a precondition that
+ * cannot decide fails closed.
+ */
+export function assertGroupableField(
+  kind: EntityKind,
+  slug: string,
+  groupBy: string | undefined,
+  opts: { overrideAccess?: boolean; frameworkFilter?: boolean } = {}
+): void {
+  if (opts.overrideAccess || opts.frameworkFilter || !groupBy) return;
+  // Nested paths address the field that OWNS the rule, as `where` does.
+  const name = groupBy.split(".")[0];
+  const denied = protectedFields(kind, slug, [name]);
+  if (denied.length > 0) refuse(denied, "groupBy");
 }
 
 /**


### PR DESCRIPTION
First of three pieces for Phase 3.1 (`groupBy`). This is the guard; the query contract and the execution follow separately, so the security question is settled before a new capability is built on it.

## The disclosure this closes

A field carrying an `access.read` rule is already refused in `where` and `sort`, because both reveal the hidden value:

- **`where`** — through which rows come back. Ask `equals` against each candidate and read the answer off the result.
- **`sort`** — through where a row lands. Bisect a neighbour's value between anchors you control.

**Grouping reveals it more directly than either.** The distinct values *become the buckets*, so the whole value set is read off the labels — while field redaction strips the column from rows nobody looks at. Selecting the field is not required for that, which is why a guard on `select` would not have closed it: the answer is the grouping, not the row.

Raised by `research:phase3-aggregation-access-control-and-charts` as a channel no existing guard covers, and flagged there specifically because it is not obviously implied by the two that do exist.

## The shape

`assertGroupableField` mirrors `assertSortableField`, and is conservative for the reason the module already states in its own words: a field read rule is a function of the ROW, there is no row at query time, and a precondition that cannot decide fails closed.

The refusal messages move from a ternary chain into a table. Each position leaks the same value by a **different** route and each refusal has to name its own; a chain that grows a branch per position stops being readable exactly when a third arrives.

## Tests

Six cases: the refusal, its distinct `FIELD_NOT_GROUPABLE` code and `groupBy.<field>` path, a nested path judged by the field that OWNS the rule, and two controls — an ordinary field groups freely, and a trusted caller is not judged.

Break-verified: not judging the key kills three, judging a nested path whole kills one, judging trusted callers kills one.

Two of the six failed on their first run, and the guard was right both times — `NextlyError.validation` carries a generic public message and puts the per-field reason in `errors`, so a regex against the thrown message asserts nothing about this guard. They assert the serialized error instead, with the reason recorded so the shape is not re-guessed.

`check-types` 42/42, `lint` 24/24, fallow `✓ No issues in 3 changed files`.