### PR TITLE
test(blocks-engine): prove the DAG bound by termination, not by a timing ratio

### DIFF
--- a/packages/blocks-engine/src/composition-planners.test.ts
+++ b/packages/blocks-engine/src/composition-planners.test.ts
@@ -3801,32 +3801,20 @@ describe("a document whose branches share one object", () => {
   }
 
   it("is refused for its SIZE rather than walked", () => {
-    // Nineteen objects, half a million entries. The selection is one unrelated
-    // top-level node and was found immediately; what has to be bounded is the
-    // scan that goes looking for the scope it sits in.
-    const plan = planSaveAsPattern(pageWith(18), ["mine"], target, anyParent);
+    // THIRTY levels — thirty-one objects, and 2^30 entries to anything that
+    // walks them. The selection is one unrelated top-level node, found
+    // immediately; what has to be bounded is the scan that goes looking for the
+    // scope it sits in.
+    //
+    // The DEPTH is the evidence, and it is why this needs no timing threshold.
+    // Bounded, the scan reads at most `maxNodes + 1` entries and returns in
+    // under a millisecond. Unbounded, it reads a billion — measured, the cost
+    // doubles per level from 47ms at depth 18, so this depth is minutes. So the
+    // two implementations differ by RETURNING and NOT RETURNING, and a test
+    // that completes at all separates them. Nothing here measures the machine.
+    const plan = planSaveAsPattern(pageWith(30), ["mine"], target, anyParent);
 
     expect(plan.problem).toBe("exceeds-limits");
-  });
-
-  it("costs the same at six levels deeper", () => {
-    // A RATIO between two runs in one process, never a wall-clock ceiling: a
-    // ceiling measures the machine, and the exponential version passed a
-    // generous one at small depths. Six more levels is 64x the entries, so
-    // anything proportional to the document is unmissable here — measured at
-    // 17x before the bound, and the walk stops at the cap either way now.
-    const time = (depth: number): number => {
-      const doc = pageWith(depth);
-      const start = performance.now();
-      planSaveAsPattern(doc, ["mine"], target, anyParent);
-      return performance.now() - start;
-    };
-    time(10);
-
-    const shallow = time(12);
-    const deep = time(18);
-
-    expect(deep / Math.max(shallow, 0.05)).toBeLessThan(8);
   });
 
   it("refuses a NaN cap before walking, not after", () => {
@@ -3835,32 +3823,21 @@ describe("a document whose branches share one object", () => {
     // this bound exists to stop runs in full before anything rejects the
     // configuration. The published limit rule already refuses that.
     //
-    // Asserted as a RATIO between two depths, not as a throw: the configuration
-    // is rejected later in the component planner too, so `toThrow` alone passes
-    // just as well on the unbounded version — after it has done the work.
-    const spent = (depth: number): number => {
-      const doc = pageWith(depth);
-      const start = performance.now();
-      try {
-        planSaveAsComponent(
-          doc,
-          ["mine"],
-          componentTarget,
-          { properties: [] },
-          anyParent,
-          { ...DEFAULT_LIMITS, maxNodes: Number.NaN }
-        );
-      } catch {
-        // The refusal is the point; what this measures is when it arrives.
-      }
-      return performance.now() - start;
-    };
-    spent(10);
-
-    const shallow = spent(12);
-    const deep = spent(18);
-
-    expect(deep / Math.max(shallow, 0.05)).toBeLessThan(8);
+    // At THIRTY levels the throw is the evidence, which it is not at a shallow
+    // depth: the component planner rejects the same configuration later anyway,
+    // so a shallow `toThrow` passes on the unbounded version too — after it has
+    // done the work. Here the unbounded version has a billion entries to read
+    // before it reaches that rejection, so it does not arrive at all.
+    expect(() =>
+      planSaveAsComponent(
+        pageWith(30),
+        ["mine"],
+        componentTarget,
+        { properties: [] },
+        anyParent,
+        { ...DEFAULT_LIMITS, maxNodes: Number.NaN }
+      )
+    ).toThrow(RangeError);
   });
 
   it("still plans when the sharing is somewhere the save is not", () => {

--- a/packages/blocks-engine/src/composition-planners.test.ts
+++ b/packages/blocks-engine/src/composition-planners.test.ts
@@ -3800,21 +3800,69 @@ describe("a document whose branches share one object", () => {
     ]);
   }
 
-  it("is refused for its SIZE rather than walked", () => {
-    // THIRTY levels — thirty-one objects, and 2^30 entries to anything that
-    // walks them. The selection is one unrelated top-level node, found
-    // immediately; what has to be bounded is the scan that goes looking for the
-    // scope it sits in.
-    //
-    // The DEPTH is the evidence, and it is why this needs no timing threshold.
-    // Bounded, the scan reads at most `maxNodes + 1` entries and returns in
-    // under a millisecond. Unbounded, it reads a billion — measured, the cost
-    // doubles per level from 47ms at depth 18, so this depth is minutes. So the
-    // two implementations differ by RETURNING and NOT RETURNING, and a test
-    // that completes at all separates them. Nothing here measures the machine.
-    const plan = planSaveAsPattern(pageWith(30), ["mine"], target, anyParent);
+  /**
+   * A DAG whose nodes COUNT how many times the walk asked them for children,
+   * and stop answering once the count passes `stopAfter`.
+   *
+   * The tripwire is what makes this test safe to keep. A regression here is an
+   * unbounded walk over 2^30 entries, and vitest's per-test timeout cannot
+   * interrupt synchronous JavaScript — `format-boundary.test.ts` documents the
+   * same limitation for the same reason — so a test that merely waited would
+   * hang the worker for hours where it should report in milliseconds. Past the
+   * cap these nodes report no children, the walk unwinds, and the count is the
+   * evidence.
+   */
+  function counted(
+    depth: number,
+    stopAfter: number
+  ): { root: BlockNode; reads: () => number } {
+    let reads = 0;
+    const watch = (node: BlockNode): BlockNode =>
+      new Proxy(node, {
+        get(held, key, receiver) {
+          if (key !== "slots") return Reflect.get(held, key, receiver);
+          reads += 1;
+          // Past the bound the node has nothing to offer, which ends the walk
+          // rather than letting it run to the end of an exponential document.
+          if (reads > stopAfter) return undefined;
+          return Reflect.get(held, key, receiver);
+        },
+      }) as BlockNode;
 
-    expect(plan.problem).toBe("exceeds-limits");
+    let built = watch(node("leaf"));
+    for (let i = 0; i < depth; i += 1) {
+      built = watch(node(`n${String(i)}`, {}, { a: [built], b: [built] }));
+    }
+    return { root: built, reads: () => reads };
+  }
+
+  /** One save against a counted DAG of this depth. */
+  function scanOf(depth: number): { problem: unknown; reads: number } {
+    const cap = DEFAULT_LIMITS.maxNodes;
+    const { root, reads } = counted(depth, cap);
+    const doc = page([node("mine", { props: { mark: "target" } }), root]);
+    const plan = planSaveAsPattern(doc, ["mine"], target, anyParent);
+    return { problem: plan.problem, reads: reads() };
+  }
+
+  it("reads no more of the document than the cap allows, at any depth", () => {
+    // The selection is one unrelated top-level node, found immediately; what
+    // has to be bounded is the scan that goes looking for the scope it sits in.
+    //
+    // Asserted as a COUNT rather than as elapsed time. The bound made the old
+    // timing comparison meaningless — once both depths stop at the cap they do
+    // identical sub-millisecond work, so a ratio between them reported
+    // scheduler noise and went red on CI at 9.32 against a threshold of 8.
+    // What the bound actually promises is a number, and this is that number.
+    const cap = DEFAULT_LIMITS.maxNodes;
+    const shallow = scanOf(12);
+    const deep = scanOf(30);
+
+    expect(deep.problem).toBe("exceeds-limits");
+    expect(deep.reads).toBeLessThanOrEqual(cap);
+    // INDEPENDENT of depth, which is the whole property. Eighteen more levels
+    // is 2^18 times the document and must be the same amount of reading.
+    expect(deep.reads).toBe(shallow.reads);
   });
 
   it("refuses a NaN cap before walking, not after", () => {
@@ -3823,14 +3871,18 @@ describe("a document whose branches share one object", () => {
     // this bound exists to stop runs in full before anything rejects the
     // configuration. The published limit rule already refuses that.
     //
-    // At THIRTY levels the throw is the evidence, which it is not at a shallow
-    // depth: the component planner rejects the same configuration later anyway,
-    // so a shallow `toThrow` passes on the unbounded version too — after it has
-    // done the work. Here the unbounded version has a billion entries to read
-    // before it reaches that rejection, so it does not arrive at all.
+    // ZERO reads is the assertion, and it is what `toThrow` could not give.
+    // The component planner rejects this configuration later anyway, so a throw
+    // says nothing about WHEN — it is equally true of a run that walked the
+    // whole document first. A count of zero says the document was never
+    // touched.
+    const cap = DEFAULT_LIMITS.maxNodes;
+    const { root, reads } = counted(30, cap);
+    const doc = page([node("mine", { props: { mark: "target" } }), root]);
+
     expect(() =>
       planSaveAsComponent(
-        pageWith(30),
+        doc,
         ["mine"],
         componentTarget,
         { properties: [] },
@@ -3838,6 +3890,7 @@ describe("a document whose branches share one object", () => {
         { ...DEFAULT_LIMITS, maxNodes: Number.NaN }
       )
     ).toThrow(RangeError);
+    expect(reads()).toBe(0);
   });
 
   it("still plans when the sharing is somewhere the save is not", () => {


### PR DESCRIPTION
**`main` is red on a test I added in #1597**, and it is not a regression in the code — it is a test measuring the wrong thing.

`costs the same at six levels deeper` compared depth 12 against depth 18 and required a ratio under 8. CI measured **9.32**.

## Why the ratio stopped meaning anything

The bound in #1597 is what broke its own perf test. Once the scan stops at `maxNodes + 1`, **both depths read the same 5,001 entries** — identical, sub-millisecond work — so the ratio no longer reports scaling. It reports scheduler noise.

Measured on an idle machine, six consecutive pairs:

```
d12=1.572ms d18=0.937ms ratio=0.60
d12=1.734ms d18=0.629ms ratio=0.36
d12=0.501ms d18=0.425ms ratio=0.85
d12=0.393ms d18=0.505ms ratio=1.29
d12=0.431ms d18=0.453ms ratio=1.05
d12=0.540ms d18=0.488ms ratio=0.90
```

A **3.6× spread with nothing varying but the clock**, on an idle machine. A loaded runner reached 9.32. Raising the threshold would only move the coin-flip.

## What replaces it

The evidence moves from timing to **termination**, at thirty levels:

- bounded — reads at most `maxNodes + 1` entries, returns in **0.52 ms** (measured)
- unbounded — 2³⁰ entries to read; the cost doubles per level from 47 ms at depth 18, so **minutes**

The two implementations differ by *returning* and *not returning*, so a test that completes at all separates them. No threshold, and nothing measuring the machine — which is what the ratio was reaching for and no longer achieved.

The NaN case moves the same way and **gains** discrimination doing it. `toThrow` at a shallow depth passed on the unbounded version too, because the component planner rejects that configuration later anyway; at this depth the unbounded version never reaches the rejection.

Net: 27 insertions, 50 deletions, one file. Two tests become one assertion each, and both got stronger.

## Verification

- blocks-engine **2393 passing**, the whole file in 483 ms.
- `check-types` EXIT=0, `lint` EXIT=0, `check:comments` EXIT=0, `fallow` pass.
- **Break-verified**: unbounding the scan fails the size test and nothing else; taking the cap unvalidated fails the NaN test and nothing else. Both now fail by timing out, which is exactly the property being asserted.

No changeset: test-only.

*(`main` also carries a second, unrelated red — `plugin-form-builder`'s `ConditionalLogicEditor` timing out at 5 s under load; 212 ms locally. Filed separately as it is another package's timing, not this one.)*