### PR TITLE
fix(blocks-engine): refuse a component-usage budget that removes the bound

### DIFF
--- a/.changeset/ask-whether-a-document-was-read-whole.md
+++ b/.changeset/ask-whether-a-document-was-read-whole.md
@@ -33,6 +33,11 @@ The existing `componentIdsIn` answers only the first half: it walks under a
 node budget and stops silently, so a document too large to read whole returns
 the same empty list as one referencing nothing. That is the wrong way round
 for anything deciding whether a component is still in use, because "references
-nothing" is the answer that allows deleting it. `componentIdsIn` is unchanged
-for its own callers and is now derived from the richer answer, so the two
+nothing" is the answer that allows deleting it. `componentIdsIn` keeps its own
+signature and result, and is now derived from the richer answer, so the two
 cannot drift apart.
+
+`componentIdsIn` and `componentUsageIn` now refuse a `maxNodes` of `NaN`
+instead of walking without a bound. `NaN` never satisfied the stop test, so
+the budget was not merely loose, it was absent — a document of any size was
+read whole. Any other numeric budget behaves as before.

--- a/packages/blocks-engine/src/resolve-instances.test.ts
+++ b/packages/blocks-engine/src/resolve-instances.test.ts
@@ -2217,6 +2217,43 @@ describe("componentUsageIn", () => {
     expect(componentUsageIn([], 10)).toEqual({ ids: [], complete: true });
   });
 
