### PR TITLE
ci: read the turbo plan out of a stream that also carries warnings

### DIFF
--- a/scripts/check-test-lanes.mjs
+++ b/scripts/check-test-lanes.mjs
@@ -192,6 +192,22 @@ export function packagesInPlan(plan, task) {
  * warnings differ from a laptop's, and the whole check failed on a
  * `SyntaxError` at position 1. Silencing pnpm removes the preamble instead of
  * teaching a scanner to skip it, and the JSON then starts at the first byte.
+ *
+ * 🔴 `--silent` is not sufficient, and no pnpm flag is. It silences the SCRIPT;
+ * a complaint about the config itself is written while pnpm READS that config,
+ * before there is a script to be silent about, and it goes to stdout. Measured
+ * on the runner: `WARN  Issue while reading "…/_temp/.npmrc". Failed to replace
+ * env in config: ${NODE_AUTH_TOKEN}` prepended 214 bytes to a 1.75 MB plan and
+ * the parse threw at position 1. Measured against that same input,
+ * `--loglevel=error` and `--reporter=silent` both leave it exactly 214 bytes
+ * long — the warning precedes flag handling, so suppression cannot reach it.
+ *
+ * So the reader separates the two instead, and the separator is the COLUMN.
+ * Note why the obvious `indexOf("{")` is still wrong, and it is the same brace
+ * the line above was bitten by: that warning quotes `${NODE_AUTH_TOKEN}`, so
+ * the first `{` in the stream belongs to the diagnostic. turbo pretty-prints
+ * the plan from column zero and every pnpm diagnostic is indented, so a
+ * LINE-INITIAL `{` is the first byte that can begin the plan.
  */
 export function planForScript(script, cwd, run = execFileSync) {
   const output = run("pnpm", ["--silent", "run", script, "--dry=json"], {
@@ -199,8 +215,13 @@ export function planForScript(script, cwd, run = execFileSync) {
     encoding: "utf8",
     maxBuffer: 64 * 1024 * 1024,
   });
+  const start = output.search(/^\{/m);
   try {
-    return JSON.parse(output.trim());
+    // Refused rather than parsed when no line begins an object: slicing from
+    // -1 would drop the last character and report a syntax error about a
+    // stream that never contained a plan at all.
+    if (start < 0) throw new SyntaxError("no line begins a JSON object");
+    return JSON.parse(output.slice(start).trim());
   } catch (error) {
     // Never a bare parse error: what this was reading is the only thing that
     // explains it, and a `SyntaxError` alone costs a CI round trip to diagnose.

--- a/scripts/check-test-lanes.test.mjs
+++ b/scripts/check-test-lanes.test.mjs
@@ -305,6 +305,50 @@ describe("this repository", () => {
         }
       });
 
+      it("finds the plan behind whatever pnpm printed first", () => {
+        // Measured on the runner rather than imagined: pnpm complained about
+        // the config it was READING — `WARN  Issue while reading
+        // ".../_temp/.npmrc". Failed to replace env in config:
+        // ${NODE_AUTH_TOKEN}` — and 214 bytes of it landed on stdout ahead of a
+        // 1.75 MB plan. Two lanes failed on `SyntaxError` at position 1 while
+        // turbo had answered perfectly, and it took three pull requests with
+        // it.
+        //
+        // No pnpm flag reaches this: the warning is written while the config is
+        // read, before there is a script to be silent about. Measured against
+        // that same input, `--loglevel=error` and `--reporter=silent` both left
+        // the output exactly 214 bytes long.
+        //
+        // The `${...}` in the warning is the whole reason the separator is the
+        // COLUMN rather than the first brace — that quoted variable puts a `{`
+        // in the diagnostic, ahead of the plan's own.
+        const plan = '{\n  "id": "x",\n  "tasks": []\n}\n';
+        const warned =
+          ' WARN  Issue while reading "/x/.npmrc". ' +
+          'Failed to replace env in config: ${NODE_AUTH_TOKEN}\n' +
+          plan;
+
+        expect(planForScript("lane:test", root, () => warned)).toEqual({
+          id: "x",
+          tasks: [],
+        });
+      });
+
+      it("still refuses a stream that carries no plan at all", () => {
+        // The other half, and the one that matters more: a reader that skips
+        // to a brace must not become a reader that invents a pass. Slicing from
+        // a `search` miss would drop the last character and blame a syntax
+        // error on a stream that never held a plan.
+        const onlyNoise = " WARN  something went wrong\n";
+
+        expect(() => planForScript("lane:test", root, () => onlyNoise)).toThrow(
+          /did not produce a turbo plan/
+        );
+        expect(() => planForScript("lane:test", root, () => "")).toThrow(
+          /did not produce a turbo plan/
+        );
+      });
+
       it("runs every package that declares the task", () => {
         // Against the real tree and the real command, not a fixture: turbo is
         // asked what the lane script would execute, so what is measured is what


### PR DESCRIPTION
Fixes a red `main`. Three open pull requests are failing `Lint / Typecheck / Test / Build` on this and cannot merge: **#1616, #1622, #1615**.

## What broke

#1620 changed the lane check to ask turbo for its plan — `pnpm --silent run <script> --dry=json`, `JSON.parse`d at `scripts/check-test-lanes.mjs:203`. On the runner, pnpm writes a warning about the config it is *reading* onto that same stream first:

```
 WARN  Issue while reading ".../_temp/.npmrc". Failed to replace env in config: ${NODE_AUTH_TOKEN}
```

214 bytes ahead of a 1.75 MB plan, so the parse throws at position 1 while turbo has answered perfectly. Two tests fail — the `test` lane and the `test:integration` lane — and three more jobs are skipped as dependents of the failing one, so `Browser tests`, `Dev script starts every watcher` and `Scaffold smoke` were never evaluated at all.

## Why no flag fixes it

The warning is written while the config is read, before there is a script to be silent about, so `--silent` cannot cover it. Measured against the same input, stdout bytes:

| | bytes | parses |
|---|---|---|
| baseline | 1,748,401 | no |
| `--loglevel=error` | 1,748,401 | no |
| `--reporter=silent` | 1,748,401 | no |
| clean control | 1,748,187 | yes, 65 tasks |

Supplying `NODE_AUTH_TOKEN` is the other tempting remedy and it treats the instance rather than the class: any pnpm diagnostic, present or future, breaks a JSON parse of stdout.

## The fix

Separate diagnostics from data, and the separator is the **column** rather than the first brace.

The first brace is the wrong one, and it is the same brace the existing note in this function was already bitten by: that warning quotes `${NODE_AUTH_TOKEN}`, which puts a `{` in the diagnostic ahead of the plan’s own. turbo prints the plan from column zero and pnpm indents every diagnostic, so a line-initial `{` is the first byte that can begin a plan.

A stream carrying no plan is still **refused** rather than read as an empty one — slicing from a `search` miss would drop the last character and blame a syntax error on a stream that never held a plan.

## Verification

- Reproduced locally by pointing pnpm at an npmrc holding an unreplaced `${NODE_AUTH_TOKEN}`: the clean control parses with 65 tasks, the polluted one throws at position 1. With the fix, the polluted stream parses with the same 65.
- Two tests added. **Break-verified three ways, each killing its own test by its own route:** parsing the whole stream (today’s code) kills the recovery test; `indexOf("{")` instead of line-initial kills the recovery test, which is what proves the column choice specifically; a lenient `{ tasks: [] }` fallback kills only the refusal test.
- Suite 37/37, eslint 0, fallow `pass` with 0 introduced findings.

No changeset — CI-only. Prettier reports both files unformatted, on `main` in place as well as here; left alone rather than folding an unrelated reformat into a fix for a red `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved test-lane planning when package-manager warnings appear before the plan output.
  - Added clearer errors when no valid test plan is produced.

- **Tests**
  - Added coverage for plans preceded by configuration warnings.
  - Added coverage for empty or warning-only output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->