### PR TITLE
fix(plugin-form-builder): check a submission wherever it is written

### DIFF
--- a/.changeset/a-submission-is-checked-wherever-it-is-written.md
+++ b/.changeset/a-submission-is-checked-wherever-it-is-written.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Form submissions are transformed, validated and sanitized on a `beforeCreate` hook on the submissions collection, so every path that writes one gets the same treatment. `nextly.forms.submit()` and a record created from the admin previously stored whatever the caller sent: undeclared keys, values that never met the form schema, and markup intact, because core skips `json` fields when it sanitizes. Spam protection stays on the HTTP route, where a honeypot and a rate limit are facts about a request rather than about a row.

--- a/.changeset/a-submission-is-checked-wherever-it-is-written.md
+++ b/.changeset/a-submission-is-checked-wherever-it-is-written.md
@@ -26,4 +26,4 @@
 "@nextlyhq/module-specifiers": patch
 ---
 
-Form submissions are transformed, validated and sanitized on a `beforeCreate` hook on the submissions collection, so every path that writes one gets the same treatment. `nextly.forms.submit()` and a record created from the admin previously stored whatever the caller sent: undeclared keys, values that never met the form schema, and markup intact, because core skips `json` fields when it sanitizes. Spam protection stays on the HTTP route, where a honeypot and a rate limit are facts about a request rather than about a row.
+Form submissions are transformed, validated and sanitized on a `beforeChange` hook on the submissions collection, the last mutating phase before the insert, so every path that writes one gets the same treatment. `nextly.forms.submit()` and a record created from the admin previously stored whatever the caller sent: undeclared keys, values that never met the form schema, and markup intact, because core skips `json` fields when it sanitizes. Spam protection stays on the HTTP route, where a honeypot and a rate limit are facts about a request rather than about a row.

--- a/.changeset/a-submission-is-checked-wherever-it-is-written.md
+++ b/.changeset/a-submission-is-checked-wherever-it-is-written.md
@@ -30,8 +30,10 @@ Form submissions are transformed, sanitized and validated on a `beforeChange` ho
 
 Sanitizing now runs before validation, so a rule judges the value that will actually be stored. `<b></b>` no longer satisfies a required field and then reduces to an empty string.
 
-Stripping markup no longer removes text that only looks like a tag. A `<` opens a tag only when what follows could name one, which is the HTML tokenizer's own rule, so an answer containing `2 < 3` survives intact.
+Stripping markup no longer removes text that only looks like a tag. A `<` opens a tag only when what follows could name one, which is the HTML tokenizer's own rule, so an answer containing `2 < 3` survives intact. Stripping repeats until the text stops changing, because removing one tag can put its neighbours together into another.
 
 `validateSubmission` asks the same rule rather than restating it, so a preflight check and the write can no longer disagree about the same submission.
+
+A submission flagged as spam is stored without being validated so a false positive stays reviewable, and that exception now ends where it should: it names the row it was granted for rather than the next write in the call, and marking a row "Not spam" checks the payload it carries against the form.
 
 Spam protection stays on `submitForm`, where a honeypot and a rate limit are facts about a request rather than about a row. The built-in submit route does not reach it, and the guide now says so.

--- a/.changeset/a-submission-is-checked-wherever-it-is-written.md
+++ b/.changeset/a-submission-is-checked-wherever-it-is-written.md
@@ -36,4 +36,8 @@ Stripping markup no longer removes text that only looks like a tag. A `<` opens 
 
 A submission flagged as spam is stored without being validated so a false positive stays reviewable, and that exception now ends where it should: it names the row it was granted for rather than the next write in the call, and marking a row "Not spam" checks the payload it carries against the form.
 
+Moving a submission to another form re-projects its answers onto that form's fields, and that change is stamped as an edit, because the visitor's stored answers changed and nothing else records it.
+
+A parent-form read that fails is no longer reported as a validation error. Only a form that is not there is; a pool timeout or a throwing hook propagates, so a server fault stops arriving as the writer's mistake.
+
 Spam protection stays on `submitForm`, where a honeypot and a rate limit are facts about a request rather than about a row. The built-in submit route does not reach it, and the guide now says so.

--- a/.changeset/a-submission-is-checked-wherever-it-is-written.md
+++ b/.changeset/a-submission-is-checked-wherever-it-is-written.md
@@ -34,7 +34,7 @@ Stripping markup no longer removes text that only looks like a tag. A `<` opens 
 
 `validateSubmission` asks the same rule rather than restating it, so a preflight check and the write can no longer disagree about the same submission.
 
-A submission flagged as spam is stored without being validated so a false positive stays reviewable, and that exception now ends where it should: it names the row it was granted for rather than the next write in the call, and marking a row "Not spam" checks the payload it carries against the form.
+A submission flagged as spam is stored without being validated so a false positive stays reviewable, and that exception now belongs to a row rather than to a call: it travels as a symbol key on the row itself, which a request body cannot carry and a second write cannot take. Marking a row "Not spam" checks the payload it carries against the form.
 
 Moving a submission to another form re-projects its answers onto that form's fields, and that change is stamped as an edit, because the visitor's stored answers changed and nothing else records it.
 

--- a/.changeset/a-submission-is-checked-wherever-it-is-written.md
+++ b/.changeset/a-submission-is-checked-wherever-it-is-written.md
@@ -30,7 +30,7 @@ Form submissions are transformed, sanitized and validated on a `beforeChange` ho
 
 Sanitizing now runs before validation, so a rule judges the value that will actually be stored. `<b></b>` no longer satisfies a required field and then reduces to an empty string.
 
-Stripping markup no longer removes text that only looks like a tag. A `<` opens a tag only when what follows could name one, which is the HTML tokenizer's own rule, so an answer containing `2 < 3` survives intact. Stripping repeats until the text stops changing, because removing one tag can put its neighbours together into another.
+Stripping markup no longer removes text that only looks like a tag. A `<` opens a tag only when what follows could name one, which is the HTML tokenizer's own rule, so an answer containing `2 < 3` survives intact. Stripping is a single pass that keeps one invariant: a `<` it kept is never followed by a character that would open a tag. Removing a tag can put its neighbours together into another one, and rescanning until the text stopped changing held the same invariant at quadratic cost, which an unauthenticated caller could spend the server's CPU on.
 
 `validateSubmission` asks the same rule rather than restating it, so a preflight check and the write can no longer disagree about the same submission.
 

--- a/.changeset/a-submission-is-checked-wherever-it-is-written.md
+++ b/.changeset/a-submission-is-checked-wherever-it-is-written.md
@@ -26,4 +26,10 @@
 "@nextlyhq/module-specifiers": patch
 ---
 
-Form submissions are transformed, validated and sanitized on a `beforeChange` hook on the submissions collection, the last mutating phase before the insert, so every path that writes one gets the same treatment. `nextly.forms.submit()` and a record created from the admin previously stored whatever the caller sent: undeclared keys, values that never met the form schema, and markup intact, because core skips `json` fields when it sanitizes. Spam protection stays on the HTTP route, where a honeypot and a rate limit are facts about a request rather than about a row.
+Form submissions are transformed, sanitized and validated on a `beforeChange` hook on the submissions collection, the last collection-level mutating phase before the insert, so every path that writes one gets the same treatment: the built-in `POST /api/forms/:slug/submit`, `nextly.forms.submit()`, a host route calling `submitForm`, the admin, and an update that replaces a stored payload. Those paths previously stored whatever the caller sent, because core skips `json` fields when it sanitizes: undeclared keys, values that never met the form schema, and markup intact.
+
+Sanitizing now runs before validation, so a rule judges the value that will actually be stored. `<b></b>` no longer satisfies a required field and then reduces to an empty string.
+
+Stripping markup no longer removes text that only looks like a tag. A `<` opens a tag only when what follows could name one, which is the HTML tokenizer's own rule, so an answer containing `2 < 3` survives intact.
+
+Spam protection stays on `submitForm`, where a honeypot and a rate limit are facts about a request rather than about a row. The built-in submit route does not reach it, and the guide now says so.

--- a/.changeset/a-submission-is-checked-wherever-it-is-written.md
+++ b/.changeset/a-submission-is-checked-wherever-it-is-written.md
@@ -26,10 +26,12 @@
 "@nextlyhq/module-specifiers": patch
 ---
 
-Form submissions are transformed, sanitized and validated on a `beforeChange` hook on the submissions collection, the last collection-level mutating phase before the insert, so every path that writes one gets the same treatment: the built-in `POST /api/forms/:slug/submit`, `nextly.forms.submit()`, a host route calling `submitForm`, the admin, and an update that replaces a stored payload. Those paths previously stored whatever the caller sent, because core skips `json` fields when it sanitizes: undeclared keys, values that never met the form schema, and markup intact.
+Form submissions are transformed, sanitized and validated on a `beforeChange` hook on the submissions collection, the last collection-level mutating phase before the insert, so every path that writes one gets the same treatment: the built-in `POST /api/forms/:slug/submit`, `nextly.forms.submit()`, a host route calling `submitForm`, the admin, an update that replaces a stored payload, and an update that moves a submission to a different form, whose stored payload has to satisfy the schema it lands on. Those paths previously stored whatever the caller sent, because core skips `json` fields when it sanitizes: undeclared keys, values that never met the form schema, and markup intact.
 
 Sanitizing now runs before validation, so a rule judges the value that will actually be stored. `<b></b>` no longer satisfies a required field and then reduces to an empty string.
 
 Stripping markup no longer removes text that only looks like a tag. A `<` opens a tag only when what follows could name one, which is the HTML tokenizer's own rule, so an answer containing `2 < 3` survives intact.
+
+`validateSubmission` asks the same rule rather than restating it, so a preflight check and the write can no longer disagree about the same submission.
 
 Spam protection stays on `submitForm`, where a honeypot and a rate limit are facts about a request rather than about a row. The built-in submit route does not reach it, and the guide now says so.

