### PR TITLE
fix(media): return a file's variants and focal point however it is read

### DIFF
--- a/.changeset/a-media-file-answers-the-same-either-way.md
+++ b/.changeset/a-media-file-answers-the-same-either-way.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Media: `sizes`, `focalX` and `focalY` are returned by `media.findByID()` and `GET /api/media/:id`, not only by a media file populated as a relationship. Every variant URL is absolutized exactly as `url` is, and the JSON string SQLite stores in the column is parsed, so all three dialects answer with the same shape.

--- a/docs/guides/media-storage.mdx
+++ b/docs/guides/media-storage.mdx
@@ -379,18 +379,19 @@ The list endpoint is permission-gated by `read-settings`; mutation endpoints req
 
 ### Using sizes from your frontend
 
-Where the variants reach you depends on how you read the media file, so it is worth
-being exact about it.
-
-A media file **populated as a relationship** on an entry or a single carries its
-variants under `sizes`, keyed by the name you configured:
+A media file carries its generated variants under `sizes`, keyed by the name you
+configured. It does so however you read it: populated as a relationship on an entry
+or a single, fetched on its own with `media.findByID()`, or returned by
+`GET /api/media/:id`.
 
 ```json
 {
   "id": "abc-123",
-  "url": "/uploads/2026/04/photo.jpg",
+  "url": "https://example.com/uploads/2026/04/photo.jpg",
   "width": 3000,
   "height": 2000,
+  "focalX": 50,
+  "focalY": 50,
   "sizes": {
     "thumbnail": { "url": "...", "width": 150, "height": 150 },
     "medium": { "url": "...", "width": 768, "height": 512 },
@@ -399,13 +400,13 @@ variants under `sizes`, keyed by the name you configured:
 }
 ```
 
-`media.findByID()` does not. It returns a `MediaFile`, which declares no `sizes`
-field, so a variant read straight off that result does not exist at runtime and does
-not compile either.
+Every URL in that response is absolute, the variants included, so a mobile client
+or an edge worker can resolve one without knowing where your storage adapter puts
+things. `sizes` is `null` for a file with no variants: a non-image, or an image
+uploaded before you configured any size.
 
-So a variant can only be selected from a value that carries one. Give that value to
-`getMediaVariant`, which asks for a name, tries your fallback name next, then
-`thumbnailUrl`, then the original:
+Select one with `getMediaVariant`, which asks for a name, tries your fallback name
+next, then `thumbnailUrl`, then the original:
 
 ```tsx
 // app/(site)/media-image.tsx
@@ -424,9 +425,8 @@ export function MediaImage({ media, alt }: { media: MediaLike; alt: string }) {
 }
 ```
 
-Hand it the media value off a populated relationship, not a `findByID` result. Called on
-a `MediaFile` the helper still returns a URL, but it can only ever be the thumbnail or the
-original, because the variants are not on that object to choose from.
+Hand it either kind of media value. `MediaLike` is the narrow shape the helper needs,
+and both a populated relationship and a `MediaFile` satisfy it.
 
 Reading a media record on its own is still a `findByID`, and it still needs a runtime:
 

