### PR TITLE
fix(nextly): vary on every credential, and keep a quoted cache directive whole

### DIFF
--- a/.changeset/a-session-response-names-its-credentials.md
+++ b/.changeset/a-session-response-names-its-credentials.md
@@ -1,0 +1,33 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A session-gated response names every credential it depends on, and keeps a quoted cache directive whole.
+
+**`Vary` names the API key as well as the cookie.** A non-public plugin route accepts `Authorization: Bearer` — `requireAuthentication` resolves an API key to its own user, roles and permissions — so two different keys had the same cache key while their responses legitimately differ. For any intermediary that stores despite `no-store`, which is the fallback this header exists for, the first key's answer could be replayed to the second. Both credentials are named now.
+
+**A quoted `Cache-Control` directive is no longer split down the middle.** `private="Set-Cookie, X-User"` is one field-qualified directive, and splitting on every comma made it two: the first was discarded as `private` and the second survived as the fragment `X-User"`. Measured on that input, the emitted header was `private, no-store, X-User"` — malformed, with an unbalanced quote, which a strict intermediary may reject along with the privacy directives it was carrying. Members are now separated only on commas outside quoted strings, with backslash escapes honoured, so a quote written inside a value does not end it.

--- a/packages/nextly/src/__tests__/routeHandler-admin-meta-workspace.test.ts
+++ b/packages/nextly/src/__tests__/routeHandler-admin-meta-workspace.test.ts
@@ -114,7 +114,13 @@ describe("admin-meta split over HTTP", () => {
     );
 
     expect(response.headers.get("cache-control")).toBe("private, no-store");
-    expect(response.headers.get("vary")).toBe("Cookie");
+    // Every credential the answer can depend on, asserted by membership: this
+    // route is session-gated and `requireAuthentication` also accepts an API
+    // key, so the header names both. Pinning the whole string would make
+    // naming another credential a test failure rather than a decision.
+    const vary = response.headers.get("vary") ?? "";
+    expect(vary).toContain("Cookie");
+    expect(vary).toContain("Authorization");
   });
 
   it("leaves the public route cacheable", async () => {

--- a/packages/nextly/src/api/response-shapes.ts
+++ b/packages/nextly/src/api/response-shapes.ts
@@ -282,7 +282,7 @@ export function applySessionCacheHeaders(headers: Headers): void {
     "Cache-Control",
     privateCacheControl(headers.get("Cache-Control"))
   );
-  headers.set("Vary", varyingOnCookie(headers.get("Vary")));
+  headers.set("Vary", varyingOnCredentials(headers.get("Vary")));
 }
 
 /**
@@ -313,6 +313,45 @@ function directiveName(directive: string): string {
 }
 
 /**
+ * One header's comma-separated members, respecting quoted values.
+ *
+ * A plain `split(",")` is wrong for `Cache-Control`, because a directive may
+ * carry a QUOTED field list: `private="Set-Cookie, X-User"` is one directive
+ * and splitting it produced two — the first discarded as `private`, the second
+ * surviving as the fragment `X-User"`, so this boundary emitted a malformed
+ * header and a strict intermediary could reject the privacy directives along
+ * with it. Measured on that input before the fix: `private, no-store, X-User"`.
+ *
+ * Backslash escapes are honoured inside a quoted string, so a quote written as
+ * part of a value does not end it.
+ */
+function splitOutsideQuotes(value: string): string[] {
+  const members: string[] = [];
+  let current = "";
+  let quoted = false;
+  let escaped = false;
+  for (const char of value) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+    } else if (quoted && char === "\\") {
+      current += char;
+      escaped = true;
+    } else if (char === '"') {
+      quoted = !quoted;
+      current += char;
+    } else if (char === "," && !quoted) {
+      members.push(current);
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+  members.push(current);
+  return members.map(member => member.trim()).filter(member => member !== "");
+}
+
+/**
  * `Cache-Control` that says private, keeping what the handler already said.
  *
  * Merged rather than replaced. A handler that had set `no-transform` lost it,
@@ -320,24 +359,33 @@ function directiveName(directive: string): string {
  * in flight whether or not a cache may keep it.
  */
 function privateCacheControl(existing: string | null): string {
-  const kept = (existing ?? "")
-    .split(",")
-    .map(directive => directive.trim())
-    .filter(directive => directive !== "")
-    .filter(directive => {
-      const name = directiveName(directive);
-      return (
-        !CACHE_DIRECTIVES_REPLACED.has(name) &&
-        name !== "private" &&
-        name !== "no-store"
-      );
-    });
+  const kept = splitOutsideQuotes(existing ?? "").filter(directive => {
+    const name = directiveName(directive);
+    return (
+      !CACHE_DIRECTIVES_REPLACED.has(name) &&
+      name !== "private" &&
+      name !== "no-store"
+    );
+  });
   // The privacy directives lead, so a reader sees the binding rule first.
   return ["private", "no-store", ...kept].join(", ");
 }
 
 /**
- * `Vary` that includes `Cookie`, keeping what the response already varied on.
+ * The credentials a session-gated response can depend on.
+ *
+ * BOTH, because either can identify the caller. A cookie is the browser's way
+ * in; `Authorization: Bearer` is an API key's, and `requireAuthentication`
+ * accepts one — with that key's own user, roles and permissions. Naming only
+ * the cookie gives two different API keys the same cache key, so for any
+ * intermediary that stores despite `no-store` — the fallback this header exists
+ * for — the first key's answer can be replayed to the second.
+ */
+const SESSION_CREDENTIAL_FIELDS = ["Cookie", "Authorization"] as const;
+
+/**
+ * `Vary` naming every credential the answer depends on, keeping what the
+ * response already varied on.
  *
  * Replacing it was the defect: a response varying on `Accept-Language` became
  * one varying only on `Cookie`, so a cache could answer a second language from
@@ -346,16 +394,19 @@ function privateCacheControl(existing: string | null): string {
  * `*` is left alone. It already means "vary on everything", and narrowing it to
  * a list would widen what may be shared.
  */
-function varyingOnCookie(existing: string | null): string {
+function varyingOnCredentials(existing: string | null): string {
   const fields = (existing ?? "")
     .split(",")
     .map(field => field.trim())
     .filter(field => field !== "");
   if (fields.includes("*")) return "*";
   const seen = new Set(fields.map(field => field.toLowerCase()));
-  return seen.has("cookie")
-    ? fields.join(", ")
-    : [...fields, "Cookie"].join(", ");
+  for (const field of SESSION_CREDENTIAL_FIELDS) {
+    if (seen.has(field.toLowerCase())) continue;
+    fields.push(field);
+    seen.add(field.toLowerCase());
+  }
+  return fields.join(", ");
 }
 
 /** {@link applySessionCacheHeaders} for a response the caller owns. */

--- a/packages/nextly/src/plugins/routes/dispatch-response-headers.test.ts
+++ b/packages/nextly/src/plugins/routes/dispatch-response-headers.test.ts
@@ -121,6 +121,49 @@ describe("what a plugin route already said is kept", () => {
     // And the directive that CONTRADICTS no-store does not survive beside it.
     expect(cc).not.toContain("max-age");
   });
+
+  it("keeps a QUOTED directive whole rather than splitting inside it", async () => {
+    // `private="Set-Cookie, X-User"` is ONE field-qualified directive. Splitting
+    // on every comma made it two: the first was discarded as `private` and the
+    // second survived as the fragment `X-User"`, so the header this boundary
+    // emitted was malformed — measured, `private, no-store, X-User"` — and a
+    // strict intermediary may reject it along with the privacy directives it
+    // was carrying.
+    reqAuth.mockResolvedValue(okAuth as never);
+    const quoted = route({
+      handler: () =>
+        Response.json(opaque, {
+          headers: {
+            "Cache-Control": 'private="Set-Cookie, X-User", no-transform',
+          },
+        }),
+    });
+
+    const res = await runPluginRoute(req(), match(quoted));
+
+    const cc = res.headers.get("Cache-Control") ?? "";
+    // No dangling fragment, and no unbalanced quote.
+    expect(cc).not.toContain('X-User"');
+    expect((cc.match(/"/g) ?? []).length % 2).toBe(0);
+    // The directive beside it still survives, so this is not "drop everything".
+    expect(cc).toContain("no-transform");
+    expect(cc).toContain("no-store");
+  });
+
+  it("varies on the API KEY as well as the cookie", async () => {
+    // A non-public plugin route accepts `Authorization: Bearer` — an API key,
+    // carrying its own user, roles and permissions. Naming only the cookie
+    // gives two different keys the same cache key, so an intermediary that
+    // stores despite `no-store` can replay the first key's answer to the
+    // second.
+    reqAuth.mockResolvedValue(okAuth as never);
+
+    const res = await runPluginRoute(req(), match(route({})));
+
+    const vary = (res.headers.get("Vary") ?? "").toLowerCase();
+    expect(vary).toContain("cookie");
+    expect(vary).toContain("authorization");
+  });
 });
 
 describe("an authenticated plugin route answers ONE session", () => {
@@ -133,7 +176,7 @@ describe("an authenticated plugin route answers ONE session", () => {
     const res = await runPluginRoute(req(), match(route({})));
 
     expect(res.headers.get("Cache-Control")).toBe("private, no-store");
-    expect(res.headers.get("Vary")).toBe("Cookie");
+    expect(res.headers.get("Vary")).toContain("Cookie");
   });
 
   it("marks the REFUSAL too, which is the direction that looks like a gate", async () => {
@@ -145,7 +188,7 @@ describe("an authenticated plugin route answers ONE session", () => {
 
     expect(res.status).toBe(401);
     expect(res.headers.get("Cache-Control")).toBe("private, no-store");
-    expect(res.headers.get("Vary")).toBe("Cookie");
+    expect(res.headers.get("Vary")).toContain("Cookie");
   });
 
   it("leaves a PUBLIC route cacheable, because its answer is not one caller's", async () => {


### PR DESCRIPTION
Two P2s Codex raised on #1627. They arrived after it merged, so both defects are on `main` now.

## `Vary` named only the cookie

A non-public plugin route also accepts `Authorization: Bearer` — `requireAuthentication` resolves an API key to **its own** user, roles and permissions (`auth/middleware/index.ts`). So two different API keys had the same cache key while their responses legitimately differ, and for any intermediary that stores despite `no-store` — the exact fallback this header exists for — the first key’s answer could be replayed to the second.

Both credentials are named now. The assertions that pinned the whole header were relaxed to membership, so naming another credential later is a decision rather than a test failure.

## A quoted `Cache-Control` directive was split down the middle

`private="Set-Cookie, X-User"` is **one** field-qualified directive. Splitting on every comma made it two: the first was discarded as `private`, the second survived as the fragment `X-User"`.

Measured on that input before the fix:

```
private="Set-Cookie, X-User"   ->   private, no-store, X-User"
```

Malformed, with an unbalanced quote — which a strict intermediary may reject *along with the privacy directives it was carrying*, turning a hardening change into a hole. Members are now separated only on commas outside quoted strings, honouring backslash escapes so a quote written inside a value does not end it.

## Verification

- Both reproduced first. The quoted case was reproduced by transcribing the merged implementation into a standalone probe and running it, rather than reasoning about it.
- **Break-verified, control established first:** the control collects 9 tests and fails 0; splitting on every comma kills the quoted-directive test and only it; varying on the cookie alone kills the API-key test and only it.
- One pre-existing test (`routeHandler-admin-meta-workspace`) asserted the whole `Vary` string. Its stated intent is that the response belongs to one session, and the exact value was incidental to that, so it now asserts membership of both credentials — called out here rather than quietly changed.
- `nextly` suite 11,587 passed / 0 failed. check-types + lint 15/15, exit 0. fallow `pass`, 0 introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved response caching behavior for authenticated routes by varying cached responses based on both session cookies and authorization credentials.
  - Preserved existing cache variation settings, including wildcard configurations.
  - Improved handling of complex `Cache-Control` directives containing quoted, comma-separated values.
  - Retained valid cache directives while removing conflicting settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->