### PR TITLE
ci: give the branch one check that can actually block a merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -802,6 +802,84 @@ jobs:
           path: .turbo
           key: turbo-v2-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
 
+  # The one check that can block a merge, standing for all of them.
+  #
+  # 🔴 Measured before this existed: the only required status check on `main`
+  # was `Decide what this commit can affect`, a job that works out which paths a
+  # commit touches and then succeeds. Lint, typecheck, the unit suites and the
+  # browser tests were every one of them ADVISORY, so a red job could sit beside
+  # a merge that went through. Adding 15,764 tests to a job made them run; it
+  # did not make them gate.
+  #
+  # Listing those jobs individually as required checks is the obvious fix, and
+  # this repository has both of the reasons it does not work. A SKIPPED job
+  # never reports, and a required check that never reports blocks the branch for
+  # ever — every job here carries `if: needs.changes.outputs.inert != 'true'`,
+  # so a commit touching only inert paths would become unmergeable. And a matrix
+  # job's check is named from the expression it interpolates, so the list would
+  # restate names the workflow generates, which is the drift `check:test-lanes`
+  # exists to stop.
+  #
+  # So this depends on them and reports their verdict, and THIS is the check to
+  # require. Jobs can be added and removed here without touching a repository
+  # setting.
+  #
+  # `needs` IS the merge policy, and putting it here is most of the value. It
+  # used to live in a repository setting, where it appeared in no diff and no
+  # review — which is how it came to require one trivial job and nothing else
+  # without anyone deciding that. It is now a list a reviewer reads beside the
+  # jobs it names.
+  #
+  # ⚠️ The limit, stated rather than covered badly: nothing checks that a NEW
+  # job was added to this list, so one that is not here is advisory. That is a
+  # hand-written list, and this repository has spent real effort removing those
+  # — but the alternatives are worse. Deriving it would mean reading the job
+  # structure out of this YAML, which is the exact fallible read `check:test-
+  # lanes` was rewritten to stop doing, and no parser is available to scripts
+  # without taking a dependency for one call. What makes the trade acceptable is
+  # that both halves are now in ONE file a few dozen lines apart, so a job added
+  # without a line here is visible in the diff that adds it.
+  #
+  # The suites below — the browser tests, the scaffold and dev-script smokes —
+  # are deliberately NOT here yet: widening what blocks a merge is a decision
+  # about how the project ships, not a detail of this mechanism, and each is one
+  # line when that decision is made.
+  gate:
+    name: CI gate
+    # `always()`, and it is the whole point: a gate that is skipped when
+    # something upstream fails reports nothing, and nothing is what a required
+    # check must never report.
+    if: always()
+    needs:
+      - changes
+      - comments
+      - ci
+      - unit-tests-nextly
+      - unit-tests-admin
+      - entry-guard-smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+
+      # No install: the verdict is computed from the `needs` context alone, so
+      # this reads no dependency and can report even when the install that every
+      # other job depends on is what failed.
+      - name: Every job this depends on passed
+        env:
+          RESULTS: ${{ toJSON(needs) }}
+          INERT: ${{ needs.changes.outputs.inert }}
+        run: node scripts/ci-gate.mjs
+
   # The admin, in a real browser, against a real server and a real database.
   # Covers the class of failure the unit and integration suites structurally
   # cannot: jsdom has no layout engine, so a column that grew to 1024px or a

