### PR TITLE
fix(nextly): the sanitizer keeps what is not a tag

### DIFF
--- a/.changeset/the-sanitizer-keeps-what-is-not-a-tag.md
+++ b/.changeset/the-sanitizer-keeps-what-is-not-a-tag.md
@@ -1,0 +1,33 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Stripping HTML from a text value no longer deletes ordinary writing. A `<` opens a tag only when what follows it could name one, which is the HTML tokenizer's own rule, so `price < 100` and `2 < 3 and 5 > 4` are stored as written. This runs on every `text`, `string`, `textarea` and `email` field of every collection, and on media alt text, captions and tags, so an author lost the rest of a sentence on save with nothing to say why.
+
+It is one pass, holding the invariant that a `<` it kept is never followed by a character that would open a tag. Removing a tag can put its neighbours together into a new one, and rescanning until the text stopped changing holds the same invariant at quadratic cost on a path every create and update reaches.
+
+`stripHtmlTags` is published from `nextly`, beside the other security utilities a plugin already reaches for. A plugin storing text a visitor typed has to strip markup the way core does, and the absence of that export is why a second copy grew in `@nextlyhq/plugin-form-builder`. That copy is gone.

--- a/packages/nextly/src/index.ts
+++ b/packages/nextly/src/index.ts
@@ -1046,6 +1046,12 @@ export {
   type TrustedClientIpOptions,
 } from "./utils/get-trusted-client-ip";
 
+// Published because a plugin storing text a visitor typed has to strip markup
+// the way core does, and the absence of this export is why a second copy grew
+// in `@nextlyhq/plugin-form-builder` and then drifted from this one. Sits with
+// the security utilities a plugin already reaches for.
+export { stripHtmlTags } from "./services/security/sanitization-service";
+
 export {
   validateExternalUrl,
   safeFetch,

--- a/packages/nextly/src/services/security/__tests__/sanitization-service.test.ts
+++ b/packages/nextly/src/services/security/__tests__/sanitization-service.test.ts
@@ -15,6 +15,7 @@ import type { FieldDefinition } from "../../../schemas/dynamic-collections";
 import {
   attachFieldGroupChildren,
   sanitizeEntryData,
+  stripHtmlTags,
 } from "../sanitization-service";
 
 const field = (f: Record<string, unknown>): FieldDefinition =>
@@ -249,5 +250,63 @@ describe("attachFieldGroupChildren", () => {
     const raw = field({ name: "seo", type: "component", component: "gone" });
     const fields = await attachFieldGroupChildren([raw], resolver);
     expect(childrenOf(fields[0])).toBeUndefined();
+  });
+});
+
+describe("stripHtmlTags", () => {
+  it("keeps a less-than sign that does not open a tag", () => {
+    // This runs on every text, string, textarea and email field of every
+    // collection, and on media alt text, captions and tags. Treating every `<`
+    // as the start of a tag deleted the rest of an author's sentence on save:
+    // `price < 100` was stored as `price`.
+    expect(stripHtmlTags("price < 100")).toBe("price < 100");
+    expect(stripHtmlTags("2 < 3 and 5 > 4")).toBe("2 < 3 and 5 > 4");
+    expect(stripHtmlTags("x <= y")).toBe("x <= y");
+    expect(stripHtmlTags("<3 heart")).toBe("<3 heart");
+  });
+
+  it("still removes what a browser would read as a tag", () => {
+    // The control for the test above: narrowing the rule must not stop it
+    // removing markup. Each of these is tag-open syntax, including the one left
+    // unclosed at the end, which a browser completes rather than shows.
+    expect(stripHtmlTags("Hello <b>world</b>")).toBe("Hello world");
+    expect(stripHtmlTags("</p>closing")).toBe("closing");
+    expect(stripHtmlTags("hello <script")).toBe("hello");
+    expect(stripHtmlTags("<!-- comment -->text")).toBe("text");
+    expect(stripHtmlTags("<?php echo 1; ?>x")).toBe("x");
+    expect(stripHtmlTags("<IMG SRC=x onerror=alert(1)>done")).toBe("done");
+  });
+
+  it("does not build a tag out of what it removed", () => {
+    // Removing a tag puts its neighbours together. One pass of a rule that
+    // matched only real tag syntax turned `<<b>img src=x onerror=alert(1)>`
+    // into live markup the sanitizer had assembled itself.
+    for (const input of [
+      "<<b>img src=x onerror=alert(1)>",
+      "<<script>script>alert(1)</script>",
+      "<<<b>div onmouseover=alert(1)>hover",
+    ]) {
+      expect(stripHtmlTags(input)).not.toMatch(/<[a-zA-Z/!?]/);
+    }
+  });
+
+  it("strips a hostile value in time proportional to its length", () => {
+    // `<`*n + `b>` + `x>`*n exposes one tag per pass, so a rule that rescanned
+    // until the text stopped changing did n passes over the whole string. Every
+    // create and update reaches this, so the difference is whose CPU a caller
+    // gets to spend.
+    const n = 120_000;
+    const hostile = "<".repeat(n) + "b>" + "x>".repeat(n);
+    const started = Date.now();
+    expect(stripHtmlTags(hostile)).not.toMatch(/<[a-zA-Z/!?]/);
+    expect(Date.now() - started).toBeLessThan(2000);
+  });
+
+  it("keeps an author's less-than through the write path", () => {
+    // Reached the way a write reaches it, so the unit above is not the only
+    // thing that has to agree.
+    const data: Record<string, unknown> = { title: "price < 100" };
+    sanitizeEntryData(data, [field({ name: "title", type: "text" })]);
+    expect(data.title).toBe("price < 100");
   });
 });

