### PR TITLE
refactor(plugin-page-builder): one usage-index machinery, class usage as its first configuration

### DIFF
--- a/.changeset/one-usage-index-machinery.md
+++ b/.changeset/one-usage-index-machinery.md
@@ -1,0 +1,37 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Nothing changes for a site. The page-builder's usage-index machinery — which
+records where a document's references live so the library can say what is still
+in use — now works over any kind of reference rather than named classes alone,
+with class usage as its first configuration. The behaviour, the stored rows and
+the published types are unchanged; the whole existing suite passes untouched,
+which is what the change is checked against.
+
+This is groundwork for the component usage index, so that deleting a component
+can tell you which pages still embed it.

--- a/packages/plugin-page-builder/src/class-usage-reconcile.ts
+++ b/packages/plugin-page-builder/src/class-usage-reconcile.ts
@@ -36,11 +36,15 @@
  *
  * @module class-usage-reconcile
  */
-import { MAX_NAMED_CLASS_NAME_LENGTH } from "@nextlyhq/blocks-engine";
-import type { DocumentLimits } from "@nextlyhq/blocks-engine";
+import {
+  DEFAULT_LIMITS,
+  MAX_NAMED_CLASS_NAME_LENGTH,
+  type DocumentLimits,
+} from "@nextlyhq/blocks-engine";
 
 import { classUsageOf } from "./class-usage";
 import type { ClassUsageRow } from "./collections/class-usage-index";
+import type { UsageIndex, UsageSubject } from "./usage-index";
 
 /**
  * The class id a marker row carries, chosen so no real reference can wear it.
@@ -165,19 +169,51 @@ export function deriveClassUsageRows(
    */
   limits?: DocumentLimits
 ): ClassUsageDerivation {
-  const usage = classUsageOf(document, limits);
+  return deriveUsageRows(classUsageIndex, subject, document, limits);
+}
+
+/**
+ * The class index, as the shared machinery sees it.
+ *
+ * Named `classUsageIndex` rather than inlined so the one place a class row is
+ * BUILT is also the one place its marker is chosen — the two have to agree
+ * about which value no real reference can wear, and separating them is how a
+ * marker becomes indistinguishable from a reference nobody noticed was legal.
+ */
+export const classUsageIndex: UsageIndex<ClassUsageRow> = {
+  referenceColumn: "classId",
+  referenceOf: row => row.classId,
+  rowFor: (subject, referenceId) => ({ ...subject, classId: referenceId }),
+  markerFor: subject => ({ ...subject, classId: UNDETERMINED_CLASS_ID }),
+  isMarker: row => row.classId === UNDETERMINED_CLASS_ID,
+  derive: (document, limits) => classUsageOf(document, limits),
+};
+
+/**
+ * The rows describing one document under ANY index, or the fact that it could
+ * not be read whole.
+ *
+ * The generic beneath {@link deriveClassUsageRows}, which is a call to it. The
+ * named function keeps its signature deliberately: its tests are the oracle
+ * for this refactor, and a test edited alongside the code it checks stops
+ * being one.
+ */
+export function deriveUsageRows<TRow extends UsageSubject>(
+  index: UsageIndex<TRow>,
+  subject: UsageSubject,
+  document: unknown,
+  limits: DocumentLimits = DEFAULT_LIMITS
+): { complete: true; rows: TRow[] } | { complete: false; undetermined: TRow } {
+  const usage = index.derive(document, limits);
   if (!usage.complete) {
     // The prefix it DID read is discarded rather than recorded. A partial list
     // stored as a list is indistinguishable from a complete one, and the whole
     // point of the marker is to be distinguishable.
-    return {
-      complete: false,
-      undetermined: { ...subject, classId: UNDETERMINED_CLASS_ID },
-    };
+    return { complete: false, undetermined: index.markerFor(subject) };
   }
   return {
     complete: true,
-    rows: usage.ids.map(classId => ({ ...subject, classId })),
+    rows: usage.ids.map(referenceId => index.rowFor(subject, referenceId)),
   };
 }
 
