### PR TITLE
ci: read turbo's plan out of a stream that carries more than the plan

### DIFF
--- a/scripts/check-test-lanes.mjs
+++ b/scripts/check-test-lanes.mjs
@@ -41,6 +41,8 @@ import { readFileSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { parseTurboPlan } from "./turbo-plan.mjs";
+
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
 /**
@@ -150,13 +152,15 @@ export function workspaceManifests(cwd, run = execFileSync) {
       maxBuffer: 32 * 1024 * 1024,
     })
   );
-  return projects
-    .map(project => relative(cwd, project.path ?? ""))
-    // The workspace root is a project to pnpm and not a package to this: it
-    // declares no suites of its own and no lane selects it.
-    .filter(directory => directory !== "" && directory !== ".")
-    .map(directory => `${directory}/package.json`)
-    .sort();
+  return (
+    projects
+      .map(project => relative(cwd, project.path ?? ""))
+      // The workspace root is a project to pnpm and not a package to this: it
+      // declares no suites of its own and no lane selects it.
+      .filter(directory => directory !== "" && directory !== ".")
+      .map(directory => `${directory}/package.json`)
+      .sort()
+  );
 }
 
 /**
@@ -186,28 +190,13 @@ export function packagesInPlan(plan, task) {
  * `--dry=json` is appended to the real command rather than reconstructed, so
  * what is measured is what CI runs.
  *
- * 🔴 `--silent` is load-bearing. Without it pnpm echoes the package name and
- * the command before handing over, and finding the plan meant scanning for the
- * first `{` — which took a brace out of that preamble on a runner whose npm
- * warnings differ from a laptop's, and the whole check failed on a
- * `SyntaxError` at position 1. Silencing pnpm removes the preamble instead of
- * teaching a scanner to skip it, and the JSON then starts at the first byte.
- *
- * 🔴 `--silent` is not sufficient, and no pnpm flag is. It silences the SCRIPT;
- * a complaint about the config itself is written while pnpm READS that config,
- * before there is a script to be silent about, and it goes to stdout. Measured
- * on the runner: `WARN  Issue while reading "…/_temp/.npmrc". Failed to replace
- * env in config: ${NODE_AUTH_TOKEN}` prepended 214 bytes to a 1.75 MB plan and
- * the parse threw at position 1. Measured against that same input,
- * `--loglevel=error` and `--reporter=silent` both leave it exactly 214 bytes
- * long — the warning precedes flag handling, so suppression cannot reach it.
- *
- * So the reader separates the two instead, and the separator is the COLUMN.
- * Note why the obvious `indexOf("{")` is still wrong, and it is the same brace
- * the line above was bitten by: that warning quotes `${NODE_AUTH_TOKEN}`, so
- * the first `{` in the stream belongs to the diagnostic. turbo pretty-prints
- * the plan from column zero and every pnpm diagnostic is indented, so a
- * LINE-INITIAL `{` is the first byte that can begin the plan.
+ * 🔴 `--silent` is load-bearing and is not sufficient alone. Without it pnpm
+ * echoes the package name and the command before handing over, so the preamble
+ * is removed rather than skipped. It does NOT remove a warning raised while
+ * READING configuration — a runner whose `.npmrc` interpolates an unset token
+ * prints one before any reporter exists to silence — so the plan is located
+ * rather than assumed to start at the first byte. `parseTurboPlan` owns that,
+ * for both readers of a turbo plan in this repo.
  */
 export function planForScript(script, cwd, run = execFileSync) {
   const output = run("pnpm", ["--silent", "run", script, "--dry=json"], {
@@ -215,21 +204,7 @@ export function planForScript(script, cwd, run = execFileSync) {
     encoding: "utf8",
     maxBuffer: 64 * 1024 * 1024,
   });
-  const start = output.search(/^\{/m);
-  try {
-    // Refused rather than parsed when no line begins an object: slicing from
-    // -1 would drop the last character and report a syntax error about a
-    // stream that never contained a plan at all.
-    if (start < 0) throw new SyntaxError("no line begins a JSON object");
-    return JSON.parse(output.slice(start).trim());
-  } catch (error) {
-    // Never a bare parse error: what this was reading is the only thing that
-    // explains it, and a `SyntaxError` alone costs a CI round trip to diagnose.
-    throw new Error(
-      `\`pnpm ${script} --dry=json\` did not produce a turbo plan. ` +
-        `${error.message}. It began: ${JSON.stringify(output.slice(0, 200))}`
-    );
-  }
+  return parseTurboPlan(output, `\`pnpm ${script} --dry=json\``);
 }
 
 /**
@@ -488,7 +463,9 @@ if (invokedDirectly) {
     process.exit(1);
   }
 
-  console.log("check-test-lanes: ok — every package's test task is run by a lane.");
+  console.log(
+    "check-test-lanes: ok — every package's test task is run by a lane."
+  );
   for (const line of summary) console.log(line);
   // Said on the way past rather than only in the source, so a reader taking
   // this as proof of coverage knows which shape it did not judge.

--- a/scripts/turbo-inputs.test.mjs
+++ b/scripts/turbo-inputs.test.mjs
@@ -51,6 +51,9 @@ const TYPESCRIPT_EXTENSIONS = /\.(?:ts|tsx|mts|cts)$/;
  * indistinguishable from a hash gap in the summary line, which is the reason
  * this is a named constant rather than a number tucked into one call.
  */
+
+import { parseTurboPlan } from "./turbo-plan.mjs";
+
 const PROBE_TIMEOUT_MS = 180_000;
 
 function dryRun() {
@@ -59,31 +62,11 @@ function dryRun() {
     ["exec", "turbo", "run", "check-types", "--dry=json"],
     { cwd: REPO_ROOT, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 }
   );
-  // Turbo's document is pretty-printed from column zero, while the tools around
-  // it are not silent: pnpm emits config warnings and turbo a version banner,
-  // and which stream each uses varies between a terminal and a runner. So the
-  // document is located by the first line that OPENS it, rather than by the
-  // first `{` anywhere — a brace inside a warning would otherwise start the
-  // parse mid-sentence and fail on the character after it.
-  const lines = raw.split("\n");
-  const start = lines.findIndex(line => line.startsWith("{"));
-  if (start === -1) {
-    throw new Error(
-      `turbo --dry=json produced no JSON document. First 400 chars:\n${raw.slice(0, 400)}`
-    );
-  }
-  const document = lines.slice(start).join("\n");
-  try {
-    return JSON.parse(document);
-  } catch (cause) {
-    // Naming what was actually received, because the parser's own message
-    // ("Expected property name at position 1") describes the text and not
-    // where it came from, which leaves the next reader with nothing to act on.
-    throw new Error(
-      `turbo --dry=json did not parse. First 400 chars of the document:\n${document.slice(0, 400)}`,
-      { cause }
-    );
-  }
+  // Located rather than assumed: pnpm emits config warnings and turbo a
+  // version banner, and which stream each uses varies between a terminal and a
+  // runner. `parseTurboPlan` is the one reader of a turbo plan in this repo,
+  // so the rule about where the document starts is stated once.
+  return parseTurboPlan(raw, "turbo run check-types --dry=json");
 }
 
 function resolvedTasks() {

--- a/scripts/turbo-plan.mjs
+++ b/scripts/turbo-plan.mjs
@@ -1,0 +1,58 @@
+/**
+ * Reading turbo's `--dry=json` plan out of a stream that may not be only the
+ * plan.
+ *
+ * One module because two callers needed this and only one of them knew it.
+ * `check-test-lanes.mjs` parsed the whole stream and `turbo-inputs.test.mjs`
+ * located the document first; the second had already met the failure the first
+ * then hit on CI, and nothing connected them. A shared reader is what stops a
+ * lesson living in one file.
+ *
+ * @module scripts/turbo-plan
+ */
+
+/**
+ * The plan turbo printed, ignoring whatever else shared the stream.
+ *
+ * 🔴 Located by the first line that OPENS the document, never by the first `{`
+ * anywhere. pnpm's config warnings quote the variable they could not resolve —
+ * `Failed to replace env in config: ${NODE_AUTH_TOKEN}` — so the first brace in
+ * the stream can sit inside a sentence. Parsing from there yields
+ * `{NODE_AUTH_TOKEN}` and a `SyntaxError` about position 1, which describes the
+ * text and says nothing about where it came from.
+ *
+ * Silencing the runner is not enough on its own and is still worth doing.
+ * `pnpm --silent` removes the package-and-command preamble, which is reporter
+ * output; it does not remove a warning raised while READING configuration,
+ * because that happens before there is a reporter to silence. A runner whose
+ * `.npmrc` interpolates an unset token therefore prints one and a laptop does
+ * not — the difference that made this look like an environment fault rather
+ * than a parsing assumption.
+ *
+ * @param {string} raw - everything the command wrote to stdout.
+ * @param {string} describeSource - how to name the command in a failure.
+ * @returns {{ tasks?: Array<Record<string, unknown>> }} turbo's plan.
+ */
+export function parseTurboPlan(raw, describeSource) {
+  const lines = raw.split("\n");
+  const start = lines.findIndex(line => line.startsWith("{"));
+  if (start === -1) {
+    throw new Error(
+      `${describeSource} did not produce a turbo plan. Nothing in its output ` +
+        `opens a JSON document. It began: ${JSON.stringify(raw.slice(0, 200))}`
+    );
+  }
+
+  const document = lines.slice(start).join("\n");
+  try {
+    return JSON.parse(document);
+  } catch (cause) {
+    // Never a bare parse error: what this was reading is the only thing that
+    // explains it, and a `SyntaxError` alone costs a CI round trip to diagnose.
+    throw new Error(
+      `${describeSource} did not produce a turbo plan. ${cause.message}. ` +
+        `The document began: ${JSON.stringify(document.slice(0, 200))}`,
+      { cause }
+    );
+  }
+}

--- a/scripts/turbo-plan.test.mjs
+++ b/scripts/turbo-plan.test.mjs
@@ -1,0 +1,70 @@
+/**
+ * What `parseTurboPlan` has to survive: a stream carrying something other than
+ * the plan.
+ *
+ * The case that reached CI is first. `pnpm --silent` removes the reporter's
+ * preamble but not a warning raised while READING configuration, and that
+ * warning quotes the variable it could not resolve — so the first `{` in the
+ * stream sits inside `${NODE_AUTH_TOKEN}` rather than opening the document.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { parseTurboPlan } from "./turbo-plan.mjs";
+
+const PLAN = '{\n  "id": "abc",\n  "turboVersion": "2.9.18",\n  "tasks": []\n}';
+
+/** Verbatim from the run that failed, minus the path. */
+const NPMRC_WARNING =
+  ' WARN  Issue while reading "/home/runner/work/_temp/.npmrc". ' +
+  "Failed to replace env in config: ${NODE_AUTH_TOKEN}";
+
+describe("parseTurboPlan", () => {
+  it("reads a plan that arrives on its own", () => {
+    expect(parseTurboPlan(PLAN, "probe")).toEqual({
+      id: "abc",
+      turboVersion: "2.9.18",
+      tasks: [],
+    });
+  });
+
+  it("reads the plan out from under a warning that contains a brace", () => {
+    // The regression. Scanning for the first `{` anywhere starts the parse at
+    // `{NODE_AUTH_TOKEN}` and fails at position 1, which is what the runner
+    // reported while the same command was clean on a laptop.
+    expect(NPMRC_WARNING).toContain("{");
+    expect(parseTurboPlan(`${NPMRC_WARNING}\n${PLAN}`, "probe")).toEqual({
+      id: "abc",
+      turboVersion: "2.9.18",
+      tasks: [],
+    });
+  });
+
+  it("reads the plan out from under several noisy lines", () => {
+    const noisy = [NPMRC_WARNING, "turbo 2.9.18", "", PLAN].join("\n");
+    expect(parseTurboPlan(noisy, "probe").tasks).toEqual([]);
+  });
+
+  it("names the command when nothing in the output opens a document", () => {
+    expect(() =>
+      parseTurboPlan(`${NPMRC_WARNING}\n`, "`pnpm lane:test`")
+    ).toThrow(/`pnpm lane:test` did not produce a turbo plan/);
+  });
+
+  it("names the command when the document is there but broken", () => {
+    // A `SyntaxError` alone describes the text and not where it came from,
+    // which is what costs a CI round trip to diagnose.
+    expect(() =>
+      parseTurboPlan(`${NPMRC_WARNING}\n{ "tasks": [`, "`pnpm lane:test`")
+    ).toThrow(/`pnpm lane:test` did not produce a turbo plan/);
+  });
+
+  it("does not treat an indented brace as the start of the document", () => {
+    // turbo pretty-prints from column zero. An indented brace belongs to
+    // something else, and starting there yields a fragment that parses into
+    // the wrong shape rather than failing loudly.
+    expect(() => parseTurboPlan('  { "not": "the plan" }\n', "probe")).toThrow(
+      /did not produce a turbo plan.*opens a JSON document/s
+    );
+  });
+});


### PR DESCRIPTION
`main` is red, and every open PR inherits it. This is the cause.

## What fails

`Lint / Typecheck / Test / Build`, on `main` itself and on every branch built
from it:

```
FAIL scripts/check-test-lanes.test.mjs > the `test` lane > runs every package that declares the task
FAIL scripts/check-test-lanes.test.mjs > the `test:integration` lane > runs every package that declares the task

Error: `pnpm lane:test --dry=json` did not produce a turbo plan.
Unexpected token 'W', "WARN  Issu"... is not valid JSON
```

The stream a runner produces does not begin with the document:

```
 WARN  Issue while reading "/home/runner/work/_temp/.npmrc".
 Failed to replace env in config: ${NODE_AUTH_TOKEN}
{
  "id": "...",
```

## Why `--silent` did not cover it

`planForScript` chose `--silent` over locating the document, and that reasoning
holds for what it covers: pnpm's package-and-command preamble is reporter
output, and removing it beats teaching a scanner to skip it.

A warning raised while READING configuration is not reporter output. It happens
before there is a reporter to silence, so the premise that follows from it — "the
JSON then starts at the first byte" — is true on a laptop and false on a runner
whose `.npmrc` interpolates an unset token. That is the whole difference between
the two environments here, and why this passed locally.

## Why scanning for the first `{` is not the repair either

The warning quotes the variable it could not resolve. The first brace in the
stream is inside `${NODE_AUTH_TOKEN}`, so a first-brace scan starts the parse at
`{NODE_AUTH_TOKEN}` and fails one character in — a different error with the same
red, and a worse one to read.

## The change

The document is located by the first LINE that opens it, which is how turbo
pretty-prints it, from column zero.

`scripts/turbo-inputs.test.mjs` already did exactly this, and already carried a
comment explaining why the first brace is wrong. Two readers of a turbo plan
existed; one had met this failure and the other had not, and nothing connected
them. Both now call one `parseTurboPlan`, so where a plan starts is stated once.

`--silent` stays. It still removes the preamble, and one fewer thing on the
stream is worth keeping.

## Evidence

- 6 new tests for `parseTurboPlan`, using the **verbatim** warning text from the
  failing run. Each is **break-verified**: replacing the line-anchored search
  with a first-brace search fails the regression case, which is what shows the
  test tells the fix apart from the version that looks equivalent.
- `scripts/check-test-lanes.test.mjs` — 37 passing, including its own
  `still refuses a stream that carries no plan at all`, whose message contract
  this deliberately keeps rather than rewriting.
- `scripts/turbo-inputs.test.mjs` — 75 passing against the shared reader.

Reported because it shaped the change: my first version renamed the
no-document message, which broke those two existing contract tests. The phrase
belongs to that check, so both messages keep it and differ in their detail
instead.

## Scope

Repository tooling only — no package source, so no changeset, matching the rule
for test- and CI-only changes.