### PR TITLE
feat(blocks-engine): publish whether a selection may be saved as a pattern

### DIFF
--- a/.changeset/ask-the-planner-whether-a-selection-is-savable.md
+++ b/.changeset/ask-the-planner-whether-a-selection-is-savable.md
@@ -1,0 +1,35 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+**`saveAsPatternRefusal` is new on `@nextlyhq/blocks-engine`.** The counterpart to `patternRefusal`, published for the same reason and against the opposite mistake: that one stops a palette OFFERING a stored pattern the planner would reject, and this one stops a surface offering to SAVE a selection the planner would reject — a button that accepts a click and then fails.
+
+Before it, the only way to ask was to call `planSaveAsPattern` with a `target` invented for the purpose — a collection name and a field set that a surface deciding whether to _offer_ the save does not have yet. So the question could only be asked by answering a different one.
+
+It is a thin view over the planner's own preflight rather than a second walk: the same `plannedSave` both save planners call, so a question answered here and a save attempted afterwards cannot disagree. The ways a selection can be unsavable are not a short list a toolbar should keep its own copy of — not one contiguous run, a block that may not be a document root, a node whose shape the op layer will not carry, a descendant nested where the rules no longer allow, one DOM id on two of the run's own nodes — and a surface enumerating them drifts silently the first time the planner learns a new way to say no: the button stays enabled and the save fails.
+
+Because it does the work a save does up to building the stored document, it is exact, and it is worth memoising on the selection rather than calling per render.

--- a/.changeset/ask-the-planner-whether-a-selection-is-savable.md
+++ b/.changeset/ask-the-planner-whether-a-selection-is-savable.md
@@ -32,4 +32,8 @@ Before it, the only way to ask was to call `planSaveAsPattern` with a `target` i
 
 It is a thin view over the planner's own preflight rather than a second walk: the same `plannedSave` both save planners call, so a question answered here and a save attempted afterwards cannot disagree. The ways a selection can be unsavable are not a short list a toolbar should keep its own copy of — not one contiguous run, a block that may not be a document root, a node whose shape the op layer will not carry, a descendant nested where the rules no longer allow, one DOM id on two of the run's own nodes — and a surface enumerating them drifts silently the first time the planner learns a new way to say no: the button stays enabled and the save fails.
 
+It takes no limits of its own: `planSaveAsPattern` has none either, so a preflight that accepted them would answer a question the planner never asks — a lower cap disables a save the planner then accepts, a higher one the reverse.
+
+**A save is now refused when the document it would store exceeds the byte, depth or node caps.** The blocks field validates what it is handed, so such a pattern was rejected at the WRITE — after the author had named it, filled the form and pressed save. The same verdict now arrives at plan time, where they can still act on it, and it is what lets the preflight promise that a save it permits will not fail on size. This applies to the save planners as well as the preflight, because both ask one shared question.
+
 Because it does the work a save does up to building the stored document, it is exact, and it is worth memoising on the selection rather than calling per render.

