### PR TITLE
fix(nextly): name the initialiser in cold-start guidance, and check what the check missed

### DIFF
--- a/.changeset/cold-start-guidance-names-the-initialiser.md
+++ b/.changeset/cold-start-guidance-names-the-initialiser.md
@@ -1,0 +1,29 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The cold-start guidance on `resolveContent` and `createSingleRoute` names `getNextly({ config })` again. The accessor rename swept those doc comments along with the code, and they had been recommending the one function that cannot do what they describe: `requireNextly` reads the already-registered singleton and throws when nothing has booted, which is exactly the case the guidance is about.

--- a/packages/nextly/src/__tests__/export-contract.test.ts
+++ b/packages/nextly/src/__tests__/export-contract.test.ts
@@ -43,6 +43,42 @@ const FORBIDDEN = [
 ];
 
 /**
+ * What a published function looks like from an import site.
+ *
+ * Arity and whether it is async, because those are the two halves a caller has
+ * to get right and the two the collision this guards against differed in.
+ */
+function shapeOf(value: (...args: unknown[]) => unknown): string {
+  const kind = value.constructor.name === "AsyncFunction" ? "async" : "sync";
+  return `${kind}/${String(value.length)}`;
+}
+
+/** Names published from more than one entry point with more than one shape. */
+function namesPublishedTwice(
+  surfaces: Map<string, Record<string, unknown>>
+): string[] {
+  const seen = new Map<string, Array<{ entry: string; shape: string }>>();
+  for (const [entry, mod] of surfaces) {
+    for (const [name, value] of Object.entries(mod)) {
+      if (typeof value !== "function") continue;
+      seen.set(name, [
+        ...(seen.get(name) ?? []),
+        { entry, shape: shapeOf(value as (...args: unknown[]) => unknown) },
+      ]);
+    }
+  }
+  return [...seen.entries()]
+    .filter(
+      ([, places]) =>
+        places.length > 1 && new Set(places.map(p => p.shape)).size > 1
+    )
+    .map(
+      ([name, places]) =>
+        `${name}: ${places.map(p => `${p.entry} ${p.shape}`).join(", ")}`
+    );
+}
+
+/**
  * Names already published from two entry points meaning different things.
  *
  * 🔴 Recorded, not accepted. Each is the same defect `getNextly` was: one name,
@@ -52,13 +88,13 @@ const FORBIDDEN = [
  * take different arguments and do different work.
  *
  * They are listed rather than fixed here because each needs the same decision
- * `getNextly` needed about which keeps the name, and answering three of those
+ * `getNextly` needed about which keeps the name, and answering several of those
  * inside one rename is how a considered API becomes an incidental one. Listing
- * them is what makes a FOURTH fail this test on the day it appears.
+ * them is what makes a NEW one fail this test on the day it appears.
  */