--- a/docs/plugins/form-builder.mdx
+++ b/docs/plugins/form-builder.mdx
@@ -333,9 +333,13 @@ it is supposed to depend on. An application that hosts its own route, as below, 
 
 The plugin generates [Zod](https://zod.dev) schemas from form field definitions at runtime. Every submission is validated against the schema before storage, and free-text fields are sanitized by stripping HTML tags to prevent injection.
 
-That happens on a `beforeChange` hook on the submissions collection, which is the last mutating phase before the insert, so it applies to every way a submission can be written: the plugin's HTTP route, `nextly.forms.submit()`, and a record created from the admin. A submission is also projected onto the fields the form declares, so a key the form does not define is dropped rather than stored.
+That happens on a `beforeChange` hook on the submissions collection, the last collection-level mutating phase before the insert, so it applies to every way a submission can be written: your own route calling `submitForm`, the built-in `POST /api/forms/:slug/submit`, `nextly.forms.submit()`, an admin editing a stored submission, and a record created from the admin. A submission is also projected onto the fields the form declares, so a key the form does not define is dropped rather than stored. Field-level `beforeChange` hooks run after this one and are handed the whole record, so one you register on this collection yourself is trusted the way core trusts a field hook on any other collection.
 
-Spam protection is not part of that, and deliberately so. The honeypot, the rate limit and reCAPTCHA are facts about an HTTP request rather than about a row: a trusted server importing a thousand submissions would rate-limit its own import, and a honeypot field means nothing without a browser to have skipped it. Those run in `submitForm` only. If you accept submissions from a browser, send them through `POST /api/forms/:slug/submit`.
+Values are sanitized before they are validated, so every rule judges the value that will actually be stored rather than the one that arrived.
+
+Spam protection is not part of that, and deliberately so. The honeypot, the rate limit and reCAPTCHA are facts about an HTTP request rather than about a row: a trusted server importing a thousand submissions would rate-limit its own import, and a honeypot field means nothing without a browser to have skipped it. Those run in `submitForm` only.
+
+That decides which route you point a browser at. `POST /api/forms/:slug/submit` is built into Nextly and does not reach this plugin's handler, so a submission arriving there is projected, validated and sanitized, and meets no honeypot, no rate limit and no reCAPTCHA. To get those, host a route that calls `submitForm`, as under "Handling Submissions" above, and send the browser to that one.
 
 You can validate data without creating a submission:
 

--- a/docs/plugins/form-builder.mdx
+++ b/docs/plugins/form-builder.mdx
@@ -333,7 +333,7 @@ it is supposed to depend on. An application that hosts its own route, as below, 
 
 The plugin generates [Zod](https://zod.dev) schemas from form field definitions at runtime. Every submission is validated against the schema before storage, and free-text fields are sanitized by stripping HTML tags to prevent injection.
 
-That happens on a `beforeCreate` hook on the submissions collection, so it applies to every way a submission can be written: the plugin's HTTP route, `nextly.forms.submit()`, and a record created from the admin. A submission is also projected onto the fields the form declares, so a key the form does not define is dropped rather than stored.
+That happens on a `beforeChange` hook on the submissions collection, which is the last mutating phase before the insert, so it applies to every way a submission can be written: the plugin's HTTP route, `nextly.forms.submit()`, and a record created from the admin. A submission is also projected onto the fields the form declares, so a key the form does not define is dropped rather than stored.
 
 Spam protection is not part of that, and deliberately so. The honeypot, the rate limit and reCAPTCHA are facts about an HTTP request rather than about a row: a trusted server importing a thousand submissions would rate-limit its own import, and a honeypot field means nothing without a browser to have skipped it. Those run in `submitForm` only. If you accept submissions from a browser, send them through `POST /api/forms/:slug/submit`.
 

--- a/docs/plugins/form-builder.mdx
+++ b/docs/plugins/form-builder.mdx
@@ -331,7 +331,11 @@ it is supposed to depend on. An application that hosts its own route, as below, 
 
 ### Validation
 
-The plugin generates [Zod](https://zod.dev) schemas from form field definitions at runtime. Every submission is validated against the schema before storage. Free-text fields are also sanitized by stripping HTML tags to prevent injection.
+The plugin generates [Zod](https://zod.dev) schemas from form field definitions at runtime. Every submission is validated against the schema before storage, and free-text fields are sanitized by stripping HTML tags to prevent injection.
+
+That happens on a `beforeCreate` hook on the submissions collection, so it applies to every way a submission can be written: the plugin's HTTP route, `nextly.forms.submit()`, and a record created from the admin. A submission is also projected onto the fields the form declares, so a key the form does not define is dropped rather than stored.
+
+Spam protection is not part of that, and deliberately so. The honeypot, the rate limit and reCAPTCHA are facts about an HTTP request rather than about a row: a trusted server importing a thousand submissions would rate-limit its own import, and a honeypot field means nothing without a browser to have skipped it. Those run in `submitForm` only. If you accept submissions from a browser, send them through `POST /api/forms/:slug/submit`.
 
 You can validate data without creating a submission:
 

--- a/docs/plugins/form-builder.mdx
+++ b/docs/plugins/form-builder.mdx
@@ -337,6 +337,8 @@ That happens on a `beforeChange` hook on the submissions collection, the last co
 
 Values are sanitized before they are validated, so every rule judges the value that will actually be stored rather than the one that arrived.
 
+A submission flagged as spam is stored without being validated, deliberately, so a false positive stays reviewable rather than being thrown away. That exception ends when the row leaves spam: marking one "Not spam" checks the payload it is carrying against the form, so a row that never satisfied the form has to be corrected in the same edit before it can become an ordinary counted submission.
+
 Spam protection is not part of that, and deliberately so. The honeypot, the rate limit and reCAPTCHA are facts about an HTTP request rather than about a row: a trusted server importing a thousand submissions would rate-limit its own import, and a honeypot field means nothing without a browser to have skipped it. Those run in `submitForm` only.
 
 That decides which route you point a browser at. `POST /api/forms/:slug/submit` is built into Nextly and does not reach this plugin's handler, so a submission arriving there is projected, validated and sanitized, and meets no honeypot, no rate limit and no reCAPTCHA. To get those, host a route that calls `submitForm`, as under "Handling Submissions" above, and send the browser to that one.

--- a/packages/plugin-form-builder/src/__tests__/collect-attachment-inputs.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/collect-attachment-inputs.test.ts
@@ -19,9 +19,7 @@ describe("collectAttachmentInputs", () => {
   });
 
   it("collects mediaId from a single-value file field", () => {
-    const fields = [
-      { type: "file", name: "resume", attachToEmail: true },
-    ];
+    const fields = [{ type: "file", name: "resume", attachToEmail: true }];
     const data = { resume: "med_abc" };
     expect(collectAttachmentInputs(fields, data)).toEqual([
       { mediaId: "med_abc" },
@@ -49,9 +47,7 @@ describe("collectAttachmentInputs", () => {
   });
 
   it("skips undefined/null file field values", () => {
-    const fields = [
-      { type: "file", name: "missing", attachToEmail: true },
-    ];
+    const fields = [{ type: "file", name: "missing", attachToEmail: true }];
     const data = {};
     expect(collectAttachmentInputs(fields, data)).toEqual([]);
   });
@@ -68,10 +64,7 @@ describe("collectAttachmentInputs", () => {
       id_doc: "med_c",
     };
     const result = collectAttachmentInputs(fields, data);
-    expect(result).toEqual([
-      { mediaId: "med_a" },
-      { mediaId: "med_b" },
-    ]);
+    expect(result).toEqual([{ mediaId: "med_a" }, { mediaId: "med_b" }]);
   });
 
   it("skips non-string values in arrays", () => {

--- a/packages/plugin-form-builder/src/__tests__/fetch-parent-form.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/fetch-parent-form.test.ts
@@ -8,10 +8,10 @@ import { describe, expect, it, vi } from "vitest";
 
 import { fetchParentForm } from "../plugin";
 
-const config = {
-  formOverrides: { slug: "forms" },
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-} as any;
+// The slug now arrives RESOLVED: a host that renames the collection takes the
+// declared name out of the registry, so the caller resolves it and this reads
+// what it is given.
+const formsSlug = "forms";
 
 function nextlyWith(findEntryById: ReturnType<typeof vi.fn>) {
   return {
@@ -28,7 +28,7 @@ describe("fetchParentForm", () => {
       .mockResolvedValue({ id: "form1", slug: "contact" });
 
     const form = await fetchParentForm(
-      config,
+      formsSlug,
       "form1",
       nextlyWith(findEntryById)
     );
@@ -42,7 +42,7 @@ describe("fetchParentForm", () => {
   it("returns null (not throws) when the form is missing", async () => {
     const findEntryById = vi.fn().mockRejectedValue(new Error("not found"));
     expect(
-      await fetchParentForm(config, "missing", nextlyWith(findEntryById))
+      await fetchParentForm(formsSlug, "missing", nextlyWith(findEntryById))
     ).toBeNull();
   });
 });

--- a/packages/plugin-form-builder/src/__tests__/fetch-parent-form.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/fetch-parent-form.test.ts
@@ -4,6 +4,7 @@
  * legacy `getCollectionsHandler()` + `overrideAccess` runtime path. (The
  * end-to-end path is covered by `before-email-filter.integration.test.ts`.)
  */
+import { NextlyError } from "nextly";
 import { describe, expect, it, vi } from "vitest";
 
 import { fetchParentForm } from "../plugin";
@@ -40,9 +41,21 @@ describe("fetchParentForm", () => {
   });
 
   it("returns null (not throws) when the form is missing", async () => {
-    const findEntryById = vi.fn().mockRejectedValue(new Error("not found"));
+    const findEntryById = vi
+      .fn()
+      .mockRejectedValue(NextlyError.notFound({ message: "No such form." }));
     expect(
       await fetchParentForm(formsSlug, "missing", nextlyWith(findEntryById))
     ).toBeNull();
+  });
+
+  it("lets a failed read stay a failed read", async () => {
+    // A form that is not there is an answer. A pool timeout or a throwing
+    // `afterRead` hook is not, and answering `null` for it told the writer
+    // their submission was invalid, with a status that says not to retry.
+    const findEntryById = vi.fn().mockRejectedValue(new Error("pool timeout"));
+    await expect(
+      fetchParentForm(formsSlug, "form1", nextlyWith(findEntryById))
+    ).rejects.toThrow("pool timeout");
   });
 });

--- a/packages/plugin-form-builder/src/__tests__/prepare-submission.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/prepare-submission.test.ts
@@ -374,6 +374,59 @@ describe("the write-seam hook on submissions", () => {
     expect(out?.data).toEqual({ name: "Ada" });
   });
 
+  it("stamps a payload the move itself changed", async () => {
+    // Moving a submission re-projects its answers onto the new form's fields
+    // and can drop one that form does not declare. The stamp on `beforeUpdate`
+    // has already run by then and only marks a patch that arrived with `data`,
+    // so the visitor's stored answers changed with nothing saying who did it.
+    const otherForm = nextlyWith({
+      id: "form2",
+      fields: [
+        { id: "9", name: "name", type: "text", label: "Name", required: true },
+      ],
+    });
+    const out = await prepareSubmissionForWrite(
+      {
+        data: { form: "form2" },
+        operation: "update",
+        user: { id: "admin1" },
+        originalData: {
+          id: "sub1",
+          form: "form1",
+          data: { name: "Ada", email: "ada@example.com" },
+        },
+      },
+      formsSlug,
+      otherForm
+    );
+    expect(out?.data).toEqual({ name: "Ada" });
+    expect(out?.editedBy).toBe("admin1");
+    expect(out?.editedAt).toBeInstanceOf(Date);
+  });
+
+  it("does not stamp a derived payload that did not change", async () => {
+    // The control: a row leaving spam whose answers already satisfy the form is
+    // not an edit, and stamping it would put a name against a change nobody
+    // made.
+    const out = await prepareSubmissionForWrite(
+      {
+        data: { status: "new" },
+        operation: "update",
+        user: { id: "admin1" },
+        originalData: {
+          id: "sub1",
+          form: "form1",
+          status: "spam",
+          data: { name: "Ada", email: "ada@example.com" },
+        },
+      },
+      formsSlug,
+      withForm
+    );
+    expect(out?.editedAt).toBeUndefined();
+    expect(out?.editedBy).toBeUndefined();
+  });
+
   it("refuses an update whose replacement payload the schema rejects", async () => {
     await expect(
       prepareSubmissionForWrite(
@@ -489,13 +542,13 @@ describe("the write-seam hook on submissions", () => {
 
   it("hands the marks to the first taker only", async () => {
     // The mechanism under the test above, stated directly.
-    const payload = { name: "bot" };
-    await asPluginSubmission({ keepAsEvidence: true, payload }, () => {
-      expect(takeSubmissionMarks(payload)?.keepAsEvidence).toBe(true);
-      expect(takeSubmissionMarks(payload)).toBeUndefined();
+    const writing = { form: "form1", status: "spam", payload: { name: "bot" } };
+    await asPluginSubmission({ keepAsEvidence: true, writing }, () => {
+      expect(takeSubmissionMarks(writing)?.keepAsEvidence).toBe(true);
+      expect(takeSubmissionMarks(writing)).toBeUndefined();
     });
     // The control: outside a marked call there is nothing to take.
-    expect(takeSubmissionMarks(payload)).toBeUndefined();
+    expect(takeSubmissionMarks(writing)).toBeUndefined();
   });
 
   it("does not hand the evidence exception to another row's write", async () => {
@@ -505,7 +558,10 @@ describe("the write-seam hook on submissions", () => {
     // the wrong row and left the evidence row to be refused.
     const evidence = { name: "<b>bot</b>", email: "not-an-email" };
     await asPluginSubmission(
-      { keepAsEvidence: true, payload: evidence },
+      {
+        keepAsEvidence: true,
+        writing: { form: "form1", status: "spam", payload: evidence },
+      },
       async () => {
         await expect(
           prepareSubmissionForWrite(
@@ -521,8 +577,23 @@ describe("the write-seam hook on submissions", () => {
           )
         ).rejects.toThrow();
 
+        // Same answers, different form: content alone would have matched.
+        await expect(
+          prepareSubmissionForWrite(
+            {
+              data: { form: "form1", data: evidence, status: "new" },
+              operation: "create",
+            },
+            formsSlug,
+            withForm
+          )
+        ).rejects.toThrow();
+
         const kept = await prepareSubmissionForWrite(
-          { data: { form: "form1", data: evidence }, operation: "create" },
+          {
+            data: { form: "form1", data: evidence, status: "spam" },
+            operation: "create",
+          },
           formsSlug,
           withForm
         );

--- a/packages/plugin-form-builder/src/__tests__/prepare-submission.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/prepare-submission.test.ts
@@ -110,6 +110,23 @@ describe("prepareSubmission", () => {
     }
   });
 
+  it("strips a hostile value in time proportional to its length", () => {
+    // `<`*n + `b>` + `x>`*n exposes one tag per pass, so a rule that rescanned
+    // until the text stopped changing did n passes over the whole string.
+    // Measured on that rule: 15KB took 23ms, 30KB 70ms and 60KB 261ms, four
+    // times the work for twice the input, while 360KB here takes about 9ms.
+    // Both public write paths sanitize before any length rule applies, so the
+    // difference is whose CPU an unauthenticated caller gets to spend.
+    const n = 120_000;
+    const hostile = "<".repeat(n) + "b>" + "x>".repeat(n);
+    const { data } = prepareSubmission({
+      data: { name: hostile, email: "ada@example.com" },
+      fields,
+      validate: false,
+    });
+    expect(String(data.name)).not.toMatch(/<[a-zA-Z/!?]/);
+  }, 2000);
+
   it("still removes what a browser would read as a tag", () => {
     // The control for the test above: narrowing the pattern must not stop it
     // removing markup. Each of these is tag-open syntax, including the one

--- a/packages/plugin-form-builder/src/__tests__/prepare-submission.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/prepare-submission.test.ts
@@ -16,6 +16,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   asPluginSubmission,
   prepareSubmission,
+  takeSubmissionMarks,
 } from "../handlers/prepare-submission";
 import { formBuilder, prepareSubmissionForWrite } from "../plugin";
 import type { AnyFormField } from "../types";
@@ -71,6 +72,69 @@ describe("prepareSubmission", () => {
     expect(validationErrors).toBeUndefined();
     expect(data.name).toBe("bot");
     expect(data.email).toBe("not-an-email");
+  });
+
+  it("leaves a less-than sign that is not a tag alone", () => {
+    // A `<` opens a tag only when what follows could name one. Treating every
+    // `<` as a tag deleted from the middle of a visitor's own words, and this
+    // sanitizer now runs on writes that were never sanitized before, so the
+    // loss would have been silent and new.
+    const { data } = prepareSubmission({
+      data: {
+        name: "2 < 3 and 5 > 4",
+        email: "ada@example.com",
+      },
+      fields,
+      validate: true,
+    });
+    expect(data.name).toBe("2 < 3 and 5 > 4");
+  });
+
+  it("still removes what a browser would read as a tag", () => {
+    // The control for the test above: narrowing the pattern must not stop it
+    // removing markup. Each of these is tag-open syntax, including the one
+    // left unclosed at the end, which a browser completes rather than shows.
+    const cases: Array<[string, string]> = [
+      ["<b>bold</b>", "bold"],
+      ["</p>closing", "closing"],
+      ["hello <script", "hello"],
+      ["<!-- comment -->text", "text"],
+      ["<?php echo 1; ?>x", "x"],
+      ["<IMG SRC=x onerror=alert(1)>done", "done"],
+    ];
+    for (const [input, expected] of cases) {
+      const { data } = prepareSubmission({
+        data: { name: input, email: "ada@example.com" },
+        fields,
+        validate: false,
+      });
+      expect(data.name).toBe(expected);
+    }
+  });
+
+  it("judges the value it is about to store, not the one that arrived", () => {
+    // `<b></b>` satisfied a required field and was then reduced to an empty
+    // string, so the row stored a value the form's own schema rejects. A rule
+    // that runs before sanitizing is a rule about a value nobody keeps.
+    const { data, validationErrors } = prepareSubmission({
+      data: { name: "<b></b>", email: "ada@example.com" },
+      fields,
+      validate: true,
+    });
+    expect(Object.keys(validationErrors ?? {})).toContain("name");
+    expect(data.name).toBe("");
+  });
+
+  it("accepts a value that is only valid once the markup is gone", () => {
+    // The control: the reorder must not turn sanitizing into a rejection
+    // machine. Markup around real content still leaves a valid answer.
+    const { data, validationErrors } = prepareSubmission({
+      data: { name: "<b>Ada</b>", email: "ada@example.com" },
+      fields,
+      validate: true,
+    });
+    expect(validationErrors).toBeUndefined();
+    expect(data.name).toBe("Ada");
   });
 
   it("is idempotent, which is what lets the hook run after the handler", () => {
@@ -220,6 +284,144 @@ describe("the write-seam hook on submissions", () => {
     expect(await prepareSubmissionForWrite(ctx, formsSlug, withForm)).toBe(
       ctx.data
     );
+  });
+
+  it("checks an update that replaces the stored payload", async () => {
+    // The create is checked and the update was not, so a caller who may edit a
+    // submission could put undeclared keys, values the schema rejects and
+    // markup into the row a moment after the create had refused them. The
+    // patch need not repeat the relationship, so the stored row says which
+    // form to check against.
+    const ctx = {
+      data: { data: { name: "<b>Ada</b>", email: "ada@example.com", x: 1 } },
+      operation: "update",
+      originalData: { id: "sub1", form: "form1" },
+    };
+    const out = await prepareSubmissionForWrite(ctx, formsSlug, withForm);
+    expect(out?.data).toEqual({ name: "Ada", email: "ada@example.com" });
+  });
+
+  it("refuses an update whose replacement payload the schema rejects", async () => {
+    await expect(
+      prepareSubmissionForWrite(
+        {
+          data: { data: { name: "Ada", email: "not-an-email" } },
+          operation: "update",
+          originalData: { id: "sub1", form: "form1" },
+        },
+        formsSlug,
+        withForm
+      )
+    ).rejects.toThrow();
+  });
+
+  it("uses the form the handler already read rather than reading it again", async () => {
+    // Reading a form runs the forms collection's `afterRead` hooks, one of
+    // which COUNTs that form's submissions, so a write was paying for a count
+    // of every write before it.
+    const nextly = nextlyWith({ id: "form1", fields });
+    const out = await asPluginSubmission(
+      { keepAsEvidence: false, form: { id: "form1", fields } },
+      () =>
+        prepareSubmissionForWrite(
+          {
+            data: {
+              form: "form1",
+              data: { name: "Ada", email: "ada@example.com" },
+            },
+            operation: "create",
+          },
+          formsSlug,
+          nextly
+        )
+    );
+    expect(out?.data).toEqual({ name: "Ada", email: "ada@example.com" });
+    expect(
+      (
+        nextly as unknown as {
+          services: {
+            collections: { findEntryById: { mock: { calls: unknown[] } } };
+          };
+        }
+      ).services.collections.findEntryById.mock.calls
+    ).toHaveLength(0);
+  });
+
+  it("reads the form when the one handed over is a different form", async () => {
+    // The control: a handed-over form is only ever used for the row that names
+    // it, so a mismatch falls back to the read rather than checking a payload
+    // against the wrong schema.
+    const nextly = nextlyWith({ id: "form1", fields });
+    await asPluginSubmission(
+      { keepAsEvidence: false, form: { id: "other-form", fields: [] } },
+      () =>
+        prepareSubmissionForWrite(
+          {
+            data: {
+              form: "form1",
+              data: { name: "Ada", email: "ada@example.com" },
+            },
+            operation: "create",
+          },
+          formsSlug,
+          nextly
+        )
+    );
+    expect(
+      (
+        nextly as unknown as {
+          services: {
+            collections: { findEntryById: { mock: { calls: unknown[] } } };
+          };
+        }
+      ).services.collections.findEntryById.mock.calls
+    ).toHaveLength(1);
+  });
+
+  it("spends the evidence exception on the one write it was granted for", async () => {
+    // `createEntry` does not resolve until its `afterCreate` hooks have run, so
+    // a hook that writes a second submission runs inside the same store. The
+    // second write must not inherit an exception granted to the first.
+    await asPluginSubmission({ keepAsEvidence: true }, async () => {
+      const kept = await prepareSubmissionForWrite(
+        {
+          data: {
+            form: "form1",
+            data: { name: "<b>bot</b>", email: "not-an-email" },
+          },
+          operation: "create",
+        },
+        formsSlug,
+        withForm
+      );
+      expect((kept?.data as Record<string, unknown>).email).toBe(
+        "not-an-email"
+      );
+
+      await expect(
+        prepareSubmissionForWrite(
+          {
+            data: {
+              form: "form1",
+              data: { name: "Ada", email: "also-not-an-email" },
+            },
+            operation: "create",
+          },
+          formsSlug,
+          withForm
+        )
+      ).rejects.toThrow();
+    });
+  });
+
+  it("hands the marks to the first taker only", async () => {
+    // The mechanism under the test above, stated directly.
+    await asPluginSubmission({ keepAsEvidence: true }, () => {
+      expect(takeSubmissionMarks()?.keepAsEvidence).toBe(true);
+      expect(takeSubmissionMarks()).toBeUndefined();
+    });
+    // The control: outside a marked call there is nothing to take.
+    expect(takeSubmissionMarks()).toBeUndefined();
   });
 
   it("refuses rather than emptying when the form cannot be read", async () => {

--- a/packages/plugin-form-builder/src/__tests__/prepare-submission.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/prepare-submission.test.ts
@@ -91,6 +91,25 @@ describe("prepareSubmission", () => {
     expect(data.name).toBe("2 < 3 and 5 > 4");
   });
 
+  it("does not build a tag out of what it removed", () => {
+    // Removing the inner `<b>` puts its neighbours together: one pass over
+    // `<<b>img src=x onerror=alert(1)>` returns `<img src=x onerror=alert(1)>`,
+    // markup the sanitizer assembled itself. Narrowing the pattern to real tag
+    // syntax is what made this reachable, so it arrived with the fix above it.
+    for (const input of [
+      "<<b>img src=x onerror=alert(1)>",
+      "<<script>script>alert(1)</script>",
+      "<<div>div onmouseover=alert(1)>hover",
+    ]) {
+      const { data } = prepareSubmission({
+        data: { name: input, email: "ada@example.com" },
+        fields,
+        validate: false,
+      });
+      expect(data.name).not.toMatch(/<[a-zA-Z/!?]/);
+    }
+  });
+
   it("still removes what a browser would read as a tag", () => {
     // The control for the test above: narrowing the pattern must not stop it
     // removing markup. Each of these is tag-open syntax, including the one
@@ -470,12 +489,107 @@ describe("the write-seam hook on submissions", () => {
 
   it("hands the marks to the first taker only", async () => {
     // The mechanism under the test above, stated directly.
-    await asPluginSubmission({ keepAsEvidence: true }, () => {
-      expect(takeSubmissionMarks()?.keepAsEvidence).toBe(true);
-      expect(takeSubmissionMarks()).toBeUndefined();
+    const payload = { name: "bot" };
+    await asPluginSubmission({ keepAsEvidence: true, payload }, () => {
+      expect(takeSubmissionMarks(payload)?.keepAsEvidence).toBe(true);
+      expect(takeSubmissionMarks(payload)).toBeUndefined();
     });
     // The control: outside a marked call there is nothing to take.
-    expect(takeSubmissionMarks()).toBeUndefined();
+    expect(takeSubmissionMarks(payload)).toBeUndefined();
+  });
+
+  it("does not hand the evidence exception to another row's write", async () => {
+    // A hook registered before this plugin runs ahead of its handler, so a
+    // submission that hook writes reaches the seam first, inside the same
+    // store. Spending the marks on whoever arrives first gave the exception to
+    // the wrong row and left the evidence row to be refused.
+    const evidence = { name: "<b>bot</b>", email: "not-an-email" };
+    await asPluginSubmission(
+      { keepAsEvidence: true, payload: evidence },
+      async () => {
+        await expect(
+          prepareSubmissionForWrite(
+            {
+              data: {
+                form: "form1",
+                data: { name: "Ada", email: "also-not-an-email" },
+              },
+              operation: "create",
+            },
+            formsSlug,
+            withForm
+          )
+        ).rejects.toThrow();
+
+        const kept = await prepareSubmissionForWrite(
+          { data: { form: "form1", data: evidence }, operation: "create" },
+          formsSlug,
+          withForm
+        );
+        expect((kept?.data as Record<string, unknown>).email).toBe(
+          "not-an-email"
+        );
+      }
+    );
+  });
+
+  it("checks an evidence row on its way out of spam", async () => {
+    // A spam row is stored without being validated so a false positive stays
+    // reviewable. "Not spam" sends only a status, and letting that through
+    // unchecked turned a payload the form rejects into a counted submission.
+    await expect(
+      prepareSubmissionForWrite(
+        {
+          data: { status: "new", spamReason: null },
+          operation: "update",
+          originalData: {
+            id: "sub1",
+            form: "form1",
+            status: "spam",
+            data: { name: "bot", email: "not-an-email" },
+          },
+        },
+        formsSlug,
+        withForm
+      )
+    ).rejects.toThrow();
+  });
+
+  it("lets a valid evidence row out of spam", async () => {
+    // The control: the check must not make every false positive unrecoverable.
+    const out = await prepareSubmissionForWrite(
+      {
+        data: { status: "new" },
+        operation: "update",
+        originalData: {
+          id: "sub1",
+          form: "form1",
+          status: "spam",
+          data: { name: "Ada", email: "ada@example.com" },
+        },
+      },
+      formsSlug,
+      withForm
+    );
+    expect(out?.status).toBe("new");
+    expect(out?.data).toEqual({ name: "Ada", email: "ada@example.com" });
+  });
+
+  it("leaves a status change between two non-spam values alone", async () => {
+    // The second control: the check is about leaving spam, not about statuses.
+    const ctx = {
+      data: { status: "read" },
+      operation: "update",
+      originalData: {
+        id: "sub1",
+        form: "form1",
+        status: "new",
+        data: { name: "Ada", email: "ada@example.com" },
+      },
+    };
+    expect(await prepareSubmissionForWrite(ctx, formsSlug, withForm)).toBe(
+      ctx.data
+    );
   });
 
   it("refuses rather than emptying when the form cannot be read", async () => {

--- a/packages/plugin-form-builder/src/__tests__/prepare-submission.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/prepare-submission.test.ts
@@ -18,6 +18,7 @@ import {
   prepareSubmission,
   takeSubmissionMarks,
 } from "../handlers/prepare-submission";
+import { validateSubmission } from "../handlers/submit-form";
 import { formBuilder, prepareSubmissionForWrite } from "../plugin";
 import type { AnyFormField } from "../types";
 
@@ -301,6 +302,59 @@ describe("the write-seam hook on submissions", () => {
     expect(out?.data).toEqual({ name: "Ada", email: "ada@example.com" });
   });
 
+  it("checks the stored payload when a submission moves to another form", async () => {
+    // A patch that only changes the relationship carries no payload, so a rule
+    // keyed on `data` alone let a caller move a submission onto any form and
+    // leave behind a payload that form rejects.
+    const otherForm = nextlyWith({
+      id: "form2",
+      fields: [
+        { id: "9", name: "note", type: "text", label: "Note", required: true },
+      ],
+    });
+    await expect(
+      prepareSubmissionForWrite(
+        {
+          data: { form: "form2" },
+          operation: "update",
+          originalData: {
+            id: "sub1",
+            form: "form1",
+            data: { name: "Ada", email: "ada@example.com" },
+          },
+        },
+        formsSlug,
+        otherForm
+      )
+    ).rejects.toThrow();
+  });
+
+  it("re-projects a moved submission onto the form it lands on", async () => {
+    // The other half: the payload is brought to the new form's shape rather
+    // than merely judged against it, so a key that form does not declare is
+    // dropped instead of staying in a row that now belongs elsewhere.
+    const otherForm = nextlyWith({
+      id: "form2",
+      fields: [
+        { id: "9", name: "name", type: "text", label: "Name", required: true },
+      ],
+    });
+    const out = await prepareSubmissionForWrite(
+      {
+        data: { form: "form2" },
+        operation: "update",
+        originalData: {
+          id: "sub1",
+          form: "form1",
+          data: { name: "<b>Ada</b>", email: "ada@example.com" },
+        },
+      },
+      formsSlug,
+      otherForm
+    );
+    expect(out?.data).toEqual({ name: "Ada" });
+  });
+
   it("refuses an update whose replacement payload the schema rejects", async () => {
     await expect(
       prepareSubmissionForWrite(
@@ -487,6 +541,56 @@ describe("the write-seam hook on submissions", () => {
     };
     const out = await prepareSubmissionForWrite(ctx, formsSlug, withForm);
     expect(out).toBe(ctx.data);
+  });
+});
+
+describe("the preflight check and the write seam", () => {
+  const storedForm = {
+    id: "form1",
+    slug: "contact",
+    fields,
+    status: "published",
+  };
+  const context = {
+    pluginContext: {
+      services: {
+        collections: {
+          listEntries: vi.fn().mockResolvedValue({ data: [storedForm] }),
+        },
+      },
+    },
+    pluginConfig: { formOverrides: { slug: "forms" } },
+  } as never;
+
+  it("agree about a value that is only markup", async () => {
+    // `validateSubmission` restated transform-then-validate, so it judged the
+    // unsanitized value while the write seam judges the sanitized one. A client
+    // was told `<b></b>` satisfied a required field and the write then refused
+    // it.
+    const preflight = await validateSubmission(
+      "contact",
+      { name: "<b></b>", email: "ada@example.com" },
+      context
+    );
+    const atTheSeam = prepareSubmission({
+      data: { name: "<b></b>", email: "ada@example.com" },
+      fields,
+      validate: true,
+    });
+    expect(preflight.valid).toBe(false);
+    expect(Object.keys(preflight.errors ?? {})).toEqual(
+      Object.keys(atTheSeam.validationErrors ?? {})
+    );
+  });
+
+  it("agree about a value that is valid once the markup is gone", async () => {
+    // The control: the two agreeing must not be two refusals of everything.
+    const preflight = await validateSubmission(
+      "contact",
+      { name: "<b>Ada</b>", email: "ada@example.com" },
+      context
+    );
+    expect(preflight.valid).toBe(true);
   });
 });
 

--- a/packages/plugin-form-builder/src/__tests__/prepare-submission.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/prepare-submission.test.ts
@@ -1,0 +1,304 @@
+/**
+ * A submission is brought to the form's shape at the write seam, so every
+ * caller gets the same answer.
+ *
+ * `submitForm` transformed, validated and sanitized; `nextly.forms.submit()`
+ * did none of it, so the same submission was stored two different ways
+ * depending on which door it came through. These cover the shared rule and the
+ * `beforeCreate` hook that applies it.
+ */
+import {
+  createTestNextly,
+  type TestNextly,
+} from "@nextlyhq/plugin-sdk/testing";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { prepareSubmission } from "../handlers/prepare-submission";
+import { formBuilder, prepareSubmissionForWrite } from "../plugin";
+import type { AnyFormField } from "../types";
+
+const fields = [
+  { id: "1", name: "name", type: "text", label: "Name", required: true },
+  { id: "2", name: "email", type: "email", label: "Email", required: true },
+  { id: "3", name: "age", type: "number", label: "Age", required: false },
+] as unknown as AnyFormField[];
+
+describe("prepareSubmission", () => {
+  it("keeps only the fields the form declares", () => {
+    const { data } = prepareSubmission({
+      data: { name: "Ada", email: "ada@example.com", isAdmin: true },
+      fields,
+      validate: true,
+    });
+    expect(data).toEqual({ name: "Ada", email: "ada@example.com" });
+    // The control: the undeclared key really was in the input, so this is a
+    // projection rather than an object that never had it.
+    expect("isAdmin" in data).toBe(false);
+  });
+
+  it("strips markup from free-text fields", () => {
+    const { data } = prepareSubmission({
+      data: { name: "<script>alert(1)</script>Ada", email: "ada@example.com" },
+      fields,
+      validate: true,
+    });
+    expect(data.name).toBe("alert(1)Ada");
+  });
+
+  it("reports the form's own validation errors rather than storing", () => {
+    const { validationErrors } = prepareSubmission({
+      data: { name: "Ada", email: "not-an-email" },
+      fields,
+      validate: true,
+    });
+    expect(validationErrors).toBeDefined();
+    expect(Object.keys(validationErrors ?? {})).toContain("email");
+  });
+
+  it("sanitizes without validating when the caller keeps the evidence", () => {
+    // A honeypot hit is stored flagged rather than dropped, so a false positive
+    // stays recoverable. Requiring it to be valid would throw away the thing
+    // being reviewed; letting it keep its markup would store the one row nobody
+    // validated with script tags intact.
+    const { data, validationErrors } = prepareSubmission({
+      data: { name: "<b>bot</b>", email: "not-an-email" },
+      fields,
+      validate: false,
+    });
+    expect(validationErrors).toBeUndefined();
+    expect(data.name).toBe("bot");
+    expect(data.email).toBe("not-an-email");
+  });
+
+  it("is idempotent, which is what lets the hook run after the handler", () => {
+    // The HTTP handler prepares, then the hook prepares again on the way to the
+    // database. If that were not a no-op the two would fight, and the second
+    // pass would be the one that decided what a visitor sent.
+    const input = {
+      name: "  <b>Ada</b>  ",
+      email: "ada@example.com",
+      age: "42",
+      extra: "dropped",
+    };
+    const once = prepareSubmission({ data: input, fields, validate: true });
+    const twice = prepareSubmission({
+      data: once.data,
+      fields,
+      validate: true,
+    });
+    expect(twice.data).toEqual(once.data);
+    expect(twice.validationErrors).toBeUndefined();
+    // The control: the first pass really did change something, so equality
+    // above is idempotence rather than two passes that both did nothing.
+    expect(once.data).not.toEqual(input);
+    expect(once.data.age).toBe(42);
+  });
+});
+
+describe("the beforeCreate hook on submissions", () => {
+  const config = { formOverrides: { slug: "forms" } } as never;
+
+  const nextlyWith = (form: unknown) =>
+    ({
+      services: {
+        collections: { findEntryById: vi.fn().mockResolvedValue(form) },
+      },
+      logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+    }) as never;
+
+  const withForm = nextlyWith({ id: "form1", fields });
+
+  it("prepares a submission the Direct API would have stored raw", async () => {
+    const ctx = {
+      data: {
+        form: "form1",
+        data: {
+          name: "<script>x</script>Ada",
+          email: "ada@example.com",
+          isAdmin: true,
+        },
+        status: "new",
+      },
+    };
+
+    const out = await prepareSubmissionForWrite(ctx, config, withForm);
+
+    expect(out?.data).toEqual({ name: "xAda", email: "ada@example.com" });
+    // The control: this is exactly what `nextly.forms.submit()` used to store,
+    // and what it would still store if the hook were not registered.
+    expect(ctx.data.data).not.toEqual({
+      name: "<script>x</script>Ada",
+      email: "ada@example.com",
+      isAdmin: true,
+    });
+  });
+
+  it("refuses a submission the form's own schema rejects", async () => {
+    await expect(
+      prepareSubmissionForWrite(
+        { data: { form: "form1", data: { name: "Ada" }, status: "new" } },
+        config,
+        withForm
+      )
+    ).rejects.toThrow();
+  });
+
+  it("keeps a spam row, which is stored as evidence rather than checked", async () => {
+    const ctx = {
+      data: {
+        form: "form1",
+        data: { name: "<b>bot</b>", email: "not-an-email" },
+        status: "spam",
+      },
+    };
+    const out = await prepareSubmissionForWrite(ctx, config, withForm);
+    expect((out?.data as Record<string, unknown>).name).toBe("bot");
+    expect((out?.data as Record<string, unknown>).email).toBe("not-an-email");
+  });
+
+  it("refuses rather than emptying when the form cannot be read", async () => {
+    // Transforming against no fields would project the submission down to `{}`
+    // and store a row saying the visitor sent nothing.
+    await expect(
+      prepareSubmissionForWrite(
+        { data: { form: "form1", data: { name: "Ada" }, status: "new" } },
+        config,
+        nextlyWith(null)
+      )
+    ).rejects.toThrow();
+  });
+
+  it("refuses a form whose fields are not a list", async () => {
+    await expect(
+      prepareSubmissionForWrite(
+        { data: { form: "form1", data: { name: "Ada" }, status: "new" } },
+        config,
+        nextlyWith({ id: "form1", fields: undefined })
+      )
+    ).rejects.toThrow();
+  });
+
+  it("reads data that arrives as the JSON a dialect stores", async () => {
+    const ctx = {
+      data: {
+        form: "form1",
+        data: JSON.stringify({ name: "Ada", email: "ada@example.com" }),
+        status: "new",
+      },
+    };
+    const out = await prepareSubmissionForWrite(ctx, config, withForm);
+    expect(out?.data).toEqual({ name: "Ada", email: "ada@example.com" });
+  });
+
+  it("refuses a data string that is not JSON, rather than storing nothing", async () => {
+    await expect(
+      prepareSubmissionForWrite(
+        { data: { form: "form1", data: "not json", status: "new" } },
+        config,
+        withForm
+      )
+    ).rejects.toThrow();
+  });
+
+  it("leaves a row that names no form to the collection's own rule", async () => {
+    // `form` is required on the collection, so it is refused a step later.
+    // Rejecting here would answer a question this hook was not asked.
+    const ctx = { data: { data: { name: "Ada" }, status: "new" } };
+    const out = await prepareSubmissionForWrite(ctx, config, withForm);
+    expect(out).toBe(ctx.data);
+  });
+});
+
+describe("a submission written straight to the collection", () => {
+  let current: TestNextly | undefined;
+
+  afterEach(async () => {
+    await current?.destroy();
+    current = undefined;
+  });
+
+  // Asserting `hasHooks("beforeCreate", ...)` does NOT work here, and the
+  // control is what said so: it answers true with this hook removed, because
+  // `register-collection-hooks` maps a collection's declared `beforeValidate`
+  // onto the `beforeCreate` phase and core registers a global sanitizer on
+  // `beforeCreate` for every collection. So this boots the real thing and reads
+  // the row instead.
+  it("is transformed, sanitized and stored in the form's own shape", async () => {
+    const { plugin } = formBuilder();
+    current = await createTestNextly({ plugins: [plugin] });
+
+    const form = await current.nextly.create({
+      collection: "forms",
+      data: {
+        name: "Contact",
+        slug: "contact",
+        fields: [
+          { type: "text", name: "message", label: "Message", required: true },
+          { type: "number", name: "rating", label: "Rating" },
+        ],
+        status: "published",
+      },
+    });
+    const formId = (form as { item: { id: string } }).item.id;
+
+    // The write `nextly.forms.submit()` performs, with markup, an undeclared
+    // key and a value needing coercion. Core's own sanitizer cannot reach any
+    // of it: `data` is a `json` field and `json` is in its SKIP_FIELD_TYPES.
+    const created = await current.nextly.create({
+      collection: "form-submissions",
+      data: {
+        form: formId,
+        data: {
+          message: "<script>alert(1)</script>hello",
+          rating: "5",
+          isAdmin: true,
+        },
+        status: "new",
+        submittedAt: new Date(),
+      },
+    });
+
+    const id = (created as { item: { id: string } }).item.id;
+    const stored = (await current.nextly.findByID({
+      collection: "form-submissions",
+      id,
+    })) as { data?: unknown } | null;
+
+    const payload =
+      typeof stored?.data === "string"
+        ? (JSON.parse(stored.data) as Record<string, unknown>)
+        : (stored?.data as Record<string, unknown>);
+
+    expect(payload).toEqual({ message: "alert(1)hello", rating: 5 });
+  });
+
+  it("refuses one the form's schema rejects, rather than storing it", async () => {
+    const { plugin } = formBuilder();
+    current = await createTestNextly({ plugins: [plugin] });
+
+    const form = await current.nextly.create({
+      collection: "forms",
+      data: {
+        name: "Contact",
+        slug: "contact-2",
+        fields: [
+          { type: "email", name: "email", label: "Email", required: true },
+        ],
+        status: "published",
+      },
+    });
+    const formId = (form as { item: { id: string } }).item.id;
+
+    await expect(
+      current.nextly.create({
+        collection: "form-submissions",
+        data: {
+          form: formId,
+          data: { email: "not-an-email" },
+          status: "new",
+          submittedAt: new Date(),
+        },
+      })
+    ).rejects.toThrow();
+  });
+});

--- a/packages/plugin-form-builder/src/__tests__/prepare-submission.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/prepare-submission.test.ts
@@ -13,7 +13,10 @@ import {
 } from "@nextlyhq/plugin-sdk/testing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { prepareSubmission } from "../handlers/prepare-submission";
+import {
+  asPluginSubmission,
+  prepareSubmission,
+} from "../handlers/prepare-submission";
 import { formBuilder, prepareSubmissionForWrite } from "../plugin";
 import type { AnyFormField } from "../types";
 
@@ -95,8 +98,8 @@ describe("prepareSubmission", () => {
   });
 });
 
-describe("the beforeCreate hook on submissions", () => {
-  const config = { formOverrides: { slug: "forms" } } as never;
+describe("the write-seam hook on submissions", () => {
+  const formsSlug = "forms";
 
   const nextlyWith = (form: unknown) =>
     ({
@@ -119,9 +122,10 @@ describe("the beforeCreate hook on submissions", () => {
         },
         status: "new",
       },
+      operation: "create",
     };
 
-    const out = await prepareSubmissionForWrite(ctx, config, withForm);
+    const out = await prepareSubmissionForWrite(ctx, formsSlug, withForm);
 
     expect(out?.data).toEqual({ name: "xAda", email: "ada@example.com" });
     // The control: this is exactly what `nextly.forms.submit()` used to store,
@@ -136,24 +140,86 @@ describe("the beforeCreate hook on submissions", () => {
   it("refuses a submission the form's own schema rejects", async () => {
     await expect(
       prepareSubmissionForWrite(
-        { data: { form: "form1", data: { name: "Ada" }, status: "new" } },
-        config,
+        {
+          data: { form: "form1", data: { name: "Ada" }, status: "new" },
+          operation: "create",
+        },
+        formsSlug,
         withForm
       )
     ).rejects.toThrow();
   });
 
-  it("keeps a spam row, which is stored as evidence rather than checked", async () => {
+  it("keeps a row the handler marked as evidence", async () => {
+    // Sanitized, not rejected. A honeypot hit is stored flagged so a false
+    // positive stays recoverable, and requiring it to be valid would throw away
+    // the thing being reviewed.
     const ctx = {
       data: {
         form: "form1",
         data: { name: "<b>bot</b>", email: "not-an-email" },
         status: "spam",
       },
+      operation: "create",
     };
-    const out = await prepareSubmissionForWrite(ctx, config, withForm);
+    const out = await asPluginSubmission({ keepAsEvidence: true }, () =>
+      prepareSubmissionForWrite(ctx, formsSlug, withForm)
+    );
     expect((out?.data as Record<string, unknown>).name).toBe("bot");
     expect((out?.data as Record<string, unknown>).email).toBe("not-an-email");
+  });
+
+  it("does not let a caller switch validation off with status", async () => {
+    // The submissions collection grants public create and nothing restricts
+    // `status`, so reading leniency off the row let anyone post
+    // `status: "spam"` and skip every required, type and enum rule on their own
+    // submission. Leniency is a fact about the call now, and this call is not
+    // marked.
+    await expect(
+      prepareSubmissionForWrite(
+        {
+          data: {
+            form: "form1",
+            data: { name: "Ada", email: "not-an-email" },
+            status: "spam",
+          },
+          operation: "create",
+        },
+        formsSlug,
+        withForm
+      )
+    ).rejects.toThrow();
+  });
+
+  it("refuses a payload that is not an object rather than storing none", async () => {
+    // `data` is required on the collection, so an omitted payload is meant to
+    // be refused. Substituting `{}` satisfied that check on the way past, and a
+    // form whose fields are all optional then accepted it.
+    for (const bad of [undefined, null, ["a"]]) {
+      await expect(
+        prepareSubmissionForWrite(
+          {
+            data: { form: "form1", data: bad, status: "new" },
+            operation: "create",
+          },
+          formsSlug,
+          withForm
+        )
+      ).rejects.toThrow();
+    }
+  });
+
+  it("leaves an update alone, because its payload is a partial", async () => {
+    // `beforeChange` runs for updates too. An admin changing a status sends no
+    // payload, and preparing that would store an empty submission over a real
+    // one.
+    const ctx = {
+      data: { form: "form1", status: "read" },
+      operation: "update",
+    };
+    expect(await prepareSubmissionForWrite(ctx, formsSlug, withForm)).toBe(
+      ctx.data
+    );
   });
 
   it("refuses rather than emptying when the form cannot be read", async () => {
@@ -161,8 +227,11 @@ describe("the beforeCreate hook on submissions", () => {
     // and store a row saying the visitor sent nothing.
     await expect(
       prepareSubmissionForWrite(
-        { data: { form: "form1", data: { name: "Ada" }, status: "new" } },
-        config,
+        {
+          data: { form: "form1", data: { name: "Ada" }, status: "new" },
+          operation: "create",
+        },
+        formsSlug,
         nextlyWith(null)
       )
     ).rejects.toThrow();
@@ -171,8 +240,11 @@ describe("the beforeCreate hook on submissions", () => {
   it("refuses a form whose fields are not a list", async () => {
     await expect(
       prepareSubmissionForWrite(
-        { data: { form: "form1", data: { name: "Ada" }, status: "new" } },
-        config,
+        {
+          data: { form: "form1", data: { name: "Ada" }, status: "new" },
+          operation: "create",
+        },
+        formsSlug,
         nextlyWith({ id: "form1", fields: undefined })
       )
     ).rejects.toThrow();
@@ -185,16 +257,20 @@ describe("the beforeCreate hook on submissions", () => {
         data: JSON.stringify({ name: "Ada", email: "ada@example.com" }),
         status: "new",
       },
+      operation: "create",
     };
-    const out = await prepareSubmissionForWrite(ctx, config, withForm);
+    const out = await prepareSubmissionForWrite(ctx, formsSlug, withForm);
     expect(out?.data).toEqual({ name: "Ada", email: "ada@example.com" });
   });
 
   it("refuses a data string that is not JSON, rather than storing nothing", async () => {
     await expect(
       prepareSubmissionForWrite(
-        { data: { form: "form1", data: "not json", status: "new" } },
-        config,
+        {
+          data: { form: "form1", data: "not json", status: "new" },
+          operation: "create",
+        },
+        formsSlug,
         withForm
       )
     ).rejects.toThrow();
@@ -203,8 +279,11 @@ describe("the beforeCreate hook on submissions", () => {
   it("leaves a row that names no form to the collection's own rule", async () => {
     // `form` is required on the collection, so it is refused a step later.
     // Rejecting here would answer a question this hook was not asked.
-    const ctx = { data: { data: { name: "Ada" }, status: "new" } };
-    const out = await prepareSubmissionForWrite(ctx, config, withForm);
+    const ctx = {
+      data: { data: { name: "Ada" }, status: "new" },
+      operation: "create",
+    };
+    const out = await prepareSubmissionForWrite(ctx, formsSlug, withForm);
     expect(out).toBe(ctx.data);
   });
 });

--- a/packages/plugin-form-builder/src/__tests__/prepare-submission.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/prepare-submission.test.ts
@@ -16,7 +16,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   asPluginSubmission,
   prepareSubmission,
-  takeSubmissionMarks,
+  submissionMarks,
 } from "../handlers/prepare-submission";
 import { validateSubmission } from "../handlers/submit-form";
 import { formBuilder, prepareSubmissionForWrite } from "../plugin";
@@ -212,6 +212,15 @@ describe("the write-seam hook on submissions", () => {
 
   const withForm = nextlyWith({ id: "form1", fields });
 
+  const readsOf = (nextly: unknown) =>
+    (
+      nextly as {
+        services: {
+          collections: { findEntryById: { mock: { calls: unknown[] } } };
+        };
+      }
+    ).services.collections.findEntryById.mock.calls;
+
   it("prepares a submission the Direct API would have stored raw", async () => {
     const ctx = {
       data: {
@@ -256,16 +265,17 @@ describe("the write-seam hook on submissions", () => {
     // positive stays recoverable, and requiring it to be valid would throw away
     // the thing being reviewed.
     const ctx = {
-      data: {
-        form: "form1",
-        data: { name: "<b>bot</b>", email: "not-an-email" },
-        status: "spam",
-      },
+      data: asPluginSubmission(
+        {
+          form: "form1",
+          data: { name: "<b>bot</b>", email: "not-an-email" },
+          status: "spam",
+        },
+        { keepAsEvidence: true }
+      ),
       operation: "create",
     };
-    const out = await asPluginSubmission({ keepAsEvidence: true }, () =>
-      prepareSubmissionForWrite(ctx, formsSlug, withForm)
-    );
+    const out = await prepareSubmissionForWrite(ctx, formsSlug, withForm);
     expect((out?.data as Record<string, unknown>).name).toBe("bot");
     expect((out?.data as Record<string, unknown>).email).toBe("not-an-email");
   });
@@ -463,31 +473,19 @@ describe("the write-seam hook on submissions", () => {
     // which COUNTs that form's submissions, so a write was paying for a count
     // of every write before it.
     const nextly = nextlyWith({ id: "form1", fields });
-    const out = await asPluginSubmission(
-      { keepAsEvidence: false, form: { id: "form1", fields } },
-      () =>
-        prepareSubmissionForWrite(
-          {
-            data: {
-              form: "form1",
-              data: { name: "Ada", email: "ada@example.com" },
-            },
-            operation: "create",
-          },
-          formsSlug,
-          nextly
-        )
+    const out = await prepareSubmissionForWrite(
+      {
+        data: asPluginSubmission(
+          { form: "form1", data: { name: "Ada", email: "ada@example.com" } },
+          { keepAsEvidence: false, form: { id: "form1", fields } }
+        ),
+        operation: "create",
+      },
+      formsSlug,
+      nextly
     );
     expect(out?.data).toEqual({ name: "Ada", email: "ada@example.com" });
-    expect(
-      (
-        nextly as unknown as {
-          services: {
-            collections: { findEntryById: { mock: { calls: unknown[] } } };
-          };
-        }
-      ).services.collections.findEntryById.mock.calls
-    ).toHaveLength(0);
+    expect(readsOf(nextly)).toHaveLength(0);
   });
 
   it("reads the form when the one handed over is a different form", async () => {
@@ -495,130 +493,109 @@ describe("the write-seam hook on submissions", () => {
     // it, so a mismatch falls back to the read rather than checking a payload
     // against the wrong schema.
     const nextly = nextlyWith({ id: "form1", fields });
-    await asPluginSubmission(
-      { keepAsEvidence: false, form: { id: "other-form", fields: [] } },
-      () =>
-        prepareSubmissionForWrite(
-          {
-            data: {
-              form: "form1",
-              data: { name: "Ada", email: "ada@example.com" },
-            },
-            operation: "create",
-          },
-          formsSlug,
-          nextly
-        )
+    await prepareSubmissionForWrite(
+      {
+        data: asPluginSubmission(
+          { form: "form1", data: { name: "Ada", email: "ada@example.com" } },
+          { keepAsEvidence: false, form: { id: "other-form", fields: [] } }
+        ),
+        operation: "create",
+      },
+      formsSlug,
+      nextly
     );
-    expect(
-      (
-        nextly as unknown as {
-          services: {
-            collections: { findEntryById: { mock: { calls: unknown[] } } };
-          };
-        }
-      ).services.collections.findEntryById.mock.calls
-    ).toHaveLength(1);
+    expect(readsOf(nextly)).toHaveLength(1);
   });
 
-  it("spends the evidence exception on the one write it was granted for", async () => {
-    // `createEntry` does not resolve until its `afterCreate` hooks have run, so
-    // a hook that writes a second submission runs inside the same store. The
-    // second write must not inherit an exception granted to the first.
-    await asPluginSubmission({ keepAsEvidence: true }, async () => {
-      const kept = await prepareSubmissionForWrite(
+  it("gives the exception to its own row and to no other", async () => {
+    // The exception belongs to a row, not to a call. A hook registered before
+    // this plugin runs ahead of its handler and a hook running after it can
+    // write another submission, and both used to reach an exception granted
+    // elsewhere: first by arriving first, then by carrying the same answers.
+    const evidence = asPluginSubmission(
+      {
+        form: "form1",
+        data: { name: "<b>bot</b>", email: "not-an-email" },
+        status: "spam",
+      },
+      { keepAsEvidence: true }
+    );
+
+    // Another row written in the same call, with the same answers on the same
+    // form under the same status. Everything about its content matches, and it
+    // is still validated, because the mark is not on it.
+    await expect(
+      prepareSubmissionForWrite(
         {
           data: {
             form: "form1",
             data: { name: "<b>bot</b>", email: "not-an-email" },
+            status: "spam",
           },
           operation: "create",
         },
         formsSlug,
         withForm
-      );
-      expect((kept?.data as Record<string, unknown>).email).toBe(
-        "not-an-email"
-      );
+      )
+    ).rejects.toThrow();
 
-      await expect(
-        prepareSubmissionForWrite(
-          {
-            data: {
-              form: "form1",
-              data: { name: "Ada", email: "also-not-an-email" },
-            },
-            operation: "create",
-          },
-          formsSlug,
-          withForm
-        )
-      ).rejects.toThrow();
-    });
-  });
-
-  it("hands the marks to the first taker only", async () => {
-    // The mechanism under the test above, stated directly.
-    const writing = { form: "form1", status: "spam", payload: { name: "bot" } };
-    await asPluginSubmission({ keepAsEvidence: true, writing }, () => {
-      expect(takeSubmissionMarks(writing)?.keepAsEvidence).toBe(true);
-      expect(takeSubmissionMarks(writing)).toBeUndefined();
-    });
-    // The control: outside a marked call there is nothing to take.
-    expect(takeSubmissionMarks(writing)).toBeUndefined();
-  });
-
-  it("does not hand the evidence exception to another row's write", async () => {
-    // A hook registered before this plugin runs ahead of its handler, so a
-    // submission that hook writes reaches the seam first, inside the same
-    // store. Spending the marks on whoever arrives first gave the exception to
-    // the wrong row and left the evidence row to be refused.
-    const evidence = { name: "<b>bot</b>", email: "not-an-email" };
-    await asPluginSubmission(
-      {
-        keepAsEvidence: true,
-        writing: { form: "form1", status: "spam", payload: evidence },
-      },
-      async () => {
-        await expect(
-          prepareSubmissionForWrite(
-            {
-              data: {
-                form: "form1",
-                data: { name: "Ada", email: "also-not-an-email" },
-              },
-              operation: "create",
-            },
-            formsSlug,
-            withForm
-          )
-        ).rejects.toThrow();
-
-        // Same answers, different form: content alone would have matched.
-        await expect(
-          prepareSubmissionForWrite(
-            {
-              data: { form: "form1", data: evidence, status: "new" },
-              operation: "create",
-            },
-            formsSlug,
-            withForm
-          )
-        ).rejects.toThrow();
-
-        const kept = await prepareSubmissionForWrite(
-          {
-            data: { form: "form1", data: evidence, status: "spam" },
-            operation: "create",
-          },
-          formsSlug,
-          withForm
-        );
-        expect((kept?.data as Record<string, unknown>).email).toBe(
-          "not-an-email"
-        );
-      }
+    // And the row the exception was granted for still has it, whichever order
+    // the two are written in.
+    const kept = await prepareSubmissionForWrite(
+      { data: evidence, operation: "create" },
+      formsSlug,
+      withForm
     );
+    expect((kept?.data as Record<string, unknown>).email).toBe("not-an-email");
+  });
+
+  it("survives the payload being rewritten before the seam sees it", async () => {
+    // A host hook can normalise `data` in an earlier phase. Identifying the row
+    // by its content meant the intended row stopped matching its own mark and
+    // was refused, which for a honeypot hit is a visible failure where the
+    // whole point is that the bot cannot tell.
+    const row = asPluginSubmission(
+      {
+        form: "form1",
+        data: { name: "<b>bot</b>", email: "not-an-email" },
+        status: "spam",
+      },
+      { keepAsEvidence: true }
+    );
+    row.data = { name: "rewritten by a host hook", email: "still-not-email" };
+    const out = await prepareSubmissionForWrite(
+      { data: row, operation: "create" },
+      formsSlug,
+      withForm
+    );
+    expect((out?.data as Record<string, unknown>).email).toBe(
+      "still-not-email"
+    );
+  });
+
+  it("cannot be asked for from a request body", async () => {
+    // The reason it is a symbol. A caller posts JSON, and `JSON.parse` never
+    // produces a symbol key, so no request can carry this mark however it is
+    // spelled.
+    const posted = JSON.parse(
+      JSON.stringify({
+        form: "form1",
+        data: { name: "bot", email: "not-an-email" },
+        status: "spam",
+        keepAsEvidence: true,
+        "Symbol(nextly.plugin-form-builder.submission)": {
+          keepAsEvidence: true,
+        },
+      })
+    ) as Record<string, unknown>;
+    expect(submissionMarks(posted)).toBeUndefined();
+    await expect(
+      prepareSubmissionForWrite(
+        { data: posted, operation: "create" },
+        formsSlug,
+        withForm
+      )
+    ).rejects.toThrow();
   });
 
   it("checks an evidence row on its way out of spam", async () => {
@@ -857,6 +834,47 @@ describe("a submission written straight to the collection", () => {
         : (stored?.data as Record<string, unknown>);
 
     expect(payload).toEqual({ message: "alert(1)hello", rating: 5 });
+  });
+
+  it("carries a marked row's exception through core to the seam", async () => {
+    // The mark is a symbol on the row, and core rebuilds a row on its way to
+    // the hook, so this is the assertion that says the symbol survives that
+    // journey. Everything about the evidence path rests on it, and if core ever
+    // stops carrying unknown symbol keys this fails rather than quietly
+    // validating a honeypot hit and answering the bot with an error.
+    const { plugin } = formBuilder();
+    current = await createTestNextly({ plugins: [plugin] });
+
+    const form = await current.nextly.create({
+      collection: "forms",
+      data: {
+        name: "Contact",
+        slug: "contact-3",
+        fields: [
+          { type: "email", name: "email", label: "Email", required: true },
+        ],
+        status: "published",
+      },
+    });
+    const formId = (form as { item: { id: string } }).item.id;
+    const row = () => ({
+      form: formId,
+      data: { email: "not-an-email" },
+      status: "spam" as const,
+      submittedAt: new Date(),
+    });
+
+    const created = await current.nextly.create({
+      collection: "form-submissions",
+      data: asPluginSubmission(row(), { keepAsEvidence: true }),
+    });
+    expect((created as { item: { id: string } }).item.id).toBeTruthy();
+
+    // The control: the same row, unmarked, is refused. Without it the test
+    // would pass on a collection that never validated anything.
+    await expect(
+      current.nextly.create({ collection: "form-submissions", data: row() })
+    ).rejects.toThrow();
   });
 
   it("refuses one the form's schema rejects, rather than storing it", async () => {

--- a/packages/plugin-form-builder/src/handlers/prepare-submission.ts
+++ b/packages/plugin-form-builder/src/handlers/prepare-submission.ts
@@ -46,15 +46,23 @@ const TEXT_FORM_FIELDS = new Set([
 ]);
 
 /**
- * Remove all HTML tags from a string, collapse whitespace, and trim.
+ * Remove HTML tags from a string, collapse whitespace, and trim.
  *
- * Uses a regex that matches both complete tags (`<b>`) and unclosed tags
- * at end-of-string (`<script`) to prevent browsers from interpreting
- * incomplete markup.
+ * A `<` opens a tag only when what follows it could name one: an ASCII letter,
+ * `/` for a closing tag, or `!` and `?` for comments and doctypes. That is the
+ * HTML tokenizer's own rule, so what survives here is what a browser would have
+ * shown as text anyway. Treating every `<` as a tag cut `2 < 3` down to `2`,
+ * which is silent loss in the one column a visitor's own words live in.
+ *
+ * `<name>` is still removed. Nothing distinguishes it from a tag, and a browser
+ * reads it as an unknown element too.
+ *
+ * A tag left unclosed at end of string is still removed: handed `hello <script`
+ * a browser completes it rather than showing it.
  */
 function stripHtmlTags(input: string): string {
   return input
-    .replace(/<[^>]*(?:>|$)/g, "")
+    .replace(/<[a-zA-Z/!?][^>]*(?:>|$)/g, "")
     .replace(/\s+/g, " ")
     .trim();
 }
@@ -110,21 +118,45 @@ export interface SubmissionOriginMarks {
    * write seam sanitizes it but does not require it to be valid.
    */
   keepAsEvidence: boolean;
+  /**
+   * The parent form the handler has already read, so the write seam can check
+   * the payload against it without reading it again. Used only when its id is
+   * the one the row names.
+   */
+  form?: Record<string, unknown>;
 }
 
-const submissionOrigin = new AsyncLocalStorage<SubmissionOriginMarks>();
+/** One marked write, and whether it has already been made. */
+interface SubmissionOriginScope {
+  marks: SubmissionOriginMarks;
+  spent: boolean;
+}
+
+const submissionOrigin = new AsyncLocalStorage<SubmissionOriginScope>();
 
 /** Run `write` marked as the plugin's own, so the write seam can trust it. */
 export function asPluginSubmission<T>(
   marks: SubmissionOriginMarks,
   write: () => T
 ): T {
-  return submissionOrigin.run(marks, write);
+  return submissionOrigin.run({ marks, spent: false }, write);
 }
 
-/** What the current write was marked as, or nothing when it is somebody else's. */
-export function currentSubmissionMarks(): SubmissionOriginMarks | undefined {
-  return submissionOrigin.getStore();
+/**
+ * The marks for the write being made now, taken once.
+ *
+ * They describe ONE row, and the scope outlives it: `createEntry` does not
+ * resolve until the `afterCreate` hooks have run, so a hook that writes a
+ * second submission runs inside the same store and would otherwise inherit an
+ * exception granted to the first. Spending them on the first taker is enough,
+ * because the row they were granted for reaches `beforeChange` before anything
+ * `afterCreate` can start.
+ */
+export function takeSubmissionMarks(): SubmissionOriginMarks | undefined {
+  const scope = submissionOrigin.getStore();
+  if (!scope || scope.spent) return undefined;
+  scope.spent = true;
+  return scope.marks;
 }
 
 /** A submission ready to store, or the reasons it is not. */
@@ -142,11 +174,12 @@ export interface PreparedSubmission {
 /**
  * Bring a submission to the shape the form declares.
  *
- * Transform, then validate, then sanitize, in that order and for reasons:
- * transforming projects the payload onto the declared fields, so an undeclared
- * key never reaches the schema or the row; validating before sanitizing means a
- * length rule counts the characters the visitor typed rather than what stripping
- * left behind.
+ * Transform, then sanitize, then validate, in that order and for reasons.
+ * Transforming projects the payload onto the declared fields, so an undeclared
+ * key never reaches the schema or the row. Sanitizing before validating is what
+ * makes every rule judge the value that will actually be stored: the other
+ * order let `<b></b>` satisfy a required field and then reduced it to an empty
+ * string, and made a length rule count markup the visitor never sees.
  *
  * `validate: false` is for content the plugin has already decided to keep as
  * evidence. A honeypot hit is stored flagged rather than dropped so a false
@@ -168,9 +201,9 @@ export function prepareSubmission({
   validate: boolean;
 }): PreparedSubmission {
   const transformed = transformFormData(data, fields);
+  sanitizeSubmissionData(transformed, fields);
 
   if (!validate) {
-    sanitizeSubmissionData(transformed, fields);
     return { data: transformed };
   }
 
@@ -179,10 +212,8 @@ export function prepareSubmission({
     // The transformed payload comes back with the errors rather than nothing,
     // so a caller that wants to store it anyway has the same value the valid
     // path would have produced, minus the schema's blessing.
-    sanitizeSubmissionData(transformed, fields);
     return { data: transformed, validationErrors: getValidationErrors(result) };
   }
 
-  sanitizeSubmissionData(result.data, fields);
   return { data: result.data };
 }

--- a/packages/plugin-form-builder/src/handlers/prepare-submission.ts
+++ b/packages/plugin-form-builder/src/handlers/prepare-submission.ts
@@ -20,6 +20,8 @@
  * stay on the HTTP path.
  */
 
+import { AsyncLocalStorage } from "node:async_hooks";
+
 import type { AnyFormField } from "../types";
 import {
   generateZodSchema,
@@ -82,6 +84,47 @@ export function sanitizeSubmissionData(
 
     data[field.name] = stripHtmlTags(value);
   }
+}
+
+/**
+ * Whether the plugin's own submit handler is the one writing.
+ *
+ * The write-seam check has to be lenient in exactly one case: a honeypot or
+ * reCAPTCHA hit is stored flagged rather than dropped, so a false positive stays
+ * recoverable, and requiring it to be valid would throw away the thing being
+ * reviewed. Deciding that from the row's own `status` made it caller-controlled:
+ * the submissions collection grants public create, nothing restricts `status`,
+ * so anyone could post `status: "spam"` and switch validation off.
+ *
+ * `AsyncLocalStorage` is the mechanism because the question is about the CALL,
+ * not about the row. The store follows the await chain into the hook and cannot
+ * be reached from a request body, a header or a field. A module-level flag would
+ * be the same idea and wrong: two submissions in flight would read each other's.
+ *
+ * Node's own API, and the same one Next.js and OpenTelemetry use for
+ * request-scoped context, rather than a channel invented here.
+ */
+export interface SubmissionOriginMarks {
+  /**
+   * The handler decided this row is spam and is keeping it as evidence, so the
+   * write seam sanitizes it but does not require it to be valid.
+   */
+  keepAsEvidence: boolean;
+}
+
+const submissionOrigin = new AsyncLocalStorage<SubmissionOriginMarks>();
+
+/** Run `write` marked as the plugin's own, so the write seam can trust it. */
+export function asPluginSubmission<T>(
+  marks: SubmissionOriginMarks,
+  write: () => T
+): T {
+  return submissionOrigin.run(marks, write);
+}
+
+/** What the current write was marked as, or nothing when it is somebody else's. */
+export function currentSubmissionMarks(): SubmissionOriginMarks | undefined {
+  return submissionOrigin.getStore();
 }
 
 /** A submission ready to store, or the reasons it is not. */

--- a/packages/plugin-form-builder/src/handlers/prepare-submission.ts
+++ b/packages/plugin-form-builder/src/handlers/prepare-submission.ts
@@ -20,8 +20,6 @@
  * stay on the HTTP path.
  */
 
-import { AsyncLocalStorage } from "node:async_hooks";
-
 import type { AnyFormField } from "../types";
 import {
   generateZodSchema,
@@ -132,23 +130,34 @@ export function sanitizeSubmissionData(
 }
 
 /**
- * Whether the plugin's own submit handler is the one writing.
+ * How the plugin's own submit handler says a row is its own.
  *
  * The write-seam check has to be lenient in exactly one case: a honeypot or
  * reCAPTCHA hit is stored flagged rather than dropped, so a false positive stays
- * recoverable, and requiring it to be valid would throw away the thing being
+ * reviewable, and requiring it to be valid would throw away the thing being
  * reviewed. Deciding that from the row's own `status` made it caller-controlled:
  * the submissions collection grants public create, nothing restricts `status`,
  * so anyone could post `status: "spam"` and switch validation off.
  *
- * `AsyncLocalStorage` is the mechanism because the question is about the CALL,
- * not about the row. The store follows the await chain into the hook and cannot
- * be reached from a request body, a header or a field. A module-level flag would
- * be the same idea and wrong: two submissions in flight would read each other's.
+ * A SYMBOL key on the row is the channel, and it is the only one that both
+ * reaches the hook and cannot be reached from a request. `JSON.parse` never
+ * produces a symbol key, so nothing a caller posts can carry it, and
+ * `JSON.stringify` ignores it, so it cannot be stored by accident. It travels
+ * with the row it describes, which is what the alternatives could not do.
  *
- * Node's own API, and the same one Next.js and OpenTelemetry use for
- * request-scoped context, rather than a channel invented here.
+ * The alternatives were measured, not assumed. `createEntry`'s `params.context`
+ * is unreachable: `wrapCollectionsForPlugin` rebuilds the trailing argument as
+ * `{ user, overrideAccess }` and drops everything else. `AsyncLocalStorage`
+ * reaches the hook but describes the CALL rather than the row, so a submission
+ * written by another hook inside the same call took the exception, and
+ * identifying the intended row by its content broke as soon as a host hook
+ * normalised the payload, since core rebuilds the payload object on the way.
+ * A symbol on the row has neither problem: booting a real Nextly and reading
+ * the hook's context back, the row's symbol arrives and the payload's does not.
  */
+const PLUGIN_SUBMISSION = Symbol.for("nextly.plugin-form-builder.submission");
+
+/** What the handler says about the row it is writing. */
 export interface SubmissionOriginMarks {
   /**
    * The handler decided this row is spam and is keeping it as evidence, so the
@@ -161,52 +170,30 @@ export interface SubmissionOriginMarks {
    * the one the row names.
    */
   form?: Record<string, unknown>;
-  /**
-   * The row this exception is for, so no other write can take it.
-   *
-   * Spending the marks on the first write in the scope is not enough on its
-   * own: a hook registered before this plugin runs ahead of its handler, and a
-   * submission that hook writes reaches the seam first. It would take an
-   * exception granted to another row, and the row it was granted for would then
-   * be validated and refused.
-   */
-  writing?: IntendedWrite;
 }
 
-/**
- * The row a marked call is writing, as much of it as tells that row apart.
- *
- * The answers alone were not enough: a hook that copies them onto a different
- * form, or writes them back under a different status, matches on content while
- * being a different row.
- *
- * Compared by content rather than by reference, which was measured rather than
- * assumed: core rebuilds both the row and its payload on the way to the hook,
- * so neither arrives as the object the handler passed.
- */
-export interface IntendedWrite {
-  /** The parent form's id. */
-  form: string;
-  /** The status the handler is storing, which is what the exception is about. */
-  status: string;
-  /** The visitor's answers. */
-  payload: Record<string, unknown>;
+/** Mark `row` as this plugin's own write, and hand it back. */
+export function asPluginSubmission(
+  row: Record<string, unknown>,
+  marks: SubmissionOriginMarks
+): Record<string, unknown> {
+  return Object.defineProperty(row, PLUGIN_SUBMISSION, {
+    value: marks,
+    enumerable: true,
+    configurable: true,
+  });
 }
 
-/** One marked write, and whether it has already been made. */
-interface SubmissionOriginScope {
-  marks: SubmissionOriginMarks;
-  spent: boolean;
+/** A row as it looks once this plugin has marked it. */
+interface MarkedSubmission {
+  [PLUGIN_SUBMISSION]?: SubmissionOriginMarks;
 }
 
-const submissionOrigin = new AsyncLocalStorage<SubmissionOriginScope>();
-
-/** Run `write` marked as the plugin's own, so the write seam can trust it. */
-export function asPluginSubmission<T>(
-  marks: SubmissionOriginMarks,
-  write: () => T
-): T {
-  return submissionOrigin.run({ marks, spent: false }, write);
+/** What this row was marked as, or nothing when it is somebody else's. */
+export function submissionMarks(
+  row: Record<string, unknown>
+): SubmissionOriginMarks | undefined {
+  return (row as MarkedSubmission)[PLUGIN_SUBMISSION];
 }
 
 /** A form value, compared the way a form value can be. */
@@ -232,38 +219,6 @@ export function sameSubmittedPayload(
   const answers = Object.entries(granted);
   if (answers.length !== Object.keys(incoming).length) return false;
   return answers.every(([field, answer]) => sameValue(answer, incoming[field]));
-}
-
-/**
- * The marks for this row, if they were granted for this row, taken once.
- *
- * The scope outlives the write it was opened for: `createEntry` does not
- * resolve until the `afterCreate` hooks have run, and a hook registered before
- * this plugin runs ahead of its handler, so a submission written from either
- * place is inside the same store. Naming the payload is what stops such a row
- * taking an exception meant for another.
- *
- * Still spent once, so a second row carrying the same answers to the same form
- * cannot be waved through on the back of the first.
- */
-export function takeSubmissionMarks(
-  writing: IntendedWrite
-): SubmissionOriginMarks | undefined {
-  const scope = submissionOrigin.getStore();
-  if (!scope || scope.spent) return undefined;
-  const granted = scope.marks.writing;
-  if (granted && !sameWrite(granted, writing)) return undefined;
-  scope.spent = true;
-  return scope.marks;
-}
-
-/** Whether two writes are the same row. */
-function sameWrite(granted: IntendedWrite, writing: IntendedWrite): boolean {
-  return (
-    granted.form === writing.form &&
-    granted.status === writing.status &&
-    sameSubmittedPayload(granted.payload, writing.payload)
-  );
 }
 
 /** A submission ready to store, or the reasons it is not. */

--- a/packages/plugin-form-builder/src/handlers/prepare-submission.ts
+++ b/packages/plugin-form-builder/src/handlers/prepare-submission.ts
@@ -1,0 +1,145 @@
+/**
+ * What a submission has to be before it is stored, wherever it came from.
+ *
+ * Two things accept a submission. `submitForm` answers `POST
+ * /api/forms/:slug/submit`, and `nextly.forms.submit()` is the Direct API a
+ * server-side caller reaches through `getNextly()`. The first transformed,
+ * validated and sanitized; the second did none of it, so a submission arriving
+ * that way was stored with undeclared keys, values that did not match the
+ * form's own schema, and markup intact.
+ *
+ * The rule lives here rather than in either caller because a rule stated in one
+ * of two places is a rule the other can disagree with, and the two had already
+ * drifted that far apart. `beforeCreate` on the submissions collection now asks
+ * this on every write, so a third caller inherits it without knowing it exists.
+ *
+ * What is NOT here is the spam machinery: the honeypot, the rate limiter and
+ * reCAPTCHA are facts about a REQUEST, not about a row. A trusted server
+ * importing a thousand submissions would be rate-limited by its own import, and
+ * a honeypot field means nothing without a browser to have skipped it. Those
+ * stay on the HTTP path.
+ */
+
+import type { AnyFormField } from "../types";
+import {
+  generateZodSchema,
+  getValidationErrors,
+  transformFormData,
+} from "../utils/generate-schema";
+
+/**
+ * Form field types that accept free-text string input from end users.
+ * These fields can contain HTML injection vectors and must be sanitized.
+ *
+ * Fields NOT in this set (select, radio, checkbox, number, date, time, file)
+ * are constrained by Zod enum/type validation and don't need sanitization.
+ */
+const TEXT_FORM_FIELDS = new Set([
+  "text",
+  "email",
+  "textarea",
+  "phone",
+  "url",
+  "hidden",
+]);
+
+/**
+ * Remove all HTML tags from a string, collapse whitespace, and trim.
+ *
+ * Uses a regex that matches both complete tags (`<b>`) and unclosed tags
+ * at end-of-string (`<script`) to prevent browsers from interpreting
+ * incomplete markup.
+ */
+function stripHtmlTags(input: string): string {
+  return input
+    .replace(/<[^>]*(?:>|$)/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Sanitize form submission data by stripping HTML tags from free-text fields.
+ *
+ * Iterates over the form's field definitions and applies `stripHtmlTags()`
+ * to values whose field type is in `TEXT_FORM_FIELDS`. Non-string values
+ * and constrained fields (select, radio, checkbox, etc.) are left unchanged.
+ *
+ * Mutates the data object in place for efficiency.
+ *
+ * @param data - Validated submission data (mutated in place)
+ * @param fields - Form field definitions (used for type-aware dispatch)
+ */
+export function sanitizeSubmissionData(
+  data: Record<string, unknown>,
+  fields: AnyFormField[]
+): void {
+  for (const field of fields) {
+    // Plugin field types are not in TEXT_FORM_FIELDS, so they skip naturally.
+    if (!TEXT_FORM_FIELDS.has(field.type)) continue;
+
+    const value = data[field.name];
+    if (typeof value !== "string") continue;
+
+    data[field.name] = stripHtmlTags(value);
+  }
+}
+
+/** A submission ready to store, or the reasons it is not. */
+export interface PreparedSubmission {
+  /** Transformed and sanitized. Present whether or not validation passed. */
+  data: Record<string, unknown>;
+  /**
+   * Field name to its first message, which is the shape `getValidationErrors`
+   * already returns and the HTTP handler already answers with. Absent when the
+   * submission is storable.
+   */
+  validationErrors?: Record<string, string>;
+}
+
+/**
+ * Bring a submission to the shape the form declares.
+ *
+ * Transform, then validate, then sanitize, in that order and for reasons:
+ * transforming projects the payload onto the declared fields, so an undeclared
+ * key never reaches the schema or the row; validating before sanitizing means a
+ * length rule counts the characters the visitor typed rather than what stripping
+ * left behind.
+ *
+ * `validate: false` is for content the plugin has already decided to keep as
+ * evidence. A honeypot hit is stored flagged rather than dropped so a false
+ * positive stays recoverable, and requiring it to be valid would throw the
+ * evidence away. It is still transformed and sanitized, because a row nobody
+ * validated is exactly the one that should not carry markup.
+ *
+ * Idempotent, which is what lets the write-seam hook run over data the HTTP
+ * handler has already prepared: transforming a projected payload projects it
+ * again, and stripping tags from text that has none returns it unchanged.
+ */
+export function prepareSubmission({
+  data,
+  fields,
+  validate,
+}: {
+  data: Record<string, unknown>;
+  fields: AnyFormField[];
+  validate: boolean;
+}): PreparedSubmission {
+  const transformed = transformFormData(data, fields);
+
+  if (!validate) {
+    sanitizeSubmissionData(transformed, fields);
+    return { data: transformed };
+  }
+
+  const result = generateZodSchema(fields).safeParse(transformed);
+  if (!result.success) {
+    // The transformed payload comes back with the errors rather than nothing,
+    // so a caller that wants to store it anyway has the same value the valid
+    // path would have produced, minus the schema's blessing.
+    sanitizeSubmissionData(transformed, fields);
+    return { data: transformed, validationErrors: getValidationErrors(result) };
+  }
+
+  sanitizeSubmissionData(result.data, fields);
+  return { data: result.data };
+}

--- a/packages/plugin-form-builder/src/handlers/prepare-submission.ts
+++ b/packages/plugin-form-builder/src/handlers/prepare-submission.ts
@@ -137,19 +137,35 @@ export interface SubmissionOriginMarks {
    */
   form?: Record<string, unknown>;
   /**
-   * The payload the handler is writing, so the exception can name its row.
+   * The row this exception is for, so no other write can take it.
    *
    * Spending the marks on the first write in the scope is not enough on its
-   * own: a hook registered before this plugin runs ahead of its handler, and if
-   * that hook writes a submission of its own the nested row reaches the seam
-   * first. It would take an exception granted to somebody else, and the row the
-   * exception was for would then be validated and refused.
-   *
-   * Compared by content rather than by reference, which was measured rather
-   * than assumed: core rebuilds both the row and its payload on the way to the
-   * hook, so neither arrives as the object the handler passed.
+   * own: a hook registered before this plugin runs ahead of its handler, and a
+   * submission that hook writes reaches the seam first. It would take an
+   * exception granted to another row, and the row it was granted for would then
+   * be validated and refused.
    */
-  payload?: Record<string, unknown>;
+  writing?: IntendedWrite;
+}
+
+/**
+ * The row a marked call is writing, as much of it as tells that row apart.
+ *
+ * The answers alone were not enough: a hook that copies them onto a different
+ * form, or writes them back under a different status, matches on content while
+ * being a different row.
+ *
+ * Compared by content rather than by reference, which was measured rather than
+ * assumed: core rebuilds both the row and its payload on the way to the hook,
+ * so neither arrives as the object the handler passed.
+ */
+export interface IntendedWrite {
+  /** The parent form's id. */
+  form: string;
+  /** The status the handler is storing, which is what the exception is about. */
+  status: string;
+  /** The visitor's answers. */
+  payload: Record<string, unknown>;
 }
 
 /** One marked write, and whether it has already been made. */
@@ -184,7 +200,7 @@ function sameValue(left: unknown, right: unknown): boolean {
 }
 
 /** Whether two submitted payloads say the same thing. */
-function samePayload(
+export function sameSubmittedPayload(
   granted: Record<string, unknown>,
   incoming: Record<string, unknown>
 ): boolean {
@@ -206,15 +222,23 @@ function samePayload(
  * cannot be waved through on the back of the first.
  */
 export function takeSubmissionMarks(
-  payload: Record<string, unknown>
+  writing: IntendedWrite
 ): SubmissionOriginMarks | undefined {
   const scope = submissionOrigin.getStore();
   if (!scope || scope.spent) return undefined;
-  if (scope.marks.payload && !samePayload(scope.marks.payload, payload)) {
-    return undefined;
-  }
+  const granted = scope.marks.writing;
+  if (granted && !sameWrite(granted, writing)) return undefined;
   scope.spent = true;
   return scope.marks;
+}
+
+/** Whether two writes are the same row. */
+function sameWrite(granted: IntendedWrite, writing: IntendedWrite): boolean {
+  return (
+    granted.form === writing.form &&
+    granted.status === writing.status &&
+    sameSubmittedPayload(granted.payload, writing.payload)
+  );
 }
 
 /** A submission ready to store, or the reasons it is not. */

--- a/packages/plugin-form-builder/src/handlers/prepare-submission.ts
+++ b/packages/plugin-form-builder/src/handlers/prepare-submission.ts
@@ -45,6 +45,18 @@ const TEXT_FORM_FIELDS = new Set([
   "hidden",
 ]);
 
+/** Whether this character would make the `<` before it open a tag. */
+function opensTag(character: string | undefined): boolean {
+  if (character === undefined) return false;
+  return (
+    character === "/" ||
+    character === "!" ||
+    character === "?" ||
+    (character >= "a" && character <= "z") ||
+    (character >= "A" && character <= "Z")
+  );
+}
+
 /**
  * Remove HTML tags from a string, collapse whitespace, and trim.
  *
@@ -55,28 +67,41 @@ const TEXT_FORM_FIELDS = new Set([
  * which is silent loss in the one column a visitor's own words live in.
  *
  * `<name>` is still removed. Nothing distinguishes it from a tag, and a browser
- * reads it as an unknown element too.
+ * reads it as an unknown element too. A tag left unclosed at the end goes with
+ * it: handed `hello <script` a browser completes it rather than showing it.
  *
- * A tag left unclosed at end of string is still removed: handed `hello <script`
- * a browser completes it rather than showing it.
+ * One pass, holding one invariant: a `<` that has been kept is never followed
+ * by a character that would open a tag. Removing a tag can put its neighbours
+ * together into a new one, and `<<b>img src=x onerror=alert(1)>` became live
+ * markup the sanitizer assembled itself, so a kept `<` is dropped the moment
+ * the next character would make it dangerous.
  *
- * Repeated until the text stops changing, because removing a tag can put its
- * neighbours together into a new one. `<<b>img src=x onerror=alert(1)>` loses
- * the inner `<b>` and one pass hands back `<img src=x onerror=alert(1)>`, which
- * is live markup the sanitizer assembled itself. Each pass can only shorten the
- * text, so the loop ends, and it ends with nothing a browser would read as a
- * tag left in it.
+ * Repeating a regex until the text stopped changing held the same invariant and
+ * was quadratic: `"<".repeat(n) + "b>" + "x>".repeat(n)` exposed one tag per
+ * pass, so 90KB of it cost 30,001 passes over the whole string. This route is
+ * public and unauthenticated, and sanitizing happens before any length rule, so
+ * that was a cheap way to spend the server's CPU. Each character is examined
+ * once and dropped at most once.
  */
-const HTML_TAG = /<[a-zA-Z/!?][^>]*(?:>|$)/g;
-
 function stripHtmlTags(input: string): string {
-  let text = input;
-  let previous;
-  do {
-    previous = text;
-    text = text.replace(HTML_TAG, "");
-  } while (text !== previous);
-  return text.replace(/\s+/g, " ").trim();
+  const kept: string[] = [];
+  for (let at = 0; at < input.length; at += 1) {
+    const character = input[at];
+    if (character === "<" && opensTag(input[at + 1])) {
+      const close = input.indexOf(">", at + 1);
+      at = close === -1 ? input.length : close;
+      continue;
+    }
+    while (
+      kept.length > 0 &&
+      kept[kept.length - 1] === "<" &&
+      opensTag(character)
+    ) {
+      kept.pop();
+    }
+    kept.push(character);
+  }
+  return kept.join("").replace(/\s+/g, " ").trim();
 }
 
 /**

--- a/packages/plugin-form-builder/src/handlers/prepare-submission.ts
+++ b/packages/plugin-form-builder/src/handlers/prepare-submission.ts
@@ -59,12 +59,24 @@ const TEXT_FORM_FIELDS = new Set([
  *
  * A tag left unclosed at end of string is still removed: handed `hello <script`
  * a browser completes it rather than showing it.
+ *
+ * Repeated until the text stops changing, because removing a tag can put its
+ * neighbours together into a new one. `<<b>img src=x onerror=alert(1)>` loses
+ * the inner `<b>` and one pass hands back `<img src=x onerror=alert(1)>`, which
+ * is live markup the sanitizer assembled itself. Each pass can only shorten the
+ * text, so the loop ends, and it ends with nothing a browser would read as a
+ * tag left in it.
  */
+const HTML_TAG = /<[a-zA-Z/!?][^>]*(?:>|$)/g;
+
 function stripHtmlTags(input: string): string {
-  return input
-    .replace(/<[a-zA-Z/!?][^>]*(?:>|$)/g, "")
-    .replace(/\s+/g, " ")
-    .trim();
+  let text = input;
+  let previous;
+  do {
+    previous = text;
+    text = text.replace(HTML_TAG, "");
+  } while (text !== previous);
+  return text.replace(/\s+/g, " ").trim();
 }
 
 /**
@@ -124,6 +136,20 @@ export interface SubmissionOriginMarks {
    * the one the row names.
    */
   form?: Record<string, unknown>;
+  /**
+   * The payload the handler is writing, so the exception can name its row.
+   *
+   * Spending the marks on the first write in the scope is not enough on its
+   * own: a hook registered before this plugin runs ahead of its handler, and if
+   * that hook writes a submission of its own the nested row reaches the seam
+   * first. It would take an exception granted to somebody else, and the row the
+   * exception was for would then be validated and refused.
+   *
+   * Compared by content rather than by reference, which was measured rather
+   * than assumed: core rebuilds both the row and its payload on the way to the
+   * hook, so neither arrives as the object the handler passed.
+   */
+  payload?: Record<string, unknown>;
 }
 
 /** One marked write, and whether it has already been made. */
@@ -142,19 +168,51 @@ export function asPluginSubmission<T>(
   return submissionOrigin.run({ marks, spent: false }, write);
 }
 
+/** A form value, compared the way a form value can be. */
+function sameValue(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) return true;
+  if (left instanceof Date && right instanceof Date) {
+    return left.getTime() === right.getTime();
+  }
+  if (Array.isArray(left) && Array.isArray(right)) {
+    return (
+      left.length === right.length &&
+      left.every((value, index) => sameValue(value, right[index]))
+    );
+  }
+  return false;
+}
+
+/** Whether two submitted payloads say the same thing. */
+function samePayload(
+  granted: Record<string, unknown>,
+  incoming: Record<string, unknown>
+): boolean {
+  const answers = Object.entries(granted);
+  if (answers.length !== Object.keys(incoming).length) return false;
+  return answers.every(([field, answer]) => sameValue(answer, incoming[field]));
+}
+
 /**
- * The marks for the write being made now, taken once.
+ * The marks for this row, if they were granted for this row, taken once.
  *
- * They describe ONE row, and the scope outlives it: `createEntry` does not
- * resolve until the `afterCreate` hooks have run, so a hook that writes a
- * second submission runs inside the same store and would otherwise inherit an
- * exception granted to the first. Spending them on the first taker is enough,
- * because the row they were granted for reaches `beforeChange` before anything
- * `afterCreate` can start.
+ * The scope outlives the write it was opened for: `createEntry` does not
+ * resolve until the `afterCreate` hooks have run, and a hook registered before
+ * this plugin runs ahead of its handler, so a submission written from either
+ * place is inside the same store. Naming the payload is what stops such a row
+ * taking an exception meant for another.
+ *
+ * Still spent once, so a second row carrying the same answers to the same form
+ * cannot be waved through on the back of the first.
  */
-export function takeSubmissionMarks(): SubmissionOriginMarks | undefined {
+export function takeSubmissionMarks(
+  payload: Record<string, unknown>
+): SubmissionOriginMarks | undefined {
   const scope = submissionOrigin.getStore();
   if (!scope || scope.spent) return undefined;
+  if (scope.marks.payload && !samePayload(scope.marks.payload, payload)) {
+    return undefined;
+  }
   scope.spent = true;
   return scope.marks;
 }

--- a/packages/plugin-form-builder/src/handlers/submit-form.ts
+++ b/packages/plugin-form-builder/src/handlers/submit-form.ts
@@ -32,7 +32,7 @@ import {
   type RedirectUrlPattern,
 } from "../utils/redirect-target";
 
-import { prepareSubmission } from "./prepare-submission";
+import { asPluginSubmission, prepareSubmission } from "./prepare-submission";
 import { checkSpam } from "./spam-detection";
 
 // ============================================================
@@ -307,12 +307,19 @@ export async function submitForm(
       submittedAt: new Date(),
     };
 
-    const submission = await collections.createEntry(
-      pluginConfig.formSubmissionOverrides.slug,
-      submissionData,
-      // Public form submission — create as system. No ambient user; an
-      // empty context already resolves to system, but be explicit.
-      { as: "system" }
+    // Marked as the plugin's own write for the length of the call, so the
+    // write-seam hook knows a flagged row is evidence this handler chose to
+    // keep rather than a caller asking for validation to be skipped.
+    const submission = await asPluginSubmission(
+      { keepAsEvidence: isContentSpam },
+      () =>
+        collections.createEntry(
+          pluginConfig.formSubmissionOverrides.slug,
+          submissionData,
+          // Public form submission — create as system. No ambient user; an
+          // empty context already resolves to system, but be explicit.
+          { as: "system" }
+        )
     );
 
     logger.info?.("Form submission created successfully", {

--- a/packages/plugin-form-builder/src/handlers/submit-form.ts
+++ b/packages/plugin-form-builder/src/handlers/submit-form.ts
@@ -305,26 +305,19 @@ export async function submitForm(
     // Marked as the plugin's own write for the length of the call, so the
     // write-seam hook knows a flagged row is evidence this handler chose to
     // keep rather than a caller asking for validation to be skipped.
-    const submission = await asPluginSubmission(
-      // The form is handed to the write seam rather than re-read there: reading
-      // a form runs its `afterRead` hooks, one of which counts submissions.
-      {
+    // Marked as this plugin's own write, so the write seam knows a flagged row
+    // is evidence this handler chose to keep rather than a caller asking for
+    // validation to be skipped. The form goes with it so the seam does not read
+    // it a second time.
+    const submission = await collections.createEntry(
+      pluginConfig.formSubmissionOverrides.slug,
+      asPluginSubmission(submissionData, {
         keepAsEvidence: isContentSpam,
         form: { id: form.id, fields: form.fields },
-        writing: {
-          form: form.id,
-          status: submissionData.status,
-          payload: storedData,
-        },
-      },
-      () =>
-        collections.createEntry(
-          pluginConfig.formSubmissionOverrides.slug,
-          submissionData,
-          // Public form submission — create as system. No ambient user; an
-          // empty context already resolves to system, but be explicit.
-          { as: "system" }
-        )
+      }),
+      // Public form submission — create as system. No ambient user; an
+      // empty context already resolves to system, but be explicit.
+      { as: "system" }
     );
 
     logger.info?.("Form submission created successfully", {

--- a/packages/plugin-form-builder/src/handlers/submit-form.ts
+++ b/packages/plugin-form-builder/src/handlers/submit-form.ts
@@ -19,11 +19,6 @@ import type {
 } from "../types";
 import { normalizeFormSettings } from "../utils/form-settings";
 import {
-  generateZodSchema,
-  transformFormData,
-  getValidationErrors,
-} from "../utils/generate-schema";
-import {
   applyRedirectPattern,
   documentReachability,
   parseRedirectReference,
@@ -644,18 +639,23 @@ export async function validateSubmission(
     return { valid: false, errors: { _form: "Form not found" } };
   }
 
-  // Transform and validate
-  const transformedData = transformFormData(data, form.fields);
-  const schema = generateZodSchema(form.fields);
-  const result = schema.safeParse(transformedData);
+  // The same rule storage applies, asked rather than restated. Restating it
+  // meant this answered on the transformed but unsanitized value while the
+  // write seam answers on the sanitized one, so a preflight check could call a
+  // submission valid that storage then refused.
+  const prepared = prepareSubmission({
+    data,
+    fields: form.fields,
+    validate: true,
+  });
 
-  if (result.success) {
+  if (!prepared.validationErrors) {
     return { valid: true };
   }
 
   return {
     valid: false,
-    errors: getValidationErrors(result),
+    errors: prepared.validationErrors,
   };
 }
 

--- a/packages/plugin-form-builder/src/handlers/submit-form.ts
+++ b/packages/plugin-form-builder/src/handlers/submit-form.ts
@@ -311,7 +311,11 @@ export async function submitForm(
       {
         keepAsEvidence: isContentSpam,
         form: { id: form.id, fields: form.fields },
-        payload: storedData,
+        writing: {
+          form: form.id,
+          status: submissionData.status,
+          payload: storedData,
+        },
       },
       () =>
         collections.createEntry(

--- a/packages/plugin-form-builder/src/handlers/submit-form.ts
+++ b/packages/plugin-form-builder/src/handlers/submit-form.ts
@@ -311,7 +311,12 @@ export async function submitForm(
     // write-seam hook knows a flagged row is evidence this handler chose to
     // keep rather than a caller asking for validation to be skipped.
     const submission = await asPluginSubmission(
-      { keepAsEvidence: isContentSpam },
+      // The form is handed to the write seam rather than re-read there: reading
+      // a form runs its `afterRead` hooks, one of which counts submissions.
+      {
+        keepAsEvidence: isContentSpam,
+        form: { id: form.id, fields: form.fields },
+      },
       () =>
         collections.createEntry(
           pluginConfig.formSubmissionOverrides.slug,

--- a/packages/plugin-form-builder/src/handlers/submit-form.ts
+++ b/packages/plugin-form-builder/src/handlers/submit-form.ts
@@ -16,7 +16,6 @@ import type {
   FormDocument,
   SubmissionDocument,
   ResolvedFormBuilderConfig,
-  AnyFormField,
 } from "../types";
 import { normalizeFormSettings } from "../utils/form-settings";
 import {
@@ -33,6 +32,7 @@ import {
   type RedirectUrlPattern,
 } from "../utils/redirect-target";
 
+import { prepareSubmission } from "./prepare-submission";
 import { checkSpam } from "./spam-detection";
 
 // ============================================================
@@ -266,38 +266,33 @@ export async function submitForm(
     // 4. Transform + validate. Content spam skips validation entirely — it
     // is stored for review exactly as the bot shaped it (declared fields
     // only, sanitized), and requiring validity would drop the evidence.
-    const transformedData = transformFormData(data, form.fields);
-    let storedData: Record<string, unknown>;
-
     if (isContentSpam) {
       logger.info?.("Spam submission detected — storing flagged", {
         formSlug,
         reason: spamResult.reason,
         ipAddress: metadata?.ipAddress,
       });
-      sanitizeSubmissionData(transformedData, form.fields);
-      storedData = transformedData;
-    } else {
-      const schema = generateZodSchema(form.fields);
-      const validationResult = schema.safeParse(transformedData);
-
-      if (!validationResult.success) {
-        const validationErrors = getValidationErrors(validationResult);
-        logger.debug?.("Form validation failed", {
-          formSlug,
-          errors: validationErrors,
-        });
-        return {
-          success: false,
-          error: "Validation failed",
-          validationErrors,
-        };
-      }
-
-      // Sanitize validated submission data (strip HTML from free-text fields)
-      sanitizeSubmissionData(validationResult.data, form.fields);
-      storedData = validationResult.data;
     }
+
+    const prepared = prepareSubmission({
+      data,
+      fields: form.fields,
+      validate: !isContentSpam,
+    });
+
+    if (prepared.validationErrors) {
+      logger.debug?.("Form validation failed", {
+        formSlug,
+        errors: prepared.validationErrors,
+      });
+      return {
+        success: false,
+        error: "Validation failed",
+        validationErrors: prepared.validationErrors,
+      };
+    }
+
+    const storedData = prepared.data;
 
     // 5. Create submission record. Content spam (honeypot/recaptcha) is
     // stored FLAGGED, never silently dropped: a false positive stays
@@ -676,67 +671,6 @@ export async function isFormAcceptingSubmissions(
   }
 
   return form.status === "published";
-}
-
-// ============================================================
-// Submission Data Sanitization
-// ============================================================
-
-/**
- * Form field types that accept free-text string input from end users.
- * These fields can contain HTML injection vectors and must be sanitized.
- *
- * Fields NOT in this set (select, radio, checkbox, number, date, time, file)
- * are constrained by Zod enum/type validation and don't need sanitization.
- */
-const TEXT_FORM_FIELDS = new Set([
-  "text",
-  "email",
-  "textarea",
-  "phone",
-  "url",
-  "hidden",
-]);
-
-/**
- * Remove all HTML tags from a string, collapse whitespace, and trim.
- *
- * Uses a regex that matches both complete tags (`<b>`) and unclosed tags
- * at end-of-string (`<script`) to prevent browsers from interpreting
- * incomplete markup.
- */
-function stripHtmlTags(input: string): string {
-  return input
-    .replace(/<[^>]*(?:>|$)/g, "")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-/**
- * Sanitize form submission data by stripping HTML tags from free-text fields.
- *
- * Iterates over the form's field definitions and applies `stripHtmlTags()`
- * to values whose field type is in `TEXT_FORM_FIELDS`. Non-string values
- * and constrained fields (select, radio, checkbox, etc.) are left unchanged.
- *
- * Mutates the data object in place for efficiency.
- *
- * @param data - Validated submission data (mutated in place)
- * @param fields - Form field definitions (used for type-aware dispatch)
- */
-function sanitizeSubmissionData(
-  data: Record<string, unknown>,
-  fields: AnyFormField[]
-): void {
-  for (const field of fields) {
-    // Plugin field types are not in TEXT_FORM_FIELDS, so they skip naturally.
-    if (!TEXT_FORM_FIELDS.has(field.type)) continue;
-
-    const value = data[field.name];
-    if (typeof value !== "string") continue;
-
-    data[field.name] = stripHtmlTags(value);
-  }
 }
 
 // ============================================================

--- a/packages/plugin-form-builder/src/handlers/submit-form.ts
+++ b/packages/plugin-form-builder/src/handlers/submit-form.ts
@@ -311,6 +311,7 @@ export async function submitForm(
       {
         keepAsEvidence: isContentSpam,
         form: { id: form.id, fields: form.fields },
+        payload: storedData,
       },
       () =>
         collections.createEntry(

--- a/packages/plugin-form-builder/src/plugin.ts
+++ b/packages/plugin-form-builder/src/plugin.ts
@@ -26,7 +26,7 @@ import {
   asSubmissionDocuments,
 } from "./document-shapes";
 import {
-  currentSubmissionMarks,
+  takeSubmissionMarks,
   prepareSubmission,
 } from "./handlers/prepare-submission";
 import type {
@@ -521,13 +521,18 @@ export function formBuilder(
       const formsSlug =
         nextly.self.collections[declaredFormsSlug] ?? declaredFormsSlug;
 
-      // `beforeChange` rather than `beforeCreate`: it is the last mutating
-      // phase before the insert. Core runs stored `beforeCreate` hooks after
-      // the code-registered ones, so a host hook could put undeclared keys or
-      // markup back into the payload after a `beforeCreate` check had passed
-      // it. Field-level `beforeChange` transforms still run after this, which
-      // is a boundary rather than a hole: those transform one declared value at
-      // a time and cannot reshape the JSON.
+      // `beforeChange` rather than `beforeCreate`: it is the last
+      // COLLECTION-level mutating phase before the insert. Core runs stored
+      // `beforeCreate` hooks after the code-registered ones, so a host hook
+      // could put undeclared keys or markup back into a payload a
+      // `beforeCreate` check had just passed.
+      //
+      // Field-level `beforeChange` hooks run after this one and are handed the
+      // whole record, so a host that registers one on this collection can still
+      // reshape `data` afterwards. No collection phase follows them to register
+      // on, and core's own sanitizer sits earlier still, on `beforeCreate`.
+      // This is the latest point a plugin can check from, which is not the same
+      // as a point nothing can follow.
       nextly.hooks.on(
         "beforeChange",
         submissionSlug,
@@ -903,20 +908,46 @@ export async function prepareSubmissionForWrite(
   const ctx = context as {
     data?: Record<string, unknown>;
     operation?: string;
+    originalData?: Record<string, unknown>;
   };
   const submission = ctx.data;
   if (!submission || typeof submission !== "object") return ctx.data;
-  // Creates only. `beforeChange` also runs for updates, where `data` is a
-  // partial: an admin changing a submission's status sends no payload at all,
-  // and preparing that would store an empty submission over a real one.
-  if (ctx.operation !== "create") return ctx.data;
+  // An update carrying no payload is left alone. `beforeChange` runs for
+  // updates too, where `data` is a partial: an admin changing a submission's
+  // status sends no payload at all, and preparing that would store an empty
+  // submission over a real one.
+  //
+  // An update that does carry one is replacing what the visitor sent, so it is
+  // checked exactly as the create was. Exempting every update meant a caller
+  // who may edit a submission could put undeclared keys, values the form's
+  // schema rejects, and markup into the row a moment after the create had
+  // refused to accept them.
+  if (ctx.operation !== "create" && submission.data === undefined) {
+    return ctx.data;
+  }
 
-  const formId = parentFormId(submission);
+  // A patch need not repeat the relationship, so the stored row is what says
+  // which form this payload has to match.
+  const formId =
+    parentFormId(submission) ??
+    (ctx.originalData ? parentFormId(ctx.originalData) : null);
   if (!formId) return ctx.data;
 
   const incoming = submittedPayload(submission.data);
 
-  const form = await fetchParentForm(formsSlug, formId, nextly);
+  // Taken once, and not before here: an early return above would spend a mark
+  // on a write that never used it, and the next write in the same call would
+  // find it gone.
+  const marks = takeSubmissionMarks();
+
+  // The handler that already read this form hands it over rather than have the
+  // write read it a second time. That read is not free: `findEntryById` runs
+  // the forms collection's `afterRead` hooks, and this plugin registers one
+  // that COUNTs the form's submissions, so a write was paying for a count of
+  // every write before it. Only ever the form this row names, because the id
+  // has to match.
+  const handedOver = marks?.form?.id === formId ? marks.form : null;
+  const form = handedOver ?? (await fetchParentForm(formsSlug, formId, nextly));
   if (!form || !Array.isArray(form.fields)) {
     throw NextlyError.validation({
       errors: [
@@ -941,7 +972,7 @@ export async function prepareSubmissionForWrite(
   const prepared = prepareSubmission({
     data: incoming,
     fields: form.fields as AnyFormField[],
-    validate: currentSubmissionMarks()?.keepAsEvidence !== true,
+    validate: marks?.keepAsEvidence !== true,
   });
 
   if (prepared.validationErrors) {

--- a/packages/plugin-form-builder/src/plugin.ts
+++ b/packages/plugin-form-builder/src/plugin.ts
@@ -553,6 +553,9 @@ export function formBuilder(
       // submitted must leave a visible trace. Registered directly on the
       // registry (like the notification hook) so it runs for every API
       // surface that updates a submission.
+      // Reads the patch as it arrived. Core runs this phase before
+      // `beforeChange`, so the payload the write seam adds to a status-only
+      // patch is not here yet and cannot be mistaken for an admin's edit.
       nextly.hooks.on("beforeUpdate", submissionSlug, (context: unknown) => {
         const ctx = context as {
           data?: Record<string, unknown>;
@@ -917,18 +920,32 @@ function submittedPayload(raw: unknown): Record<string, unknown> {
  * move a submission onto any form and leave behind a payload the form it now
  * belongs to rejects.
  *
- * An update that does neither leaves nothing to check: an admin changing a
- * status sends only that, and preparing an absent payload would store an empty
- * submission over a real one. A move is left alone for the same reason when the
- * stored row did not reach this hook, since there is then no payload to judge.
+ * A patch that takes the row out of spam is the third. An evidence row was
+ * stored WITHOUT being validated, deliberately, so that a false positive stays
+ * reviewable. The admin's "Not spam" action sends only a status, and letting it
+ * through unchecked turned a payload the form rejects into an ordinary counted
+ * submission. Leaving spam is the moment that payload has to satisfy the form,
+ * and a row that cannot has to be corrected in the same update.
+ *
+ * An update that does none of these leaves nothing to check: an admin changing
+ * a status between two non-spam values sends only that, and preparing an absent
+ * payload would store an empty submission over a real one. The last two are
+ * left alone for the same reason when the stored row did not reach this hook,
+ * since there is then no payload to judge.
  */
 function updateNeedsChecking(
   submission: Record<string, unknown>,
   stored: Record<string, unknown> | undefined
 ): boolean {
   if (submission.data !== undefined) return true;
-  if (submission.form === undefined) return false;
-  return stored?.data !== undefined;
+  // Everything below judges the STORED payload, so there has to be one.
+  if (stored?.data === undefined) return false;
+  if (submission.form !== undefined) return true;
+  return (
+    stored.status === "spam" &&
+    submission.status !== undefined &&
+    submission.status !== "spam"
+  );
 }
 
 export async function prepareSubmissionForWrite(
@@ -959,10 +976,9 @@ export async function prepareSubmissionForWrite(
     submission.data !== undefined ? submission.data : stored?.data
   );
 
-  // Taken once, and not before here: an early return above would spend a mark
-  // on a write that never used it, and the next write in the same call would
-  // find it gone.
-  const marks = takeSubmissionMarks();
+  // Taken once, for this payload, and not before here: an early return above
+  // would spend a mark on a write that never used it.
+  const marks = takeSubmissionMarks(incoming);
 
   // The handler that already read this form hands it over rather than have the
   // write read it a second time. That read is not free: `findEntryById` runs

--- a/packages/plugin-form-builder/src/plugin.ts
+++ b/packages/plugin-form-builder/src/plugin.ts
@@ -900,6 +900,37 @@ function submittedPayload(raw: unknown): Record<string, unknown> {
   });
 }
 
+/**
+ * Whether an update has to be brought back to the form's shape.
+ *
+ * Two kinds of update do, and one does not.
+ *
+ * A patch that replaces `data` is replacing what the visitor sent, so it is
+ * checked exactly as the create was. Exempting every update meant a caller who
+ * may edit a submission could put undeclared keys, values the form's schema
+ * rejects and markup into the row a moment after the create had refused to
+ * accept them.
+ *
+ * A patch that touches `form` moves the row under a different schema, and the
+ * payload it already holds is what has to satisfy that one. Such a patch
+ * carries no `data` of its own, so a rule keyed on `data` alone let a caller
+ * move a submission onto any form and leave behind a payload the form it now
+ * belongs to rejects.
+ *
+ * An update that does neither leaves nothing to check: an admin changing a
+ * status sends only that, and preparing an absent payload would store an empty
+ * submission over a real one. A move is left alone for the same reason when the
+ * stored row did not reach this hook, since there is then no payload to judge.
+ */
+function updateNeedsChecking(
+  submission: Record<string, unknown>,
+  stored: Record<string, unknown> | undefined
+): boolean {
+  if (submission.data !== undefined) return true;
+  if (submission.form === undefined) return false;
+  return stored?.data !== undefined;
+}
+
 export async function prepareSubmissionForWrite(
   context: unknown,
   formsSlug: string,
@@ -912,28 +943,21 @@ export async function prepareSubmissionForWrite(
   };
   const submission = ctx.data;
   if (!submission || typeof submission !== "object") return ctx.data;
-  // An update carrying no payload is left alone. `beforeChange` runs for
-  // updates too, where `data` is a partial: an admin changing a submission's
-  // status sends no payload at all, and preparing that would store an empty
-  // submission over a real one.
-  //
-  // An update that does carry one is replacing what the visitor sent, so it is
-  // checked exactly as the create was. Exempting every update meant a caller
-  // who may edit a submission could put undeclared keys, values the form's
-  // schema rejects, and markup into the row a moment after the create had
-  // refused to accept them.
-  if (ctx.operation !== "create" && submission.data === undefined) {
-    return ctx.data;
-  }
+  const stored = ctx.originalData;
 
   // A patch need not repeat the relationship, so the stored row is what says
   // which form this payload has to match.
   const formId =
-    parentFormId(submission) ??
-    (ctx.originalData ? parentFormId(ctx.originalData) : null);
+    parentFormId(submission) ?? (stored ? parentFormId(stored) : null);
   if (!formId) return ctx.data;
 
-  const incoming = submittedPayload(submission.data);
+  if (ctx.operation !== "create" && !updateNeedsChecking(submission, stored)) {
+    return ctx.data;
+  }
+
+  const incoming = submittedPayload(
+    submission.data !== undefined ? submission.data : stored?.data
+  );
 
   // Taken once, and not before here: an early return above would spend a mark
   // on a write that never used it, and the next write in the same call would

--- a/packages/plugin-form-builder/src/plugin.ts
+++ b/packages/plugin-form-builder/src/plugin.ts
@@ -844,6 +844,57 @@ export function buildNotificationEmails(input: {
  * the collection, so it is already refused a step later, and rejecting it here
  * would answer a question this hook was not asked.
  */
+/**
+ * The parent form's id, however the row spells the relationship.
+ *
+ * A relationship arrives as an id string from a write and as a populated object
+ * from a read, and both hooks on this collection have to cope with either.
+ * Stated once so they cannot come to disagree about what counts as a reference.
+ */
+function parentFormId(submission: Record<string, unknown>): string | null {
+  const raw = submission.form;
+  if (typeof raw === "string") return raw;
+  if (raw && typeof raw === "object") {
+    const maybeId = (raw as { id?: unknown }).id;
+    if (typeof maybeId === "string") return maybeId;
+  }
+  return null;
+}
+
+/**
+ * The submitted payload, as an object, or a refusal.
+ *
+ * `data` arrives as an object from every caller in this repository. A string is
+ * read as the JSON a dialect stores rather than assumed to be one field's
+ * value, and anything else is refused: that column is `required`, so an omitted
+ * payload is meant to be refused, and substituting `{}` satisfied the check on
+ * the way past. A form whose fields are all optional then accepted the empty
+ * object and the row was stored.
+ */
+function submittedPayload(raw: unknown): Record<string, unknown> {
+  if (typeof raw === "string") {
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      // Falls through to the refusal below.
+    }
+  } else if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+    return raw as Record<string, unknown>;
+  }
+  throw NextlyError.validation({
+    errors: [
+      {
+        path: "data",
+        code: "INVALID",
+        message: "Submission data must be an object.",
+      },
+    ],
+  });
+}
+
 export async function prepareSubmissionForWrite(
   context: unknown,
   formsSlug: string,
@@ -861,58 +912,10 @@ export async function prepareSubmissionForWrite(
   // and preparing that would store an empty submission over a real one.
   if (ctx.operation !== "create") return ctx.data;
 
-  const rawFormId = submission.form;
-  let formId: string | null = null;
-  if (typeof rawFormId === "string") {
-    formId = rawFormId;
-  } else if (rawFormId && typeof rawFormId === "object") {
-    const maybeId = (rawFormId as { id?: unknown }).id;
-    if (typeof maybeId === "string") formId = maybeId;
-  }
+  const formId = parentFormId(submission);
   if (!formId) return ctx.data;
 
-  // `data` arrives as an object from every caller in this repository. A string
-  // is read as the JSON a dialect stores rather than assumed to be one field's
-  // value, and an unparseable one stops here: `parseJsonColumn` answers `{}` for
-  // it, which would store an empty submission under a form the visitor filled in.
-  const raw = submission.data;
-  let incoming: Record<string, unknown>;
-  if (typeof raw === "string") {
-    try {
-      const parsed: unknown = JSON.parse(raw);
-      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-        throw new Error("not an object");
-      }
-      incoming = parsed as Record<string, unknown>;
-    } catch {
-      throw NextlyError.validation({
-        errors: [
-          {
-            path: "data",
-            code: "INVALID",
-            message: "Submission data must be an object.",
-          },
-        ],
-      });
-    }
-  } else if (raw && typeof raw === "object" && !Array.isArray(raw)) {
-    incoming = raw as Record<string, unknown>;
-  } else {
-    // Absent, null, or an array. Substituting `{}` was worse than it looked:
-    // `data` is `required` on the collection, so an omitted payload is meant to
-    // be refused, and filling one in satisfied that check on the way past. A
-    // form whose fields are all optional then accepted the empty object and the
-    // row was stored. The string branch above already refuses the equivalent.
-    throw NextlyError.validation({
-      errors: [
-        {
-          path: "data",
-          code: "INVALID",
-          message: "Submission data must be an object.",
-        },
-      ],
-    });
-  }
+  const incoming = submittedPayload(submission.data);
 
   const form = await fetchParentForm(formsSlug, formId, nextly, ctx.executor);
   if (!form || !Array.isArray(form.fields)) {
@@ -970,14 +973,7 @@ async function handleSubmissionCreated(
   // every bot hit would trigger the form's notification rules.
   if (submission.status === "spam") return;
 
-  const rawFormId = submission.form;
-  let formId: string | null = null;
-  if (typeof rawFormId === "string") {
-    formId = rawFormId;
-  } else if (rawFormId && typeof rawFormId === "object") {
-    const maybeId = (rawFormId as { id?: unknown }).id;
-    if (typeof maybeId === "string") formId = maybeId;
-  }
+  const formId = parentFormId(submission);
   if (!formId) return;
 
   // Fetch the parent form

--- a/packages/plugin-form-builder/src/plugin.ts
+++ b/packages/plugin-form-builder/src/plugin.ts
@@ -10,7 +10,11 @@
 
 import { createRequire } from "node:module";
 
-import { definePlugin, type PluginDefinition } from "@nextlyhq/plugin-sdk";
+import {
+  definePlugin,
+  NextlyError,
+  type PluginDefinition,
+} from "@nextlyhq/plugin-sdk";
 import type { CollectionConfig } from "nextly";
 // Author against the SDK — the stable, experimental plugin boundary.
 
@@ -21,7 +25,9 @@ import {
   asSubmissionDocument,
   asSubmissionDocuments,
 } from "./document-shapes";
+import { prepareSubmission } from "./handlers/prepare-submission";
 import type {
+  AnyFormField,
   BeforeEmailFilterContext,
   FormNotification,
   FormBuilderPluginOptions,
@@ -492,6 +498,24 @@ export function formBuilder(
         );
       }
 
+      // Every submission is brought to the form's own shape here, whatever
+      // created it. Registered directly on the registry, like the two below, so
+      // it runs for every API surface that writes one: the plugin's HTTP
+      // handler, `nextly.forms.submit()`, and an admin creating a row by hand.
+      //
+      // The Direct API did none of this. A submission arriving that way was
+      // stored with whatever keys the caller sent, values that never met the
+      // form's schema, and markup intact, while the same submission over HTTP
+      // was transformed, validated and sanitized. Putting the rule at the write
+      // seam rather than in the second caller is what stops a third one
+      // inheriting the gap.
+      nextly.hooks.on(
+        "beforeCreate",
+        submissionSlug,
+        async (context: unknown) =>
+          prepareSubmissionForWrite(context, resolvedConfig, nextly)
+      );
+
       // Register afterCreate hook for email notifications
       nextly.hooks.on(
         "afterCreate",
@@ -784,6 +808,111 @@ export function buildNotificationEmails(input: {
 /**
  * Send email notifications after a form submission is created.
  */
+/**
+ * Bring an incoming submission to the shape its form declares.
+ *
+ * Runs on `beforeCreate` for the submissions collection, so it sees every write
+ * rather than every caller. The cost is one read of the parent form per
+ * submission: the HTTP handler has already loaded it and cannot hand it over,
+ * because a hook receives the row and not the request. Submissions are written
+ * one visitor at a time and the read is by primary key, which is the cheaper
+ * side of the trade against a rule two callers have to remember.
+ *
+ * Refuses rather than storing when it cannot judge. A form it cannot read, or
+ * one whose `fields` is not a list, leaves nothing to transform against, and
+ * transforming against an empty list would project the submission down to `{}`
+ * and store a row that says the visitor sent nothing. Silently emptying someone's
+ * submission is worse than declining it.
+ *
+ * A row that names no form is passed through untouched. `form` is `required` on
+ * the collection, so it is already refused a step later, and rejecting it here
+ * would answer a question this hook was not asked.
+ */
+export async function prepareSubmissionForWrite(
+  context: unknown,
+  config: ResolvedFormBuilderConfig,
+  nextly: NextlyInstance
+): Promise<Record<string, unknown> | undefined> {
+  const ctx = context as { data?: Record<string, unknown> };
+  const submission = ctx.data;
+  if (!submission || typeof submission !== "object") return ctx.data;
+
+  const rawFormId = submission.form;
+  let formId: string | null = null;
+  if (typeof rawFormId === "string") {
+    formId = rawFormId;
+  } else if (rawFormId && typeof rawFormId === "object") {
+    const maybeId = (rawFormId as { id?: unknown }).id;
+    if (typeof maybeId === "string") formId = maybeId;
+  }
+  if (!formId) return ctx.data;
+
+  // `data` arrives as an object from every caller in this repository. A string
+  // is read as the JSON a dialect stores rather than assumed to be one field's
+  // value, and an unparseable one stops here: `parseJsonColumn` answers `{}` for
+  // it, which would store an empty submission under a form the visitor filled in.
+  const raw = submission.data;
+  let incoming: Record<string, unknown>;
+  if (typeof raw === "string") {
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        throw new Error("not an object");
+      }
+      incoming = parsed as Record<string, unknown>;
+    } catch {
+      throw NextlyError.validation({
+        errors: [
+          {
+            path: "data",
+            code: "INVALID",
+            message: "Submission data must be an object.",
+          },
+        ],
+      });
+    }
+  } else if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+    incoming = raw as Record<string, unknown>;
+  } else {
+    incoming = {};
+  }
+
+  const form = await fetchParentForm(config, formId, nextly);
+  if (!form || !Array.isArray(form.fields)) {
+    throw NextlyError.validation({
+      errors: [
+        {
+          path: "form",
+          code: "INVALID",
+          message:
+            "The form this submission belongs to could not be read, so the submission could not be checked against it.",
+        },
+      ],
+    });
+  }
+
+  // Content spam keeps its evidence. The handler stores a honeypot or reCAPTCHA
+  // hit flagged rather than dropping it, so a false positive stays recoverable,
+  // and requiring it to be valid would throw away the thing being reviewed. It
+  // is still transformed and sanitized.
+  const prepared = prepareSubmission({
+    data: incoming,
+    fields: form.fields as AnyFormField[],
+    validate: submission.status !== "spam",
+  });
+
+  if (prepared.validationErrors) {
+    throw NextlyError.validation({
+      errors: Object.entries(prepared.validationErrors).map(
+        ([path, message]) => ({ path, code: "INVALID", message })
+      ),
+    });
+  }
+
+  ctx.data = { ...submission, data: prepared.data };
+  return ctx.data;
+}
+
 async function handleSubmissionCreated(
   context: unknown,
   config: ResolvedFormBuilderConfig,

--- a/packages/plugin-form-builder/src/plugin.ts
+++ b/packages/plugin-form-builder/src/plugin.ts
@@ -25,7 +25,10 @@ import {
   asSubmissionDocument,
   asSubmissionDocuments,
 } from "./document-shapes";
-import { prepareSubmission } from "./handlers/prepare-submission";
+import {
+  currentSubmissionMarks,
+  prepareSubmission,
+} from "./handlers/prepare-submission";
 import type {
   AnyFormField,
   BeforeEmailFilterContext,
@@ -509,11 +512,27 @@ export function formBuilder(
       // was transformed, validated and sanitized. Putting the rule at the write
       // seam rather than in the second caller is what stops a third one
       // inheriting the gap.
+      // The forms slug, resolved the way the submissions one above is. A host
+      // that renames a contributed collection takes the declared slug out of
+      // the registry, so reading the parent form by `formOverrides.slug` finds
+      // nothing, and this hook would then refuse every submission on a renamed
+      // install. Resolved once here and used by both readers.
+      const declaredFormsSlug = resolvedConfig.formOverrides.slug;
+      const formsSlug =
+        nextly.self.collections[declaredFormsSlug] ?? declaredFormsSlug;
+
+      // `beforeChange` rather than `beforeCreate`: it is the last mutating
+      // phase before the insert. Core runs stored `beforeCreate` hooks after
+      // the code-registered ones, so a host hook could put undeclared keys or
+      // markup back into the payload after a `beforeCreate` check had passed
+      // it. Field-level `beforeChange` transforms still run after this, which
+      // is a boundary rather than a hole: those transform one declared value at
+      // a time and cannot reshape the JSON.
       nextly.hooks.on(
-        "beforeCreate",
+        "beforeChange",
         submissionSlug,
         async (context: unknown) =>
-          prepareSubmissionForWrite(context, resolvedConfig, nextly)
+          prepareSubmissionForWrite(context, formsSlug, nextly)
       );
 
       // Register afterCreate hook for email notifications
@@ -543,9 +562,6 @@ export function formBuilder(
 
       // Inject a real submissionCount into form reads (spam excluded — the
       // number answers "how many people submitted", not "how many bots").
-      const declaredFormsSlug = resolvedConfig.formOverrides.slug;
-      const formsSlug =
-        nextly.self.collections[declaredFormsSlug] ?? declaredFormsSlug;
       nextly.hooks.on("afterRead", formsSlug, async (context: unknown) => {
         const data = (context as { data?: unknown }).data;
         // afterRead fires for single reads (one record) and list reads
@@ -830,12 +846,20 @@ export function buildNotificationEmails(input: {
  */
 export async function prepareSubmissionForWrite(
   context: unknown,
-  config: ResolvedFormBuilderConfig,
+  formsSlug: string,
   nextly: NextlyInstance
 ): Promise<Record<string, unknown> | undefined> {
-  const ctx = context as { data?: Record<string, unknown> };
+  const ctx = context as {
+    data?: Record<string, unknown>;
+    operation?: string;
+    executor?: unknown;
+  };
   const submission = ctx.data;
   if (!submission || typeof submission !== "object") return ctx.data;
+  // Creates only. `beforeChange` also runs for updates, where `data` is a
+  // partial: an admin changing a submission's status sends no payload at all,
+  // and preparing that would store an empty submission over a real one.
+  if (ctx.operation !== "create") return ctx.data;
 
   const rawFormId = submission.form;
   let formId: string | null = null;
@@ -874,10 +898,23 @@ export async function prepareSubmissionForWrite(
   } else if (raw && typeof raw === "object" && !Array.isArray(raw)) {
     incoming = raw as Record<string, unknown>;
   } else {
-    incoming = {};
+    // Absent, null, or an array. Substituting `{}` was worse than it looked:
+    // `data` is `required` on the collection, so an omitted payload is meant to
+    // be refused, and filling one in satisfied that check on the way past. A
+    // form whose fields are all optional then accepted the empty object and the
+    // row was stored. The string branch above already refuses the equivalent.
+    throw NextlyError.validation({
+      errors: [
+        {
+          path: "data",
+          code: "INVALID",
+          message: "Submission data must be an object.",
+        },
+      ],
+    });
   }
 
-  const form = await fetchParentForm(config, formId, nextly);
+  const form = await fetchParentForm(formsSlug, formId, nextly, ctx.executor);
   if (!form || !Array.isArray(form.fields)) {
     throw NextlyError.validation({
       errors: [
@@ -895,10 +932,14 @@ export async function prepareSubmissionForWrite(
   // hit flagged rather than dropping it, so a false positive stays recoverable,
   // and requiring it to be valid would throw away the thing being reviewed. It
   // is still transformed and sanitized.
+  // Leniency is a fact about the CALL, not about the row. Reading it off
+  // `status` made it caller-controlled: the collection grants public create and
+  // nothing restricts that field, so anyone could post `status: "spam"` and
+  // switch validation off for their own row.
   const prepared = prepareSubmission({
     data: incoming,
     fields: form.fields as AnyFormField[],
-    validate: submission.status !== "spam",
+    validate: currentSubmissionMarks()?.keepAsEvidence !== true,
   });
 
   if (prepared.validationErrors) {
@@ -940,7 +981,12 @@ async function handleSubmissionCreated(
   if (!formId) return;
 
   // Fetch the parent form
-  const form = await fetchParentForm(config, formId, nextly);
+  const declaredFormsSlug = config.formOverrides.slug;
+  const form = await fetchParentForm(
+    nextly.self.collections[declaredFormsSlug] ?? declaredFormsSlug,
+    formId,
+    nextly
+  );
   if (!form) return;
 
   const notifications = Array.isArray(form.notifications)
@@ -1038,18 +1084,30 @@ async function handleSubmissionCreated(
  * Fetch the parent form document for a submission.
  */
 export async function fetchParentForm(
-  config: ResolvedFormBuilderConfig,
+  formsSlug: string,
   formId: string,
-  nextly: NextlyInstance
+  nextly: NextlyInstance,
+  executor?: unknown
 ): Promise<Record<string, unknown> | null> {
   try {
     // D35/D56: read the parent form through the secure managed service as
     // system — the afterCreate hook runs without an ambient user. Replaces the
     // legacy `getCollectionsHandler()` + `overrideAccess` runtime path.
+    //
+    // The slug arrives RESOLVED. Passing `formOverrides.slug` read the declared
+    // name, which a host that renames the collection has taken out of the
+    // registry, so the lookup found nothing on exactly the installs the rename
+    // API supports.
+    //
+    // On the caller's transaction when there is one. A write inside a
+    // transaction can be preparing a submission for a form created earlier in
+    // that same transaction, which a read on the global service cannot see, and
+    // on a single-connection pool it would wait for a transaction that is
+    // waiting for it.
     const form = await nextly.services.collections.findEntryById(
-      config.formOverrides.slug,
+      formsSlug,
       formId,
-      { as: "system" }
+      { as: "system", ...(executor ? { executor } : {}) }
     );
     return form;
   } catch (err) {

--- a/packages/plugin-form-builder/src/plugin.ts
+++ b/packages/plugin-form-builder/src/plugin.ts
@@ -27,8 +27,8 @@ import {
 } from "./document-shapes";
 import {
   sameSubmittedPayload,
+  submissionMarks,
   type SubmissionOriginMarks,
-  takeSubmissionMarks,
   prepareSubmission,
 } from "./handlers/prepare-submission";
 import type {
@@ -979,13 +979,8 @@ export async function prepareSubmissionForWrite(
     submission.data !== undefined ? submission.data : stored?.data
   );
 
-  // Taken once, for this payload, and not before here: an early return above
-  // would spend a mark on a write that never used it.
-  const marks = takeSubmissionMarks({
-    form: formId,
-    status: typeof submission.status === "string" ? submission.status : "",
-    payload: incoming,
-  });
+  // Read off the row itself, so it describes this write and no other.
+  const marks = submissionMarks(submission);
 
   const fields = await fieldsToCheckAgainst(marks, formsSlug, formId, nextly);
 

--- a/packages/plugin-form-builder/src/plugin.ts
+++ b/packages/plugin-form-builder/src/plugin.ts
@@ -903,7 +903,6 @@ export async function prepareSubmissionForWrite(
   const ctx = context as {
     data?: Record<string, unknown>;
     operation?: string;
-    executor?: unknown;
   };
   const submission = ctx.data;
   if (!submission || typeof submission !== "object") return ctx.data;
@@ -917,7 +916,7 @@ export async function prepareSubmissionForWrite(
 
   const incoming = submittedPayload(submission.data);
 
-  const form = await fetchParentForm(formsSlug, formId, nextly, ctx.executor);
+  const form = await fetchParentForm(formsSlug, formId, nextly);
   if (!form || !Array.isArray(form.fields)) {
     throw NextlyError.validation({
       errors: [
@@ -1082,8 +1081,7 @@ async function handleSubmissionCreated(
 export async function fetchParentForm(
   formsSlug: string,
   formId: string,
-  nextly: NextlyInstance,
-  executor?: unknown
+  nextly: NextlyInstance
 ): Promise<Record<string, unknown> | null> {
   try {
     // D35/D56: read the parent form through the secure managed service as
@@ -1095,15 +1093,24 @@ export async function fetchParentForm(
     // registry, so the lookup found nothing on exactly the installs the rename
     // API supports.
     //
-    // On the caller's transaction when there is one. A write inside a
-    // transaction can be preparing a submission for a form created earlier in
-    // that same transaction, which a read on the global service cannot see, and
-    // on a single-connection pool it would wait for a transaction that is
-    // waiting for it.
+    // NOT on the caller's transaction, and it cannot be here. The plugin facade
+    // rebuilds its context from `user` and `overrideAccess` alone, and
+    // `CollectionService.findEntryById` forwards only those two to the entry
+    // service, so an executor has nowhere to go on this path: passing one
+    // looked like transaction awareness and was discarded before the query.
+    //
+    // The cost is written down rather than hidden. A submission created inside
+    // a transaction alongside a form created in that same transaction cannot
+    // see it and is refused, and on a pool whose only connection the
+    // transaction holds, this read waits for it. Both fail safely. The pattern
+    // for fixing it exists in collection-hook-service and
+    // collection-access-service, which forward a context's executor for exactly
+    // this reason; bringing it here means changing the entry service and the
+    // plugin facade with it.
     const form = await nextly.services.collections.findEntryById(
       formsSlug,
       formId,
-      { as: "system", ...(executor ? { executor } : {}) }
+      { as: "system" }
     );
     return form;
   } catch (err) {

--- a/packages/plugin-form-builder/src/plugin.ts
+++ b/packages/plugin-form-builder/src/plugin.ts
@@ -26,6 +26,8 @@ import {
   asSubmissionDocuments,
 } from "./document-shapes";
 import {
+  sameSubmittedPayload,
+  type SubmissionOriginMarks,
   takeSubmissionMarks,
   prepareSubmission,
 } from "./handlers/prepare-submission";
@@ -957,6 +959,7 @@ export async function prepareSubmissionForWrite(
     data?: Record<string, unknown>;
     operation?: string;
     originalData?: Record<string, unknown>;
+    user?: { id?: string };
   };
   const submission = ctx.data;
   if (!submission || typeof submission !== "object") return ctx.data;
@@ -978,14 +981,59 @@ export async function prepareSubmissionForWrite(
 
   // Taken once, for this payload, and not before here: an early return above
   // would spend a mark on a write that never used it.
-  const marks = takeSubmissionMarks(incoming);
+  const marks = takeSubmissionMarks({
+    form: formId,
+    status: typeof submission.status === "string" ? submission.status : "",
+    payload: incoming,
+  });
 
-  // The handler that already read this form hands it over rather than have the
-  // write read it a second time. That read is not free: `findEntryById` runs
-  // the forms collection's `afterRead` hooks, and this plugin registers one
-  // that COUNTs the form's submissions, so a write was paying for a count of
-  // every write before it. Only ever the form this row names, because the id
-  // has to match.
+  const fields = await fieldsToCheckAgainst(marks, formsSlug, formId, nextly);
+
+  // Content spam keeps its evidence. The handler stores a honeypot or reCAPTCHA
+  // hit flagged rather than dropping it, so a false positive stays recoverable,
+  // and requiring it to be valid would throw away the thing being reviewed. It
+  // is still transformed and sanitized.
+  // Leniency is a fact about the CALL, not about the row. Reading it off
+  // `status` made it caller-controlled: the collection grants public create and
+  // nothing restricts that field, so anyone could post `status: "spam"` and
+  // switch validation off for their own row.
+  const prepared = prepareSubmission({
+    data: incoming,
+    fields,
+    validate: marks?.keepAsEvidence !== true,
+  });
+
+  if (prepared.validationErrors) {
+    throw NextlyError.validation({
+      errors: Object.entries(prepared.validationErrors).map(
+        ([path, message]) => ({ path, code: "INVALID", message })
+      ),
+    });
+  }
+
+  ctx.data = { ...submission, data: prepared.data };
+  if (ctx.operation !== "create" && submission.data === undefined) {
+    stampDerivedEdit(ctx.data, ctx.user, incoming, prepared.data);
+  }
+  return ctx.data;
+}
+
+/**
+ * The fields a submission has to satisfy.
+ *
+ * The handler that already read this form hands it over rather than have the
+ * write read it a second time. That read is not free: `findEntryById` runs the
+ * forms collection's `afterRead` hooks, and this plugin registers one that
+ * COUNTs the form's submissions, so a write was paying for a count of every
+ * write before it. Only ever the form this row names, because the id has to
+ * match.
+ */
+async function fieldsToCheckAgainst(
+  marks: SubmissionOriginMarks | undefined,
+  formsSlug: string,
+  formId: string,
+  nextly: NextlyInstance
+): Promise<AnyFormField[]> {
   const handedOver = marks?.form?.id === formId ? marks.form : null;
   const form = handedOver ?? (await fetchParentForm(formsSlug, formId, nextly));
   if (!form || !Array.isArray(form.fields)) {
@@ -1000,31 +1048,28 @@ export async function prepareSubmissionForWrite(
       ],
     });
   }
+  return form.fields as AnyFormField[];
+}
 
-  // Content spam keeps its evidence. The handler stores a honeypot or reCAPTCHA
-  // hit flagged rather than dropping it, so a false positive stays recoverable,
-  // and requiring it to be valid would throw away the thing being reviewed. It
-  // is still transformed and sanitized.
-  // Leniency is a fact about the CALL, not about the row. Reading it off
-  // `status` made it caller-controlled: the collection grants public create and
-  // nothing restricts that field, so anyone could post `status: "spam"` and
-  // switch validation off for their own row.
-  const prepared = prepareSubmission({
-    data: incoming,
-    fields: form.fields as AnyFormField[],
-    validate: marks?.keepAsEvidence !== true,
-  });
-
-  if (prepared.validationErrors) {
-    throw NextlyError.validation({
-      errors: Object.entries(prepared.validationErrors).map(
-        ([path, message]) => ({ path, code: "INVALID", message })
-      ),
-    });
-  }
-
-  ctx.data = { ...submission, data: prepared.data };
-  return ctx.data;
+/**
+ * Record a payload change this hook derived, since nothing else will.
+ *
+ * A patch that did not carry a payload but changed one is still an edit of what
+ * the visitor sent: moving a submission to another form re-projects its answers
+ * onto that form's fields and can drop one it does not declare. The stamp on
+ * `beforeUpdate` has already run by then and only marks a patch that arrived
+ * with `data`, so without this the stored answers change with nothing in the
+ * row saying who changed them.
+ */
+function stampDerivedEdit(
+  row: Record<string, unknown>,
+  user: { id?: string } | undefined,
+  before: Record<string, unknown>,
+  after: Record<string, unknown>
+): void {
+  if (sameSubmittedPayload(before, after)) return;
+  row.editedAt = new Date();
+  row.editedBy = user?.id ?? null;
 }
 
 async function handleSubmissionCreated(
@@ -1185,7 +1230,14 @@ export async function fetchParentForm(
     );
     return form;
   } catch (err) {
-    nextly.logger.error?.("Form Builder: failed to fetch form", {
+    // A form that is not there is an answer, and the caller decides what a
+    // submission naming no form means. Anything else is the read itself
+    // failing, and it is rethrown: swallowing a pool timeout or a throwing
+    // `afterRead` hook turned a server fault into "this form could not be
+    // read", so the writer was told their submission was invalid, with a status
+    // that says not to retry.
+    if (!NextlyError.isNotFound(err)) throw err;
+    nextly.logger.error?.("Form Builder: form not found", {
       formId,
       error: err instanceof Error ? err.message : String(err),
     });


### PR DESCRIPTION
Closes `finding:direct-api-form-submit-skips-the-protections`, on the design you chose: enforce at the write seam, and export the shared parts rather than keep a second copy.

## What was wrong

Two things accept a submission, and only one checked it.

| | `submitForm` (HTTP) | `nextly.forms.submit()` (Direct API) |
| --- | --- | --- |
| projected onto the form's declared fields | yes | **no** |
| validated against the generated schema | yes | **no** |
| markup stripped from free-text fields | yes | **no** |
| honeypot / rate limit / reCAPTCHA | yes | no |

So the same submission was stored two different ways depending on which door it came through: undeclared keys kept, values that never met the form's own schema, markup intact.

**Core's global sanitizer does not cover it.** It registers on `beforeCreate` for every collection, and `json` is in its `SKIP_FIELD_TYPES` (`packages/nextly/src/services/security/sanitization-service.ts:91`) which is exactly the type the submissions `data` column is. I checked this before writing anything, because if core had covered it, most of this PR would have been unnecessary.

## The shape

The rule is now one exported function, `prepareSubmission`, asked from two places: a `beforeCreate` hook on the submissions collection, and the HTTP handler, which no longer restates it. A third caller inherits it without knowing it exists, which is the reason for putting it at the seam rather than in the second caller.

**Spam protection deliberately stays on the HTTP route.** A honeypot and a rate limit are facts about a *request*, not about a row: a trusted server importing a thousand submissions would rate-limit its own import, and a honeypot field means nothing without a browser to have skipped it. The guide now says this in as many words, so the difference is documented rather than discovered.

**Content spam keeps its evidence.** The handler stores a honeypot hit flagged rather than dropping it, so a false positive stays recoverable. The hook skips validation for those rows and still sanitizes them, because the row nobody validated is the one that should not carry markup.

**It refuses rather than storing when it cannot judge.** A form it cannot read, or one whose `fields` is not a list, leaves nothing to transform against, and transforming against an empty list would project the submission down to `{}` and record that the visitor sent nothing. Silently emptying someone's submission is worse than declining it.

## Evidence, and a control that failed first

The interesting part. My first wiring test asserted `hooks.hasHooks("beforeCreate", "form-submissions")`. **It passed with the hook removed**, so it proved nothing: `register-collection-hooks` maps a collection's declared `beforeValidate` onto the `beforeCreate` phase, and core registers a global sanitizer on `beforeCreate` for `*`. The registry could not tell my handler from theirs.

It is replaced by two tests that boot a real Nextly through `createTestNextly`, write a submission straight to the collection, and read the row back. Those fail with the registration removed and pass with it:

```
× is transformed, sanitized and stored in the form's own shape
× refuses one the form's schema rejects, rather than storing it
```

Fifteen tests in total. Beyond the two above:

- idempotence, which is what lets the hook run over data the handler already prepared, with a control asserting the first pass really did change something
- a spam row sanitized but not rejected
- a form that cannot be read, and one whose `fields` is not a list, both refused
- `data` arriving as the JSON string a dialect stores, parsed; an unparseable one refused rather than stored as `{}`
- a row naming no form passed through, because `form` is `required` on the collection and refusing here would answer a question the hook was not asked

357 tests in the package (up from 342), `check-types` clean, doc-samples/comment/docs-claims gates clean. Changeset included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Form submissions are now normalized to the form’s declared fields before being stored.
  * HTML markup is removed from supported free-text fields to improve submission safety.
  * Validation errors are consistently reported across supported submission methods, including admin-created records.
  * Submissions can be validated and sanitized even when created outside the standard browser submission flow.

* **Documentation**
  * Clarified the distinction between write-time validation and browser-only spam protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->