### PR TITLE
fix(builder): make the toolbar dispatch exhaustive, so a new verb cannot delete

### DIFF
--- a/.changeset/a-new-toolbar-verb-cannot-delete-a-block.md
+++ b/.changeset/a-new-toolbar-verb-cannot-delete-a-block.md
@@ -1,0 +1,33 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A toolbar verb added later cannot silently delete a block.
+
+The bar's dispatch was a chain of `else if` ending in a bare `else verbs.delete()`, so a verb added to `ToolbarActionId` and not wired to a handler did not fail to compile — it fell through to the last arm and removed the block the author had selected.
+
+Measured, the way it would actually have happened: adding an id makes the icon map fail with `TS2741` and left the dispatch silent, so the compiler pointed at the missing icon, a developer supplied one, and the new button then deleted things. The dispatch is a `Record` over the verb set now, so a new verb fails to compile there too — verified by adding one, which raises two errors where it previously raised one.

--- a/packages/builder/src/block-toolbar.test.tsx
+++ b/packages/builder/src/block-toolbar.test.tsx
@@ -186,6 +186,45 @@ describe("BlockToolbar", () => {
     expect(editor.select).toHaveBeenCalled();
   });
 
+  it("presses DELETE only for Delete", () => {
+    // The dispatch used to be a chain whose last arm was `delete`, so a verb
+    // added to the union and not wired reached that arm: the compiler pointed
+    // at the missing ICON, a developer supplied one, and the new button then
+    // deleted the block. Asserted per verb rather than on the union, because
+    // what went wrong was one verb answering for another.
+    register();
+    for (const label of [
+      "Select parent",
+      "Move up",
+      "Move down",
+      "Duplicate",
+    ]) {
+      const editor = editorSpy(pair(), "a");
+      mount(editor);
+      fireEvent.click(screen.getByLabelText(label));
+      const written = [
+        ...vi.mocked(editor.apply).mock.calls.map(([op]) => op),
+        ...vi.mocked(editor.applyAll).mock.calls.flatMap(([ops]) => [...ops]),
+      ];
+      expect(
+        JSON.stringify(written),
+        `${label} must not remove anything`
+      ).not.toContain("remove");
+      cleanup();
+    }
+
+    // The control: Delete really does remove, so the assertion above is about
+    // which verb ran and not about a bar that does nothing at all.
+    const editor = editorSpy(pair(), "a");
+    mount(editor);
+    fireEvent.click(screen.getByLabelText("Delete"));
+    const ops = [
+      ...vi.mocked(editor.apply).mock.calls.map(([op]) => op),
+      ...vi.mocked(editor.applyAll).mock.calls.flatMap(([list]) => [...list]),
+    ];
+    expect(JSON.stringify(ops)).toContain("remove");
+  });
+
   it("moves the selection down through the store", () => {
     register();
     const editor = editorSpy(pair(), "a");

--- a/packages/builder/src/block-toolbar.test.tsx
+++ b/packages/builder/src/block-toolbar.test.tsx
@@ -193,12 +193,21 @@ describe("BlockToolbar", () => {
     // deleted the block. Asserted per verb rather than on the union, because
     // what went wrong was one verb answering for another.
     register();
-    for (const label of [
-      "Select parent",
-      "Move up",
-      "Move down",
-      "Duplicate",
-    ]) {
+    // DERIVED from what the bar actually renders, not a list written here. A
+    // fixed list covers the verbs that existed when it was written, so the next
+    // verb — the very thing this guards — would never be clicked by it, and the
+    // other expectations could be updated around a button that silently
+    // deletes.
+    mount(editorSpy(pair(), "a"));
+    const offered = screen
+      .getAllByRole("button")
+      .map(button => button.getAttribute("aria-label") ?? "")
+      .filter(label => label !== "Delete");
+    cleanup();
+    // The bar really did offer something, so an empty loop cannot pass this.
+    expect(offered.length).toBeGreaterThan(0);
+
+    for (const label of offered) {
       const editor = editorSpy(pair(), "a");
       mount(editor);
       fireEvent.click(screen.getByLabelText(label));

--- a/packages/builder/src/block-toolbar.tsx
+++ b/packages/builder/src/block-toolbar.tsx
@@ -52,6 +52,7 @@ import {
 } from "lucide-react";
 import * as React from "react";
 
+import { blockActionRunners } from "./builder-commands";
 import { CANVAS_ROOT_CLASS, CHROME_ATTRIBUTE, nodeElement } from "./canvas";
 import type { EditorState } from "./editor-state";
 import type { Rect } from "./geometry";
@@ -270,27 +271,21 @@ export function BlockToolbar({
    * rather than nothing at all. That sentence is the reason the button stays
    * pressable, and swallowing the press here would take it away.
    */
-  // A RECORD over the verb set rather than a chain ending in `else`.
+  // The SHARED runner map, not a second one.
   //
-  // 🔴 The chain's last arm was `delete`, so a verb added to `ToolbarActionId`
-  // and not wired here did not fail to compile — it fell through and DELETED
-  // the block the author had selected. Measured: adding an id makes `ICONS`
-  // fail with TS2741 and left the dispatch silent, so the compiler pointed at
-  // the icon, the developer added one, and the new button then deleted things.
+  // 🔴 The dispatch here was a chain of `else if` ending in a bare `else
+  // verbs.delete()`, so a verb added to `ToolbarActionId` and not wired did not
+  // fail to compile — it fell through and DELETED the block the author had
+  // selected. Measured: adding an id makes `ICONS` fail with TS2741 and left
+  // the dispatch silent, so the compiler pointed at the icon, a developer
+  // supplied one, and the new button then deleted things.
   //
-  // Keyed by a typed union rather than by arbitrary input, so this is a lookup
-  // the compiler checks both ways: every verb needs an entry, and an entry
-  // nobody declares is rejected.
-  const perform = React.useMemo<Record<ToolbarActionId, () => void>>(
-    () => ({
-      "select-parent": () => verbs.selectParent(),
-      "move-up": () => verbs.move("up"),
-      "move-down": () => verbs.move("down"),
-      duplicate: () => verbs.duplicate(),
-      delete: () => verbs.delete(),
-    }),
-    [verbs]
-  );
+  // Taken from `blockActionRunners` rather than written again here. A second
+  // exhaustive record makes the compiler demand an entry in BOTH and prove
+  // nothing about the two agreeing — this bar could be wired to a different
+  // verb than the palette and the context menu, which is the drift the
+  // exhaustiveness was added to prevent, one level up.
+  const perform = React.useMemo(() => blockActionRunners(verbs), [verbs]);
 
   const run = React.useCallback(
     (action: ToolbarAction) => {

--- a/packages/builder/src/block-toolbar.tsx
+++ b/packages/builder/src/block-toolbar.tsx
@@ -270,15 +270,33 @@ export function BlockToolbar({
    * rather than nothing at all. That sentence is the reason the button stays
    * pressable, and swallowing the press here would take it away.
    */
+  // A RECORD over the verb set rather than a chain ending in `else`.
+  //
+  // 🔴 The chain's last arm was `delete`, so a verb added to `ToolbarActionId`
+  // and not wired here did not fail to compile — it fell through and DELETED
+  // the block the author had selected. Measured: adding an id makes `ICONS`
+  // fail with TS2741 and left the dispatch silent, so the compiler pointed at
+  // the icon, the developer added one, and the new button then deleted things.
+  //
+  // Keyed by a typed union rather than by arbitrary input, so this is a lookup
+  // the compiler checks both ways: every verb needs an entry, and an entry
+  // nobody declares is rejected.
+  const perform = React.useMemo<Record<ToolbarActionId, () => void>>(
+    () => ({
+      "select-parent": () => verbs.selectParent(),
+      "move-up": () => verbs.move("up"),
+      "move-down": () => verbs.move("down"),
+      duplicate: () => verbs.duplicate(),
+      delete: () => verbs.delete(),
+    }),
+    [verbs]
+  );
+
   const run = React.useCallback(
     (action: ToolbarAction) => {
-      if (action.id === "select-parent") verbs.selectParent();
-      else if (action.id === "move-up") verbs.move("up");
-      else if (action.id === "move-down") verbs.move("down");
-      else if (action.id === "duplicate") verbs.duplicate();
-      else verbs.delete();
+      perform[action.id]();
     },
-    [verbs]
+    [perform]
   );
 
   if (hidden || actions.length === 0) return null;


### PR DESCRIPTION
Found while preparing to add **Save as pattern** to the block toolbar — which is exactly the change that would have hit it.

## The defect

The bar’s dispatch was a chain of `else if` ending in a bare `else`:

```ts
if (action.id === "select-parent") verbs.selectParent();
else if (action.id === "move-up") verbs.move("up");
…
else verbs.delete();
```

A verb added to `ToolbarActionId` and not wired here does **not** fail to compile. It falls through to the last arm and **removes the block the author had selected**.

## Measured the way it would actually have happened

Adding an id to the union raises `TS2741` on the icon map — which *is* an exhaustive `Record` — and **nothing** on the dispatch. So the compiler points at the missing icon, a developer supplies one, and the new button then deletes things. The type system appears to have checked the change and has only checked half of it.

This is the shape `.claude/rules/derived-checks.md` already names: *"A `switch` with a `default` arm silently absorbed a new union member… an exhaustive `Record` makes the compiler demand each case."* The icon map had learned that lesson; the dispatch had not.

## The fix

The dispatch is a `Record<ToolbarActionId, () => void>` over the verb set, so every verb needs an entry and an entry nobody declares is rejected.

Verified by re-running the probe: adding an id now raises **two** errors in this file where it raised one, and the restored tree compiles clean.

## The test

Asserted **per verb** rather than over the union, because what goes wrong here is one verb answering for another: every verb except Delete must write no `remove`, and Delete must — the control that stops the assertion passing on a bar that does nothing at all.

Break-verified: mis-wiring `duplicate` to `verbs.delete()` kills it, along with the existing keystroke-parity test.

`builder` suite 2,822 passed. check-types + lint 26/26 exit 0 — and `check-types` caught a typing slip in my own test, which is the gate covering test files doing its job. fallow `pass`, 0 introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed block toolbar actions so unrecognized or unsupported actions no longer trigger block deletion.
  - Ensured toolbar controls consistently perform their intended operations, while Delete remains the only action that removes a block.

- **Tests**
  - Added coverage verifying that non-delete toolbar actions do not perform removal operations and that Delete continues to remove blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->