-const KNOWN_ARITY_CLASHES = [
-  "isFieldGroupType: nextly takes 1, nextly/field-group-type takes 2",
-  "createAdapter: nextly takes 1, nextly/database takes 1, nextly/cli/utils takes 0",
+const KNOWN_SHAPE_CLASHES = [
+  "isFieldGroupType: nextly sync/1, nextly/field-group-type sync/2",
+  "createAdapter: nextly async/1, nextly/database async/1, nextly/cli/utils async/0",
 ];
 
 const manifestUrl = new URL("../../package.json", import.meta.url);
@@ -121,43 +157,45 @@ describe("published export surface", () => {
   // 🔴 The defect this generalises: `getNextly` was published from `nextly` as
   // an async function taking a required config, and from `nextly/runtime` as a
   // synchronous one taking none. Same name, opposite tolerance for an
-  // uninitialised process, and nothing said so at an import site. It cost a
-  // wrong example in the package's own JSDoc, a wrong sentence in a test
-  // header, and a defensive assertion in the admin's code generator.
+  // uninitialised process, and nothing said so at an import site.
   //
-  // Arity is the cheap half of a signature and it separates the two cases that
-  // matter: a function that demands configuration from one that takes none.
-  it("does not publish one name from two entries with different arities", async () => {
-    const seen = new Map<string, Array<{ entry: string; arity: number }>>();
+  // Arity alone cannot separate that pair, which is worth stating because the
+  // first version of this test used it and would have passed with the defect
+  // reinstated: an optional TypeScript parameter is still a declared JavaScript
+  // parameter, so `getNextly(options)` and `getNextly(config?)` both report a
+  // `length` of 1. Whether the function is async is the half that separates
+  // them, and `namesPublishedTwice` compares both.
+  it("does not publish one name from two entries with different shapes", async () => {
+    const surfaces = new Map<string, Record<string, unknown>>();
     for (const [entry, source] of ENTRY_POINTS) {
-      const mod = (await import(pathToFileURL(source).href)) as Record<
-        string,
-        unknown
-      >;
-      for (const [name, value] of Object.entries(mod)) {
-        if (typeof value !== "function") continue;
-        seen.set(name, [
-          ...(seen.get(name) ?? []),
-          { entry, arity: value.length },
-        ]);
-      }
-    }
-    const clashing = [...seen.entries()]
-      .filter(
-        ([, places]) =>
-          places.length > 1 &&
-          new Set(places.map(place => place.arity)).size > 1
-      )
-      .map(
-        ([name, places]) =>
-          `${name}: ${places
-            .map(place => `${place.entry} takes ${String(place.arity)}`)
-            .join(", ")}`
+      surfaces.set(
+        entry,
+        (await import(pathToFileURL(source).href)) as Record<string, unknown>
       );
-    expect(clashing).toEqual(KNOWN_ARITY_CLASHES);
+    }
+    expect(namesPublishedTwice(surfaces)).toEqual(KNOWN_SHAPE_CLASHES);
     // The control: a scan that imported nothing would report no clash. This
     // asserts the scan actually read a surface.
-    expect(seen.size).toBeGreaterThan(50);
+    expect(surfaces.size).toEqual(ENTRY_POINTS.length);
+  });
+
+  it("catches the pair it was written for", () => {
+    // The control the first version of this check lacked. These are the two
+    // real shapes, and putting them back under one name has to be reported.
+    const reinstated = new Map<string, Record<string, unknown>>([
+      ["nextly", { getNextly: async (options: unknown) => options }],
+      ["nextly/runtime", { getNextly: (config: unknown) => config }],
+    ]);
+    expect(namesPublishedTwice(reinstated)).toEqual([
+      "getNextly: nextly async/1, nextly/runtime sync/1",
+    ]);
+    // And the other direction: one name, one shape, published twice is a
+    // re-export rather than a collision.
+    const reexported = new Map<string, Record<string, unknown>>([
+      ["nextly", { shared: (a: unknown) => a }],
+      ["nextly/runtime", { shared: (a: unknown) => a }],
+    ]);
+    expect(namesPublishedTwice(reexported)).toEqual([]);
   });
 
   it("publishes each way to reach an instance under its own name", async () => {

--- a/packages/nextly/src/runtime/routing/resolve-content.ts
+++ b/packages/nextly/src/runtime/routing/resolve-content.ts
@@ -28,7 +28,7 @@ export type ContentEntry = Record<string, unknown>;
  * The booted-Nextly surface these helpers need: a `find` reader, plus
  * `findByID` for the working-draft overlay. Typed structurally (not as the
  * Direct API class) so BOTH the internal singleton and the public instance
- * returned by `await requireNextly(config)` satisfy it — the public interface does
+ * returned by `await getNextly({ config })` satisfy it — the public interface does
  * not expose the Direct API's internal handlers.
  */
 export type NextlyContentReader = Pick<Nextly, "find" | "findByID">;
@@ -38,7 +38,8 @@ interface ResolveContentOptionsBase {
   /**
    * A booted Nextly instance. Defaults to the runtime singleton (`requireNextly()`),
    * which requires services to be registered — pass one explicitly (e.g. the
-   * value from `await requireNextly(config)`) from a frontend read path that boots
+   * value from `await getNextly({ config })` from `nextly`) from a frontend read
+   * path that boots
    * the config itself.
    */
   nextly?: NextlyContentReader;

--- a/packages/nextly/src/runtime/routing/single-route.ts
+++ b/packages/nextly/src/runtime/routing/single-route.ts
@@ -48,7 +48,7 @@ export type SingleDocument = Record<string, unknown>;
  * The booted-Nextly surface these helpers need.
  *
  * Typed structurally rather than as the Direct API class so BOTH the internal
- * singleton and the public instance returned by `await requireNextly(config)`
+ * singleton and the public instance returned by `await getNextly({ config })`
  * satisfy it — the public interface does not expose the Direct API's internal
  * handlers.
  */
@@ -169,7 +169,8 @@ export interface SingleRouteConfig<TNode> {
   /**
    * A booted Nextly instance. Defaults to the runtime singleton, which requires
    * services to be registered — pass one explicitly (the value from
-   * `await requireNextly(config)`) from a frontend that boots the config itself,
+   * `await getNextly({ config })` from `nextly`) from a frontend that boots the
+   * config itself,
    * because a public page can be the first request a cold server handles.
    */
   nextly?: NextlySingleReader;


### PR DESCRIPTION
Two findings on #1646 after it merged. Both are mine, and the first is user-facing.

## The rename swept guidance into being wrong

`resolveContent` and `createSingleRoute` both tell a frontend read path what to pass when *a public page can be the first request a cold server handles*. After the rename they said:

```
pass one explicitly (the value from `await requireNextly(config)`)
```

`requireNextly` is synchronous and throws when nothing has registered services, so following that fails in precisely the scenario the sentence exists for. Both name `await getNextly({ config })` from `nextly` again.

Four doc comments were swept; the other eight `await requireNextly()` sites are correct, because those await the *method* rather than the accessor. `await requireNextly(` with an argument is the shape that is always wrong, and there are none left.

## The check could not catch what it was written for

Worse than not having it, because it read as a guarantee. An optional TypeScript parameter is still a declared JavaScript parameter, so arity cannot separate the pair:

```
root  getNextly(options: GetNextlyOptions)   .length = 1
old   getNextly(config?: DirectAPIConfig)    .length = 1
```

Reinstating the collision would have left it green. It compares **shape** now, arity together with whether the function is async, and it carries the control it lacked:

- the two real shapes put back under one name **must** be reported
- one shape published twice **must not** be, since that is an ordinary re-export

The two recorded clashes come back with their shapes: `isFieldGroupType` is `sync/1` against `sync/2`, `createAdapter` is `async/1`, `async/1` and `async/0`.

## Evidence

- 11,604 tests, `check-types` clean over both configs, Fallow `new-only` zero introduced.
- Only three source files touched, checked deliberately after last time.