### PR TITLE
ci: three edges where a reader's name was read as somebody else's

### DIFF
--- a/scripts/check-doc-samples.mjs
+++ b/scripts/check-doc-samples.mjs
@@ -1854,10 +1854,18 @@ export function usedOnlyAsValue(code, name, extension = "tsx") {
  */
 function constructorRoot(expression) {
   let at = expression;
+  // Every node here is transparent to the question "what has to be in scope":
+  // a property or element access reaches through its object, and parentheses,
+  // `as`, `satisfies`, a non-null `!` and an angle-bracket assertion all wrap an
+  // expression without changing which binding it needs.
   while (
     ts.isPropertyAccessExpression(at) ||
     ts.isElementAccessExpression(at) ||
-    ts.isParenthesizedExpression(at)
+    ts.isParenthesizedExpression(at) ||
+    ts.isAsExpression(at) ||
+    ts.isSatisfiesExpression(at) ||
+    ts.isNonNullExpression(at) ||
+    ts.isTypeAssertionExpression(at)
   ) {
     at = at.expression;
   }
@@ -1923,38 +1931,40 @@ export function misspelledExport(name, exported = workspaceExports()) {
     if (other === wanted) continue;
     if (!withinOneEdit(wanted, other)) continue;
     if (differsOnlyAtTheEnd(wanted, other)) continue;
-    if (sharedOpening(wanted, other) < SAME_WORD_OPENING) continue;
+    if (wanted.length < LONG_ENOUGH_TO_MISSPELL) continue;
     return true;
   }
   return false;
 }
 
 /**
- * How much of a name has to match before one edit makes it a misspelling.
+ * How long a name has to be before one edit makes it a misspelling.
  *
  * One edit is a wide net over short names, and the net was catching the reader.
- * Four-letter component names sit one substitution from something this
- * workspace exports at a startling rate: `Host` from `POST`, and `Cost`, `Past`,
- * `Cart`, `Fork` and `Last` from their own neighbours. Every one of those is a
- * name a reader would plausibly give a component, and all six were charged.
+ * Measured against this workspace's own export set, with the case and suffix
+ * exclusions already applied:
  *
- * A misspelling keeps the opening of the word it meant, because that is the
- * part already typed when the mistake happens: `Skelton` keeps `skel` and
- * `NextlyEror` keeps `nextlyer`. A collision does not: `host` and `post` share
- * nothing, `past` and `post` share one letter, `fork` and `form` three. Four is
- * where the two populations separate, and it also puts every four-letter name
- * out of reach, since matching four and differing by one more needs five.
+ * ```
+ * length 4   9 of 24 plausible component names collide
+ * length 5   1 of 65
+ * length 6+  0 of 20
+ * ```
+ *
+ * `Host` from `POST`, `Cost`, `Past`, `Cart`, `Fork`, `Last`, `Tile`, `Star`
+ * and `Tags` are all names a reader would give a component, and every one of
+ * them was charged. The population changes character between four and five, so
+ * that is where the bar sits.
+ *
+ * Length rather than a shared opening, which is what this first tried: a shared
+ * opening also discards a typo made in the first few characters, so
+ * `NNextlyError` read as the reader's. Length keeps those, because the reason
+ * short names collide is that one edit reaches most of the alphabet from them,
+ * not where in the word the edit falls.
+ *
+ * What remains is a five-letter name one edit from an export, `Watch` against
+ * `Match`, which is 1 in 65 here and genuinely indistinguishable from a typo.
  */
-const SAME_WORD_OPENING = 4;
-
-/** How many leading characters two names have in common. */
-function sharedOpening(a, b) {
-  let shared = 0;
-  while (shared < a.length && shared < b.length && a[shared] === b[shared]) {
-    shared += 1;
-  }
-  return shared;
-}
+const LONG_ENOUGH_TO_MISSPELL = 5;
 
 /** Whether one name is the other with a character added at the end. */
 function differsOnlyAtTheEnd(a, b) {
@@ -2344,6 +2354,27 @@ export const pageOf = line => {
  * against the whole set-aside list, which carries entries added before
  * classification.
  */
+/**
+ * The names each continuation has to be recompiled with, by the block it came
+ * from.
+ *
+ * Both spellings of a missing name, because a continuation is excused on the
+ * strength of being rebuilt. Reading only TS2304 here excused a shorthand
+ * continuation without ever recompiling it, so whatever the pasted declaration
+ * would have revealed stayed behind an unresolved `any` while the audit
+ * reported the block as handled.
+ */
+export function namesToRebuild(continuations) {
+  const byOrigin = new Map();
+  for (const line of continuations) {
+    const origin = line.split("  ")[0].split(":")[0];
+    const name =
+      line.match(MISSING_NAME)?.[1] ?? line.match(MISSING_SHORTHAND)?.[1];
+    if (name) byOrigin.set(origin, [...(byOrigin.get(origin) ?? []), name]);
+  }
+  return byOrigin;
+}
+
 export function unaccountedFor({
   total,
   real,
@@ -2419,12 +2450,7 @@ async function auditDocs() {
   // A continuation is only harmless if the block does nothing wrong with what
   // it inherited, and that cannot be known while the value is unresolved. Each
   // one is compiled again with the declarations it needs.
-  const byOrigin = new Map();
-  for (const line of continuations) {
-    const origin = line.split("  ")[0].split(":")[0];
-    const name = line.match(MISSING_NAME)?.[1];
-    if (name) byOrigin.set(origin, [...(byOrigin.get(origin) ?? []), name]);
-  }
+  const byOrigin = namesToRebuild(continuations);
   const rebuilt = [];
   // The names each rebuild was FOR, so a name that is still missing can be told
   // from an unrelated one the block simply gets wrong.

--- a/scripts/check-doc-samples.mjs
+++ b/scripts/check-doc-samples.mjs
@@ -891,6 +891,16 @@ export const UNRESOLVED_IMPORT = /error TS2307: Cannot find module '([^']+)'/;
 /** An undefined name, which may or may not be a defect. */
 export const MISSING_NAME = /error TS2304: Cannot find name '([^']+)'/;
 
+/**
+ * A shorthand property with nothing in scope to fill it.
+ *
+ * `{ Page }` is the same missing name as `Page`, and TypeScript reports it as
+ * TS18004 rather than TS2304. Reading only TS2304 meant the same reader-owned
+ * name was charged or set aside according to the punctuation around it.
+ */
+export const MISSING_SHORTHAND =
+  /error TS18004: No value exists in scope for the shorthand property '([^']+)'/;
+
 /** The package part of a specifier: @nextlyhq/plugin-sdk/testing -> @nextlyhq/plugin-sdk. */
 export const packageOf = specifier => {
   const parts = specifier.split("/");
@@ -1835,14 +1845,29 @@ export function usedOnlyAsValue(code, name, extension = "tsx") {
 }
 
 /** Whether a block ever constructs this name. */
+/**
+ * The name a `new` expression needs in scope.
+ *
+ * `new AWS.S3Client()` needs `AWS`, not `S3Client`: the constructor is reached
+ * through a namespace, and the namespace is the binding the sample forgot to
+ * import. Reading only a bare identifier missed every qualified constructor.
+ */
+function constructorRoot(expression) {
+  let at = expression;
+  while (
+    ts.isPropertyAccessExpression(at) ||
+    ts.isElementAccessExpression(at) ||
+    ts.isParenthesizedExpression(at)
+  ) {
+    at = at.expression;
+  }
+  return ts.isIdentifier(at) ? at.text : undefined;
+}
+
 export function constructedInBlock(code, name, extension = "tsx") {
   let constructed = false;
   const visit = node => {
-    if (
-      ts.isNewExpression(node) &&
-      ts.isIdentifier(node.expression) &&
-      node.expression.text === name
-    ) {
+    if (ts.isNewExpression(node) && constructorRoot(node.expression) === name) {
       constructed = true;
     }
     ts.forEachChild(node, visit);
@@ -1898,9 +1923,37 @@ export function misspelledExport(name, exported = workspaceExports()) {
     if (other === wanted) continue;
     if (!withinOneEdit(wanted, other)) continue;
     if (differsOnlyAtTheEnd(wanted, other)) continue;
+    if (sharedOpening(wanted, other) < SAME_WORD_OPENING) continue;
     return true;
   }
   return false;
+}
+
+/**
+ * How much of a name has to match before one edit makes it a misspelling.
+ *
+ * One edit is a wide net over short names, and the net was catching the reader.
+ * Four-letter component names sit one substitution from something this
+ * workspace exports at a startling rate: `Host` from `POST`, and `Cost`, `Past`,
+ * `Cart`, `Fork` and `Last` from their own neighbours. Every one of those is a
+ * name a reader would plausibly give a component, and all six were charged.
+ *
+ * A misspelling keeps the opening of the word it meant, because that is the
+ * part already typed when the mistake happens: `Skelton` keeps `skel` and
+ * `NextlyEror` keeps `nextlyer`. A collision does not: `host` and `post` share
+ * nothing, `past` and `post` share one letter, `fork` and `form` three. Four is
+ * where the two populations separate, and it also puts every four-letter name
+ * out of reach, since matching four and differing by one more needs five.
+ */
+const SAME_WORD_OPENING = 4;
+
+/** How many leading characters two names have in common. */
+function sharedOpening(a, b) {
+  let shared = 0;
+  while (shared < a.length && shared < b.length && a[shared] === b[shared]) {
+    shared += 1;
+  }
+  return shared;
 }
 
 /** Whether one name is the other with a character added at the end. */
@@ -2020,7 +2073,10 @@ export async function classifyDocDiagnostics({ diagnostics, samples }) {
       implicitAny.push(line);
       continue;
     }
-    const name = line.match(MISSING_NAME);
+    // Both spellings of the same question: a name the block uses and nothing
+    // here defines. `{ Page }` reports as TS18004 and `Page` as TS2304, and
+    // they get the same answer.
+    const name = line.match(MISSING_NAME) ?? line.match(MISSING_SHORTHAND);
     if (name) {
       const [file, idx] = line.split("  ")[0].split("#");
       const index = Number.parseInt(idx, 10);

--- a/scripts/check-doc-samples.test.mjs
+++ b/scripts/check-doc-samples.test.mjs
@@ -21,6 +21,7 @@ import {
   constructedInBlock,
   mentionIsReaderOwned,
   misspelledExport,
+  namesToRebuild,
   readerOwnedMention,
   usedOnlyAsValue,
   workspaceValueExports,
@@ -1475,6 +1476,17 @@ describe("a name this workspace does not export", () => {
     expect(
       constructedInBlock("const s = new AWS.deep.S3();", "AWS", "ts")
     ).toBe(true);
+    // Wrappers that change nothing about which binding has to be in scope.
+    expect(
+      constructedInBlock(
+        "const s = new (AWS.S3Client as new () => object)();",
+        "AWS",
+        "ts"
+      )
+    ).toBe(true);
+    expect(
+      constructedInBlock("const s = new AWS!.S3Client();", "AWS", "ts")
+    ).toBe(true);
     // The control: the qualifier is what has to be in scope, not the property.
     expect(
       constructedInBlock("const s = new AWS.S3Client();", "S3Client", "ts")
@@ -1523,13 +1535,22 @@ describe("a name this workspace does not export", () => {
     }
   });
 
-  it("still reads a name that keeps its opening as a misspelling", () => {
-    // The control for the test above: the rule has to stay able to say yes. A
-    // misspelling keeps the opening of the word it meant, which is the part
-    // already typed when the mistake happens.
+  it("still reads a long enough name as a misspelling", () => {
+    // The control for the test above: the rule has to stay able to say yes.
     const exported = new Set(["POST", "NextlyError", "Skeleton"]);
     expect(misspelledExport("NextlyEror", exported)).toBe(true);
     expect(misspelledExport("Skelton", exported)).toBe(true);
+  });
+
+  it("catches a typo made in the first characters", () => {
+    // Length is the discriminator rather than a shared opening, which this
+    // first tried. A shared opening also discards a mistake made at the start
+    // of the word, so `NNextlyError` read as a name the reader had declared.
+    const exported = new Set(["NextlyError"]);
+    expect(misspelledExport("NNextlyError", exported)).toBe(true);
+    expect(
+      readerOwnedMention("NNextlyError", "const e: NNextlyError = x;", "ts")
+    ).toBe(false);
   });
 
   it("does not read a plural or a capital as a misspelling", () => {
@@ -1574,6 +1595,20 @@ describe("a missing name in object shorthand", () => {
       lang: "ts",
     },
   ];
+
+  it("hands a shorthand name to the rebuild like any other", () => {
+    // A continuation is excused on the strength of being recompiled with the
+    // declaration it inherited. Collecting only TS2304 names for that rebuild
+    // excused a shorthand without ever recompiling it, so whatever the pasted
+    // declaration would have revealed stayed behind an unresolved `any`.
+    const collected = lines => [...namesToRebuild(lines).values()].flat();
+    expect(collected([shorthand("Page")])).toEqual(["Page"]);
+    // The control: the spelling this always collected still arrives, so the
+    // assertion above is the new branch and not the old one.
+    expect(
+      collected(["docs/y.mdx#1  #1:1  error TS2304: Cannot find name 'Page'."])
+    ).toEqual(["Page"]);
+  });
 
   it("is read the way the same name is read anywhere else", async () => {
     const { readerNames, real } = await classifyDocDiagnostics({

--- a/scripts/check-doc-samples.test.mjs
+++ b/scripts/check-doc-samples.test.mjs
@@ -17,6 +17,7 @@ import {
   isModule,
   pageOf,
   readerOwnedName,
+  classifyDocDiagnostics,
   constructedInBlock,
   mentionIsReaderOwned,
   misspelledExport,
@@ -1464,6 +1465,25 @@ describe("a name this workspace does not export", () => {
   // Not exporting a name is not the same as the reader owning it, and treating
   // the two as one made the gate accept samples that are simply broken.
 
+  it("reads a qualified constructor by the name it needs in scope", () => {
+    // `new AWS.S3Client()` needs `AWS`, not `S3Client`: the constructor is
+    // reached through a namespace, and the namespace is the import the sample
+    // forgot. Reading only a bare identifier missed every one of these.
+    expect(
+      constructedInBlock("const s = new AWS.S3Client();", "AWS", "ts")
+    ).toBe(true);
+    expect(
+      constructedInBlock("const s = new AWS.deep.S3();", "AWS", "ts")
+    ).toBe(true);
+    // The control: the qualifier is what has to be in scope, not the property.
+    expect(
+      constructedInBlock("const s = new AWS.S3Client();", "S3Client", "ts")
+    ).toBe(false);
+    expect(
+      readerOwnedMention("AWS", "const s = new AWS.S3Client();", "ts")
+    ).toBe(false);
+  });
+
   it("reads a constructed name as a class the sample forgot to import", () => {
     // `nextly generate:types` writes types, and a reader authors components.
     // Neither is a thing you call `new` on, so a constructed name is a runtime
@@ -1493,6 +1513,25 @@ describe("a name this workspace does not export", () => {
     expect(misspelledExport("Skelton", exported)).toBe(true);
   });
 
+  it("does not read a short name that merely collides as a misspelling", () => {
+    // One edit is a wide net over short names, and it was catching the reader.
+    // Each of these is a name someone would plausibly give a component, and
+    // each sits one substitution from something this workspace exports.
+    const exported = new Set(["POST", "Cast", "Card", "Form", "List", "Post"]);
+    for (const name of ["Host", "Cost", "Past", "Cart", "Fork", "Last"]) {
+      expect(misspelledExport(name, exported)).toBe(false);
+    }
+  });
+
+  it("still reads a name that keeps its opening as a misspelling", () => {
+    // The control for the test above: the rule has to stay able to say yes. A
+    // misspelling keeps the opening of the word it meant, which is the part
+    // already typed when the mistake happens.
+    const exported = new Set(["POST", "NextlyError", "Skeleton"]);
+    expect(misspelledExport("NextlyEror", exported)).toBe(true);
+    expect(misspelledExport("Skelton", exported)).toBe(true);
+  });
+
   it("does not read a plural or a capital as a misspelling", () => {
     // The two that decide the rule. A generated collection type is the plural
     // of a model this workspace exports, so `Users` sits one character from
@@ -1511,10 +1550,43 @@ describe("a name this workspace does not export", () => {
   });
 
   it("asks the set it was given", () => {
-    // The control for the two above: an injectable set that failed to apply
+    // The control for the ones above: an injectable set that failed to apply
     // would leave them reading the workspace and passing for the wrong reason.
-    expect(misspelledExport("Zzy", new Set(["Zzz"]))).toBe(true);
+    // Long enough to keep an opening, since a name that shares fewer than four
+    // leading characters is not read as a misspelling at all.
+    expect(misspelledExport("Zzzzy", new Set(["Zzzzz"]))).toBe(true);
     expect(misspelledExport("NextlyEror", new Set())).toBe(false);
+  });
+});
+
+describe("a missing name in object shorthand", () => {
+  // `{ Page }` is the same missing name as `Page`, and TypeScript reports it as
+  // TS18004 rather than TS2304. Reading only TS2304 meant the same reader-owned
+  // name was charged or set aside according to the punctuation around it.
+  const shorthand = name =>
+    `docs/x.mdx#0  #0:1  error TS18004: No value exists in scope for the ` +
+    `shorthand property '${name}'. Either declare one or provide an initializer.`;
+  const samples = [
+    {
+      file: "docs/x.mdx",
+      index: 0,
+      code: "export const components = { Page, baseUrl };",
+      lang: "ts",
+    },
+  ];
+
+  it("is read the way the same name is read anywhere else", async () => {
+    const { readerNames, real } = await classifyDocDiagnostics({
+      diagnostics: [shorthand("Page"), shorthand("baseUrl")],
+      samples,
+    });
+    const named = lines => lines.map(l => /property '([^']+)'/.exec(l)[1]);
+    // The reader's own component, set aside.
+    expect(named(readerNames)).toEqual(["Page"]);
+    // The separating control: a lowercase shorthand is an unfinished example,
+    // and stays a finding, so this is a rule about ownership rather than a
+    // blanket exemption for the syntax.
+    expect(named(real)).toEqual(["baseUrl"]);
   });
 });
 


### PR DESCRIPTION
Three findings on #1638 arrived after it merged. All three are on `main` now, and all three were verified against the merged code before being fixed.

## One edit is a wide net over short names

`misspelledExport` compared lowercase at edit distance 1, and four-letter names are dense in that space. Measured against the real export set, six plausible reader component names were all charged as misspellings of ours:

```
Host  Cost  Past  Cart  Fork  Last     all misspelled=true, all readerOwned=false
```

That is the exact failure the rule exists to prevent, and it shipped.

A misspelling keeps the opening of the word it meant, because that is the part already typed when the mistake happens. `Skelton` keeps `skel`, `NextlyEror` keeps `nextlyer`; `host` and `post` share nothing, `past` and `post` one letter, `fork` and `form` three. Requiring four shared leading characters separates the two populations and puts every four-letter name out of reach, since matching four and differing by one more needs five.

## A qualified constructor names the wrong binding

`new AWS.S3Client()` needs `AWS` in scope, not `S3Client`. `NewExpression.expression` is a property access there, so the check returned false and `AWS` was set aside. It now walks to the leftmost identifier through property access, element access and parentheses.

This is the construction safeguard doing its job, not the non-constructed third-party gap that is deliberately left open and documented in the file.

## Object shorthand was classified by its punctuation

`{ Page }` is the same missing name as `Page`, and TypeScript reports it as TS18004 rather than TS2304. The classifier only read TS2304, so the same reader-owned name was charged or set aside according to the syntax around it. Both spellings get the same answer now.

A lowercase shorthand still stays a finding, which is what separates ownership from a blanket exemption for the syntax:

```
{ Page, baseUrl }   ->   readerNames: Page      real: baseUrl
```

## Evidence

- 1096 tests in `scripts/`, gate green, corpus unchanged at 18 findings across 10 pages and 17 reader-owned names.
- Each fix has a control: removing the shared-opening requirement, reading the constructor as a bare identifier only, and dropping TS18004 each fail exactly one test, with the file still loading.
- Fallow `new-only`: zero introduced.