--- a/packages/nextly/src/services/security/sanitization-service.ts
+++ b/packages/nextly/src/services/security/sanitization-service.ts
@@ -20,25 +20,68 @@ import type { SanitizationConfigInput } from "../../schemas/security-config";
 
 const TEXT_LIKE_FIELDS = new Set(["text", "string", "textarea", "email"]);
 
+/** Whether this character would make the `<` before it open a tag. */
+function opensTag(character: string | undefined): boolean {
+  if (character === undefined) return false;
+  return (
+    character === "/" ||
+    character === "!" ||
+    character === "?" ||
+    (character >= "a" && character <= "z") ||
+    (character >= "A" && character <= "Z")
+  );
+}
+
 /**
- * Remove all HTML tags from a string, collapse whitespace, and trim.
+ * Remove HTML tags from a string, collapse whitespace, and trim.
  *
- * Uses a regex that matches both complete tags (`<b>`) and unclosed tags
- * at end-of-string (`<script`) to prevent browsers from interpreting
- * incomplete markup.
+ * A `<` opens a tag only when what follows it could name one: an ASCII letter,
+ * `/` for a closing tag, or `!` and `?` for comments and doctypes. That is the
+ * HTML tokenizer's own rule, so what survives is what a browser would have
+ * shown as text anyway.
+ *
+ * Treating every `<` as the start of a tag deleted ordinary writing. This runs
+ * on every text, string, textarea and email field of every collection, and on
+ * media alt text, captions and tags, so `price < 100` was stored as `price` and
+ * `2 < 3 and 5 > 4` as `2 4`. An author lost the rest of a sentence on save
+ * with nothing to say why.
+ *
+ * One pass, holding one invariant: a `<` that has been kept is never followed
+ * by a character that would open a tag. Removing a tag can put its neighbours
+ * together into a new one, so `<<b>img src=x onerror=alert(1)>` would otherwise
+ * come back as live markup the sanitizer assembled itself, and a kept `<` is
+ * dropped the moment the next character would make it dangerous. Rescanning
+ * until the text stopped changing holds the same invariant and is quadratic:
+ * `"<".repeat(n) + "b>" + "x>".repeat(n)` exposes one tag per pass. Each
+ * character here is examined once and dropped at most once.
  *
  * @example
  * stripHtmlTags('Hello <b>world</b>')          // 'Hello world'
- * stripHtmlTags('<script>alert(1)</script>')    // ''
+ * stripHtmlTags('<script>alert(1)</script>')   // 'alert(1)'
  * stripHtmlTags('hello <script')               // 'hello'
  * stripHtmlTags('hello <br/> world')           // 'hello world'
- * stripHtmlTags('&lt;script&gt;')              // '&lt;script&gt;' (already encoded — safe)
+ * stripHtmlTags('price < 100')                 // 'price < 100'
+ * stripHtmlTags('&lt;script&gt;')              // '&lt;script&gt;' (already encoded)
  */
 export function stripHtmlTags(input: string): string {
-  return input
-    .replace(/<[^>]*(?:>|$)/g, "") // Remove HTML tags (including unclosed at end-of-string)
-    .replace(/\s+/g, " ") // Collapse multiple whitespace into single space
-    .trim();
+  const kept: string[] = [];
+  for (let at = 0; at < input.length; at += 1) {
+    const character = input[at];
+    if (character === "<" && opensTag(input[at + 1])) {
+      const close = input.indexOf(">", at + 1);
+      at = close === -1 ? input.length : close;
+      continue;
+    }
+    while (
+      kept.length > 0 &&
+      kept[kept.length - 1] === "<" &&
+      opensTag(character)
+    ) {
+      kept.pop();
+    }
+    kept.push(character);
+  }
+  return kept.join("").replace(/\s+/g, " ").trim();
 }
 
 /**

--- a/packages/plugin-form-builder/src/handlers/prepare-submission.ts
+++ b/packages/plugin-form-builder/src/handlers/prepare-submission.ts
@@ -20,6 +20,8 @@
  * stay on the HTTP path.
  */
 
