### PR TITLE
ci: account for every diagnostic, and ratchet coverage in both directions

### DIFF
--- a/scripts/check-doc-samples.mjs
+++ b/scripts/check-doc-samples.mjs
@@ -129,9 +129,15 @@ export function unterminatedFences(text) {
     const m = line.match(opener);
     if (!m) continue;
     const last = open[open.length - 1];
-    // A closer is the same delimiter run with no language after it. Anything
-    // else opens a nested block, which Markdown allows only with a longer run.
-    if (last && m[1].startsWith(last.delimiter) && !m[2]) open.pop();
+    // A closer carries the delimiter and nothing else. Checking only that the
+    // language capture was empty accepted ```` ```{.foo} ```` as one, because
+    // `\w*` matches nothing before a brace; `extractFrom` rejects that line, so
+    // the fence went neither extracted nor reported.
+    const closes =
+      last &&
+      m[1].startsWith(last.delimiter) &&
+      /^[ \t]*(?:>[ \t]*)*(?:```+|~~~+)[ \t\r]*$/.test(line);
+    if (closes) open.pop();
     else if (!last) open.push({ delimiter: m[1], lang: m[2], line });
   }
   return open.filter(f => isTypeScript(f.lang)).map(f => f.line.trim());
@@ -265,20 +271,45 @@ export const SUPPLIED_BY_THE_READER = [
  * filed all ten as fragments, so the API mistakes inside them were never read;
  * the missing name they open with is what the continuation pass is for.
  */
-export const isModule = code =>
-  /^\s*import\b/m.test(code) ||
-  /^\s*export\b/m.test(code) ||
-  // CommonJS counts. A fence opening `const crypto = require("crypto")` is a
-  // program a reader runs, and requiring ESM syntax filed it as a fragment so
-  // nothing compiled it: the webhook-verification example on the form-builder
-  // page is exactly that shape, and its undefined names were never read.
-  /(?:^|[^.\w])require\s*\(/m.test(code) ||
-  // So does a dynamic one. `const nx = await import("nextly")` loads a package
-  // exactly as the declaration form does, and reading only declarations left
-  // such a fence extracted, never compiled, and free to call methods that do
-  // not exist. `.import(` is excluded for the same reason `require` is: a
-  // property access of that name is not a module load.
-  /(?:^|[^.\w])import\s*\(/m.test(code);
+export const isModule = (code, extension = "tsx") => {
+  const parsed = parseSample(code, extension);
+  // A call to `require` or to `import`, anywhere in the tree. Both load a
+  // package exactly as a declaration does, and a fence opening
+  // `const crypto = require("crypto")` is a program a reader runs; requiring
+  // ESM syntax filed those as fragments so nothing compiled them.
+  //
+  // From the tree rather than from the text, because the text cannot tell a
+  // call from a mention: `// dynamically import("nextly")` in a comment, or
+  // `"import(x)"` in a string, made a fragment look like a module and had the
+  // audit compile a block it deliberately excludes. A property access named
+  // `require` or `import` is not a load either, and is not an identifier call.
+  let loads = false;
+  const walk = node => {
+    if (loads) return;
+    if (
+      ts.isCallExpression(node) &&
+      (node.expression.kind === ts.SyntaxKind.ImportKeyword ||
+        (ts.isIdentifier(node.expression) && node.expression.text === "require"))
+    ) {
+      loads = true;
+      return;
+    }
+    ts.forEachChild(node, walk);
+  };
+  ts.forEachChild(parsed, walk);
+  if (loads) return true;
+
+  return parsed.statements.some(
+    statement =>
+      ts.isImportDeclaration(statement) ||
+      ts.isImportEqualsDeclaration(statement) ||
+      ts.isExportDeclaration(statement) ||
+      ts.isExportAssignment(statement) ||
+      (ts.getModifiers?.(statement) ?? statement.modifiers ?? []).some(
+        modifier => modifier.kind === ts.SyntaxKind.ExportKeyword
+      )
+  );
+};
 
 /**
  * The documentation this repository owns and publishes.
@@ -803,7 +834,10 @@ export function exportsMapAnswers(exports, subpath) {
  */
 export function declaredEarlier(name, file, index, samples) {
   return samples.some(
-    s => s.file === file && s.index < index && declaresName(s.code, name)
+    s =>
+      s.file === file &&
+      s.index < index &&
+      declaresName(s.code, name, extensionFor(s))
   );
 }
 
@@ -818,8 +852,8 @@ export function declaredEarlier(name, file, index, samples) {
  * and then not found when the rebuild went looking for it. The continuation was
  * never compiled.
  */
-export function declaresName(code, name) {
-  if (declaredNamesIn(code).includes(name)) return true;
+export function declaresName(code, name, extension = "tsx") {
+  if (declaredNamesIn(code, extension).includes(name)) return true;
   // An arrow or method bound without a declaration keyword: `handler: (req) =>`
   // in an object literal, or a property assignment. Not something
   // `declaredNamesIn` collects, because it is not a declaration, but a later
@@ -987,18 +1021,34 @@ function topLevelOnly(code) {
  * exception, and a statement list that is short of a broken import is the right
  * answer anyway.
  */
-function importsIn(source) {
-  const parsed = ts.createSourceFile(
-    "sample.tsx",
+export function parseSample(source, extension = "tsx") {
+  return ts.createSourceFile(
+    `sample.${extension}`,
     source,
     ts.ScriptTarget.Latest,
     false,
-    ts.ScriptKind.TSX
+    extension === "tsx" ? ts.ScriptKind.TSX : ts.ScriptKind.TS
   );
-  return parsed.statements.filter(ts.isImportDeclaration);
 }
 
-export function declaredNamesIn(source) {
+/**
+ * The import declarations a source actually has, read under the grammar the
+ * compiler will use for it.
+ *
+ * The two grammars disagree before they agree: `const id = <T>(x: T) => x;` is
+ * a generic arrow in `.ts` and an unclosed element in `.tsx`, and parsing a
+ * `.ts` sample as TSX produces a recovery tree that can drop every import after
+ * it. The fence still compiles, because compilation uses the right extension,
+ * so the names simply went missing and a later fence using one was reported as
+ * undefined rather than rebuilt with its context.
+ */
+function importsIn(source, extension) {
+  return parseSample(source, extension).statements.filter(
+    ts.isImportDeclaration
+  );
+}
+
+export function declaredNamesIn(source, extension = "tsx") {
   const code = topLevelOnly(source);
   const names = new Set();
   const add = n => {
@@ -1044,7 +1094,7 @@ export function declaredNamesIn(source) {
   // fence that used `ghost` as a continuation of a page that never bound it. A
   // parser has neither problem: a comment produces no statement, and a wrapped
   // clause is one statement however it is laid out.
-  for (const statement of importsIn(source)) {
+  for (const statement of importsIn(source, extension)) {
     const clause = statement.importClause;
     if (!clause) continue;
     if (clause.name) add(clause.name.text);
@@ -1075,7 +1125,7 @@ export function declaredNamesIn(source) {
  * program a reader pastes. `await nextly.logout()` calls a value an earlier
  * fence built, and is.
  */
-export function declaredValuesIn(source) {
+export function declaredValuesIn(source, extension = "tsx") {
   const code = topLevelOnly(source);
   const names = new Set();
   for (const m of code.matchAll(
@@ -1121,7 +1171,9 @@ export function inheritedNames(sample, samples) {
     // `radio({ ... })` on the field catalogue out: it mentions `option`, which
     // an earlier fence imported, and is a shape being illustrated rather than a
     // program a reader pastes.
-    const values = earlier.flatMap(s => declaredValuesIn(s.code));
+    const values = earlier.flatMap(s =>
+      declaredValuesIn(s.code, extensionFor(s))
+    );
     const callsOne = values.some(name =>
       new RegExp(
         `\\b${name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*[.(]`
@@ -1129,11 +1181,13 @@ export function inheritedNames(sample, samples) {
     );
     if (!callsOne) return [];
   }
-  const declared = new Set(earlier.flatMap(s => declaredNamesIn(s.code)));
+  const declared = new Set(
+    earlier.flatMap(s => declaredNamesIn(s.code, extensionFor(s)))
+  );
   const used = new Set(
     [...sample.code.matchAll(/[A-Za-z_$][\w$]*/g)].map(m => m[0])
   );
-  const own = new Set(declaredNamesIn(sample.code));
+  const own = new Set(declaredNamesIn(sample.code, extensionFor(sample)));
   return [...declared].filter(n => used.has(n) && !own.has(n));
 }
 
@@ -1182,7 +1236,7 @@ export function withEarlierContext(sample, missingNames, samples) {
   // identifiers — a fence is pulled in only when the page really does define
   // what it is being pulled in for.
   const declaredEarlierOnThePage = new Set(
-    earlier.flatMap(s => declaredNamesIn(s.code))
+    earlier.flatMap(s => declaredNamesIn(s.code, extensionFor(s)))
   );
   const chosen = new Map();
   const wanted = [...missingNames];
@@ -1196,7 +1250,7 @@ export function withEarlierContext(sample, missingNames, samples) {
     );
     if (!nearest || chosen.has(nearest.index)) continue;
     chosen.set(nearest.index, nearest);
-    const own = new Set(declaredNamesIn(nearest.code));
+    const own = new Set(declaredNamesIn(nearest.code, extensionFor(nearest)));
     for (const m of nearest.code.matchAll(/[A-Za-z_$][\w$]*/g)) {
       const used = m[0];
       if (!own.has(used) && declaredEarlierOnThePage.has(used)) {
@@ -1479,6 +1533,31 @@ export const pageOf = line => {
  * on the next fetch, so a red here would be a red this repository cannot clear,
  * and a check that cannot be cleared teaches people to ignore it.
  */
+/**
+ * How many diagnostics the classifier produced that nobody kept.
+ *
+ * Zero is the only acceptable answer: `real` is charged to a page, the other
+ * buckets are set aside by identity, and `continued` comes back through this
+ * same partition after its recompile. Anything else is a class of diagnostic
+ * the gate cannot see, which is the shape of every bucket that has escaped.
+ *
+ * `unchecked` is deliberately not a term: the classifier appends it to `real`
+ * before returning, so counting it again would inflate the sum and let a
+ * missing bucket hide behind the surplus. That is the same mistake as comparing
+ * against the whole set-aside list, which carries entries added before
+ * classification.
+ */
+export function unaccountedFor({
+  total,
+  real,
+  continued,
+  readerFiles,
+  uninstalled,
+  implicitAny,
+}) {
+  return total - (real + continued + readerFiles + uninstalled + implicitAny);
+}
+
 async function auditDocs() {
   let all;
   try {
@@ -1505,7 +1584,7 @@ async function auditDocs() {
   // that introduces a value in a fence with no import of its own, and uses it
   // in the next one, is a documentation shape, and reading it as an undefined
   // name would put a finding on the page that a reader never meets.
-  const samples = all.filter(s => isModule(s.code));
+  const samples = all.filter(s => isModule(s.code, extensionFor(s)));
   // Everything the gate ignores EXCEPT the reader's own files: those are kept
   // so the samples carrying them can be named unchecked rather than counted as
   // compiled clean.
@@ -1573,7 +1652,7 @@ async function auditDocs() {
   // keeps this from compiling things that are not programs.
   const continuedWithoutImports = new Set();
   for (const sample of all) {
-    if (isModule(sample.code)) continue;
+    if (isModule(sample.code, extensionFor(sample))) continue;
     const names = inheritedNames(sample, all);
     if (names.length === 0) continue;
     const withContext = withEarlierContext(sample, names, all);
@@ -1734,19 +1813,33 @@ async function auditDocs() {
     ...readerFiles.map(text => ({ mark: "reader-file", text }))
   );
 
-  // Nothing may be dropped on the floor. `real` is charged to a page and
-  // `setAside` is ratcheted by identity; a diagnostic in neither is one the
-  // gate cannot see, which is the shape of every bucket that has escaped so
-  // far. Counted rather than enumerated, because enumerating is what kept
-  // leaving room for the next one. `continued` is excluded: those are
-  // recompiled with their context and come back through this same partition.
-  const accountedFor = real.length + setAside.length + continued.length;
-  if (accountedFor < classified) {
+  // Nothing may be dropped on the floor. `real` is charged to a page, the
+  // classifier's other buckets are set aside by identity, and `continued` is
+  // recompiled and comes back through this same partition; a diagnostic in
+  // none of them is one the gate cannot see, which is the shape of every
+  // bucket that has escaped so far.
+  //
+  // EXACT, not "at least". Comparing against the whole of `setAside` counted
+  // entries added before classification, the first pass's suppressions among
+  // them, and that surplus could cover for a bucket left out of both sides. An
+  // equality over the classifier's own output has nothing to hide behind.
+  //
+  // `unchecked` is not added: the classifier appends it to `real` before
+  // returning, so counting it again would be the same surplus one line down.
+  const missing = unaccountedFor({
+    total: classified,
+    real: real.length,
+    continued: continued.length,
+    readerFiles: readerFiles.length,
+    uninstalled: uninstalled.length,
+    implicitAny: implicitAny.length,
+  });
+  if (missing !== 0) {
     throw new Error(
-      `doc samples: ${String(classified - accountedFor)} diagnostic(s) were ` +
-        `classified into neither the findings nor the set-aside list, so the ` +
-        `gate cannot see them. A new bucket has to be recorded, not just ` +
-        `reported.`
+      `doc samples: the classifier produced ${String(classified)} diagnostic(s) ` +
+        `and ${String(classified - missing)} were accounted for. A bucket has ` +
+        `to be charged to a page or recorded by identity, not just reported: ` +
+        `the gate cannot see one that is neither.`
     );
   }
 

--- a/scripts/check-doc-samples.mjs
+++ b/scripts/check-doc-samples.mjs
@@ -1340,6 +1340,13 @@ export async function classifyDocDiagnostics({ diagnostics, samples }) {
     uncheckedSamples,
     readerFiles,
     implicitAny,
+    // Every diagnostic that came in, so a caller can prove it kept them all.
+    // The buckets above are a partition, and the audit's job is to record each
+    // one somewhere the ratchet can see. Four times a bucket was reported to
+    // the console and left out of the baseline, and each fix enumerated the
+    // buckets it knew about, which is why a fifth kept being available. A count
+    // the caller can check does not depend on anybody remembering.
+    total: diagnostics.length,
   };
 }
 
@@ -1697,6 +1704,7 @@ async function auditDocs() {
     uncheckedSamples,
     readerFiles,
     implicitAny,
+    total: classified,
   } = await classifyDocDiagnostics({
     diagnostics: [...firstPass, ...fromContext],
     samples: all,
@@ -1712,6 +1720,12 @@ async function auditDocs() {
     // not see.
     ...implicitAny.map(text => ({ mark: "implicit-any", text })),
     ...fromInheritedBlocks.map(text => ({ mark: "implicit-any", text })),
+    // An import of a package that is published but not installed here. The
+    // reader has it and this checkout does not, so the page is not charged.
+    // TypeScript types everything reached through that import as `any` all the
+    // same, so misspelling a package name removed a fence's checking while
+    // moving no number: the fourth bucket to do exactly that.
+    ...uninstalled.map(text => ({ mark: "uninstalled", text })),
     // An import of a file only the reader has. It is right not to charge the
     // page, since the file legitimately is not here. But the binding becomes
     // `any`, so everything reached through it stops being checked while the
@@ -1719,6 +1733,22 @@ async function auditDocs() {
     // is what stops one quietly joining them.
     ...readerFiles.map(text => ({ mark: "reader-file", text }))
   );
+
+  // Nothing may be dropped on the floor. `real` is charged to a page and
+  // `setAside` is ratcheted by identity; a diagnostic in neither is one the
+  // gate cannot see, which is the shape of every bucket that has escaped so
+  // far. Counted rather than enumerated, because enumerating is what kept
+  // leaving room for the next one. `continued` is excluded: those are
+  // recompiled with their context and come back through this same partition.
+  const accountedFor = real.length + setAside.length + continued.length;
+  if (accountedFor < classified) {
+    throw new Error(
+      `doc samples: ${String(classified - accountedFor)} diagnostic(s) were ` +
+        `classified into neither the findings nor the set-aside list, so the ` +
+        `gate cannot see them. A new bucket has to be recorded, not just ` +
+        `reported.`
+    );
+  }
 
   // The survivors are actionable, and their first-pass copies stop counting as
   // continuations: the same page and the same name, whatever line each landed
@@ -1904,6 +1934,7 @@ export function compareToBaseline({
   const mine = file => only === null || file === only;
 
   const lost = [];
+  const gained = [];
   if (only === null) {
     const seen = {
       pages: coverage.files.length,
@@ -1913,6 +1944,14 @@ export function compareToBaseline({
     for (const [what, was] of Object.entries(baseline.coverage ?? {})) {
       if ((seen[what] ?? 0) < was) {
         lost.push(`${what}: was ${String(was)}, now ${String(seen[what] ?? 0)}`);
+      }
+      // A GAIN has to be recorded too, or it is not protected. Accepting one
+      // silently meant a fence added today could be deleted tomorrow, returning
+      // every count to what the baseline holds, and both changes passed: a
+      // ratchet that only resists decreases from a number nobody updates
+      // protects the corpus as it was and nothing since.
+      if ((seen[what] ?? 0) > was) {
+        gained.push(`${what}: was ${String(was)}, now ${String(seen[what] ?? 0)}`);
       }
     }
   }
@@ -1925,6 +1964,18 @@ export function compareToBaseline({
           `${file}: ${what} was ${String(was[what])}, now ${String(now[what] ?? 0)}`
         );
       }
+      if ((now[what] ?? 0) > (was[what] ?? 0)) {
+        gained.push(
+          `${file}: ${what} was ${String(was[what])}, now ${String(now[what] ?? 0)}`
+        );
+      }
+    }
+  }
+  // A page the baseline has never seen is a gain as well.
+  for (const file of coverage.files) {
+    if (!mine(file)) continue;
+    if (!(baseline.samplesPerPage ?? {})[file]) {
+      gained.push(`${file}: not in the baseline`);
     }
   }
 
@@ -1962,7 +2013,7 @@ export function compareToBaseline({
       better.push(`${file}: allowed ${String(cap)}, found ${String(count)}`);
   }
 
-  return { lost, appeared, gone, worse, better };
+  return { lost, gained, appeared, gone, worse, better };
 }
 
 /**
@@ -1970,7 +2021,10 @@ export function compareToBaseline({
  * Shared by the repository-wide and single-page paths so the two cannot drift
  * into telling a contributor different things about the same state.
  */
-function reportComparison({ lost, appeared, gone, worse, better }, findings) {
+function reportComparison(
+  { lost, gained, appeared, gone, worse, better },
+  findings
+) {
   if (lost.length > 0) {
     console.error(
       "\ndoc samples: fewer samples are being checked than the baseline records. " +
@@ -1978,6 +2032,16 @@ function reportComparison({ lost, appeared, gone, worse, better }, findings) {
         "was fixed. If the loss is intended, rewrite the baseline and say why.\n"
     );
     for (const line of lost) console.error(`  ${line}`);
+    return true;
+  }
+
+  if ((gained ?? []).length > 0) {
+    console.error(
+      "\ndoc samples: more samples are being checked than the baseline records, " +
+        "which is good news it has not been told. Rewrite it so the gate starts " +
+        "protecting them; until then they can be deleted again for free.\n"
+    );
+    for (const line of gained) console.error(`  ${line}`);
     return true;
   }
 

--- a/scripts/check-doc-samples.mjs
+++ b/scripts/check-doc-samples.mjs
@@ -80,9 +80,9 @@ const ROOT = fileURLToPath(new URL("..", import.meta.url));
 // passed. The closing run is a backreference, so a fence still has to close with
 // what it opened with.
 const RAW_FENCE =
-  /(?:^|\n)([ \t]*(?:>[ \t]*)*)(```+|~~~+)(\w*)[^\n]*\n([\s\S]*?)\r?\n[ \t]*(?:>[ \t]*)*\2[`~]*[ \t\r]*(?=\n|$)/g;
+  /(?:^|\n)([ \t]*(?:>[ \t]*)*)(```+|~~~+)(\w*)([^\n]*)\n([\s\S]*?)\r?\n[ \t]*(?:>[ \t]*)*\2[`~]*[ \t\r]*(?=\n|$)/g;
 const ESCAPED_FENCE =
-  /(?:^|\n)([ \t]*(?:>[ \t]*)*)((?:\\`){3,})(\w*)[^\n]*\n([\s\S]*?)\r?\n[ \t]*(?:>[ \t]*)*\2(?:\\`)*[ \t\r]*(?=\n|$)/g;
+  /(?:^|\n)([ \t]*(?:>[ \t]*)*)((?:\\`){3,})(\w*)([^\n]*)\n([\s\S]*?)\r?\n[ \t]*(?:>[ \t]*)*\2(?:\\`)*[ \t\r]*(?=\n|$)/g;
 
 /**
  * Take the blockquote markers off a body, and only when it had them.
@@ -108,11 +108,40 @@ const isTypeScript = lang =>
 /** JSX needs a .tsx extension or the parser reads `<` as a type argument. */
 const looksLikeJsx = code => /<\/[A-Za-z]|\/>/.test(code);
 
+/**
+ * A TypeScript fence that opens and never closes.
+ *
+ * `matchAll` yields nothing for one, so the sample is not extracted, not
+ * counted and not compiled. On an existing page the coverage ratchet catches
+ * the loss; on a NEW page, or one that had no TypeScript before, there is no
+ * held count to fall below, so a malformed block changes no protected value and
+ * passes while the rest of the page renders as code. Breaking a fence and then
+ * rewriting the baseline over the broken tree is how this gate was defeated
+ * once already, from the inside.
+ *
+ * Returns the opening lines, one per unterminated fence, so the report can say
+ * where to look.
+ */
+export function unterminatedFences(text) {
+  const opener = /^[ \t]*(?:>[ \t]*)*(```+|~~~+)(\w*)/;
+  const open = [];
+  for (const line of text.split("\n")) {
+    const m = line.match(opener);
+    if (!m) continue;
+    const last = open[open.length - 1];
+    // A closer is the same delimiter run with no language after it. Anything
+    // else opens a nested block, which Markdown allows only with a longer run.
+    if (last && m[1].startsWith(last.delimiter) && !m[2]) open.pop();
+    else if (!last) open.push({ delimiter: m[1], lang: m[2], line });
+  }
+  return open.filter(f => isTypeScript(f.lang)).map(f => f.line.trim());
+}
+
 export function extractFrom(kind, text, file) {
   const out = [];
-  const push = (code, index, lang) => {
+  const push = (code, index, lang, meta = "") => {
     const trimmed = code.trim();
-    if (trimmed) out.push({ file, index, code: trimmed, lang });
+    if (trimmed) out.push({ file, index, code: trimmed, lang, meta });
   };
   if (kind === "fenced-in-template-literal" || kind === "markdown-dir") {
     // A Markdown FILE is not a template literal, so its backslashes are already
@@ -123,10 +152,10 @@ export function extractFrom(kind, text, file) {
     const literal = kind === "fenced-in-template-literal";
     for (const m of text.matchAll(literal ? ESCAPED_FENCE : RAW_FENCE)) {
       // 1 is the container prefix, 2 the delimiter, 3 the language token,
-      // 4 the body.
+      // 4 the rest of the info string, 5 the body.
       if (!isTypeScript(m[3])) continue;
-      const body = stripContainer(m[4], m[1]);
-      push(literal ? unescapeTemplate(body) : body, out.length, m[3]);
+      const body = stripContainer(m[5], m[1]);
+      push(literal ? unescapeTemplate(body) : body, out.length, m[3], m[4]);
     }
   } else if (kind === "template-literal-consts") {
     // Exported const NAME = `...`; where the body is TypeScript, not Markdown.
@@ -156,8 +185,24 @@ export function extractFrom(kind, text, file) {
  * sample advertised as tsx would have been checked under rules a reader
  * pasting it never gets.
  */
-export const extensionFor = sample =>
-  sample.lang === "tsx" || looksLikeJsx(sample.code) ? "tsx" : "ts";
+export const extensionFor = sample => {
+  // A stated filename wins over anything inferred from the body. A fence
+  // headed `ts title="nextly.config.ts"` advertises the file a reader is meant
+  // to paste it into, and compiling it as TSX because it happens to contain
+  // angle brackets checks it under rules that reader never gets. 46 fences in
+  // these pages name a file, and the names carry real extensions.
+  //
+  // Not for a file this harness built, though. A rebuilt sample carries the
+  // original fence's metadata, and the concatenation of earlier fences in front
+  // of it is not the file that title names: forcing `.ts` on it when the pasted
+  // part contains JSX makes it fail to parse for a reason the page does not
+  // have. `prependedLines` is only set on a rebuild.
+  const stated = sample.prependedLines
+    ? undefined
+    : sample.meta?.match(/\.(tsx?)\b/)?.[1];
+  if (stated) return stated;
+  return sample.lang === "tsx" || looksLikeJsx(sample.code) ? "tsx" : "ts";
+};
 
 /**
  * A file the sample quotes and the reader writes: ./collections/Posts, or the
@@ -227,7 +272,13 @@ export const isModule = code =>
   // program a reader runs, and requiring ESM syntax filed it as a fragment so
   // nothing compiled it: the webhook-verification example on the form-builder
   // page is exactly that shape, and its undefined names were never read.
-  /(?:^|[^.\w])require\s*\(/m.test(code);
+  /(?:^|[^.\w])require\s*\(/m.test(code) ||
+  // So does a dynamic one. `const nx = await import("nextly")` loads a package
+  // exactly as the declaration form does, and reading only declarations left
+  // such a fence extracted, never compiled, and free to call methods that do
+  // not exist. `.import(` is excluded for the same reason `require` is: a
+  // property access of that name is not a module load.
+  /(?:^|[^.\w])import\s*\(/m.test(code);
 
 /**
  * The documentation this repository owns and publishes.
@@ -252,12 +303,30 @@ export function collectDocSamples() {
           ? [join(dir, e.name)]
           : []
     );
-  return walk(root).flatMap(full =>
-    extractFrom(
-      "markdown-dir",
-      readFileSync(full, "utf-8"),
-      relative(ROOT, full)
-    )
+  const pages = walk(root).map(full => ({
+    file: relative(ROOT, full),
+    text: readFileSync(full, "utf-8"),
+  }));
+  // A fence that never closes is checked here rather than inferred from a
+  // count, because on a page with no held count there is nothing for a count to
+  // fall below.
+  const broken = pages.flatMap(page =>
+    unterminatedFences(page.text).map(line => `${page.file}: ${line}`)
+  );
+  if (broken.length > 0) {
+    const detail = broken.map(line => `  ${line}`).join("\n");
+    const err = new Error(
+      `these TypeScript fences open and never close, so the samples in them ` +
+        `are not extracted and the rest of each page renders as code:\n${detail}`
+    );
+    // Marked, because the caller treats a failure to read the tree as a reason
+    // to stop quietly. This is the opposite: a page IS readable and is wrong,
+    // and stopping quietly is how a broken fence gets recorded as normal.
+    err.brokenFences = broken;
+    throw err;
+  }
+  return pages.flatMap(page =>
+    extractFrom("markdown-dir", page.text, page.file)
   );
 }
 
@@ -910,6 +979,25 @@ function topLevelOnly(code) {
   return chars.join("");
 }
 
+/**
+ * The import declarations a source actually has.
+ *
+ * Parsed as TSX, because these samples are, and a parse never throws here: on
+ * malformed input TypeScript produces a tree with diagnostics rather than an
+ * exception, and a statement list that is short of a broken import is the right
+ * answer anyway.
+ */
+function importsIn(source) {
+  const parsed = ts.createSourceFile(
+    "sample.tsx",
+    source,
+    ts.ScriptTarget.Latest,
+    false,
+    ts.ScriptKind.TSX
+  );
+  return parsed.statements.filter(ts.isImportDeclaration);
+}
+
 export function declaredNamesIn(source) {
   const code = topLevelOnly(source);
   const names = new Set();
@@ -947,27 +1035,23 @@ export function declaredNamesIn(source) {
       add(renamed ? renamed[1] : piece.match(/^[A-Za-z_$][\w$]*/)?.[0]);
     }
   }
-  // Imports are read from the ORIGINAL source, not the top-level view. An
-  // import clause spans lines and opens a brace, so blanking by depth erased
-  // the middle of `import {\n  defineConfig,\n} from "nextly"` and a later
-  // fence using the name was reported as undefined. An import binding is
-  // top-level wherever its clause happens to wrap.
-  for (const m of source.matchAll(/^\s*import\s+([^;]*?)\s+from\s/gms)) {
-    // `import type { Foo }` and `import type Foo`: the keyword belongs to the
-    // whole clause and is not a binding. Stripped here, before the braces
-    // become commas, so that what survives inside them is only bindings.
-    const clause = m[1].replace(/^type\s+/, "");
-    for (const part of clause.replace(/[{}]/g, ",").split(",")) {
-      // `import { type Foo }` binds Foo. Taking the first identifier recorded
-      // `type` and lost the name, so a later fence using it was reported as a
-      // missing name rather than rebuilt with its context: a false finding on a
-      // common syntax. The keyword is dropped only when an identifier follows
-      // it, because `import { type }` legally binds something called `type`.
-      const piece = part.trim().replace(/^type\s+(?=[A-Za-z_$])/, "");
-      if (!piece) continue;
-      const alias = piece.match(/\bas\s+([A-Za-z_$][\w$]*)$/);
-      add(alias ? alias[1] : piece.match(/^[A-Za-z_$][\w$]*/)?.[0]);
-    }
+  // Imports come from the PARSE, not from a pattern over the text. They cannot
+  // be read from the top-level view either: an import clause opens a brace, so
+  // masking by depth erases the middle of `import {\n  defineConfig,\n} from
+  // "nextly"` and a later fence using the name reads as undefined. Reading the
+  // raw text instead recorded an `import { ghost } from "pkg"` written inside a
+  // block comment or a template literal as a real binding, which then excused a
+  // fence that used `ghost` as a continuation of a page that never bound it. A
+  // parser has neither problem: a comment produces no statement, and a wrapped
+  // clause is one statement however it is laid out.
+  for (const statement of importsIn(source)) {
+    const clause = statement.importClause;
+    if (!clause) continue;
+    if (clause.name) add(clause.name.text);
+    const bindings = clause.namedBindings;
+    if (!bindings) continue;
+    if (ts.isNamespaceImport(bindings)) add(bindings.name.text);
+    else for (const element of bindings.elements) add(element.name.text);
   }
   return [...names];
 }
@@ -1393,6 +1477,9 @@ async function auditDocs() {
   try {
     all = collectDocSamples();
   } catch (err) {
+    // A malformed page is a finding, not a reason to stop looking. Only an
+    // unreadable tree is the latter.
+    if (err.brokenFences) throw err;
     console.log(
       `docs: the tree is present but incomplete, so nothing was audited.\n  ${String(err.message ?? err)}`
     );

--- a/scripts/check-doc-samples.test.mjs
+++ b/scripts/check-doc-samples.test.mjs
@@ -8,6 +8,7 @@ import {
   identityOf,
   isModule,
   pageOf,
+  unaccountedFor,
   unterminatedFences,
 } from "./check-doc-samples.mjs";
 
@@ -543,5 +544,96 @@ describe("compareToBaseline and coverage gains", () => {
 
     expect(gained).toEqual([]);
     expect(lost).toEqual([]);
+  });
+});
+
+describe("isModule reads the tree, not the text", () => {
+  const cases = [
+    ['// dynamically import("nextly")\nconst a = { b: 1 };', false, "a mention in a comment"],
+    ['const s = "import(x)";', false, "a mention in a string"],
+    ['const nx = await import("nextly");', true, "a real dynamic import"],
+    ['const c = require("crypto");', true, "a require call"],
+    ["registry.require(thing);", false, "a property access named require"],
+    ['import x from "nextly";', true, "a declaration"],
+    ["export const a = 1;", true, "an export modifier"],
+    ["export default {};", true, "an export assignment"],
+    ['export { a } from "m";', true, "a re-export"],
+    ["const a = 1;", false, "a plain fragment"],
+  ];
+
+  for (const [code, want, what] of cases) {
+    it(`answers ${String(want)} for ${what}`, () => {
+      expect(isModule(code)).toBe(want);
+    });
+  }
+
+  it("differs from the text pattern it replaced", () => {
+    // The control. A pattern cannot tell a call from a mention, so a comment
+    // made a fragment look like a module and the audit compiled a block it
+    // deliberately excludes.
+    const mention = '// dynamically import("nextly")\nconst a = { b: 1 };';
+    expect(/(?:^|[^.\w])import\s*\(/m.test(mention)).toBe(true);
+    expect(isModule(mention)).toBe(false);
+  });
+});
+
+describe("declaredNamesIn under the right grammar", () => {
+  const code = ['const id = <T>(x: T) => x;', 'import { defineConfig } from "nextly";'].join("\n");
+
+  it("keeps the imports of a .ts sample that TSX would misparse", () => {
+    // `<T>(x: T) => x` is a generic arrow in .ts and an unclosed element in
+    // .tsx. Parsing a .ts sample as TSX yields a recovery tree that drops every
+    // import after it, so the names went missing while the fence still
+    // compiled, and a later fence using one was reported as undefined.
+    expect(declaredNamesIn(code, "ts").sort()).toEqual(["defineConfig", "id"]);
+    // The control: the grammar this used unconditionally loses the import.
+    expect(declaredNamesIn(code, "tsx")).toEqual(["id"]);
+  });
+});
+
+describe("unaccountedFor", () => {
+  const complete = {
+    total: 10,
+    real: 4,
+    continued: 2,
+    readerFiles: 2,
+    uninstalled: 1,
+    implicitAny: 1,
+  };
+
+  it("is zero when every diagnostic went somewhere", () => {
+    expect(unaccountedFor(complete)).toBe(0);
+  });
+
+  it("counts what a forgotten bucket would leave behind", () => {
+    // The case this exists for: a future bucket reported to the console and
+    // left out of both the findings and the set-aside list.
+    expect(unaccountedFor({ ...complete, uninstalled: 0 })).toBe(1);
+  });
+
+  it("would not have noticed with a surplus term in the sum", () => {
+    // Why the comparison is exact rather than "at least". Adding a term that
+    // is not part of the partition, as counting the whole set-aside list did,
+    // lets a missing bucket hide behind it.
+    const withSurplus = { ...complete, uninstalled: 0, real: complete.real + 1 };
+    expect(unaccountedFor(withSurplus)).toBe(0);
+  });
+});
+
+describe("unterminatedFences and closing lines", () => {
+  it("does not accept a delimiter carrying attributes as a closer", () => {
+    // ```` ```{.foo} ```` has an empty language capture, so checking only that
+    // capture treated it as a closer. `extractFrom` rejects the same line,
+    // because a closing fence may hold only the delimiter and whitespace, so
+    // the sample went neither extracted nor reported.
+    const page = ["```ts", "const a = 1;", "```{.foo}", "", "prose"].join("\n");
+
+    expect(unterminatedFences(page)).toEqual(["```ts"]);
+    expect(extractFrom("markdown-dir", page, "d.mdx")).toEqual([]);
+  });
+
+  it("still accepts a plain closer, and one with trailing whitespace", () => {
+    expect(unterminatedFences(["```ts", "const a = 1;", "```", ""].join("\n"))).toEqual([]);
+    expect(unterminatedFences(["```ts", "const a = 1;", "```   ", ""].join("\n"))).toEqual([]);
   });
 });

--- a/scripts/check-doc-samples.test.mjs
+++ b/scripts/check-doc-samples.test.mjs
@@ -3,9 +3,12 @@ import { describe, expect, it } from "vitest";
 import {
   compareToBaseline,
   declaredNamesIn,
+  extensionFor,
   extractFrom,
   identityOf,
+  isModule,
   pageOf,
+  unterminatedFences,
 } from "./check-doc-samples.mjs";
 
 /**
@@ -182,6 +185,7 @@ describe("compareToBaseline", () => {
 
       expect(verdict).toEqual({
         lost: [],
+        gained: [],
         appeared: [],
         gone: [],
         worse: [],
@@ -389,5 +393,155 @@ describe("declaredNamesIn and regex literals", () => {
 
     expect(declaredNamesIn(code).includes("re")).toBe(true);
     expect(declaredNamesIn(code).includes("after")).toBe(true);
+  });
+});
+
+describe("isModule", () => {
+  it("counts a dynamic import, which loads a package like the declaration does", () => {
+    expect(isModule('const nx = await import("nextly");')).toBe(true);
+    // The control: the rule this replaced saw only declarations, exports and
+    // require, so such a fence was extracted and never compiled.
+    const declarationsOnly = c =>
+      /^\s*import\b/m.test(c) || /^\s*export\b/m.test(c) || /(?:^|[^.\w])require\s*\(/m.test(c);
+    expect(declarationsOnly('const nx = await import("nextly");')).toBe(false);
+  });
+
+  it("does not count a property access that happens to be named import", () => {
+    expect(isModule("registry.import(thing);")).toBe(false);
+    expect(isModule("const a = 1;")).toBe(false);
+  });
+});
+
+describe("unterminatedFences", () => {
+  const body = 'import { defineConfig } from "nextly";';
+
+  it("reports a TypeScript fence that never closes", () => {
+    expect(
+      unterminatedFences(["```ts", body, "", "prose that never closes"].join("\n"))
+    ).toEqual(["```ts"]);
+  });
+
+  it("reports nothing for a fence that does close", () => {
+    expect(
+      unterminatedFences(["```ts", body, "```", "", "prose"].join("\n"))
+    ).toEqual([]);
+  });
+
+  it("ignores an unclosed fence that is not TypeScript", () => {
+    // The gate compiles TypeScript. An unclosed shell block is a rendering
+    // problem for somebody else to care about, and refusing on it would make
+    // this check fail for reasons it cannot act on.
+    expect(unterminatedFences(["```bash", "echo hi", "", "prose"].join("\n"))).toEqual([]);
+  });
+
+  it("reports an unclosed tilde fence too", () => {
+    expect(unterminatedFences(["~~~ts", body, "", "prose"].join("\n"))).toEqual(["~~~ts"]);
+  });
+});
+
+describe("extensionFor", () => {
+  const jsx = "const a = <div />;";
+
+  it("lets a stated .ts filename beat an inference from the body", () => {
+    // A fence headed `ts title="nextly.config.ts"` names the file a reader
+    // pastes into. Compiling it as tsx because it holds an angle bracket
+    // checks it under rules that reader never gets.
+    expect(extensionFor({ lang: "ts", meta: ' title="nextly.config.ts"', code: jsx })).toBe("ts");
+    expect(extensionFor({ lang: "ts", meta: ' title="app/page.tsx"', code: jsx })).toBe("tsx");
+  });
+
+  it("infers from the body when no filename is stated", () => {
+    expect(extensionFor({ lang: "ts", meta: "", code: jsx })).toBe("tsx");
+    expect(extensionFor({ lang: "ts", meta: "", code: "const a = 1;" })).toBe("ts");
+  });
+
+  it("ignores a stated filename on a rebuilt sample", () => {
+    // A rebuilt sample carries the original fence's metadata while being a
+    // concatenation that title does not describe. Forcing `.ts` on one whose
+    // pasted prefix holds JSX makes it fail to parse for a reason the page
+    // does not have.
+    expect(
+      extensionFor({ lang: "ts", meta: ' title="nextly.config.ts"', code: jsx, prependedLines: 4 })
+    ).toBe("tsx");
+  });
+});
+
+describe("declaredNamesIn and imports that are not declarations", () => {
+  it("does not bind a name from an import inside a block comment", () => {
+    const code = ["/*", 'import { ghost } from "pkg";', "*/", "const real = 1;"].join("\n");
+
+    expect(declaredNamesIn(code)).toEqual(["real"]);
+    // The control: the pattern this replaced read the raw text and could not
+    // tell a comment from a statement, so a later fence using `ghost` was
+    // excused as a continuation of a page that never bound it.
+    const byPattern = [...code.matchAll(/^\s*import\s+([^;]*?)\s+from\s/gms)].length;
+    expect(byPattern).toBe(1);
+  });
+
+  it("still binds every form a real import declares", () => {
+    // A parser swap can quietly lose a shape, so all four are asserted.
+    const wrapped = ["import {", "  defineConfig,", "  type Foo,", '} from "nextly";'].join("\n");
+    expect(declaredNamesIn(wrapped).sort()).toEqual(["Foo", "defineConfig"]);
+    expect(declaredNamesIn('import D, * as NS from "p";').sort()).toEqual(["D", "NS"]);
+    expect(declaredNamesIn('import { a as b } from "p";')).toEqual(["b"]);
+  });
+});
+
+describe("compareToBaseline and coverage gains", () => {
+  const perPage = { "docs/a.mdx": { samples: 4, compiled: 3 } };
+  const baseline = {
+    coverage: { pages: 1, samples: 4, compiled: 3 },
+    samplesPerPage: perPage,
+    pages: {},
+    findings: {},
+  };
+  const coverageOf = p => ({
+    files: Object.keys(p),
+    samples: Object.values(p).reduce((n, x) => n + x.samples, 0),
+    compiled: Object.values(p).reduce((n, x) => n + x.compiled, 0),
+    perPage: p,
+  });
+
+  it("asks for a rewrite when a page gains a sample", () => {
+    // A gain the baseline is never told about is not protected: the fence can
+    // be deleted again tomorrow, every count returns to what is recorded, and
+    // both changes pass.
+    const grown = { "docs/a.mdx": { samples: 5, compiled: 4 } };
+    const { gained, lost } = compareToBaseline({
+      baseline,
+      coverage: coverageOf(grown),
+      counted: {},
+      fingerprint: {},
+    });
+
+    expect(gained.length).toBeGreaterThan(0);
+    expect(lost).toEqual([]);
+  });
+
+  it("asks for a rewrite when a page the baseline never saw appears", () => {
+    const withNewPage = {
+      "docs/a.mdx": { samples: 4, compiled: 3 },
+      "docs/b.mdx": { samples: 2, compiled: 2 },
+    };
+    const { gained } = compareToBaseline({
+      baseline,
+      coverage: coverageOf(withNewPage),
+      counted: {},
+      fingerprint: {},
+    });
+
+    expect(gained.join("\n")).toContain("docs/b.mdx");
+  });
+
+  it("says nothing when coverage matches what is recorded", () => {
+    const { gained, lost } = compareToBaseline({
+      baseline,
+      coverage: coverageOf(perPage),
+      counted: {},
+      fingerprint: {},
+    });
+
+    expect(gained).toEqual([]);
+    expect(lost).toEqual([]);
   });
 });

--- a/scripts/doc-samples-baseline.json
+++ b/scripts/doc-samples-baseline.json
@@ -243,12 +243,14 @@
     "docs/plugins/admin-ui.mdx": {
       "#9 error TS2304: Cannot find name 'Skeleton'.": 1,
       "#9 error TS2304: Cannot find name 'Chart'.": 1,
+      "uninstalled #11 error TS2307: Cannot find module '@acme/nextly-plugin-reports' or its corresponding type declarations.": 1,
       "reader-file #0 error TS2307: Cannot find module './ReportsView' or its corresponding type declarations.": 1
     },
     "docs/plugins/auth.mdx": {
       "#1 error TS2304: Cannot find name 'verifyGoogleToken'.": 1,
       "#2 error TS2304: Cannot find name 'isTotpEnabled'.": 1,
-      "#2 error TS2304: Cannot find name 'verifyTotp'.": 1
+      "#2 error TS2304: Cannot find name 'verifyTotp'.": 1,
+      "uninstalled #0 error TS2307: Cannot find module '@acme/nextly-plugin-google' or its corresponding type declarations.": 1
     },
     "docs/plugins/author-guide.mdx": {
       "#0 error TS2304: Cannot find name 'MyPluginOptions'.": 1,


### PR DESCRIPTION
Follow-up to **#1604**, carrying one commit that missed its merge plus the two findings raised afterwards.

`9b2635b32` was pushed after #1604 was squashed at `af597c83f`, so it reached no main. Verified by content rather than by log: `git show origin/main:scripts/check-doc-samples.mjs | grep unterminatedFences` returns nothing.

## The fourth bucket, and why there was room for it

An unresolved third-party import went only to `uninstalled` and the console. TypeScript types everything reached through such an import as `any`, so misspelling a package name removed a fence's checking while moving no number the gate compares.

That is the fourth time a class of diagnostic has been reported and left out of the baseline: suppressions, implicit-any, reader-owned files, and now this. Each fix enumerated the buckets it knew about, and the comment added last time claimed "nothing is set aside without being recorded" — which was not true, because enumerating is exactly what leaves room for the next one.

So the audit **counts** instead. Every diagnostic the classifier produced has to end up charged to a page, set aside by identity, or sent back through the recompile; one that lands nowhere raises an error saying how many were lost. A bucket added later cannot escape by being forgotten, because nothing has to be remembered.

## Coverage ratchets in both directions

A gain the baseline was never told about was not protected: a fence added today could be deleted tomorrow, every count would return to what the baseline holds, and both changes passed. So everything added after a baseline write was unprotected. A gain now asks for a rewrite, exactly as a lost diagnostic already did, and a page the baseline has never seen counts as one.

## Round 10, recovered and now tested

Carried from the lost commit: dynamic imports count as modules; an unterminated TypeScript fence is an error rather than a sample nobody extracts; imports are read from the parse instead of a pattern that cannot tell a comment from a statement; a stated filename decides the parser, except on a rebuilt sample, which carries the original fence's metadata while being a concatenation that title does not describe.

**That round shipped with no unit tests.** It was checked by hand with throwaway probes and one end-to-end fence break, which was real evidence at the time and left nothing behind. It has tests now, each against a control: reverting the dynamic-import rule, the stated-extension rule and the import parse fails three tests and nothing else.

## Evidence

- `pnpm check:doc-samples` exit 0 — 36 findings across 12 pages, 199 of 330 samples compiled, 51 set aside
- `pnpm test:scripts` 29 files, 1035 tests, exit 0
- `pnpm check:comments` exit 0
- The conservation check runs against the real corpus and does not fire, which is the positive control for it: the partition is complete today, and the error exists for the day it is not.