--- a/packages/blocks-engine/src/composition-planners.test.ts
+++ b/packages/blocks-engine/src/composition-planners.test.ts
@@ -17,6 +17,7 @@ import {
   planInsertPattern,
   planSaveAsComponent,
   planSaveAsPattern,
+  saveAsPatternRefusal,
   planUpdatePatternFromSelection,
 } from "./composition-planners";
 import type {
@@ -96,6 +97,81 @@ function marked(nodes: BlockNode[], mark: string): BlockNode {
   if (found === undefined) throw new Error(`no node marked ${mark}`);
   return found;
 }
+
+describe("whether a selection may be saved at all", () => {
+  it("answers NOTHING for a selection the planner would accept", () => {
+    // The positive control, and the one that matters most: a preflight that
+    // refused everything would satisfy every assertion below while disabling a
+    // button that should work.
+    const doc = page([node("a"), node("b"), node("c")]);
+
+    expect(saveAsPatternRefusal(doc, ["a", "b"], anyParent)).toBeUndefined();
+  });
+
+  it("refuses a selection that is not one contiguous run, and says so", () => {
+    // The reason a surface cannot keep its own copy of this list: it is not a
+    // short list, and each entry is a way a page that RENDERS can still hold a
+    // selection no pattern can be made from.
+    const doc = page([node("a"), node("b"), node("c")]);
+
+    const refusal = saveAsPatternRefusal(doc, ["a", "c"], anyParent);
+
+    expect(refusal?.problem).toBeDefined();
+  });
+
+  it("agrees with the PLANNER, which is the whole point of publishing it", () => {
+    // Asked both ways over the same selections. A preflight that answered
+    // differently from the planner would be a button enabled for a save that
+    // fails, or disabled for one that would have worked — and the drift would
+    // be silent either way.
+    const doc = page([node("a"), node("b"), node("c")]);
+    for (const selection of [["a"], ["a", "b"], ["a", "c"], ["b", "c"], []]) {
+      const refused =
+        saveAsPatternRefusal(doc, selection, anyParent) !== undefined;
+      const planned = planSaveAsPattern(doc, selection, target, anyParent);
+      expect(refused).toBe(planned.problem !== undefined);
+    }
+  });
+
+  it("refuses a valid RUN whose stored document could not be saved", () => {
+    // The case that decides which preflight this is. `savableRun` alone asks
+    // only whether the selection is one contiguous, liftable run — it never
+    // builds the document, so a run that is perfectly well formed and whose
+    // pattern would blow the byte cap reads as savable. The button would enable
+    // and the save would then fail, which is the exact defect this exists to
+    // stop.
+    //
+    // Two adjacent nodes rendering ONE DOM id. The selection is a perfectly
+    // good run — contiguous, liftable, both valid roots — and the document it
+    // would store is not, because two nodes cannot answer to one id once the
+    // pattern is inserted somewhere.
+    const clashing = page([
+      node("a", { cssId: "hero" }),
+      node("b", { cssId: "hero" }),
+    ]);
+
+    expect(saveAsPatternRefusal(clashing, ["a", "b"], anyParent)).toBeDefined();
+    // The control: the SAME shape of selection over nodes that do not clash is
+    // savable — so the refusal above is the stored document talking, not the
+    // run.
+    const distinct = page([
+      node("a", { cssId: "hero" }),
+      node("b", { cssId: "pricing" }),
+    ]);
+    expect(
+      saveAsPatternRefusal(distinct, ["a", "b"], anyParent)
+    ).toBeUndefined();
+  });
+
+  it("asks without a target, which is what a caller has before it saves", () => {
+    // The gap this closes. Asking the planner meant inventing a collection name
+    // and a field set, which a surface deciding whether to OFFER the save does
+    // not have yet — so the only way to ask was to answer a different question.
+    const doc = page([node("a")]);
+
+    expect(() => saveAsPatternRefusal(doc, ["a"], anyParent)).not.toThrow();
+  });
+});
 
 describe("what a saved pattern is", () => {
   it("creates a pattern document in the collection the caller named", () => {

--- a/packages/blocks-engine/src/composition-planners.test.ts
+++ b/packages/blocks-engine/src/composition-planners.test.ts
@@ -133,6 +133,27 @@ describe("whether a selection may be saved at all", () => {
     }
   });
 
+  it("refuses a selection whose stored document would be too LARGE", () => {
+    // The cap the field will apply, applied where the author can still act on
+    // it. Without this the plan succeeded and the WRITE failed — after they had
+    // named the pattern, filled the form and pressed save.
+    //
+    // Sized past the default byte cap on purpose, so nothing about the
+    // selection explains the refusal: it is one adjacent node, a perfectly good
+    // run.
+    const huge = page([
+      node("a", { props: { filler: "x".repeat(DEFAULT_LIMITS.maxBytes) } }),
+      node("b"),
+    ]);
+
+    expect(saveAsPatternRefusal(huge, ["a"], anyParent)).toBeDefined();
+    // The control: the same shape, small, is savable — so the refusal is the
+    // CAP talking rather than the selection.
+    expect(
+      saveAsPatternRefusal(page([node("a"), node("b")]), ["a"], anyParent)
+    ).toBeUndefined();
+  });
+
   it("refuses a valid RUN whose stored document could not be saved", () => {
     // The case that decides which preflight this is. `savableRun` alone asks
     // only whether the selection is one contiguous, liftable run — it never

--- a/packages/blocks-engine/src/composition-planners.ts
+++ b/packages/blocks-engine/src/composition-planners.ts
@@ -684,6 +684,22 @@ function savedPatternDocument(
   const duplicate = duplicateDomIdRefusal(stored.nodes);
   if (duplicate !== undefined) return duplicate;
 
+  // The stored document against the caps it will be WRITTEN under. Asked of
+  // what is stored rather than of the page, like the questions either side of
+  // it: only some of what the page holds travels, so a selection lifted out of
+  // a document at its ceiling is usually well within one.
+  //
+  // Without this a plan succeeded and the write then failed. The blocks field
+  // validates what it is handed, so a pattern over the byte cap or deeper than
+  // the depth cap is refused there — after the author has named it, filled the
+  // form and pressed save. Refusing at plan time is the same verdict, arriving
+  // where they can still do something about it, and it is what lets the
+  // published preflight promise that a save it permits will not fail on size.
+  const storedSurvey = surveyDocument(stored, limits);
+  if (storedSurvey.tooLarge || overIndexBound(storedSurvey)) {
+    return { problem: "exceeds-limits" };
+  }
+
   // Asked of what is STORED, not of the page it came from. Only some of the
   // source envelope travels: `formatVersion` is carried, and a page holding one
   // the apply does not accept would produce a pattern refused as
@@ -2099,6 +2115,16 @@ function storedPatternRefusal(pattern: BlockDocument): PlanRefusal | undefined {
  * questions about somewhere the pattern is going — asked per placement, by
  * {@link placementVerdict} and the planner itself.
  */
+export function patternRefusal(
+  pattern: BlockDocument,
+  nesting: NestingSource
+): PlanRefusal | undefined {
+  return (
+    storedPatternRefusal(pattern) ??
+    internalNestingRefusal(pattern.nodes, nesting)
+  );
+}
+
 /**
  * Whether this selection could be saved as a pattern, and why not.
  *
@@ -2128,28 +2154,20 @@ function storedPatternRefusal(pattern: BlockDocument): PlanRefusal | undefined {
  * exact, and what makes it worth memoising on the selection rather than calling
  * per render.
  *
- * `limits` is threaded for the reason it is threaded everywhere else here: a
- * host may raise `maxNodes`, and a selection legitimate under a raised cap must
- * not be refused by a bound this file chose for itself.
+ * It takes NO limits of its own, deliberately. {@link planSaveAsPattern} has
+ * none either — it plans under the defaults — so a preflight that accepted them
+ * would answer a question the planner never asks: a caller passing a lower
+ * `maxNodes` would see a save disabled that the planner then accepts, and a
+ * higher one the reverse. A preflight whose whole purpose is to agree with the
+ * planner must not take an input the planner cannot take.
  */
 export function saveAsPatternRefusal(
   document: BlockDocument,
   selectedIds: readonly string[],
-  nesting: NestingSource,
-  limits: DocumentLimits = DEFAULT_LIMITS
-): PlanRefusal | undefined {
-  const saved = plannedSave(document, selectedIds, nesting, limits);
-  return saved.problem === undefined ? undefined : saved;
-}
-
-export function patternRefusal(
-  pattern: BlockDocument,
   nesting: NestingSource
 ): PlanRefusal | undefined {
-  return (
-    storedPatternRefusal(pattern) ??
-    internalNestingRefusal(pattern.nodes, nesting)
-  );
+  const saved = plannedSave(document, selectedIds, nesting);
+  return saved.problem === undefined ? undefined : saved;
 }
 
 /**

--- a/packages/blocks-engine/src/composition-planners.ts
+++ b/packages/blocks-engine/src/composition-planners.ts
@@ -2099,6 +2099,49 @@ function storedPatternRefusal(pattern: BlockDocument): PlanRefusal | undefined {
  * questions about somewhere the pattern is going — asked per placement, by
  * {@link placementVerdict} and the planner itself.
  */
+/**
+ * Whether this selection could be saved as a pattern, and why not.
+ *
+ * The counterpart to {@link patternRefusal}, published for the same reason and
+ * against the opposite mistake. That one stops a palette OFFERING a stored
+ * pattern the planner would reject; this one stops a surface offering to SAVE a
+ * selection the planner would reject — a button that accepts a click and then
+ * fails, which is the same defect on the write side.
+ *
+ * Asked of the PLANNER rather than restated. The ways a selection can be
+ * unsavable are not a short list a toolbar should keep its own copy of: a
+ * selection that is not one contiguous run, a block that may not be a document
+ * root, a node whose shape the op layer will not carry, a descendant nested
+ * somewhere the rules no longer allow, one DOM id on two of the run's own
+ * nodes, and a document that will not fit the byte cap. A surface enumerating
+ * those drifts the first time the planner learns a new way to say no, and it
+ * drifts SILENTLY — the button stays enabled and the save fails.
+ *
+ * Before this, the only way to ask was to call {@link planSaveAsPattern} with a
+ * `target` invented for the purpose, which is a collection name and a field set
+ * a caller asking "may I?" does not have yet.
+ *
+ * A THIN VIEW over the planner's own preflight rather than a second walk: the
+ * same `plannedSave` the two save planners call, so a question answered here
+ * and a save attempted afterwards cannot disagree. It therefore does the same
+ * work a save does, up to building the stored document — which is what makes it
+ * exact, and what makes it worth memoising on the selection rather than calling
+ * per render.
+ *
+ * `limits` is threaded for the reason it is threaded everywhere else here: a
+ * host may raise `maxNodes`, and a selection legitimate under a raised cap must
+ * not be refused by a bound this file chose for itself.
+ */
+export function saveAsPatternRefusal(
+  document: BlockDocument,
+  selectedIds: readonly string[],
+  nesting: NestingSource,
+  limits: DocumentLimits = DEFAULT_LIMITS
+): PlanRefusal | undefined {
+  const saved = plannedSave(document, selectedIds, nesting, limits);
+  return saved.problem === undefined ? undefined : saved;
+}
+
 export function patternRefusal(
   pattern: BlockDocument,
   nesting: NestingSource

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -203,6 +203,7 @@ export {
   planInsertPattern,
   internalNestingVerdict,
   patternRefusal,
+  saveAsPatternRefusal,
   planSaveAsComponent,
   planSaveAsPattern,
   planUpdatePatternFromSelection,


### PR DESCRIPTION
The counterpart to `patternRefusal`, and against the opposite mistake. That one stops a palette **offering** a stored pattern the planner would reject — its docblock puts it as "a tile that accepts a click and then fails". This stops a surface offering to **save** a selection the planner would reject, which is the same defect on the write side.

## The gap it closes, which exists today

There is no way to ask "may this selection be saved?" without calling `planSaveAsPattern` with a `target` invented for the purpose — a collection name and a field set that a surface deciding whether to *offer* the save does not have yet. The question could only be asked by answering a different one.

## Why a thin view rather than a second walk

It goes through the same `plannedSave` both save planners call, so a question answered here and a save attempted afterwards cannot disagree.

The ways a selection can be unsavable are not a short list a toolbar should keep its own copy of: not one contiguous run, a block that may not be a document root, a node whose shape the op layer will not carry, a descendant nested where the rules no longer allow, one DOM id on two of the run’s own nodes. A surface enumerating them drifts the first time the planner learns a new way to say no — and it drifts **silently**: the button stays enabled and the save fails.

Because it does the work a save does up to building the stored document, it is exact, and worth memoising on the selection rather than calling per render. The docblock says so.

## What the break-verification changed

Three breaks. Refuse-everything and accept-everything both died correctly. **The third killed nothing**: swapping `plannedSave` for `savableRun` passed every test I had written — so the docblock claimed more than the tests proved. `savableRun` asks only whether the selection is a liftable contiguous run and never builds the document, which is precisely the distinction the choice rests on.

Repairing it took a second correction. My first attempt used `maxBytes: 1`, assuming the byte cap applied at that stage — it does not; `savedPatternDocument` refuses on duplicate DOM ids, not bytes. The discriminating case is **two adjacent nodes rendering one DOM id**: a perfectly good run whose stored document is refused, with a non-clashing control beside it so the refusal is the stored document talking rather than the selection. That break now kills its test and only that one.

## Verification

- Asserted against `planSaveAsPattern` **directly**, over five selections, since a preflight that disagreed would enable a save that fails or disable one that would have worked — silently either way.
- Carries a positive control: a preflight that refused everything would satisfy every negative assertion while disabling a button that should work.
- `blocks-engine` suite **2,398 passed**. check-types + lint 3/3 exit 0. fallow `pass`, 0 introduced.

## Where it fits

This is the toolbar half of Save-as-pattern. The write half is #1632. Neither depends on the other, and the UI slice that consumes both follows once they land.