--- a/packages/nextly/src/domains/media/__tests__/media-file-carries-variants.test.ts
+++ b/packages/nextly/src/domains/media/__tests__/media-file-carries-variants.test.ts
@@ -1,0 +1,213 @@
+/**
+ * A media file describes itself the same way however it is read.
+ *
+ * `sizes`, `focalX` and `focalY` are stored in every dialect, and the mapper
+ * behind `media.findById()` and `GET /api/media/:id` used to drop all three, so
+ * the same file carried its variants when populated as a relationship on
+ * another collection and carried none when fetched on its own. These hold the
+ * two paths to one answer.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { getMediaVariant } from "../../../lib/media-variant";
+import { UploadValidator } from "../../../services/upload-validation";
+import type { RequestContext } from "../../../shared/types";
+import { MediaService } from "../services/media-service";
+
+const context: RequestContext = {
+  user: {
+    id: "user-001",
+    email: "t@example.com",
+    role: "admin",
+    permissions: ["media:read"],
+  },
+  locale: "en",
+};
+
+const silentLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+/** A stored row as the legacy service hands it back. */
+const row = (overrides: Record<string, unknown> = {}) => ({
+  id: "media-1",
+  filename: "photo.jpg",
+  originalFilename: "photo.jpg",
+  mimeType: "image/jpeg",
+  size: 4096,
+  width: 3000,
+  height: 2000,
+  duration: null,
+  url: "/uploads/2026/04/photo.jpg",
+  thumbnailUrl: "/uploads/2026/04/photo-thumb.jpg",
+  altText: null,
+  caption: null,
+  tags: null,
+  folderId: null,
+  uploadedBy: "user-001",
+  uploadedAt: new Date("2026-04-01T00:00:00Z"),
+  updatedAt: new Date("2026-04-01T00:00:00Z"),
+  ...overrides,
+});
+
+const variants = {
+  thumbnail: {
+    url: "/uploads/2026/04/photo-150x150.jpg",
+    path: "2026/04/photo-150x150.jpg",
+    width: 150,
+    height: 150,
+    filesize: 900,
+    mimeType: "image/jpeg",
+    filename: "photo-150x150.jpg",
+  },
+  large: {
+    url: "/uploads/2026/04/photo-1200x800.jpg",
+    path: "2026/04/photo-1200x800.jpg",
+    width: 1200,
+    height: 800,
+    filesize: 40_000,
+    mimeType: "image/jpeg",
+    filename: "photo-1200x800.jpg",
+  },
+};
+
+describe("a media file fetched on its own carries what the row holds", () => {
+  let service: MediaService;
+  let legacyMedia: Record<string, ReturnType<typeof vi.fn>>;
+
+  beforeEach(() => {
+    legacyMedia = {
+      uploadMedia: vi.fn(),
+      getMediaById: vi.fn(),
+      listMedia: vi.fn(),
+      updateMedia: vi.fn(),
+      deleteMedia: vi.fn(),
+    };
+    service = new MediaService(
+      legacyMedia as never,
+      {} as never,
+      { getType: vi.fn().mockReturnValue("local") } as never,
+      {} as never,
+      new UploadValidator(undefined),
+      true,
+      silentLogger
+    );
+  });
+
+  const answer = (data: unknown) => ({
+    success: true,
+    statusCode: 200,
+    message: "OK",
+    data,
+  });
+
+  it("returns every generated variant, with each URL absolutized", async () => {
+    legacyMedia.getMediaById.mockResolvedValue(
+      answer(row({ sizes: variants }))
+    );
+
+    const file = await service.findById("media-1", context);
+
+    // The variant URLs get the same treatment as `url`, which is the whole
+    // reason a caller can hand this object to `getMediaVariant` and put the
+    // result straight into an <Image src>.
+    expect(file.sizes?.large.url).toBe(
+      "http://localhost:3000/uploads/2026/04/photo-1200x800.jpg"
+    );
+    expect(file.sizes?.thumbnail.url).toBe(
+      "http://localhost:3000/uploads/2026/04/photo-150x150.jpg"
+    );
+    // The control: the fields that were already carried still are, so a mapper
+    // that returned the raw row would not pass this.
+    expect(file.url).toBe("http://localhost:3000/uploads/2026/04/photo.jpg");
+    expect(file.sizes?.large.width).toBe(1200);
+  });
+
+  it("leaves a cloud adapter's absolute variant URLs alone", async () => {
+    legacyMedia.getMediaById.mockResolvedValue(
+      answer(
+        row({
+          url: "https://cdn.example.com/photo.jpg",
+          sizes: {
+            large: {
+              ...variants.large,
+              url: "https://cdn.example.com/photo-1200x800.jpg",
+            },
+          },
+        })
+      )
+    );
+
+    const file = await service.findById("media-1", context);
+
+    expect(file.sizes?.large.url).toBe(
+      "https://cdn.example.com/photo-1200x800.jpg"
+    );
+    expect(file.url).toBe("https://cdn.example.com/photo.jpg");
+  });
+
+  it("parses the JSON string SQLite returns, so every dialect answers alike", async () => {
+    // SQLite stores the column as TEXT and the driver returns it as a string.
+    // A mapper that assigned the column straight through would hand a caller a
+    // string on one dialect and an object on the other two, and
+    // `sizes.large.url` would be undefined on exactly one of them.
+    legacyMedia.getMediaById.mockResolvedValue(
+      answer(row({ sizes: JSON.stringify(variants) }))
+    );
+
+    const file = await service.findById("media-1", context);
+
+    expect(typeof file.sizes).toBe("object");
+    expect(file.sizes?.large.url).toBe(
+      "http://localhost:3000/uploads/2026/04/photo-1200x800.jpg"
+    );
+  });
+
+  it("carries the focal point", async () => {
+    legacyMedia.getMediaById.mockResolvedValue(
+      answer(row({ focalX: 30, focalY: 70 }))
+    );
+
+    const file = await service.findById("media-1", context);
+
+    expect(file.focalX).toBe(30);
+    expect(file.focalY).toBe(70);
+  });
+
+  it("answers null for a file that has no variants", async () => {
+    // A non-image, or an image uploaded before any size was configured. Null
+    // rather than a missing key, so a caller can branch on one shape.
+    legacyMedia.getMediaById.mockResolvedValue(
+      answer(row({ mimeType: "application/pdf", sizes: null }))
+    );
+
+    const file = await service.findById("media-1", context);
+
+    expect(file.sizes).toBeNull();
+    expect(file.focalX ?? null).toBeNull();
+  });
+
+  it("can be handed straight to getMediaVariant", async () => {
+    // The claim the guide makes. Before this, the helper called on a findById
+    // result could only ever return the thumbnail or the original, because the
+    // variants were not on the object to choose from.
+    legacyMedia.getMediaById.mockResolvedValue(
+      answer(row({ sizes: variants }))
+    );
+
+    const file = await service.findById("media-1", context);
+
+    expect(getMediaVariant(file, "large", { fallback: "thumbnail" })).toBe(
+      "http://localhost:3000/uploads/2026/04/photo-1200x800.jpg"
+    );
+    // The control: a name that exists in neither falls back to the thumbnail,
+    // so the assertion above is reading the variant rather than the fallback.
+    expect(getMediaVariant(file, "missing", { fallback: "alsoMissing" })).toBe(
+      "http://localhost:3000/uploads/2026/04/photo-thumb.jpg"
+    );
+  });
+});