+import { stripHtmlTags } from "nextly";
+
 import type { AnyFormField } from "../types";
 import {
   generateZodSchema,
@@ -42,65 +44,6 @@ const TEXT_FORM_FIELDS = new Set([
   "url",
   "hidden",
 ]);
-
-/** Whether this character would make the `<` before it open a tag. */
-function opensTag(character: string | undefined): boolean {
-  if (character === undefined) return false;
-  return (
-    character === "/" ||
-    character === "!" ||
-    character === "?" ||
-    (character >= "a" && character <= "z") ||
-    (character >= "A" && character <= "Z")
-  );
-}
-
-/**
- * Remove HTML tags from a string, collapse whitespace, and trim.
- *
- * A `<` opens a tag only when what follows it could name one: an ASCII letter,
- * `/` for a closing tag, or `!` and `?` for comments and doctypes. That is the
- * HTML tokenizer's own rule, so what survives here is what a browser would have
- * shown as text anyway. Treating every `<` as a tag cut `2 < 3` down to `2`,
- * which is silent loss in the one column a visitor's own words live in.
- *
- * `<name>` is still removed. Nothing distinguishes it from a tag, and a browser
- * reads it as an unknown element too. A tag left unclosed at the end goes with
- * it: handed `hello <script` a browser completes it rather than showing it.
- *
- * One pass, holding one invariant: a `<` that has been kept is never followed
- * by a character that would open a tag. Removing a tag can put its neighbours
- * together into a new one, and `<<b>img src=x onerror=alert(1)>` became live
- * markup the sanitizer assembled itself, so a kept `<` is dropped the moment
- * the next character would make it dangerous.
- *
- * Repeating a regex until the text stopped changing held the same invariant and
- * was quadratic: `"<".repeat(n) + "b>" + "x>".repeat(n)` exposed one tag per
- * pass, so 90KB of it cost 30,001 passes over the whole string. This route is
- * public and unauthenticated, and sanitizing happens before any length rule, so
- * that was a cheap way to spend the server's CPU. Each character is examined
- * once and dropped at most once.
- */
-function stripHtmlTags(input: string): string {
-  const kept: string[] = [];
-  for (let at = 0; at < input.length; at += 1) {
-    const character = input[at];
-    if (character === "<" && opensTag(input[at + 1])) {
-      const close = input.indexOf(">", at + 1);
-      at = close === -1 ? input.length : close;
-      continue;
-    }
-    while (
-      kept.length > 0 &&
-      kept[kept.length - 1] === "<" &&
-      opensTag(character)
-    ) {
-      kept.pop();
-    }
-    kept.push(character);
-  }
-  return kept.join("").replace(/\s+/g, " ").trim();
-}
 
 /**
  * Sanitize form submission data by stripping HTML tags from free-text fields.


### PR DESCRIPTION
Core's `stripHtmlTags` deletes ordinary writing. Measured against the current implementation:

```
"price < 100"        ->  "price"
"2 < 3 and 5 > 4"    ->  "2 4"
```

It treats every `<` as the start of a tag and removes to the next `>` or to the end of the value. This runs on **every `text`, `string`, `textarea` and `email` field of every collection** via the global sanitization hook, and on media alt text, captions and tags. An author typing a comparison into a text field loses the rest of the sentence on save, with nothing to say why.

## The rule

A `<` opens a tag only when what follows it could name one: an ASCII letter, `/` for a closing tag, or `!` and `?` for comments and doctypes. That is the HTML tokenizer's own tag-open rule, so what survives here is what a browser would have shown as text anyway.

## Why narrowing alone would be worse

Removing a tag puts its neighbours together, and a narrowed pattern will happily hand back markup it assembled itself:

```
input           <<b>img src=x onerror=alert(1)>
narrowed, 1 pass  <img src=x onerror=alert(1)>
```

So the two changes are one change. This holds the invariant directly rather than by rescanning: **a `<` that has been kept is never followed by a character that would open a tag.** Each character is examined once and dropped at most once, so `"<".repeat(n) + "b>" + "x>".repeat(n)` costs time proportional to its length instead of its square — which matters on a path every create and update reaches, from callers who are not always authenticated.

## One implementation instead of two

`stripHtmlTags` is published from `nextly`, beside `getTrustedClientIp` and `safeFetch`, which this plugin already imports from there. A plugin storing text a visitor typed has to strip markup the way core does, and the absence of that export is exactly why a second copy grew in `@nextlyhq/plugin-form-builder` — and then drifted, since the plugin's copy was fixed first and core's was not. The copy is deleted; Fallow's changed-files gate flagged the duplication the moment both existed, which is what forced the question.

## Also

The JSDoc example claiming `<script>alert(1)</script>` becomes `''` was wrong before this change. It has always been `alert(1)`: the tags go, their content stays. Corrected, and it is the third unchecked-JSDoc defect this week.

## Evidence

- 11,609 tests in `nextly`, 384 in the plugin — the plugin's own sanitizer tests now run against core's implementation, which is a cross-check that the two were equivalent.
- Controls: the old regex fails the two "keeps a less-than" tests; a narrowed regex *without* the invariant fails the assembly and the linear-time tests. Both leave the file loading, so the failures are the assertions.
- Fallow `new-only`: zero introduced, duplication back to zero.