### PR TITLE
feat(plugin-page-builder): let an author save a selection into the pattern library

### DIFF
--- a/.changeset/a-pattern-an-author-can-actually-save.md
+++ b/.changeset/a-pattern-an-author-can-actually-save.md
@@ -1,0 +1,47 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+An author could browse the pattern library and never put anything in it. The
+planner that turns a selection into a stored pattern had no caller, so the
+Patterns tier shipped with nothing to show and no way to add to it.
+
+The page builder now contributes the write that fills it. The editor posts the
+document and the selection, and the SERVER plans the save — because the planner
+decides what a pattern is by asking the block registry, and the two registries
+are not the same: the browser holds the core blocks, while the server also holds
+every block another plugin declared. A browser that planned its own save would
+answer nesting questions about blocks it has never heard of, and store a pattern
+nothing can place.
+
+The row is created published, because a draft pattern is deliberately kept out
+of the insert panel — leaving the column's default would answer the author with
+a pattern their own library does not show. The write runs as the user, so an
+author without permission to publish one is refused by the collection rather
+than by the route having been careful. A selection the planner will not save is
+refused before anything is written, with the planner's own cause travelling
+verbatim so the caller compares against the vocabulary it already has.

--- a/packages/blocks-engine/src/composition-planners.test.ts
+++ b/packages/blocks-engine/src/composition-planners.test.ts
@@ -154,6 +154,43 @@ describe("whether a selection may be saved at all", () => {
     ).toBeUndefined();
   });
 
