### PR TITLE
feat(nextly): make a group key part of the widget query contract

### DIFF
--- a/.changeset/a-group-key-is-part-of-the-query.md
+++ b/.changeset/a-group-key-is-part-of-the-query.md
@@ -1,0 +1,44 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A widget query can now carry a group key, and the validator judges it together
+with the operation rather than separately. `groupBy` means something only to
+the `groupBy` operation, so a key travelling beside `count` is refused instead
+of being accepted and then dropped — an accepted-and-ignored key reads back to
+the caller as a grouped count that was never computed. A `groupBy` operation
+arriving with no key is refused for the matching reason, at the point that can
+still say which part is missing.
+
+The key is read once, with every other property of the query, so an accessor
+cannot answer one field to the check and another to the query that ships. It is
+checked against the fields its source declares, the same set `sort` and
+`select` are checked against.
+
+Sources that answer one fixed question say so: `keyof WidgetQuery` drives an
+exhaustive table in each, so a query naming a key they cannot honour is refused
+by name rather than silently discarded.

--- a/packages/nextly/src/domains/releases/releases-widget-source.ts
+++ b/packages/nextly/src/domains/releases/releases-widget-source.ts
@@ -161,6 +161,7 @@ const QUERY_FIELD_USE: Record<keyof WidgetQuery, "consumed" | "refused"> = {
   where: "refused",
   sort: "refused",
   status: "refused",
+  groupBy: "refused",
 };
 
 /**

--- a/packages/nextly/src/domains/versions/versions-widget-source.ts
+++ b/packages/nextly/src/domains/versions/versions-widget-source.ts
@@ -190,6 +190,7 @@ const QUERY_FIELD_USE: Record<keyof WidgetQuery, "consumed" | "refused"> = {
   where: "refused",
   sort: "refused",
   status: "refused",
+  groupBy: "refused",
 };
 
 function refuseUnconsumed(query: WidgetQuery): void {

--- a/packages/nextly/src/domains/widgets/__tests__/query.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/query.test.ts
@@ -759,3 +759,91 @@ describe("a geo filter cannot be counted", () => {
     expect(counting({ location: { equals: "here" } })).not.toThrow();
   });
 });
+
+describe("validateWidgetQuery, group key", () => {
+  beforeEach(() => {
+    registerSource({
+      id: "collection:grouped",
+      label: "Grouped",
+      kind: "collection",
+      supports: ["count", "list", "groupBy"],
+      fields: [
+        { name: "title", type: "string" },
+        { name: "status", type: "string" },
+      ],
+    });
+  });
+
+  it("carries a declared group key through onto the returned query", () => {
+    // Asserts the WHOLE object: a version that validated the key and then
+    // dropped it on the way out would satisfy any assertion that only read
+    // `groupBy` back off the input.
+    expect(
+      validateWidgetQuery({
+        source: "collection:grouped",
+        op: "groupBy",
+        groupBy: "status",
+      })
+    ).toEqual({
+      source: "collection:grouped",
+      op: "groupBy",
+      groupBy: "status",
+      limit: 5,
+    });
+  });
+
+  it("refuses a group key carried by an op that would ignore it", () => {
+    // The case worth refusing rather than dropping: accepted and ignored, a
+    // `count` reads back as a grouped count that was never computed.
+    expect(() =>
+      validateWidgetQuery({
+        source: "collection:grouped",
+        op: "count",
+        groupBy: "status",
+      })
+    ).toThrow(/groupBy is not valid for op "count"/);
+  });
+
+  it("refuses a groupBy op carrying no key", () => {
+    expect(() =>
+      validateWidgetQuery({ source: "collection:grouped", op: "groupBy" })
+    ).toThrow(/op "groupBy" requires a groupBy field/);
+  });
+
+  it("refuses a group key that is not a string", () => {
+    expect(() =>
+      validateWidgetQuery({
+        source: "collection:grouped",
+        op: "groupBy",
+        groupBy: ["status"],
+      })
+    ).toThrow(/groupBy must be a string/);
+  });
+
+  it("refuses a group key naming a field the source never declared", () => {
+    expect(() =>
+      validateWidgetQuery({
+        source: "collection:grouped",
+        op: "groupBy",
+        groupBy: "secretScore",
+      })
+    ).toThrow(/groupBy references undeclared field "secretScore"/);
+  });
+
+  it("reads the group key exactly once, so an accessor cannot swap it past the check", () => {
+    // The invariant the whole module is built on: a property read twice is a
+    // seam where the value that was checked and the value that ships differ.
+    let reads = 0;
+    const q = validateWidgetQuery({
+      source: "collection:grouped",
+      op: "groupBy",
+      get groupBy() {
+        reads += 1;
+        return reads === 1 ? "status" : "secretScore";
+      },
+    });
+
+    expect(reads).toBe(1);
+    expect(q.groupBy).toBe("status");
+  });
+});

--- a/packages/nextly/src/domains/widgets/query.ts
+++ b/packages/nextly/src/domains/widgets/query.ts
@@ -45,6 +45,7 @@ export interface WidgetQuery {
   status?: "published" | "draft" | "all";
   select?: string[];
   sort?: string;
+  groupBy?: string;
   limit?: number;
 }
 
@@ -82,6 +83,7 @@ export interface RawWidgetQuery {
   status: unknown;
   select: unknown;
   sort: unknown;
+  groupBy: unknown;
   limit: unknown;
 }
 
@@ -105,6 +107,7 @@ export function readWidgetQuery(query: unknown): RawWidgetQuery {
     status: q.status,
     select: q.select,
     sort: q.sort,
+    groupBy: q.groupBy,
     limit: q.limit,
   };
 }
@@ -550,6 +553,43 @@ function assertSortFieldDeclared(
   return sort;
 }
 
+/**
+ * Confirms the group key agrees with the op, and names a field the source
+ * declared.
+ *
+ * Op and key are judged TOGETHER rather than by two independent guards,
+ * because the failure worth closing is a key that validates and is then
+ * ignored. `groupBy` means something only to the `groupBy` op: carried
+ * alongside `count` it would pass a field check, ride along in the returned
+ * query and change no result, which reads back to the caller as a grouped
+ * count they asked for and did not get. A refusal names the mismatch instead.
+ *
+ * The empty direction is refused for the same reason. `op: "groupBy"` with no
+ * key has no bucket to group into, and leaving that for execution to discover
+ * moves the failure a long way from the thing that caused it.
+ *
+ * The key is checked against the same `declared` set `sort` and `select` are
+ * checked against, so one naming a field the source never published is refused
+ * here rather than reaching a compiler that would have to guess at its column.
+ */
+function assertGroupByAgreesWithOp(
+  source: WidgetSource,
+  groupBy: unknown,
+  declared: ReadonlySet<string>,
+  op: WidgetOp
+): string | undefined {
+  if (op !== "groupBy") {
+    if (groupBy !== undefined) fail(`groupBy is not valid for op "${op}"`);
+    return undefined;
+  }
+  if (groupBy === undefined) fail('op "groupBy" requires a groupBy field');
+  if (typeof groupBy !== "string") fail("groupBy must be a string");
+  if (!declared.has(groupBy)) {
+    fail(`groupBy references undeclared field "${groupBy}" on "${source.id}"`);
+  }
+  return groupBy;
+}
+
 /** Confirms `status`, when present, is one of the known values, and returns it. */
 function assertValidStatus(status: unknown): WidgetQuery["status"] | undefined {
   if (status === undefined) return undefined;
@@ -600,8 +640,8 @@ function clampLimit(limit: unknown): number {
  * The returned query is safe to compile: its source exists, its op is
  * supported, every field it names was declared by that source (at every
  * `where` nesting depth, and only via operators the query layer actually
- * understands, on conditions that are neither `null` nor empty), and its
- * limit is a bounded, finite integer.
+ * understands, on conditions that are neither `null` nor empty), its group
+ * key agrees with its op, and its limit is a bounded, finite integer.
  */
 export function validateWidgetQuery(query: unknown): WidgetQuery {
   const raw = readWidgetQuery(query);
@@ -637,6 +677,7 @@ export function validateReadWidgetQuery(
   assertSelectFieldsDeclared(source, select, declared);
   const sort = assertSortFieldDeclared(source, raw.sort, declared);
   const status = assertValidStatus(raw.status);
+  const groupBy = assertGroupByAgreesWithOp(source, raw.groupBy, declared, op);
 
   return {
     source: source.id,
@@ -645,6 +686,7 @@ export function validateReadWidgetQuery(
     ...(status ? { status } : {}),
     ...(select ? { select } : {}),
     ...(sort ? { sort } : {}),
+    ...(groupBy ? { groupBy } : {}),
     limit: clampLimit(raw.limit),
   };
 }


### PR DESCRIPTION
Piece 2 of Phase 3.1. `groupBy` becomes part of the widget query contract.

## What was wrong

`WidgetQuery` had no `groupBy`. `readWidgetQuery` reads the caller's object
into a fixed record, so a `groupBy` in the request body was dropped there —
silently. The query then validated, executed, and returned an **ungrouped**
result, which is indistinguishable from a grouped one that happened to produce
a single bucket.

`WIDGET_OPS` has declared `groupBy` since the ops were introduced, and
`sources.ts` validates a source's `supports` against it, so a plugin source can
declare `supports: ["groupBy"]` today. Declaring an op is not implementing it.

## The change

`groupBy?: string` on `WidgetQuery`, read in `readWidgetQuery` with everything
else, validated by one guard that judges the key **together with the op**:

| Query | Before | After |
| --- | --- | --- |
| `op: "groupBy"`, `groupBy: "status"` | key dropped | carried through |
| `op: "count"`, `groupBy: "status"` | accepted, ignored | refused |
| `op: "groupBy"`, no key | accepted | refused |
| `groupBy: ["status"]` | accepted, ignored | refused |
| `groupBy: "undeclaredField"` | accepted, ignored | refused |

Op and key are judged in one guard rather than two because the failure being
closed is a key that validates and is then ignored: accepted beside `count`, it
reads back to the caller as a grouped count that was never computed. Refusing
names the mismatch instead of answering a different question convincingly.

The key is checked against the same `declared` set `sort` and `select` use, and
is read exactly once — the invariant `readWidgetQuery` exists to hold. A
property read twice is a seam where the value that was checked and the value
that ships can differ.

## Why two unrelated files changed

`releases-widget-source.ts` and `versions-widget-source.ts` each key an
exhaustive `Record<keyof WidgetQuery, "consumed" | "refused">` table, so
`check-types` failed in both until each said what a group key means to it. Both
answer one fixed question and refuse it, by name, through the generic
`refuseUnconsumed` walk — no new refusal logic. That coupling is deliberate and
documented in those files; it did its job here.

## Evidence

- 6 new tests, each **break-verified individually** with the mutation string
  asserted to occur exactly once. Each kills its own test; the unmutated
  control is clean.
- The first mutation written for the single-read test **killed nothing** —
  it re-read `raw.groupBy`, which is the already-read record, not the caller's
  accessor. Re-aimed at `readWidgetQuery`, where the caller's object is still
  live, it kills that test alone. Reported because a break that kills nothing
  reads exactly like a test that cannot fail.
- `pnpm check-types` clean (both `tsc` passes, tests included).
- `pnpm lint` clean.
- `vitest run src/domains/widgets src/domains/releases src/domains/versions` →
  **67 files, 1161 tests**, all passing.
- `@nextlyhq/plugin-sdk` → 22 passing; its export snapshot records names, so a
  new property does not move it.
- `npx changeset status` parses the changeset.

## Scope

No execution. `execute.ts` still implements `runCount` and `runList` only and
refuses the rest by name, and no built-in source declares `groupBy` support.
Piece 3 pushes the aggregate into SQL through the pipeline that already owns
access, and is deliberately not bundled here: it depends on #1611 landing,
which closes the `getAccessQueryConstraint` ambiguity aggregation would
otherwise inherit.

Bucket truncation stays refused. A partial, read-order-biased scan can invert
which bucket is largest, so a chart would confidently rank the wrong category
first — the failure mode behind Hasura #7660/#7773 and Directus #25803.