### PR TITLE
test(blocks-engine): make the read-count probe prove it observed the walk

### DIFF
--- a/packages/blocks-engine/src/composition-planners.test.ts
+++ b/packages/blocks-engine/src/composition-planners.test.ts
@@ -3859,6 +3859,14 @@ describe("a document whose branches share one object", () => {
     const deep = scanOf(30);
 
     expect(deep.problem).toBe("exceeds-limits");
+    // The counter OBSERVED the walk. Without this the test is satisfied by a
+    // probe that never counts: a mistyped key leaves both scans at zero, and
+    // `0 <= cap` and the equality below both hold while `problem` keeps coming
+    // from the production cap. The suite would then accept a dead tripwire —
+    // and the tripwire is what stops a later loss of the bound from hanging
+    // this test for hours instead of failing it. Measured: with this assertion
+    // removed, a mistyped key in the probe failed nothing at all.
+    expect(deep.reads).toBeGreaterThan(cap / 2);
     expect(deep.reads).toBeLessThanOrEqual(cap);
     // INDEPENDENT of depth, which is the whole property. Eighteen more levels
     // is 2^18 times the document and must be the same amount of reading.
@@ -3880,6 +3888,14 @@ describe("a document whose branches share one object", () => {
     const { root, reads } = counted(30, cap);
     const doc = page([node("mine", { props: { mark: "target" } }), root]);
 
+    // The CONTROL, and this test needs one more than most: zero reads is the
+    // answer being asserted, so a probe that never counts gives it for free.
+    // A valid save over the same document proves the counter observes this
+    // walk before the count of zero is allowed to mean anything.
+    planSaveAsPattern(doc, ["mine"], target, anyParent);
+    expect(reads()).toBeGreaterThan(0);
+    const before = reads();
+
     expect(() =>
       planSaveAsComponent(
         doc,
@@ -3890,7 +3906,8 @@ describe("a document whose branches share one object", () => {
         { ...DEFAULT_LIMITS, maxNodes: Number.NaN }
       )
     ).toThrow(RangeError);
-    expect(reads()).toBe(0);
+    // NOTHING was added by the refused call — the document was never touched.
+    expect(reads()).toBe(before);
   });
 
   it("still plans when the sharing is somewhere the save is not", () => {


### PR DESCRIPTION
**A stranded tail from #1618.** That PR's merge was computed at `3e8ccb1d1`; this commit was pushed after, so it never landed. The PR reads merged and clean and `main` does not have it — found by verifying against `main` by CONTENT rather than by the PR's state.

## What `main` is currently missing

#1618 landed the read-count probe. As merged, that probe is **satisfied by a counter that never counts**: `reads <= cap` and `reads(shallow) === reads(deep)` both hold at zero, while `problem` keeps coming from the production bound.

Measured on `main` as it stands — mistyping the probe's key from `slots` to `slotz`, so the counter never increments:

```
BREAK - dead counter, on top of current main
  0 failing of 154        (before this commit)
  2 failing of 154        (with it)
```

**Why that matters more than an ordinarily weak assertion.** The tripwire is what stops a later loss of the production `maxNodes` bound from *hanging* the suite — at depth 30 an unbounded walk is 2³⁰ entries, and vitest cannot interrupt synchronous JavaScript, as `format-boundary.test.ts` documents. A dead counter silently removes the protection the trap exists for, so the two failures compound rather than merely coexisting.

## The fix

- The depth test asserts the counter **observed** the walk (`reads > cap / 2`), so a dead probe fails.
- The NaN test needed a **control**, not a threshold: zero reads is the answer it asserts, so a probe that never counts gives that for free. It now runs a valid save over the same counted document first and requires a nonzero count before a count of zero is allowed to mean anything.

## Verification

- blocks-engine **2393 passing**; `check-types` / `lint` / `check:comments` EXIT=0; `fallow` pass, one file changed.
- Break-verified against current `main`: the exact defect described fails both tests, and the control is clean.

No changeset: test-only.