### PR TITLE
ci: set aside a missing name the reader owns, rather than charging the page

### DIFF
--- a/scripts/check-doc-samples.mjs
+++ b/scripts/check-doc-samples.mjs
@@ -305,7 +305,8 @@ export const isModule = (code, extension = "tsx") => {
     if (
       ts.isCallExpression(node) &&
       (node.expression.kind === ts.SyntaxKind.ImportKeyword ||
-        (ts.isIdentifier(node.expression) && node.expression.text === "require"))
+        (ts.isIdentifier(node.expression) &&
+          node.expression.text === "require"))
     ) {
       loads = true;
       return;
@@ -753,7 +754,10 @@ export function deprecatedPropertiesIn(sourceFile, checker) {
           found.push({
             name,
             start: property.getStart(sourceFile),
-            note: (tag.text ?? []).map(part => part.text).join("").trim(),
+            note: (tag.text ?? [])
+              .map(part => part.text)
+              .join("")
+              .trim(),
           });
         }
       }
@@ -812,7 +816,10 @@ function applicableConstituents(constituents, literal, checker) {
     const name = writtenPropertyName(property);
     if (name === null) continue;
     const written = checker.getTypeAtLocation(property.initializer);
-    if (!written.isLiteral() && !(written.flags & ts.TypeFlags.BooleanLiteral)) {
+    if (
+      !written.isLiteral() &&
+      !(written.flags & ts.TypeFlags.BooleanLiteral)
+    ) {
       continue;
     }
     discriminants.push({ name, written });
@@ -1036,6 +1043,18 @@ export function exportsMapAnswers(exports, subpath) {
  * a continuation would hide a genuine typo or a missing import, which is one of
  * the things this audit exists to find.
  */
+/**
+ * The block a diagnostic came from, asked whether the name is the reader's.
+ *
+ * Falls back to the name alone when the block cannot be found, which keeps the
+ * finding rather than dropping it.
+ */
+export function mentionIsReaderOwned(name, file, index, samples) {
+  const sample = samples.find(s => s.file === file && s.index === index);
+  if (!sample) return readerOwnedName(name);
+  return readerOwnedMention(name, sample.code, extensionFor(sample));
+}
+
 export function declaredEarlier(name, file, index, samples) {
   return samples.some(
     s =>
@@ -1230,7 +1249,9 @@ export function parseSample(source, extension = "tsx") {
     `sample.${extension}`,
     source,
     ts.ScriptTarget.Latest,
-    false,
+    // Parents, because asking whether a mention sits in a type position means
+    // walking up from it. Still the one place a sample is parsed.
+    true,
     extension === "tsx" ? ts.ScriptKind.TSX : ts.ScriptKind.TS
   );
 }
@@ -1545,24 +1566,119 @@ function workspaceManifest(pkg) {
  * Measured rather than assumed, which is the whole point of asking the exports:
  * a rule keyed on the shape alone would have silenced those two.
  *
- * From `src`, not from `dist`. Reading the built types made this answer depend
- * on whether a build had run, and CI runs the script suite BEFORE the build
- * step: the set came back empty there, every name read as the reader's, and the
- * unit tests failed on a clean checkout while passing on a laptop. The two
- * sources agree exactly, 2386 names either way, so nothing is given up by
- * asking the one that is always there.
+ * From `src`, never from `dist`, so the answer cannot depend on whether a build
+ * has run. CI runs the script suite BEFORE the build step, and reading the built
+ * types there returned an empty set: every name read as the reader's, and the
+ * unit tests failed on a clean checkout while passing on a laptop.
  *
  * EVERY typed entry a package declares, not only `"."`. A symbol published from
  * a subpath is still published: `@nextlyhq/builder` exports `BuilderShell` from
  * `./shell` and keeps it out of the root barrel, and reading the barrel alone
  * called it the reader's.
+ *
+ * An entry is found in one of two ways, because neither alone is enough.
+ * `dist/shell.d.ts` names `src/shell.ts` and that mirror covers most of them,
+ * but not `nextly/document-lock`, which is built from
+ * `src/domains/document-lock/contract.ts`. Guessing the source from the output
+ * name left six entries unresolved, and with them went `DocumentLockHolder`,
+ * `FieldTypeCatalogEntry` and `Hsv`: reader-owned on a clean checkout and ours
+ * after a build, which is the build-state dependence this was supposed to end.
+ *
+ * So the build's own configuration is asked as well, by PARSING it for the
+ * source paths it names. Parsed rather than imported, because most of these
+ * configs are TypeScript and this gate runs under plain `node`, and because a
+ * gate that must not consult the network should not be executing build scripts
+ * either. An import chain inside the package is followed, since `@nextlyhq/ui`
+ * declares which barrel each subpath is built from in a module beside its
+ * config rather than in the config.
  */
 const exportedNames = new Set();
+/**
+ * The subset that can supply a VALUE.
+ *
+ * TypeScript keeps two namespaces and a name can be in either. `Media` is in
+ * only one: `packages/nextly/src/types/media.ts` exports it as a type and
+ * `packages/admin/src/types/media.ts` as an interface, and nothing in the
+ * workspace exports a value by that name. So `collections: [Posts, Users,
+ * Media]` needs a value no import here can supply, which makes that `Media` the
+ * reader's own collection exactly as `Posts` is, while `const m: Media` is a
+ * defect a reader meets because the type is importable. Flattening the two
+ * namespaces into one set answered the first case wrongly.
+ */
+const exportedValues = new Set();
 
 /** `./dist/shell.d.ts` as its source, since that is what is always present. */
 function sourceCandidatesFor(typesPath) {
   const built = typesPath.replace(/^\.\//, "").match(/^dist\/(.+)\.d\.ts$/);
   return built ? [`src/${built[1]}.ts`, `src/${built[1]}.tsx`] : [];
+}
+
+/** A relative import specifier, as the files it could mean. */
+function localModuleCandidates(base) {
+  const withoutJs = base.replace(/\.js$/, "");
+  return [
+    `${withoutJs}.ts`,
+    `${withoutJs}.tsx`,
+    base,
+    `${withoutJs}.mjs`,
+    join(withoutJs, "index.ts"),
+  ];
+}
+
+/**
+ * The source files a package's build configuration names.
+ *
+ * Read by parsing, so nothing here runs a build script or needs a TypeScript
+ * loader to read a `.ts` config. Relative imports are followed within the
+ * package, because a config may keep its entry map in a module beside it.
+ */
+function buildConfigEntries(packageDir) {
+  let names;
+  try {
+    names = readdirSync(packageDir);
+  } catch {
+    return [];
+  }
+  const queue = names
+    .filter(name => /^tsup(\..+)?\.config\.[cm]?[jt]s$/.test(name))
+    .map(name => join(packageDir, name));
+  const seen = new Set();
+  const found = new Set();
+  while (queue.length > 0) {
+    const file = queue.pop();
+    if (seen.has(file) || !existsSync(file)) continue;
+    seen.add(file);
+    const source = ts.createSourceFile(
+      file,
+      readFileSync(file, "utf-8"),
+      ts.ScriptTarget.ES2022,
+      false,
+      ts.ScriptKind.TS
+    );
+    const visit = node => {
+      if (ts.isStringLiteral(node) && /^src\/.+\.tsx?$/.test(node.text)) {
+        const full = join(packageDir, node.text);
+        if (existsSync(full)) found.add(full);
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(source);
+    for (const statement of source.statements) {
+      if (!ts.isImportDeclaration(statement)) continue;
+      const specifier = statement.moduleSpecifier;
+      if (!ts.isStringLiteral(specifier)) continue;
+      if (!specifier.text.startsWith(".")) continue;
+      for (const candidate of localModuleCandidates(
+        join(dirname(file), specifier.text)
+      )) {
+        if (existsSync(candidate)) {
+          queue.push(candidate);
+          break;
+        }
+      }
+    }
+  }
+  return [...found];
 }
 
 /** Every typed entry a package declares, resolved to a file that exists. *
@@ -1577,7 +1693,8 @@ function typedEntriesOf(packageDir, manifest) {
   if (map && typeof map === "object") {
     for (const target of Object.values(map)) {
       if (!target || typeof target !== "object") continue;
-      const types = target.types ?? target.import?.types ?? target.default?.types;
+      const types =
+        target.types ?? target.import?.types ?? target.default?.types;
       if (typeof types === "string") declared.push(types);
     }
   }
@@ -1585,17 +1702,17 @@ function typedEntriesOf(packageDir, manifest) {
   if (typeof root === "string") declared.push(root);
   if (declared.length === 0) declared.push("dist/index.d.ts");
 
-  const resolved = [];
+  const resolved = new Set(buildConfigEntries(packageDir));
   for (const entry of new Set(declared)) {
-    for (const candidate of [...sourceCandidatesFor(entry), entry]) {
+    for (const candidate of sourceCandidatesFor(entry)) {
       const full = join(packageDir, candidate.replace(/^\.\//, ""));
       if (existsSync(full)) {
-        resolved.push(full);
+        resolved.add(full);
         break;
       }
     }
   }
-  return resolved;
+  return [...resolved];
 }
 
 function workspaceExports() {
@@ -1636,6 +1753,16 @@ function workspaceExports() {
     if (!symbol) continue;
     for (const exported of checker.getExportsOfModule(symbol)) {
       exportedNames.add(exported.getName());
+      // A re-export is an alias, and an alias carries no namespace of its own:
+      // asking the alias whether it is a value answers for the binding rather
+      // than for the thing bound.
+      const target =
+        exported.flags & ts.SymbolFlags.Alias
+          ? checker.getAliasedSymbol(exported)
+          : exported;
+      if (target.flags & ts.SymbolFlags.Value) {
+        exportedValues.add(exported.getName());
+      }
     }
   }
   return exportedNames;
@@ -1643,6 +1770,59 @@ function workspaceExports() {
 
 export const readerOwnedName = (name, exported = workspaceExports()) =>
   /^[A-Z][A-Za-z0-9]*$/.test(name) && !exported.has(name);
+
+/** The value half of {@link workspaceExports}, built by the same pass. */
+export function workspaceValueExports() {
+  workspaceExports();
+  return exportedValues;
+}
+
+/**
+ * Whether every mention of `name` in this block needs a value.
+ *
+ * Asked of the block rather than of the diagnostic's position, because a
+ * position has to survive the prelude a continuation fence is recompiled with,
+ * and a mention that moved is a wrong answer given confidently. A fence that
+ * uses the name in a type position anywhere keeps its finding, which is the
+ * loud direction: the alternative silences a reference a reader would meet.
+ */
+export function usedOnlyAsValue(code, name, extension = "tsx") {
+  let mentioned = false;
+  let asType = false;
+  const visit = node => {
+    if (ts.isIdentifier(node) && node.text === name) {
+      mentioned = true;
+      for (let at = node.parent; at; at = at.parent) {
+        if (ts.isTypeNode(at) || ts.isTypeQueryNode(at)) {
+          asType = true;
+          break;
+        }
+        if (ts.isExpression(at) || ts.isStatement(at)) break;
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(parseSample(code, extension));
+  return mentioned && !asType;
+}
+
+/**
+ * Whether a missing name belongs to the reader, for the way this block used it.
+ *
+ * The name alone cannot answer it: `Media` is exported as a type and never as a
+ * value, so it is the reader's in `collections: [Posts, Users, Media]` and ours
+ * in `const m: Media`.
+ */
+export function readerOwnedMention(name, code, extension) {
+  if (!/^[A-Z][A-Za-z0-9]*$/.test(name)) return false;
+  if (workspaceExports().has(name)) {
+    return (
+      !workspaceValueExports().has(name) &&
+      usedOnlyAsValue(code, name, extension)
+    );
+  }
+  return true;
+}
 
 export async function classifyDocDiagnostics({ diagnostics, samples }) {
   const uninstalled = [];
@@ -1716,7 +1896,8 @@ export async function classifyDocDiagnostics({ diagnostics, samples }) {
       const [file, idx] = line.split("  ")[0].split("#");
       const index = Number.parseInt(idx, 10);
       if (declaredEarlier(name[1], file, index, samples)) continued.push(line);
-      else if (readerOwnedName(name[1])) readerNames.push(line);
+      else if (mentionIsReaderOwned(name[1], file, index, samples))
+        readerNames.push(line);
       else real.push(line);
       continue;
     }
@@ -2508,7 +2689,9 @@ export function compareToBaseline({
     };
     for (const [what, was] of Object.entries(baseline.coverage ?? {})) {
       if ((seen[what] ?? 0) < was) {
-        lost.push(`${what}: was ${String(was)}, now ${String(seen[what] ?? 0)}`);
+        lost.push(
+          `${what}: was ${String(was)}, now ${String(seen[what] ?? 0)}`
+        );
       }
       // A GAIN has to be recorded too, or it is not protected. Accepting one
       // silently meant a fence added today could be deleted tomorrow, returning
@@ -2516,7 +2699,9 @@ export function compareToBaseline({
       // ratchet that only resists decreases from a number nobody updates
       // protects the corpus as it was and nothing since.
       if ((seen[what] ?? 0) > was) {
-        gained.push(`${what}: was ${String(was)}, now ${String(seen[what] ?? 0)}`);
+        gained.push(
+          `${what}: was ${String(was)}, now ${String(seen[what] ?? 0)}`
+        );
       }
     }
   }

--- a/scripts/check-doc-samples.mjs
+++ b/scripts/check-doc-samples.mjs
@@ -1532,7 +1532,7 @@ function workspaceManifest(pkg) {
  * those hid real defects.
  */
 /**
- * Every name the workspace publishes, from its built type entries.
+ * Every name the workspace publishes, read from its SOURCE entries.
  *
  * The question a missing PascalCase name raises is not what it looks like but
  * whether the reader could have imported it. `Posts`, `Users` and `Page` are
@@ -1545,11 +1545,59 @@ function workspaceManifest(pkg) {
  * Measured rather than assumed, which is the whole point of asking the exports:
  * a rule keyed on the shape alone would have silenced those two.
  *
- * Read from the built `.d.ts` entries in ONE program, because the same question
- * asked twenty times costs twenty type-checker startups. An unbuilt tree is
- * refused before any of this runs.
+ * From `src`, not from `dist`. Reading the built types made this answer depend
+ * on whether a build had run, and CI runs the script suite BEFORE the build
+ * step: the set came back empty there, every name read as the reader's, and the
+ * unit tests failed on a clean checkout while passing on a laptop. The two
+ * sources agree exactly, 2386 names either way, so nothing is given up by
+ * asking the one that is always there.
+ *
+ * EVERY typed entry a package declares, not only `"."`. A symbol published from
+ * a subpath is still published: `@nextlyhq/builder` exports `BuilderShell` from
+ * `./shell` and keeps it out of the root barrel, and reading the barrel alone
+ * called it the reader's.
  */
 const exportedNames = new Set();
+
+/** `./dist/shell.d.ts` as its source, since that is what is always present. */
+function sourceCandidatesFor(typesPath) {
+  const built = typesPath.replace(/^\.\//, "").match(/^dist\/(.+)\.d\.ts$/);
+  return built ? [`src/${built[1]}.ts`, `src/${built[1]}.tsx`] : [];
+}
+
+/** Every typed entry a package declares, resolved to a file that exists. *
+ * The export set is a parameter with the workspace as its default, so the rule
+ * can be stated as a test without a build having run. That mattered: reading it
+ * unconditionally made the unit tests depend on build state, and they failed on
+ * a clean CI checkout while passing on a laptop.
+ */
+function typedEntriesOf(packageDir, manifest) {
+  const declared = [];
+  const map = manifest.exports;
+  if (map && typeof map === "object") {
+    for (const target of Object.values(map)) {
+      if (!target || typeof target !== "object") continue;
+      const types = target.types ?? target.import?.types ?? target.default?.types;
+      if (typeof types === "string") declared.push(types);
+    }
+  }
+  const root = manifest.types ?? manifest.typings;
+  if (typeof root === "string") declared.push(root);
+  if (declared.length === 0) declared.push("dist/index.d.ts");
+
+  const resolved = [];
+  for (const entry of new Set(declared)) {
+    for (const candidate of [...sourceCandidatesFor(entry), entry]) {
+      const full = join(packageDir, candidate.replace(/^\.\//, ""));
+      if (existsSync(full)) {
+        resolved.push(full);
+        break;
+      }
+    }
+  }
+  return resolved;
+}
+
 function workspaceExports() {
   if (exportedNames.size > 0) return exportedNames;
   const entries = [];
@@ -1557,7 +1605,8 @@ function workspaceExports() {
     withFileTypes: true,
   })) {
     if (!dirent.isDirectory()) continue;
-    const manifestPath = join(ROOT, "packages", dirent.name, "package.json");
+    const packageDir = join(ROOT, "packages", dirent.name);
+    const manifestPath = join(packageDir, "package.json");
     if (!existsSync(manifestPath)) continue;
     let manifest;
     try {
@@ -1566,20 +1615,16 @@ function workspaceExports() {
       continue;
     }
     if (!manifest.name || manifest.private) continue;
-    const declared =
-      manifest.types ??
-      manifest.typings ??
-      manifest.exports?.["."]?.types ??
-      manifest.exports?.["."]?.import?.types ??
-      "dist/index.d.ts";
-    const full = join(ROOT, "packages", dirent.name, declared);
-    if (existsSync(full)) entries.push(full);
+    entries.push(...typedEntriesOf(packageDir, manifest));
   }
   if (entries.length === 0) return exportedNames;
+  // One program over every entry, because the same question asked twenty times
+  // costs twenty type-checker startups.
   const program = ts.createProgram(entries, {
     noEmit: true,
     skipLibCheck: true,
     target: ts.ScriptTarget.ES2022,
+    jsx: ts.JsxEmit.ReactJSX,
     module: ts.ModuleKind.ESNext,
     moduleResolution: ts.ModuleResolutionKind.Bundler,
   });
@@ -1596,24 +1641,8 @@ function workspaceExports() {
   return exportedNames;
 }
 
-/**
- * A missing name that belongs to the reader rather than to this documentation.
- *
- * Two conditions, both load-bearing. The shape narrows the question to names a
- * reader declares: a generated collection type or a component of their own,
- * which is what PascalCase means in these pages, and it is why `orderData` and
- * a bare `a` stay findings. The exports answer it: a name the workspace
- * publishes is one the sample should have imported, and setting that aside
- * would silence a defect rather than a false alarm.
- *
- * Set aside, not excused. These stay ratcheted by identity, so a page cannot
- * quietly start mentioning a new one. What stops is charging a page for them,
- * which is what made completing an example read as a regression: a routing
- * example fetched an entry and rendered nothing, giving a reader a blank page,
- * and adding the render RAISED the count.
- */
-export const readerOwnedName = name =>
-  /^[A-Z][A-Za-z0-9]*$/.test(name) && !workspaceExports().has(name);
+export const readerOwnedName = (name, exported = workspaceExports()) =>
+  /^[A-Z][A-Za-z0-9]*$/.test(name) && !exported.has(name);
 
 export async function classifyDocDiagnostics({ diagnostics, samples }) {
   const uninstalled = [];

--- a/scripts/check-doc-samples.mjs
+++ b/scripts/check-doc-samples.mjs
@@ -1531,6 +1531,90 @@ function workspaceManifest(pkg) {
  * was once a pattern match asserting something nobody had checked, and each of
  * those hid real defects.
  */
+/**
+ * Every name the workspace publishes, from its built type entries.
+ *
+ * The question a missing PascalCase name raises is not what it looks like but
+ * whether the reader could have imported it. `Posts`, `Users` and `Page` are
+ * the reader's own: types `nextly generate:types` writes into their project,
+ * and components they author. Nothing here can define them and a page that
+ * mentions one is not broken. `Media` and `Skeleton` look exactly the same and
+ * are the opposite case: both ARE exported, from `nextly` and `@nextlyhq/ui`,
+ * so a sample using one without importing it is a defect a reader meets.
+ *
+ * Measured rather than assumed, which is the whole point of asking the exports:
+ * a rule keyed on the shape alone would have silenced those two.
+ *
+ * Read from the built `.d.ts` entries in ONE program, because the same question
+ * asked twenty times costs twenty type-checker startups. An unbuilt tree is
+ * refused before any of this runs.
+ */
+const exportedNames = new Set();
+function workspaceExports() {
+  if (exportedNames.size > 0) return exportedNames;
+  const entries = [];
+  for (const dirent of readdirSync(join(ROOT, "packages"), {
+    withFileTypes: true,
+  })) {
+    if (!dirent.isDirectory()) continue;
+    const manifestPath = join(ROOT, "packages", dirent.name, "package.json");
+    if (!existsSync(manifestPath)) continue;
+    let manifest;
+    try {
+      manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+    } catch {
+      continue;
+    }
+    if (!manifest.name || manifest.private) continue;
+    const declared =
+      manifest.types ??
+      manifest.typings ??
+      manifest.exports?.["."]?.types ??
+      manifest.exports?.["."]?.import?.types ??
+      "dist/index.d.ts";
+    const full = join(ROOT, "packages", dirent.name, declared);
+    if (existsSync(full)) entries.push(full);
+  }
+  if (entries.length === 0) return exportedNames;
+  const program = ts.createProgram(entries, {
+    noEmit: true,
+    skipLibCheck: true,
+    target: ts.ScriptTarget.ES2022,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+  });
+  const checker = program.getTypeChecker();
+  for (const entry of entries) {
+    const sourceFile = program.getSourceFile(entry);
+    if (!sourceFile) continue;
+    const symbol = checker.getSymbolAtLocation(sourceFile);
+    if (!symbol) continue;
+    for (const exported of checker.getExportsOfModule(symbol)) {
+      exportedNames.add(exported.getName());
+    }
+  }
+  return exportedNames;
+}
+
+/**
+ * A missing name that belongs to the reader rather than to this documentation.
+ *
+ * Two conditions, both load-bearing. The shape narrows the question to names a
+ * reader declares: a generated collection type or a component of their own,
+ * which is what PascalCase means in these pages, and it is why `orderData` and
+ * a bare `a` stay findings. The exports answer it: a name the workspace
+ * publishes is one the sample should have imported, and setting that aside
+ * would silence a defect rather than a false alarm.
+ *
+ * Set aside, not excused. These stay ratcheted by identity, so a page cannot
+ * quietly start mentioning a new one. What stops is charging a page for them,
+ * which is what made completing an example read as a regression: a routing
+ * example fetched an entry and rendered nothing, giving a reader a blank page,
+ * and adding the render RAISED the count.
+ */
+export const readerOwnedName = name =>
+  /^[A-Z][A-Za-z0-9]*$/.test(name) && !workspaceExports().has(name);
+
 export async function classifyDocDiagnostics({ diagnostics, samples }) {
   const uninstalled = [];
   const continued = [];
@@ -1542,6 +1626,8 @@ export async function classifyDocDiagnostics({ diagnostics, samples }) {
   // Implicit `any` on a parameter: a reader's generated types may or may not
   // answer it, and nothing in the diagnostic says which.
   const implicitAny = [];
+  // Names the reader declares in their own project, which nothing here can.
+  const readerNames = [];
   // A sample whose import did not resolve was not really checked: TypeScript
   // types the unresolved bindings as `any`, so a wrong call through them
   // produces no diagnostic at all. Counting such a sample as clean overstates
@@ -1601,6 +1687,7 @@ export async function classifyDocDiagnostics({ diagnostics, samples }) {
       const [file, idx] = line.split("  ")[0].split("#");
       const index = Number.parseInt(idx, 10);
       if (declaredEarlier(name[1], file, index, samples)) continued.push(line);
+      else if (readerOwnedName(name[1])) readerNames.push(line);
       else real.push(line);
       continue;
     }
@@ -1616,6 +1703,7 @@ export async function classifyDocDiagnostics({ diagnostics, samples }) {
     unchecked,
     uncheckedSamples,
     readerFiles,
+    readerNames,
     implicitAny,
     // Every diagnostic that came in, so a caller can prove it kept them all.
     // The buckets above are a partition, and the audit's job is to record each
@@ -1866,10 +1954,14 @@ export function unaccountedFor({
   real,
   continued,
   readerFiles,
+  readerNames,
   uninstalled,
   implicitAny,
 }) {
-  return total - (real + continued + readerFiles + uninstalled + implicitAny);
+  return (
+    total -
+    (real + continued + readerFiles + readerNames + uninstalled + implicitAny)
+  );
 }
 
 async function auditDocs() {
@@ -2122,6 +2214,7 @@ async function auditDocs() {
     unchecked,
     uncheckedSamples,
     readerFiles,
+    readerNames,
     implicitAny,
     total: classified,
   } = await classifyDocDiagnostics({
@@ -2150,7 +2243,11 @@ async function auditDocs() {
     // `any`, so everything reached through it stops being checked while the
     // fence still counts as compiled; recording which fences are in that state
     // is what stops one quietly joining them.
-    ...readerFiles.map(text => ({ mark: "reader-file", text }))
+    ...readerFiles.map(text => ({ mark: "reader-file", text })),
+    // Names the reader declares in their own project. Recorded by identity like
+    // every other set-aside bucket, so a page cannot start mentioning a new one
+    // unnoticed; what it no longer does is charge the page a finding.
+    ...readerNames.map(text => ({ mark: "reader-name", text }))
   );
 
   // Nothing may be dropped on the floor. `real` is charged to a page, the
@@ -2171,6 +2268,7 @@ async function auditDocs() {
     real: real.length,
     continued: continued.length,
     readerFiles: readerFiles.length,
+    readerNames: readerNames.length,
     uninstalled: uninstalled.length,
     implicitAny: implicitAny.length,
   });
@@ -2227,6 +2325,11 @@ async function auditDocs() {
         ? `\n  ${String(implicitAny.length + fromInheritedBlocks.length)} leave a parameter implicitly ` +
           `\`any\`, which a reader's generated types answer for a document ` +
           `field and do not answer for a plain function.`
+        : "") +
+      (readerNames.length > 0
+        ? `\n  ${String(readerNames.length)} name a type or component the reader ` +
+          `declares, such as a generated Posts or their own Page, which no ` +
+          `package here exports.`
         : "") +
       (readerFiles.length > 0
         ? `\n  ${String(readerFiles.length)} import a file the reader writes, ` +

--- a/scripts/check-doc-samples.mjs
+++ b/scripts/check-doc-samples.mjs
@@ -1046,12 +1046,14 @@ export function exportsMapAnswers(exports, subpath) {
 /**
  * The block a diagnostic came from, asked whether the name is the reader's.
  *
- * Falls back to the name alone when the block cannot be found, which keeps the
- * finding rather than dropping it.
+ * A diagnostic whose block cannot be found keeps its finding. Two of the three
+ * tests need the block to answer, so falling back to the name alone was the
+ * PERMISSIVE direction, not the strict one it was described as: a constructed
+ * name and a misspelled export would both have been set aside there.
  */
 export function mentionIsReaderOwned(name, file, index, samples) {
   const sample = samples.find(s => s.file === file && s.index === index);
-  if (!sample) return readerOwnedName(name);
+  if (!sample) return false;
   return readerOwnedMention(name, sample.code, extensionFor(sample));
 }
 

--- a/scripts/check-doc-samples.mjs
+++ b/scripts/check-doc-samples.mjs
@@ -1817,7 +1817,11 @@ export function usedOnlyAsValue(code, name, extension = "tsx") {
     if (ts.isIdentifier(node) && node.text === name) {
       mentioned = true;
       for (let at = node.parent; at; at = at.parent) {
-        if (ts.isTypeNode(at) || ts.isTypeQueryNode(at)) {
+        // `typeof X` is written in a type position and reads X out of the
+        // VALUE namespace, so it is a value use however it looks. Asked before
+        // the general test below, because a type query is itself a type node.
+        if (ts.isTypeQueryNode(at)) break;
+        if (ts.isTypeNode(at)) {
           asType = true;
           break;
         }

--- a/scripts/check-doc-samples.mjs
+++ b/scripts/check-doc-samples.mjs
@@ -1715,6 +1715,21 @@ function typedEntriesOf(packageDir, manifest) {
   return [...resolved];
 }
 
+/**
+ * Whether an export is declared type-only, whatever it points at.
+ *
+ * Both spellings say it: `export type { X }` marks the declaration and
+ * `export { type X }` marks the specifier. A symbol exported by several
+ * specifiers is type-only only when every one of them is.
+ */
+function exportedAsTypeOnly(symbol) {
+  const specifiers = (symbol.declarations ?? []).filter(ts.isExportSpecifier);
+  if (specifiers.length === 0) return false;
+  return specifiers.every(
+    specifier => specifier.isTypeOnly || specifier.parent.parent.isTypeOnly
+  );
+}
+
 function workspaceExports() {
   if (exportedNames.size > 0) return exportedNames;
   const entries = [];
@@ -1754,8 +1769,15 @@ function workspaceExports() {
     for (const exported of checker.getExportsOfModule(symbol)) {
       exportedNames.add(exported.getName());
       // A re-export is an alias, and an alias carries no namespace of its own:
-      // asking the alias whether it is a value answers for the binding rather
-      // than for the thing bound.
+      // asking the alias whether it is a value answers for the thing bound
+      // rather than for the binding. Both questions matter, and in this order.
+      //
+      // `export type { QueryClient } from "./types/query"` points at TanStack's
+      // runtime class, so the target is a value while the export is not: an
+      // importer of `@nextlyhq/admin` cannot get that class from it. Reading
+      // only the target put `QueryClient` among the values and kept `new
+      // QueryClient()` reported as a name the workspace could have supplied.
+      if (exportedAsTypeOnly(exported)) continue;
       const target =
         exported.flags & ts.SymbolFlags.Alias
           ? checker.getAliasedSymbol(exported)

--- a/scripts/check-doc-samples.mjs
+++ b/scripts/check-doc-samples.mjs
@@ -1828,22 +1828,110 @@ export function usedOnlyAsValue(code, name, extension = "tsx") {
   return mentioned && !asType;
 }
 
+/** Whether a block ever constructs this name. */
+export function constructedInBlock(code, name, extension = "tsx") {
+  let constructed = false;
+  const visit = node => {
+    if (
+      ts.isNewExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === name
+    ) {
+      constructed = true;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(parseSample(code, extension));
+  return constructed;
+}
+
+/** Whether two names are the same but for one character. */
+function withinOneEdit(a, b) {
+  const [short, long] = a.length <= b.length ? [a, b] : [b, a];
+  if (long.length - short.length > 1) return false;
+  let i = 0;
+  let j = 0;
+  let edits = 0;
+  while (i < short.length && j < long.length) {
+    if (short[i] === long[j]) {
+      i += 1;
+      j += 1;
+      continue;
+    }
+    if (edits === 1) return false;
+    edits += 1;
+    if (short.length === long.length) i += 1;
+    j += 1;
+  }
+  return true;
+}
+
+/**
+ * Whether the name is one of ours with a character wrong.
+ *
+ * `NextlyEror` and `Skelton` are not names a reader declares, they are
+ * `NextlyError` and `Skeleton` misspelled, and a rule that only asks whether
+ * the workspace exports the name as written waves both through.
+ *
+ * Compared in lower case so a wrong capital counts as the same word, and a
+ * difference of ONLY capitals is then excluded rather than reported: a reader's
+ * generated `Users` sits one capital from an internal `users`, and calling that
+ * a misspelling would charge the most ordinary reader-owned name there is.
+ *
+ * A difference at the END is excluded for the same reason, and it is the one
+ * that matters most: a generated collection type is the PLURAL of a model this
+ * workspace exports, so `Users` is one character from `User` and `Posts` one
+ * from `Post`. Those two names are the whole point of the exemption. A
+ * misspelling puts its wrong character in the middle, which is what separates
+ * `NextlyEror` from `NextlyError` and `Skelton` from `Skeleton`.
+ */
+export function misspelledExport(name, exported = workspaceExports()) {
+  const wanted = name.toLowerCase();
+  for (const candidate of exported) {
+    const other = candidate.toLowerCase();
+    if (other === wanted) continue;
+    if (!withinOneEdit(wanted, other)) continue;
+    if (differsOnlyAtTheEnd(wanted, other)) continue;
+    return true;
+  }
+  return false;
+}
+
+/** Whether one name is the other with a character added at the end. */
+function differsOnlyAtTheEnd(a, b) {
+  const [short, long] = a.length <= b.length ? [a, b] : [b, a];
+  return long.length !== short.length && long.startsWith(short);
+}
+
 /**
  * Whether a missing name belongs to the reader, for the way this block used it.
  *
- * The name alone cannot answer it: `Media` is exported as a type and never as a
- * value, so it is the reader's in `collections: [Posts, Users, Media]` and ours
- * in `const m: Media`.
+ * The name alone cannot answer it, in both directions.
+ *
+ * `Media` is exported as a type and never as a value, so it is the reader's in
+ * `collections: [Posts, Users, Media]` and ours in `const m: Media`.
+ *
+ * And a name this workspace does not export is not the reader's just for that.
+ * `new S3Client({})` asks for a runtime class, which is not a thing
+ * `nextly generate:types` writes into a reader's project or a component they
+ * author, so a sample using one has forgotten an import. `NextlyEror` is a name
+ * of ours with a letter missing. Both were being set aside, which is the docs
+ * gate accepting samples that are simply broken.
  */
 export function readerOwnedMention(name, code, extension) {
   if (!/^[A-Z][A-Za-z0-9]*$/.test(name)) return false;
+  // Asked before anything else, because it settles the question on its own:
+  // whatever the workspace does or does not export, a constructed name has to
+  // be a runtime class, and neither a generated type nor an authored component
+  // is one.
+  if (constructedInBlock(code, name, extension)) return false;
   if (workspaceExports().has(name)) {
     return (
       !workspaceValueExports().has(name) &&
       usedOnlyAsValue(code, name, extension)
     );
   }
-  return true;
+  return !misspelledExport(name);
 }
 
 export async function classifyDocDiagnostics({ diagnostics, samples }) {

--- a/scripts/check-doc-samples.mjs
+++ b/scripts/check-doc-samples.mjs
@@ -1923,6 +1923,19 @@ function differsOnlyAtTheEnd(a, b) {
  * author, so a sample using one has forgotten an import. `NextlyEror` is a name
  * of ours with a letter missing. Both were being set aside, which is the docs
  * gate accepting samples that are simply broken.
+ *
+ * What is still set aside, deliberately: a third-party VALUE used without `new`
+ * and without an import, from a package no sample imports, such as `[S3Client]`
+ * or `err instanceof ZodError`. Closing it needs one of two things, and both
+ * were measured and cost more than the gap. Resolving what the corpus imports
+ * reaches `next`, `next/navigation` and `next/image` and none of those three,
+ * because `next/server` and the AWS and Zod packages are never imported here;
+ * enumerating every installed package and subpath is neither cheap nor
+ * hermetic. Requiring the corpus to introduce a name first charges `Users` in
+ * `collections: [Posts, Users, Media]` while setting `Posts` aside, because
+ * `Posts` happens to be imported on another page, and charges `<Chart />` as
+ * well. A report that treats three names in one array differently is not one
+ * anyone can act on.
  */
 export function readerOwnedMention(name, code, extension) {
   if (!/^[A-Z][A-Za-z0-9]*$/.test(name)) return false;

--- a/scripts/check-doc-samples.test.mjs
+++ b/scripts/check-doc-samples.test.mjs
@@ -1375,9 +1375,16 @@ describe("the workspace's own exported names", () => {
       // `Media` is exported as a type by `nextly` and as an interface by
       // `@nextlyhq/admin`, and by nothing as a value.
       expect(workspaceValueExports().has("Media")).toBe(false);
-      // The control: the same set answers yes for a real component, so the
-      // check above is a namespace distinction rather than an empty set.
+      // Declared type-only over a target that IS a value.
+      // `export type { QueryClient } from "./types/query"` points at TanStack's
+      // runtime class, so resolving the alias and stopping there called it a
+      // value that `@nextlyhq/admin` cannot actually supply.
+      expect(workspaceValueExports().has("QueryClient")).toBe(false);
+      // The control: the same set answers yes for a real component and for a
+      // value published from a subpath, so the two checks above are a namespace
+      // distinction rather than an empty set.
       expect(workspaceValueExports().has("Skeleton")).toBe(true);
+      expect(workspaceValueExports().has("BuilderShell")).toBe(true);
     },
     BUILDS_THE_PROGRAM
   );

--- a/scripts/check-doc-samples.test.mjs
+++ b/scripts/check-doc-samples.test.mjs
@@ -1183,14 +1183,22 @@ describe("a sample that writes a property the API has deprecated", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+});
 
 describe("a missing name the reader owns", () => {
+  // An explicit set, so these state the RULE rather than the workspace. Reading
+  // the workspace here made them depend on whether a build had run: CI runs the
+  // script suite before the build step, the set came back empty, and every name
+  // read as the reader's.
+  const exported = new Set(["Media", "Skeleton", "Nextly", "NextlyError"]);
+  const owned = name => readerOwnedName(name, exported);
+
   it("sets aside a type the reader's own project declares", () => {
     // `nextly generate:types` writes these into a reader's project, and a
     // component is theirs to write. Nothing in this workspace can define one,
     // so a page mentioning it is not broken.
     for (const name of ["Posts", "Users", "Page", "MyCollection", "Chart"]) {
-      expect(readerOwnedName(name)).toBe(true);
+      expect(owned(name)).toBe(true);
     }
   });
 
@@ -1201,7 +1209,7 @@ describe("a missing name the reader owns", () => {
     // defect a reader meets. A rule keyed on the shape alone would have
     // silenced five findings in the current corpus.
     for (const name of ["Media", "Skeleton", "Nextly", "NextlyError"]) {
-      expect(readerOwnedName(name)).toBe(false);
+      expect(owned(name)).toBe(false);
     }
   });
 
@@ -1210,7 +1218,7 @@ describe("a missing name the reader owns", () => {
     // `orderData` or a bare `a` is an example that was left unfinished, which
     // is a finding.
     for (const name of ["orderData", "where", "a", "getPostBySlug"]) {
-      expect(readerOwnedName(name)).toBe(false);
+      expect(owned(name)).toBe(false);
     }
   });
 
@@ -1220,8 +1228,24 @@ describe("a missing name the reader owns", () => {
     // alone accepts `orderData`.
     const looksOwned = name => /^[A-Z][A-Za-z0-9]*$/.test(name);
     expect(looksOwned("Media")).toBe(true);
-    expect(readerOwnedName("Media")).toBe(false);
+    expect(owned("Media")).toBe(false);
     expect(looksOwned("orderData")).toBe(false);
-    expect(readerOwnedName("orderData")).toBe(false);
+    expect(owned("orderData")).toBe(false);
+  });
+});
+
+describe("the workspace's own exported names", () => {
+  // The rule above is stated against a fixture, so this is what ties it to
+  // reality. Read from `src`, which is present whether or not a build has run,
+  // so it answers the same on a clean checkout as on a laptop.
+  it("knows what this workspace publishes and what it does not", () => {
+    expect(readerOwnedName("Media")).toBe(false);
+    expect(readerOwnedName("Skeleton")).toBe(false);
+    // Published from a subpath and deliberately kept out of the root barrel.
+    expect(readerOwnedName("BuilderShell")).toBe(false);
+    // The reader's, and the control: a set that answered "exported" to
+    // everything would satisfy the three above.
+    expect(readerOwnedName("Posts")).toBe(true);
+    expect(readerOwnedName("MyCollection")).toBe(true);
   });
 });

--- a/scripts/check-doc-samples.test.mjs
+++ b/scripts/check-doc-samples.test.mjs
@@ -18,6 +18,7 @@ import {
   pageOf,
   readerOwnedName,
   constructedInBlock,
+  mentionIsReaderOwned,
   misspelledExport,
   readerOwnedMention,
   usedOnlyAsValue,
@@ -1509,6 +1510,27 @@ describe("a name this workspace does not export", () => {
     // would leave them reading the workspace and passing for the wrong reason.
     expect(misspelledExport("Zzy", new Set(["Zzz"]))).toBe(true);
     expect(misspelledExport("NextlyEror", new Set())).toBe(false);
+  });
+});
+
+describe("a diagnostic whose block cannot be found", () => {
+  it("keeps its finding rather than reading the name alone", () => {
+    // Two of the three tests need the block, so answering from the name alone
+    // was the permissive direction: a constructed name and a misspelled export
+    // would both have been set aside there.
+    expect(mentionIsReaderOwned("Posts", "docs/nope.mdx", 0, [])).toBe(false);
+    // The control: with the block present the same name is the reader's, so
+    // the line above is the fallback answering and not the rule.
+    expect(
+      mentionIsReaderOwned("Posts", "docs/a.mdx", 0, [
+        {
+          file: "docs/a.mdx",
+          index: 0,
+          code: "const c = [Posts];",
+          lang: "ts",
+        },
+      ])
+    ).toBe(true);
   });
 });
 

--- a/scripts/check-doc-samples.test.mjs
+++ b/scripts/check-doc-samples.test.mjs
@@ -1446,6 +1446,11 @@ describe("the workspace's own exported names", () => {
       expect(readerOwnedMention("Media", "declare const m: Media;", "ts")).toBe(
         false
       );
+      // And `typeof Media` needs the value, which nothing here exports, so it
+      // is the reader's the way `collections: [Media]` is.
+      expect(readerOwnedMention("Media", "type X = typeof Media;", "ts")).toBe(
+        true
+      );
       // A name exported as a value stays a finding however it is used.
       expect(
         readerOwnedMention("Skeleton", "const el = <Skeleton />;", "tsx")
@@ -1540,9 +1545,10 @@ describe("how a block used a name", () => {
     expect(usedOnlyAsValue("declare const m: Media;", "Media", "ts")).toBe(
       false
     );
-    expect(usedOnlyAsValue("type X = typeof Media;", "Media", "ts")).toBe(
-      false
-    );
+    // `typeof X` is written in a type position and reads X out of the VALUE
+    // namespace, so it is a value use however it looks. This assertion used to
+    // record the opposite.
+    expect(usedOnlyAsValue("type X = typeof Media;", "Media", "ts")).toBe(true);
   });
 
   it("keeps the finding when a block uses the name both ways", () => {

--- a/scripts/check-doc-samples.test.mjs
+++ b/scripts/check-doc-samples.test.mjs
@@ -17,6 +17,8 @@ import {
   isModule,
   pageOf,
   readerOwnedName,
+  constructedInBlock,
+  misspelledExport,
   readerOwnedMention,
   usedOnlyAsValue,
   workspaceValueExports,
@@ -1390,6 +1392,42 @@ describe("the workspace's own exported names", () => {
   );
 
   it(
+    "keeps a broken sample rather than calling its name the reader's",
+    () => {
+      // Three shapes that are not reader-owned however they look: a class the
+      // sample forgot to import, one of ours with a letter missing, and a
+      // component of ours misspelled.
+      expect(
+        readerOwnedMention("S3Client", "const s = new S3Client({});", "ts")
+      ).toBe(false);
+      expect(
+        readerOwnedMention("NextlyEror", "const e: NextlyEror = x;", "ts")
+      ).toBe(false);
+      expect(
+        readerOwnedMention("Skelton", "const s = <Skelton />;", "tsx")
+      ).toBe(false);
+      // Construction settles it even for a name the workspace does export,
+      // because a type-only export cannot supply the class either.
+      expect(
+        readerOwnedMention("QueryClient", "const q = new QueryClient();", "ts")
+      ).toBe(false);
+      // The control, and the reason the rule exists: the reader's own names
+      // are still set aside, including the two that sit one character from a
+      // model this workspace exports.
+      for (const name of ["Posts", "Users", "Page", "Chart", "MyCollection"]) {
+        expect(
+          readerOwnedMention(
+            name,
+            `const c = { collections: [${name}] };`,
+            "ts"
+          )
+        ).toBe(true);
+      }
+    },
+    BUILDS_THE_PROGRAM
+  );
+
+  it(
     "reads a type-only name by how the block used it",
     () => {
       // `collections: [Posts, Users, Media]` needs a value, and no import here
@@ -1414,6 +1452,64 @@ describe("the workspace's own exported names", () => {
     },
     BUILDS_THE_PROGRAM
   );
+});
+
+describe("a name this workspace does not export", () => {
+  // Not exporting a name is not the same as the reader owning it, and treating
+  // the two as one made the gate accept samples that are simply broken.
+
+  it("reads a constructed name as a class the sample forgot to import", () => {
+    // `nextly generate:types` writes types, and a reader authors components.
+    // Neither is a thing you call `new` on, so a constructed name is a runtime
+    // class the sample did not import.
+    expect(
+      constructedInBlock("const s = new S3Client({});", "S3Client", "ts")
+    ).toBe(true);
+    // The controls: the same name used as a value is not construction, and a
+    // name the block never mentions cannot be constructed by it.
+    expect(constructedInBlock("const s = [S3Client];", "S3Client", "ts")).toBe(
+      false
+    );
+    expect(constructedInBlock("const s = new Date();", "S3Client", "ts")).toBe(
+      false
+    );
+  });
+
+  it("reads one of our own names with a letter wrong as a misspelling", () => {
+    const exported = new Set([
+      "NextlyError",
+      "Skeleton",
+      "User",
+      "Post",
+      "users",
+    ]);
+    expect(misspelledExport("NextlyEror", exported)).toBe(true);
+    expect(misspelledExport("Skelton", exported)).toBe(true);
+  });
+
+  it("does not read a plural or a capital as a misspelling", () => {
+    // The two that decide the rule. A generated collection type is the plural
+    // of a model this workspace exports, so `Users` sits one character from
+    // `User` and `Posts` one from `Post`; and `Users` sits one capital from an
+    // internal `users`. Those are the names the exemption exists for.
+    const exported = new Set([
+      "NextlyError",
+      "Skeleton",
+      "User",
+      "Post",
+      "users",
+    ]);
+    expect(misspelledExport("Users", exported)).toBe(false);
+    expect(misspelledExport("Posts", exported)).toBe(false);
+    expect(misspelledExport("Page", exported)).toBe(false);
+  });
+
+  it("asks the set it was given", () => {
+    // The control for the two above: an injectable set that failed to apply
+    // would leave them reading the workspace and passing for the wrong reason.
+    expect(misspelledExport("Zzy", new Set(["Zzz"]))).toBe(true);
+    expect(misspelledExport("NextlyEror", new Set())).toBe(false);
+  });
 });
 
 describe("how a block used a name", () => {

--- a/scripts/check-doc-samples.test.mjs
+++ b/scripts/check-doc-samples.test.mjs
@@ -17,6 +17,9 @@ import {
   isModule,
   pageOf,
   readerOwnedName,
+  readerOwnedMention,
+  usedOnlyAsValue,
+  workspaceValueExports,
   parseSample,
   rebaseContextDiagnostics,
   unaccountedFor,
@@ -41,7 +44,8 @@ const declarationHost = text => {
       ? ts.createSourceFile(name, text, langVersion, true, ts.ScriptKind.TS)
       : original(name, langVersion, ...rest);
   host.fileExists = name => name === "/probe.d.ts" || ts.sys.fileExists(name);
-  host.readFile = name => (name === "/probe.d.ts" ? text : ts.sys.readFile(name));
+  host.readFile = name =>
+    name === "/probe.d.ts" ? text : ts.sys.readFile(name);
   return host;
 };
 
@@ -53,7 +57,8 @@ const fingerprintBy = (key, byFile) =>
   Object.fromEntries(
     Object.entries(byFile).map(([file, lines]) => {
       const counts = {};
-      for (const line of lines) counts[key(line)] = (counts[key(line)] ?? 0) + 1;
+      for (const line of lines)
+        counts[key(line)] = (counts[key(line)] ?? 0) + 1;
       return [file, counts];
     })
   );
@@ -67,8 +72,12 @@ const coverageOf = perPage => ({
 
 describe("identityOf", () => {
   it("keeps the fence and drops the line, so an edit above a fence does not churn the baseline", () => {
-    const before = identityOf("docs/a.mdx#3:12  error TS2304: Cannot find name 'Post'.");
-    const after = identityOf("docs/a.mdx#3:40  error TS2304: Cannot find name 'Post'.");
+    const before = identityOf(
+      "docs/a.mdx#3:12  error TS2304: Cannot find name 'Post'."
+    );
+    const after = identityOf(
+      "docs/a.mdx#3:40  error TS2304: Cannot find name 'Post'."
+    );
 
     expect(before).toBe(after);
     expect(before).toBe("#3 error TS2304: Cannot find name 'Post'.");
@@ -125,8 +134,12 @@ describe("compareToBaseline", () => {
       fingerprint: fingerprintBy(identityOf, { "docs/a.mdx": now }),
     });
 
-    expect(appeared).toEqual(["docs/a.mdx: #7 error TS2304: Cannot find name 'Post'."]);
-    expect(gone).toEqual(["docs/a.mdx: #3 error TS2304: Cannot find name 'Post'."]);
+    expect(appeared).toEqual([
+      "docs/a.mdx: #7 error TS2304: Cannot find name 'Post'.",
+    ]);
+    expect(gone).toEqual([
+      "docs/a.mdx: #3 error TS2304: Cannot find name 'Post'.",
+    ]);
     // The control: the count is equal either way, so nothing but the identities
     // is left to notice. Scored on messages alone, this state was accepted.
     expect(worse).toEqual([]);
@@ -165,7 +178,9 @@ describe("compareToBaseline", () => {
         coverage: coverageOf(twoPages),
         counted: { "docs/a.mdx": 1, "docs/b.mdx": 1 },
         fingerprint: {
-          "docs/a.mdx": { "#3 error TS2551: Property 'sizes' does not exist.": 1 },
+          "docs/a.mdx": {
+            "#3 error TS2551: Property 'sizes' does not exist.": 1,
+          },
           "docs/b.mdx": { "#0 error TS2339: Property 'x' does not exist.": 1 },
         },
         only: "docs/a.mdx",
@@ -259,7 +274,9 @@ describe("compareToBaseline", () => {
           coverage: { pages: 1, samples: 4, compiled: 3 },
           samplesPerPage: perPageHere,
           pages: { "docs/a.mdx": 1 },
-          findings: { "docs/a.mdx": { "#3 error TS2304: Cannot find name 'Post'.": 1 } },
+          findings: {
+            "docs/a.mdx": { "#3 error TS2304: Cannot find name 'Post'.": 1 },
+          },
         },
         coverage: coverageOf(perPageHere),
         counted: { "docs/a.mdx": 2 },
@@ -271,7 +288,9 @@ describe("compareToBaseline", () => {
         },
       });
 
-      expect(appeared).toEqual(["docs/a.mdx: #4 error TS2304: Cannot find name 'Page'."]);
+      expect(appeared).toEqual([
+        "docs/a.mdx: #4 error TS2304: Cannot find name 'Page'.",
+      ]);
     });
 
     it("reports nothing when the audit matches what the baseline holds", () => {
@@ -299,9 +318,9 @@ describe("compareToBaseline", () => {
 
 describe("pageOf", () => {
   it("takes the page off an attributed diagnostic", () => {
-    expect(pageOf("docs/a.mdx#3:12  error TS2304: Cannot find name 'Post'.")).toBe(
-      "docs/a.mdx"
-    );
+    expect(
+      pageOf("docs/a.mdx#3:12  error TS2304: Cannot find name 'Post'.")
+    ).toBe("docs/a.mdx");
   });
 
   it("groups an unattributed diagnostic under `?` rather than under its own message", () => {
@@ -347,9 +366,12 @@ describe("declaredNamesIn scope tracking", () => {
   });
 
   it("does not promote a nested name when a comment contains a closing brace", () => {
-    const code = ["function setup() {", "  // closes here: }", "  const hidden = 1;", "}"].join(
-      "\n"
-    );
+    const code = [
+      "function setup() {",
+      "  // closes here: }",
+      "  const hidden = 1;",
+      "}",
+    ].join("\n");
 
     expect(declaredNamesIn(code).includes("hidden")).toBe(false);
     expect(blankNestedByCounting(code)).toContain("hidden");
@@ -364,13 +386,18 @@ describe("declaredNamesIn scope tracking", () => {
 });
 
 describe("extractFrom fence delimiters", () => {
-  const body = 'import { defineConfig } from "nextly";\nexport default defineConfig({});';
+  const body =
+    'import { defineConfig } from "nextly";\nexport default defineConfig({});';
 
   it("reads a tilde-fenced TypeScript block", () => {
     // CommonMark allows `~~~`. Recognising only backticks made such a block
     // invisible to extraction, so publishing one that does not compile lowered
     // no coverage number and passed.
-    const samples = extractFrom("markdown-dir", `~~~ts\n${body}\n~~~\n`, "docs/a.mdx");
+    const samples = extractFrom(
+      "markdown-dir",
+      `~~~ts\n${body}\n~~~\n`,
+      "docs/a.mdx"
+    );
 
     expect(samples).toHaveLength(1);
     expect(samples[0].code).toContain("defineConfig");
@@ -428,7 +455,9 @@ describe("isModule", () => {
     // The control: the rule this replaced saw only declarations, exports and
     // require, so such a fence was extracted and never compiled.
     const declarationsOnly = c =>
-      /^\s*import\b/m.test(c) || /^\s*export\b/m.test(c) || /(?:^|[^.\w])require\s*\(/m.test(c);
+      /^\s*import\b/m.test(c) ||
+      /^\s*export\b/m.test(c) ||
+      /(?:^|[^.\w])require\s*\(/m.test(c);
     expect(declarationsOnly('const nx = await import("nextly");')).toBe(false);
   });
 
@@ -443,7 +472,9 @@ describe("unterminatedFences", () => {
 
   it("reports a TypeScript fence that never closes", () => {
     expect(
-      unterminatedFences(["```ts", body, "", "prose that never closes"].join("\n"))
+      unterminatedFences(
+        ["```ts", body, "", "prose that never closes"].join("\n")
+      )
     ).toEqual(["```ts"]);
   });
 
@@ -457,11 +488,15 @@ describe("unterminatedFences", () => {
     // The gate compiles TypeScript. An unclosed shell block is a rendering
     // problem for somebody else to care about, and refusing on it would make
     // this check fail for reasons it cannot act on.
-    expect(unterminatedFences(["```bash", "echo hi", "", "prose"].join("\n"))).toEqual([]);
+    expect(
+      unterminatedFences(["```bash", "echo hi", "", "prose"].join("\n"))
+    ).toEqual([]);
   });
 
   it("reports an unclosed tilde fence too", () => {
-    expect(unterminatedFences(["~~~ts", body, "", "prose"].join("\n"))).toEqual(["~~~ts"]);
+    expect(unterminatedFences(["~~~ts", body, "", "prose"].join("\n"))).toEqual(
+      ["~~~ts"]
+    );
   });
 });
 
@@ -472,13 +507,19 @@ describe("extensionFor", () => {
     // A fence headed `ts title="nextly.config.ts"` names the file a reader
     // pastes into. Compiling it as tsx because it holds an angle bracket
     // checks it under rules that reader never gets.
-    expect(extensionFor({ lang: "ts", meta: ' title="nextly.config.ts"', code: jsx })).toBe("ts");
-    expect(extensionFor({ lang: "ts", meta: ' title="app/page.tsx"', code: jsx })).toBe("tsx");
+    expect(
+      extensionFor({ lang: "ts", meta: ' title="nextly.config.ts"', code: jsx })
+    ).toBe("ts");
+    expect(
+      extensionFor({ lang: "ts", meta: ' title="app/page.tsx"', code: jsx })
+    ).toBe("tsx");
   });
 
   it("infers from the body when no filename is stated", () => {
     expect(extensionFor({ lang: "ts", meta: "", code: jsx })).toBe("tsx");
-    expect(extensionFor({ lang: "ts", meta: "", code: "const a = 1;" })).toBe("ts");
+    expect(extensionFor({ lang: "ts", meta: "", code: "const a = 1;" })).toBe(
+      "ts"
+    );
   });
 
   it("ignores a stated filename on a rebuilt sample", () => {
@@ -487,28 +528,47 @@ describe("extensionFor", () => {
     // pasted prefix holds JSX makes it fail to parse for a reason the page
     // does not have.
     expect(
-      extensionFor({ lang: "ts", meta: ' title="nextly.config.ts"', code: jsx, prependedLines: 4 })
+      extensionFor({
+        lang: "ts",
+        meta: ' title="nextly.config.ts"',
+        code: jsx,
+        prependedLines: 4,
+      })
     ).toBe("tsx");
   });
 });
 
 describe("declaredNamesIn and imports that are not declarations", () => {
   it("does not bind a name from an import inside a block comment", () => {
-    const code = ["/*", 'import { ghost } from "pkg";', "*/", "const real = 1;"].join("\n");
+    const code = [
+      "/*",
+      'import { ghost } from "pkg";',
+      "*/",
+      "const real = 1;",
+    ].join("\n");
 
     expect(declaredNamesIn(code)).toEqual(["real"]);
     // The control: the pattern this replaced read the raw text and could not
     // tell a comment from a statement, so a later fence using `ghost` was
     // excused as a continuation of a page that never bound it.
-    const byPattern = [...code.matchAll(/^\s*import\s+([^;]*?)\s+from\s/gms)].length;
+    const byPattern = [...code.matchAll(/^\s*import\s+([^;]*?)\s+from\s/gms)]
+      .length;
     expect(byPattern).toBe(1);
   });
 
   it("still binds every form a real import declares", () => {
     // A parser swap can quietly lose a shape, so all four are asserted.
-    const wrapped = ["import {", "  defineConfig,", "  type Foo,", '} from "nextly";'].join("\n");
+    const wrapped = [
+      "import {",
+      "  defineConfig,",
+      "  type Foo,",
+      '} from "nextly";',
+    ].join("\n");
     expect(declaredNamesIn(wrapped).sort()).toEqual(["Foo", "defineConfig"]);
-    expect(declaredNamesIn('import D, * as NS from "p";').sort()).toEqual(["D", "NS"]);
+    expect(declaredNamesIn('import D, * as NS from "p";').sort()).toEqual([
+      "D",
+      "NS",
+    ]);
     expect(declaredNamesIn('import { a as b } from "p";')).toEqual(["b"]);
   });
 });
@@ -574,7 +634,11 @@ describe("compareToBaseline and coverage gains", () => {
 
 describe("isModule reads the tree, not the text", () => {
   const cases = [
-    ['// dynamically import("nextly")\nconst a = { b: 1 };', false, "a mention in a comment"],
+    [
+      '// dynamically import("nextly")\nconst a = { b: 1 };',
+      false,
+      "a mention in a comment",
+    ],
     ['const s = "import(x)";', false, "a mention in a string"],
     ['const nx = await import("nextly");', true, "a real dynamic import"],
     ['const c = require("crypto");', true, "a require call"],
@@ -603,7 +667,10 @@ describe("isModule reads the tree, not the text", () => {
 });
 
 describe("declaredNamesIn under the right grammar", () => {
-  const code = ['const id = <T>(x: T) => x;', 'import { defineConfig } from "nextly";'].join("\n");
+  const code = [
+    "const id = <T>(x: T) => x;",
+    'import { defineConfig } from "nextly";',
+  ].join("\n");
 
   it("keeps the imports of a .ts sample that TSX would misparse", () => {
     // `<T>(x: T) => x` is a generic arrow in .ts and an unclosed element in
@@ -641,7 +708,11 @@ describe("unaccountedFor", () => {
     // Why the comparison is exact rather than "at least". Adding a term that
     // is not part of the partition, as counting the whole set-aside list did,
     // lets a missing bucket hide behind it.
-    const withSurplus = { ...complete, uninstalled: 0, real: complete.real + 1 };
+    const withSurplus = {
+      ...complete,
+      uninstalled: 0,
+      real: complete.real + 1,
+    };
     expect(unaccountedFor(withSurplus)).toBe(0);
   });
 });
@@ -659,8 +730,12 @@ describe("unterminatedFences and closing lines", () => {
   });
 
   it("still accepts a plain closer, and one with trailing whitespace", () => {
-    expect(unterminatedFences(["```ts", "const a = 1;", "```", ""].join("\n"))).toEqual([]);
-    expect(unterminatedFences(["```ts", "const a = 1;", "```   ", ""].join("\n"))).toEqual([]);
+    expect(
+      unterminatedFences(["```ts", "const a = 1;", "```", ""].join("\n"))
+    ).toEqual([]);
+    expect(
+      unterminatedFences(["```ts", "const a = 1;", "```   ", ""].join("\n"))
+    ).toEqual([]);
   });
 });
 
@@ -687,7 +762,7 @@ describe("isModule asks the compiler rather than listing node kinds", () => {
     // TypeScript sets its module indicator for `import.meta`, so this fence is
     // a module to the compiler that would compile it while the list read it as
     // a fragment. Neither the reviewer nor the list found this one.
-    const code = 'const here = import.meta.url;\nconsole.log(here);\n';
+    const code = "const here = import.meta.url;\nconsole.log(here);\n";
     expect(isModule(code, "ts")).toBe(true);
     expect(byKindList(code)).toBe(false);
   });
@@ -721,7 +796,10 @@ describe("rebaseContextDiagnostics accounts for every line", () => {
     // nothing the gate compares, so a fence could stop being checked while
     // every number stood still.
     const line = at(2, "error TS2304: Cannot find name 'PluginDefinition'.");
-    const result = rebaseContextDiagnostics({ lines: [line], prependedByOrigin });
+    const result = rebaseContextDiagnostics({
+      lines: [line],
+      prependedByOrigin,
+    });
     expect(result.contextOnly).toEqual([line]);
     expect([...result.unresolvedInContext]).toEqual(["docs/p.mdx#3"]);
     // The control: it is still not rebased onto the reader's page, because it
@@ -756,7 +834,8 @@ describe("rebaseContextDiagnostics accounts for every line", () => {
 });
 
 describe("a fence whose only module syntax is a namespace export", () => {
-  const namespaceOnly = "export as namespace Nextly;\ndeclare const a: number;\n";
+  const namespaceOnly =
+    "export as namespace Nextly;\ndeclare const a: number;\n";
 
   it("stays a fragment", () => {
     expect(isModule(namespaceOnly, "ts")).toBe(false);
@@ -820,7 +899,12 @@ describe("a fence whose only module syntax is a namespace export", () => {
 
 describe("withEarlierContext says which fence each pasted line came from", () => {
   const page = [
-    { file: "docs/p.mdx", index: 0, lang: "ts", code: "const first = 1;\nconst unused = 2;" },
+    {
+      file: "docs/p.mdx",
+      index: 0,
+      lang: "ts",
+      code: "const first = 1;\nconst unused = 2;",
+    },
     { file: "docs/p.mdx", index: 1, lang: "ts", code: "const second = first;" },
     { file: "docs/p.mdx", index: 2, lang: "ts", code: "console.log(second);" },
   ];
@@ -888,9 +972,9 @@ describe("contextOnlyWorthRecording deduplicates on identity", () => {
     );
     // The control: matched the old way, this one disappears.
     const messageOf = line => line.split("  ").slice(1).join("  ");
-    expect(new Set(firstPass.map(messageOf)).has(messageOf(contextOnly[0]))).toBe(
-      true
-    );
+    expect(
+      new Set(firstPass.map(messageOf)).has(messageOf(contextOnly[0]))
+    ).toBe(true);
   });
 
   it("drops one the same fence already reported", () => {
@@ -935,8 +1019,13 @@ describe("contextOnlyWorthRecording deduplicates on identity", () => {
   });
 
   it("records a block pasted into several continuations once", () => {
-    const contextOnly = [missingFoo("docs/a.mdx#1", 3), missingFoo("docs/a.mdx#1", 3)];
-    expect(contextOnlyWorthRecording({ contextOnly, firstPass: [] })).toHaveLength(1);
+    const contextOnly = [
+      missingFoo("docs/a.mdx#1", 3),
+      missingFoo("docs/a.mdx#1", 3),
+    ];
+    expect(
+      contextOnlyWorthRecording({ contextOnly, firstPass: [] })
+    ).toHaveLength(1);
   });
 });
 
@@ -1126,7 +1215,11 @@ describe("a sample that writes a property the API has deprecated", () => {
     // deprecated FUNCTION is reported, a deprecated property written in an
     // object literal is not, and the corpus's suggestions are otherwise
     // "declared but never read" on samples that show a shape rather than run.
-    const { files, program: built, dir } = program(
+    const {
+      files,
+      program: built,
+      dir,
+    } = program(
       'import type { Plugin } from "./api";\n' +
         'export const p: Plugin = { collections: ["a"] };\n'
     );
@@ -1238,22 +1331,106 @@ describe("the workspace's own exported names", () => {
   // The rule above is stated against a fixture, so this is what ties it to
   // reality. Read from `src`, which is present whether or not a build has run,
   // so it answers the same on a clean checkout as on a laptop.
-  it("knows what this workspace publishes and what it does not", () => {
-    expect(readerOwnedName("Media")).toBe(false);
-    expect(readerOwnedName("Skeleton")).toBe(false);
-    // Published from a subpath and deliberately kept out of the root barrel.
-    expect(readerOwnedName("BuilderShell")).toBe(false);
-    // Six subpath entries in `nextly` and `@nextlyhq/ui` are bundle names with
-    // no same-named source, so they resolve from `dist` and contribute nothing
-    // on an unbuilt tree. These two are what a symbol behind one of them looks
-    // like, and both are reached through an entry that does resolve, so the
-    // answer is the same either way. Pinned because it is the case that would
-    // otherwise silence a real finding.
-    expect(readerOwnedName("FIELD_TYPE_CATALOG")).toBe(false);
-    expect(readerOwnedName("WidgetResult")).toBe(false);
-    // The reader's, and the control: a set that answered "exported" to
-    // everything would satisfy the three above.
-    expect(readerOwnedName("Posts")).toBe(true);
-    expect(readerOwnedName("MyCollection")).toBe(true);
+  //
+  // The timeout is explicit because this is the one test that builds the real
+  // program over every published entry. It took 13.7 seconds on an inspected
+  // clean checkout, and vitest's 5-second default made that a red run on a
+  // slower machine rather than a slow one.
+  const BUILDS_THE_PROGRAM = 120_000;
+
+  it(
+    "knows what this workspace publishes and what it does not",
+    () => {
+      expect(readerOwnedName("Media")).toBe(false);
+      expect(readerOwnedName("Skeleton")).toBe(false);
+      // Published from a subpath and deliberately kept out of the root barrel.
+      expect(readerOwnedName("BuilderShell")).toBe(false);
+      // Entries whose output name does not mirror their source, which is what
+      // made this answer depend on a build. `nextly/document-lock` is built
+      // from `src/domains/document-lock/contract.ts`, and `@nextlyhq/ui`
+      // declares its subpath sources in a module beside its build config, so
+      // neither is reachable by turning `dist/X.d.ts` into `src/X.ts`. Each of
+      // these read as the reader's on a clean checkout and as ours after a
+      // build, which is the case that silences a real finding.
+      expect(readerOwnedName("DocumentLockHolder")).toBe(false);
+      expect(readerOwnedName("FieldTypeCatalogEntry")).toBe(false);
+      expect(readerOwnedName("Hsv")).toBe(false);
+      expect(readerOwnedName("FIELD_TYPE_CATALOG")).toBe(false);
+      expect(readerOwnedName("WidgetResult")).toBe(false);
+      // The reader's, and the control: a set that answered "exported" to
+      // everything would satisfy every assertion above. `Users` is the one that
+      // catches the opposite error: a scan of all source rather than of the
+      // published entries picks up an icon barrel's `Users` and charges four
+      // diagnostics for a name every reader generates.
+      expect(readerOwnedName("Posts")).toBe(true);
+      expect(readerOwnedName("MyCollection")).toBe(true);
+      expect(readerOwnedName("Users")).toBe(true);
+    },
+    BUILDS_THE_PROGRAM
+  );
+
+  it(
+    "separates the names that can supply a value",
+    () => {
+      // `Media` is exported as a type by `nextly` and as an interface by
+      // `@nextlyhq/admin`, and by nothing as a value.
+      expect(workspaceValueExports().has("Media")).toBe(false);
+      // The control: the same set answers yes for a real component, so the
+      // check above is a namespace distinction rather than an empty set.
+      expect(workspaceValueExports().has("Skeleton")).toBe(true);
+    },
+    BUILDS_THE_PROGRAM
+  );
+
+  it(
+    "reads a type-only name by how the block used it",
+    () => {
+      // `collections: [Posts, Users, Media]` needs a value, and no import here
+      // can supply one, so that `Media` is the reader's own collection exactly
+      // as `Posts` is.
+      expect(
+        readerOwnedMention(
+          "Media",
+          "const config = { collections: [Posts, Users, Media] };",
+          "ts"
+        )
+      ).toBe(true);
+      // The opposite, and the control: as a type it IS importable, so a sample
+      // using it without the import is a defect a reader meets.
+      expect(readerOwnedMention("Media", "declare const m: Media;", "ts")).toBe(
+        false
+      );
+      // A name exported as a value stays a finding however it is used.
+      expect(
+        readerOwnedMention("Skeleton", "const el = <Skeleton />;", "tsx")
+      ).toBe(false);
+    },
+    BUILDS_THE_PROGRAM
+  );
+});
+
+describe("how a block used a name", () => {
+  it("tells a value position from a type position", () => {
+    expect(usedOnlyAsValue("const a = [Media];", "Media", "ts")).toBe(true);
+    expect(usedOnlyAsValue("declare const m: Media;", "Media", "ts")).toBe(
+      false
+    );
+    expect(usedOnlyAsValue("type X = typeof Media;", "Media", "ts")).toBe(
+      false
+    );
+  });
+
+  it("keeps the finding when a block uses the name both ways", () => {
+    // The loud direction. Setting it aside would silence the type reference,
+    // which is one a reader would meet.
+    expect(usedOnlyAsValue("const m: Media = Media;", "Media", "ts")).toBe(
+      false
+    );
+  });
+
+  it("answers no for a name the block never mentions", () => {
+    // The control for the two above: `mentioned` is load-bearing, so an absent
+    // name cannot read as a value use.
+    expect(usedOnlyAsValue("const a = 1;", "Media", "ts")).toBe(false);
   });
 });

--- a/scripts/check-doc-samples.test.mjs
+++ b/scripts/check-doc-samples.test.mjs
@@ -1243,6 +1243,14 @@ describe("the workspace's own exported names", () => {
     expect(readerOwnedName("Skeleton")).toBe(false);
     // Published from a subpath and deliberately kept out of the root barrel.
     expect(readerOwnedName("BuilderShell")).toBe(false);
+    // Six subpath entries in `nextly` and `@nextlyhq/ui` are bundle names with
+    // no same-named source, so they resolve from `dist` and contribute nothing
+    // on an unbuilt tree. These two are what a symbol behind one of them looks
+    // like, and both are reached through an entry that does resolve, so the
+    // answer is the same either way. Pinned because it is the case that would
+    // otherwise silence a real finding.
+    expect(readerOwnedName("FIELD_TYPE_CATALOG")).toBe(false);
+    expect(readerOwnedName("WidgetResult")).toBe(false);
     // The reader's, and the control: a set that answered "exported" to
     // everything would satisfy the three above.
     expect(readerOwnedName("Posts")).toBe(true);

--- a/scripts/check-doc-samples.test.mjs
+++ b/scripts/check-doc-samples.test.mjs
@@ -16,6 +16,7 @@ import {
   identityOf,
   isModule,
   pageOf,
+  readerOwnedName,
   parseSample,
   rebaseContextDiagnostics,
   unaccountedFor,
@@ -621,6 +622,7 @@ describe("unaccountedFor", () => {
     real: 4,
     continued: 2,
     readerFiles: 2,
+    readerNames: 0,
     uninstalled: 1,
     implicitAny: 1,
   };
@@ -1180,5 +1182,46 @@ describe("a sample that writes a property the API has deprecated", () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+
+describe("a missing name the reader owns", () => {
+  it("sets aside a type the reader's own project declares", () => {
+    // `nextly generate:types` writes these into a reader's project, and a
+    // component is theirs to write. Nothing in this workspace can define one,
+    // so a page mentioning it is not broken.
+    for (const name of ["Posts", "Users", "Page", "MyCollection", "Chart"]) {
+      expect(readerOwnedName(name)).toBe(true);
+    }
+  });
+
+  it("keeps a name this workspace actually exports", () => {
+    // The case that decides the rule. `Media` and `Skeleton` look exactly like
+    // the names above and are the opposite: both ARE exported, from `nextly`
+    // and `@nextlyhq/ui`, so a sample using one without importing it is a
+    // defect a reader meets. A rule keyed on the shape alone would have
+    // silenced five findings in the current corpus.
+    for (const name of ["Media", "Skeleton", "Nextly", "NextlyError"]) {
+      expect(readerOwnedName(name)).toBe(false);
+    }
+  });
+
+  it("leaves a value alone, whatever it is called", () => {
+    // The shape narrows the question to names a reader DECLARES. An undefined
+    // `orderData` or a bare `a` is an example that was left unfinished, which
+    // is a finding.
+    for (const name of ["orderData", "where", "a", "getPostBySlug"]) {
+      expect(readerOwnedName(name)).toBe(false);
+    }
+  });
+
+  it("differs from the shape rule it replaces", () => {
+    // The control. Both halves are load-bearing and this shows which half each
+    // name needs: the shape rule alone accepts `Media`, and the export rule
+    // alone accepts `orderData`.
+    const looksOwned = name => /^[A-Z][A-Za-z0-9]*$/.test(name);
+    expect(looksOwned("Media")).toBe(true);
+    expect(readerOwnedName("Media")).toBe(false);
+    expect(looksOwned("orderData")).toBe(false);
+    expect(readerOwnedName("orderData")).toBe(false);
   });
 });

--- a/scripts/doc-samples-baseline.json
+++ b/scripts/doc-samples-baseline.json
@@ -210,8 +210,6 @@
     "docs/plugins/auth.mdx": 3,
     "docs/plugins/author-guide.mdx": 2,
     "docs/plugins/distribution.mdx": 1,
-    "docs/plugins/form-builder.mdx": 2,
-    "docs/plugins/index.mdx": 2,
     "docs/plugins/lifecycle.mdx": 2,
     "docs/database/mysql.mdx": 3,
     "docs/guides/isr-caching.mdx": 1
@@ -261,25 +259,6 @@
     "docs/plugins/distribution.mdx": {
       "#0 error TS2304: Cannot find name 'myPlugin'.": 1
     },
-    "docs/plugins/form-builder.mdx": {
-      "#0 error TS2304: Cannot find name 'Media'.": 1,
-      "#20 error TS2304: Cannot find name 'Media'.": 1,
-      "reader-name #0 error TS2304: Cannot find name 'Posts'.": 1,
-      "reader-name #0 error TS2304: Cannot find name 'Users'.": 1,
-      "reader-name #20 error TS2304: Cannot find name 'Posts'.": 1,
-      "reader-name #20 error TS2304: Cannot find name 'Users'.": 1
-    },
-    "docs/plugins/index.mdx": {
-      "#0 error TS2304: Cannot find name 'Media'.": 1,
-      "#1 error TS2304: Cannot find name 'Media'.": 1,
-      "suppressed #3 error TS2339: Property 'id' does not exist on type '{}'.": 1,
-      "reader-file #4 error TS2307: Cannot find module './collections/my-collection' or its corresponding type declarations.": 1,
-      "reader-name #0 error TS2304: Cannot find name 'Posts'.": 1,
-      "reader-name #0 error TS2304: Cannot find name 'Users'.": 1,
-      "reader-name #1 error TS2304: Cannot find name 'Posts'.": 1,
-      "reader-name #1 error TS2304: Cannot find name 'Users'.": 1,
-      "reader-name #2 error TS2304: Cannot find name 'MyCollection'.": 1
-    },
     "docs/plugins/lifecycle.mdx": {
       "#1 error TS2304: Cannot find name 'a'.": 1,
       "#1 error TS2304: Cannot find name 'b'.": 1
@@ -303,6 +282,17 @@
     "docs/getting-started/index.mdx": {
       "suppressed #1 error TS2322: Type 'unknown' is not assignable to type 'Key | null | undefined'.": 1,
       "suppressed #1 error TS2322: Type 'unknown' is not assignable to type 'ReactNode'.": 1
+    },
+    "docs/plugins/index.mdx": {
+      "suppressed #3 error TS2339: Property 'id' does not exist on type '{}'.": 1,
+      "reader-file #4 error TS2307: Cannot find module './collections/my-collection' or its corresponding type declarations.": 1,
+      "reader-name #0 error TS2304: Cannot find name 'Posts'.": 1,
+      "reader-name #0 error TS2304: Cannot find name 'Users'.": 1,
+      "reader-name #0 error TS2304: Cannot find name 'Media'.": 1,
+      "reader-name #1 error TS2304: Cannot find name 'Posts'.": 1,
+      "reader-name #1 error TS2304: Cannot find name 'Users'.": 1,
+      "reader-name #1 error TS2304: Cannot find name 'Media'.": 1,
+      "reader-name #2 error TS2304: Cannot find name 'MyCollection'.": 1
     },
     "docs/guides/email.mdx": {
       "implicit-any #4 error TS7006: Parameter 'data' implicitly has an 'any' type.": 3,
@@ -348,6 +338,14 @@
     },
     "docs/plugins/testing.mdx": {
       "reader-file #0 error TS2307: Cannot find module '../src' or its corresponding type declarations.": 1
+    },
+    "docs/plugins/form-builder.mdx": {
+      "reader-name #0 error TS2304: Cannot find name 'Posts'.": 1,
+      "reader-name #0 error TS2304: Cannot find name 'Users'.": 1,
+      "reader-name #0 error TS2304: Cannot find name 'Media'.": 1,
+      "reader-name #20 error TS2304: Cannot find name 'Posts'.": 1,
+      "reader-name #20 error TS2304: Cannot find name 'Users'.": 1,
+      "reader-name #20 error TS2304: Cannot find name 'Media'.": 1
     }
   }
 }

--- a/scripts/doc-samples-baseline.json
+++ b/scripts/doc-samples-baseline.json
@@ -205,13 +205,13 @@
   "pages": {
     "docs/getting-started/quick-start.mdx": 1,
     "docs/guides/media-storage.mdx": 1,
-    "docs/guides/routing-and-seo.mdx": 6,
-    "docs/plugins/admin-ui.mdx": 2,
+    "docs/guides/routing-and-seo.mdx": 3,
+    "docs/plugins/admin-ui.mdx": 1,
     "docs/plugins/auth.mdx": 3,
     "docs/plugins/author-guide.mdx": 2,
     "docs/plugins/distribution.mdx": 1,
-    "docs/plugins/form-builder.mdx": 6,
-    "docs/plugins/index.mdx": 7,
+    "docs/plugins/form-builder.mdx": 2,
+    "docs/plugins/index.mdx": 2,
     "docs/plugins/lifecycle.mdx": 2,
     "docs/database/mysql.mdx": 3,
     "docs/guides/isr-caching.mdx": 1
@@ -232,19 +232,19 @@
       "reader-file #12 error TS2307: Cannot find module '../../../nextly.config' or its corresponding type declarations.": 1
     },
     "docs/guides/routing-and-seo.mdx": {
-      "#3 error TS2304: Cannot find name 'Page'.": 1,
-      "#4 error TS2304: Cannot find name 'Page'.": 1,
-      "#6 error TS2304: Cannot find name 'Page'.": 1,
       "#7 error TS2304: Cannot find name 'getPostBySlug'.": 1,
       "#8 error TS2304: Cannot find name 'services'.": 1,
       "#8 error TS18004: No value exists in scope for the shorthand property 'baseUrl'. Either declare one or provide an initializer.": 1,
-      "implicit-any #5 error TS7006: Parameter 'entry' implicitly has an 'any' type.": 1
+      "implicit-any #5 error TS7006: Parameter 'entry' implicitly has an 'any' type.": 1,
+      "reader-name #3 error TS2304: Cannot find name 'Page'.": 1,
+      "reader-name #4 error TS2304: Cannot find name 'Page'.": 1,
+      "reader-name #6 error TS2304: Cannot find name 'Page'.": 1
     },
     "docs/plugins/admin-ui.mdx": {
       "#9 error TS2304: Cannot find name 'Skeleton'.": 1,
-      "#9 error TS2304: Cannot find name 'Chart'.": 1,
       "uninstalled #11 error TS2307: Cannot find module '@acme/nextly-plugin-reports' or its corresponding type declarations.": 1,
-      "reader-file #0 error TS2307: Cannot find module './ReportsView' or its corresponding type declarations.": 1
+      "reader-file #0 error TS2307: Cannot find module './ReportsView' or its corresponding type declarations.": 1,
+      "reader-name #9 error TS2304: Cannot find name 'Chart'.": 1
     },
     "docs/plugins/auth.mdx": {
       "#1 error TS2304: Cannot find name 'verifyGoogleToken'.": 1,
@@ -262,23 +262,23 @@
       "#0 error TS2304: Cannot find name 'myPlugin'.": 1
     },
     "docs/plugins/form-builder.mdx": {
-      "#0 error TS2304: Cannot find name 'Posts'.": 1,
-      "#0 error TS2304: Cannot find name 'Users'.": 1,
       "#0 error TS2304: Cannot find name 'Media'.": 1,
-      "#20 error TS2304: Cannot find name 'Posts'.": 1,
-      "#20 error TS2304: Cannot find name 'Users'.": 1,
-      "#20 error TS2304: Cannot find name 'Media'.": 1
+      "#20 error TS2304: Cannot find name 'Media'.": 1,
+      "reader-name #0 error TS2304: Cannot find name 'Posts'.": 1,
+      "reader-name #0 error TS2304: Cannot find name 'Users'.": 1,
+      "reader-name #20 error TS2304: Cannot find name 'Posts'.": 1,
+      "reader-name #20 error TS2304: Cannot find name 'Users'.": 1
     },
     "docs/plugins/index.mdx": {
-      "#0 error TS2304: Cannot find name 'Posts'.": 1,
-      "#0 error TS2304: Cannot find name 'Users'.": 1,
       "#0 error TS2304: Cannot find name 'Media'.": 1,
-      "#1 error TS2304: Cannot find name 'Posts'.": 1,
-      "#1 error TS2304: Cannot find name 'Users'.": 1,
       "#1 error TS2304: Cannot find name 'Media'.": 1,
-      "#2 error TS2304: Cannot find name 'MyCollection'.": 1,
       "suppressed #3 error TS2339: Property 'id' does not exist on type '{}'.": 1,
-      "reader-file #4 error TS2307: Cannot find module './collections/my-collection' or its corresponding type declarations.": 1
+      "reader-file #4 error TS2307: Cannot find module './collections/my-collection' or its corresponding type declarations.": 1,
+      "reader-name #0 error TS2304: Cannot find name 'Posts'.": 1,
+      "reader-name #0 error TS2304: Cannot find name 'Users'.": 1,
+      "reader-name #1 error TS2304: Cannot find name 'Posts'.": 1,
+      "reader-name #1 error TS2304: Cannot find name 'Users'.": 1,
+      "reader-name #2 error TS2304: Cannot find name 'MyCollection'.": 1
     },
     "docs/plugins/lifecycle.mdx": {
       "#1 error TS2304: Cannot find name 'a'.": 1,


### PR DESCRIPTION
Closes `finding:the-ratchet-charges-a-page-for-being-complete`.

## The problem

About half the remaining findings were undefined PascalCase names that belong to the reader: types `nextly generate:types` writes into their project, and components they author. Counted per occurrence, so a page that mentions its own component twice was charged twice, and **adding a render call to an incomplete example raised the count**.

That is an incentive to leave examples unfinished, which is the opposite of what this gate is for. It was found the hard way: the routing example fetched an entry, null-checked it and returned nothing, so a reader got a blank route. Making it render what it resolved added a finding, and the ratchet called the better page worse.

## The rule, and why the obvious one is wrong

**The test is whether the workspace exports the name, not whether it looks like a component.** That distinction decides real cases:

| name | shape says | exports say | verdict |
| --- | --- | --- | --- |
| `Posts`, `Users`, `Page`, `MyCollection`, `Chart` | reader's | exported by nothing here | **set aside** |
| `Media` | reader's | **exported by `nextly`** | **stays a finding** |
| `Skeleton` | reader's | **exported by `@nextlyhq/ui`** | **stays a finding** |
| `orderData`, `where`, `a` | not a declared type | n/a | **stays a finding** |

A rule keyed on the shape alone would have silenced five findings in the current corpus. `Media` and `Skeleton` look exactly like the reader-owned names and are the opposite case: both are real exports, so a sample using one without importing it is a defect a reader meets.

The shape still narrows the question to names a reader *declares*, which is why an undefined `orderData` or a bare `a` stays reported: those are examples left unfinished, not the reader's project showing through.

The names come from the built `.d.ts` entries of every publishable package, read in one program, because that is what a reader installs.

## Set aside, not excused

`readerNames` is a term in the `unaccountedFor` conservation post-condition rather than a fifth thing to remember, and the lines are ratcheted by identity like every other set-aside bucket. A page cannot start mentioning a new one unnoticed; what stops is charging the page for it.

## Evidence

35 findings become **22**, with 13 recorded by identity instead. The corpus moving is not the proof, though, so:

**The incentive is demonstrably gone.** Adding another reference to the reader's own `Page` type to `routing-and-seo.mdx` leaves findings at 22 and moves the set-aside count from 13 to 14. Under the old rule that same edit made the page worse.

**`Media` and `Skeleton` still fail**, verified in the report after the change.

Four unit tests, including a control that shows which half of the rule each name needs: the shape rule alone accepts `Media`, and the export rule alone accepts `orderData`.

1069 tests across `scripts/`, `check:comments` and `check:docs-claims` clean. Baseline rewritten with `--allow-new-findings`, deliberately: the same lines are re-marked, so their identities change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Documentation sample checks now distinguish reader-defined names from workspace-provided names.
  - Reports classify reader-owned names separately, improving diagnostic clarity and reducing misleading findings.
  - Updated documentation baselines reclassify sample findings, including missing symbols and reader-owned files, for more accurate results.

- **Tests**
  - Added coverage for reader-owned names, value-versus-type usage, and published workspace exports to improve validation of documentation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->