--- a/scripts/ci-gate.mjs
+++ b/scripts/ci-gate.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+
+/**
+ * One check that can block a merge, standing for all of them.
+ *
+ * 🔴 The problem this solves is not hypothetical. Measured on this repository:
+ * the only required status check is `Decide what this commit can affect`, a job
+ * that computes which paths a commit touches and then succeeds. Every job that
+ * actually verifies anything — lint, typecheck, the unit suites, the browser
+ * tests — is advisory, so a red one can sit beside a merge that goes through.
+ * Adding 15,764 tests to a job made them RUN; it did not make them gate.
+ *
+ * Listing those jobs individually as required checks is the obvious fix and it
+ * does not work here, for two reasons this repository has both of:
+ *
+ *   - a job that is SKIPPED never reports, and a required check that never
+ *     reports blocks the branch for ever. Every job here carries
+ *     `if: needs.changes.outputs.inert != 'true'`, so a commit touching only
+ *     inert paths skips them all — and could then never be merged.
+ *   - a matrix job's check is named from the expression it interpolates
+ *     (`Scaffold smoke (ubuntu-latest)`), so the list has to restate names the
+ *     workflow generates, which is the same drift the lane check exists to stop.
+ *
+ * So one job depends on all of them and reports their verdict, and IT is the
+ * required check. Jobs can be added and removed without touching a repository
+ * setting, and nothing has to restate a name.
+ *
+ * Usage (in the workflow):
+ *   RESULTS='${{ toJSON(needs) }}' INERT='${{ needs.changes.outputs.inert }}' \
+ *     node scripts/ci-gate.mjs
+ */
+
+/**
+ * Whether a skipped job is acceptable, and the answer is almost never.
+ *
+ * 🔴 Treating `skipped` as a pass is how a gate stops gating: a job switched
+ * off by an `if:` that no longer matches reports nothing, and a check reading
+ * that as success is a green light nobody chose to give. It is accepted for
+ * exactly ONE reason, which the workflow states rather than this inferring:
+ * `changes` decided the commit cannot affect anything it would have verified.
+ */
+export function skipIsAcceptable(inert) {
+  return inert === "true";
+}
+
+/**
+ * The verdict for a set of job results.
+ *
+ * `results` is GitHub's `needs` context: a name to `{ result }` map, where
+ * `result` is `success`, `failure`, `cancelled` or `skipped`.
+ *
+ * Fails closed twice over. An EMPTY set is refused rather than passed — a gate
+ * that depends on nothing agrees with everything, and that is the shape a
+ * mistyped `needs:` produces. And a result this does not recognise is refused
+ * rather than assumed benign, because the set of outcomes is GitHub's to change.
+ */
+export function gateVerdict(results, inert) {
+  const entries = Object.entries(results ?? {});
+  if (entries.length === 0) {
+    return {
+      ok: false,
+      reasons: [
+        "this gate depends on no job, so it has nothing to report. A gate " +
+          "that needs nothing agrees with everything.",
+      ],
+    };
+  }
+
+  const reasons = [];
+  for (const [name, value] of entries) {
+    const result = value?.result;
+    if (result === "success") continue;
+    if (result === "skipped") {
+      if (skipIsAcceptable(inert)) continue;
+      reasons.push(
+        `${name} was skipped, and this commit is not inert. A job that did ` +
+          "not run has verified nothing."
+      );
+      continue;
+    }
+    if (result === "failure" || result === "cancelled") {
+      reasons.push(`${name} reported ${result}.`);
+      continue;
+    }
+    reasons.push(
+      `${name} reported ${JSON.stringify(result)}, which this does not know ` +
+        "how to read. Refused rather than assumed to be good news."
+    );
+  }
+  return { ok: reasons.length === 0, reasons };
+}
+
+const invokedDirectly =
+  process.argv[1] && process.argv[1].endsWith("ci-gate.mjs");
+
+if (invokedDirectly) {
+  const raw = process.env.RESULTS;
+  if (typeof raw !== "string" || raw.trim() === "") {
+    console.error(
+      "ci-gate: RESULTS was not set, so no job's outcome could be read. The " +
+        "workflow passes `toJSON(needs)`."
+    );
+    process.exit(2);
+  }
+
+  let results;
+  try {
+    results = JSON.parse(raw);
+  } catch (error) {
+    console.error(
+      `ci-gate: RESULTS was not JSON (${error.message}). It began: ` +
+        JSON.stringify(raw.slice(0, 200))
+    );
+    process.exit(2);
+  }
+
+  const inert = process.env.INERT;
+  const { ok, reasons } = gateVerdict(results, inert);
+
+  // The population before the verdict, on the way past: a reader taking a green
+  // gate as proof should be able to see WHAT it stood for.
+  const names = Object.keys(results);
+  console.log(`ci-gate: ${names.length} job(s) reported — ${names.join(", ")}`);
+  if (inert === "true") {
+    console.log("  this commit is inert, so a skipped job is expected.");
+  }
+
+  if (!ok) {
+    console.error("\nci-gate: FAILED\n");
+    for (const reason of reasons) console.error(`  - ${reason}`);
+    process.exit(1);
+  }
+  console.log("ci-gate: ok — every job this depends on passed.");
+}

