### PR TITLE
fix(blocks-engine): take the caps by name, so how a caller stores them does not matter

### DIFF
--- a/.changeset/a-caps-object-can-be-shaped-however-a-caller-likes.md
+++ b/.changeset/a-caps-object-can-be-shaped-however-a-caller-likes.md
@@ -1,0 +1,36 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Converting a selection into a component threw a `RangeError` when the caps
+object passed to it kept its values on a prototype or as non-enumerable
+properties, rather than as plain own properties — a shape that worked before
+the previous release. It also ran any unrelated getter such an object carried,
+so a throwing one took the conversion down with it.
+
+The three caps are now read by name, so how a caller chooses to store them no
+longer matters.

--- a/packages/blocks-engine/src/composition-planners.test.ts
+++ b/packages/blocks-engine/src/composition-planners.test.ts
@@ -1870,6 +1870,66 @@ describe("what a definition may not be", () => {
     }
   });
 
+  it("takes the caps by name, so how they are stored does not matter", () => {
+    // The snapshot above has to copy the RIGHT SET, and a spread copies own
+    // enumerable properties — the wrong set at both ends. It misses a member
+    // reached through the prototype or defined non-enumerably, so a caps
+    // object that reads perfectly well arrives with every cap `undefined`;
+    // and it reads members the planner never uses, so an unrelated getter on
+    // the caller's object runs, and a throwing one takes the call down.
+    //
+    // Each case is a caps object that behaves identically under a NAMED read
+    // and differently under a spread, so all three fail together the moment
+    // the snapshot goes back to copying properties wholesale.
+    const doc = page([
+      node("i1", {
+        type: COMPONENT_INSTANCE_TYPE,
+        props: { componentId: "def-1" },
+      }),
+    ]);
+    const convert = (limits: DocumentLimits) =>
+      planConvertToComponent(
+        doc,
+        ["i1"],
+        componentTarget,
+        "def-1",
+        {},
+        anyParent,
+        limits
+      ).problem;
+
+    // Reached through the prototype: `Object.create` leaves no own property.
+    const inherited = Object.create(DEFAULT_LIMITS) as DocumentLimits;
+
+    // Own, but not enumerable — as a class instance's accessors would be.
+    const nonEnumerable = {} as DocumentLimits;
+    for (const key of ["maxDepth", "maxNodes", "maxBytes"] as const) {
+      Object.defineProperty(nonEnumerable, key, {
+        value: DEFAULT_LIMITS[key],
+        enumerable: false,
+      });
+    }
+
+    // A caller's own metadata riding along on the caps object.
+    const withUnrelated = { ...DEFAULT_LIMITS } as DocumentLimits;
+    Object.defineProperty(withUnrelated, "meta", {
+      enumerable: true,
+      get() {
+        throw new Error("this getter is not the planner's business");
+      },
+    });
+
+    expect({
+      inherited: convert(inherited),
+      nonEnumerable: convert(nonEnumerable),
+      withUnrelated: convert(withUnrelated),
+    }).toEqual({
+      inherited: "self-reference",
+      nonEnumerable: "self-reference",
+      withUnrelated: "self-reference",
+    });
+  });
+
   it("refuses an exposure list whose indices are accessors", () => {
     // A genuine array, with entries that would be well formed, that computes
     // them. Neither the array check nor the entry guards see it, and reading

--- a/packages/blocks-engine/src/composition-planners.ts
+++ b/packages/blocks-engine/src/composition-planners.ts
@@ -1133,11 +1133,24 @@ export function planConvertToComponent<TFields>(
   // OTHER single read was refused, which is what makes this the fifth read's
   // agreement with the first rather than a general validation weakness.
   //
-  // A spread rather than a per-member copy so a member added to
-  // `DocumentLimits` is snapshotted too: a list written out here would go on
-  // reading the new one live, which is the failure this exists to prevent
-  // wearing a different member's name.
-  const bounds: DocumentLimits = { ...limits };
+  // Named property reads rather than a spread. A spread copies OWN ENUMERABLE
+  // properties, which is the wrong set at both ends: it MISSES a member reached
+  // through the prototype or defined non-enumerably — measured, a
+  // `Object.create(DEFAULT_LIMITS)` reads `maxNodes` as 5,000 and spreads to
+  // `{}`, so every cap arrives `undefined` and a call that worked throws from
+  // `renameScopes` — and it READS unrelated members the planner never uses, so
+  // a caller whose limits object carries an enumerable getter for something
+  // else has that getter run, and a throwing one takes this call down.
+  //
+  // The annotation is what keeps the list honest: `DocumentLimits` is a closed
+  // set of required members, so a member added to it stops this literal
+  // compiling rather than being quietly read live. An OPTIONAL member added
+  // later would not, and would have to be added here by hand.
+  const bounds: DocumentLimits = {
+    maxDepth: limits.maxDepth,
+    maxNodes: limits.maxNodes,
+    maxBytes: limits.maxBytes,
+  };
 
   const saved = plannedSave(document, selectedIds, nesting, bounds);
   if (saved.problem !== undefined) return saved;


### PR DESCRIPTION
## This fixes a regression that is live on `main`

**#1643 merged at 08:10:04Z with head `b0a92badf`.** The fix below was pushed
after that merge was computed, so it never reached `main`. Verified by content
rather than by PR state:

```
git show ae5ea52d2:.../composition-planners.ts  →  const bounds: DocumentLimits = { ...limits };
git grep -c -F 'maxDepth: limits.maxDepth' ae5ea52d2  →  0     (fix absent from main)
git grep -c -F 'maxDepth: limits.maxDepth' HEAD       →  1     (positive control)
```

So `main` currently carries the spread, and the spread is the regression.

## The defect

`planConvertToComponent` snapshots the caps object it is given so its stages
cannot disagree about the cap. #1643 did that with a spread — and a spread
copies **own enumerable** properties, which is the wrong set at both ends.

Measured, with a plain-object control that stays working throughout:

| caps object | on `main` today | with this change |
|---|---|---|
| plain own properties | works | works |
| `Object.create(DEFAULT_LIMITS)` | **`RangeError` from `renameScopes`** | works |
| own but non-enumerable | **`RangeError` from `renameScopes`** | works |
| plus an unrelated throwing enumerable getter | **throws that getter's error** | works |

The prototype case is the one that matters. `inherited.maxNodes` reads `5000`
perfectly well; the spread yields `{}`, so every cap arrives `undefined`. That
call **worked before #1643**, which makes this a regression rather than a
pre-existing gap — and a worse one than the defect #1643 closed, because it
breaks ordinary conversions rather than only an adversarial one.

## The fix

Read the three declared caps by name. That keeps the single-read property the
snapshot exists for, while making how a caller stores them irrelevant.

I had argued in a comment on #1643 that a hand-written list would silently go
stale when a member is added to `DocumentLimits`. **That was wrong**, and I
checked rather than leaving it as prose: the type annotation on the literal is
itself the exhaustiveness guard. Adding a required member fails `tsc` with
`TS2741` naming that exact line, and the restored tree compiles clean as the
control. The comment now says this, and names the one case it does not cover —
an *optional* member added later, which would have to be added by hand.

## Break-verification

Two properties, guarded by two tests, and each break kills only its own:

| break | test that fails |
|---|---|
| restore the spread | `takes the caps by name, so how they are stored does not matter` |
| remove the snapshot entirely | `reads the caller's node cap once, so it cannot answer twice` |

## Gates

| gate | result |
|---|---|
| `pnpm build` (after clearing every `dist` from the previous branch) | exit 0, 19/19 |
| `blocks-engine` `check-types` | exit 0 (both `tsc` invocations) |
| `blocks-engine` `lint` | exit 0 |
| `blocks-engine` tests | 52 files, 2406 tests, exit 0 |
| `fallow audit --base origin/main` | `pass`, `changed_files_count: 3`, introduced 0 across all four categories |
| `pnpm changeset status` | parses; contributes 25 packages, verified by diffing status with and without the file |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved component conversion limit handling so configured depth, node, and byte limits are consistently respected.
  - Conversion now behaves correctly when limits are inherited or defined as non-enumerable properties.
  - Unrelated properties on the limits configuration no longer interfere with conversion checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->