### PR TITLE
feat(blocks-engine): ask whether a document's component references could all be read

### DIFF
--- a/.changeset/ask-whether-a-document-was-read-whole.md
+++ b/.changeset/ask-whether-a-document-was-read-whole.md
@@ -1,0 +1,38 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Plugins and hosts can now ask which components a block document references
+AND whether the whole document could be read, through `componentUsageIn`.
+
+The existing `componentIdsIn` answers only the first half: it walks under a
+node budget and stops silently, so a document too large to read whole returns
+the same empty list as one referencing nothing. That is the wrong way round
+for anything deciding whether a component is still in use, because "references
+nothing" is the answer that allows deleting it. `componentIdsIn` is unchanged
+for its own callers and is now derived from the richer answer, so the two
+cannot drift apart.

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -266,6 +266,7 @@ export { measureBytes, surveyDocument } from "./measure-bytes";
 // what to FETCH, asked before anything can be resolved.
 export {
   componentIdsIn,
+  componentUsageIn,
   resolveComponentInstances,
   // Why an instance was left standing. Published because the surfaces that
   // REPORT one are in other packages — the renderer draws a placeholder, the
@@ -277,6 +278,7 @@ export {
 export type {
   ComponentLookup,
   ComponentUnresolvedReason,
+  ComponentUsage,
   DefinitionsById,
   ResolveComponentOptions,
   ResolvedBlockNode,

--- a/packages/blocks-engine/src/resolve-instances.test.ts
+++ b/packages/blocks-engine/src/resolve-instances.test.ts
@@ -19,6 +19,7 @@ import { DEFAULT_LIMITS, MAX_ENVELOPE_ENTRIES } from "./limits";
 import { isConditionGated } from "./visibility";
 import {
   componentIdsIn,
+  componentUsageIn,
   resolveComponentInstances,
   type DefinitionsById,
   type ResolvedBlockNode,
@@ -2173,5 +2174,59 @@ describe("componentIdsIn", () => {
 
     expect(componentIdsIn(nodes, 2)).toEqual([]);
     expect(componentIdsIn(nodes, 3)).toEqual(["late"]);
+  });
+});
+
+describe("componentUsageIn", () => {
+  // Three entries exactly, so the budget can be set above, at and below the
+  // size of the forest. The reference is the LAST of them, which is what makes
+  // a prefix distinguishable from the whole answer at all: a truncated walk
+  // returns `[]` here, and `[]` is also what a document referencing nothing
+  // returns — the pair the `complete` flag exists to separate.
+  const nodes = [node("a"), node("b"), instance("i1", "late")];
+
+  it("reports a whole read, with what it found", () => {
+    expect(componentUsageIn(nodes, 10)).toEqual({
+      ids: ["late"],
+      complete: true,
+    });
+  });
+
+  it("reports a truncated read, and the prefix it managed", () => {
+    // Both halves asserted together. `ids: []` alone is the answer a document
+    // holding no instances gives, so an assertion on it cannot tell the two
+    // apart — which is the whole defect this function exists to close.
+    expect(componentUsageIn(nodes, 2)).toEqual({ ids: [], complete: false });
+  });
+
+  it("calls a forest of exactly the budget COMPLETE, not truncated", () => {
+    // The boundary, and the reason `complete` is set on the branch that ends
+    // the walk rather than derived from the budget afterwards. Three entries
+    // under a budget of three spends the last of it on the last entry and
+    // reads the forest WHOLE; a check on the remaining budget would report
+    // this as unreadable, at exactly the size the rest of the engine accepts.
+    expect(componentUsageIn(nodes, 3)).toEqual({
+      ids: ["late"],
+      complete: true,
+    });
+  });
+
+  it("gives an empty forest a complete answer, not an unread one", () => {
+    // "Nothing to read" and "could not be read" are the two states this
+    // separates, and the empty forest is the one a caller meets first.
+    expect(componentUsageIn([], 10)).toEqual({ ids: [], complete: true });
+  });
+
+  it("answers what componentIdsIn answers, truncation included", () => {
+    // `componentIdsIn` is derived from this, and the case where a
+    // reimplementation would diverge is the bounded one: a second walk with
+    // its own budget arithmetic returns a different prefix here while both
+    // agree on every document small enough to be read whole.
+    for (const budget of [1, 2, 3, 10]) {
+      expect({ budget, ids: componentIdsIn(nodes, budget) }).toEqual({
+        budget,
+        ids: componentUsageIn(nodes, budget).ids,
+      });
+    }
   });
 });

--- a/packages/blocks-engine/src/resolve-instances.ts
+++ b/packages/blocks-engine/src/resolve-instances.ts
@@ -262,16 +262,58 @@ const SCOPED_ID_PREFIX = "cx-";
  */
 const MAX_PROP_PATH_SEGMENTS = 16;
 
-/** The component ids a document references directly, in first-reached order. */
-export function componentIdsIn(
+/**
+ * What a document says about the components it references directly.
+ *
+ * Two values, because an empty list and an unread document are different
+ * answers and a caller must be able to tell them apart. The walk is bounded,
+ * and a bound that ends it early leaves a PREFIX — which, for the question an
+ * index of this asks, is the dangerous direction: "references nothing" is what
+ * permits deleting a component a page still renders.
+ */
+export interface ComponentUsage {
+  /** The component ids the document references, in first-reached order. */
+  ids: string[];
+  /**
+   * Whether the whole forest was read.
+   *
+   * False means `ids` is a prefix of the answer rather than the answer. A
+   * caller must not read a missing id as absent while this is false.
+   */
+  complete: boolean;
+}
+
+/**
+ * The components a document references, and whether it could all be read.
+ *
+ * The richer of the two answers this module gives, with {@link componentIdsIn}
+ * derived from it rather than computed beside it. They are one question, and
+ * two walks over one forest agree on the day they are written: the narrow one
+ * would go on returning a prefix silently after a change to the bound, the
+ * ordering or the descent rule moved only the other.
+ *
+ * ORDER IS FIRST-REACHED, not sorted, because `componentIdsIn` publishes that
+ * and its consumer is cache tagging. A caller comparing two answers for
+ * equality has to sort them itself.
+ */
+export function componentUsageIn(
   nodes: readonly unknown[],
   maxNodes: number = DEFAULT_LIMITS.maxNodes
-): string[] {
+): ComponentUsage {
   const ids: string[] = [];
   const seen = new Set<string>();
   let budget = maxNodes;
+  // Set on the branch that ENDS the walk early, rather than derived afterwards
+  // from `budget === 0`. A forest holding exactly `maxNodes` entries spends the
+  // last of the budget on its last entry and is read WHOLE, so a check on the
+  // remaining budget calls a complete read truncated — and reports a document
+  // as unreadable at exactly the size the rest of the engine still accepts.
+  let truncated = false;
   walkForest(nodes, entry => {
-    if (budget <= 0) return "stop";
+    if (budget <= 0) {
+      truncated = true;
+      return "stop";
+    }
     budget -= 1;
     const id = componentIdOf(entry.node);
     if (id !== undefined && !seen.has(id)) {
@@ -280,7 +322,22 @@ export function componentIdsIn(
     }
     return "descend";
   });
-  return ids;
+  return { ids, complete: !truncated };
+}
+
+/**
+ * The component ids a document references directly, in first-reached order.
+ *
+ * Answers nothing about whether the whole document was read. A caller deciding
+ * whether a component is USED needs {@link componentUsageIn} instead: a walk
+ * this one truncated returns a prefix that is indistinguishable here from a
+ * document referencing nothing.
+ */
+export function componentIdsIn(
+  nodes: readonly unknown[],
+  maxNodes: number = DEFAULT_LIMITS.maxNodes
+): string[] {
+  return componentUsageIn(nodes, maxNodes).ids;
 }
 
 /**


### PR DESCRIPTION
First slice of Plan 06 **T-5**, the component usage index. This is the
primitive the index rests on; no storage and no hook yet.

## The problem

`componentIdsIn` walks a bounded forest and **stops silently**. A document too
large to read whole therefore returns the same `[]` as a document that
references no components at all.

That is the wrong way round for the question a usage index asks. The index
exists to decide whether a component may be deleted, and a delete check reads
absence as evidence — so an absence produced by a *bound* rather than by the
document is exactly the answer that permits deleting a component a live page
still renders.

The class usage index already solved this for classes: `classUsageOf` returns
`{ ids, complete }` for precisely this reason. This gives components the same
two-valued answer.

## The shape

`componentUsageIn(nodes, maxNodes) → { ids, complete }`, and **`componentIdsIn`
is now derived from it** rather than walking beside it. They are one question,
and two walks over one forest agree on the day they are written — the narrow
one goes on returning a prefix silently once a bound, an ordering or a descent
rule moves only the other.

Order stays first-reached rather than sorted, because `componentIdsIn`
publishes that and its consumer is cache tagging.

## The boundary case, and why it has its own test

`complete` is set on the branch that **ends** the walk, not derived afterwards
from the leftover budget. A forest holding exactly `maxNodes` entries spends
the last of the budget on its last entry and is read **whole** — so
`complete: budget > 0` would report a complete read as truncated, at exactly
the size the rest of the engine still accepts.

## Break-verification

Three wrong implementations, each killing a **different** test:

| wrong implementation | test that fails |
|---|---|
| `complete` derived from the leftover budget | `calls a forest of exactly the budget COMPLETE, not truncated` |
| never records truncation | `reports a truncated read, and the prefix it managed` |
| `componentIdsIn` walks under its own budget | `answers what componentIdsIn answers, truncation included`, and the pre-existing budget test |

One caveat stated rather than glossed: the second break's edit matched in two
places (`truncated = true` occurs twice in the file), so it was broader than a
single-site mutation. The target test still failed, but it was not surgical.

The truncated-case test asserts `ids` **and** `complete` together, deliberately:
`ids: []` alone is also what a document holding no instances returns, so an
assertion on it cannot separate the two states this function exists to separate.

## Gates

| gate | result |
|---|---|
| `blocks-engine` `check-types` | exit 0 (both `tsc` invocations) |
| `blocks-engine` `lint` | exit 0 |
| `blocks-engine` tests | 52 files, 2411 tests, exit 0 |
| `blocks-react` tests (names `componentIdsIn`) | 48 files, 1162 tests, exit 0 |
| `builder` tests | 102 files, 2869 tests, exit 0 |
| `fallow audit --base origin/main` | `pass`, `changed_files_count: 4`, introduced 0 across all four categories |
| `pnpm changeset status` | parses; contributes 25 packages, verified by diffing status with and without the file |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a component usage API that returns referenced component IDs and indicates whether traversal completed or was limited by the configured budget.
  - Exposed the new usage result type for consumers integrating with the blocks engine.
  - Existing component ID retrieval continues to provide the same array-based results while using the enhanced traversal information internally.
- **Tests**
  - Added coverage for complete and truncated traversal, budget boundaries, empty inputs, and consistency with existing component ID results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->