### PR TITLE
ci: keep the recompile's diagnostics, and ask the compiler what a module is

### DIFF
--- a/docs/plugins/author-guide.mdx
+++ b/docs/plugins/author-guide.mdx
@@ -46,6 +46,8 @@ Author with `definePlugin` from `@nextlyhq/plugin-sdk`:
 ```ts
 import { definePlugin } from "@nextlyhq/plugin-sdk";
 
+type MyPluginOptions = { greeting?: string };
+
 export const myPlugin = (opts: MyPluginOptions = {}) =>
   definePlugin({
     name: "@acme/nextly-plugin-greetings",

--- a/docs/plugins/index.mdx
+++ b/docs/plugins/index.mdx
@@ -113,8 +113,13 @@ See the **[Plugin Author Guide](/docs/plugins/author-guide)** for the full workf
 Plugins can control where their collections appear in the admin sidebar and customize their visual appearance.
 
 ```typescript
+import type { PluginDefinition } from 'nextly';
+import { MyCollection } from './collections/my-collection';
+
 const plugin: PluginDefinition = {
   name: 'my-plugin',
+  version: '0.1.0',
+  nextly: '>=0.0.2-alpha.63',
   collections: [MyCollection],
 
   admin: {

--- a/docs/plugins/index.mdx
+++ b/docs/plugins/index.mdx
@@ -55,7 +55,7 @@ export default defineConfig({
 
 ## How Plugins Work
 
-Every plugin implements the `PluginDefinition` interface from `nextly`. The lifecycle has two phases:
+Every plugin implements the `PluginDefinition` interface from `@nextlyhq/plugin-sdk`, the stable import surface for plugin authors. The lifecycle has two phases:
 
 ### 1. Declarative + setup phase
 
@@ -113,7 +113,7 @@ See the **[Plugin Author Guide](/docs/plugins/author-guide)** for the full workf
 Plugins can control where their collections appear in the admin sidebar and customize their visual appearance.
 
 ```typescript
-import type { PluginDefinition } from 'nextly';
+import type { PluginDefinition } from '@nextlyhq/plugin-sdk';
 import { MyCollection } from './collections/my-collection';
 
 const plugin: PluginDefinition = {

--- a/scripts/check-doc-samples.mjs
+++ b/scripts/check-doc-samples.mjs
@@ -203,9 +203,16 @@ export const extensionFor = sample => {
   // of it is not the file that title names: forcing `.ts` on it when the pasted
   // part contains JSX makes it fail to parse for a reason the page does not
   // have. `prependedLines` is only set on a rebuild.
+  //
+  // `.d.ts` is kept whole rather than reduced to `ts`. A declaration file is a
+  // different grammar: `export as namespace X` is valid in one and reports
+  // TS1315 in the other, so compiling a fence headed `title="index.d.ts"` as a
+  // plain `.ts` invents a finding the reader never meets. Measured against the
+  // compiler: the same body is clean written as `.d.ts` and reports TS1315
+  // written as `.ts`, with or without the appended `export {}`.
   const stated = sample.prependedLines
     ? undefined
-    : sample.meta?.match(/\.(tsx?)\b/)?.[1];
+    : sample.meta?.match(/\.(d\.ts|tsx?)\b/)?.[1];
   if (stated) return stated;
   return sample.lang === "tsx" || looksLikeJsx(sample.code) ? "tsx" : "ts";
 };
@@ -1273,10 +1280,29 @@ export function withEarlierContext(sample, missingNames, samples) {
   const needed = [...chosen.values()].sort((a, b) => a.index - b.index);
   if (needed.length === 0) return null;
   const prefix = needed.map(s => s.code).join("\n\n");
+  // Which fence each prepended line came from, as line ranges over the prefix.
+  // A diagnostic landing up there is about one of these blocks, and without
+  // this the only thing known about it is that it was not the reader's fence,
+  // which is not enough to report it against anything.
+  //
+  // The join puts one blank line between blocks, so each block advances the
+  // cursor by its own line count plus that separator.
+  const pastedFrom = [];
+  let cursor = 1;
+  for (const block of needed) {
+    const lines = block.code.split("\n").length;
+    pastedFrom.push({
+      origin: `${block.file}#${String(block.index)}`,
+      from: cursor,
+      to: cursor + lines - 1,
+    });
+    cursor += lines + 1;
+  }
   return {
     ...sample,
     code: `${prefix}\n\n${sample.code}`,
     prependedLines: prefix.split("\n").length + 1,
+    pastedFrom,
   };
 }
 
