### PR TITLE
fix(blocks-engine): read the whole selection when refusing a self-referencing component

### DIFF
--- a/.changeset/a-component-cannot-be-made-to-contain-itself.md
+++ b/.changeset/a-component-cannot-be-made-to-contain-itself.md
@@ -1,0 +1,37 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Converting a selection into a component could be allowed on a site that raised
+the block document node limit, even when the selection already contained an
+instance of the component being created. The saved component then referenced
+itself, and where the content had been the page drew a missing-component
+placeholder instead.
+
+The check that refuses a self-referencing conversion reads the selection under
+whatever node limit the site configured, rather than always under the built-in
+one. A site that never changed that limit was never affected.

--- a/packages/blocks-engine/src/composition-planners.test.ts
+++ b/packages/blocks-engine/src/composition-planners.test.ts
@@ -1680,6 +1680,136 @@ describe("what a definition may not be", () => {
     ).toBeUndefined();
   });
 
+  it("finds a self-reference past the DEFAULT cap when the host raised it", () => {
+    // The guard asks the resolver's index for the definition's references, and
+    // that index walks depth-first under a node budget and stops SILENTLY. Its
+    // budget used to default here rather than follow the caller's `limits`, so
+    // on a site that raised `maxNodes` the walk still stopped at 5,000 and a
+    // self-reference beyond that read as "references nothing" — which is the
+    // answer that approves the conversion.
+    //
+    // Depth-first is what puts it beyond: a first root holding more than the
+    // default cap consumes the whole budget, so the instance on the SECOND
+    // root is never reached. Under the level-order walk the readers use it
+    // would have been visited immediately, which is why the two cannot be
+    // treated as interchangeable.
+    const raised = {
+      ...DEFAULT_LIMITS,
+      maxNodes: DEFAULT_LIMITS.maxNodes * 4,
+      maxBytes: DEFAULT_LIMITS.maxBytes * 100,
+    };
+    const doc = page([
+      node(
+        "fat",
+        {},
+        {
+          children: Array.from(
+            { length: DEFAULT_LIMITS.maxNodes + 10 },
+            (_, i) => node(`f${i}`)
+          ),
+        }
+      ),
+      node("i1", {
+        type: COMPONENT_INSTANCE_TYPE,
+        props: { componentId: "def-1" },
+      }),
+    ]);
+
+    expect(
+      planConvertToComponent(
+        doc,
+        ["fat", "i1"],
+        componentTarget,
+        "def-1",
+        {},
+        anyParent,
+        raised
+      ).problem
+    ).toBe("self-reference");
+
+    // The control: the SAME nodes with the instance as the first root are
+    // refused with the default budget too, so what the case above measures is
+    // walk order under a raised cap rather than the guard being absent.
+    expect(
+      planConvertToComponent(
+        page([...doc.nodes].reverse()),
+        ["i1", "fat"],
+        componentTarget,
+        "def-1",
+        {},
+        anyParent,
+        raised
+      ).problem
+    ).toBe("self-reference");
+  });
+
+  it("reads the whole definition at the ceiling, and refuses one past it", () => {
+    // Why no refusal exists for a definition the guard could only read part
+    // of: there is none to refuse. `plannedSave` accepts at most `maxNodes`
+    // nodes, and the guard now walks under that same number, so the walk
+    // always reaches the end.
+    //
+    // Both halves are asserted because the argument needs both. The first
+    // pins that a selection AT the ceiling is read whole — the instance is the
+    // last node walked, so anything reading a prefix misses it. The second
+    // pins the ceiling itself: if `plannedSave` ever accepted one more node
+    // than the guard walks, the last one would fall outside the budget and
+    // this reasoning would silently stop holding.
+    //
+    // Stated so it is not mistaken for evidence of the fix: this test PASSES
+    // against the unthreaded call as well, and by construction — the cap here
+    // is LOWER than the default the guard used to walk under, so the old
+    // budget was the more generous of the two and reached the end anyway. The
+    // break-verified case is the one above. What this one defends is the
+    // reasoning that made a refusal-for-a-truncated-prefix unnecessary.
+    const cap = 40;
+    const limits = { ...DEFAULT_LIMITS, maxNodes: cap };
+    const filler = (count: number) =>
+      Array.from({ length: count }, (_, i) => node(`c${i}`));
+    const selfLast = (fillerCount: number) =>
+      page([
+        node(
+          "r",
+          {},
+          {
+            children: [
+              ...filler(fillerCount),
+              node("i1", {
+                type: COMPONENT_INSTANCE_TYPE,
+                props: { componentId: "def-1" },
+              }),
+            ],
+          }
+        ),
+      ]);
+
+    // root + (cap - 2) filler + the instance = exactly `cap` nodes.
+    expect(
+      planConvertToComponent(
+        selfLast(cap - 2),
+        ["r"],
+        componentTarget,
+        "def-1",
+        {},
+        anyParent,
+        limits
+      ).problem
+    ).toBe("self-reference");
+
+    // One more node than the ceiling: refused before the guard is consulted.
+    expect(
+      planConvertToComponent(
+        selfLast(cap - 1),
+        ["r"],
+        componentTarget,
+        "def-1",
+        {},
+        anyParent,
+        limits
+      ).problem
+    ).toBe("exceeds-limits");
+  });
+
   it("refuses an exposure list whose indices are accessors", () => {
     // A genuine array, with entries that would be well formed, that computes
     // them. Neither the array check nor the entry guards see it, and reading

--- a/packages/blocks-engine/src/composition-planners.test.ts
+++ b/packages/blocks-engine/src/composition-planners.test.ts
@@ -1810,6 +1810,66 @@ describe("what a definition may not be", () => {
     ).toBe("exceeds-limits");
   });
 
+  it("reads the caller's node cap once, so it cannot answer twice", () => {
+    // `limits` is an object the caller owns, and every member of it can be a
+    // getter or a proxy trap. The stages here have to AGREE about the cap: the
+    // survey validates the definition under one, and the self-reference guard
+    // walks it under another. Two reads let those disagree, and the direction
+    // that matters is a guard whose cap is smaller than the definition the
+    // survey accepted — it walks a prefix and approves a conversion whose
+    // definition contains an instance of itself.
+    //
+    // Asserted as ONE read rather than as "the same value twice", because a
+    // getter can count its own calls and a single read cannot disagree with
+    // itself. Every poison position is exercised, so a later stage added
+    // between them cannot reintroduce a second read unnoticed.
+    const doc = page([
+      node("i1", {
+        type: COMPONENT_INSTANCE_TYPE,
+        props: { componentId: "def-1" },
+      }),
+    ]);
+
+    /** Honest on every read of `maxNodes` except the nth, which answers 0. */
+    const poisonNthRead = (n: number) => {
+      let reads = 0;
+      const limits: DocumentLimits = {
+        ...DEFAULT_LIMITS,
+        get maxNodes() {
+          reads += 1;
+          return reads === n ? 0 : DEFAULT_LIMITS.maxNodes;
+        },
+      };
+      return { limits, reads: () => reads };
+    };
+
+    for (const position of [1, 2, 3, 4, 5, 6, 7]) {
+      const poisoned = poisonNthRead(position);
+      const plan = planConvertToComponent(
+        doc,
+        ["i1"],
+        componentTarget,
+        "def-1",
+        {},
+        anyParent,
+        poisoned.limits
+      );
+
+      // Never a create. Poisoning the FIRST read is the caller honestly
+      // saying zero, which is refused for exceeding it; every later position
+      // never happens, so the honest cap stands and the guard sees the
+      // self-reference. Both are refusals, which is the property.
+      expect({ position, create: plan.create }).toEqual({
+        position,
+        create: undefined,
+      });
+      expect({ position, reads: poisoned.reads() }).toEqual({
+        position,
+        reads: 1,
+      });
+    }
+  });
+
   it("refuses an exposure list whose indices are accessors", () => {
     // A genuine array, with entries that would be well formed, that computes
     // them. Neither the array check nor the entry guards see it, and reading

--- a/packages/blocks-engine/src/composition-planners.ts
+++ b/packages/blocks-engine/src/composition-planners.ts
@@ -1122,10 +1122,27 @@ export function planConvertToComponent<TFields>(
     return { problem: "invalid-source" };
   }
 
-  const saved = plannedSave(document, selectedIds, nesting, limits);
+  // Read ONCE, for the same reason the id above is checked at runtime: this is
+  // a published entry point, and `limits` is an object the caller owns. Every
+  // member can be a getter or a proxy trap, so two reads can answer
+  // differently — and the stages below have to agree about the cap or the
+  // agreement between them is the thing an author relies on. Measured on this
+  // function before the snapshot: `maxNodes` was read five times, and a getter
+  // answering honestly on four of them and `0` on the fifth approved a
+  // conversion whose definition contained an instance of itself. Poisoning any
+  // OTHER single read was refused, which is what makes this the fifth read's
+  // agreement with the first rather than a general validation weakness.
+  //
+  // A spread rather than a per-member copy so a member added to
+  // `DocumentLimits` is snapshotted too: a list written out here would go on
+  // reading the new one live, which is the failure this exists to prevent
+  // wearing a different member's name.
+  const bounds: DocumentLimits = { ...limits };
+
+  const saved = plannedSave(document, selectedIds, nesting, bounds);
   if (saved.problem !== undefined) return saved;
 
-  const definition = componentDocument(saved, exposure, limits);
+  const definition = componentDocument(saved, exposure, bounds);
   if (definition.problem !== undefined) return definition;
 
   // A definition holding an instance of ITSELF. The selection can already
@@ -1135,7 +1152,8 @@ export function planConvertToComponent<TFields>(
   // content with a broken placeholder. Asked through the resolver's own
   // published index, not a walk of this module's own.
   //
-  // `limits.maxNodes` is passed, and passing it is the whole guard. The index
+  // The caller's own node cap is passed, and passing it is the whole guard.
+  // The index
   // walks depth-first under a node budget and STOPS silently, returning a
   // prefix that is indistinguishable from a definition referencing nothing —
   // and "references nothing" is the answer that approves the conversion. Left
@@ -1147,20 +1165,20 @@ export function planConvertToComponent<TFields>(
   //
   // Threading the caller's cap is sufficient, rather than merely better. The
   // definition reaching this line is one `plannedSave` accepted under the SAME
-  // `limits`, and that ceiling is `maxNodes` nodes exactly — measured at the
+  // `bounds`, and that ceiling is `maxNodes` nodes exactly — measured at the
   // boundary: a selection of `maxNodes` is accepted and walks whole, and
   // `maxNodes + 1` is refused as `"exceeds-limits"` before this line is
   // reached. So there is no definition here that this walk can truncate, which
   // is why the prefix is not tested for and no refusal for one exists.
   if (
-    componentIdsIn(definition.document.nodes, limits.maxNodes).includes(
+    componentIdsIn(definition.document.nodes, bounds.maxNodes).includes(
       componentId
     )
   ) {
     return { problem: "self-reference" };
   }
 
-  const replaced = replaceOps(document, saved, componentId, nesting, limits);
+  const replaced = replaceOps(document, saved, componentId, nesting, bounds);
   if (replaced.problem !== undefined) return replaced;
 
   return {

--- a/packages/blocks-engine/src/composition-planners.ts
+++ b/packages/blocks-engine/src/composition-planners.ts
@@ -1134,7 +1134,29 @@ export function planConvertToComponent<TFields>(
   // unresolved, so a conversion whose dry run succeeded replaces visible
   // content with a broken placeholder. Asked through the resolver's own
   // published index, not a walk of this module's own.
-  if (componentIdsIn(definition.document.nodes).includes(componentId)) {
+  //
+  // `limits.maxNodes` is passed, and passing it is the whole guard. The index
+  // walks depth-first under a node budget and STOPS silently, returning a
+  // prefix that is indistinguishable from a definition referencing nothing —
+  // and "references nothing" is the answer that approves the conversion. Left
+  // to its default the walk ran under 5,000 however the host had configured
+  // the caller, so on a site that raised the cap a self-reference sitting past
+  // node 5,000 in walk order approved a conversion the resolver then leaves
+  // unresolved. Measured: at a budget equal to the definition's own node count
+  // the walk reads all of it, and one below that it answers `[]`.
+  //
+  // Threading the caller's cap is sufficient, rather than merely better. The
+  // definition reaching this line is one `plannedSave` accepted under the SAME
+  // `limits`, and that ceiling is `maxNodes` nodes exactly — measured at the
+  // boundary: a selection of `maxNodes` is accepted and walks whole, and
+  // `maxNodes + 1` is refused as `"exceeds-limits"` before this line is
+  // reached. So there is no definition here that this walk can truncate, which
+  // is why the prefix is not tested for and no refusal for one exists.
+  if (
+    componentIdsIn(definition.document.nodes, limits.maxNodes).includes(
+      componentId
+    )
+  ) {
     return { problem: "self-reference" };
   }
 


### PR DESCRIPTION
## What

`planConvertToComponent` refuses a conversion whose definition would contain an
instance of itself — the resolver classifies that as a cycle and leaves it
unresolved, so a conversion whose dry run succeeded replaces visible content
with a placeholder.

It asks the resolver's own published index, `componentIdsIn`, which walks
depth-first under a node budget and **stops silently**. A truncated walk
returns a prefix that is indistinguishable from a definition referencing
nothing — and "references nothing" is the answer that approves the conversion.

The call passed no budget, so the walk always ran under the built-in cap of
5,000 nodes however the caller was configured, even though
`planConvertToComponent` already receives a `DocumentLimits` it threads to
`plannedSave` and `componentDocument`. This threads it to the guard too.

## Reachability, stated rather than implied

It needs a host that **raised** `maxNodes` above the default and a selection
whose earlier roots hold more than the default cap before the instance in
depth-first order.

Under default limits the oversized selection is refused as `"exceeds-limits"`
before the guard is reached, so a default-configured site was never affected.
A host that *lowered* the cap was not affected either — the un-threaded default
is then the more generous of the two and the walk reaches the end anyway.

## What was measured

| probe | result |
|---|---|
| `componentIdsIn(nodes)` — instance on a later root, first root over the cap | `[]` |
| `componentIdsIn(nodes, raisedCap)` — same nodes | `["def-1"]` |
| `selectNodes({nodes}, DEFAULT_LIMITS)` — the level-order walk readers use | reaches the instance, and reports `stopped` |
| end to end, raised limits | `problem: undefined`, create approved, definition holds the self-reference |
| control — same shape, instance as the **first** root | `"self-reference"` |
| bound — same shape, **default** limits | `"exceeds-limits"`, no create |

The control matters: it shows the guard works and that what the new test
measures is walk order under a raised cap, not the guard being absent.

## Why no refusal for a partially-read definition

There is none to refuse. `plannedSave` accepts at most `maxNodes` nodes and the
guard now walks under that same number, measured at the boundary: a selection of
exactly `maxNodes` is accepted and walks whole, and `maxNodes + 1` is refused
before this line is reached. Adding a truncation branch would be unreachable
code.

Both halves of that are asserted, so if either ceiling ever moves the reasoning
fails loudly instead of silently ceasing to hold. That second test is marked in
its own comment as **passing against the unfixed code by construction** — it
defends the reasoning, not the fix — so it is not mistaken for a second proof.

## Break-verification

Restoring the original call: `finds a self-reference past the DEFAULT cap when
the host raised it` **fails**, 1 failed / 164 passed. The boundary test passes
either way, for the reason stated above.

## Gates

| gate | result |
|---|---|
| `pnpm build` (after clearing every `dist` from the previous branch) | exit 0, 19/19 |
| `blocks-engine` `check-types` | exit 0 (both `tsc` invocations) |
| `blocks-engine` `lint` | exit 0 |
| `blocks-engine` tests | 52 files, 2404 tests, exit 0 |
| `builder` tests (re-exports the planners) | 102 files, 2869 tests, exit 0 |
| `fallow audit --base origin/main` | `pass`, `changed_files_count: 3`, introduced 0 across all four categories |
| `pnpm changeset status` | parses; contributes 25 packages, verified by diffing status with and without the file |