--- a/packages/nextly/src/domains/media/services/media-service.ts
+++ b/packages/nextly/src/domains/media/services/media-service.ts
@@ -56,7 +56,7 @@ import { NextlyError } from "../../../errors";
 import { errorFromServiceEnvelope } from "../../../errors/from-service-envelope";
 import { emitMediaEvent } from "../../../events/domain-events";
 import { normalizeDbTimestamp } from "../../../lib/date-formatting";
-import { toAbsoluteMediaUrl } from "../../../lib/media-variant";
+import { absolutizeMediaUrls } from "../../../lib/media-variant";
 import type { MediaService as LegacyMediaService } from "../../../services/media";
 import type {
   MediaFolderService as LegacyFolderService,
@@ -1243,8 +1243,26 @@ export class MediaService {
 
   /**
    * Map legacy media data to MediaFile type
+   *
+   * `sizes`, `focalX` and `focalY` are carried through rather than dropped. The
+   * row holds all three in every dialect, and dropping them meant the same
+   * media file described itself differently depending on how it was read: with
+   * variants when populated as a relationship on another collection, without
+   * them from `media.findByID()` and `GET /api/media/:id`.
+   *
+   * The URLs go through `absolutizeMediaUrls` rather than a second pass of
+   * `toAbsoluteMediaUrl` per field. That function is what the relationship path
+   * already uses, so the two answers cannot disagree about what an absolute
+   * media URL is, and it carries the part that is easy to get wrong by hand:
+   * SQLite stores `sizes` as TEXT and returns a JSON string, which it parses,
+   * so the shape a caller receives is the same on all three dialects.
    */
   private mapToMediaFile(data: MediaRow): MediaFile {
+    const { url, thumbnailUrl, sizes } = absolutizeMediaUrls({
+      url: data.url,
+      thumbnailUrl: data.thumbnailUrl,
+      sizes: data.sizes,
+    });
     return {
       id: String(data.id),
       filename: data.filename,
@@ -1254,8 +1272,11 @@ export class MediaService {
       width: data.width,
       height: data.height,
       duration: data.duration,
-      url: toAbsoluteMediaUrl(data.url),
-      thumbnailUrl: toAbsoluteMediaUrl(data.thumbnailUrl),
+      url,
+      thumbnailUrl,
+      sizes,
+      focalX: data.focalX,
+      focalY: data.focalY,
       altText: data.altText,
       caption: data.caption,
       tags: data.tags,

--- a/packages/nextly/src/domains/media/types.ts
+++ b/packages/nextly/src/domains/media/types.ts
@@ -5,6 +5,8 @@
  * These types represent the public API surface for media operations.
  */
 
+import type { ImageSizeVariant } from "../../types/media";
+
 /**
  * Media file returned from operations
  */
@@ -19,6 +21,19 @@ export interface MediaFile {
   duration?: number | null;
   url: string;
   thumbnailUrl?: string | null;
+  /**
+   * Generated image variants, keyed by the configured size name.
+   *
+   * Optional and nullable because the column is: a non-image, or an image
+   * uploaded before any size was configured, carries none. Every variant URL is
+   * absolutized exactly as `url` is, so a caller reading `sizes.large.url` and
+   * a caller reading `url` get the same kind of value.
+   */
+  sizes?: Record<string, ImageSizeVariant> | null;
+  /** Horizontal focal point, 0 is the left edge and 100 the right. */
+  focalX?: number | null;
+  /** Vertical focal point, 0 is the top edge and 100 the bottom. */
+  focalY?: number | null;
   altText?: string | null;
   caption?: string | null;
   tags?: string[] | null;


### PR DESCRIPTION
Closes the media half of `finding:media-findbyid-never-returns-sizes`, which you decided to build rather than document away.

## What was wrong

`mapToMediaFile` dropped `sizes`, `focalX` and `focalY`. The row carries all three in every dialect (`jsonb` on Postgres, `json` on MySQL, `text` on SQLite; `focal_x` / `focal_y` as integers on all three), so the same media file described itself two different ways depending on how you read it:

| read as | `sizes` |
| --- | --- |
| a relationship populated on an entry or a single | present, URLs absolute |
| `nextly.media.findByID()` | **absent** |
| `GET /api/media/:id` | **absent** |

Both of the latter go through that mapper, so a reader following the guide's direct-fetch example got `undefined` and `getMediaVariant` on the result could only ever return the thumbnail or the original.

## The two questions you left open, and how they are settled

**Do variant URLs get absolutized?** Yes, and not by writing a second pass. `absolutizeMediaUrls` is what the relationship path already uses, so the mapper calls it instead of `toAbsoluteMediaUrl` per field. One answer to what an absolute media URL is, and it carries the part that is easy to get wrong by hand: SQLite returns the column as a JSON **string**, which that function parses. A mapper assigning the column straight through would have handed back a string on one dialect and an object on the other two, and `sizes.large.url` would be undefined on exactly one of them.

**Are the fields optional?** Yes, `?: T | null`, which is not a compatibility compromise but what the row already says: `MediaSchema` declares all three `.nullable().optional()`. Matching it keeps the two in agreement and keeps existing callers compiling, and a file with no variants reads as `null` rather than a missing key, so a caller branches on one shape.

`sizes` is typed `Record<string, ImageSizeVariant> | null`, reusing the interface the variant generator already produces, rather than a new inline shape. No cast was needed; `absolutizeMediaUrls` is generic and preserves it.

## The documentation moved with it

The guide had already been corrected to say `findByID` does **not** carry variants, which was true and is now false. Leaving it would have been the same defect pointing the other way. It now states what all three paths return, that every URL including the variants is absolute, and that `sizes` is `null` for a file with no variants.

## Evidence

Six tests, and the reason they matter is in the control: with the three fields dropped again, **all six fail and the package still typechecks clean under both tsconfigs**. Nothing in the compile gate could have caught this.

- every variant returned, each URL absolutized
- a cloud adapter's already-absolute URLs left alone
- the JSON string SQLite returns parsed, so all three dialects answer alike
- the focal point carried
- `sizes: null` for a file with no variants
- the result handed straight to `getMediaVariant`, with a control asserting the fallback path so the first assertion is reading the variant rather than the fallback

`pnpm run check-types` (both configs) clean, 102 media tests pass, doc-samples and docs-claims gates green.