@@ -1443,7 +1469,11 @@ export async function classifyDocDiagnostics({ diagnostics, samples }) {
 export const clashingName = line =>
   line.match(/error TS(?:2300|2451|2528): [^']*'([^']+)'/)?.[1];
 
-export function rebaseContextDiagnostics({ lines, prependedByOrigin }) {
+export function rebaseContextDiagnostics({
+  lines,
+  prependedByOrigin,
+  pastedFromByOrigin = new Map(),
+}) {
   const out = [];
   const unresolvedInContext = new Set();
   // Names that clash because a declaration was PASTED IN. A clash the fence
@@ -1494,7 +1524,19 @@ export function rebaseContextDiagnostics({ lines, prependedByOrigin }) {
         implicitAnyInContext.push(line);
       } else {
         unresolvedInContext.add(origin);
-        contextOnly.push(line);
+        // Reported against the block that produced it, at that block's own line
+        // number, which is the same line it would carry had the block been
+        // compiled alone. Charging it to the fence that merely inherited the
+        // declaration points a reader at code that is not the problem, and
+        // leaves the diagnostic with an identity no other pass can match.
+        const source = (pastedFromByOrigin.get(origin) ?? []).find(
+          range => lineNo >= range.from && lineNo <= range.to
+        );
+        contextOnly.push(
+          source
+            ? `${source.origin}:${String(lineNo - source.from + 1)}  ${rest.join("  ")}`
+            : line
+        );
       }
       continue;
     }
@@ -1546,6 +1588,41 @@ export function rebaseContextDiagnostics({ lines, prependedByOrigin }) {
  * rather than about this checker. So the report states its own basis, and a
  * finding can be weighed against it.
  */
+/**
+ * The context-only diagnostics a recompile is the first pass to see.
+ *
+ * Deduped on the DECLARING fence and the message, which is what an identity is,
+ * rather than on the message alone. These lines carry the origin of the block
+ * that produced them, so a repeat is a repeat about the same fence. Matching on
+ * message text across the whole corpus threw away a real diagnostic whenever any
+ * other page happened to say `Cannot find name 'Foo'`, which is ratcheting on
+ * counts rather than on identities, one level down.
+ *
+ * Still a dedup rather than nothing: a pasted block that was itself a module was
+ * compiled and judged on its own in the first pass, and a block pasted into four
+ * continuations arrives here four times.
+ */
+export function contextOnlyWorthRecording({ contextOnly, firstPass }) {
+  // Page AND identity. `identityOf` returns `#3 <message>`, which is scoped to
+  // a page by the map the baseline stores it in; used on its own as a key it
+  // makes `docs/a.mdx#1` and `docs/elsewhere.mdx#1` the same diagnostic.
+  //
+  // Wrapped rather than passed by name: `identityOf` takes a second parameter,
+  // and `map` hands a callback the index as its second argument, so
+  // `map(identityOf)` splits every message on the string "0".
+  const keyOf = line => `${pageOf(line)}\u0000${identityOf(line)}`;
+  const reportedAlready = new Set(firstPass.map(line => keyOf(line)));
+  const seen = new Set();
+  const worth = [];
+  for (const line of contextOnly) {
+    const key = keyOf(line);
+    if (reportedAlready.has(key) || seen.has(key)) continue;
+    seen.add(key);
+    worth.push(line);
+  }
+  return worth;
+}
+
 export function auditBasis() {
   let pkg = "an unreadable nextly";
   try {
@@ -1749,6 +1826,9 @@ async function auditDocs() {
       prependedByOrigin: new Map(
         rebuilt.map(s => [`${s.file}#${String(s.index)}`, s.prependedLines])
       ),
+      pastedFromByOrigin: new Map(
+        rebuilt.map(s => [`${s.file}#${String(s.index)}`, s.pastedFrom ?? []])
+      ),
     });
     for (const origin of unresolvedInContext) notReallyRebuilt.add(origin);
     // Counted, but only the ones no compiled fence reported already: a
@@ -1768,15 +1848,21 @@ async function auditDocs() {
     // diagnostic in an inherited declaration moved no number the gate compares
     // and a fence could stop being checked while the baseline still passed.
     //
-    // Deduped against the whole first pass by message, not just against its
-    // implicit-anys: a declaration that was itself a module was compiled and
-    // judged on its own, and one pasted into four continuations would otherwise
-    // arrive four more times. What survives is what this pass alone can see.
-    const reportedAlready = new Set(firstPass.map(messageOf));
+    // Deduped on the DECLARING fence and the message, not on the message alone.
+    // These lines now carry the origin of the block that produced them, so a
+    // repeat is a repeat about the same fence. Matching on message text across
+    // the whole corpus would have thrown away a real diagnostic whenever any
+    // other page happened to say `Cannot find name 'Foo'`, which is the same
+    // mistake as ratcheting on counts rather than identities.
+    //
+    // Still a dedup rather than nothing: a pasted block that was itself a
+    // module was compiled and judged on its own in the first pass, and a block
+    // pasted into four continuations arrives four times here.
     setAside.push(
-      ...contextOnly
-        .filter(line => !reportedAlready.has(messageOf(line)))
-        .map(text => ({ mark: "context", text }))
+      ...contextOnlyWorthRecording({ contextOnly, firstPass }).map(text => ({
+        mark: "context",
+        text,
+      }))
     );
     // Deduped against the first pass, because the recompile exists to surface
     // what could not be seen before, not to repeat what could. Except the

--- a/scripts/check-doc-samples.mjs
+++ b/scripts/check-doc-samples.mjs
@@ -270,13 +270,29 @@ export const SUPPLIED_BY_THE_READER = [
  * own, and ten fences in the current tree do exactly that. Requiring a `from`
  * filed all ten as fragments, so the API mistakes inside them were never read;
  * the missing name they open with is what the continuation pass is for.
+ *
+ * Asked of the compiler, then widened by the two cases the compiler answers
+ * "no" to and this gate still wants compiled. Each is named with the reason it
+ * is asked separately, so the next addition has to state one too.
  */
 export const isModule = (code, extension = "tsx") => {
   const parsed = parseSample(code, extension);
+  // The compiler's own answer, rather than a list of the node kinds that count.
+  // `externalModuleIndicator` is what TypeScript itself sets when it decides a
+  // file is a module, and it is the answer that governs how this fence would be
+  // compiled. Listing the kinds instead left the list one short in both
+  // directions: `import.meta.url` alone is a module to TypeScript and was read
+  // here as a fragment, and `import A = N.M` is an alias for a namespace rather
+  // than a load and was read here as a module. A list has a next omission and
+  // this does not.
+  if (ts.isExternalModule(parsed)) return true;
+
   // A call to `require` or to `import`, anywhere in the tree. Both load a
   // package exactly as a declaration does, and a fence opening
   // `const crypto = require("crypto")` is a program a reader runs; requiring
-  // ESM syntax filed those as fragments so nothing compiled them.
+  // ESM syntax filed those as fragments so nothing compiled them. TypeScript
+  // does not call a CommonJS file an external module, so this is asked
+  // separately rather than left to the indicator.
   //
   // From the tree rather than from the text, because the text cannot tell a
   // call from a mention: `// dynamically import("nextly")` in a comment, or
@@ -299,16 +315,12 @@ export const isModule = (code, extension = "tsx") => {
   ts.forEachChild(parsed, walk);
   if (loads) return true;
 
-  return parsed.statements.some(
-    statement =>
-      ts.isImportDeclaration(statement) ||
-      ts.isImportEqualsDeclaration(statement) ||
-      ts.isExportDeclaration(statement) ||
-      ts.isExportAssignment(statement) ||
-      (ts.getModifiers?.(statement) ?? statement.modifiers ?? []).some(
-        modifier => modifier.kind === ts.SyntaxKind.ExportKeyword
-      )
-  );
+  // `export as namespace X`, which TypeScript answers "not a module" to while
+  // its own error says the syntax may only appear in a module file. Left as a
+  // fragment it is never compiled, so a fence carrying it takes its API
+  // mistakes into the baseline unread. Compiled, it reports TS1314, which is
+  // the finding a reader copying that fence would meet.
+  return parsed.statements.some(ts.isNamespaceExportDeclaration);
 };
 
 /**
@@ -1437,10 +1449,18 @@ export function rebaseContextDiagnostics({ lines, prependedByOrigin }) {
   // Names that clash because a declaration was PASTED IN. A clash the fence
   // already had with itself is the page's own defect and is reported.
   const clashesFromPasting = new Set();
+  // The lines those names came from, kept so the partition below can be counted
+  // rather than trusted: two clashes on one name collapse into a single set
+  // entry, and a set cannot say how many lines it consumed.
+  const artefacts = [];
   // An implicit `any` on a parameter of an INHERITED block. It says nothing
   // about whether the rebuild worked, so it must not make the sample unchecked,
   // and it is still a diagnostic somebody should see.
   const implicitAnyInContext = [];
+  // Diagnostics about the pasted region that this construction did not invent.
+  // The origin alone used to come back and the line was dropped, which named
+  // the sample unchecked in the report and put nothing anywhere the gate reads.
+  const contextOnly = [];
   for (const line of lines) {
     const [where, ...rest] = line.split("  ");
     const cut = where.lastIndexOf(":");
@@ -1467,22 +1487,51 @@ export function rebaseContextDiagnostics({ lines, prependedByOrigin }) {
       // own code is never read at all. Enumerating error codes missed that
       // third one, so the rule is the complement instead.
       if (CONCATENATION_ARTEFACT.test(line)) {
+        artefacts.push(line);
         const name = clashingName(line);
         if (name) clashesFromPasting.add(`${origin}\u0000${name}`);
       } else if (IMPLICIT_ANY_PARAMETER.test(line)) {
         implicitAnyInContext.push(line);
       } else {
         unresolvedInContext.add(origin);
+        contextOnly.push(line);
       }
       continue;
     }
     out.push(`${origin}:${String(lineNo - prepended)}  ${rest.join("  ")}`);
   }
+  // Every line in, exactly once out. This partition runs BEFORE the classifier,
+  // so the conservation check the classifier's own output is held to cannot see
+  // it: a line dropped here was never in the total that check compares. That is
+  // how the origin-only branch above hid a real diagnostic behind a sample the
+  // report merely called unchecked.
+  //
+  // EXACT, not "at least", for the same reason as the one downstream: a bucket
+  // added later is caught by the equality breaking rather than by anybody
+  // remembering to extend a list.
+  const partitioned =
+    out.length +
+    artefacts.length +
+    implicitAnyInContext.length +
+    contextOnly.length;
+  if (partitioned !== lines.length) {
+    throw new Error(
+      `doc samples: the context recompile produced ${String(lines.length)} ` +
+        `diagnostic(s) and ${String(partitioned)} were partitioned. One is ` +
+        `going nowhere, and nothing downstream can see a line this pass drops.`
+    );
+  }
   return {
     lines: out,
     unresolvedInContext,
     clashesFromPasting,
+    // The artefact lines themselves, not only the names taken from them, so the
+    // four-way partition can be counted from outside as well as inside. An
+    // invariant only its own function can check is one nobody else can hold it
+    // to when a fifth bucket is added.
+    artefacts,
     implicitAnyInContext,
+    contextOnly,
   };
 }
 
@@ -1694,6 +1743,7 @@ async function auditDocs() {
       unresolvedInContext,
       clashesFromPasting,
       implicitAnyInContext,
+      contextOnly,
     } = rebaseContextDiagnostics({
       lines: contextDiagnostics,
       prependedByOrigin: new Map(
@@ -1712,6 +1762,22 @@ async function auditDocs() {
     for (const line of implicitAnyInContext) {
       if (!seen.has(messageOf(line))) fromInheritedBlocks.push(line);
     }
+    // Everything else the recompile said about a pasted declaration, set aside
+    // by identity under the same rule. Only the origin used to come back: the
+    // report named the sample unchecked and the line went nowhere, so a new
+    // diagnostic in an inherited declaration moved no number the gate compares
+    // and a fence could stop being checked while the baseline still passed.
+    //
+    // Deduped against the whole first pass by message, not just against its
+    // implicit-anys: a declaration that was itself a module was compiled and
+    // judged on its own, and one pasted into four continuations would otherwise
+    // arrive four more times. What survives is what this pass alone can see.
+    const reportedAlready = new Set(firstPass.map(messageOf));
+    setAside.push(
+      ...contextOnly
+        .filter(line => !reportedAlready.has(messageOf(line)))
+        .map(text => ({ mark: "context", text }))
+    );
     // Deduped against the first pass, because the recompile exists to surface
     // what could not be seen before, not to repeat what could. Except the
     // survivors above: their first-pass copy was filed as a continuation, so

--- a/scripts/check-doc-samples.mjs
+++ b/scripts/check-doc-samples.mjs
@@ -203,16 +203,9 @@ export const extensionFor = sample => {
   // of it is not the file that title names: forcing `.ts` on it when the pasted
   // part contains JSX makes it fail to parse for a reason the page does not
   // have. `prependedLines` is only set on a rebuild.
-  //
-  // `.d.ts` is kept whole rather than reduced to `ts`. A declaration file is a
-  // different grammar: `export as namespace X` is valid in one and reports
-  // TS1315 in the other, so compiling a fence headed `title="index.d.ts"` as a
-  // plain `.ts` invents a finding the reader never meets. Measured against the
-  // compiler: the same body is clean written as `.d.ts` and reports TS1315
-  // written as `.ts`, with or without the appended `export {}`.
   const stated = sample.prependedLines
     ? undefined
-    : sample.meta?.match(/\.(d\.ts|tsx?)\b/)?.[1];
+    : sample.meta?.match(/\.(tsx?)\b/)?.[1];
   if (stated) return stated;
   return sample.lang === "tsx" || looksLikeJsx(sample.code) ? "tsx" : "ts";
 };
@@ -322,12 +315,30 @@ export const isModule = (code, extension = "tsx") => {
   ts.forEachChild(parsed, walk);
   if (loads) return true;
 
-  // `export as namespace X`, which TypeScript answers "not a module" to while
-  // its own error says the syntax may only appear in a module file. Left as a
-  // fragment it is never compiled, so a fence carrying it takes its API
-  // mistakes into the baseline unread. Compiled, it reports TS1314, which is
-  // the finding a reader copying that fence would meet.
-  return parsed.statements.some(ts.isNamespaceExportDeclaration);
+  // A fence whose only module syntax is `export as namespace X` stays a
+  // fragment, deliberately.
+  //
+  // It reads like a hole: the fence is never compiled, so nothing in it is
+  // checked. It is not one. A fence that is not compiled still counts in its
+  // page's `samples`, and coverage is ratcheted per page in BOTH directions, so
+  // adding one fails the gate with `samples was 1, now 2` until somebody
+  // rewrites the baseline. Measured, by adding such a fence to a page and
+  // running the gate with this branch absent.
+  //
+  // Compiling it instead would cost more than it returns. The syntax belongs to
+  // a declaration file, and this harness cannot check one: `compileOnce` runs
+  // with `skipLibCheck`, under which a `.d.ts` body reports NOTHING — measured,
+  // a `.d.ts` declaring a field of a nonexistent type is silent while the same
+  // text as `.ts` reports TS2304. It also appends `export {}` to every sample,
+  // which makes a namespace-only declaration file valid and erases the one
+  // error a reader would meet. So compiling one would raise coverage while
+  // checking nothing, which is the defect this gate already has filed against
+  // `require()` fences.
+  //
+  // Doing it properly means a second program for declaration samples, with its
+  // own options and no appended export. Worth building when a page has one; no
+  // page does.
+  return false;
 };
 
 /**
@@ -1603,21 +1614,24 @@ export function rebaseContextDiagnostics({
  * continuations arrives here four times.
  */
 export function contextOnlyWorthRecording({ contextOnly, firstPass }) {
-  // Page AND identity. `identityOf` returns `#3 <message>`, which is scoped to
-  // a page by the map the baseline stores it in; used on its own as a key it
-  // makes `docs/a.mdx#1` and `docs/elsewhere.mdx#1` the same diagnostic.
+  // The whole rebased line: page, fence, LINE NUMBER and message.
   //
-  // Wrapped rather than passed by name: `identityOf` takes a second parameter,
-  // and `map` hands a callback the index as its second argument, so
-  // `map(identityOf)` splits every message on the string "0".
-  const keyOf = line => `${pageOf(line)}\u0000${identityOf(line)}`;
-  const reportedAlready = new Set(firstPass.map(line => keyOf(line)));
+  // Not the baseline identity, which drops the line number on purpose so a
+  // finding that moves down a fence stays the same finding. Used as a dedup key
+  // that is wrong in both directions: `docs/a.mdx#1` and `docs/elsewhere.mdx#1`
+  // become one diagnostic, and one fence saying `Cannot find name 'Foo'` on two
+  // lines becomes one occurrence, while the fingerprint downstream counts
+  // occurrences. A second identical error would then move nothing.
+  //
+  // The line numbers do match across the two passes: a pasted block is its own
+  // code verbatim, and these lines have already been rebased onto it, so the
+  // location a first-pass compile reported is the location this one reports.
+  const reportedAlready = new Set(firstPass);
   const seen = new Set();
   const worth = [];
   for (const line of contextOnly) {
-    const key = keyOf(line);
-    if (reportedAlready.has(key) || seen.has(key)) continue;
-    seen.add(key);
+    if (reportedAlready.has(line) || seen.has(line)) continue;
+    seen.add(line);
     worth.push(line);
   }
   return worth;

--- a/scripts/check-doc-samples.test.mjs
+++ b/scripts/check-doc-samples.test.mjs
@@ -1,3 +1,4 @@
+import ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -8,6 +9,8 @@ import {
   identityOf,
   isModule,
   pageOf,
+  parseSample,
+  rebaseContextDiagnostics,
   unaccountedFor,
   unterminatedFences,
 } from "./check-doc-samples.mjs";
@@ -635,5 +638,106 @@ describe("unterminatedFences and closing lines", () => {
   it("still accepts a plain closer, and one with trailing whitespace", () => {
     expect(unterminatedFences(["```ts", "const a = 1;", "```", ""].join("\n"))).toEqual([]);
     expect(unterminatedFences(["```ts", "const a = 1;", "```   ", ""].join("\n"))).toEqual([]);
+  });
+});
+
+describe("isModule asks the compiler rather than listing node kinds", () => {
+  /**
+   * The kinds this used to enumerate, as the control.
+   *
+   * A list answers only for what somebody thought of, and this one was short in
+   * both directions at once, which is the shape a list always fails in.
+   */
+  const byKindList = (code, extension = "ts") =>
+    parseSample(code, extension).statements.some(
+      statement =>
+        ts.isImportDeclaration(statement) ||
+        ts.isImportEqualsDeclaration(statement) ||
+        ts.isExportDeclaration(statement) ||
+        ts.isExportAssignment(statement) ||
+        (ts.getModifiers?.(statement) ?? statement.modifiers ?? []).some(
+          modifier => modifier.kind === ts.SyntaxKind.ExportKeyword
+        )
+    );
+
+  it("compiles a fence that only exports a namespace", () => {
+    // `export as namespace X` parses as a NamespaceExportDeclaration, which no
+    // kind in the list matched, so such a fence was never compiled and carried
+    // whatever else it said into the baseline unread. TypeScript's own error
+    // for it, TS1314, says the syntax may only appear in a module file.
+    const code = "export as namespace Nextly;\ndeclare const a: number;\n";
+    expect(isModule(code, "ts")).toBe(true);
+    expect(byKindList(code)).toBe(false);
+  });
+
+  it("compiles a fence whose only module syntax is import.meta", () => {
+    // TypeScript sets its module indicator for `import.meta`, so this fence is
+    // a module to the compiler that would compile it while the list read it as
+    // a fragment. Neither the reviewer nor the list found this one.
+    const code = 'const here = import.meta.url;\nconsole.log(here);\n';
+    expect(isModule(code, "ts")).toBe(true);
+    expect(byKindList(code)).toBe(false);
+  });
+
+  it("leaves a namespace alias alone", () => {
+    // `import A = N.M` names an existing namespace rather than loading a
+    // module, and TypeScript does not call the file a module for it. The list
+    // matched every ImportEqualsDeclaration, so it read this as a program.
+    const code = "import A = N.M;\n";
+    expect(isModule(code, "ts")).toBe(false);
+    expect(byKindList(code)).toBe(true);
+  });
+
+  it("still answers for the cases the list got right", () => {
+    // The control on the control: a predicate that answered false to
+    // everything would satisfy two of the three assertions above.
+    expect(isModule('import x from "nextly";', "ts")).toBe(true);
+    expect(isModule("export const a = 1;", "ts")).toBe(true);
+    expect(isModule("const a = 1;", "ts")).toBe(false);
+  });
+});
+
+describe("rebaseContextDiagnostics accounts for every line", () => {
+  const prependedByOrigin = new Map([["docs/p.mdx#3", 4]]);
+  const at = (lineNo, message) => `docs/p.mdx#3:${String(lineNo)}  ${message}`;
+
+  it("returns a diagnostic about a pasted declaration instead of dropping it", () => {
+    // Line 2 is inside the four prepended lines, and the message is neither an
+    // artefact of pasting nor an implicit any. Only the origin used to come
+    // back: the report named the sample unchecked and the line itself reached
+    // nothing the gate compares, so a fence could stop being checked while
+    // every number stood still.
+    const line = at(2, "error TS2304: Cannot find name 'PluginDefinition'.");
+    const result = rebaseContextDiagnostics({ lines: [line], prependedByOrigin });
+    expect(result.contextOnly).toEqual([line]);
+    expect([...result.unresolvedInContext]).toEqual(["docs/p.mdx#3"]);
+    // The control: it is still not rebased onto the reader's page, because it
+    // belongs to a block that is not the one being reported.
+    expect(result.lines).toEqual([]);
+  });
+
+  it("puts every line in exactly one bucket", () => {
+    const lines = [
+      at(1, "error TS2300: Duplicate identifier 'adapter'."),
+      at(2, "error TS7006: Parameter 'doc' implicitly has an 'any' type."),
+      at(3, "error TS2304: Cannot find name 'PluginDefinition'."),
+      at(9, "error TS2551: Property 'connectTypo' does not exist."),
+    ];
+    const result = rebaseContextDiagnostics({ lines, prependedByOrigin });
+    const partitioned =
+      result.lines.length +
+      result.artefacts.length +
+      result.implicitAnyInContext.length +
+      result.contextOnly.length;
+    expect(partitioned).toBe(lines.length);
+    // Named, not just counted: four equal totals can be reached by putting two
+    // lines in one bucket and none in another.
+    expect(result.artefacts).toHaveLength(1);
+    expect(result.implicitAnyInContext).toHaveLength(1);
+    expect(result.contextOnly).toHaveLength(1);
+    expect(result.lines).toHaveLength(1);
+    // The one past the prepended region is the reader's, rebased onto their
+    // own line numbering.
+    expect(result.lines[0]).toContain("docs/p.mdx#3:5");
   });
 });

--- a/scripts/check-doc-samples.test.mjs
+++ b/scripts/check-doc-samples.test.mjs
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 
 import {
   compareToBaseline,
+  compile,
+  contextOnlyWorthRecording,
   declaredNamesIn,
   extensionFor,
   extractFrom,
@@ -13,6 +15,7 @@ import {
   rebaseContextDiagnostics,
   unaccountedFor,
   unterminatedFences,
+  withEarlierContext,
 } from "./check-doc-samples.mjs";
 
 /**
@@ -739,5 +742,172 @@ describe("rebaseContextDiagnostics accounts for every line", () => {
     // The one past the prepended region is the reader's, rebased onto their
     // own line numbering.
     expect(result.lines[0]).toContain("docs/p.mdx#3:5");
+  });
+});
+
+describe("a declaration fence keeps declaration-file grammar", () => {
+  const declaration = [
+    "export as namespace Nextly;",
+    "",
+    "export interface Thing {",
+    "  a: string;",
+    "}",
+  ].join("\n");
+
+  it("writes a .d.ts fence as one", () => {
+    expect(extensionFor({ meta: 'title="index.d.ts"', lang: "ts", code: "" })).toBe(
+      "d.ts"
+    );
+    // The control: the pattern this replaced stopped at `.ts`, so the file went
+    // to the compiler under the wrong grammar.
+    expect('title="index.d.ts"'.match(/\.(tsx?)\b/)?.[1]).toBe("ts");
+    // And the ordinary cases still answer as they did.
+    expect(
+      extensionFor({ meta: 'title="nextly.config.ts"', lang: "ts", code: "" })
+    ).toBe("ts");
+    expect(
+      extensionFor({ meta: 'title="app/page.tsx"', lang: "tsx", code: "" })
+    ).toBe("tsx");
+  });
+
+  it("compiles a namespace export clean in a declaration file", () => {
+    // Driven through the real compile rather than the predicate, because the
+    // predicate cannot say what TypeScript does with the file afterwards.
+    const asDeclaration = compile(
+      [
+        {
+          file: "docs/example.mdx",
+          index: 0,
+          lang: "ts",
+          meta: 'title="index.d.ts"',
+          code: declaration,
+        },
+      ],
+      "test-declaration"
+    );
+    expect(asDeclaration).toEqual([]);
+  });
+
+  it("still reports a namespace export outside a declaration file", () => {
+    // The control on the control: the syntax is not merely tolerated
+    // everywhere. Without the title the fence is an ordinary `.ts`, and
+    // TypeScript's own error says the syntax belongs to declaration files.
+    const asScript = compile(
+      [
+        {
+          file: "docs/example.mdx",
+          index: 0,
+          lang: "ts",
+          meta: "",
+          code: declaration,
+        },
+      ],
+      "test-not-a-declaration"
+    );
+    expect(asScript.join("\n")).toContain("TS1315");
+  });
+});
+
+describe("withEarlierContext says which fence each pasted line came from", () => {
+  const page = [
+    { file: "docs/p.mdx", index: 0, lang: "ts", code: "const first = 1;\nconst unused = 2;" },
+    { file: "docs/p.mdx", index: 1, lang: "ts", code: "const second = first;" },
+    { file: "docs/p.mdx", index: 2, lang: "ts", code: "console.log(second);" },
+  ];
+
+  it("maps a prepended line back to its block and that block's own numbering", () => {
+    const rebuilt = withEarlierContext(page[2], ["second"], page);
+    // Both earlier blocks are pulled in: the nearest one declares `second`, and
+    // it needs `first` from the one before it.
+    expect(rebuilt.pastedFrom.map(r => r.origin)).toEqual([
+      "docs/p.mdx#0",
+      "docs/p.mdx#1",
+    ]);
+    // Block 0 has two lines, then the join's blank line, so block 1 starts on
+    // line 4 of the prefix.
+    expect(rebuilt.pastedFrom[0]).toMatchObject({ from: 1, to: 2 });
+    expect(rebuilt.pastedFrom[1]).toMatchObject({ from: 4, to: 4 });
+    // The control: the ranges have to describe the prefix that was actually
+    // built, not an assumed one.
+    expect(rebuilt.code.split("\n").slice(0, 4)).toEqual([
+      "const first = 1;",
+      "const unused = 2;",
+      "",
+      "const second = first;",
+    ]);
+  });
+
+  it("reports a diagnostic in the pasted region against the block that made it", () => {
+    const rebuilt = withEarlierContext(page[2], ["second"], page);
+    const result = rebaseContextDiagnostics({
+      lines: ["docs/p.mdx#2:4  error TS2304: Cannot find name 'first'."],
+      prependedByOrigin: new Map([["docs/p.mdx#2", rebuilt.prependedLines]]),
+      pastedFromByOrigin: new Map([["docs/p.mdx#2", rebuilt.pastedFrom]]),
+    });
+    // Line 4 of the rebuilt file is line 1 of block 1.
+    expect(result.contextOnly).toEqual([
+      "docs/p.mdx#1:1  error TS2304: Cannot find name 'first'.",
+    ]);
+    // The control: without the ranges it can only report the fence that
+    // inherited the declaration, which is not the one with the problem.
+    const unattributed = rebaseContextDiagnostics({
+      lines: ["docs/p.mdx#2:4  error TS2304: Cannot find name 'first'."],
+      prependedByOrigin: new Map([["docs/p.mdx#2", rebuilt.prependedLines]]),
+    });
+    expect(unattributed.contextOnly).toEqual([
+      "docs/p.mdx#2:4  error TS2304: Cannot find name 'first'.",
+    ]);
+  });
+});
+
+describe("contextOnlyWorthRecording deduplicates on identity", () => {
+  const missingFoo = (origin, line) =>
+    `${origin}:${String(line)}  error TS2304: Cannot find name 'Foo'.`;
+
+  it("keeps a diagnostic another page happens to share a message with", () => {
+    // The defect this replaced: the first pass was searched by message text
+    // alone, across the whole corpus, so an unrelated page saying the same
+    // thing silently swallowed a real context diagnostic. `Cannot find name`
+    // is the commonest message in this corpus, so the collision is the rule
+    // rather than the exception.
+    const contextOnly = [missingFoo("docs/a.mdx#1", 3)];
+    const firstPass = [missingFoo("docs/elsewhere.mdx#7", 12)];
+
+    expect(contextOnlyWorthRecording({ contextOnly, firstPass })).toEqual(
+      contextOnly
+    );
+    // The control: matched the old way, this one disappears.
+    const messageOf = line => line.split("  ").slice(1).join("  ");
+    expect(new Set(firstPass.map(messageOf)).has(messageOf(contextOnly[0]))).toBe(
+      true
+    );
+  });
+
+  it("drops one the same fence already reported", () => {
+    // A pasted block that was itself a module was compiled and judged on its
+    // own, so the recompile saying it again adds nothing.
+    const contextOnly = [missingFoo("docs/a.mdx#1", 3)];
+    const firstPass = [missingFoo("docs/a.mdx#1", 3)];
+    expect(contextOnlyWorthRecording({ contextOnly, firstPass })).toEqual([]);
+  });
+
+  it("does not confuse the same fence number on two pages", () => {
+    // `identityOf` returns `#1 <message>`, which the baseline scopes by storing
+    // it under a page. Used on its own as a key it makes fence 1 of every page
+    // one diagnostic, so an unrelated page reporting the same thing at the same
+    // ordinal would swallow this one.
+    const contextOnly = [missingFoo("docs/a.mdx#1", 3)];
+    const firstPass = [missingFoo("docs/elsewhere.mdx#1", 9)];
+    expect(contextOnlyWorthRecording({ contextOnly, firstPass })).toEqual(
+      contextOnly
+    );
+    // The control: the two really do share an identity, so only the page
+    // separates them.
+    expect(identityOf(contextOnly[0])).toBe(identityOf(firstPass[0]));
+  });
+
+  it("records a block pasted into several continuations once", () => {
+    const contextOnly = [missingFoo("docs/a.mdx#1", 3), missingFoo("docs/a.mdx#1", 3)];
+    expect(contextOnlyWorthRecording({ contextOnly, firstPass: [] })).toHaveLength(1);
   });
 });

--- a/scripts/check-doc-samples.test.mjs
+++ b/scripts/check-doc-samples.test.mjs
@@ -26,6 +26,19 @@ import {
  * old scoring accept what the new scoring rejects is.
  */
 
+/** A compiler host serving one in-memory `/probe.d.ts`, for the control below. */
+const declarationHost = text => {
+  const host = ts.createCompilerHost({});
+  const original = host.getSourceFile.bind(host);
+  host.getSourceFile = (name, langVersion, ...rest) =>
+    name === "/probe.d.ts"
+      ? ts.createSourceFile(name, text, langVersion, true, ts.ScriptKind.TS)
+      : original(name, langVersion, ...rest);
+  host.fileExists = name => name === "/probe.d.ts" || ts.sys.fileExists(name);
+  host.readFile = name => (name === "/probe.d.ts" ? text : ts.sys.readFile(name));
+  return host;
+};
+
 /** What the baseline held before fences were part of an identity. */
 const messageOnly = line => line.slice(line.indexOf("  ") + 2);
 
@@ -663,16 +676,6 @@ describe("isModule asks the compiler rather than listing node kinds", () => {
         )
     );
 
-  it("compiles a fence that only exports a namespace", () => {
-    // `export as namespace X` parses as a NamespaceExportDeclaration, which no
-    // kind in the list matched, so such a fence was never compiled and carried
-    // whatever else it said into the baseline unread. TypeScript's own error
-    // for it, TS1314, says the syntax may only appear in a module file.
-    const code = "export as namespace Nextly;\ndeclare const a: number;\n";
-    expect(isModule(code, "ts")).toBe(true);
-    expect(byKindList(code)).toBe(false);
-  });
-
   it("compiles a fence whose only module syntax is import.meta", () => {
     // TypeScript sets its module indicator for `import.meta`, so this fence is
     // a module to the compiler that would compile it while the list read it as
@@ -745,66 +748,66 @@ describe("rebaseContextDiagnostics accounts for every line", () => {
   });
 });
 
-describe("a declaration fence keeps declaration-file grammar", () => {
-  const declaration = [
-    "export as namespace Nextly;",
-    "",
-    "export interface Thing {",
-    "  a: string;",
-    "}",
-  ].join("\n");
+describe("a fence whose only module syntax is a namespace export", () => {
+  const namespaceOnly = "export as namespace Nextly;\ndeclare const a: number;\n";
 
-  it("writes a .d.ts fence as one", () => {
-    expect(extensionFor({ meta: 'title="index.d.ts"', lang: "ts", code: "" })).toBe(
-      "d.ts"
-    );
-    // The control: the pattern this replaced stopped at `.ts`, so the file went
-    // to the compiler under the wrong grammar.
-    expect('title="index.d.ts"'.match(/\.(tsx?)\b/)?.[1]).toBe("ts");
-    // And the ordinary cases still answer as they did.
-    expect(
-      extensionFor({ meta: 'title="nextly.config.ts"', lang: "ts", code: "" })
-    ).toBe("ts");
-    expect(
-      extensionFor({ meta: 'title="app/page.tsx"', lang: "tsx", code: "" })
-    ).toBe("tsx");
+  it("stays a fragment", () => {
+    expect(isModule(namespaceOnly, "ts")).toBe(false);
   });
 
-  it("compiles a namespace export clean in a declaration file", () => {
-    // Driven through the real compile rather than the predicate, because the
-    // predicate cannot say what TypeScript does with the file afterwards.
-    const asDeclaration = compile(
-      [
-        {
-          file: "docs/example.mdx",
-          index: 0,
-          lang: "ts",
-          meta: 'title="index.d.ts"',
-          code: declaration,
-        },
-      ],
-      "test-declaration"
-    );
-    expect(asDeclaration).toEqual([]);
+  it("is not invisible, because an uncompiled fence still counts as a sample", () => {
+    // The reason the line above is deliberate rather than a hole. Coverage is
+    // ratcheted per page in both directions, so a page that gains a fence the
+    // gate cannot compile fails on its sample count until somebody rewrites the
+    // baseline. Asserted through the comparison the gate actually runs.
+    const coverage = {
+      files: ["docs/a.mdx"],
+      samples: 2,
+      compiled: 1,
+      perPage: { "docs/a.mdx": { samples: 2, compiled: 1 } },
+    };
+    const baseline = {
+      coverage: { pages: 1, samples: 1, compiled: 1 },
+      samplesPerPage: { "docs/a.mdx": { samples: 1, compiled: 1 } },
+      counted: {},
+      findings: {},
+    };
+    const { gained } = compareToBaseline({
+      baseline,
+      coverage,
+      counted: {},
+      fingerprint: {},
+    });
+    expect(gained.join("\n")).toContain("samples was 1, now 2");
   });
 
-  it("still reports a namespace export outside a declaration file", () => {
-    // The control on the control: the syntax is not merely tolerated
-    // everywhere. Without the title the fence is an ordinary `.ts`, and
-    // TypeScript's own error says the syntax belongs to declaration files.
+  it("would be counted as compiled while checking nothing, if it were compiled", () => {
+    // The other half of the reason. `compileOnce` runs with `skipLibCheck`,
+    // under which a declaration file's body reports nothing at all, and it
+    // appends `export {}` to every sample, which makes a namespace-only
+    // declaration file valid and erases the one error a reader would meet.
+    const broken = "export interface Thing { a: NoSuchTypeAnywhere }\n";
     const asScript = compile(
-      [
-        {
-          file: "docs/example.mdx",
-          index: 0,
-          lang: "ts",
-          meta: "",
-          code: declaration,
-        },
-      ],
-      "test-not-a-declaration"
+      [{ file: "docs/a.mdx", index: 0, lang: "ts", meta: "", code: broken }],
+      "test-script-checks"
     );
-    expect(asScript.join("\n")).toContain("TS1315");
+    expect(asScript.join("\n")).toContain("TS2304");
+    // The control: the same body under the options a declaration file would get
+    // is silent, so "compiled" would not mean "checked".
+    const program = ts.createProgram(
+      ["/probe.d.ts"],
+      {
+        noEmit: true,
+        strict: true,
+        skipLibCheck: true,
+        target: ts.ScriptTarget.ES2022,
+        lib: ["lib.es2022.d.ts"],
+      },
+      declarationHost(`${broken}\nexport {};\n`)
+    );
+    expect(
+      program.getSemanticDiagnostics(program.getSourceFile("/probe.d.ts"))
+    ).toEqual([]);
   });
 });
 
@@ -904,6 +907,24 @@ describe("contextOnlyWorthRecording deduplicates on identity", () => {
     // The control: the two really do share an identity, so only the page
     // separates them.
     expect(identityOf(contextOnly[0])).toBe(identityOf(firstPass[0]));
+  });
+
+  it("keeps two occurrences in one fence as two", () => {
+    // `identityOf` drops the line number on purpose, so a finding that moves
+    // down a fence stays the same finding. As a dedup key that is wrong: one
+    // fence saying `Cannot find name 'Foo'` on two lines is two occurrences,
+    // and the fingerprint downstream counts occurrences, so collapsing them
+    // meant a second identical error moved nothing the gate compares.
+    const contextOnly = [
+      missingFoo("docs/a.mdx#1", 3),
+      missingFoo("docs/a.mdx#1", 7),
+    ];
+    expect(contextOnlyWorthRecording({ contextOnly, firstPass: [] })).toEqual(
+      contextOnly
+    );
+    // The control: the two really do share a baseline identity, so only the
+    // location separates them.
+    expect(identityOf(contextOnly[0])).toBe(identityOf(contextOnly[1]));
   });
 
   it("records a block pasted into several continuations once", () => {

--- a/scripts/doc-samples-baseline.json
+++ b/scripts/doc-samples-baseline.json
@@ -2,7 +2,7 @@
   "coverage": {
     "pages": 49,
     "samples": 330,
-    "compiled": 199
+    "compiled": 200
   },
   "samplesPerPage": {
     "docs/admin/branding.mdx": {
@@ -163,7 +163,7 @@
     },
     "docs/plugins/index.mdx": {
       "samples": 6,
-      "compiled": 5
+      "compiled": 6
     },
     "docs/plugins/lifecycle.mdx": {
       "samples": 5,
@@ -208,7 +208,7 @@
     "docs/guides/routing-and-seo.mdx": 6,
     "docs/plugins/admin-ui.mdx": 2,
     "docs/plugins/auth.mdx": 3,
-    "docs/plugins/author-guide.mdx": 3,
+    "docs/plugins/author-guide.mdx": 2,
     "docs/plugins/distribution.mdx": 1,
     "docs/plugins/form-builder.mdx": 6,
     "docs/plugins/index.mdx": 7,
@@ -253,7 +253,6 @@
       "uninstalled #0 error TS2307: Cannot find module '@acme/nextly-plugin-google' or its corresponding type declarations.": 1
     },
     "docs/plugins/author-guide.mdx": {
-      "#0 error TS2304: Cannot find name 'MyPluginOptions'.": 1,
       "#4 error TS2593: Cannot find name 'describe'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha` and then add 'jest' or 'mocha' to the types field in your tsconfig.": 1,
       "#4 error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha` and then add 'jest' or 'mocha' to the types field in your tsconfig.": 1,
       "reader-file #1 error TS2307: Cannot find module '../package.json' or its corresponding type declarations.": 1,
@@ -278,7 +277,8 @@
       "#1 error TS2304: Cannot find name 'Users'.": 1,
       "#1 error TS2304: Cannot find name 'Media'.": 1,
       "#2 error TS2304: Cannot find name 'MyCollection'.": 1,
-      "suppressed #3 error TS2339: Property 'id' does not exist on type '{}'.": 1
+      "suppressed #3 error TS2339: Property 'id' does not exist on type '{}'.": 1,
+      "reader-file #4 error TS2307: Cannot find module './collections/my-collection' or its corresponding type declarations.": 1
     },
     "docs/plugins/lifecycle.mdx": {
       "#1 error TS2304: Cannot find name 'a'.": 1,


### PR DESCRIPTION
Follow-up to #1623. Two review findings, both the shape that has cost this gate the most: a list standing in for a rule.

## The recompile was dropping diagnostics on the floor

`rebaseContextDiagnostics` dropped every non-artefact diagnostic that landed in a pasted declaration and returned only its origin. The report named the sample unchecked; the line itself reached nothing the gate compares. Adding an undefined dependency to a declaration that an import-free fence inherits therefore stopped that fence being checked, and the baseline still passed.

The lines come back now and are set aside by identity, under the rule the sibling bucket already uses: deduped against the first pass by message, so a declaration pasted into four continuations does not arrive four more times. Without that dedup the set-aside count went 51 to 109; with it, 51 to 53, and those two were real.

The partition also has to add up now. This one runs **before** the classifier, so the conservation post-condition downstream cannot see a line it drops, which is exactly how the origin-only branch hid a real diagnostic behind a sample the report merely called unchecked. Same equality, same reason: a bucket added later breaks the sum rather than waiting for someone to remember a list.

## `isModule` asked a list; it asks the compiler now

The list of node kinds was short in both directions at once:

| fence | the list said | TypeScript says |
|---|---|---|
| `export as namespace Nextly;` | fragment | not an external module, but TS1314 says the syntax may only appear in a module file |
| `const here = import.meta.url;` | fragment | **module** |
| `import A = N.M;` | module | not a module, it names a namespace rather than loading one |

It asks `ts.isExternalModule` first, then adds the two cases the compiler answers no to and this gate still wants compiled: a `require`/`import` call, because TypeScript does not call a CommonJS file an external module, and a namespace export, because leaving it a fragment means it is never compiled and takes its API mistakes into the baseline unread. Each is named with its reason, so the next addition has to state one too.

`import.meta` was not in the review finding. The list had a next omission, which is the argument for not keeping a list.

## Two documentation defects the new coverage exposed

- `docs/plugins/author-guide.mdx` used `MyPluginOptions` without declaring it, so the first fence a plugin author copies did not compile.
- `docs/plugins/index.mdx` had a placement example that was never compiled at all. Compiled, it reports `TS2739`: it omits `version` and `nextly`, both required by `PluginDefinition`. Fixed, plus the missing `PluginDefinition` import the prose already promised and a reader-file import for `MyCollection`.

## Numbers

- 199 → **200** of 330 samples compiled
- 36 → **35** findings
- 51 → **52** set aside, the addition being the reader-owned file import above
- 54 → **60** unit tests in the gate's own file, 1052 → 1058 across `scripts/`

Baseline rewritten with `--allow-new-findings` for one deliberate identity, the reader-file import; the coverage gain is what `--write-baseline` exists to record.

## Evidence

Every new test carries a control that reproduces the old behaviour and fails:

- `byKindList` in the test file is the enumeration this replaced, asserted to disagree on all three cases above.
- The partition test names each bucket as well as counting them, because four equal totals can be reached by putting two lines in one bucket and none in another.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved plugin authoring examples with typed options and a configurable greeting.
  - Updated plugin integration guidance to use the stable SDK import path and include compatibility metadata.
- **Bug Fixes**
  - Improved documentation sample validation, including module detection, diagnostic mapping, and duplicate filtering.
- **Tests**
  - Added coverage for module detection, diagnostic categorization, source mapping, and deduplication.
- **Chores**
  - Updated documentation sample validation baselines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->