### PR TITLE
refactor(builder): one name for a placement target, and delete the translation

### DIFF
--- a/.changeset/one-name-for-a-placement-target.md
+++ b/.changeset/one-name-for-a-placement-target.md
@@ -1,0 +1,34 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Builder: a placement destination now has ONE name. `@nextlyhq/builder` re-exports the engine's `PlacementTarget` instead of declaring its own `InsertTarget`, and the function that translated between the two spellings is gone.
+
+`InsertTarget` remains exported from `@nextlyhq/builder` as a deprecated alias for one release and will be removed after it. Two things to know when migrating:
+
+- The discriminant moved with the name. A target is written `{ kind: "root" }` and `{ kind: "slot", parentType, slot }`; the old `at` member is no longer accepted, and a value still spelling `at` is a type error rather than a silent fall-through. `DropRegion.at` and `DropTarget.target` hold these values, so a host narrowing them reads `.kind`.
+- `@nextlyhq/blocks-engine` exports an unrelated type that is also called `InsertTarget` — where a saved pattern is inserted, `OpPosition | "document"`. That collision is what the deprecation removes: after the alias goes, `InsertTarget` names only the engine's pattern position.

--- a/packages/builder/src/drop-targets.test.ts
+++ b/packages/builder/src/drop-targets.test.ts
@@ -77,7 +77,7 @@ function documentOf(nodes: BlockNode[]): BlockDocument {
 function rootRegion(childIds: string[], axis: "x" | "y" = "y"): DropRegion {
   return {
     id: ROOT_REGION,
-    at: { at: "root" },
+    at: { kind: "root" },
     depth: 0,
     rect: { x: 0, y: 0, width: 400, height: 1000 },
     axis,
@@ -178,7 +178,7 @@ describe("targetsInRegion", () => {
     // would read as "beside this container" rather than "inside it".
     const region: DropRegion = {
       id: "box::children",
-      at: { at: "slot", parentType: "core/box", slot: "children" },
+      at: { kind: "slot", parentType: "core/box", slot: "children" },
       parentId: "box",
       slot: "children",
       depth: 1,
@@ -219,7 +219,7 @@ describe("targetsInRegion", () => {
   it("addresses a slot region by parent and slot, never by position", () => {
     const region: DropRegion = {
       id: "box::children",
-      at: { at: "slot", parentType: "core/box", slot: "children" },
+      at: { kind: "slot", parentType: "core/box", slot: "children" },
       parentId: "box",
       slot: "children",
       depth: 1,
@@ -298,12 +298,45 @@ describe("collectRegions", () => {
 
     expect(regions.map(r => r.id)).toEqual([ROOT_REGION]);
   });
+
+  it("carries the placement target the nesting rule will be asked about", () => {
+    // The region's `at` is what `blockAllowedAt` receives for every drop into
+    // it, and a slot region reporting itself as the root asks a DIFFERENT
+    // question: the root case reads only the child's permitted parents, so the
+    // container's own allow-list is never consulted and a child restricted to
+    // that container is refused where it belongs. Nothing throws either way —
+    // the two are both valid targets — so the discriminant is asserted here
+    // rather than inferred from a drop that happened to resolve.
+    //
+    // `parentType` is the CONTAINER's type, never the dragged block's: the rule
+    // asks what this container admits, and a target naming the child would have
+    // the container answer for itself.
+    const regions = collectRegions(
+      documentOf([
+        node("outer", "core/box", { children: [node("inner", "core/row")] }),
+      ]),
+      slots,
+      rectsOf({
+        outer: { x: 0, y: 0, width: 400, height: 300 },
+        inner: { x: 20, y: 20, width: 360, height: 100 },
+      })
+    );
+
+    expect(regions.map(r => [r.id, r.at])).toEqual([
+      [ROOT_REGION, { kind: "root" }],
+      [
+        "outer::children",
+        { kind: "slot", parentType: "core/box", slot: "children" },
+      ],
+      ["inner::items", { kind: "slot", parentType: "core/row", slot: "items" }],
+    ]);
+  });
 });
 
 describe("regionAt", () => {
   const outer: DropRegion = {
     id: "outer::children",
-    at: { at: "slot", parentType: "core/box", slot: "children" },
+    at: { kind: "slot", parentType: "core/box", slot: "children" },
     parentId: "outer",
     slot: "children",
     depth: 1,
@@ -313,7 +346,7 @@ describe("regionAt", () => {
   };
   const inner: DropRegion = {
     id: "inner::items",
-    at: { at: "slot", parentType: "core/row", slot: "items" },
+    at: { kind: "slot", parentType: "core/row", slot: "items" },
     parentId: "inner",
     slot: "items",
     depth: 2,
@@ -426,7 +459,7 @@ describe("resolveDrop", () => {
     const regions = [
       {
         id: "acc::panels",
-        at: { at: "slot", parentType: "core/accordion", slot: "panels" },
+        at: { kind: "slot", parentType: "core/accordion", slot: "panels" },
         parentId: "acc",
         slot: "panels",
         depth: 1,
@@ -482,7 +515,7 @@ describe("resolveDrop", () => {
         regions: [
           {
             id: ROOT_REGION,
-            at: { at: "root" },
+            at: { kind: "root" },
             depth: 0,
             rect: { x: 0, y: 0, width: 400, height: 200 },
             axis: "y",

--- a/packages/builder/src/drop-targets.ts
+++ b/packages/builder/src/drop-targets.ts
@@ -70,7 +70,11 @@ import type {
 } from "@nextlyhq/blocks-engine";
 
 import type { Point, Rect } from "./geometry";
-import { blockAllowedAt, type InsertTarget, type SlotSource } from "./inserter";
+import {
+  blockAllowedAt,
+  type PlacementTarget,
+  type SlotSource,
+} from "./inserter";
 import type { OpPosition } from "./ops";
 
 /**
@@ -113,7 +117,7 @@ export interface DropRegion {
   /** Stable identity: {@link ROOT_REGION}, or `"<parentId>::<slot>"`. */
   readonly id: string;
   /** What this region is, as the nesting rule needs to see it. */
-  readonly at: InsertTarget;
+  readonly at: PlacementTarget;
   /** The container node, absent for the root region. */
   readonly parentId?: string;
   /** The slot within that container, absent for the root region. */
@@ -151,7 +155,7 @@ export interface DropTarget {
   /** Where the block goes. */
   readonly at: OpPosition;
   /** What that position is, for the nesting rule. */
-  readonly target: InsertTarget;
+  readonly target: PlacementTarget;
   /** The axis children are separated along. */
   readonly axis: DropAxis;
   /**
@@ -298,7 +302,7 @@ export function collectRegions(
           .filter((child): child is Rect => child !== undefined);
         regions.push({
           id: `${node.id}::${slot}`,
-          at: { at: "slot", parentType: node.type, slot },
+          at: { kind: "slot", parentType: node.type, slot },
           parentId: node.id,
           slot,
           depth,
@@ -317,7 +321,7 @@ export function collectRegions(
 
   regions.push({
     id: ROOT_REGION,
-    at: { at: "root" },
+    at: { kind: "root" },
     depth: 0,
     rect: rects.rootRect(),
     axis: axisOfRects(rootChildRects),

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -179,9 +179,9 @@ export type { BuilderCommand, CommandPaletteProps } from "./command-palette";
  * carrying its own copy of this ranking would certify its own copy, and would
  * keep passing through exactly the correction it exists to catch.
  *
- * `InsertTarget` and `SlotSource` travel with them because the region types are
- * written in terms of both: a consumer that can name a region but not what it
- * accepts cannot ask the nesting rule about one.
+ * `PlacementTarget` and `SlotSource` travel with them because the region types
+ * are written in terms of both: a consumer that can name a region but not what
+ * it accepts cannot ask the nesting rule about one.
  */
 export {
   axisOfRects,
@@ -203,6 +203,13 @@ export {
   blockAllowedAt,
   registryBlockSource,
   registrySlotSource,
+  // The engine spells the placement destination, and this package re-exports
+  // that spelling rather than a second one: the drop and region types below are
+  // written in terms of it, and a consumer holding one has to be able to hand it
+  // straight to the nesting rule. `InsertTarget` is the name it used to carry,
+  // kept for one release so a host importing it still compiles.
+  type PlacementTarget,
+  /** @deprecated Import `PlacementTarget`; its discriminant is `kind`. */
   type InsertTarget,
   // The shape a host has to supply for the panel to offer saved patterns. The
   // prop has existed since the tier landed and the type did not, so a host

--- a/packages/builder/src/insert-panel.tsx
+++ b/packages/builder/src/insert-panel.tsx
@@ -639,7 +639,7 @@ export function InsertPanel({
             point,
             point.kind === "inside-selection"
               ? getBlock(
-                  point.target.at === "slot" ? point.target.parentType : ""
+                  point.target.kind === "slot" ? point.target.parentType : ""
                 )?.editor?.label
               : undefined
           )}

--- a/packages/builder/src/inserter.test.ts
+++ b/packages/builder/src/inserter.test.ts
@@ -401,7 +401,7 @@ describe("entryAllowedAt and allowedEntries", () => {
     const entries = palette();
     const verdict = entryAllowedAt(
       entry(entries, "acme/column"),
-      { at: "root" },
+      { kind: "root" },
       registryNestingSource()
     );
 
@@ -419,7 +419,7 @@ describe("entryAllowedAt and allowedEntries", () => {
     expect(
       entryAllowedAt(
         entry(entries, "acme/column"),
-        { at: "slot", parentType: "acme/columns", slot: "children" },
+        { kind: "slot", parentType: "acme/columns", slot: "children" },
         registryNestingSource()
       ).allowed
     ).toBe(true);
@@ -429,7 +429,7 @@ describe("entryAllowedAt and allowedEntries", () => {
     const entries = palette();
     const verdict = entryAllowedAt(
       entry(entries, "acme/column"),
-      { at: "slot", parentType: "acme/text", slot: "children" },
+      { kind: "slot", parentType: "acme/text", slot: "children" },
       registryNestingSource()
     );
 
@@ -444,13 +444,13 @@ describe("entryAllowedAt and allowedEntries", () => {
     const source = registryNestingSource();
 
     expect(
-      entryAllowedAt(entry(entries, "acme/text"), { at: "root" }, source)
+      entryAllowedAt(entry(entries, "acme/text"), { kind: "root" }, source)
         .allowed
     ).toBe(true);
     expect(
       entryAllowedAt(
         entry(entries, "acme/text"),
-        { at: "slot", parentType: "acme/columns", slot: "children" },
+        { kind: "slot", parentType: "acme/columns", slot: "children" },
         source
       ).allowed
     ).toBe(true);
@@ -460,7 +460,7 @@ describe("entryAllowedAt and allowedEntries", () => {
     const entries = palette();
     const offered = allowedEntries(
       entries,
-      { at: "root" },
+      { kind: "root" },
       registryNestingSource()
     );
 
@@ -486,7 +486,7 @@ describe("entryAllowedAt and allowedEntries", () => {
     expect(
       entryAllowedAt(
         entry(entries, "acme/column#narrow"),
-        { at: "root" },
+        { kind: "root" },
         registryNestingSource()
       ).allowed
     ).toBe(false);
@@ -513,7 +513,7 @@ describe("entryAllowedAt and allowedEntries", () => {
 
     const refused = entryAllowedAt(
       entry(entries, "acme/text"),
-      { at: "slot", parentType: "acme/gallery", slot: "children" },
+      { kind: "slot", parentType: "acme/gallery", slot: "children" },
       source
     );
     expect(refused.allowed).toBe(false);
@@ -525,7 +525,7 @@ describe("entryAllowedAt and allowedEntries", () => {
     expect(
       entryAllowedAt(
         entry(entries, "acme/photo"),
-        { at: "slot", parentType: "acme/gallery", slot: "children" },
+        { kind: "slot", parentType: "acme/gallery", slot: "children" },
         source
       ).allowed
     ).toBe(true);
@@ -551,7 +551,7 @@ describe("entryAllowedAt and allowedEntries", () => {
 
     const verdict = entryAllowedAt(
       entry(entries, "acme/stray"),
-      { at: "slot", parentType: "acme/grid", slot: "cells" },
+      { kind: "slot", parentType: "acme/grid", slot: "cells" },
       registryNestingSource()
     );
     expect(verdict.allowed).toBe(false);
@@ -573,7 +573,7 @@ describe("insertionPointFor", () => {
     expect(insertionPointFor(document, null)).toEqual({
       kind: "document-end",
       at: { index: 1 },
-      target: { at: "root" },
+      target: { kind: "root" },
     });
   });
 
@@ -588,7 +588,7 @@ describe("insertionPointFor", () => {
     expect(insertionPointFor(document, "a")).toEqual({
       kind: "after-selection",
       at: { index: 1 },
-      target: { at: "root" },
+      target: { kind: "root" },
     });
   });
 
@@ -613,7 +613,7 @@ describe("insertionPointFor", () => {
     expect(point).toEqual({
       kind: "after-selection",
       at: { parentId: "wrap", slot: "children", index: 1 },
-      target: { at: "slot", parentType: "acme/columns", slot: "children" },
+      target: { kind: "slot", parentType: "acme/columns", slot: "children" },
     });
   });
 
@@ -646,7 +646,7 @@ describe("insertionPointFor", () => {
     ).toEqual({
       kind: "inside-selection",
       at: { parentId: "wrap", slot: "children", index: 0 },
-      target: { at: "slot", parentType: "acme/columns", slot: "children" },
+      target: { kind: "slot", parentType: "acme/columns", slot: "children" },
     });
   });
 
@@ -708,7 +708,7 @@ describe("insertionPointFor", () => {
     expect(insertionPointFor(documentOf([]), null)).toEqual({
       kind: "document-end",
       at: { index: 0 },
-      target: { at: "root" },
+      target: { kind: "root" },
     });
   });
 });
@@ -1179,7 +1179,7 @@ describe("the pattern tier", () => {
 
     const verdict = entryAllowedAt(
       pattern as never,
-      { at: "root" },
+      { kind: "root" },
       registryNestingSource()
     );
 
@@ -1205,8 +1205,11 @@ describe("the pattern tier", () => {
     );
 
     expect(
-      entryAllowedAt(pattern as never, { at: "root" }, registryNestingSource())
-        .allowed
+      entryAllowedAt(
+        pattern as never,
+        { kind: "root" },
+        registryNestingSource()
+      ).allowed
     ).toBe(true);
   });
 
@@ -1229,7 +1232,7 @@ describe("the pattern tier", () => {
     );
 
     expect(
-      allowedEntries(patterns, { at: "root" }, registryNestingSource()).map(
+      allowedEntries(patterns, { kind: "root" }, registryNestingSource()).map(
         offered => offered.patternId
       )
     ).toEqual(["ok"]);

--- a/packages/builder/src/inserter.ts
+++ b/packages/builder/src/inserter.ts
@@ -235,10 +235,28 @@ export interface SlotSource {
   slotsOf(type: string): readonly string[] | undefined;
 }
 
-/** Where an insert would land, as the nesting rule needs to see it. */
-export type InsertTarget =
-  | { readonly at: "root" }
-  | { readonly at: "slot"; readonly parentType: string; readonly slot: string };
+/**
+ * Where an insert would land, as the nesting rule needs to see it.
+ *
+ * The engine's type, re-exported rather than restated. It is the input to
+ * `placementVerdict`, which is the one implementation of the placement rule, so
+ * a second declaration here would be a second vocabulary for the rule's own
+ * argument — and every caller would reach the rule through a translation whose
+ * two sides could drift.
+ */
+export type { PlacementTarget } from "@nextlyhq/blocks-engine";
+
+/**
+ * @deprecated Renamed to `PlacementTarget`, which is the engine's name for it
+ * and now the only one. Kept as an alias for one release because this type is
+ * published from the package entry; import `PlacementTarget` instead.
+ *
+ * Note the discriminant moved with the name: the member is `kind`, not `at`.
+ * A value written as `{ at: "slot", ... }` no longer satisfies this type, and
+ * that is deliberate — a silently accepted `at` would fall through every
+ * `kind === "slot"` narrowing and be judged as a root placement.
+ */
+export type InsertTarget = PlacementTarget;
 
 /**
  * A position to insert at, with the target that position implies.
@@ -254,7 +272,7 @@ export type InsertTarget =
 export interface InsertionPoint {
   readonly kind: "after-selection" | "document-end" | "inside-selection";
   readonly at: OpPosition;
-  readonly target: InsertTarget;
+  readonly target: PlacementTarget;
 }
 
 /**
@@ -504,7 +522,7 @@ function humanise(name: string): string {
  */
 export function entryAllowedAt(
   entry: InsertEntry,
-  target: InsertTarget,
+  target: PlacementTarget,
   source: NestingSource
 ): NestingVerdict {
   if (entry.kind === "pattern") {
@@ -535,12 +553,12 @@ export function entryAllowedAt(
  */
 function patternAllowedAt(
   document: BlockDocument,
-  target: InsertTarget,
+  target: PlacementTarget,
   source: NestingSource
 ): NestingVerdict {
   return placementVerdict(
     document.nodes.map(root => root.type),
-    placedAt(target),
+    target,
     source
   );
 }
@@ -565,27 +583,10 @@ function patternAllowedAt(
  */
 export function blockAllowedAt(
   blockName: string,
-  target: InsertTarget,
+  target: PlacementTarget,
   source: NestingSource
 ): NestingVerdict {
-  return placementVerdict([blockName], placedAt(target), source);
-}
-
-/**
- * This module's target, in the vocabulary the rule is written in.
- *
- * Two names for one idea, and the translation is here so it happens ONCE.
- * `InsertTarget` is published by this package and spells the discriminant
- * `at`; the engine's `PlacementTarget` spells it `kind`. Converging them is a
- * change to a published type across every drag, drop and refusal surface that
- * reads one, so the rule is shared first and the spelling after — a second
- * implementation of the RULE is what produces a palette that offers what the
- * insert refuses, where two spellings of the target produce a rename.
- */
-function placedAt(target: InsertTarget): PlacementTarget {
-  return target.at === "root"
-    ? { kind: "root" }
-    : { kind: "slot", parentType: target.parentType, slot: target.slot };
+  return placementVerdict([blockName], target, source);
 }
 
 /**
@@ -600,7 +601,7 @@ function placedAt(target: InsertTarget): PlacementTarget {
  */
 export function allowedEntries<TEntry extends InsertEntry>(
   entries: readonly TEntry[],
-  target: InsertTarget,
+  target: PlacementTarget,
   source: NestingSource
 ): TEntry[] {
   return entries.filter(entry => entryAllowedAt(entry, target, source).allowed);
@@ -713,7 +714,7 @@ export function insertionPointFor(
   const end: InsertionPoint = {
     kind: "document-end",
     at: { index: document.nodes.length },
-    target: { at: "root" },
+    target: { kind: "root" },
   };
   if (selectedId === null) return end;
 
@@ -739,7 +740,7 @@ export function insertionPointFor(
     return {
       kind: "inside-selection",
       at: { parentId: selected.id, slot: emptySlot, index: 0 },
-      target: { at: "slot", parentType: selected.type, slot: emptySlot },
+      target: { kind: "slot", parentType: selected.type, slot: emptySlot },
     };
   }
 
@@ -756,7 +757,7 @@ export function insertionPointFor(
   }
 
   if (location.parent === undefined) {
-    return { kind: "after-selection", at: after, target: { at: "root" } };
+    return { kind: "after-selection", at: after, target: { kind: "root" } };
   }
   // `positionOf` has already refused the slot-less case, so a parent here has a
   // slot. Read it from the location rather than re-deriving from `after`, whose
@@ -765,7 +766,7 @@ export function insertionPointFor(
     kind: "after-selection",
     at: after,
     target: {
-      at: "slot",
+      kind: "slot",
       parentType: location.parent.type,
       slot: location.slot ?? "",
     },

--- a/packages/builder/src/move-refusal.ts
+++ b/packages/builder/src/move-refusal.ts
@@ -71,8 +71,12 @@ export function nestingRefusalForMove(
   if (to.parentId !== undefined && parent === undefined) return null;
   const target =
     parent === undefined
-      ? ({ at: "root" } as const)
-      : ({ at: "slot", parentType: parent.type, slot: to.slot ?? "" } as const);
+      ? ({ kind: "root" } as const)
+      : ({
+          kind: "slot",
+          parentType: parent.type,
+          slot: to.slot ?? "",
+        } as const);
 
   const verdict = blockAllowedAt(moving.type, target, nesting);
   // ALLOWED is null: the rule permits this placement. Whether it survives the


### PR DESCRIPTION
## What

`@nextlyhq/builder` declared `InsertTarget` for where an insert would land; `@nextlyhq/blocks-engine` declared `PlacementTarget` for the same idea. `inserter.ts`'s `placedAt` translated between them on every call into the shared nesting rule, so every reader had to hold two names for one concept.

The builder now re-exports the engine's `PlacementTarget`, and **`placedAt` is deleted**. `InsertTarget` stays exported from the package entry as a `@deprecated` alias for one release, because it is a published type.

## The fact that decided which name wins

`@nextlyhq/blocks-engine` **already exports a different type called `InsertTarget`**:

| name | package | is | discriminates on |
|---|---|---|---|
| `InsertTarget` | `@nextlyhq/builder` (before this PR) | a placement destination | `at` |
| `PlacementTarget` | `@nextlyhq/blocks-engine` | the same placement destination | `kind` |
| `InsertTarget` | `@nextlyhq/blocks-engine` | where a saved pattern goes: `OpPosition \| "document"` | — |

Both packages expose `"."` in their export maps, so a consumer importing from each got two incompatible types under one name and had to alias one away. The row was filed as *two names for one idea*; the tree also held **one name for two ideas**, across two published packages. Retiring the builder's is what leaves `InsertTarget` meaning exactly one thing after the deprecation window.

Rationale recorded in full at `decision:pb6-builder-adopts-placementtarget`, including the option of keeping a distinct builder name and why it was rejected.

## Breaking change, and why it is a type error rather than a fall-through

The discriminant moves with the name: `{ kind: "root" }` and `{ kind: "slot", parentType, slot }`. A value still spelling `at` no longer satisfies the type — deliberately. `placementVerdict` branches `where.kind === "root" ? canBeRoot(...) : bothHalves(where.parentType, where.slot, ...)`, so a silently accepted `at` would take the slot branch with `undefined` for both and produce a wrong verdict rather than an error. `DropRegion.at` and `DropTarget.target` hold these values, so a host narrowing them reads `.kind`.

## Coverage this adds, and why it was needed

Break-verification found that **the discriminant this PR rewrites had no coverage at all**. Mapping every slot drop region to the root — which makes the nesting rule skip the container's allow-list on every drag — left all 102 files / 2869 tests in `builder` passing, exit 0.

So this adds one assertion to `collectRegions`: a slot region carries a slot target naming the **container's** type, and the root region carries a root target. Break-verified in both directions, each failing that test alone and nothing else:

| mutation | before | after |
|---|---|---|
| slot region → `{ kind: "root" }` | 2869 passed, exit 0 | 1 failed (the named test) |
| `parentType` = the child's type | not previously expressible | 1 failed (the named test) |

`move-refusal`'s construction site was already covered — the same mutation there fails two named tests — so no test was added for it.

## Found while in there, filed rather than fixed

- `finding:pb-insert-panel-placement-label-uncovered` — the panel's `aria-live` placement label has no test at all. Deleting the branch that names the container leaves the whole suite green. Pre-existing; this PR only respelled the discriminant on that line.
- `finding:pb-drop-targets-at-means-two-things` — in `drop-targets.ts`, `DropRegion.at` is a placement target while `DropTarget.at` is an `OpPosition`. Same class of defect one level down, and a **property** name has no alias, so it is a hard break with no migration window and needs its own decision.

## Gates

All from the committed tree, exit status read on its own line.

| gate | exit |
|---|---|
| `pnpm build` | 0 |
| `builder`: `check-types` / `lint` / `vitest run` | 0 / 0 / 0 — **102 files, 2870 tests** |
| `blocks-engine`: `check-types` / `lint` / `vitest run` | 0 / 0 / 0 — 52 files, 2413 tests |
| `fallow audit --base origin/main` | 0 — `pass`, `changed_files_count: 8`, everything `*_introduced: 0` |
| `pnpm changeset status` | 0 |

The builder file count is reconciled against disk: `find src -name '*.test.ts' -o -name '*.test.tsx'` reports 101, and the 102nd is `module-extensions.test.mts`, which the `.ts`/`.tsx` glob does not match.

`@nextlyhq/plugin-sdk`'s export-surface snapshot and `STABILITY.md` are untouched: neither name appears in either (`grep` over `packages/plugin-sdk` returns nothing).

Verified in the built artifact rather than in intent — `packages/builder/dist/index.d.ts` re-exports `PlacementTarget` from `@nextlyhq/blocks-engine` and exports `type InsertTarget` carrying its `@deprecated` docblock.
