### PR TITLE
test(e2e): enter the list passage at its end instead of navigating there

### DIFF
--- a/e2e/tests/inline-rich-text.spec.ts
+++ b/e2e/tests/inline-rich-text.spec.ts
@@ -284,6 +284,11 @@ test.describe("a passage edited on the canvas", () => {
      * item, the second should end the list. Counting items is what separates
      * the two outcomes — with the behaviour registered the empty item is
      * consumed, without it there are three.
+     *
+     * Three items is NOT proof of the behaviour being absent on its own, which
+     * is worth saying because it reads that way. A caret that is not where this
+     * case believes it is reaches the same count by splitting the word instead,
+     * so the intermediate assertion below is what tells the two apart.
      */
     await openBuilderWith(page, [
       {
@@ -308,17 +313,37 @@ test.describe("a passage edited on the canvas", () => {
         ],
       },
     ]);
-    await enterPassage(page, 0.5);
+    /*
+     * Entered AT THE END rather than in the middle and navigated there with
+     * `End`, and the difference is the whole reliability of this case.
+     *
+     * A caret placed here is written straight into the editor's own state, so
+     * the editor and the DOM agree before anything is typed. A navigation KEY
+     * does not work that way: it moves the browser's caret immediately, and the
+     * editor is told through `selectionchange`, which the browser dispatches on
+     * a later turn. Two synthetic keys land back to back faster than that, so
+     * the second one was applied at the caret the first had already moved away
+     * from — `Item` split into `Ite` and `m` — and the case failed roughly one
+     * run in three. Measured: a 50ms gap between the keys passed 30 of 30, so
+     * the window is far inside one human keystroke and no author can reach it.
+     * It was a race between this test and the browser, not in the product.
+     */
+    await enterPassage(page, 1);
 
-    await page.keyboard.press("End");
-    await page.keyboard.press("Enter");
     await page.keyboard.press("Enter");
 
     const items = page.locator(`${PASSAGE} li`);
-    // The control on the fixture itself: if the list never rendered as a list,
-    // this count would be 0 and the assertion below would pass for the wrong
-    // reason.
-    await expect(items).not.toHaveCount(0);
+    /*
+     * The precondition, asserted rather than assumed, and it carries the
+     * fixture control too. Two items reading `Item` and nothing prove the list
+     * rendered AS a list and that the caret really was at the end — a caret
+     * anywhere inside the word splits it here, and the final count would then
+     * be reached for a reason this case is not about.
+     */
+    await expect(items).toHaveText(["Item", ""]);
+
+    await page.keyboard.press("Enter");
+
     await expect(items).toHaveCount(1);
   });
 });


### PR DESCRIPTION
`Browser tests` has been failing on `main` about one run in eight. It is a race
**between the test and the browser**, not in the product, and this is the
evidence for that rather than an assertion of it.

## What the failure actually was

The case double-clicked the middle of the only list item and pressed `End` to
reach the end. The reported symptom is three `<li>` where one is expected, and
the header comment says three is the signature of the list behaviour not being
registered. **It is not**, and that reading sent two separate investigations the
wrong way.

The page snapshot from the failing CI run names the three items:

```
- list:
  - listitem: Ite
  - listitem
  - listitem: m
```

`Item` was split at offset 3 — the double-click position. The list behaviour was
working the whole time. The caret was in the wrong place.

## Why

`End` moves the browser's caret immediately. Lexical is told about it through
`selectionchange`, which the browser dispatches on a **later turn**. Two
synthetic key events arrive back to back faster than that, so the editor was
still holding the caret from the double-click and applied Enter there.

Reproduced and instrumented locally — **9 of 30 failed**, same signature as CI:

| run | DOM caret after `End` | editor's own caret | `selectionchange` seen | outcome |
|---|---|---|---|---|
| passing | 4 | **4** | 1 | 1 item |
| failing | 4 | **3** | **0** | 3 items |

100% correlation across every run. The failing runs had received no
`selectionchange` at all.

**And the window is not one an author can reach.** A 50ms gap between the two
keys passed **30 of 30** — far inside one human keystroke. That is why this is a
test fix and not a product fix: there is nothing here a person can hit, and
adding product code to absorb a synthetic-input timing artifact would be a
workaround rather than a repair.

## The fix

Enter the passage **at its end** instead of navigating there. A caret placed on
entry is written straight into the editor's own state, so nothing has to travel
back from the DOM and there is no window to lose. A fixed pause would have been
the same race with a number in front of it.

The intermediate assertion is what keeps the case honest:

```ts
await page.keyboard.press("Enter");
await expect(items).toHaveText(["Item", ""]);   // list rendered AND caret at the end
await page.keyboard.press("Enter");
await expect(items).toHaveCount(1);
```

It replaces the old `not.toHaveCount(0)` fixture control and does strictly more:
a caret anywhere inside the word splits it here, so the final count can no
longer be reached for the wrong reason. The header comment now records that
three items has two possible causes, which is the thing that was missing.

## Evidence

| | before | after |
|---|---|---|
| 30 consecutive local runs | **9 failed** | **0 failed** |

Mutation-tested, with the mutation asserted and a control run that passes:

| mutation | result |
|---|---|
| `registerList` not registered (the defect this case exists for) | **CAUGHT** — 6/6 fail |
| caret not at the end (the new precondition) | **CAUGHT** — 6/6 fail |

The first one matters most: the case still fails for the reason it was written,
so this has not been made to pass by weakening it.

Full spec green (3 passed), `eslint` and `tsc --noEmit` clean in `@nextlyhq/e2e`.
Test-only, no changeset.
