### PR TITLE
refactor(nextly): one name per way of reaching an instance

### DIFF
--- a/.changeset/one-name-per-nextly-accessor.md
+++ b/.changeset/one-name-per-nextly-accessor.md
@@ -1,0 +1,35 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The synchronous Direct API accessor is now `requireNextly`, exported from `nextly/runtime`. It was `getNextly`, which is also what `nextly` exports for a different function: one initialises, takes a required config and returns a promise; the other reads the already-registered singleton, takes nothing and throws when the process has not booted. One name, two functions, opposite tolerance for an uninitialised runtime, and nothing at an import site to say which one arrived.
+
+`getNextly({ config })` from `nextly` is unchanged. It is the one to reach for: it initialises rather than assuming, so it is correct whether or not something else has booted, and it caches, so calling it per request is a lookup after the first. `requireNextly()` is for code that provably runs after initialisation, and its name now says that it will throw otherwise.
+
+Two pieces of documentation that the shared name had made wrong are corrected with it. The accessor's own example told readers to import it from `nextly`, where that name resolves to the other function, so the snippet could not compile. The convenience proxy's note said the runtime is initialised "via `getNextly()`", which is the other one again.
+
+A test asserts that no name is published from two entry points with different arities. It found two more of the same shape, `isFieldGroupType` and `createAdapter`, which are recorded so a fourth fails on the day it appears.

--- a/apps/playground/src/lib/site-content.ts
+++ b/apps/playground/src/lib/site-content.ts
@@ -28,7 +28,7 @@ type NextlyInstance = Awaited<ReturnType<typeof getNextly>>;
 /**
  * The instance, resolved per call.
  *
- * A route helper otherwise falls back to the synchronous `getNextly()` from
+ * A route helper otherwise falls back to the synchronous `requireNextly()` from
  * `nextly/runtime`, which returns the already-registered singleton and throws
  * when nothing has registered it. A public page can be the FIRST request a cold
  * server handles, so relying on that means the route works only once something

--- a/packages/blocks-react/src/next.ts
+++ b/packages/blocks-react/src/next.ts
@@ -37,7 +37,7 @@ import {
   createPublicSingleRoute,
   createSingleRoute,
   entryIdTag,
-  getNextly,
+  requireNextly,
   nextlyTags,
   releaseBoundedRevalidate,
   nextlySingleTags,
@@ -390,7 +390,7 @@ function emitPath(slug: string): string | null {
  * them explicitly on every call, so they never depended on those defaults.
  */
 function readerFor(config: BlocksPageConfig): NextlyContentReader {
-  return config.nextly ?? getNextly();
+  return config.nextly ?? requireNextly();
 }
 
 /** An empty page, for a field that exists and holds no document yet. */

--- a/packages/nextly/src/__tests__/export-contract.test.ts
+++ b/packages/nextly/src/__tests__/export-contract.test.ts
@@ -42,6 +42,25 @@ const FORBIDDEN = [
   "COMPONENT_MIGRATION_STATUSES",
 ];
 
+/**
+ * Names already published from two entry points meaning different things.
+ *
+ * 🔴 Recorded, not accepted. Each is the same defect `getNextly` was: one name,
+ * two functions, and nothing at an import site to say which one arrived.
+ * `isFieldGroupType` is a boolean test in one place and a generic narrowing in
+ * the other; `createAdapter` is the CLI's and the database factory's, which
+ * take different arguments and do different work.
+ *
+ * They are listed rather than fixed here because each needs the same decision
+ * `getNextly` needed about which keeps the name, and answering three of those
+ * inside one rename is how a considered API becomes an incidental one. Listing
+ * them is what makes a FOURTH fail this test on the day it appears.
+ */
+const KNOWN_ARITY_CLASHES = [
+  "isFieldGroupType: nextly takes 1, nextly/field-group-type takes 2",
+  "createAdapter: nextly takes 1, nextly/database takes 1, nextly/cli/utils takes 0",
+];
+
 const manifestUrl = new URL("../../package.json", import.meta.url);
 const packageRoot = path.dirname(fileURLToPath(manifestUrl));
 
@@ -98,6 +117,60 @@ describe("published export surface", () => {
       expect(leaked).toEqual([]);
     }
   );
