### PR TITLE
docs: use contributes.collections in the plugin example, and catch the next one

### DIFF
--- a/docs/plugins/index.mdx
+++ b/docs/plugins/index.mdx
@@ -120,8 +120,10 @@ const plugin: PluginDefinition = {
   name: 'my-plugin',
   version: '0.1.0',
   nextly: '>=0.0.2-alpha.63',
-  collections: [MyCollection],
+  contributes: { collections: [MyCollection] },
 
+  // Placement and appearance stay at the top level. This is complementary to
+  // `contributes.admin`, which is the declarative menu, pages and views surface.
   admin: {
     order: 50,
     description: 'What this plugin does',

--- a/scripts/check-doc-samples.mjs
+++ b/scripts/check-doc-samples.mjs
@@ -680,6 +680,25 @@ function compileOnce(samples, label, ignore = SUPPLIED_BY_THE_READER) {
 
     // The API's own split. Nothing here guesses from the error code.
     const unparsed = program.getSyntacticDiagnostics().map(render).filter(keep);
+    // Deprecations, asked of the checker rather than read off the diagnostics,
+    // for the reason written on `deprecatedPropertiesIn`. Rendered in the same
+    // shape as everything else and put in the same list, so the classifier
+    // charges the page and the conservation count downstream sees it without a
+    // bucket of its own. TS6385 is TypeScript's own code for this sentence,
+    // used rather than an invented one so a reader can look it up.
+    const checker = program.getTypeChecker();
+    const deprecated = fileNames.flatMap(file => {
+      const sourceFile = program.getSourceFile(file);
+      if (!sourceFile) return [];
+      const where = origin.get(file) ?? file;
+      return deprecatedPropertiesIn(sourceFile, checker).map(d => ({
+        origin: where,
+        text:
+          `${where}:${String(sourceFile.getLineAndCharacterOfPosition(d.start).line + 1)}  ` +
+          `error TS6385: '${d.name}' is deprecated.` +
+          (d.note ? ` ${d.note}` : ""),
+      }));
+    });
     const diagnostics = [
       ...setup.map(d => d.text),
       ...unparsed.map(d => d.text),
@@ -688,11 +707,63 @@ function compileOnce(samples, label, ignore = SUPPLIED_BY_THE_READER) {
         .map(render)
         .filter(keep)
         .map(d => d.text),
+      ...deprecated.filter(keep).map(d => d.text),
     ];
     return { unparsed, diagnostics };
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+}
+
+/**
+ * Properties a sample writes that the API it is writing them for has deprecated.
+ *
+ * TypeScript reports a deprecated FUNCTION as a suggestion diagnostic, and this
+ * audit reads semantic ones, so adding suggestions was the obvious answer. It
+ * was measured and it was wrong twice over: the corpus's suggestions are 24
+ * "declared but never read" and a handful of others, all of them expected in a
+ * sample that shows a shape rather than a program, and TypeScript does not
+ * report this class at all. `{ collections: [...] }` written against a type
+ * whose `collections` carries `@deprecated` produces no suggestion, no error and
+ * no warning. A documented example taught the deprecated spelling of a plugin's
+ * collections for as long as anyone had been reading it, and the gate compiled
+ * it clean every time.
+ *
+ * So it is asked of the checker rather than read off the diagnostics. Every
+ * object literal that has a contextual type is one the reader is filling in for
+ * a declared API, and the property they wrote either exists on that type
+ * carrying a `@deprecated` tag or it does not.
+ *
+ * The contextual type is what makes this narrow. A bare literal with no
+ * declared shape has nothing to be deprecated against and is skipped, and a
+ * nested literal is judged against its own property's type, so the `collections`
+ * inside `contributes` is a different property from the one beside it.
+ */
+export function deprecatedPropertiesIn(sourceFile, checker) {
+  const found = [];
+  const walk = node => {
+    if (ts.isObjectLiteralExpression(node)) {
+      const contextual = checker.getContextualType(node);
+      if (contextual) {
+        for (const property of node.properties) {
+          if (!property.name || !ts.isIdentifier(property.name)) continue;
+          const target = contextual.getProperty(property.name.text);
+          const tag = target
+            ?.getJsDocTags(checker)
+            .find(t => t.name === "deprecated");
+          if (!tag) continue;
+          found.push({
+            name: property.name.text,
+            start: property.getStart(sourceFile),
+            note: (tag.text ?? []).map(part => part.text).join("").trim(),
+          });
+        }
+      }
+    }
+    ts.forEachChild(node, walk);
+  };
+  ts.forEachChild(sourceFile, walk);
+  return found;
 }
 
 /**

--- a/scripts/check-doc-samples.mjs
+++ b/scripts/check-doc-samples.mjs
@@ -746,14 +746,12 @@ export function deprecatedPropertiesIn(sourceFile, checker) {
       const contextual = checker.getContextualType(node);
       if (contextual) {
         for (const property of node.properties) {
-          if (!property.name || !ts.isIdentifier(property.name)) continue;
-          const target = contextual.getProperty(property.name.text);
-          const tag = target
-            ?.getJsDocTags(checker)
-            .find(t => t.name === "deprecated");
+          const name = writtenPropertyName(property);
+          if (name === null) continue;
+          const tag = deprecationOf(contextual, name, checker);
           if (!tag) continue;
           found.push({
-            name: property.name.text,
+            name,
             start: property.getStart(sourceFile),
             note: (tag.text ?? []).map(part => part.text).join("").trim(),
           });
@@ -764,6 +762,51 @@ export function deprecatedPropertiesIn(sourceFile, checker) {
   };
   ts.forEachChild(sourceFile, walk);
   return found;
+}
+
+/**
+ * The property name a literal member writes, when it can be known from the text.
+ *
+ * `{ collections: [] }` and `{ "collections": [] }` name the same member, and
+ * reading only identifiers meant the quoted spelling walked past the check. The
+ * test is `.text`, which every static property name carries, rather than a list
+ * of the node kinds that have one.
+ *
+ * Null for a computed name and for a spread, which writes no name here at all:
+ * neither can be resolved against a declared property without evaluating
+ * something, and a guess is worse than the silence.
+ */
+function writtenPropertyName(property) {
+  const name = property.name;
+  if (!name || ts.isComputedPropertyName(name)) return null;
+  return typeof name.text === "string" ? name.text : null;
+}
+
+/**
+ * The `@deprecated` tag on a property, across everything the literal might be.
+ *
+ * A contextual type is often a union, and `getProperty` on one answers for the
+ * union rather than for its parts: a property present on a single constituent
+ * comes back `undefined`, so a deprecated option in a union-shaped API passed
+ * unread. The constituents are asked one at a time instead.
+ *
+ * Reported only when EVERY constituent that declares the property deprecates
+ * it. Where one arm deprecates a name the other still offers, which arm this
+ * literal is depends on a discriminant, and nothing here reads discriminants.
+ * Reporting anyway would charge a page for writing the current spelling of a
+ * name that is merely obsolete elsewhere; requiring agreement gives up the
+ * mixed case and keeps the answer true.
+ */
+function deprecationOf(contextual, name, checker) {
+  const constituents = contextual.isUnion() ? contextual.types : [contextual];
+  const declared = constituents
+    .map(type => type.getProperty(name))
+    .filter(symbol => symbol !== undefined);
+  if (declared.length === 0) return undefined;
+  const tags = declared.map(symbol =>
+    symbol.getJsDocTags(checker).find(tag => tag.name === "deprecated")
+  );
+  return tags.every(tag => tag !== undefined) ? tags[0] : undefined;
 }
 
 /**

--- a/scripts/check-doc-samples.mjs
+++ b/scripts/check-doc-samples.mjs
@@ -748,7 +748,7 @@ export function deprecatedPropertiesIn(sourceFile, checker) {
         for (const property of node.properties) {
           const name = writtenPropertyName(property);
           if (name === null) continue;
-          const tag = deprecationOf(contextual, name, checker);
+          const tag = deprecationOf(contextual, name, checker, node);
           if (!tag) continue;
           found.push({
             name,
@@ -778,8 +778,64 @@ export function deprecatedPropertiesIn(sourceFile, checker) {
  */
 function writtenPropertyName(property) {
   const name = property.name;
-  if (!name || ts.isComputedPropertyName(name)) return null;
+  if (!name) return null;
+  // `{ ["collections"]: [] }` names the same member as the other two
+  // spellings, and TypeScript resolves it the same way. Only the expression
+  // inside decides: a literal is read, anything that has to be evaluated is
+  // not.
+  if (ts.isComputedPropertyName(name)) {
+    const inner = name.expression;
+    return ts.isStringLiteralLike(inner) || ts.isNumericLiteral(inner)
+      ? inner.text
+      : null;
+  }
   return typeof name.text === "string" ? name.text : null;
+}
+
+/**
+ * The union constituents a literal could still be, after its own discriminants.
+ *
+ * `{ kind: "legacy", old: "x" }` against `Legacy | Current` is not ambiguous:
+ * the literal says which arm it is. Asking every arm and requiring them to
+ * agree gave that up, so a key deprecated on the arm actually being written
+ * passed whenever the other arm still offered it.
+ *
+ * A constituent is dropped when the literal writes a literal value for a
+ * property that constituent declares as a different literal type. Nothing else
+ * narrows: a property whose value is computed, or whose declared type is not a
+ * literal, says nothing about which arm this is and is left alone.
+ */
+function applicableConstituents(constituents, literal, checker) {
+  const discriminants = [];
+  for (const property of literal.properties) {
+    if (!ts.isPropertyAssignment(property)) continue;
+    const name = writtenPropertyName(property);
+    if (name === null) continue;
+    const written = checker.getTypeAtLocation(property.initializer);
+    if (!written.isLiteral() && !(written.flags & ts.TypeFlags.BooleanLiteral)) {
+      continue;
+    }
+    discriminants.push({ name, written });
+  }
+  if (discriminants.length === 0) return constituents;
+
+  const applicable = constituents.filter(constituent =>
+    discriminants.every(({ name, written }) => {
+      const declared = constituent.getProperty(name);
+      if (!declared) return true;
+      const type = checker.getTypeOfSymbolAtLocation(
+        declared,
+        declared.valueDeclaration ?? literal
+      );
+      if (!type.isLiteral() && !(type.flags & ts.TypeFlags.BooleanLiteral)) {
+        return true;
+      }
+      return checker.typeToString(type) === checker.typeToString(written);
+    })
+  );
+  // Every arm ruled out means the discriminants describe none of them, which is
+  // the compiler's complaint to make rather than this one's.
+  return applicable.length === 0 ? constituents : applicable;
 }
 
 /**
@@ -790,15 +846,19 @@ function writtenPropertyName(property) {
  * comes back `undefined`, so a deprecated option in a union-shaped API passed
  * unread. The constituents are asked one at a time instead.
  *
- * Reported only when EVERY constituent that declares the property deprecates
- * it. Where one arm deprecates a name the other still offers, which arm this
- * literal is depends on a discriminant, and nothing here reads discriminants.
- * Reporting anyway would charge a page for writing the current spelling of a
- * name that is merely obsolete elsewhere; requiring agreement gives up the
- * mixed case and keeps the answer true.
+ * The constituents are narrowed by the literal's own discriminants first, so a
+ * literal that says which arm it is gets answered by that arm. Where the
+ * discriminants leave more than one arm standing, it reports only when every
+ * remaining arm that declares the property deprecates it: charging a page for
+ * writing the current spelling of a name that is merely obsolete on some other
+ * arm would be claiming to know something this does not.
  */
-function deprecationOf(contextual, name, checker) {
-  const constituents = contextual.isUnion() ? contextual.types : [contextual];
+function deprecationOf(contextual, name, checker, literal) {
+  const constituents = applicableConstituents(
+    contextual.isUnion() ? contextual.types : [contextual],
+    literal,
+    checker
+  );
   const declared = constituents
     .map(type => type.getProperty(name))
     .filter(symbol => symbol !== undefined);

--- a/scripts/check-doc-samples.test.mjs
+++ b/scripts/check-doc-samples.test.mjs
@@ -1,3 +1,7 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import ts from "typescript";
 import { describe, expect, it } from "vitest";
 
@@ -5,6 +9,7 @@ import {
   compareToBaseline,
   compile,
   contextOnlyWorthRecording,
+  deprecatedPropertiesIn,
   declaredNamesIn,
   extensionFor,
   extractFrom,
@@ -930,5 +935,157 @@ describe("contextOnlyWorthRecording deduplicates on identity", () => {
   it("records a block pasted into several continuations once", () => {
     const contextOnly = [missingFoo("docs/a.mdx#1", 3), missingFoo("docs/a.mdx#1", 3)];
     expect(contextOnlyWorthRecording({ contextOnly, firstPass: [] })).toHaveLength(1);
+  });
+});
+
+describe("a sample that writes a property the API has deprecated", () => {
+  /** A two-file program: one declaring the API, one writing against it. */
+  const program = source => {
+    const dir = mkdtempSync(join(tmpdir(), "deprecated-"));
+    writeFileSync(
+      join(dir, "api.ts"),
+      [
+        "export interface Plugin {",
+        "  /** @deprecated Prefer contributes.collections */",
+        "  collections?: string[];",
+        "  contributes?: { collections?: string[] };",
+        "  admin?: { order?: number };",
+        "}",
+        "",
+      ].join("\n")
+    );
+    writeFileSync(join(dir, "use.ts"), source);
+    const files = [join(dir, "api.ts"), join(dir, "use.ts")];
+    const built = ts.createProgram(files, {
+      noEmit: true,
+      strict: true,
+      target: ts.ScriptTarget.ES2022,
+      module: ts.ModuleKind.ESNext,
+      skipLibCheck: true,
+    });
+    return {
+      dir,
+      sourceFile: built.getSourceFile(join(dir, "use.ts")),
+      checker: built.getTypeChecker(),
+      program: built,
+      files,
+    };
+  };
+
+  const namesFlaggedIn = source => {
+    const { sourceFile, checker, dir } = program(source);
+    try {
+      return deprecatedPropertiesIn(sourceFile, checker).map(d => d.name);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  };
+
+  it("names the deprecated property and leaves its siblings alone", () => {
+    expect(
+      namesFlaggedIn(
+        'import type { Plugin } from "./api";\n' +
+          'export const p: Plugin = { collections: ["a"], admin: { order: 1 } };\n'
+      )
+    ).toEqual(["collections"]);
+  });
+
+  it("judges a nested literal against its own property's type", () => {
+    // `contributes.collections` is a different property from the one beside
+    // it, and only one of the two is deprecated. A check that matched on the
+    // name would fail this.
+    expect(
+      namesFlaggedIn(
+        'import type { Plugin } from "./api";\n' +
+          'export const p: Plugin = { contributes: { collections: ["a"] } };\n'
+      )
+    ).toEqual([]);
+  });
+
+  it("skips a literal with no declared shape to be judged against", () => {
+    // Nothing contextual, so nothing can be deprecated against it. This is
+    // what keeps the check narrow rather than matching every property named
+    // `collections` in the corpus.
+    expect(
+      namesFlaggedIn('export const p = { collections: ["a"] };\n')
+    ).toEqual([]);
+  });
+
+  it("carries the deprecation's own note, which is where the fix is written", () => {
+    const { sourceFile, checker, dir } = program(
+      'import type { Plugin } from "./api";\n' +
+        'export const p: Plugin = { collections: ["a"] };\n'
+    );
+    try {
+      expect(deprecatedPropertiesIn(sourceFile, checker)[0].note).toBe(
+        "Prefer contributes.collections"
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("is not something TypeScript already reports", () => {
+    // The control, and the whole reason this function exists. Adding
+    // suggestion diagnostics was the obvious answer and does not work: a
+    // deprecated FUNCTION is reported, a deprecated property written in an
+    // object literal is not, and the corpus's suggestions are otherwise
+    // "declared but never read" on samples that show a shape rather than run.
+    const { files, program: built, dir } = program(
+      'import type { Plugin } from "./api";\n' +
+        'export const p: Plugin = { collections: ["a"] };\n'
+    );
+    try {
+      const service = ts.createLanguageService({
+        getScriptFileNames: () => files,
+        getScriptVersion: () => "1",
+        getScriptSnapshot: f =>
+          ts.ScriptSnapshot.fromString(readFileSync(f, "utf-8")),
+        getCurrentDirectory: () => dir,
+        getCompilationSettings: () => built.getCompilerOptions(),
+        getDefaultLibFileName: o => ts.getDefaultLibFilePath(o),
+        fileExists: ts.sys.fileExists,
+        readFile: ts.sys.readFile,
+        readDirectory: ts.sys.readDirectory,
+        directoryExists: ts.sys.directoryExists,
+        getDirectories: ts.sys.getDirectories,
+      });
+      const reported = files.flatMap(f =>
+        service.getSuggestionDiagnostics(f).filter(d => d.reportsDeprecated)
+      );
+      expect(reported).toEqual([]);
+      // And the control on the control: the same service DOES report a
+      // deprecated call, so the empty result above is a limit of what
+      // TypeScript reports rather than a service that answers nothing.
+      const fnDir = mkdtempSync(join(tmpdir(), "deprecated-fn-"));
+      const fnFile = join(fnDir, "fn.ts");
+      writeFileSync(
+        fnFile,
+        "/** @deprecated */\nfunction old(): void {}\nold();\nexport {};\n"
+      );
+      const fnProgram = ts.createProgram([fnFile], { noEmit: true });
+      const fnService = ts.createLanguageService({
+        getScriptFileNames: () => [fnFile],
+        getScriptVersion: () => "1",
+        getScriptSnapshot: f =>
+          ts.ScriptSnapshot.fromString(readFileSync(f, "utf-8")),
+        getCurrentDirectory: () => fnDir,
+        getCompilationSettings: () => fnProgram.getCompilerOptions(),
+        getDefaultLibFileName: o => ts.getDefaultLibFilePath(o),
+        fileExists: ts.sys.fileExists,
+        readFile: ts.sys.readFile,
+        readDirectory: ts.sys.readDirectory,
+        directoryExists: ts.sys.directoryExists,
+        getDirectories: ts.sys.getDirectories,
+      });
+      expect(
+        fnService
+          .getSuggestionDiagnostics(fnFile)
+          .filter(d => d.reportsDeprecated).length
+      ).toBeGreaterThan(0);
+      rmSync(fnDir, { recursive: true, force: true });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/scripts/check-doc-samples.test.mjs
+++ b/scripts/check-doc-samples.test.mjs
@@ -951,6 +951,19 @@ describe("a sample that writes a property the API has deprecated", () => {
         "  contributes?: { collections?: string[] };",
         "  admin?: { order?: number };",
         "}",
+        "export interface Legacy {",
+        '  kind: "legacy";',
+        "  /** @deprecated Prefer nu */",
+        "  old?: string;",
+        "}",
+        "export interface Current {",
+        '  kind: "current";',
+        "  nu?: string;",
+        "}",
+        "export interface StillOffered {",
+        '  kind: "kept";',
+        "  old?: string;",
+        "}",
         "",
       ].join("\n")
     );
@@ -1023,6 +1036,51 @@ describe("a sample that writes a property the API has deprecated", () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+
+  it("reads a quoted key, which names the same member", () => {
+    // `{ "collections": [] }` and `{ collections: [] }` are the same property.
+    // Reading only identifiers let the quoted spelling walk past.
+    expect(
+      namesFlaggedIn(
+        'import type { Plugin } from "./api";\n' +
+          'export const p: Plugin = { "collections": ["a"] };\n'
+      )
+    ).toEqual(["collections"]);
+  });
+
+  it("looks inside a union rather than at the union", () => {
+    // `getProperty` on a union answers for the union: a property present on one
+    // constituent comes back undefined, so a deprecated option in a
+    // union-shaped API passed unread.
+    expect(
+      namesFlaggedIn(
+        'import type { Legacy, Current } from "./api";\n' +
+          'export const u: Legacy | Current = { kind: "legacy", old: "x" };\n'
+      )
+    ).toEqual(["old"]);
+  });
+
+  it("stays quiet when one arm of a union still offers the name", () => {
+    // Which arm this literal is depends on a discriminant, and nothing here
+    // reads discriminants. Charging the page would be claiming the writer meant
+    // the obsolete arm.
+    expect(
+      namesFlaggedIn(
+        'import type { Legacy, StillOffered } from "./api";\n' +
+          'export const u: Legacy | StillOffered = { kind: "kept", old: "x" };\n'
+      )
+    ).toEqual([]);
+  });
+
+  it("says nothing about a computed key it cannot resolve", () => {
+    expect(
+      namesFlaggedIn(
+        'import type { Plugin } from "./api";\n' +
+          'const k = "collections" as const;\n' +
+          "export const p: Plugin = { [k]: ['a'] };\n"
+      )
+    ).toEqual([]);
   });
 
   it("is not something TypeScript already reports", () => {

--- a/scripts/check-doc-samples.test.mjs
+++ b/scripts/check-doc-samples.test.mjs
@@ -964,6 +964,10 @@ describe("a sample that writes a property the API has deprecated", () => {
         '  kind: "kept";',
         "  old?: string;",
         "}",
+        "export interface Current2 {",
+        '  kind: "current";',
+        "  old?: string;",
+        "}",
         "",
       ].join("\n")
     );
@@ -1059,6 +1063,37 @@ describe("a sample that writes a property the API has deprecated", () => {
           'export const u: Legacy | Current = { kind: "legacy", old: "x" };\n'
       )
     ).toEqual(["old"]);
+  });
+
+  it("answers from the arm the literal says it is", () => {
+    // `{ kind: "legacy", old: "x" }` is not ambiguous: the discriminant names
+    // the arm. Asking every arm and requiring agreement gave that up, so a key
+    // deprecated on the arm actually being written passed whenever another arm
+    // still offered it.
+    expect(
+      namesFlaggedIn(
+        'import type { Legacy, Current2 } from "./api";\n' +
+          'export const u: Legacy | Current2 = { kind: "legacy", old: "x" };\n'
+      )
+    ).toEqual(["old"]);
+    // The other arm of the same union, which does not deprecate it.
+    expect(
+      namesFlaggedIn(
+        'import type { Legacy, Current2 } from "./api";\n' +
+          'export const u: Legacy | Current2 = { kind: "current", old: "x" };\n'
+      )
+    ).toEqual([]);
+  });
+
+  it("reads a computed key whose expression is a literal", () => {
+    // `{ ["collections"]: [] }` names the same member and TypeScript resolves
+    // it the same way. Only an expression that has to be evaluated is skipped.
+    expect(
+      namesFlaggedIn(
+        'import type { Plugin } from "./api";\n' +
+          'export const p: Plugin = { ["collections"]: ["a"] };\n'
+      )
+    ).toEqual(["collections"]);
   });
 
   it("stays quiet when one arm of a union still offers the name", () => {


### PR DESCRIPTION
A CodeRabbit finding on #1629, which merged before it could be worked, plus the gate change that stops the class recurring. The two belong together: the check fails without the fix, and the fix without the check leaves the blind spot that let it through.

## The docs fix

Verified against the type rather than taken on trust. In `packages/nextly/src/plugins/plugin-context.ts`:

- top-level `collections` carries `@deprecated Prefer contributes.collections (wired by the schema pipeline in P2). Still read by the admin sidebar (routeHandler) - kept for backward compatibility.`
- top-level `admin` carries no deprecation. Its own comment calls it **complementary** to `contributes.admin`: `admin` is placement and appearance, `contributes.admin` is the declarative menu, pages, settings and views surface, and "both are retained".

So `collections` moves under `contributes` and `admin` stays where it is.

## Why the gate could not see it, and what I tried first

**Reading suggestion diagnostics was the obvious answer. Measurement refuted it twice.**

TypeScript does not report this class at all. A deprecated *function call* is reported (TS6385/TS6387 with `reportsDeprecated`), but `{ collections: [...] }` written against a type whose `collections` carries `@deprecated` produces no suggestion, no warning and no error. I restored the deprecated spelling in the corpus with a suggestion-reading probe in place: still zero.

And the corpus's suggestion stream is noise for this purpose:

```
TS6133=24  (declared but never read)   TS6192=2   TS6198=2   TS7028=1   TS80007=1
deprecated usages: 0
```

Twenty-four "declared but never read" on samples whose job is to show a shape rather than run. Adding that bucket would have cost a baseline of noise and still missed the defect, while making it look covered.

## What works instead

Ask the checker. Every object literal with a **contextual type** is one a reader is filling in for a declared API, and the property they wrote either carries `@deprecated` on that type or it does not.

The contextual type is what keeps it narrow, and the corpus proves it: `docs/plugins/index.mdx` has `contributes: { collections: [MyCollection] }` at line 72, the correct shape, and it is not flagged, because a nested literal is judged against its own property's type.

Diagnostics are rendered in the same shape as everything else and put in the same list, so the classifier charges the page and the conservation post-condition sees them without a bucket of its own. TS6385 is TypeScript's own code for this sentence, used rather than an invented one so a reader can look it up.

## Evidence

**The corpus does not move**: 200 of 330 compiled, 35 findings, 52 set aside, all unchanged, because the example in this PR is the only instance and it is fixed here. That is why the control matters more than the numbers. Restoring the deprecated spelling:

```
gate exit=1
  36 diagnostic(s) a reader would hit
  docs/plugins/index.mdx  #4:8  error TS6385: 'collections' is deprecated.
    Prefer `contributes.collections` (wired by the schema pipeline in P2)...
```

Five unit tests, including two controls that matter:

- the nested `contributes.collections` is not flagged, so the check is not matching on a name
- TypeScript's own suggestion diagnostics report nothing for this input, **and** the same language service reports a deprecated function call, so the empty result is a limit of what TypeScript reports rather than a service that answers nothing

1070 tests across `scripts/`, `check:comments` and `check:docs-claims` clean.
