### PR TITLE
ci: ask which name is missing in one place

### DIFF
--- a/scripts/check-doc-samples.mjs
+++ b/scripts/check-doc-samples.mjs
@@ -2086,12 +2086,12 @@ export async function classifyDocDiagnostics({ diagnostics, samples }) {
     // Both spellings of the same question: a name the block uses and nothing
     // here defines. `{ Page }` reports as TS18004 and `Page` as TS2304, and
     // they get the same answer.
-    const name = line.match(MISSING_NAME) ?? line.match(MISSING_SHORTHAND);
-    if (name) {
+    const name = nameIn(line);
+    if (name !== undefined) {
       const [file, idx] = line.split("  ")[0].split("#");
       const index = Number.parseInt(idx, 10);
-      if (declaredEarlier(name[1], file, index, samples)) continued.push(line);
-      else if (mentionIsReaderOwned(name[1], file, index, samples))
+      if (declaredEarlier(name, file, index, samples)) continued.push(line);
+      else if (mentionIsReaderOwned(name, file, index, samples))
         readerNames.push(line);
       else real.push(line);
       continue;
@@ -2317,7 +2317,18 @@ export function auditBasis() {
 
 /** The page and the name a diagnostic is about: `page.mdx#3` and `adapter`. */
 export const originOf = line => line.split("  ")[0].split(":")[0];
-export const nameIn = line => line.match(MISSING_NAME)?.[1];
+/**
+ * The name a diagnostic says is missing, in either spelling.
+ *
+ * `Page` reports as TS2304 and `{ Page }` as TS18004, and every question asked
+ * of a missing name downstream is the same question. Asking it in one place is
+ * what stops the two drifting: the classifier learned the shorthand first, then
+ * the rebuild, while the survivor pass below still read TS2304 alone, so a
+ * rebased shorthand was dropped as already-reported and its continuation stayed
+ * excused without ever being recompiled.
+ */
+export const nameIn = line =>
+  line.match(MISSING_NAME)?.[1] ?? line.match(MISSING_SHORTHAND)?.[1];
 
 /**
  * The page a diagnostic belongs to, for grouping and for the baseline's keys.
@@ -2368,8 +2379,7 @@ export function namesToRebuild(continuations) {
   const byOrigin = new Map();
   for (const line of continuations) {
     const origin = line.split("  ")[0].split(":")[0];
-    const name =
-      line.match(MISSING_NAME)?.[1] ?? line.match(MISSING_SHORTHAND)?.[1];
+    const name = nameIn(line);
     if (name) byOrigin.set(origin, [...(byOrigin.get(origin) ?? []), name]);
   }
   return byOrigin;
@@ -2580,7 +2590,7 @@ async function auditDocs() {
       )
     );
     for (const line of rebased) {
-      if (MISSING_NAME.test(line)) {
+      if (nameIn(line) !== undefined) {
         const origin = originOf(line);
         const name = String(nameIn(line));
         const inherited = (inheritedByOrigin.get(origin) ?? []).includes(name);

--- a/scripts/check-doc-samples.test.mjs
+++ b/scripts/check-doc-samples.test.mjs
@@ -21,6 +21,7 @@ import {
   constructedInBlock,
   mentionIsReaderOwned,
   misspelledExport,
+  nameIn,
   namesToRebuild,
   readerOwnedMention,
   usedOnlyAsValue,
@@ -1595,6 +1596,25 @@ describe("a missing name in object shorthand", () => {
       lang: "ts",
     },
   ];
+
+  it("answers for both spellings, everywhere the answer is needed", () => {
+    // One place, because three asked the same question and they drifted: the
+    // classifier learned the shorthand first, then the rebuild, while the
+    // survivor pass still read TS2304 alone. A rebased shorthand was dropped as
+    // already-reported and its continuation stayed excused without ever having
+    // been recompiled.
+    expect(
+      nameIn("docs/x.mdx#0  #0:1  error TS2304: Cannot find name 'Page'.")
+    ).toBe("Page");
+    expect(nameIn(shorthand("Page"))).toBe("Page");
+    // The control: a diagnostic about something else names nothing missing, so
+    // the two above are the pattern matching rather than the string.
+    expect(
+      nameIn(
+        "docs/x.mdx#0  #0:1  error TS2322: Type 'a' is not assignable to type 'b'."
+      )
+    ).toBeUndefined();
+  });
 
   it("hands a shorthand name to the rebuild like any other", () => {
     // A continuation is excused on the strength of being recompiled with the


### PR DESCRIPTION
A finding on #1645 after it merged, and it is the shape worth naming: **three places asked the same question and they drifted.**

`Page` reports as TS2304 and `{ Page }` as TS18004. The classifier learned that first. Then the rebuild learned it. The survivor pass still read TS2304 alone, so a rebased shorthand matched nothing there, was dropped as already-reported, and its continuation stayed excused **without ever having been recompiled** — which is exactly what a continuation's excuse is supposed to be conditional on.

`nameIn` answers for both spellings now, and the other two ask it rather than restating it. That removes two copies of the pattern along with the defect.

## Evidence

- 1099 tests in `scripts/`, gate green, corpus unchanged at 18 findings across 10 pages.
- The control is the shape of the defect: reverting `nameIn` fails **three** tests, not one, because three readers depend on the single answer.
- Fallow `new-only`: zero introduced.