+  it("refuses a budget that would remove the bound rather than set one", () => {
+    // `NaN` is not a loose bound, it is NO bound: every `budget <= 0` test
+    // against it is false, so the walk never stops and reads a stored document
+    // of any size whole. Asserted through the published helper's own message,
+    // which names both the subject and the field — a bare `toThrow()` would
+    // pass on any error this function might raise for another reason.
+    expect(() => componentUsageIn(nodes, Number.NaN)).toThrow(
+      /componentUsageIn: maxNodes/
+    );
+
+    // The derived function inherits the refusal, which is the point of it
+    // being derived. Its previous behaviour was to walk unbounded in silence.
+    expect(() => componentIdsIn(nodes, Number.NaN)).toThrow(
+      /componentUsageIn: maxNodes/
+    );
+
+    // The control: an ordinary budget is untouched by the guard, so what the
+    // test above measures is the refusal rather than the function being broken.
+    expect(componentUsageIn(nodes, 10).complete).toBe(true);
+  });
+
+  it("keeps the answer truthful under a fractional budget", () => {
+    // A fractional budget is accepted — that is `boundedLimit`'s decision, and
+    // refusing it here alone would make this walk disagree with the helper
+    // that exists to stop walks disagreeing. It costs at most one node beyond
+    // the cap.
+    //
+    // What must hold either way is that `complete` describes what the walk
+    // REACHED rather than what the budget permitted. Both cases are asserted,
+    // because a rule that only ever reports `true` would satisfy the first.
+    expect(componentUsageIn(nodes, 2.5)).toEqual({
+      ids: ["late"],
+      complete: true,
+    });
+    expect(componentUsageIn(nodes, 1.5)).toEqual({ ids: [], complete: false });
+  });
+
   it("answers what componentIdsIn answers, truncation included", () => {
     // `componentIdsIn` is derived from this, and the case where a
     // reimplementation would diverge is the bounded one: a second walk with

--- a/packages/blocks-engine/src/resolve-instances.ts
+++ b/packages/blocks-engine/src/resolve-instances.ts
@@ -65,6 +65,7 @@ import {
   MAX_ENVELOPE_ENTRIES,
   type DocumentLimits,
 } from "./limits";
+import { boundedLimit } from "./measure-bytes";
 import { isPlainRecord } from "./plain-record";
 import { boundedOwnKeys, defineEntry, ownEntry } from "./safe-record";
 import { hashId } from "./style/node-class";
@@ -300,9 +301,34 @@ export function componentUsageIn(
   nodes: readonly unknown[],
   maxNodes: number = DEFAULT_LIMITS.maxNodes
 ): ComponentUsage {
+  // Through the published helper rather than a check written here, because its
+  // own docblock says why it is published: more than one walk is held to these
+  // numbers and they have to agree about what counts as a bound. A second rule
+  // spelled locally is how two walks come to accept different budgets.
+  //
+  // `NaN` is the case that matters. Every `budget <= 0` comparison against it
+  // is false, so the walk never stops — the bound is not loosened, it is GONE,
+  // and an unbounded read of an arbitrarily large stored document is exactly
+  // what the budget exists to prevent.
+  //
+  // A FRACTIONAL budget is accepted, and that is the helper's decision rather
+  // than an oversight here. It costs at most one node beyond the cap — 2.5
+  // reads three entries — and the answer stays truthful, because `complete`
+  // reports what the walk actually reached rather than what the budget
+  // allowed. Refusing it here and nowhere else would make this walk disagree
+  // with the helper that exists to stop walks disagreeing.
+  //
+  // The RETURNED value is what the walk spends, though nothing can currently
+  // tell it from `maxNodes`: the helper validates and returns its input
+  // unchanged, so the two are the same number on every path that gets past it,
+  // and a break-verify swapping them kills no test. Stated rather than left to
+  // look tested, and kept anyway — a helper that later normalises, by flooring
+  // a fraction say, is honoured here for free and silently ignored by the
+  // other spelling.
+  const cap = boundedLimit(maxNodes, "maxNodes", "componentUsageIn");
   const ids: string[] = [];
   const seen = new Set<string>();
-  let budget = maxNodes;
+  let budget = cap;
   // Set on the branch that ENDS the walk early, rather than derived afterwards
   // from `budget === 0`. A forest holding exactly `maxNodes` entries spends the
   // last of the budget on its last entry and is read WHOLE, so a check on the


### PR DESCRIPTION
## Recovers a fix stranded by #1647's merge

**#1647 merged at 10:49:29Z at head `de91716a9`** — the commit before the fix
below. Verified by content rather than by PR state:

```
git grep -c 'export function componentUsageIn' origin/main                → 1   (feature landed)
git grep -c 'boundedLimit(maxNodes, "maxNodes", "componentUsageIn")' main → 0   (guard did NOT)
git grep -c 'export function componentIdsIn' origin/main                  → 1   (control: search works)
```

So `main` currently carries `componentUsageIn` with the hole CodeRabbit found
on that PR.

## The defect

`componentUsageIn(nodes, NaN)` read every entry of the forest and reported it
complete. Every `budget <= 0` test against `NaN` is false, so the walk had **no
stop condition at all** — the bound was not loosened, it was absent, and a
stored document of any size was read whole.

Measured on three entries:

| `maxNodes` | ids | complete | |
|---|---|---|---|
| `3` | `["late"]` | `true` | correct |
| `2` | `[]` | `false` | correct |
| `2.5` | `["late"]` | `true` | reads 3 — one over the cap |
| `NaN` | `["late"]` | `true` | **no bound** |

## The fix

Guarded through **`boundedLimit`**, the helper already published in this package
for exactly this, rather than a check written at the call site. Its own docblock
says why it is published: *"more than one walk is held to these numbers and they
have to agree about what counts as a bound."* A second rule spelled locally is
how two walks come to accept different budgets — the same failure this feature
is about, one level up. It also already refuses non-numbers, and deliberately
permits `Infinity` as the supported way to ask for an exact count.

**Fractional budgets stay accepted, deliberately.** Refusing them here and
nowhere else would make this walk disagree with the helper that exists to stop
walks disagreeing. The cost is bounded at one node past the cap and the answer
stays truthful, because `complete` reports what the walk *reached* rather than
what the budget *allowed*. Both directions are asserted (`2.5` → complete,
`1.5` → truncated), so a rule that only ever reported `complete: true` would not
satisfy the test.

`componentIdsIn` inherits the refusal, which is what being derived means. Its
previous behaviour on `NaN` was to walk unbounded in silence, so the changeset
says so.

## Break-verification, including one that killed nothing

| break | result |
|---|---|
| remove the guard | fails `refuses a budget that would remove the bound rather than set one` |
| use the raw value instead of the validated one | **kills nothing** |

The second is not a hole in the test: `boundedLimit` validates and returns its
input unchanged, so the two spellings are the same number on every path past it
and no test could tell them apart. The validated value is kept anyway — a helper
that later normalises would be honoured for free — and the code now says
outright that this is untested, so it does not read as covered.

## Recorded, not fixed here

`surveyHost` in the same file has the identical unbounded-`NaN` shape, and it
matters more there: the published `resolveComponentInstances` refuses to compose
when the survey reports truncation, and under `NaN` that refusal never fires, so
it composes a document it never bounded. The remedy is one line, but it makes a
published function start throwing on a path this change does not otherwise
touch. Filed as `finding:surveyhost-walks-unbounded-under-a-nan-budget`.

## Gates

| gate | result |
|---|---|
| `pnpm build` (after clearing every `dist` from the previous branch) | exit 0 |
| `blocks-engine` `check-types` | exit 0 (both `tsc` invocations) |
| `blocks-engine` `lint` | exit 0 |
| `blocks-engine` tests | 52 files, 2413 tests, exit 0 |
| `fallow audit --base origin/main` | `pass`, `changed_files_count: 3`, introduced 0 across all four categories |
| `pnpm changeset status` | exit 0 |