--- a/scripts/ci-gate.test.mjs
+++ b/scripts/ci-gate.test.mjs
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { gateVerdict, skipIsAcceptable } from "./ci-gate.mjs";
+
+const ok = (name = "ci") => ({ [name]: { result: "success" } });
+
+describe("skipIsAcceptable", () => {
+  it("is true only when the workflow said the commit is inert", () => {
+    expect(skipIsAcceptable("true")).toBe(true);
+  });
+
+  it("is false for everything else, including an unset flag", () => {
+    // 🔴 Reading a skipped job as a pass is how a gate stops gating, so the
+    // ONE reason it is allowed has to be stated by the workflow rather than
+    // inferred here. An absent flag is not that statement.
+    for (const value of [undefined, "", "false", "TRUE", "1"]) {
+      expect(skipIsAcceptable(value)).toBe(false);
+    }
+  });
+});
+
+describe("gateVerdict", () => {
+  it("passes when every job succeeded", () => {
+    expect(gateVerdict({ ...ok("ci"), ...ok("unit") }, "false")).toEqual({
+      ok: true,
+      reasons: [],
+    });
+  });
+
+  it("fails on a failed job, and names it", () => {
+    const verdict = gateVerdict(
+      { ...ok("ci"), unit: { result: "failure" } },
+      "false"
+    );
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reasons).toEqual(["unit reported failure."]);
+  });
+
+  it("fails on a cancelled job", () => {
+    // A cancelled job verified nothing, and a run cancelled midway is exactly
+    // when a gate is most tempting to wave through.
+    expect(gateVerdict({ unit: { result: "cancelled" } }, "false").ok).toBe(false);
+  });
+
+  it("fails on a skipped job when the commit is not inert", () => {
+    const verdict = gateVerdict({ unit: { result: "skipped" } }, "false");
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reasons[0]).toContain("did not run");
+  });
+
+  it("passes a skipped job only when the commit is inert", () => {
+    // The one legitimate skip: `changes` decided the commit cannot affect
+    // anything these jobs would have verified. Without this the branch could
+    // never merge a docs-only change, because a required check that never
+    // reports blocks for ever.
+    expect(gateVerdict({ unit: { result: "skipped" } }, "true").ok).toBe(true);
+  });
+
+  it("refuses to pass when it depends on nothing", () => {
+    // 🔴 The shape a mistyped `needs:` produces. A gate that needs nothing
+    // agrees with everything, which is the failure it exists to prevent
+    // wearing a green tick.
+    const verdict = gateVerdict({}, "true");
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reasons[0]).toContain("nothing to report");
+  });
+
+  it("refuses a result it does not recognise", () => {
+    // The set of outcomes belongs to GitHub, not to this. A new one is not
+    // assumed to be good news.
+    const verdict = gateVerdict({ unit: { result: "neutral" } }, "false");
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reasons[0]).toContain("does not know");
+  });
+
+  it("refuses a job with no result at all", () => {
+    expect(gateVerdict({ unit: {} }, "false").ok).toBe(false);
+  });
+
+  it("names every failing job, not just the first", () => {
+    const verdict = gateVerdict(
+      { a: { result: "failure" }, b: { result: "cancelled" }, c: { result: "success" } },
+      "false"
+    );
+    expect(verdict.reasons).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## The finding

I claimed on #1612 that adding `nextly` and `@nextlyhq/admin` to the unit lane
made **15,764 tests gate merges**. Half of that was wrong, and this is the
correction.

They now *run* on every push, and the job goes red when they fail. But that job
has never been a required check. Measured against the live ruleset:

| job | required? |
|---|---|
| `Decide what this commit can affect` | **REQUIRED** |
| `Lint / Typecheck / Test / Build` | advisory |
| `Unit tests (nextly)` | advisory |
| `Unit tests (admin)` | advisory |
| `Browser tests` | advisory |
| `Scaffold smoke`, `Dev script`, `CLI entry guard`, `Comment convention` | advisory |

The one check that can block a merge is the job that works out **which paths a
commit touches** and then succeeds. Everything that verifies anything is
advisory, so a red job can sit beside a merge that goes through.

Codex raised this on #1625 as a P1. Its conclusion was right and its premise was
not: it assumed `Lint / Typecheck / Test / Build` was the blocking check. Nothing
test-shaped is, and that predates both splits.

## Why not just require those jobs

Both reasons apply here:

- **A skipped job never reports, and a required check that never reports blocks
  the branch for ever.** Every job carries
  `if: needs.changes.outputs.inert != 'true'`, so a commit touching only inert
  paths skips them all — and could then never be merged.
- **A matrix job's check is named from the expression it interpolates**
  (`Scaffold smoke (ubuntu-latest)`), so the list would restate names the
  workflow generates. That is the same drift `check:test-lanes` exists to stop.

## What this adds

One `gate` job that `needs` the others, runs `if: always()`, and reports their
verdict. **That** is the check to require, and jobs can then be added or removed
without touching a repository setting.

It fails closed in four ways, each with a test:

| case | verdict |
|---|---|
| a job reported `failure` or `cancelled` | **FAIL**, naming every one, not just the first |
| a job was `skipped` while the commit is **not** inert | **FAIL** — a job that did not run has verified nothing |
| a result it does not recognise | **FAIL** — the outcome set is GitHub's to change, so a new one is not assumed to be good news |
| `needs` is empty | **FAIL** — a gate that depends on nothing agrees with everything, which is what a mistyped `needs:` produces |

The one accepted skip is the one the **workflow states** rather than this
infers: `changes` decided the commit cannot affect what those jobs verify.

The verdict comes from the `needs` context alone, so the job installs nothing
and can still report when the install every other job depends on is what failed.

## The part that needs you

**Merging this changes nothing on its own.** The required check has to be
switched from `Decide what this commit can affect` to `CI gate` in the
`protect-main` ruleset — a repository setting, which is yours.

## What it covers, and the limit

`needs` is now the merge policy, in a file that appears in diffs instead of a
setting that appears in none — which is how it came to require one trivial job
without anyone deciding that.

Deliberately **not** included yet: `Browser tests`, `Production browser tests`,
`Scaffold smoke`, `Dev script starts every watcher`. Widening what blocks a
merge is a decision about how the project ships; each is one line when you make
it.

⚠️ **Stated rather than covered badly:** nothing checks that a *new* job was
added to this list, so one that is not there is advisory. Deriving it would mean
reading the job structure out of this YAML — the exact fallible read
`check:test-lanes` was rewritten to stop doing — and no YAML parser is available
to `scripts/` without taking a dependency for one call. What makes the trade
acceptable is that both halves now sit in one file a few dozen lines apart, so a
job added without a line here is visible in the diff that adds it.

## Evidence

11 unit tests on the verdict function, plus the four scenarios run end to end
against the real script:

```
all green                 -> exit 0
admin red                 -> exit 1  "unit-tests-admin reported failure."
inert commit, all skipped -> exit 0  "this commit is inert, so a skipped job is expected."
skipped but not inert     -> exit 1  "a job that did not run has verified nothing."
```

CI-only, no changeset.