+
+  // 🔴 The defect this generalises: `getNextly` was published from `nextly` as
+  // an async function taking a required config, and from `nextly/runtime` as a
+  // synchronous one taking none. Same name, opposite tolerance for an
+  // uninitialised process, and nothing said so at an import site. It cost a
+  // wrong example in the package's own JSDoc, a wrong sentence in a test
+  // header, and a defensive assertion in the admin's code generator.
+  //
+  // Arity is the cheap half of a signature and it separates the two cases that
+  // matter: a function that demands configuration from one that takes none.
+  it("does not publish one name from two entries with different arities", async () => {
+    const seen = new Map<string, Array<{ entry: string; arity: number }>>();
+    for (const [entry, source] of ENTRY_POINTS) {
+      const mod = (await import(pathToFileURL(source).href)) as Record<
+        string,
+        unknown
+      >;
+      for (const [name, value] of Object.entries(mod)) {
+        if (typeof value !== "function") continue;
+        seen.set(name, [
+          ...(seen.get(name) ?? []),
+          { entry, arity: value.length },
+        ]);
+      }
+    }
+    const clashing = [...seen.entries()]
+      .filter(
+        ([, places]) =>
+          places.length > 1 &&
+          new Set(places.map(place => place.arity)).size > 1
+      )
+      .map(
+        ([name, places]) =>
+          `${name}: ${places
+            .map(place => `${place.entry} takes ${String(place.arity)}`)
+            .join(", ")}`
+      );
+    expect(clashing).toEqual(KNOWN_ARITY_CLASHES);
+    // The control: a scan that imported nothing would report no clash. This
+    // asserts the scan actually read a surface.
+    expect(seen.size).toBeGreaterThan(50);
+  });
+
+  it("publishes each way to reach an instance under its own name", async () => {
+    // The two are kept apart on purpose. `getNextly` initialises and is correct
+    // whether or not the process has booted; `requireNextly` reads what is
+    // already registered and throws when there is none.
+    const root = (await import("../index")) as Record<string, unknown>;
+    const runtime = (await import("../runtime")) as Record<string, unknown>;
+    expect(typeof root.getNextly).toBe("function");
+    expect(typeof runtime.requireNextly).toBe("function");
+    expect("getNextly" in runtime).toBe(false);
+    expect("requireNextly" in root).toBe(false);
+  });
 
   it("exposes the field-group vocabulary from the config entry point", async () => {
     // The counterpart to the list above: absence alone would also be satisfied

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -35,7 +35,7 @@ import type {
 import type { FieldConfig } from "../collections/fields/types";
 import { createAdapterFromEnv, validateDatabaseEnv } from "../database/factory";
 import type { SchemaRegistry } from "../database/schema-registry";
-import { getNextly } from "../direct-api/nextly";
+import { requireNextly } from "../direct-api/nextly";
 import type { ResolvedAuditRetentionConfig } from "../domains/audit/retention-config";
 import type { ApiKeyService } from "../domains/auth/services/api-key-service";
 import type { AuthService } from "../domains/auth/services/auth-service";
@@ -1259,17 +1259,17 @@ export async function registerServices(
   //
   // `req.nextly` is how a hook reaches other collections, and the collections
   // guide's own examples use it. It resolved through this container binding,
-  // which `getNextly()` created as a side effect of its FIRST call -- so a
+  // which `requireNextly()` created as a side effect of its FIRST call -- so a
   // process that never called it handed every hook `undefined`. A REST or admin
   // write does not call it, which made the documented handle absent on exactly
   // the paths hooks run on most.
   //
   // Registered here instead, where service wiring belongs, so the binding
-  // exists from boot. The factory is lazy: `getNextly()` still builds the
+  // exists from boot. The factory is lazy: `requireNextly()` still builds the
   // instance on first resolution, and still returns the current one afterwards,
   // so `resetNextlyInstance()` keeps working for tests.
   if (!container.has("nextlyDirectAPI")) {
-    container.register("nextlyDirectAPI", () => getNextly());
+    container.register("nextlyDirectAPI", () => requireNextly());
   }
 
   // Opened immediately BEFORE registration publishes, which is the last point

--- a/packages/nextly/src/direct-api/__tests__/gate-before-direct-api.test.ts
+++ b/packages/nextly/src/direct-api/__tests__/gate-before-direct-api.test.ts
@@ -1,6 +1,7 @@
 /**
- * The Direct API's `getNextly()` is exported from the package root, so a Server
- * Component can call `nextly.find()` on it. It is SYNCHRONOUS, so it cannot
+ * The Direct API's `requireNextly()` is exported from `nextly/runtime`, and the
+ * `nextly` proxy on the package root resolves every call through it, so a
+ * Server Component reaches it either way. It is SYNCHRONOUS, so it cannot
  * wait for boot migrations the way the async surfaces do — and it decided
  * readiness from `isServicesRegistered()` alone, which is true throughout a
  * production boot's migration wait.
@@ -24,7 +25,7 @@ vi.mock("../../di/register", () => ({
   getService: () => undefined,
 }));
 
-const { getNextly } = await import("../nextly");
+const { requireNextly } = await import("../nextly");
 
 beforeEach(() => {
   // `mockReset`, not `clearAllMocks`: the latter clears recorded CALLS but
@@ -41,18 +42,18 @@ describe("the Direct API consults the boot-migrations gate", () => {
       });
     });
 
-    expect(() => getNextly()).toThrow(
+    expect(() => requireNextly()).toThrow(
       expect.objectContaining({ code: "NEXTLY_BOOT_MIGRATIONS_PENDING" })
     );
   });
 
   /**
-   * The control. Without it the assertion above is satisfied by a `getNextly`
+   * The control. Without it the assertion above is satisfied by a `requireNextly`
    * that throws unconditionally — which would break every Direct API call in
    * development and in any app that does not run boot migrations.
    */
   it("returns an instance once the gate has settled", () => {
-    expect(() => getNextly()).not.toThrow();
+    expect(() => requireNextly()).not.toThrow();
     expect(assertBootMigrationsSettled).toHaveBeenCalled();
   });
 });

--- a/packages/nextly/src/direct-api/index.ts
+++ b/packages/nextly/src/direct-api/index.ts
@@ -32,7 +32,7 @@
  */
 
 // Export Nextly class, factory, and convenience object
-export { Nextly, getNextly, resetNextlyInstance, nextly } from "./nextly";
+export { Nextly, requireNextly, resetNextlyInstance, nextly } from "./nextly";
 export * from "./types";
 // Canonical NextlyError replaces the legacy direct-api error subclass
 // hierarchy (NotFoundError, ValidationError, etc.) — those were deleted in

--- a/packages/nextly/src/direct-api/nextly.ts
+++ b/packages/nextly/src/direct-api/nextly.ts
@@ -15,9 +15,9 @@
  *
  * @example
  * ```typescript
- * import { getNextly } from 'nextly';
+ * import { requireNextly } from 'nextly/runtime';
  *
- * const nextly = getNextly();
+ * const nextly = requireNextly();
  *
  * // Find documents -> ListResult<T> = { items, meta }
  * const result = await nextly.find({
@@ -221,7 +221,7 @@ import type { JobSlug, QueueJobArgs } from "./types/jobs";
  *
  * @example
  * ```typescript
- * const nextly = getNextly();
+ * const nextly = requireNextly();
  *
  * // Default: bypass access control (trusted server context)
  * // Returns ListResult<T> = { items, meta }.
@@ -657,12 +657,22 @@ const globalForDirectApi = globalThis as unknown as {
 };
 
 /**
- * Get the Nextly Direct API instance.
+ * The Nextly instance this process has already registered.
  *
- * Returns a singleton instance of the Nextly class for direct server-side
- * database operations.
+ * Named for what it demands rather than what it returns. It does NOT
+ * initialise: it reads the singleton and throws when there is none, so it is
+ * only correct where something else has provably booted the runtime. Where you
+ * are not sure, `getNextly({ config })` from `nextly` initialises and is
+ * correct in both cases.
  *
- * **Important:** `registerServices()` must be called before using this function.
+ * That difference is why the two no longer share a name. Both were called
+ * `getNextly`, one exported from `nextly` and one from `nextly/runtime`, with
+ * different arities, different return types and opposite tolerance for an
+ * uninitialised process. The example on this function even told readers to
+ * import it from `nextly`, where the name resolves to the other one, so the
+ * snippet could not compile.
+ *
+ * **Important:** `registerServices()` must have run before this is called.
  *
  * @param config - Optional configuration to apply to new instance
  * @returns Nextly instance
@@ -670,9 +680,9 @@ const globalForDirectApi = globalThis as unknown as {
  *
  * @example
  * ```typescript
- * import { getNextly } from 'nextly';
+ * import { requireNextly } from 'nextly/runtime';
  *
- * const nextly = getNextly();
+ * const nextly = requireNextly();
  *
  * // Find posts. Returns ListResult<T> = { items, meta }.
  * const result = await nextly.find({
@@ -683,7 +693,7 @@ const globalForDirectApi = globalThis as unknown as {
  * result.meta.total;  // number
  * ```
  */
-export function getNextly(config?: DirectAPIConfig): Nextly {
+export function requireNextly(config?: DirectAPIConfig): Nextly {
   // Registration is not readiness. A production boot publishes services and
   // THEN waits for the migrate lock, so this flag is true throughout a window
   // in which the schema is unverified — and this getter is synchronous, so it
@@ -728,7 +738,7 @@ export function resetNextlyInstance(): void {
 /**
  * Whether the Direct API singleton has been built in this process.
  *
- * Answers the question without building it, which `getNextly()` cannot: asking
+ * Answers the question without building it, which `requireNextly()` cannot: asking
  * it constructs the instance and registers the container binding. That makes
  * "was the Direct API resolved?" unobservable through the ordinary surface, so
  * a test cannot tell a caller that resolved it lazily from one that never
@@ -745,10 +755,12 @@ export function isNextlyInstantiated(): boolean {
  *
  * Each method lazily resolves the Nextly singleton on first call,
  * so it's safe to import at module scope. All methods delegate to
- * `getNextly()` internally.
+ * `requireNextly()` internally.
  *
- * **Important:** Services must be initialized (via `getNextly()` from
- * `nextly`) before calling any method on this object.
+ * **Important:** the runtime must already be initialised before any method on
+ * this object is called, because each one resolves through `requireNextly()`,
+ * which throws when nothing has registered services. `getNextly({ config })`
+ * from `nextly` is what initialises.
  *
  * @example
  * ```typescript
@@ -767,195 +779,204 @@ export function isNextlyInstantiated(): boolean {
  */
 export const nextly = {
   find: <TSlug extends CollectionSlug>(args: FindArgs<TSlug>) =>
-    getNextly().find(args),
+    requireNextly().find(args),
   findByID: <TSlug extends CollectionSlug>(args: FindByIDArgs<TSlug>) =>
-    getNextly().findByID(args),
+    requireNextly().findByID(args),
   create: <TSlug extends CollectionSlug>(args: CreateArgs<TSlug>) =>
-    getNextly().create(args),
+    requireNextly().create(args),
   update: <TSlug extends CollectionSlug>(args: UpdateArgs<TSlug>) =>
-    getNextly().update(args),
-  delete: (args: DeleteArgs) => getNextly().delete(args),
-  count: (args: CountArgs) => getNextly().count(args),
-  group: (args: GroupArgs) => getNextly().group(args),
-  bulkDelete: (args: BulkDeleteArgs) => getNextly().bulkDelete(args),
+    requireNextly().update(args),
+  delete: (args: DeleteArgs) => requireNextly().delete(args),
+  count: (args: CountArgs) => requireNextly().count(args),
+  group: (args: GroupArgs) => requireNextly().group(args),
+  bulkDelete: (args: BulkDeleteArgs) => requireNextly().bulkDelete(args),
   duplicate: <TSlug extends CollectionSlug>(args: DuplicateArgs<TSlug>) =>
-    getNextly().duplicate(args),
+    requireNextly().duplicate(args),
 
   findSingle: <TSlug extends SingleSlug>(args: FindSingleArgs<TSlug>) =>
-    getNextly().findSingle(args),
+    requireNextly().findSingle(args),
   updateSingle: <TSlug extends SingleSlug>(args: UpdateSingleArgs<TSlug>) =>
-    getNextly().updateSingle(args),
-  findSingles: (args?: FindSinglesArgs) => getNextly().findSingles(args ?? {}),
+    requireNextly().updateSingle(args),
+  findSingles: (args?: FindSinglesArgs) =>
+    requireNextly().findSingles(args ?? {}),
 
-  login: (args: LoginArgs) => getNextly().login(args),
-  logout: () => getNextly().logout(),
-  me: (args: { user: UserContext }) => getNextly().me(args),
+  login: (args: LoginArgs) => requireNextly().login(args),
+  logout: () => requireNextly().logout(),
+  me: (args: { user: UserContext }) => requireNextly().me(args),
   updateMe: (args: {
     user: UserContext;
     data: { name?: string; image?: string };
-  }) => getNextly().updateMe(args),
-  register: (args: RegisterArgs) => getNextly().register(args),
+  }) => requireNextly().updateMe(args),
+  register: (args: RegisterArgs) => requireNextly().register(args),
   changePassword: (args: ChangePasswordArgs & { user: UserContext }) =>
-    getNextly().changePassword(args),
+    requireNextly().changePassword(args),
   forgotPassword: (args: ForgotPasswordArgs) =>
-    getNextly().forgotPassword(args),
-  resetPassword: (args: ResetPasswordArgs) => getNextly().resetPassword(args),
-  verifyEmail: (args: VerifyEmailArgs) => getNextly().verifyEmail(args),
+    requireNextly().forgotPassword(args),
+  resetPassword: (args: ResetPasswordArgs) =>
+    requireNextly().resetPassword(args),
+  verifyEmail: (args: VerifyEmailArgs) => requireNextly().verifyEmail(args),
 
   jobs: {
     queue: <TTask extends JobSlug>(args: QueueJobArgs<TTask>) =>
-      getNextly().jobs.queue(args),
+      requireNextly().jobs.queue(args),
   },
 
   releases: {
     create: (args: Parameters<ReleasesNamespace["create"]>[0]) =>
-      getNextly().releases.create(args),
+      requireNextly().releases.create(args),
     find: (args?: Parameters<ReleasesNamespace["find"]>[0]) =>
-      getNextly().releases.find(args),
+      requireNextly().releases.find(args),
     findByID: (args: Parameters<ReleasesNamespace["findByID"]>[0]) =>
-      getNextly().releases.findByID(args),
+      requireNextly().releases.findByID(args),
     addMember: (args: Parameters<ReleasesNamespace["addMember"]>[0]) =>
-      getNextly().releases.addMember(args),
+      requireNextly().releases.addMember(args),
     removeMember: (args: Parameters<ReleasesNamespace["removeMember"]>[0]) =>
-      getNextly().releases.removeMember(args),
+      requireNextly().releases.removeMember(args),
     listMembers: (args: Parameters<ReleasesNamespace["listMembers"]>[0]) =>
-      getNextly().releases.listMembers(args),
+      requireNextly().releases.listMembers(args),
     schedule: (args: Parameters<ReleasesNamespace["schedule"]>[0]) =>
-      getNextly().releases.schedule(args),
+      requireNextly().releases.schedule(args),
     cancel: (args: Parameters<ReleasesNamespace["cancel"]>[0]) =>
-      getNextly().releases.cancel(args),
+      requireNextly().releases.cancel(args),
   },
 
   users: {
-    find: (args?: FindUsersArgs) => getNextly().users.find(args),
-    findOne: (args?: FindOneUserArgs) => getNextly().users.findOne(args),
-    findByID: (args: FindUserByIDArgs) => getNextly().users.findByID(args),
-    create: (args: CreateUserArgs) => getNextly().users.create(args),
-    update: (args: UpdateUserArgs) => getNextly().users.update(args),
-    delete: (args: DeleteUserArgs) => getNextly().users.delete(args),
+    find: (args?: FindUsersArgs) => requireNextly().users.find(args),
+    findOne: (args?: FindOneUserArgs) => requireNextly().users.findOne(args),
+    findByID: (args: FindUserByIDArgs) => requireNextly().users.findByID(args),
+    create: (args: CreateUserArgs) => requireNextly().users.create(args),
+    update: (args: UpdateUserArgs) => requireNextly().users.update(args),
+    delete: (args: DeleteUserArgs) => requireNextly().users.delete(args),
   },
 
   media: {
-    upload: (args: UploadMediaArgs) => getNextly().media.upload(args),
-    find: (args?: FindMediaArgs) => getNextly().media.find(args),
-    findByID: (args: FindMediaByIDArgs) => getNextly().media.findByID(args),
-    update: (args: UpdateMediaArgs) => getNextly().media.update(args),
-    delete: (args: DeleteMediaArgs) => getNextly().media.delete(args),
+    upload: (args: UploadMediaArgs) => requireNextly().media.upload(args),
+    find: (args?: FindMediaArgs) => requireNextly().media.find(args),
+    findByID: (args: FindMediaByIDArgs) => requireNextly().media.findByID(args),
+    update: (args: UpdateMediaArgs) => requireNextly().media.update(args),
+    delete: (args: DeleteMediaArgs) => requireNextly().media.delete(args),
     bulkDelete: (args: BulkDeleteMediaArgs) =>
-      getNextly().media.bulkDelete(args),
+      requireNextly().media.bulkDelete(args),
     folders: {
-      list: (args?: ListFoldersArgs) => getNextly().media.folders.list(args),
+      list: (args?: ListFoldersArgs) =>
+        requireNextly().media.folders.list(args),
       create: (args: CreateFolderArgs) =>
-        getNextly().media.folders.create(args),
+        requireNextly().media.folders.create(args),
     },
   },
 
   forms: {
-    find: (args?: FindFormsArgs) => getNextly().forms.find(args),
+    find: (args?: FindFormsArgs) => requireNextly().forms.find(args),
     findBySlug: (args: FindFormBySlugArgs) =>
-      getNextly().forms.findBySlug(args),
-    submit: (args: SubmitFormArgs) => getNextly().forms.submit(args),
+      requireNextly().forms.findBySlug(args),
+    submit: (args: SubmitFormArgs) => requireNextly().forms.submit(args),
     submissions: (args: FormSubmissionsArgs) =>
-      getNextly().forms.submissions(args),
+      requireNextly().forms.submissions(args),
   },
 
   fieldGroups: {
-    find: (args?: FindFieldGroupsArgs) => getNextly().fieldGroups.find(args),
+    find: (args?: FindFieldGroupsArgs) =>
+      requireNextly().fieldGroups.find(args),
     findBySlug: (args: FindFieldGroupBySlugArgs) =>
-      getNextly().fieldGroups.findBySlug(args),
+      requireNextly().fieldGroups.findBySlug(args),
     create: (args: CreateFieldGroupArgs) =>
-      getNextly().fieldGroups.create(args),
+      requireNextly().fieldGroups.create(args),
     update: (args: UpdateFieldGroupArgs) =>
-      getNextly().fieldGroups.update(args),
+      requireNextly().fieldGroups.update(args),
     delete: (args: DeleteFieldGroupArgs) =>
-      getNextly().fieldGroups.delete(args),
+      requireNextly().fieldGroups.delete(args),
   },
 
   email: {
-    send: (args: SendEmailArgs) => getNextly().email.send(args),
+    send: (args: SendEmailArgs) => requireNextly().email.send(args),
     sendWithTemplate: (args: SendTemplateEmailArgs) =>
-      getNextly().email.sendWithTemplate(args),
+      requireNextly().email.sendWithTemplate(args),
   },
 
   emailProviders: {
     find: (args?: FindEmailProvidersArgs) =>
-      getNextly().emailProviders.find(args),
+      requireNextly().emailProviders.find(args),
     findByID: (args: FindEmailProviderByIDArgs) =>
-      getNextly().emailProviders.findByID(args),
+      requireNextly().emailProviders.findByID(args),
     create: (args: CreateEmailProviderArgs) =>
-      getNextly().emailProviders.create(args),
+      requireNextly().emailProviders.create(args),
     update: (args: UpdateEmailProviderArgs) =>
-      getNextly().emailProviders.update(args),
+      requireNextly().emailProviders.update(args),
     delete: (args: DeleteEmailProviderArgs) =>
-      getNextly().emailProviders.delete(args),
+      requireNextly().emailProviders.delete(args),
     setDefault: (args: SetDefaultProviderArgs) =>
-      getNextly().emailProviders.setDefault(args),
+      requireNextly().emailProviders.setDefault(args),
     test: (args: TestEmailProviderArgs) =>
-      getNextly().emailProviders.test(args),
+      requireNextly().emailProviders.test(args),
   },
 
   emailTemplates: {
     find: (args?: FindEmailTemplatesArgs) =>
-      getNextly().emailTemplates.find(args),
+      requireNextly().emailTemplates.find(args),
     findByID: (args: FindEmailTemplateByIDArgs) =>
-      getNextly().emailTemplates.findByID(args),
+      requireNextly().emailTemplates.findByID(args),
     findBySlug: (args: FindEmailTemplateBySlugArgs) =>
-      getNextly().emailTemplates.findBySlug(args),
+      requireNextly().emailTemplates.findBySlug(args),
     create: (args: CreateEmailTemplateArgs) =>
-      getNextly().emailTemplates.create(args),
+      requireNextly().emailTemplates.create(args),
     update: (args: UpdateEmailTemplateArgs) =>
-      getNextly().emailTemplates.update(args),
+      requireNextly().emailTemplates.update(args),
     delete: (args: DeleteEmailTemplateArgs) =>
-      getNextly().emailTemplates.delete(args),
+      requireNextly().emailTemplates.delete(args),
     preview: (args: PreviewEmailTemplateArgs) =>
-      getNextly().emailTemplates.preview(args),
+      requireNextly().emailTemplates.preview(args),
   },
 
   userFields: {
-    find: (args?: FindUserFieldsArgs) => getNextly().userFields.find(args),
+    find: (args?: FindUserFieldsArgs) => requireNextly().userFields.find(args),
     findByID: (args: FindUserFieldByIDArgs) =>
-      getNextly().userFields.findByID(args),
-    create: (args: CreateUserFieldArgs) => getNextly().userFields.create(args),
-    update: (args: UpdateUserFieldArgs) => getNextly().userFields.update(args),
-    delete: (args: DeleteUserFieldArgs) => getNextly().userFields.delete(args),
+      requireNextly().userFields.findByID(args),
+    create: (args: CreateUserFieldArgs) =>
+      requireNextly().userFields.create(args),
+    update: (args: UpdateUserFieldArgs) =>
+      requireNextly().userFields.update(args),
+    delete: (args: DeleteUserFieldArgs) =>
+      requireNextly().userFields.delete(args),
     reorder: (args: ReorderUserFieldsArgs) =>
-      getNextly().userFields.reorder(args),
+      requireNextly().userFields.reorder(args),
   },
 
   roles: {
-    find: (args?: FindRolesArgs) => getNextly().roles.find(args),
-    findByID: (args: FindRoleByIDArgs) => getNextly().roles.findByID(args),
-    create: (args: CreateRoleArgs) => getNextly().roles.create(args),
-    update: (args: UpdateRoleArgs) => getNextly().roles.update(args),
-    delete: (args: DeleteRoleArgs) => getNextly().roles.delete(args),
+    find: (args?: FindRolesArgs) => requireNextly().roles.find(args),
+    findByID: (args: FindRoleByIDArgs) => requireNextly().roles.findByID(args),
+    create: (args: CreateRoleArgs) => requireNextly().roles.create(args),
+    update: (args: UpdateRoleArgs) => requireNextly().roles.update(args),
+    delete: (args: DeleteRoleArgs) => requireNextly().roles.delete(args),
     getPermissions: (args: GetRolePermissionsArgs) =>
-      getNextly().roles.getPermissions(args),
+      requireNextly().roles.getPermissions(args),
     setPermissions: (args: SetRolePermissionsArgs) =>
-      getNextly().roles.setPermissions(args),
+      requireNextly().roles.setPermissions(args),
   },
 
   permissions: {
-    find: (args?: FindPermissionsArgs) => getNextly().permissions.find(args),
+    find: (args?: FindPermissionsArgs) =>
+      requireNextly().permissions.find(args),
     findByID: (args: FindPermissionByIDArgs) =>
-      getNextly().permissions.findByID(args),
+      requireNextly().permissions.findByID(args),
     create: (args: CreatePermissionArgs) =>
-      getNextly().permissions.create(args),
+      requireNextly().permissions.create(args),
     delete: (args: DeletePermissionArgs) =>
-      getNextly().permissions.delete(args),
+      requireNextly().permissions.delete(args),
   },
 
   apiKeys: {
-    list: (args?: ListApiKeysArgs) => getNextly().apiKeys.list(args),
-    findByID: (args: FindApiKeyByIDArgs) => getNextly().apiKeys.findByID(args),
-    create: (args: CreateApiKeyArgs) => getNextly().apiKeys.create(args),
-    update: (args: UpdateApiKeyArgs) => getNextly().apiKeys.update(args),
-    revoke: (args: RevokeApiKeyArgs) => getNextly().apiKeys.revoke(args),
+    list: (args?: ListApiKeysArgs) => requireNextly().apiKeys.list(args),
+    findByID: (args: FindApiKeyByIDArgs) =>
+      requireNextly().apiKeys.findByID(args),
+    create: (args: CreateApiKeyArgs) => requireNextly().apiKeys.create(args),
+    update: (args: UpdateApiKeyArgs) => requireNextly().apiKeys.update(args),
+    revoke: (args: RevokeApiKeyArgs) => requireNextly().apiKeys.revoke(args),
   },
 
   access: {
-    check: (args: CheckAccessArgs) => getNextly().access.check(args),
+    check: (args: CheckAccessArgs) => requireNextly().access.check(args),
     checkApiKey: (args: CheckApiKeyArgs) =>
-      getNextly().access.checkApiKey(args),
+      requireNextly().access.checkApiKey(args),
   },
 };
 

--- a/packages/nextly/src/domains/collections/__tests__/hook-req-nextly.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/hook-req-nextly.integration.test.ts
@@ -1,7 +1,7 @@
 /**
  * `req.nextly` is bound for hooks from the moment services are registered.
  *
- * The handle resolved through a container binding that `getNextly()` created as
+ * The handle resolved through a container binding that `requireNextly()` created as
  * a side effect of its FIRST call. A process that never called it therefore
  * handed every hook `undefined` — and a REST or admin write does not call it,
  * so the handle the collections guide's own example reads was absent on exactly
@@ -10,7 +10,7 @@
  * Asserted against a production-shaped boot, and — since the harness stopped
  * resolving the Direct API while building its return value — through the
  * ordinary `createTestNextly` harness as well. The harness case is the one that
- * matters for everything written afterwards: while it called `getNextly()`
+ * matters for everything written afterwards: while it called `requireNextly()`
  * eagerly, the binding existed under it whatever the code did, so a test
  * written there could not fail.
  */
@@ -68,7 +68,7 @@ describe("the Direct API is bound for hook contexts at boot", () => {
     resetAll();
   });
 
-  it("binds nextlyDirectAPI during registerServices, before anything calls getNextly", async () => {
+  it("binds nextlyDirectAPI during registerServices, before anything calls requireNextly", async () => {
     await shutdownServices();
     resetAll();
 
@@ -81,7 +81,7 @@ describe("the Direct API is bound for hook contexts at boot", () => {
     expect(container.has("nextlyDirectAPI")).toBe(true);
   });
 
-  it("resolves to a usable Direct API without a prior getNextly call", async () => {
+  it("resolves to a usable Direct API without a prior requireNextly call", async () => {
     // A binding that cannot produce a working instance is no better than an
     // absent one, so this resolves it and checks the surface a hook would use.
     await shutdownServices();
@@ -123,7 +123,7 @@ describe("the ordinary test harness leaves the binding to service registration",
     // whether the harness resolves the Direct API or not, and a guard reading
     // only that stays green if the harness goes back to resolving it eagerly.
     // Whether the singleton was BUILT is the independent observation, because
-    // that is what an eager `getNextly()` does and a lazy property does not.
+    // that is what an eager `requireNextly()` does and a lazy property does not.
     expect(isNextlyInstantiated()).toBe(false);
     expect(container.has("nextlyDirectAPI")).toBe(true);
 

--- a/packages/nextly/src/domains/webhooks/webhook-drain-job.ts
+++ b/packages/nextly/src/domains/webhooks/webhook-drain-job.ts
@@ -15,7 +15,7 @@
  * import cycles.
  *
  * A handler that needs CONTENT does not need this: the Direct API resolves
- * itself lazily (`direct-api/nextly.ts` calls `getNextly()` per method), so a
+ * itself lazily (`direct-api/nextly.ts` calls `requireNextly()` per method), so a
  * job can import and use it without anything being threaded through. Only a
  * consumer like this one, which wants the adapter beneath the API, takes deps
  * at registration.

--- a/packages/nextly/src/domains/widgets/__tests__/execute.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/execute.test.ts
@@ -4,7 +4,7 @@ const find = vi.fn();
 const count = vi.fn();
 
 vi.mock("../../../direct-api/nextly", () => ({
-  getNextly: () => ({ find, count }),
+  requireNextly: () => ({ find, count }),
 }));
 
 import { NextlyError } from "../../../errors/nextly-error";

--- a/packages/nextly/src/domains/widgets/__tests__/system-sources.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/system-sources.test.ts
@@ -10,7 +10,7 @@ const count = vi.fn();
 // The collection path's collaborator, stubbed so the control below exercises a
 // real dispatch rather than falling over on a missing Direct API.
 vi.mock("../../../direct-api/nextly", () => ({
-  getNextly: () => ({ find, count }),
+  requireNextly: () => ({ find, count }),
 }));
 
 import { executeWidgetQuery } from "../execute";

--- a/packages/nextly/src/domains/widgets/execute.ts
+++ b/packages/nextly/src/domains/widgets/execute.ts
@@ -19,7 +19,7 @@
  * @module domains/widgets/execute
  */
 
-import { getNextly } from "../../direct-api/nextly";
+import { requireNextly } from "../../direct-api/nextly";
 import type { FindArgs } from "../../direct-api/types/collections";
 import type { ReadCaller } from "../../services/dashboard/readable-resources";
 import type { WhereFilter } from "../collections/query/query-operators";
@@ -104,7 +104,7 @@ async function runCount(
   query: WidgetQuery,
   caller: ReadCaller
 ): Promise<WidgetResult> {
-  const result = await getNextly().count({
+  const result = await requireNextly().count({
     collection,
     ...sharedReadArgs(query, caller),
   });
@@ -130,7 +130,7 @@ async function runGroupBy(
   // a query reaches execution the key is present. The fallback keeps that
   // assumption from becoming an unchecked cast.
   const groupBy = query.groupBy ?? "";
-  const result = await getNextly().group({
+  const result = await requireNextly().group({
     collection,
     groupBy,
     // The query's own limit bounds the BUCKETS, which is what a limit means for
@@ -210,7 +210,7 @@ async function runList(
   source: WidgetSource
 ): Promise<WidgetResult> {
   const select = toSelect(query.select);
-  const result = await getNextly().find({
+  const result = await requireNextly().find({
     collection,
     limit: query.limit,
     ...(query.sort ? { sort: query.sort } : {}),

--- a/packages/nextly/src/hooks/types.ts
+++ b/packages/nextly/src/hooks/types.ts
@@ -254,7 +254,7 @@ export interface HookContext<T = any> {
    * and the Nextly Direct API instance for performing database operations
    * within hooks.
    *
-   * **`req.nextly`** provides the same Direct API available via `getNextly()`,
+   * **`req.nextly`** provides the same Direct API available via `requireNextly()`,
    * allowing hooks to perform CRUD operations on other collections.
    * This allows hooks to perform CRUD operations on other collections.
    *

--- a/packages/nextly/src/init.ts
+++ b/packages/nextly/src/init.ts
@@ -42,7 +42,7 @@ import {
   shutdownServices,
 } from "./di/register";
 import { installLegacyFieldGroupsNamespaceGuard } from "./direct-api/legacy-field-groups-namespace";
-import { getNextly as getDirectAPI } from "./direct-api/nextly";
+import { requireNextly as getDirectAPI } from "./direct-api/nextly";
 import { resolveCollectionTableName } from "./domains/schema/utils/resolve-table-name";
 import { NextlyError } from "./errors/nextly-error";
 import { runBootTimeApplyIfDev } from "./init/boot-apply";

--- a/packages/nextly/src/plugins/__tests__/hmr-idempotency.integration.test.ts
+++ b/packages/nextly/src/plugins/__tests__/hmr-idempotency.integration.test.ts
@@ -19,7 +19,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { defineCollection, text } from "../../config";
 import { createAdapter } from "../../database/factory";
 import { registerServices, shutdownServices } from "../../di/register";
-import { getNextly, resetNextlyInstance } from "../../direct-api/nextly";
+import { requireNextly, resetNextlyInstance } from "../../direct-api/nextly";
 import { resetEventBus } from "../../events/event-bus";
 import { resetFilterRegistry } from "../../filters";
 import { getHookRegistry, resetHookRegistry } from "../../hooks/hook-registry";
@@ -122,7 +122,7 @@ describe("HMR idempotency (B2/T5)", () => {
 
     const a1 = await freshAdapter();
     await boot(a1, [probe]);
-    await getNextly().create({ collection: "notes", data: { title: "x" } });
+    await requireNextly().create({ collection: "notes", data: { title: "x" } });
     expect(counter.n).toBe(1);
 
     // Simulate HMR: tear services down but keep the global bus + hook registry,
@@ -130,7 +130,7 @@ describe("HMR idempotency (B2/T5)", () => {
     await hmrReset();
     const a2 = await freshAdapter();
     await boot(a2, [probe]);
-    await getNextly().create({ collection: "notes", data: { title: "y" } });
+    await requireNextly().create({ collection: "notes", data: { title: "y" } });
 
     // Without the fix the stale handler also fires -> 3. With it -> 2.
     expect(counter.n).toBe(2);

--- a/packages/nextly/src/plugins/__tests__/plugin-services.integration.test.ts
+++ b/packages/nextly/src/plugins/__tests__/plugin-services.integration.test.ts
@@ -8,7 +8,7 @@
  */
 import { afterEach, describe, expect, it } from "vitest";
 
-import { getNextly } from "../../direct-api/nextly";
+import { requireNextly } from "../../direct-api/nextly";
 import { definePlugin } from "../plugin-context";
 import { createTestNextly, type TestNextly } from "../test-nextly";
 
@@ -45,7 +45,7 @@ describe("plugin custom services", () => {
     current = await createTestNextly({ plugins: [a, b] });
     expect(observed.fromB).toBe("hi from A");
 
-    const greeter = getNextly().plugins["@test/svc-a"]?.greeter as {
+    const greeter = requireNextly().plugins["@test/svc-a"]?.greeter as {
       hi: () => string;
     };
     expect(greeter.hi()).toBe("hi from A");
@@ -68,7 +68,7 @@ describe("plugin custom services", () => {
     });
 
     current = await createTestNextly({ plugins: [a] });
-    const n = getNextly();
+    const n = requireNextly();
     const s1 = n.plugins["@test/svc-once"].counter;
     const s2 = n.plugins["@test/svc-once"].counter;
     expect(s1).toBe(s2);

--- a/packages/nextly/src/plugins/test-nextly.ts
+++ b/packages/nextly/src/plugins/test-nextly.ts
@@ -32,7 +32,7 @@ import {
   registerServices,
   shutdownServices,
 } from "../di/register";
-import { getNextly, resetNextlyInstance } from "../direct-api/nextly";
+import { requireNextly, resetNextlyInstance } from "../direct-api/nextly";
 import type { Nextly } from "../direct-api/nextly";
 import { resetEmailProviderRegistry } from "../domains/email/services/email-provider-registry";
 import { normalizeLocalization } from "../domains/i18n/config/normalize";
@@ -771,7 +771,7 @@ async function bootServices(
   let nextlyOverride: Nextly | undefined;
 
   return {
-    // Resolved on access, not while assembling this object. `getNextly()`
+    // Resolved on access, not while assembling this object. `requireNextly()`
     // registers the `nextlyDirectAPI` container binding as a side effect of
     // building its instance, so calling it here made that binding exist under
     // this harness whatever the code under test did. `req.nextly` resolves
@@ -780,7 +780,7 @@ async function bootServices(
     // the harness was answering the question the test was asking. Deferring
     // leaves the container the shape service registration alone gives it.
     get nextly(): Nextly {
-      return nextlyOverride ?? getNextly();
+      return nextlyOverride ?? requireNextly();
     },
     set nextly(replacement: Nextly) {
       nextlyOverride = replacement;

--- a/packages/nextly/src/runtime.ts
+++ b/packages/nextly/src/runtime.ts
@@ -89,12 +89,22 @@ export type {
 
 // Content routing + sitemap/robots delivery. `next`/`react` are type-only and
 // `next/navigation` resolves lazily, so importing these never forces them.
-// `getNextly` is the documented default for `ContentRouteConfig.nextly`, and a
-// helper built ON a content route needs the same instance the route resolves
-// through — on a per-tenant setup a second instance is a second DATABASE. It is
-// exported so such a helper can resolve it the same way, rather than having the
-// route hand a general reader to every callback in order to share one.
-export { getNextly } from "./direct-api/nextly";
+// `requireNextly` is the default a content route falls back to when
+// `ContentRouteConfig.nextly` names no reader, and a helper built ON such a
+// route needs the instance the route reads through. It is exported so the
+// helper can reach it the same way, rather than the route handing a reader to
+// every callback in order to share one.
+//
+// It reads the registered singleton and throws when there is none, so it says
+// so in its name. It used to be exported here as `getNextly`, which is also the
+// name `nextly` exports for a function that initialises, takes required config
+// and returns a promise — two different functions, one name, opposite tolerance
+// for an uninitialised process.
+//
+// Worth knowing before reaching for it: where the route was given an explicit
+// `nextly` reader, as a per-tenant setup must, this resolves the GLOBAL
+// singleton and not that reader. Pass the reader for those.
+export { requireNextly } from "./direct-api/nextly";
 
 export {
   resolveContent,

--- a/packages/nextly/src/runtime/routing/content-route.ts
+++ b/packages/nextly/src/runtime/routing/content-route.ts
@@ -28,7 +28,7 @@
  */
 import type { Metadata } from "next";
 
-import { getNextly } from "../../direct-api/nextly";
+import { requireNextly } from "../../direct-api/nextly";
 import type { UserContext } from "../../domains/collections/services/collection-types";
 import { NextlyError } from "../../errors/nextly-error";
 
@@ -239,7 +239,7 @@ export interface ContentRouteConfig<TNode> {
    * would see beside the page being previewed.
    */
   trustedCollections?: string[];
-  /** A booted Nextly instance (defaults to `getNextly()`). */
+  /** A booted Nextly instance (defaults to `requireNextly()`). */
   nextly?: NextlyContentReader;
   /**
    * Extra cache tags attached to every resolved read, so a write to a related
@@ -458,7 +458,8 @@ function buildRoute<TNode>(
   // The predicate form, for the reads this module issues directly.
   const trusted = (name: string): boolean => trustedSet.has(name);
 
-  const getInstance = (): NextlyContentReader => config.nextly ?? getNextly();
+  const getInstance = (): NextlyContentReader =>
+    config.nextly ?? requireNextly();
 
   /** Whether this request may see unpublished edits at one collection + slug. */
   /**

--- a/packages/nextly/src/runtime/routing/resolve-content.ts
+++ b/packages/nextly/src/runtime/routing/resolve-content.ts
@@ -10,7 +10,7 @@
  *
  * @module runtime/routing/resolve-content
  */
-import { getNextly } from "../../direct-api/nextly";
+import { requireNextly } from "../../direct-api/nextly";
 import type { Nextly } from "../../direct-api/nextly";
 import type { UserContext } from "../../direct-api/types/shared";
 import { NextlyError } from "../../errors/nextly-error";
@@ -28,7 +28,7 @@ export type ContentEntry = Record<string, unknown>;
  * The booted-Nextly surface these helpers need: a `find` reader, plus
  * `findByID` for the working-draft overlay. Typed structurally (not as the
  * Direct API class) so BOTH the internal singleton and the public instance
- * returned by `await getNextly(config)` satisfy it — the public interface does
+ * returned by `await requireNextly(config)` satisfy it — the public interface does
  * not expose the Direct API's internal handlers.
  */
 export type NextlyContentReader = Pick<Nextly, "find" | "findByID">;
@@ -36,9 +36,9 @@ export type NextlyContentReader = Pick<Nextly, "find" | "findByID">;
 /** Options for {@link resolveContent}. */
 interface ResolveContentOptionsBase {
   /**
-   * A booted Nextly instance. Defaults to the runtime singleton (`getNextly()`),
+   * A booted Nextly instance. Defaults to the runtime singleton (`requireNextly()`),
    * which requires services to be registered — pass one explicitly (e.g. the
-   * value from `await getNextly(config)`) from a frontend read path that boots
+   * value from `await requireNextly(config)`) from a frontend read path that boots
    * the config itself.
    */
   nextly?: NextlyContentReader;
@@ -274,7 +274,7 @@ export async function resolveContent(
   slug: string,
   options: ResolveContentOptions = {}
 ): Promise<ContentEntry | null> {
-  const nextly = options.nextly ?? getNextly();
+  const nextly = options.nextly ?? requireNextly();
   const slugField = options.slugField ?? "slug";
   const draft = options.draft ?? false;
   const grantedEntryId = options.entryId;

--- a/packages/nextly/src/runtime/routing/single-route.ts
+++ b/packages/nextly/src/runtime/routing/single-route.ts
@@ -30,7 +30,7 @@
  */
 import type { Metadata } from "next";
 
-import { getNextly } from "../../direct-api/nextly";
+import { requireNextly } from "../../direct-api/nextly";
 import type { Nextly } from "../../direct-api/nextly";
 import type { UserContext } from "../../direct-api/types/shared";
 import { NextlyError } from "../../errors/nextly-error";
@@ -48,7 +48,7 @@ export type SingleDocument = Record<string, unknown>;
  * The booted-Nextly surface these helpers need.
  *
  * Typed structurally rather than as the Direct API class so BOTH the internal
- * singleton and the public instance returned by `await getNextly(config)`
+ * singleton and the public instance returned by `await requireNextly(config)`
  * satisfy it — the public interface does not expose the Direct API's internal
  * handlers.
  */
@@ -169,7 +169,7 @@ export interface SingleRouteConfig<TNode> {
   /**
    * A booted Nextly instance. Defaults to the runtime singleton, which requires
    * services to be registered — pass one explicitly (the value from
-   * `await getNextly(config)`) from a frontend that boots the config itself,
+   * `await requireNextly(config)`) from a frontend that boots the config itself,
    * because a public page can be the first request a cold server handles.
    */
   nextly?: NextlySingleReader;
@@ -383,7 +383,7 @@ function buildSingleRoute<TNode>(
   async function read(
     grant: SingleDraftGrantResult
   ): Promise<SingleDocument | null> {
-    const reader = config.nextly ?? getNextly();
+    const reader = config.nextly ?? requireNextly();
     try {
       const document = await reader.findSingle(readArgs(grant));
       return document ?? null;

--- a/packages/nextly/src/services/dashboard/__tests__/collection-counts.test.ts
+++ b/packages/nextly/src/services/dashboard/__tests__/collection-counts.test.ts
@@ -21,7 +21,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { count } = vi.hoisted(() => ({ count: vi.fn() }));
-vi.mock("../../../direct-api/nextly", () => ({ getNextly: () => ({ count }) }));
+vi.mock("../../../direct-api/nextly", () => ({
+  requireNextly: () => ({ count }),
+}));
 
 const { containerGet } = vi.hoisted(() => ({ containerGet: vi.fn() }));
 vi.mock("../../../di/container", () => ({ container: { get: containerGet } }));

--- a/packages/nextly/src/services/dashboard/__tests__/dashboard-scope.test.ts
+++ b/packages/nextly/src/services/dashboard/__tests__/dashboard-scope.test.ts
@@ -33,7 +33,9 @@ vi.mock("../../../di/container", () => ({
 // itself is pinned at zero; `collection-counts.test.ts` is where the number
 // being the caller's rather than the table's is asserted.
 const { count } = vi.hoisted(() => ({ count: vi.fn() }));
-vi.mock("../../../direct-api/nextly", () => ({ getNextly: () => ({ count }) }));
+vi.mock("../../../direct-api/nextly", () => ({
+  requireNextly: () => ({ count }),
+}));
 
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 

--- a/packages/nextly/src/services/dashboard/__tests__/recent-entries.test.ts
+++ b/packages/nextly/src/services/dashboard/__tests__/recent-entries.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const find = vi.fn();
 
 vi.mock("../../../direct-api/nextly", () => ({
-  getNextly: () => ({ find }),
+  requireNextly: () => ({ find }),
 }));
 
 // Backs `getRegisteredCollections`'s real (unstubbed) path -- see "does not

--- a/packages/nextly/src/services/dashboard/__tests__/status-breakdown.test.ts
+++ b/packages/nextly/src/services/dashboard/__tests__/status-breakdown.test.ts
@@ -22,7 +22,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { count } = vi.hoisted(() => ({ count: vi.fn() }));
-vi.mock("../../../direct-api/nextly", () => ({ getNextly: () => ({ count }) }));
+vi.mock("../../../direct-api/nextly", () => ({
+  requireNextly: () => ({ count }),
+}));
 
 const { containerGet } = vi.hoisted(() => ({ containerGet: vi.fn() }));
 vi.mock("../../../di/container", () => ({ container: { get: containerGet } }));

--- a/packages/nextly/src/services/dashboard/dashboard-service.ts
+++ b/packages/nextly/src/services/dashboard/dashboard-service.ts
@@ -20,7 +20,7 @@ import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import type { SqlParam } from "@nextlyhq/adapter-drizzle/types";
 
 import { container } from "../../di/container";
-import { getNextly } from "../../direct-api/nextly";
+import { requireNextly } from "../../direct-api/nextly";
 import type { CountArgs, FindArgs } from "../../direct-api/types";
 import { COMMON_TITLE_FIELDS } from "../../domains/collections/entry-title";
 import { entryHeading } from "../../lib/entry-heading";
@@ -577,7 +577,7 @@ export class DashboardService extends BaseService {
     status: "all" | "published" | "draft" = "all"
   ): Promise<number> {
     try {
-      const result = await getNextly().count({
+      const result = await requireNextly().count({
         collection: coll.slug,
         overrideAccess: false,
         user: caller.user,
@@ -691,7 +691,7 @@ export class DashboardService extends BaseService {
   ): Promise<RecentEntry[]> {
     try {
       const titleField = coll.useAsTitle ?? "title";
-      const result = await getNextly().find({
+      const result = await requireNextly().find({
         collection: coll.slug,
         limit,
         sort: "-updatedAt",

--- a/packages/nextly/src/services/lib/readable-documents.ts
+++ b/packages/nextly/src/services/lib/readable-documents.ts
@@ -31,7 +31,7 @@
  * @module services/lib/readable-documents
  */
 
-import { getNextly } from "../../direct-api/nextly";
+import { requireNextly } from "../../direct-api/nextly";
 import type { ReadCaller } from "../dashboard/readable-resources";
 
 /**
@@ -119,7 +119,7 @@ async function idsReturnedBy(
   // loop put the identity and locale decisions on every iteration.
   const scoped = identityOptions(locale, access);
   for (const chunk of chunked(entryIds)) {
-    const result = await getNextly().find({
+    const result = await requireNextly().find({
       collection,
       where: { id: { in: chunk } },
       select: { id: true },


### PR DESCRIPTION
`getNextly` named **two different functions on two published entry points**.

| | entry | shape | on an uninitialised process |
|---|---|---|---|
| `getNextly(options)` | `nextly` | async, config **required** | initialises |
| `getNextly(config?)` | `nextly/runtime` | sync, no arguments | **throws** |

Same name, opposite tolerance for an uninitialised runtime, and nothing at an import site to say which one had arrived.

## Which keeps the name, and why

The initialiser. It is the one already reached for — every usage across docs, templates and apps is this one — and it is the one that is *safe*: the docs state the contract themselves, that it "initialises rather than assuming, so it is correct in both cases".

It is also called **per request**, inside `GET()` handlers and Server Components, and it caches. That is why it is not renamed to `initNextly` despite `initializeApp`/`getApp` being the usual SDK convention: Firebase's runs **once at module load** in a long-lived app, this one runs **per request** in a serverless function, and telling readers to `init` per request invites hoisting it to module scope, which in Next.js runs at build time and breaks per-tenant resolution outright.

Giving the sync accessor the prime name would also promote the fragile one: it throws unless services are registered and, by its own comment, cannot wait for the migration lock.

So the accessor is `requireNextly`, named for what it demands.

## The documentation the shared name had made wrong

- Its own `@example` said `import { getNextly } from 'nextly'` then `const nextly = getNextly()`. From `nextly` that name is the async one, which requires an argument and returns a promise, so the snippet could not compile. Verified against the built types.
- The convenience proxy's note said the runtime is initialised "via `getNextly()`", which is the other function again.
- A test header claimed the accessor is exported from the package root. It is not.
- The admin's API Playground already carried a defensive assertion against exactly this: *"The package's own examples show `getNextly()` — no await, no config — which is the other function."*

## The check that stops it recurring

A test asserts no name is published from two entry points with different arities. **It immediately found two more of the same shape**, both genuinely different functions:

```
isFieldGroupType: nextly takes 1, nextly/field-group-type takes 2
createAdapter:    nextly takes 1, nextly/database takes 1, nextly/cli/utils takes 0
```

They are recorded rather than fixed here, because each needs the same decision this one needed about which keeps the name, and answering three of those inside one rename is how a considered API becomes an incidental one. Recording them is what makes a fourth fail on the day it appears.

## Evidence

- 11,603 tests pass, `check-types` clean over both configs, build green across 8 packages.
- Fallow `new-only`: zero introduced.
- Controls: re-exporting the accessor as `getNextly` fails the name test; emptying the known-clash list fails the arity test, so it is a ratchet rather than a mute.