@@ -208,6 +244,22 @@ export function reconcileClassUsage(
   derived: readonly ClassUsageRow[],
   stored: readonly StoredClassUsageRow[]
 ): ClassUsageReconciliation {
+  return reconcileUsage(classUsageIndex, subject, derived, stored);
+}
+
+/**
+ * The same reconciliation, for any index.
+ *
+ * The generic beneath {@link reconcileClassUsage}. Every rule below is the
+ * class index's, unchanged — what moved is only WHICH column carries the
+ * reference, which the descriptor answers.
+ */
+export function reconcileUsage<TRow extends UsageSubject>(
+  index: UsageIndex<TRow>,
+  subject: UsageSubject,
+  derived: readonly TRow[],
+  stored: readonly (TRow & { id: string })[]
+): { insert: TRow[]; remove: string[] } {
   for (const row of derived) {
     if (!describesSubject(row, subject)) {
       throw new Error(
@@ -228,7 +280,7 @@ export function reconcileClassUsage(
     }
   }
 
-  const wanted = new Set(derived.map(row => row.classId));
+  const wanted = new Set(derived.map(row => index.referenceOf(row)));
   // Which classes a SURVIVING stored row records. A class reaches this set only
   // by having a row that is both wanted and the first of its class, which is
   // what makes it the right thing to subtract the inserts from: a class whose
@@ -256,16 +308,16 @@ export function reconcileClassUsage(
     // re-derives from the row that won. That is a property of the write path,
     // which cannot be established here, and this comment is where it is
     // recorded rather than assumed.
-    const duplicate = kept.has(row.classId);
-    if (duplicate || !wanted.has(row.classId)) {
+    const duplicate = kept.has(index.referenceOf(row));
+    if (duplicate || !wanted.has(index.referenceOf(row))) {
       remove.push(row.id);
       continue;
     }
-    kept.add(row.classId);
+    kept.add(index.referenceOf(row));
   }
 
   return {
-    insert: derived.filter(row => !kept.has(row.classId)),
+    insert: derived.filter(row => !kept.has(index.referenceOf(row))),
     remove,
   };
 }

--- a/packages/plugin-page-builder/src/collections/class-usage-index.ts
+++ b/packages/plugin-page-builder/src/collections/class-usage-index.ts
@@ -36,84 +36,33 @@
  */
 import { defineCollection, text } from "nextly/config";
 
+import type { UsageScope, UsageSubject, UsageVariant } from "../usage-index";
+
 /** The slug this plugin's usage index is stored under. */
 export const CLASS_USAGE_INDEX_SLUG = "nx_pb_class_usage";
 
 /**
  * Which kind of content a row points at.
  *
- * Collections and singles are addressed differently and the difference is not
- * cosmetic, so the kind is stored rather than inferred from whether `entityKey`
- * happens to be empty.
+ * An alias of the shared vocabulary rather than a second closed set: every
+ * usage index answers about the same documents, so a scope one of them
+ * accepted and another did not would describe a subject the shared pass
+ * cannot reconcile. Kept under this name because it is what this collection's
+ * readers already call it.
  */
-export type ClassUsageScope = "collection" | "single";
+export type ClassUsageScope = UsageScope;
 
 /**
  * Which of a document's two stored forms a row was read from.
  *
- * A closed set rather than free text, for the same reason `scope` is one. Both
- * are stored as text and both partition the index into subject families, so a
- * value outside the set produces rows that no query built from a real subject
- * can ever select — neither to reconcile nor to sweep. A typo does not fail, it
- * accumulates.
+ * An alias, for the reason `ClassUsageScope` is one. Kept under this name
+ * because it is PUBLISHED from the package entry, so removing it would be a
+ * breaking change for a rename that buys a caller nothing.
  */
-export type ClassUsageVariant = "published" | "draft";
+export type ClassUsageVariant = UsageVariant;
 
 /** One reference: this document, through this field, uses this class. */
-export interface ClassUsageRow {
-  scope: ClassUsageScope;
-  /** The collection's or single's slug. */
-  entity: string;
-  /**
-   * Which document within `entity`, or empty for a single.
-   *
-   * A single has one document, and its ROW MAY NOT EXIST — an unedited single
-   * still renders its declared defaults. So a single is addressed by its slug
-   * alone, in `entity`, and this stays empty rather than holding an id that is
-   * absent until somebody types.
-   *
-   * Kept as an empty string rather than null so the five columns form a total
-   * key. Nothing in the database enforces that today — a collection's declared
-   * indexes do not reach the schema pipeline, so the composite constraint this
-   * key describes cannot currently be created — and it is the reconciler that
-   * keeps the rows unique instead. A null here would still be wrong the day
-   * that changes, because a nullable member of a uniqueness constraint compares
-   * as unknown on most dialects.
-   */
-  entityKey: string;
-  /** The blocks field the reference was found in. */
-  field: string;
-  /**
-   * Which locale's document the reference was found in, or empty when the field
-   * is not localized.
-   *
-   * A localized blocks field stores a DOCUMENT PER LOCALE, and each may apply a
-   * different set of classes. Without this column every locale would share one
-   * key, so maintaining one locale's document would remove the rows for classes
-   * only another locale uses — and a class still rendered by that other locale
-   * would read as unused, which is the answer that permits deleting it.
-   *
-   * Empty rather than null for the reason `entityKey` is: the columns have to
-   * form a total key, and a nullable member of a uniqueness constraint compares
-   * as unknown on most dialects.
-   */
-  locale: string;
-  /**
-   * Which stored variant of the document the reference was found in —
-   * `"published"` or `"draft"`.
-   *
-   * A collection with drafts holds TWO documents under one id, and they can
-   * apply different classes: a pure draft edit leaves the live row untouched,
-   * so the published page and the pending draft disagree until it is
-   * published. Without this column they share one key, and indexing either
-   * removes the rows the other justifies — so a class the published page still
-   * renders reads as unused because a draft dropped it.
-   *
-   * Both are worth counting rather than only the published one. The count
-   * answers "is this class safe to delete", and deleting a class an unpublished
-   * draft applies breaks that draft the moment somebody publishes it.
-   */
-  variant: ClassUsageVariant;
+export interface ClassUsageRow extends UsageSubject {
   /**
    * The named class's id, as stored in `node.classes`, or the marker id on a
    * marker row.

--- a/packages/plugin-page-builder/src/usage-index.ts
+++ b/packages/plugin-page-builder/src/usage-index.ts
@@ -1,0 +1,178 @@
+/**
+ * What every usage index has in common, and what each one supplies for itself.
+ *
+ * Two indexes derive rows from the same documents by the same rules and differ
+ * only in WHAT they record a reference to: `nx_pb_class_usage` records the
+ * named classes a document applies, and the component index records the
+ * component definitions it embeds. Everything between — which subjects a
+ * written document has, how stored rows are read back, which are inserted and
+ * which removed, how a rebuild sweeps — is one question, and this is what lets
+ * it have one implementation.
+ *
+ * ## Why a descriptor rather than two families
+ *
+ * Measured before this existed: the class-usage modules are 2,655 non-test
+ * lines and the token `classId` appears in FOUR of the ten, fourteen times.
+ * `subjectWhere` already binds only the six subject columns; a row reaches
+ * storage by being spread, so the row's own field name is the column name. The
+ * machinery was already generic in all but name, and a second copy of it would
+ * have agreed with the first on the day it was written and drifted afterwards —
+ * which is the failure the repository has a rule about, and which the clone
+ * detector would have reported besides.
+ *
+ * ## What a descriptor may NOT decide
+ *
+ * The SUBJECT. Both indexes answer questions about the same documents, so a
+ * row that identified its subject differently could not be reconciled or swept
+ * by the shared pass — and the two would disagree about which document a row
+ * describes, which is the one thing no amount of per-index freedom is worth.
+ *
+ * @module usage-index
+ */
+import type { DocumentLimits } from "@nextlyhq/blocks-engine";
+
+/**
+ * Which kind of content a row points at.
+ *
+ * Collections and singles are addressed differently and the difference is not
+ * cosmetic, so the kind is stored rather than inferred from whether
+ * `entityKey` happens to be empty.
+ */
+export type UsageScope = "collection" | "single";
+
+/**
+ * Which of a document's two stored forms a row was read from.
+ *
+ * A closed set rather than free text. Both are stored as text and both
+ * partition the index into subject families, so a value outside the set
+ * produces rows that no query built from a real subject can ever select —
+ * neither to reconcile nor to sweep. A typo does not fail, it accumulates.
+ */
+export type UsageVariant = "published" | "draft";
+
+/**
+ * The document a row describes, without the reference it records.
+ *
+ * SHARED between indexes deliberately, and the one thing a descriptor cannot
+ * override. Six columns identify a subject and every query binds all six; an
+ * index that identified its subjects differently could not be reconciled by
+ * the shared pass at all.
+ *
+ * `entityKey` and `locale` are empty strings rather than null, because the
+ * columns have to form a total key and a nullable member of a uniqueness
+ * constraint compares as unknown on most dialects. Nothing in the database
+ * enforces that key today — a collection's declared indexes do not reach the
+ * schema pipeline — so the reconciler is what keeps rows unique instead.
+ */
+export interface UsageSubject {
+  scope: UsageScope;
+  /** The collection's or single's slug. */
+  entity: string;
+  /**
+   * Which document within `entity`, or empty for a single.
+   *
+   * A single has one document, and its ROW MAY NOT EXIST — an unedited single
+   * still renders its declared defaults. So a single is addressed by its slug
+   * alone, in `entity`, and this stays empty rather than holding an id that is
+   * absent until somebody types.
+   *
+   * Kept as an empty string rather than null so the five columns form a total
+   * key. Nothing in the database enforces that today — a collection's declared
+   * indexes do not reach the schema pipeline, so the composite constraint this
+   * key describes cannot currently be created — and it is the reconciler that
+   * keeps the rows unique instead. A null here would still be wrong the day
+   * that changes, because a nullable member of a uniqueness constraint compares
+   * as unknown on most dialects.
+   */
+  entityKey: string;
+  /** The blocks field the reference was found in. */
+  field: string;
+  /**
+   * Which locale's document the reference was found in, or empty when the field
+   * is not localized.
+   *
+   * A localized blocks field stores a DOCUMENT PER LOCALE, and each may apply a
+   * different set of classes. Without this column every locale would share one
+   * key, so maintaining one locale's document would remove the rows for classes
+   * only another locale uses — and a class still rendered by that other locale
+   * would read as unused, which is the answer that permits deleting it.
+   *
+   * Empty rather than null for the reason `entityKey` is: the columns have to
+   * form a total key, and a nullable member of a uniqueness constraint compares
+   * as unknown on most dialects.
+   */
+  locale: string;
+  /**
+   * Which stored variant of the document the reference was found in —
+   * `"published"` or `"draft"`.
+   *
+   * A collection with drafts holds TWO documents under one id, and they can
+   * apply different classes: a pure draft edit leaves the live row untouched,
+   * so the published page and the pending draft disagree until it is
+   * published. Without this column they share one key, and indexing either
+   * removes the rows the other justifies — so a class the published page still
+   * renders reads as unused because a draft dropped it.
+   *
+   * Both are worth counting rather than only the published one. The count
+   * answers "is this class safe to delete", and deleting a class an unpublished
+   * draft applies breaks that draft the moment somebody publishes it.
+   */
+  variant: UsageVariant;
+}
+
+/** What a document references, and whether the whole of it could be read. */
+export interface UsageDerivation {
+  /** The reference ids the document holds, without repeats. */
+  ids: readonly string[];
+  /**
+   * Whether the whole document was read.
+   *
+   * False means `ids` is a PREFIX. A caller must not read a missing id as
+   * absent while this is false — an absence produced by a bound is what
+   * permits deleting something a page still renders.
+   */
+  complete: boolean;
+}
+
+/**
+ * One index's own answers, supplied to the shared machinery.
+ *
+ * Generic over the row so each index keeps a TYPED row rather than a record of
+ * unknowns: the reference column's name differs between them, and reading it
+ * through a string key would give up the checking that stops a row being built
+ * with the wrong column in the first place.
+ */
+export interface UsageIndex<TRow extends UsageSubject> {
+  /**
+   * The stored column the reference id lives in.
+   *
+   * A string because the row PARSER validates columns by name against data
+   * that arrives unvalidated. Everywhere a row is built or read as a value,
+   * the typed members below are used instead.
+   */
+  readonly referenceColumn: string;
+
+  /** The reference a row records. */
+  referenceOf(row: TRow): string;
+
+  /** A row recording that `subject` references `referenceId`. */
+  rowFor(subject: UsageSubject, referenceId: string): TRow;
+
+  /**
+   * The row recording that `subject` could not be read whole.
+   *
+   * ONE row rather than a row per reference the walk managed, because a
+   * partial list stored as a list is indistinguishable from a complete one.
+   * Each index chooses how to make it disjoint from every real reference: the
+   * class index can exceed the length its ids are capped at, and the component
+   * index cannot, because a component id is constrained by nothing but being a
+   * nonempty string.
+   */
+  markerFor(subject: UsageSubject): TRow;
+
+  /** Whether a row is that marker rather than a reference. */
+  isMarker(row: TRow): boolean;
+
+  /** What the stored document references, under the bounds it is drawn with. */
+  derive(document: unknown, limits: DocumentLimits): UsageDerivation;
+}


### PR DESCRIPTION
Groundwork for Plan 06 **T-5**, the component usage index. **No behaviour
change** — that is the claim this PR is checked against.

## Why generalise rather than add a second family

A component usage index derives rows from the same documents, by the same
rules, and differs only in **what** it records a reference to.

Measured before writing anything:

| fact | value |
|---|---|
| class-usage modules, non-test lines | 2,655 across 10 files |
| files containing the token `classId` | **4 of 10** |
| occurrences of `classId` | **14** |
| `subjectWhere` | already binds only the six subject columns |
| how a row reaches storage | spread — so the row's field name *is* the column name |

The machinery was already generic in all but name. A copy would have agreed
with the original on the day it was written and drifted afterwards — which
`AGENTS.md` forbids outright, and which the clone detector would have reported
besides.

## The shape

`UsageSubject` is shared; a `UsageIndex<TRow>` descriptor supplies the rest —
which column carries the reference, how to read and build one, and what the
"could not read this document whole" marker is.

The marker is a descriptor concern for a measured reason. The class index makes
its marker disjoint by **length** (`UNDETERMINED_CLASS_ID` exceeds the cap class
ids are held to). A component id has no such lever — `validation.ts:2775`
requires only a nonempty string — so the component index will need a different
answer, and baking the class one into the shared code would have forced it.

`ClassUsageRow` now **extends** the shared subject rather than restating it, and
the field docblocks moved with the fields they explain rather than being
summarised. `ClassUsageScope` and `ClassUsageVariant` become aliases;
`ClassUsageVariant` is **published from the package entry**, so removing it
would be a breaking change for a rename that buys a caller nothing.

## The oracle: signatures kept, tests untouched

`deriveClassUsageRows` and `reconcileClassUsage` keep their **exact signatures**
and call the generics beneath them. That is deliberate — their tests are the
evidence that this refactor preserves behaviour, and a test edited alongside the
code it checks stops being evidence.

| check | result |
|---|---|
| `plugin-page-builder` `check-types` | exit 0 |
| `plugin-page-builder` `lint` | exit 0 |
| `plugin-page-builder` tests | 69 files, **768 tests, unchanged** |

## Passing tests do not show it is WIRED — so that is verified separately

A wrapper that quietly kept its old body would also pass all 768. Two breaks in
the generic code, each killing class-index tests:

| break | fails |
|---|---|
| generic reconcile stops removing duplicates | `removes a duplicate row without re-inserting the class it duplicates` |
| generic derive never reports the marker | 5 tests, across `class-usage-reconcile` **and** `class-usage-index-rebuild` |

## Packaging checked

`ClassUsageVariant` is published, and is now an alias of a type in a module that
is not. Verified against the built declarations rather than assumed: the bundler
inlines `UsageVariant` into the same `index.d.ts` (line 770), the alias resolves
inside the bundle, no path outside `dist` is referenced, and the public export
list is unchanged.

## Gates

| gate | result |
|---|---|
| `pnpm --filter @nextlyhq/plugin-page-builder build` | exit 0 |
| `check-types` / `lint` / tests | 0 / 0 / 768 passing |
| `fallow audit --base origin/main` | `pass`, `changed_files_count: 4`, introduced 0 across all four categories |
| `pnpm changeset status` | parses; 25 packages |

The changeset says plainly that nothing changes for a site — that *is* the
user-facing fact here.