+  it.each([
+    ["an envelope with no nodes at all", { formatVersion: 1, kind: "page" }],
+    [
+      "nodes that are not a list",
+      { formatVersion: 1, kind: "page", nodes: "x" },
+    ],
+  ])("ANSWERS about %s rather than throwing", (_name, document) => {
+    // The preflight's whole promise is a verdict, and a caller that gets an
+    // exception instead has no verdict to act on: a toolbar asking whether the
+    // selected blocks can be saved would crash where it meant to disable a
+    // button, and a route would report a bad request as a server fault.
+    //
+    // These are not hypothetical shapes. A stored page reaches this unvalidated
+    // and a request body is whatever was posted, so the document arrives from
+    // outside either way.
+    //
+    // The ENVELOPE is what has to be asked about, and only the envelope: a
+    // `null` among otherwise good roots is measured to answer rather than
+    // throw, so refusing on the forest would refuse documents this already
+    // reads correctly.
+    const refusal = saveAsPatternRefusal(
+      document as unknown as BlockDocument,
+      ["a"],
+      anyParent
+    );
+
+    expect(refusal?.problem).toBe("unusable-document");
+  });
+
+  it("still answers about a document it CAN read, so the guard is not a blanket refusal", () => {
+    // The control. A guard that refused everything would satisfy every
+    // assertion above while making the verb permanently unavailable.
+    expect(
+      saveAsPatternRefusal(page([node("a")]), ["a"], anyParent)
+    ).toBeUndefined();
+  });
+
   it("refuses a valid RUN whose stored document could not be saved", () => {
     // The case that decides which preflight this is. `savableRun` alone asks
     // only whether the selection is one contiguous, liftable run — it never

--- a/packages/blocks-engine/src/composition-planners.ts
+++ b/packages/blocks-engine/src/composition-planners.ts
@@ -361,6 +361,28 @@ export interface PlanRefusal {
 export type PlanResult<TFields> = CompositionPlan<TFields> | PlanRefusal;
 
 /**
+ * A plan that is guaranteed to have created something, or the cause it did not.
+ *
+ * {@link CompositionPlan.create} is optional because a composition action need
+ * not create anything — `planDetach` only edits the page — so the shared shape
+ * cannot promise a row. A planner whose whole purpose is to fill the library
+ * always does, and saying so in the type is what stops every caller writing a
+ * branch for a state its planner cannot reach: an impossible branch is one that
+ * can never be exercised, so nothing ever proves it does the right thing, and
+ * the first reader to simplify it has no way to tell whether it was defensive
+ * or load-bearing.
+ *
+ * It narrows nothing else, and it is applied per planner rather than to a group
+ * of them. Each planner's guarantee is its own — a `create` here, a `create` and
+ * `pageOps` for a convert, an `update` for a save-over — and one alias spanning
+ * them would assert whichever guarantee its name suggested for planners that
+ * were never checked against it.
+ */
+export type CreatePlanResult<TFields> =
+  | (CompositionPlan<TFields> & { readonly create: PlannedCreate<TFields> })
+  | PlanRefusal;
+
+/**
  * Where a saved selection is stored, in the caller's vocabulary.
  *
  * One type for all three library kinds rather than one per planner. A pattern,
@@ -424,7 +446,7 @@ export function planSaveAsPattern<TFields>(
   selectedIds: readonly string[],
   target: LibraryTarget<TFields>,
   nesting: NestingSource
-): PlanResult<TFields> {
+): CreatePlanResult<TFields> {
   const saved = plannedSave(document, selectedIds, nesting);
   if (saved.problem !== undefined) return saved;
 

--- a/packages/blocks-engine/src/composition-planners.ts
+++ b/packages/blocks-engine/src/composition-planners.ts
@@ -494,6 +494,30 @@ function plannedSave(
   // host's cap rather than the default.
   limits: DocumentLimits = DEFAULT_LIMITS
 ): PlannedSave | PlanRefusal {
+  // The one thing the SOURCE has to be for the search to happen at all: a list
+  // of roots. `contiguousRun` walks `document.nodes` to locate the selection, so
+  // a document whose `nodes` is absent or is not a list fails there as a native
+  // `TypeError` rather than as the refusal this returns — and that difference
+  // reaches a caller. A route reports it as a server fault instead of a bad
+  // request, and the published preflight throws where it promised a verdict, so
+  // a toolbar asking whether a save is possible crashes instead of disabling a
+  // button.
+  //
+  // Deliberately NOT `documentRefusal`, which is what `planInsertPattern` asks
+  // of the document it EDITS. That one also judges the source's `formatVersion`
+  // and `kind`, and a save reads neither: `kind` is written here, so a page
+  // whose own kind is unreadable still yields a perfectly good pattern —
+  // {@link savedPatternDocument} says so, and refusing it would be asking about
+  // the origin rather than about the thing.
+  //
+  // Not `forestRefusal` either, which walks every entry. An insert applies ops
+  // across the whole forest, so a malformed node the selection never touched
+  // still throws on apply; a save applies nothing to the page, and refusing on
+  // rubbish elsewhere would stop an author rescuing the part of their page that
+  // is still good. Measured: a `null` beside good roots already answers rather
+  // than throwing.
+  if (!Array.isArray(document.nodes)) return { problem: "unusable-document" };
+
   const run = savableRun(document, selectedIds, nesting);
   if (run.problem !== undefined) return run;
 

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -211,6 +211,7 @@ export {
 export type {
   ComponentExposure,
   CompositionPlan,
+  CreatePlanResult,
   InsertTarget,
   StoredPattern,
   PlacementTarget,

--- a/packages/nextly/src/config.ts
+++ b/packages/nextly/src/config.ts
@@ -193,6 +193,16 @@ export type { RouteMethod } from "./plugins/routes/route-types";
 // they meant.
 export type { JsonValue } from "./plugins/admin-contributions";
 
+// And what a plugin route may have to say about a write that already
+// committed. Published here for the same reason the two above are: a plugin
+// route reporting a post-commit hook failure and the plugin UI reading that
+// report are two halves of one package, and only one of them may load the
+// framework. Without a shared name the browser half either restates the shape
+// -- a second definition that drifts the first time a field is added -- or
+// types the field as `unknown` and stops being able to say anything about it.
+// A pure interface of strings, so this costs the browser nothing.
+export type { HookWarning } from "./hooks/side-effect-warnings";
+
 // The admin CONTRIBUTION shapes, published so the admin panel can DERIVE its
 // `/admin-meta` types from the declaration the server serializes rather than
 // restating them. `buildPluginAdminMeta` copies a contributed widget verbatim

--- a/packages/nextly/src/index.ts
+++ b/packages/nextly/src/index.ts
@@ -136,6 +136,28 @@ export { nextly } from "./direct-api";
 // were removed in PR 12 (final unified-error-system cleanup).
 export { NextlyError } from "./errors";
 
+// The canonical mutation builder, published so a CONTRIBUTED route can answer
+// in the same envelope every first-party write answers in.
+//
+// A plugin route is the one HTTP surface here that could not reach it, and the
+// consequence is not stylistic: `respondMutation` reads the request's own
+// side-effect warning scope, so a hand-built mutation body silently drops a
+// post-commit hook failure that every other write reports. A route rebuilding
+// the shape by hand also gains whatever the builder gains next only if somebody
+// remembers to copy it — the same defect the plugin error path already had, one
+// level along.
+export { respondMutation } from "./api/response-shapes";
+
+// The slug rule, published because it was already documented as though it were.
+// `prebuilt`'s own auto-slug docblock shows `slugify(context.data.title)` as the
+// way to derive one, and the name does not survive to this entry: two modules in
+// this package export a `slugify`, so the star re-export that would have carried
+// it drops the ambiguous name and the advertised call does not resolve. Named
+// explicitly here, which is also what decides WHICH of the two is the public
+// one — the unicode-normalising rule the hook uses, not the filename helper the
+// migration writer uses.
+export { slugify } from "./hooks/prebuilt";
+
 // Direct API types - type-safe slug resolution (for generated types integration)
 export type {
   GeneratedTypes,

--- a/packages/plugin-page-builder/src/library-contract.ts
+++ b/packages/plugin-page-builder/src/library-contract.ts
@@ -163,25 +163,61 @@ export const SAVE_PATTERN_ROUTE_PATH = "/save-as-pattern";
  * The metadata a saved pattern carries, as the surface that saves it states
  * them.
  *
- * These are the `patterns` collection's own fields, and the route does not
- * trust this list at runtime: it takes the field names from the collection
- * itself, so a caller cannot reach a column the collection never declared.
- * What this type is for is the DIALOG — the surface filling the form needs to
- * know what to ask for, and it runs in a browser that cannot load the
- * collection module.
+ * These are the `patterns` collection's own fields, and the route does not trust
+ * this list at runtime: it takes the field names from the collection itself, so
+ * a caller cannot reach a column the collection never declared. What this type
+ * is for is the DIALOG — the surface filling the form needs to know what to ask
+ * for, and it runs in a browser that cannot load the collection module.
  *
  * A type naming a source of truth it cannot track is how a contract goes quietly
- * stale, so `save-pattern-contract.test.ts` compares these keys against the
- * collection's declared fields and fails when they part company.
+ * stale, so {@link SAVE_PATTERN_FIELD_NAMES} carries these keys as a VALUE and
+ * `save-pattern-contract.test.ts` compares that value against the collection's
+ * declared fields.
  */
 export interface SavePatternFields {
   readonly title: string;
-  readonly slug: string;
+  /**
+   * The identifier the library keys this pattern by, when the caller has one.
+   *
+   * OPTIONAL, and the dialog does not ask for it. It is not a URL — nothing
+   * resolves a pattern by slug — so it is an identity rather than an address,
+   * and asking an author to type one is a second field that restates the name
+   * they already gave. The route derives it from the title, which is also the
+   * only place that could ever disambiguate one.
+   */
+  readonly slug?: string;
   readonly granularity: PatternGranularity;
   readonly description?: string;
   readonly category?: string;
   readonly keywords?: string;
 }
+
+/**
+ * The keys of {@link SavePatternFields}, as a value something can compare.
+ *
+ * The `satisfies` is the whole point: it is checked by `tsc`, in a file the
+ * package's type program actually reads, so a property added to or removed from
+ * the interface fails the build here until this list moves with it. The obvious
+ * place for a witness like this is the test that uses it, and in this package
+ * that would not work — `tsconfig.tests.json` deliberately keeps `*.test.ts` out
+ * of the program, so a `Record<keyof …>` written there is transpiled and never
+ * evaluated, and the guard silently checks nothing.
+ *
+ * With both halves in place the drift is caught from either side: this fails to
+ * compile when the interface moves, and the contract test fails when the
+ * collection moves.
+ */
+export const SAVE_PATTERN_FIELD_NAMES = Object.keys({
+  title: true,
+  slug: true,
+  granularity: true,
+  description: true,
+  category: true,
+  keywords: true,
+} satisfies Record<
+  keyof SavePatternFields,
+  true
+>) as readonly (keyof SavePatternFields)[];
 
 /**
  * What the editor sends to store a selection as a pattern.
@@ -211,14 +247,21 @@ export interface SavePatternRequest {
 /**
  * What a completed save answers.
  *
- * The id, because the surface that saved has nothing else to address the new
- * pattern by, and the warnings, because a post-commit hook can fail after the
- * row is durable. Dropping those would report a save as wholly successful when
- * part of it was not — and the row cannot be un-saved, so the only remedy is to
- * say so.
+ * The CANONICAL mutation envelope, which is what every other write in this
+ * codebase answers with — `{ message, item }`, and `warnings` when a hook failed
+ * after the row was already durable. A route inventing its own shape here would
+ * make a plugin's write the one write a shared client cannot read, and the
+ * warnings are the part that goes wrong quietly: a post-commit failure cannot be
+ * undone, so a body that omits it reports a partial success as a whole one.
+ *
+ * Built by `respondMutation` rather than assembled, so it cannot drift from the
+ * envelope and so the warnings come from the request's own scope rather than
+ * from a second path to the same list.
  */
 export interface SavePatternResponse {
-  readonly id: string;
+  readonly message: string;
+  /** The row that was created, as the collection stored it. */
+  readonly item: { readonly id: string } & Record<string, unknown>;
   /** Side effects that failed after the row committed, when any did. */
   readonly warnings?: readonly HookWarning[];
 }

--- a/packages/plugin-page-builder/src/library-contract.ts
+++ b/packages/plugin-page-builder/src/library-contract.ts
@@ -1,8 +1,11 @@
 /**
  * What the pattern library route answers, named where both ends can read it.
  *
- * IMPORT-FREE, deliberately, and that is the whole reason this file is separate
- * from the route that implements it. The route reaches the collection through
+ * FREE OF RUNTIME IMPORTS, deliberately, and that is the whole reason this file
+ * is separate from the route that implements it. Types are the exception and
+ * cost nothing — they are erased before a browser sees them — so the shapes
+ * both ends must agree on can be named here without either end's runtime
+ * arriving with them. The route reaches the collection through
  * `nextly/config`, which pulls the Direct API — server-only, and it says so at
  * load time. A browser module importing the route for one path constant brings
  * that with it: measured, importing it from the admin client took eleven test
@@ -15,7 +18,9 @@
  *
  * @module library-contract
  */
+import type { BlockDocument } from "@nextlyhq/blocks-engine";
 import type { SavedPattern } from "@nextlyhq/builder";
+import type { HookWarning } from "nextly/config";
 
 /**
  * The name this plugin registers under, which is also how its routes are
@@ -140,4 +145,80 @@ export interface LibraryResponse {
     /** Whether the ceiling stopped the read before the collection ended. */
     readonly truncated: boolean;
   };
+}
+
+/**
+ * Where the editor sends a selection to be stored as a pattern.
+ *
+ * Named for the VERB rather than for a resource, because the verbs that follow
+ * it are not all creations. `Save as component` creates a definition, and
+ * `Convert to component` and `Detach` also hand back ops that change the page
+ * the author is editing — so a resource path would fit the first two and have
+ * nothing to address for the others. One shape for the whole family is what
+ * lets a reader of `contributes.routes` see them as one family.
+ */
+export const SAVE_PATTERN_ROUTE_PATH = "/save-as-pattern";
+
+/**
+ * The metadata a saved pattern carries, as the surface that saves it states
+ * them.
+ *
+ * These are the `patterns` collection's own fields, and the route does not
+ * trust this list at runtime: it takes the field names from the collection
+ * itself, so a caller cannot reach a column the collection never declared.
+ * What this type is for is the DIALOG — the surface filling the form needs to
+ * know what to ask for, and it runs in a browser that cannot load the
+ * collection module.
+ *
+ * A type naming a source of truth it cannot track is how a contract goes quietly
+ * stale, so `save-pattern-contract.test.ts` compares these keys against the
+ * collection's declared fields and fails when they part company.
+ */
+export interface SavePatternFields {
+  readonly title: string;
+  readonly slug: string;
+  readonly granularity: PatternGranularity;
+  readonly description?: string;
+  readonly category?: string;
+  readonly keywords?: string;
+}
+
+/**
+ * What the editor sends to store a selection as a pattern.
+ *
+ * The DOCUMENT and the SELECTION, not a pattern the browser already built. The
+ * planner decides what a saved pattern is — which nodes travel, what is
+ * re-identified, which selections are refusable — and it decides it against the
+ * block registry, which is not the same registry at both ends: the browser
+ * registers the core blocks, while the server also holds every block another
+ * plugin declared. A browser that planned the save would answer a nesting
+ * question about blocks it has never heard of, and store a pattern nothing can
+ * place.
+ *
+ * It is also the difference between a rule and a convention. A pattern posted
+ * ready-made would be whatever its caller decided to send, and the guarantee the
+ * insert panel leans on — that a stored pattern is one the planner would place —
+ * would hold only for callers that chose to honour it.
+ */
+export interface SavePatternRequest {
+  /** The document the selection was made in. */
+  readonly document: BlockDocument;
+  /** The nodes to lift out of it, in the editor's own vocabulary. */
+  readonly selectedIds: readonly string[];
+  readonly fields: SavePatternFields;
+}
+
+/**
+ * What a completed save answers.
+ *
+ * The id, because the surface that saved has nothing else to address the new
+ * pattern by, and the warnings, because a post-commit hook can fail after the
+ * row is durable. Dropping those would report a save as wholly successful when
+ * part of it was not — and the row cannot be un-saved, so the only remedy is to
+ * say so.
+ */
+export interface SavePatternResponse {
+  readonly id: string;
+  /** Side effects that failed after the row committed, when any did. */
+  readonly warnings?: readonly HookWarning[];
 }

--- a/packages/plugin-page-builder/src/plugin-save-pattern-route-wiring.test.ts
+++ b/packages/plugin-page-builder/src/plugin-save-pattern-route-wiring.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Whether installing the plugin actually accepts a saved pattern.
+ *
+ * `save-pattern-route.test.ts` exercises the write directly, so every one of its
+ * assertions passes with the route deleted from `contributes.routes` — the
+ * module would be perfectly correct and never mounted, and the editor would post
+ * to a path that answers 404. An author would click Save and be told nothing.
+ *
+ * This is the one assertion that fails when the wiring is absent.
+ *
+ * @module plugin-save-pattern-route-wiring.test
+ */
+import { describe, expect, it } from "vitest";
+
+import { SAVE_PATTERN_ROUTE_PATH } from "./library-contract";
+import { pageBuilder } from "./plugin";
+
+describe("the save-as-pattern route is contributed, not merely written", () => {
+  const routes = pageBuilder().contributes?.routes ?? [];
+  const save = routes.find(route => route.path === SAVE_PATTERN_ROUTE_PATH);
+
+  it("is mounted at the path the editor will post to", () => {
+    expect(save).toBeDefined();
+    expect(save?.method).toBe("POST");
+  });
+
+  it("is NOT public", () => {
+    // A plugin route is authenticated unless it opts out, so this asserts the
+    // opt-out is absent rather than that a flag is set. An anonymous write here
+    // would let anyone add a pattern every author on the site is then offered.
+    expect(save?.public).not.toBe(true);
+  });
+
+  it("declares no permission, so a renamed collection stays writable", () => {
+    // The same deliberate omission the read makes, and worth pinning for the
+    // same reason: a declared permission has to spell the collection slug, a
+    // host may rename that collection, and the seeded grant then carries the
+    // new name while the route demands the old one. The write runs as the user,
+    // so the service enforces the real, resolved permission instead.
+    expect(save?.requiredPermission).toBeUndefined();
+  });
+
+  it("is a route of its own, not the library read wearing a second method", () => {
+    // The read and the write are separate contributions. One route object with
+    // a method that varied would be a dispatcher this package wrote itself, and
+    // the framework's own registry is what refuses a duplicate mount.
+    const paths = routes.map(route => `${route.method} ${route.path}`);
+    expect(new Set(paths).size).toBe(paths.length);
+    expect(paths).toContain(`POST ${SAVE_PATTERN_ROUTE_PATH}`);
+  });
+});

--- a/packages/plugin-page-builder/src/plugin.ts
+++ b/packages/plugin-page-builder/src/plugin.ts
@@ -44,6 +44,7 @@ import { hostFetchPolicy } from "./host-policy";
 import { PAGE_BUILDER_PLUGIN_NAME } from "./library-contract";
 import { patternLibraryRoute } from "./library-route";
 import { previewViewportsFromSiteStyle } from "./preview-viewports";
+import { savePatternRoute } from "./save-pattern-route";
 import { resolveSiteStyle, siteBreakpoints } from "./site-style";
 import type { SiteStyleData } from "./site-style";
 import { siteStyleSingle } from "./site-style-storage";
@@ -542,7 +543,13 @@ export const pageBuilder = (opts: PageBuilderOptions = {}) => {
       // not exported from `@nextlyhq/plugin-sdk/admin`, which is the only
       // surface this package may import from, so there is no browser-side
       // collection read available to it at all.
-      routes: [patternLibraryRoute()],
+      //
+      // And the one write that fills it. Contributed beside the read rather
+      // than left to the collection API, because what a saved pattern IS is
+      // the planner's answer and the planner needs the server's block
+      // registry — the browser holds the core blocks and not the ones another
+      // plugin declared.
+      routes: [patternLibraryRoute(), savePatternRoute()],
 
       // No `publish` permission. One was declared here and nothing ever read
       // it: publishing a page is a status change on the entry, which

--- a/packages/plugin-page-builder/src/save-pattern-contract.test.ts
+++ b/packages/plugin-page-builder/src/save-pattern-contract.test.ts
@@ -8,32 +8,23 @@
  * stale — a field added to the collection is simply never asked for, and nothing
  * fails.
  *
- * This is the one assertion that notices. It runs in both directions: the record
- * below must gain a key when the interface does, or it will not compile, and its
- * keys are compared against what the collection actually declares.
+ * The drift is caught from both sides, in two places, because neither place can
+ * catch both. `SAVE_PATTERN_FIELD_NAMES` carries a `satisfies Record<keyof …>`
+ * in the contract itself, which `tsc` evaluates, so the interface cannot move
+ * without that list moving. This compares the list against the collection, which
+ * only a running test can do.
+ *
+ * It is deliberately NOT the `Record<keyof …>` witness itself: this package's
+ * `tsconfig.tests.json` keeps `*.test.ts` out of the type program, so a type
+ * constraint written here is transpiled and never evaluated — a guard that
+ * checks nothing while reading as though it checks everything.
  *
  * @module save-pattern-contract.test
  */
 import { describe, expect, it } from "vitest";
 
 import { patternsCollection } from "./collections/patterns";
-import type { SavePatternFields } from "./library-contract";
-
-/**
- * Every field of the request shape, as a value a test can read.
- *
- * `Record<keyof …>` rather than a literal list: adding a property to
- * `SavePatternFields` fails to compile here until it is named, which is what
- * makes this a witness for the interface rather than a second copy of it.
- */
-const REQUEST_FIELDS: Record<keyof SavePatternFields, true> = {
-  title: true,
-  slug: true,
-  granularity: true,
-  description: true,
-  category: true,
-  keywords: true,
-};
+import { SAVE_PATTERN_FIELD_NAMES } from "./library-contract";
 
 /**
  * The field the planner owns.
@@ -56,7 +47,7 @@ describe("the save request and the collection it writes to", () => {
     // not to the request is one an author can never fill; a field added to the
     // request and not to the collection is one the route will drop, so the
     // dialog would offer a control whose value goes nowhere.
-    expect(Object.keys(REQUEST_FIELDS).sort()).toEqual([...declared].sort());
+    expect([...SAVE_PATTERN_FIELD_NAMES].sort()).toEqual([...declared].sort());
   });
 
   it("finds fields at all, so the comparison is not vacuous", () => {

--- a/packages/plugin-page-builder/src/save-pattern-contract.test.ts
+++ b/packages/plugin-page-builder/src/save-pattern-contract.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Whether the shape the dialog fills still matches the table it writes to.
+ *
+ * `SavePatternFields` names the `patterns` collection's fields and cannot read
+ * them: it lives in the import-free contract, because the surface that fills the
+ * form runs in a browser and the collection module reaches the framework. A type
+ * that names a source of truth it cannot track is how a contract goes quietly
+ * stale — a field added to the collection is simply never asked for, and nothing
+ * fails.
+ *
+ * This is the one assertion that notices. It runs in both directions: the record
+ * below must gain a key when the interface does, or it will not compile, and its
+ * keys are compared against what the collection actually declares.
+ *
+ * @module save-pattern-contract.test
+ */
+import { describe, expect, it } from "vitest";
+
+import { patternsCollection } from "./collections/patterns";
+import type { SavePatternFields } from "./library-contract";
+
+/**
+ * Every field of the request shape, as a value a test can read.
+ *
+ * `Record<keyof …>` rather than a literal list: adding a property to
+ * `SavePatternFields` fails to compile here until it is named, which is what
+ * makes this a witness for the interface rather than a second copy of it.
+ */
+const REQUEST_FIELDS: Record<keyof SavePatternFields, true> = {
+  title: true,
+  slug: true,
+  granularity: true,
+  description: true,
+  category: true,
+  keywords: true,
+};
+
+/**
+ * The field the planner owns.
+ *
+ * Excluded from the comparison rather than from the collection: the tree is
+ * stored like any other field, and what makes it different is that a caller may
+ * not supply it.
+ */
+const PLANNER_OWNED = "content";
+
+describe("the save request and the collection it writes to", () => {
+  const declared = patternsCollection()
+    .fields.map(field => field.name)
+    .filter(
+      (name): name is string => name !== undefined && name !== PLANNER_OWNED
+    );
+
+  it("asks for exactly the fields the collection declares", () => {
+    // Both directions in one comparison. A field added to the collection and
+    // not to the request is one an author can never fill; a field added to the
+    // request and not to the collection is one the route will drop, so the
+    // dialog would offer a control whose value goes nowhere.
+    expect(Object.keys(REQUEST_FIELDS).sort()).toEqual([...declared].sort());
+  });
+
+  it("finds fields at all, so the comparison is not vacuous", () => {
+    // The control. An empty declared list would make the assertion above pass
+    // against an empty request shape, and a collection this could not read
+    // would look exactly like a contract in perfect agreement.
+    expect(declared.length).toBeGreaterThan(1);
+  });
+});

--- a/packages/plugin-page-builder/src/save-pattern-route.test.ts
+++ b/packages/plugin-page-builder/src/save-pattern-route.test.ts
@@ -1,0 +1,420 @@
+/**
+ * What actually reaches the table when an author saves a selection.
+ *
+ * The assertions that matter most are the ones an author never sees. That the
+ * write runs as the USER rather than with the instance's identity, that it names
+ * the collection the host actually has, that the tree is stored under the field
+ * the collection declares, and that the row is created in a state the library
+ * will offer — each of those fails silently. A pattern written with the
+ * instance's identity is a permission check nobody performs; one written to the
+ * declared slug on a renamed collection is a table that does not exist; one
+ * stored under the wrong field is a row the panel drops without a word; and one
+ * left in the default state is a save the author cannot find afterwards.
+ */
+import {
+  DOCUMENT_FORMAT_VERSION,
+  type BlockNode,
+} from "@nextlyhq/blocks-engine";
+import { NextlyError } from "nextly/errors";
+import { describe, expect, it, vi } from "vitest";
+
+import { PATTERNS_SLUG, patternsCollection } from "./collections/patterns";
+import {
+  savePattern,
+  type SavePatternRouteContext,
+} from "./save-pattern-route";
+
+function node(id: string, type = "core/box"): BlockNode {
+  return { id, type, version: 1, props: {} };
+}
+
+/** A page holding three top-level siblings, so a run and a gap are both sayable. */
+const pageDocument = {
+  formatVersion: DOCUMENT_FORMAT_VERSION,
+  kind: "page",
+  nodes: [node("a"), node("b", "core/text"), node("c")],
+};
+
+/** The metadata the collection requires of every pattern. */
+const fields = { title: "Hero", slug: "hero", granularity: "section" };
+
+function request(body: unknown): Request {
+  return new Request("https://example.test/save-as-pattern", {
+    method: "POST",
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+/**
+ * A context whose service records the write rather than performing one.
+ *
+ * The spy is the point: what this route decides is WHAT it writes and AS WHOM,
+ * so the arguments it passed are the observable behaviour.
+ */
+function contextOver(
+  self: Record<string, string | undefined> = {},
+  answer: { item: unknown; warnings?: unknown } = { item: { id: "p1" } }
+) {
+  const createEntry = vi.fn(
+    (_slug: string, _data: Record<string, unknown>, _ctx: unknown) =>
+      Promise.resolve(answer as { item: unknown })
+  );
+  const ctx = {
+    self: { collections: self },
+    user: { id: "u1" },
+    services: { collections: { createEntry } },
+  } as unknown as SavePatternRouteContext;
+  return { ctx, createEntry };
+}
+
+/** The data the route handed the collection service. */
+function written(createEntry: ReturnType<typeof contextOver>["createEntry"]) {
+  return createEntry.mock.calls[0]?.[1] as Record<string, unknown>;
+}
+
+/** The error a call threw, refusing to let a resolved promise pass as one. */
+async function thrownBy(run: Promise<unknown>): Promise<NextlyError> {
+  try {
+    await run;
+  } catch (error) {
+    if (NextlyError.is(error)) return error;
+    throw error;
+  }
+  throw new Error("expected the save to be refused, and it was not");
+}
+
+describe("where a saved pattern goes", () => {
+  it("writes to the collection the host actually has", async () => {
+    // A host may rename a plugin's collection. Writing to the DECLARED slug
+    // then writes to a table that does not exist, and the failure names a
+    // collection nobody has heard of.
+    const { ctx, createEntry } = contextOver({
+      [PATTERNS_SLUG]: "site_blocks",
+    });
+
+    await savePattern(
+      request({ document: pageDocument, selectedIds: ["a"], fields }),
+      ctx
+    );
+
+    expect(createEntry.mock.calls[0]?.[0]).toBe("site_blocks");
+  });
+
+  it("falls back to the declared slug when the host renamed nothing", async () => {
+    const { ctx, createEntry } = contextOver();
+
+    await savePattern(
+      request({ document: pageDocument, selectedIds: ["a"], fields }),
+      ctx
+    );
+
+    expect(createEntry.mock.calls[0]?.[0]).toBe(PATTERNS_SLUG);
+  });
+
+  it("writes AS THE USER, not with the instance's identity", async () => {
+    // What makes an authenticated route also AUTHORIZED. A write with the
+    // instance's own identity lets any signed-in caller create a pattern
+    // whatever the collection's permissions say, and records the wrong author
+    // on the version it writes.
+    const { ctx, createEntry } = contextOver();
+
+    await savePattern(
+      request({ document: pageDocument, selectedIds: ["a"], fields }),
+      ctx
+    );
+
+    expect(createEntry.mock.calls[0]?.[2]).toEqual({
+      as: "user",
+      user: { id: "u1" },
+    });
+  });
+});
+
+describe("what a saved pattern is made of", () => {
+  it("stores the run as a PATTERN document, under the field the collection declares", async () => {
+    const { ctx, createEntry } = contextOver();
+
+    await savePattern(
+      request({ document: pageDocument, selectedIds: ["a", "b"], fields }),
+      ctx
+    );
+
+    // The field name is the translation this module makes: the collection calls
+    // the tree `content` and every other surface calls it the document. Stored
+    // under any other name, the row reads back as a pattern with no tree, which
+    // the panel drops in silence.
+    const stored = written(createEntry).content as {
+      kind: string;
+      nodes: BlockNode[];
+    };
+    expect(stored.kind).toBe("pattern");
+    expect(stored.nodes.map(root => root.type)).toEqual([
+      "core/box",
+      "core/text",
+    ]);
+  });
+
+  it("stores a COPY, with ids of its own", async () => {
+    // Copy-on-insert is the whole difference between a pattern and a component,
+    // and it starts here: a stored pattern that kept the page's ids would
+    // collide with the page it was saved from the first time it was inserted
+    // back into it.
+    const { ctx, createEntry } = contextOver();
+
+    await savePattern(
+      request({ document: pageDocument, selectedIds: ["a", "b"], fields }),
+      ctx
+    );
+
+    const stored = written(createEntry).content as { nodes: BlockNode[] };
+    expect(stored.nodes.map(root => root.id)).not.toContain("a");
+    expect(stored.nodes.map(root => root.id)).not.toContain("b");
+  });
+
+  it("creates it PUBLISHED, so the library it was saved for shows it", async () => {
+    // The status column defaults to `draft`, and the library read is bounded to
+    // public states — so a save that left the default answers the author with a
+    // pattern their own insert panel does not list, which looks exactly like a
+    // save that failed.
+    const { ctx, createEntry } = contextOver();
+
+    await savePattern(
+      request({ document: pageDocument, selectedIds: ["a"], fields }),
+      ctx
+    );
+
+    expect(written(createEntry).status).toBe("published");
+  });
+
+  it("carries the metadata the collection declares, and NOTHING else the caller sent", async () => {
+    // The whole key set rather than a check per unwanted name: a route that
+    // forwarded the body would keep passing a `not.toHaveProperty` written
+    // about whichever key someone thought of.
+    const { ctx, createEntry } = contextOver();
+
+    await savePattern(
+      request({
+        document: pageDocument,
+        selectedIds: ["a"],
+        fields: {
+          ...fields,
+          description: "The top of the page",
+          // A column rather than a declared field: settable here would let a
+          // caller choose the row's primary key.
+          id: "forged",
+          // The state this route decides. A caller choosing it could save a
+          // pattern nobody can find, or publish without the route saying so.
+          status: "draft",
+          // The planner's output. Two answers about what to store, and the one
+          // the insert panel's guarantee rests on is the planner's.
+          content: { kind: "pattern", nodes: [] },
+          // A key no version of this collection has ever declared.
+          invented: true,
+        },
+      }),
+      ctx
+    );
+
+    expect(Object.keys(written(createEntry)).sort()).toEqual([
+      "content",
+      "description",
+      "granularity",
+      "slug",
+      "status",
+      "title",
+    ]);
+    expect(written(createEntry).status).toBe("published");
+    expect(
+      (written(createEntry).content as { nodes: BlockNode[] }).nodes
+    ).toHaveLength(1);
+  });
+
+  it("settles what may be sent against the collection, not against a list", async () => {
+    // The guard above passes for a hardcoded allowlist too. This is the part
+    // that cannot: every field the collection declares, except the one the
+    // planner owns, is accepted — so a field added to the collection is
+    // settable without this module being edited, and a column the collection
+    // never declared is not settable however it is spelled.
+    const declared = patternsCollection()
+      .fields.map(field => field.name)
+      .filter(
+        (name): name is string => name !== undefined && name !== "content"
+      );
+    const { ctx, createEntry } = contextOver();
+
+    await savePattern(
+      request({
+        document: pageDocument,
+        selectedIds: ["a"],
+        fields: Object.fromEntries(
+          declared.map(name => [
+            name,
+            name === "granularity" ? "section" : name,
+          ])
+        ),
+      }),
+      ctx
+    );
+
+    expect(declared.length).toBeGreaterThan(1);
+    for (const name of declared) {
+      expect(written(createEntry)).toHaveProperty(name);
+    }
+  });
+});
+
+describe("what a completed save answers", () => {
+  it("answers the id the collection assigned", async () => {
+    const { ctx } = contextOver({}, { item: { id: "pattern-7" } });
+
+    await expect(
+      savePattern(
+        request({ document: pageDocument, selectedIds: ["a"], fields }),
+        ctx
+      )
+    ).resolves.toEqual({ id: "pattern-7" });
+  });
+
+  it("reports a post-commit failure beside the id, rather than swallowing it", async () => {
+    // The row is durable and the hook is not; the write cannot be undone, so the
+    // only remedy is to say so. Reporting the save as wholly successful is how
+    // a failure nobody can retry becomes a failure nobody knows about.
+    const warnings = [
+      {
+        severity: "failure",
+        phase: "afterChange",
+        key: "patterns",
+        message: "x",
+      },
+    ];
+    const { ctx } = contextOver({}, { item: { id: "p1" }, warnings });
+
+    await expect(
+      savePattern(
+        request({ document: pageDocument, selectedIds: ["a"], fields }),
+        ctx
+      )
+    ).resolves.toEqual({ id: "p1", warnings });
+  });
+
+  it("omits the warnings key when nothing went wrong", async () => {
+    const { ctx } = contextOver({}, { item: { id: "p1" }, warnings: [] });
+
+    const answer = await savePattern(
+      request({ document: pageDocument, selectedIds: ["a"], fields }),
+      ctx
+    );
+
+    expect(answer).not.toHaveProperty("warnings");
+  });
+
+  it("refuses to report a save it cannot address afterwards", async () => {
+    // The row has already committed, so this is not a rollback — it is the
+    // difference between telling the caller the save is unusable and handing
+    // them `{ id: undefined }`, which every surface reads as a success.
+    const { ctx } = contextOver({}, { item: { title: "Hero" } });
+
+    const error = await thrownBy(
+      savePattern(
+        request({ document: pageDocument, selectedIds: ["a"], fields }),
+        ctx
+      )
+    );
+
+    expect(error.statusCode).toBe(500);
+  });
+});
+
+describe("what the route refuses, and how it says so", () => {
+  it("refuses a selection the planner will not save, and names the rule", async () => {
+    // `a` and `c` share a parent with `b` between them. The cause travels
+    // verbatim because it is a `PlanProblem`, which is what the caller compares
+    // against — a re-spelling would agree only while someone maintained it.
+    const { ctx, createEntry } = contextOver();
+
+    const error = await thrownBy(
+      savePattern(
+        request({ document: pageDocument, selectedIds: ["a", "c"], fields }),
+        ctx
+      )
+    );
+
+    expect(error.statusCode).toBe(422);
+    expect(error.publicData).toEqual({
+      errors: [
+        { path: "selectedIds", code: "gap", message: expect.any(String) },
+      ],
+    });
+    // Refused BEFORE the write, not after it: a refusal that has already
+    // created the row is a pattern the author was told they could not save.
+    expect(createEntry).not.toHaveBeenCalled();
+  });
+
+  it("refuses an id the document does not hold", async () => {
+    const { ctx } = contextOver();
+
+    const error = await thrownBy(
+      savePattern(
+        request({ document: pageDocument, selectedIds: ["nowhere"], fields }),
+        ctx
+      )
+    );
+
+    expect(error.statusCode).toBe(422);
+  });
+
+  it("refuses a body that is not JSON at all", async () => {
+    // 400 rather than the 500 an unhandled parse failure produces. A caller
+    // sending a broken body is not a server fault, and reporting it as one
+    // sends whoever reads the log looking at the wrong side.
+    const { ctx } = contextOver();
+
+    const error = await thrownBy(savePattern(request("{"), ctx));
+
+    expect(error.statusCode).toBe(400);
+  });
+
+  it.each([
+    ["document", { selectedIds: ["a"], fields }],
+    ["selectedIds", { document: pageDocument, fields }],
+    ["fields", { document: pageDocument, selectedIds: ["a"] }],
+  ])("refuses a request with no %s", async (path, body) => {
+    const { ctx, createEntry } = contextOver();
+
+    const error = await thrownBy(savePattern(request(body), ctx));
+
+    expect(error.statusCode).toBe(400);
+    expect(error.publicData).toMatchObject({ errors: [{ path }] });
+    expect(createEntry).not.toHaveBeenCalled();
+  });
+
+  it("refuses an empty selection rather than saving an empty pattern", async () => {
+    const { ctx } = contextOver();
+
+    const error = await thrownBy(
+      savePattern(
+        request({ document: pageDocument, selectedIds: [], fields }),
+        ctx
+      )
+    );
+
+    expect(error.statusCode).toBe(400);
+  });
+
+  it("leaves the collection's own rules to the collection", async () => {
+    // Which metadata are required, how long they may be, and whether a slug is
+    // taken are enforced on every other path into the same table. A second copy
+    // here would drift, and it would drift silently — two copies passing looks
+    // exactly like one of them being right. So a save with no title reaches the
+    // service, which refuses it.
+    const { ctx, createEntry } = contextOver();
+
+    await savePattern(
+      request({ document: pageDocument, selectedIds: ["a"], fields: {} }),
+      ctx
+    );
+
+    expect(createEntry).toHaveBeenCalled();
+    expect(written(createEntry)).not.toHaveProperty("title");
+  });
+});

--- a/packages/plugin-page-builder/src/save-pattern-route.test.ts
+++ b/packages/plugin-page-builder/src/save-pattern-route.test.ts
@@ -36,7 +36,7 @@ const pageDocument = {
 };
 
 /** The metadata the collection requires of every pattern. */
-const fields = { title: "Hero", slug: "hero", granularity: "section" };
+const fields = { title: "Hero", granularity: "section" };
 
 function request(body: unknown): Request {
   return new Request("https://example.test/save-as-pattern", {
@@ -223,6 +223,9 @@ describe("what a saved pattern is made of", () => {
       "status",
       "title",
     ]);
+    // Present because the route derived it, not because the caller sent one —
+    // which is what makes the key set above six rather than five.
+    expect(written(createEntry).slug).toBe("hero");
     expect(written(createEntry).status).toBe("published");
     expect(
       (written(createEntry).content as { nodes: BlockNode[] }).nodes
@@ -264,54 +267,33 @@ describe("what a saved pattern is made of", () => {
 });
 
 describe("what a completed save answers", () => {
-  it("answers the id the collection assigned", async () => {
-    const { ctx } = contextOver({}, { item: { id: "pattern-7" } });
+  it("answers the CANONICAL mutation envelope, not a shape of its own", async () => {
+    // Every other write in this codebase answers `{ message, item }`, and a
+    // plugin's write inventing its own shape is the one write a shared client
+    // cannot read. Asserted as the whole key set rather than by picking `item`
+    // out of it, because a body that carried the row beside some other spelling
+    // would satisfy a narrower check.
+    const { ctx } = contextOver(
+      {},
+      { item: { id: "pattern-7", title: "Hero" } }
+    );
 
-    await expect(
-      savePattern(
-        request({ document: pageDocument, selectedIds: ["a"], fields }),
-        ctx
-      )
-    ).resolves.toEqual({ id: "pattern-7" });
-  });
-
-  it("reports a post-commit failure beside the id, rather than swallowing it", async () => {
-    // The row is durable and the hook is not; the write cannot be undone, so the
-    // only remedy is to say so. Reporting the save as wholly successful is how
-    // a failure nobody can retry becomes a failure nobody knows about.
-    const warnings = [
-      {
-        severity: "failure",
-        phase: "afterChange",
-        key: "patterns",
-        message: "x",
-      },
-    ];
-    const { ctx } = contextOver({}, { item: { id: "p1" }, warnings });
-
-    await expect(
-      savePattern(
-        request({ document: pageDocument, selectedIds: ["a"], fields }),
-        ctx
-      )
-    ).resolves.toEqual({ id: "p1", warnings });
-  });
-
-  it("omits the warnings key when nothing went wrong", async () => {
-    const { ctx } = contextOver({}, { item: { id: "p1" }, warnings: [] });
-
-    const answer = await savePattern(
+    const response = await savePattern(
       request({ document: pageDocument, selectedIds: ["a"], fields }),
       ctx
     );
+    const body = (await response.json()) as Record<string, unknown>;
 
-    expect(answer).not.toHaveProperty("warnings");
+    expect(response.status).toBe(201);
+    expect(Object.keys(body).sort()).toEqual(["item", "message"]);
+    expect(body.item).toEqual({ id: "pattern-7", title: "Hero" });
+    expect(typeof body.message).toBe("string");
   });
 
   it("refuses to report a save it cannot address afterwards", async () => {
     // The row has already committed, so this is not a rollback — it is the
-    // difference between telling the caller the save is unusable and handing
-    // them `{ id: undefined }`, which every surface reads as a success.
+    // difference between telling the caller the save is unusable and putting a
+    // row with no id in the envelope, which every surface reads as a success.
     const { ctx } = contextOver({}, { item: { title: "Hero" } });
 
     const error = await thrownBy(
@@ -322,6 +304,81 @@ describe("what a completed save answers", () => {
     );
 
     expect(error.statusCode).toBe(500);
+  });
+});
+
+describe("the identifier a pattern is keyed by", () => {
+  it("derives the slug from the title, so nobody is asked for one", async () => {
+    const { ctx, createEntry } = contextOver();
+
+    await savePattern(
+      request({
+        document: pageDocument,
+        selectedIds: ["a"],
+        fields: { title: "Hero Banner!", granularity: "section" },
+      }),
+      ctx
+    );
+
+    expect(written(createEntry).slug).toBe("hero-banner");
+  });
+
+  it("keeps a slug the caller stated, because an API caller may own one", async () => {
+    const { ctx, createEntry } = contextOver();
+
+    await savePattern(
+      request({
+        document: pageDocument,
+        selectedIds: ["a"],
+        fields: { title: "Hero", slug: "legacy-hero", granularity: "section" },
+      }),
+      ctx
+    );
+
+    expect(written(createEntry).slug).toBe("legacy-hero");
+  });
+
+  it.each([["見出しセクション"], ["Заголовок"], ["Πρότυπο"], ["!!!"]])(
+    "still produces a usable slug for %s",
+    async title => {
+      // `slugify` keeps `[a-z0-9]`, so every one of these derives to the empty
+      // string — and an empty slug is refused by a required field. Without the
+      // fallback the whole feature is unavailable on any site that does not
+      // write its titles in Latin script.
+      const { ctx, createEntry } = contextOver();
+
+      await savePattern(
+        request({
+          document: pageDocument,
+          selectedIds: ["a"],
+          fields: { title, granularity: "section" },
+        }),
+        ctx
+      );
+
+      expect(written(createEntry).slug).toEqual(expect.stringMatching(/^.+$/));
+    }
+  );
+
+  it("gives two untransliterable titles DIFFERENT slugs", async () => {
+    // The fallback has to be an identifier rather than a constant: one shared
+    // fallback would make the second such pattern collide with the first on a
+    // unique column, so a Japanese site could store exactly one pattern.
+    const slugs = new Set<string>();
+    for (const _ of [0, 1]) {
+      const { ctx, createEntry } = contextOver();
+      await savePattern(
+        request({
+          document: pageDocument,
+          selectedIds: ["a"],
+          fields: { title: "見出し", granularity: "section" },
+        }),
+        ctx
+      );
+      slugs.add(String(written(createEntry).slug));
+    }
+
+    expect(slugs.size).toBe(2);
   });
 });
 
@@ -376,9 +433,26 @@ describe("what the route refuses, and how it says so", () => {
 
   it.each([
     ["document", { selectedIds: ["a"], fields }],
+    ["document", { document: {}, selectedIds: ["a"], fields }],
+    [
+      "document",
+      {
+        document: { formatVersion: 1, kind: "page" },
+        selectedIds: ["a"],
+        fields,
+      },
+    ],
+    [
+      "document",
+      {
+        document: { formatVersion: 1, kind: "page", nodes: "x" },
+        selectedIds: ["a"],
+        fields,
+      },
+    ],
     ["selectedIds", { document: pageDocument, fields }],
     ["fields", { document: pageDocument, selectedIds: ["a"] }],
-  ])("refuses a request with no %s", async (path, body) => {
+  ])("refuses a request whose %s is not one", async (path, body) => {
     const { ctx, createEntry } = contextOver();
 
     const error = await thrownBy(savePattern(request(body), ctx));

--- a/packages/plugin-page-builder/src/save-pattern-route.ts
+++ b/packages/plugin-page-builder/src/save-pattern-route.ts
@@ -265,27 +265,45 @@ function refusal(refused: PlanRefusal): NextlyError {
  * both copies passing is indistinguishable from one of them being right.
  */
 async function readRequest(req: Request): Promise<SavePatternRequest> {
-  const body = await readJson(req);
-  if (typeof body !== "object" || body === null) throw malformed("body");
-  const { document, selectedIds, fields } = body as Record<string, unknown>;
+  const body = objectAt(await readJson(req), "body");
+  return {
+    document: objectAt(body.document, "document") as unknown as BlockDocument,
+    selectedIds: selectionAt(body.selectedIds),
+    fields: settableFields(objectAt(body.fields, "fields")),
+  };
+}
 
-  if (typeof document !== "object" || document === null) {
-    throw malformed("document");
-  }
-  if (
-    !Array.isArray(selectedIds) ||
-    selectedIds.length === 0 ||
-    !selectedIds.every(id => typeof id === "string" && id !== "")
-  ) {
+/**
+ * One part of the request that has to be an object, or the refusal that it is
+ * not.
+ *
+ * Three parts ask the same question, and asking it in one place is what keeps
+ * them answering it identically: written out three times, the check that `null`
+ * is an object too is three chances to forget it, and forgetting it hands the
+ * planner a `null` document that fails as a server fault rather than as the bad
+ * request it is.
+ */
+function objectAt(value: unknown, path: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null) throw malformed(path);
+  return value as Record<string, unknown>;
+}
+
+/**
+ * The selected ids, or the refusal that they are not a selection.
+ *
+ * An empty list is refused HERE rather than left to the planner. The planner
+ * would call it `empty` and this would answer 422 — a rule the caller broke
+ * rather than a request that could not be read — and a caller who selected
+ * nothing has not broken a rule about patterns. Which side answers decides
+ * which status the caller gets, and only one of them is true.
+ */
+function selectionAt(value: unknown): readonly string[] {
+  const ids = Array.isArray(value) ? (value as unknown[]) : undefined;
+  if (ids === undefined || ids.length === 0) throw malformed("selectedIds");
+  if (!ids.every(id => typeof id === "string" && id !== "")) {
     throw malformed("selectedIds");
   }
-  if (typeof fields !== "object" || fields === null) throw malformed("fields");
-
-  return {
-    document: document as BlockDocument,
-    selectedIds: selectedIds as string[],
-    fields: settableFields(fields as Record<string, unknown>),
-  };
+  return ids as string[];
 }
 
 /**

--- a/packages/plugin-page-builder/src/save-pattern-route.ts
+++ b/packages/plugin-page-builder/src/save-pattern-route.ts
@@ -1,0 +1,359 @@
+/**
+ * The one write that puts a pattern in the library.
+ *
+ * Without it `planSaveAsPattern` has no caller, so the library the insert panel
+ * reads is a screen nobody can put anything into: an author can browse patterns
+ * and never make one.
+ *
+ * ## Why the server plans the save
+ *
+ * The request carries the DOCUMENT and the SELECTION, not a finished pattern.
+ * What a saved pattern is — which nodes travel, what is re-identified, which
+ * selections are refused — is the planner's question, and the planner answers it
+ * against the block registry. That registry is not the same at both ends: the
+ * browser holds the core blocks, while the server also holds every block another
+ * plugin declared. A browser planning the save answers nesting questions about
+ * blocks it has never heard of.
+ *
+ * It is also what makes the guarantee a rule rather than a convention. The
+ * insert panel offers a tile only for a pattern the planner would place; a
+ * pattern posted ready-made would be whatever its sender decided to send, and
+ * that guarantee would hold only for senders who chose to honour it.
+ *
+ * ## Published, deliberately, and that is a WRITE decision
+ *
+ * The row is created `published`. The status column defaults to `draft`, and a
+ * draft pattern is deliberately kept out of the insert panel — so a save that
+ * left the default would answer the author with a pattern their own library
+ * does not show, which is indistinguishable from a save that failed.
+ *
+ * Saving as a pattern is not a half-finished act: the author selected a run,
+ * named it, and asked for it back. The draft state belongs to the OTHER path,
+ * where a stored pattern is opened in the admin and revised.
+ *
+ * Stating the state NAME here is not the mistake the library READ avoids. That
+ * read must not name a state, because it is asking which patterns are public
+ * and the workflow owns that answer. This is stating an intent, which is what
+ * every publish does — the admin's own entry form posts `status: "published"`
+ * for exactly the same reason.
+ *
+ * It grants nothing, either: the write runs AS THE USER, so an author without
+ * permission to publish a pattern is refused by core rather than by this route
+ * having been careful.
+ *
+ * ## No declared permission, for the reason the read has none
+ *
+ * A declared permission has to spell the collection slug, and a host may rename
+ * the collection — the grant is then seeded under the new name and demanded
+ * under the old one, which is a route nobody can call. The write runs as the
+ * user, so core enforces whatever the resolved collection actually seeded.
+ *
+ * ## No request size cap of its own
+ *
+ * The document posted here is the same document the page save posts through the
+ * collection API. A cap invented here would be a second, different answer to a
+ * question the platform answers once, and it would refuse a page the platform
+ * itself accepts. What the STORED pattern may weigh is already bounded, by the
+ * planner, against the host's own limits.
+ *
+ * @module save-pattern-route
+ */
+import {
+  planSaveAsPattern,
+  registryNestingSource,
+  type BlockDocument,
+  type PlanRefusal,
+} from "@nextlyhq/blocks-engine";
+import { NextlyError } from "nextly/errors";
+
+import { PATTERNS_SLUG, patternsCollection } from "./collections/patterns";
+import {
+  SAVE_PATTERN_ROUTE_PATH,
+  type SavePatternFields,
+  type SavePatternRequest,
+  type SavePatternResponse,
+} from "./library-contract";
+
+/**
+ * The lifecycle state a saved pattern is created in.
+ *
+ * See the module docblock: the default is `draft`, and a draft pattern is not
+ * offered, so leaving it would save a pattern the author cannot find.
+ */
+const SAVED_PATTERN_STATUS = "published";
+
+/**
+ * The field the collection stores the tree under.
+ *
+ * Named once, here, because this is the write half of the same translation
+ * `library-route.ts` makes on the read half: the collection calls it `content`
+ * and every other surface calls it the document. Getting it wrong stores a
+ * pattern with no tree, which reads back as a row the panel silently drops.
+ */
+const PATTERN_DOCUMENT_FIELD = "content";
+
+/**
+ * The metadata keys a caller may set, taken FROM the collection.
+ *
+ * Derived rather than listed, and that is the point. A listed allowlist is a
+ * second statement of what a pattern carries: a field added to the collection
+ * would be unsettable here with nothing failing, and — the direction that
+ * matters — a key the collection never declared could otherwise be forwarded to
+ * the write. `id`, `status` and the timestamps are columns rather than declared
+ * fields, so they are not in this set and a caller cannot reach them by naming
+ * them.
+ *
+ * The document field is excluded because the PLANNER owns it. A caller
+ * supplying `content` beside a selection would be saying two different things
+ * about what to store, and the one the panel's guarantee rests on is the
+ * planner's.
+ *
+ * A field may legitimately have no name — a presentational group is one — and
+ * those are dropped rather than carried as a hole in the set: an unnamed field
+ * is not a key a caller could send in the first place.
+ *
+ * Computed once: the collection is declared in code and cannot change between
+ * requests, and building it per save would parse the whole collection on every
+ * write.
+ */
+const SETTABLE_FIELDS: ReadonlySet<string> = new Set(
+  patternsCollection()
+    .fields.map(field => field.name)
+    .filter(
+      (name): name is string =>
+        name !== undefined && name !== PATTERN_DOCUMENT_FIELD
+    )
+);
+
+/** The capabilities this route uses, named rather than imported whole. */
+export interface SavePatternRouteContext {
+  self: { collections: Record<string, string | undefined> };
+  user: unknown;
+  services: {
+    collections: {
+      createEntry(
+        collection: string,
+        data: Record<string, unknown>,
+        context: unknown
+      ): Promise<{
+        item: unknown;
+        warnings?: SavePatternResponse["warnings"];
+      }>;
+    };
+  };
+}
+
+/**
+ * Store a selection as a pattern, as the user asking for it.
+ *
+ * Separate from the route declaration so it can be tested against a stub
+ * without a server, exactly as the library read is: what this decides — what is
+ * planned, what is written, and what a refusal answers with — is the part worth
+ * holding still.
+ */
+export async function savePattern(
+  req: Request,
+  ctx: SavePatternRouteContext
+): Promise<SavePatternResponse> {
+  const request = await readRequest(req);
+  const slug = ctx.self.collections[PATTERNS_SLUG] ?? PATTERNS_SLUG;
+
+  const plan = planSaveAsPattern(
+    request.document,
+    request.selectedIds,
+    { collection: slug, fields: request.fields },
+    // The SERVER's registry, which is the one that knows every block: the
+    // declared blocks another plugin contributed are registered here and not in
+    // the browser.
+    registryNestingSource()
+  );
+  if (plan.problem !== undefined) throw refusal(plan);
+
+  const written = await ctx.services.collections.createEntry(
+    plan.create.collection,
+    {
+      ...plan.create.fields,
+      [PATTERN_DOCUMENT_FIELD]: plan.create.document,
+      status: SAVED_PATTERN_STATUS,
+    },
+    // AS THE USER. A write with the instance's own identity would let any
+    // authenticated caller create a pattern whatever the collection's
+    // permissions say — and would record the wrong author on the version.
+    { as: "user" as const, user: ctx.user ?? undefined }
+  );
+
+  return { id: writtenId(written.item), ...warningsOf(written.warnings) };
+}
+
+/**
+ * The id of the row that was just created.
+ *
+ * Read defensively for the reason the library read reads its rows defensively:
+ * what comes back has been through the collection's `afterChange` hooks, and a
+ * hook may return anything. A row with no usable id is a save the caller cannot
+ * address afterwards, and answering `{ id: undefined }` would report that as a
+ * success — so it is reported as the failure it is, AFTER the row has committed,
+ * which is what the message says.
+ */
+function writtenId(item: unknown): string {
+  const id = (item as { id?: unknown } | null | undefined)?.id;
+  if (typeof id === "string" && id !== "") return id;
+  throw new NextlyError({
+    code: "INTERNAL_ERROR",
+    publicMessage: "The pattern was saved but could not be identified.",
+    logMessage: "createEntry returned no usable id for a saved pattern",
+    logContext: { reason: "save-pattern-no-id" },
+  });
+}
+
+/** The post-commit warnings, present only when there are any to report. */
+function warningsOf(
+  warnings: SavePatternResponse["warnings"]
+): Pick<SavePatternResponse, "warnings"> {
+  return warnings === undefined || warnings.length === 0 ? {} : { warnings };
+}
+
+/**
+ * The error a planner refusal answers with.
+ *
+ * 422 rather than 400: the request was understood and well formed, and it was
+ * refused on a rule the caller can act on — which is what that status is for
+ * here, and what `BUSINESS_RULE_VIOLATION` already carries.
+ *
+ * ONE message for every refusal, with the planner's own cause as the machine
+ * code beside it. Phrasing a sentence per cause would put a second vocabulary of
+ * refusals here, and the surface that has to phrase them for an author already
+ * holds the first: it asks `saveAsPatternRefusal` before it offers the button,
+ * and that answer carries what this one cannot — which parents a refused block
+ * requires, which nominated property was invalid. A caller reaching this has
+ * either skipped that question or disagreed with the server about the
+ * registry, and neither is a case for inventing prose here.
+ *
+ * The cause travels VERBATIM. It is a `PlanProblem`, which is what the caller
+ * compares against, and re-spelling it — screaming it, prefixing it — would make
+ * the two ends agree only for as long as someone maintained the translation.
+ */
+function refusal(refused: PlanRefusal): NextlyError {
+  return new NextlyError({
+    code: "BUSINESS_RULE_VIOLATION",
+    publicMessage: "The selection cannot be saved as a pattern.",
+    publicData: {
+      errors: [
+        {
+          path: "selectedIds",
+          code: refused.problem,
+          message: "The selection cannot be saved as a pattern.",
+        },
+      ],
+    },
+    logMessage: "Refused a save-as-pattern request",
+    logContext: { reason: "save-pattern-refused", problem: refused.problem },
+  });
+}
+
+/**
+ * The request, or the refusal that it is not one.
+ *
+ * Only what THIS route needs to do its own job is checked here: the planner
+ * takes a document and a list of ids, and handing it something else is a
+ * `TypeError` reported as a server fault rather than as the bad request it is.
+ *
+ * The metadata are deliberately NOT validated. Which of them are required, how
+ * long they may be, and whether a slug is already taken are the collection's
+ * rules, and it enforces them on every other path into the same table. A second
+ * copy here would be a copy that drifts — and it would drift SILENTLY, since
+ * both copies passing is indistinguishable from one of them being right.
+ */
+async function readRequest(req: Request): Promise<SavePatternRequest> {
+  const body = await readJson(req);
+  if (typeof body !== "object" || body === null) throw malformed("body");
+  const { document, selectedIds, fields } = body as Record<string, unknown>;
+
+  if (typeof document !== "object" || document === null) {
+    throw malformed("document");
+  }
+  if (
+    !Array.isArray(selectedIds) ||
+    selectedIds.length === 0 ||
+    !selectedIds.every(id => typeof id === "string" && id !== "")
+  ) {
+    throw malformed("selectedIds");
+  }
+  if (typeof fields !== "object" || fields === null) throw malformed("fields");
+
+  return {
+    document: document as BlockDocument,
+    selectedIds: selectedIds as string[],
+    fields: settableFields(fields as Record<string, unknown>),
+  };
+}
+
+/**
+ * The metadata this write will carry, and nothing else the caller sent.
+ *
+ * Unknown keys are DROPPED rather than refused. A refusal would make an older
+ * editor unable to save against a newer server the moment the dialog learns a
+ * field, for a key that would have been ignored anyway; dropping keeps the two
+ * versions working together, which is what a route serving a browser it does not
+ * ship with has to do.
+ */
+function settableFields(fields: Record<string, unknown>): SavePatternFields {
+  const kept: Record<string, unknown> = {};
+  for (const [name, value] of Object.entries(fields)) {
+    if (SETTABLE_FIELDS.has(name)) kept[name] = value;
+  }
+  return kept as unknown as SavePatternFields;
+}
+
+/** The body as JSON, or the refusal that it was not JSON at all. */
+async function readJson(req: Request): Promise<unknown> {
+  try {
+    return (await req.json()) as unknown;
+  } catch {
+    throw malformed("body");
+  }
+}
+
+/**
+ * What a request this route cannot read answers with.
+ *
+ * The PATH is named and the value is not. Which part of the request was wrong is
+ * what a caller needs to fix it; echoing what they sent would put arbitrary
+ * caller content into an error body, which the public-message rubric refuses for
+ * every other error in the codebase.
+ */
+function malformed(path: string): NextlyError {
+  return NextlyError.validation({
+    errors: [
+      {
+        path,
+        code: "INVALID_TYPE",
+        message: "The request is not a save-as-pattern request.",
+      },
+    ],
+  });
+}
+
+/**
+ * The route declaration, thin on purpose.
+ *
+ * Everything it decides lives in {@link savePattern}. What is left here is the
+ * shape of the contribution — the method, the path, the created status it
+ * answers with, and the fact that it declares no permission — which is the part
+ * a reader of `contributes.routes` needs to see without following a call.
+ */
+export function savePatternRoute(): {
+  method: "POST";
+  path: string;
+  handler: (req: Request, ctx: SavePatternRouteContext) => Promise<Response>;
+} {
+  return {
+    method: "POST",
+    path: SAVE_PATTERN_ROUTE_PATH,
+    // No `public: true`, which is what makes this authenticated, and no
+    // `requiredPermission`, which is what keeps it callable on a site that
+    // renamed the collection. See the module docblock.
+    handler: async (req: Request, ctx: SavePatternRouteContext) =>
+      Response.json(await savePattern(req, ctx), { status: 201 }),
+  };
+}

--- a/packages/plugin-page-builder/src/save-pattern-route.ts
+++ b/packages/plugin-page-builder/src/save-pattern-route.ts
@@ -59,11 +59,13 @@
  * @module save-pattern-route
  */
 import {
+  documentRefusal,
   planSaveAsPattern,
   registryNestingSource,
   type BlockDocument,
   type PlanRefusal,
 } from "@nextlyhq/blocks-engine";
+import { respondMutation, slugify } from "nextly";
 import { NextlyError } from "nextly/errors";
 
 import { PATTERNS_SLUG, patternsCollection } from "./collections/patterns";
@@ -154,7 +156,7 @@ export interface SavePatternRouteContext {
 export async function savePattern(
   req: Request,
   ctx: SavePatternRouteContext
-): Promise<SavePatternResponse> {
+): Promise<Response> {
   const request = await readRequest(req);
   const slug = ctx.self.collections[PATTERNS_SLUG] ?? PATTERNS_SLUG;
 
@@ -173,6 +175,7 @@ export async function savePattern(
     plan.create.collection,
     {
       ...plan.create.fields,
+      slug: plan.create.fields.slug ?? derivedSlug(plan.create.fields.title),
       [PATTERN_DOCUMENT_FIELD]: plan.create.document,
       status: SAVED_PATTERN_STATUS,
     },
@@ -182,35 +185,64 @@ export async function savePattern(
     { as: "user" as const, user: ctx.user ?? undefined }
   );
 
-  return { id: writtenId(written.item), ...warningsOf(written.warnings) };
+  // The canonical envelope, BUILT rather than assembled. `respondMutation`
+  // reads the request's own side-effect warning scope — the same scope the
+  // plugin collection facade writes post-commit failures into, because a
+  // failure is recorded against every collector that is open — so forwarding
+  // the facade's own `warnings` beside it would report each of them twice.
+  return respondMutation("Pattern created.", writtenRow(written.item), {
+    status: 201,
+  });
 }
 
 /**
- * The id of the row that was just created.
+ * The identifier a pattern is keyed by when its author gave none.
+ *
+ * Derived from the title through the framework's own `slugify`, so a pattern's
+ * slug is made the way every other slug in the product is made rather than by a
+ * fourth rule that agrees with the others only until one of them moves.
+ *
+ * **A derivation can legitimately produce nothing, and that is not an edge
+ * case.** `slugify` keeps `[a-z0-9]` and replaces everything else, so a title
+ * written in a script it cannot transliterate comes back empty — measured,
+ * `"見出しセクション"`, `"Заголовок"` and `"Πρότυπο"` all yield `""`. On a
+ * Japanese or Russian site that is EVERY pattern, and an empty slug is refused
+ * by a required field, so the feature would simply not work there.
+ *
+ * An empty derivation therefore falls back to a generated identifier. The slug
+ * is an identity rather than an address — nothing resolves a pattern by it — so
+ * a pattern keyed `pattern-3f2a1b2c` is as usable as one keyed `hero-banner`,
+ * and the author is shown neither. The consequence worth knowing: two patterns
+ * whose titles both derive to nothing never collide, where two titled "Hero" do.
+ */
+function derivedSlug(title: unknown): string {
+  const derived = typeof title === "string" ? slugify(title) : "";
+  return derived === ""
+    ? `pattern-${crypto.randomUUID().slice(0, 8)}`
+    : derived;
+}
+
+/**
+ * The row that was just created, once it is one a caller can address.
  *
  * Read defensively for the reason the library read reads its rows defensively:
  * what comes back has been through the collection's `afterChange` hooks, and a
  * hook may return anything. A row with no usable id is a save the caller cannot
- * address afterwards, and answering `{ id: undefined }` would report that as a
+ * address afterwards, and putting it in the envelope would report that as a
  * success — so it is reported as the failure it is, AFTER the row has committed,
  * which is what the message says.
  */
-function writtenId(item: unknown): string {
-  const id = (item as { id?: unknown } | null | undefined)?.id;
-  if (typeof id === "string" && id !== "") return id;
+function writtenRow(item: unknown): { id: string } & Record<string, unknown> {
+  const row = (item ?? {}) as Record<string, unknown>;
+  if (typeof row.id === "string" && row.id !== "") {
+    return row as { id: string } & Record<string, unknown>;
+  }
   throw new NextlyError({
     code: "INTERNAL_ERROR",
     publicMessage: "The pattern was saved but could not be identified.",
     logMessage: "createEntry returned no usable id for a saved pattern",
     logContext: { reason: "save-pattern-no-id" },
   });
-}
-
-/** The post-commit warnings, present only when there are any to report. */
-function warningsOf(
-  warnings: SavePatternResponse["warnings"]
-): Pick<SavePatternResponse, "warnings"> {
-  return warnings === undefined || warnings.length === 0 ? {} : { warnings };
 }
 
 /**
@@ -267,10 +299,28 @@ function refusal(refused: PlanRefusal): NextlyError {
 async function readRequest(req: Request): Promise<SavePatternRequest> {
   const body = objectAt(await readJson(req), "body");
   return {
-    document: objectAt(body.document, "document") as unknown as BlockDocument,
+    document: documentAt(body.document),
     selectedIds: selectionAt(body.selectedIds),
     fields: settableFields(objectAt(body.fields, "fields")),
   };
+}
+
+/**
+ * The document the selection was made in, or the refusal that it is not one.
+ *
+ * Asked HERE as well as inside the planner, and the two are different questions.
+ * The planner asks whether a document can be edited at all, and refuses one that
+ * cannot as a rule the caller broke; this asks whether the REQUEST carried a
+ * document, which is a question about the request and answers 400. Without it a
+ * body of `{"document":{}}` reaches the planner as a well-formed request whose
+ * refusal reads as the author's fault.
+ *
+ * The same published question either way, never a second predicate for it:
+ * `documentRefusal` is the op layer's own rule about what it will edit.
+ */
+function documentAt(value: unknown): BlockDocument {
+  if (documentRefusal(value) !== undefined) throw malformed("document");
+  return value as BlockDocument;
 }
 
 /**
@@ -355,10 +405,14 @@ function malformed(path: string): NextlyError {
 /**
  * The route declaration, thin on purpose.
  *
- * Everything it decides lives in {@link savePattern}. What is left here is the
- * shape of the contribution — the method, the path, the created status it
- * answers with, and the fact that it declares no permission — which is the part
- * a reader of `contributes.routes` needs to see without following a call.
+ * Everything it decides lives in {@link savePattern}, which answers with a
+ * finished `Response` rather than a body to be wrapped: the status a create
+ * carries and the envelope it carries it in are two halves of one answer, and
+ * splitting them puts the status here and the shape there.
+ *
+ * What is left is the shape of the CONTRIBUTION — the method, the path, and the
+ * fact that it declares no permission — which is the part a reader of
+ * `contributes.routes` needs to see without following a call.
  */
 export function savePatternRoute(): {
   method: "POST";
@@ -371,7 +425,6 @@ export function savePatternRoute(): {
     // No `public: true`, which is what makes this authenticated, and no
     // `requiredPermission`, which is what keeps it callable on a site that
     // renamed the collection. See the module docblock.
-    handler: async (req: Request, ctx: SavePatternRouteContext) =>
-      Response.json(await savePattern(req, ctx), { status: 201 }),
+    handler: savePattern,
   };
 }


### PR DESCRIPTION
## What this is

An author could browse the pattern library and never put anything in it.
`planSaveAsPattern` has had **no production caller** since T-2, so the Patterns
tier #1616 shipped is a screen with nothing to show and no way to add to it.
This is the write that fills it — the first of T-3's three slices.

## The one decision worth a ruling

**The row is created `published`.** The status column defaults to `draft`, and
the library read is deliberately bounded to public states — so a save that left
the default answers the author with a pattern their own insert panel does not
list, which is indistinguishable from a save that failed.

Stating the state name here is *not* the mistake the library READ avoids. That
read must not name a state, because it is asking which patterns are public and
the workflow owns that answer. This states an intent, which is what every
publish does: the admin's own entry form posts `status: "published"`
(`EntryForm/useEntryForm.ts`) for exactly the same reason. It grants nothing —
the write runs as the user, so an author without permission to publish a pattern
is refused by the collection.

If you would rather save-as create a draft, it is a one-line change and the
dialog in slice 3 would need a "publish" affordance.

## Why the server plans the save

The request carries the **document and the selection**, not a finished pattern.
The planner decides what a pattern is by asking the block registry, and that
registry is not the same at both ends: the browser holds the core blocks, while
the server also holds every block another plugin declared. A browser that
planned its own save answers nesting questions about blocks it has never heard
of.

It is also what makes the insert panel's guarantee a rule rather than a
convention. A pattern posted ready-made would be whatever its sender decided to
send, and "a tile exists only for a pattern the planner would place" would hold
only for senders who chose to honour it.

## What the route does and does not decide

- **Settable metadata are taken FROM the collection**, not listed. A column the
  collection never declared cannot be reached however it is spelled (`id`,
  `status`, the timestamps), and a field added to the collection becomes
  settable without editing the route. `content` is excluded because the planner
  owns it.
- **The collection's own rules stay the collection's.** What is required, how
  long it may be, whether a slug is taken — a second copy here would drift, and
  silently, since both copies passing looks exactly like one of them being
  right.
- **A refusal answers 422 before anything is written**, with the planner's own
  `PlanProblem` as the machine code, verbatim. One message for every cause: the
  surface that phrases refusals for an author already asks
  `saveAsPatternRefusal` before it offers the button, and that answer carries
  what this one cannot.
- **No `requiredPermission`**, for the reason the read has none: a declared one
  must spell the collection slug, and a host may rename the collection.
- **No request size cap of its own.** The document posted here is the same
  document the page save posts through the collection API; a cap invented here
  would be a second, different answer to a question the platform answers once.

## Two supporting changes

- `planSaveAsPattern` now returns `CreatePlanResult`, which says it always
  creates a row. `CompositionPlan.create` is optional because `planDetach`
  creates nothing — so every caller had to write a branch for a state its
  planner cannot reach, and an impossible branch is one nothing ever proves.
  Applied per planner, not as a shared alias, so it asserts no guarantee that
  was not checked.
- `nextly/config` publishes `HookWarning`, beside `RouteMethod` and `JsonValue`
  and for the same reason: a route reporting a post-commit failure and the
  plugin UI reading that report are two halves of one package, and only one of
  them may load the framework.

## Evidence

- **26 tests**, 3 files. **21 break-verifications**, each a wrong implementation
  rather than a mutation; every one killed a *named* test, and every run
  collected 26 tests / 3 files against the control. The breaks covered: writing
  with the instance identity, the declared slug instead of the resolved one, the
  wrong document field, the default status, forwarding every caller key, a
  hardcoded allowlist, an unguarded id, writing before checking the refusal,
  dropping the warnings, always sending warnings, the route not wired, the
  collection gaining a field, each request-shape check, and the route
  re-validating what the collection owns.
- `pnpm check-types` — 0, in `blocks-engine`, `nextly`, `plugin-page-builder`,
  and in `builder`, `admin`, `blocks-react`, `plugin-sdk` downstream.
- `pnpm lint` — 0 in all three touched packages.
- Suites — `plugin-page-builder` 708 passed / 66 files; `blocks-engine` 2,399
  passed / 52 files; `nextly` 11,593 passed / 42 skipped / 911 files.
- `fallow audit --base origin/main` — exit 0, **10 files analysed**, 0
  introduced. (The first run failed on `readRequest` at CC 10; the second commit
  decomposes it, which was a real duplication — the same "is this an object"
  check written three times.)
- `changeset status` — exit 0.

## What is next

Slice 2 is the toolbar verb, gated on `saveAsPatternRefusal` with the runner
wired in the shared `blockActionRunners` map — it waits on #1637, which is
fixing the exact union it would add to. Slice 3 is the metadata dialog.
