### PR TITLE
feat(nextly): a plugin can pass a hook context

### DIFF
--- a/.changeset/a-plugin-can-pass-a-hook-context.md
+++ b/.changeset/a-plugin-can-pass-a-hook-context.md
@@ -1,0 +1,35 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A plugin can pass a hook context. `ctx.services.collections` operations take an optional `context`, which reaches this operation's hooks as `ctx.context`. It is how a caller tells a hook something about the CALL that the row cannot say.
+
+Core has accepted this on every collection operation for a while and seeds the shared hook context from it. The plugin facade rebuilt its trailing argument as `{ user, overrideAccess }` and dropped everything else, and `CollectionService` forwarded only those two, so nothing above could reach it.
+
+It is data, not permission: nothing passed here bypasses access, validation or any hook. A hook decides for itself what to do with what it is told.
+
+The form-builder plugin uses it for the case that prompted it. A submission write reads its parent form only to check the payload against that form's fields, and the form's `afterRead` hook was counting that form's submissions on the way past. That count is presentation work nobody on the write path reads, and it grows with the form's history, so every submission paid for a count of every submission before it. The write now says it wants the schema alone, and the hook skips the count.

--- a/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
@@ -603,6 +603,9 @@ export class CollectionBulkService extends BaseService {
           routeAuthorized: params.routeAuthorized,
           // Judge the create-as-published on the key's own publish grant.
           authenticatedScope: params.authenticatedScope,
+          // Each row in a batch is its own create, and a caller's hook context
+          // describes the CALL, so every row in it carries the same one.
+          context: params.context,
         },
         duplicateData
       );
@@ -1259,6 +1262,8 @@ export class CollectionBulkService extends BaseService {
       collectionName: string;
       user?: UserContext;
       overrideAccess?: boolean;
+      /** Arbitrary data passed to hooks via context */
+      context?: Record<string, unknown>;
       // A scoped API key is judged on its OWN publish grant when the batch's
       // transition authorization is pre-resolved, not the key owner's RBAC.
       authenticatedScope?: AuthenticatedScope;

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -395,6 +395,8 @@ export interface TransitionAuthorization {
 /** Everything both transaction update entry points accept. */
 /** Everything both transaction delete entry points accept. */
 interface DeleteEntryWriteParams {
+  /** Arbitrary data passed to this operation's hooks via context. */
+  context?: Record<string, unknown>;
   collectionName: string;
   user?: UserContext;
   /**
@@ -419,6 +421,8 @@ interface DeleteEntryWriteOptions {
 }
 
 interface UpdateEntryWriteParams {
+  /** Arbitrary data passed to this operation's hooks via context. */
+  context?: Record<string, unknown>;
   collectionName: string;
   user?: UserContext;
   overrideAccess?: boolean;
@@ -460,6 +464,8 @@ interface UpdateEntryWriteOptions {
 }
 
 interface CreateEntryWriteParams {
+  /** Arbitrary data passed to this operation's hooks via context. */
+  context?: Record<string, unknown>;
   collectionName: string;
   user?: UserContext;
   overrideAccess?: boolean;
@@ -8276,7 +8282,11 @@ export class CollectionMutationService extends BaseService {
         : { ...body };
 
       // Shared context between all hooks in this request
-      const sharedContext: Record<string, unknown> = {};
+      // Seeded from the caller, like the non-transactional pipelines. An
+      // empty literal here meant a hook context reached every write EXCEPT
+      // one made inside a transaction, which is the least obvious place for
+      // a flag such as recursion suppression to stop working.
+      const sharedContext: Record<string, unknown> = { ...params.context };
 
       // Execute hooks (unless skipped)
       if (options.runHooks) {
@@ -8844,7 +8854,11 @@ export class CollectionMutationService extends BaseService {
       let currentData: Record<string, unknown> = { ...body };
 
       // Shared context between all hooks in this request
-      const sharedContext: Record<string, unknown> = {};
+      // Seeded from the caller, like the non-transactional pipelines. An
+      // empty literal here meant a hook context reached every write EXCEPT
+      // one made inside a transaction, which is the least obvious place for
+      // a flag such as recursion suppression to stop working.
+      const sharedContext: Record<string, unknown> = { ...params.context };
 
       // Execute hooks (unless skipped)
       if (options.runHooks) {
@@ -9599,7 +9613,11 @@ export class CollectionMutationService extends BaseService {
       }
 
       // Shared context between all hooks in this request
-      const sharedContext: Record<string, unknown> = {};
+      // Seeded from the caller, like the non-transactional pipelines. An
+      // empty literal here meant a hook context reached every write EXCEPT
+      // one made inside a transaction, which is the least obvious place for
+      // a flag such as recursion suppression to stop working.
+      const sharedContext: Record<string, unknown> = { ...params.context };
 
       // Execute hooks (unless skipped)
       if (options.runHooks) {

--- a/packages/nextly/src/domains/collections/services/collection-service-hook-context.test.ts
+++ b/packages/nextly/src/domains/collections/services/collection-service-hook-context.test.ts
@@ -1,0 +1,119 @@
+/**
+ * The collection facade forwards `RequestContext.context` to the entry service
+ * on every ENTRY operation.
+ *
+ * `context` is advertised on the shared `RequestContext`, which every method on
+ * this service takes, so a method that quietly drops it is worse than one that
+ * never offered it: a caller reads the type, passes a flag, and watches a hook
+ * ignore it with nothing to say why. The first version of this threading
+ * reached five methods and left the batch, count and transactional paths
+ * behind, which is exactly that trap.
+ *
+ * Sibling of the `overrideAccess` threading test, and for the same reason: the
+ * live create path cannot exercise this, so the threading is asserted directly.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { CollectionService } from "./collection-service";
+
+const noopLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+function make(entry: Record<string, unknown>): CollectionService {
+  return new CollectionService(
+    {} as never,
+    noopLogger as never,
+    {} as never,
+    entry as never
+  );
+}
+
+const ok = { success: true, data: { id: "1" }, statusCode: 200 };
+const okList = { success: true, data: [], statusCode: 200 };
+const okCount = { success: true, data: { totalDocs: 0 }, statusCode: 200 };
+const hookContext = { formBuilder: { schemaOnlyRead: true } };
+const ctx = { overrideAccess: true, context: hookContext };
+const tx = {} as never;
+
+/**
+ * Every entry operation, the entry-service method it delegates to, and how to
+ * call it. Listed so a NEW operation that forgets to forward is a failing case
+ * rather than a silent gap.
+ */
+const OPERATIONS: Array<
+  [string, string, (s: CollectionService) => Promise<unknown>]
+> = [
+  ["createEntry", "createEntry", s => s.createEntry("vault", { a: 1 }, ctx)],
+  ["listEntries", "listEntries", s => s.listEntries("vault", {}, ctx)],
+  ["findEntryById", "getEntry", s => s.findEntryById("vault", "1", ctx)],
+  [
+    "updateEntry",
+    "updateEntry",
+    s => s.updateEntry("vault", "1", { a: 1 }, ctx),
+  ],
+  ["deleteEntry", "deleteEntry", s => s.deleteEntry("vault", "1", ctx)],
+  ["count", "countEntries", s => s.count("vault", {}, ctx)],
+  ["createMany", "createEntries", s => s.createMany("vault", [{ a: 1 }], ctx)],
+  [
+    "createEntryInTransaction",
+    "createEntryInTransaction",
+    s => s.createEntryInTransaction(tx, "vault", { a: 1 }, ctx),
+  ],
+  [
+    "updateEntryInTransaction",
+    "updateEntryInTransaction",
+    s => s.updateEntryInTransaction(tx, "vault", "1", { a: 1 }, ctx),
+  ],
+  [
+    "deleteEntryInTransaction",
+    "deleteEntryInTransaction",
+    s => s.deleteEntryInTransaction(tx, "vault", "1", ctx),
+  ],
+];
+
+describe("CollectionService threads RequestContext.context", () => {
+  it.each(OPERATIONS)(
+    "%s forwards the hook context to %s",
+    async (_name, delegate, call) => {
+      const spy = vi
+        .fn()
+        .mockResolvedValue(
+          delegate === "countEntries"
+            ? okCount
+            : delegate === "listEntries"
+              ? okList
+              : ok
+        );
+      const service = make({ [delegate]: spy });
+      await call(service).catch(() => undefined);
+      expect(spy).toHaveBeenCalled();
+      const passed = spy.mock.calls[0]!.find(
+        (arg): arg is { context?: unknown } =>
+          typeof arg === "object" && arg !== null && "context" in arg
+      );
+      expect(passed?.context).toEqual(hookContext);
+    }
+  );
+
+  it("covers every entry operation the facade exposes", () => {
+    // The control. A table that lost entries would delete its own cases and
+    // leave a suite whose every remaining case passes, which reads exactly like
+    // a passing one.
+    expect(OPERATIONS).toHaveLength(10);
+  });
+
+  it("passes nothing when the caller passed nothing", () => {
+    // The other control: a facade that invented a context would satisfy every
+    // case above without carrying what the caller actually said.
+    const spy = vi.fn().mockResolvedValue(ok);
+    return make({ getEntry: spy })
+      .findEntryById("vault", "1", { overrideAccess: true })
+      .then(() => {
+        expect(spy.mock.calls[0]![0]).toMatchObject({ context: undefined });
+      });
+  });
+});

--- a/packages/nextly/src/domains/collections/services/collection-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-service.ts
@@ -559,6 +559,7 @@ export class CollectionService extends BaseService {
         collectionName,
         user: context.user,
         overrideAccess: context.overrideAccess,
+        context: context.context,
       },
       data
     );
@@ -636,6 +637,7 @@ export class CollectionService extends BaseService {
       collectionName,
       user: context.user,
       overrideAccess: context.overrideAccess,
+      context: context.context,
       page,
       limit,
       // D56: forward the rich-query options the facade previously dropped, so
@@ -720,6 +722,7 @@ export class CollectionService extends BaseService {
       entryId,
       user: context.user,
       overrideAccess: context.overrideAccess,
+      context: context.context,
     });
 
     if (!result.success) {
@@ -762,6 +765,7 @@ export class CollectionService extends BaseService {
         entryId,
         user: context.user,
         overrideAccess: context.overrideAccess,
+        context: context.context,
       },
       data
     );
@@ -809,6 +813,7 @@ export class CollectionService extends BaseService {
       entryId,
       user: context.user,
       overrideAccess: context.overrideAccess,
+      context: context.context,
     });
 
     if (!result.success) {

--- a/packages/nextly/src/domains/collections/services/collection-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-service.ts
@@ -608,6 +608,7 @@ export class CollectionService extends BaseService {
         collectionName,
         user: context.user,
         overrideAccess: context.overrideAccess,
+        context: context.context,
       },
       data
     );
@@ -690,6 +691,7 @@ export class CollectionService extends BaseService {
       collectionName,
       user: context.user,
       overrideAccess: context.overrideAccess,
+      context: context.context,
       where: options.where as WhereFilter | undefined,
       search: options.search,
     });
@@ -890,6 +892,7 @@ export class CollectionService extends BaseService {
       {
         collectionName,
         user: context.user,
+        context: context.context,
       },
       data
     );
@@ -953,6 +956,7 @@ export class CollectionService extends BaseService {
         collectionName,
         entryId,
         user: context.user,
+        context: context.context,
       },
       data
     );
@@ -1020,6 +1024,7 @@ export class CollectionService extends BaseService {
       entryId,
       user: context.user,
       actor,
+      context: context.context,
     });
 
     // Collect before the success check, so a caller that commits despite a

--- a/packages/nextly/src/plugins/service-opts-wrapper.test.ts
+++ b/packages/nextly/src/plugins/service-opts-wrapper.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { wrapCollectionsForPlugin } from "./service-opts";
+import { resolveServiceOpts, wrapCollectionsForPlugin } from "./service-opts";
 
 function mockCollections() {
   return {
@@ -135,5 +135,52 @@ describe("wrapCollectionsForPlugin (D35, Unit C)", () => {
     const m = mockCollections();
     await wrapCollectionsForPlugin(m as never).listCollections();
     expect(m.listCollections).toHaveBeenCalledWith();
+  });
+});
+
+describe("the hook context a plugin passes", () => {
+  // How a plugin tells a hook something about the CALL that the row cannot say.
+  // Core has accepted this on every collection operation for some time and
+  // seeds the shared hook context from it; this facade dropped it, so an
+  // `afterRead` hook doing expensive presentation work could not be told that a
+  // read was internal.
+  it("reaches the service", async () => {
+    const m = mockCollections();
+    await wrapCollectionsForPlugin(m as never).findEntryById("vault", "1", {
+      as: "system",
+      context: { internalRead: true },
+    });
+    expect(m.findEntryById).toHaveBeenCalledWith("vault", "1", {
+      user: undefined,
+      overrideAccess: true,
+      context: { internalRead: true },
+    });
+  });
+
+  it("travels with a user context too", async () => {
+    const m = mockCollections();
+    await wrapCollectionsForPlugin(m as never).createEntry(
+      "vault",
+      { title: "a" },
+      {
+        as: "user",
+        user: { id: "u1", email: "u@x" } as never,
+        context: { seeded: 1 },
+      }
+    );
+    expect(m.createEntry).toHaveBeenCalledWith(
+      "vault",
+      { title: "a" },
+      expect.objectContaining({ context: { seeded: 1 } })
+    );
+  });
+
+  it("is absent when the caller passes none", () => {
+    // The control: a facade that invented a context would satisfy the two
+    // above without carrying anything the caller said.
+    expect(resolveServiceOpts({ as: "system" }).context).toBeUndefined();
+    expect(
+      resolveServiceOpts({ as: "system", context: { a: 1 } }).context
+    ).toEqual({ a: 1 });
   });
 });

--- a/packages/nextly/src/plugins/service-opts.ts
+++ b/packages/nextly/src/plugins/service-opts.ts
@@ -21,14 +21,29 @@ import type { AuthUser } from "../types/auth";
 export interface ServiceOpts {
   as?: "user" | "system";
   user?: AuthUser;
+  /**
+   * Arbitrary data handed to this operation's hooks as `ctx.context`.
+   *
+   * How a plugin tells a hook something about the CALL that the row cannot say.
+   * A hook doing expensive presentation work can be told a read is internal and
+   * skip it, and a hook that writes can be told not to recurse. Core has
+   * accepted this on every collection operation for some time and seeds the
+   * shared hook context from it; this facade dropped it, so a plugin could
+   * reach neither.
+   *
+   * It is data, not permission: nothing here bypasses access, validation or any
+   * hook. A hook decides for itself what to do with what it is told.
+   */
+  context?: Record<string, unknown>;
 }
 
 /** Translate {@link ServiceOpts} into the facade's `{ user, overrideAccess }`. */
 export function resolveServiceOpts(opts: ServiceOpts): {
   user?: RequestContext["user"];
   overrideAccess: boolean;
+  context?: Record<string, unknown>;
 } {
-  const { as, user } = opts;
+  const { as, user, context } = opts;
   const wantsUser = as === "user" || (as === undefined && user !== undefined);
   if (wantsUser) {
     if (!user) {
@@ -43,9 +58,10 @@ export function resolveServiceOpts(opts: ServiceOpts): {
     return {
       overrideAccess: false,
       user: { id: user.id, email: user.email, role: "", permissions: [] },
+      context,
     };
   }
-  return { overrideAccess: true };
+  return { overrideAccess: true, context };
 }
 
 /**
@@ -161,9 +177,14 @@ export function wrapCollectionsForPlugin(
       return async (...args: unknown[]) => {
         const resolved = resolveServiceOpts((args[idx] as ServiceOpts) ?? {});
         const next = [...args];
+        // Rebuilt rather than forwarded, so anything not named here is dropped.
+        // That is what kept a plugin from reaching the hook context: core has
+        // accepted one on every collection operation for some time, and this
+        // literal was the whole reason nothing above could pass one.
         next[idx] = {
           user: resolved.user,
           overrideAccess: resolved.overrideAccess,
+          context: resolved.context,
         };
         const call = () =>
           (fn as (...a: unknown[]) => Promise<unknown>).apply(target, next);

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -733,6 +733,8 @@ export class CollectionEntryService extends BaseService {
       user?: UserContext;
       /** Who performed the delete, recorded on the outbox event. */
       actor?: RequestActor;
+      /** Arbitrary data passed to this operation's hooks via context. */
+      context?: Record<string, unknown>;
     }
   ): Promise<CollectionServiceResult<{ deleted: boolean }>> {
     return this.mutationService.deleteEntryInTransaction(tx, params);
@@ -905,6 +907,8 @@ export class CollectionEntryService extends BaseService {
       disableRevalidate?: boolean;
       user?: UserContext;
       overrideAccess?: boolean;
+      /** Arbitrary data passed to hooks via context */
+      context?: Record<string, unknown>;
       /**
        * Which collections a trusted read may reach as relationships are expanded.
        * Absent means every populated target inherits the caller's trust. Only ever

--- a/packages/nextly/src/shared/types/index.ts
+++ b/packages/nextly/src/shared/types/index.ts
@@ -64,6 +64,17 @@ export interface RequestContext {
    * skipped. Default: undefined (enforce access).
    */
   overrideAccess?: boolean;
+  /**
+   * Arbitrary data handed to this operation's hooks as `ctx.context`.
+   *
+   * The way a caller tells a hook something about the CALL that the row cannot
+   * say. A hook that does expensive presentation work can be told this read is
+   * internal and skip it; a hook that writes can be told not to recurse. The
+   * entry service has accepted this on every operation for some time and seeds
+   * the shared hook context from it, but the service layer dropped it, so
+   * nothing above could reach it.
+   */
+  context?: Record<string, unknown>;
 }
 
 /**

--- a/packages/plugin-form-builder/src/__tests__/fetch-parent-form.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/fetch-parent-form.test.ts
@@ -34,8 +34,11 @@ describe("fetchParentForm", () => {
       nextlyWith(findEntryById)
     );
 
+    // Asks for the schema alone, so the form's `afterRead` hook can skip the
+    // submission count it would otherwise run on every write.
     expect(findEntryById).toHaveBeenCalledWith("forms", "form1", {
       as: "system",
+      context: { "formBuilder.schemaOnlyRead": true },
     });
     expect(form).toMatchObject({ id: "form1" });
   });

--- a/packages/plugin-form-builder/src/__tests__/prepare-submission.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/prepare-submission.test.ts
@@ -19,7 +19,11 @@ import {
   submissionMarks,
 } from "../handlers/prepare-submission";
 import { validateSubmission } from "../handlers/submit-form";
-import { formBuilder, prepareSubmissionForWrite } from "../plugin";
+import {
+  formBuilder,
+  injectSubmissionCount,
+  prepareSubmissionForWrite,
+} from "../plugin";
 import type { AnyFormField } from "../types";
 
 const fields = [
@@ -905,5 +909,50 @@ describe("a submission written straight to the collection", () => {
         },
       })
     ).rejects.toThrow();
+  });
+});
+
+describe("the submission count on a form read", () => {
+  const nextlyCounting = () => {
+    const count = vi.fn().mockResolvedValue(7);
+    return {
+      count,
+      nextly: { services: { collections: { count } } } as never,
+    };
+  };
+
+  it("counts on an ordinary read", async () => {
+    const { count, nextly } = nextlyCounting();
+    const form: Record<string, unknown> = { id: "form1" };
+    await injectSubmissionCount({ data: form }, "form-submissions", nextly);
+    expect(form.submissionCount).toBe(7);
+    expect(count).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips the count when the read asked for the schema alone", async () => {
+    // A submission write reads its parent form only to check the payload
+    // against that form's fields. Counting there is presentation work nobody on
+    // that path reads, and it grows with the form's history, so every
+    // submission was paying for a count of every submission before it.
+    const { count, nextly } = nextlyCounting();
+    const form: Record<string, unknown> = { id: "form1" };
+    await injectSubmissionCount(
+      { data: form, context: { "formBuilder.schemaOnlyRead": true } },
+      "form-submissions",
+      nextly
+    );
+    expect(count).toHaveBeenCalledTimes(0);
+    expect(form.submissionCount).toBeUndefined();
+  });
+
+  it("counts every form a list read returned", async () => {
+    // The control for the two above: `afterRead` fires for single reads and for
+    // list reads, so a rule that only handled one shape would pass the first
+    // test and do nothing here.
+    const { count, nextly } = nextlyCounting();
+    const forms = [{ id: "a" }, { id: "b" }] as Record<string, unknown>[];
+    await injectSubmissionCount({ data: forms }, "form-submissions", nextly);
+    expect(count).toHaveBeenCalledTimes(2);
+    expect(forms.map(f => f.submissionCount)).toEqual([7, 7]);
   });
 });

--- a/packages/plugin-form-builder/src/plugin.ts
+++ b/packages/plugin-form-builder/src/plugin.ts
@@ -572,37 +572,9 @@ export function formBuilder(
 
       // Inject a real submissionCount into form reads (spam excluded — the
       // number answers "how many people submitted", not "how many bots").
-      nextly.hooks.on("afterRead", formsSlug, async (context: unknown) => {
-        const data = (context as { data?: unknown }).data;
-        // afterRead fires for single reads (one record) and list reads
-        // (array); count each form either way. Counts run concurrently —
-        // form lists are paginated, so this is a bounded fan-out of small
-        // indexed queries, not a serial N+1 walk.
-        const records = Array.isArray(data) ? data : data ? [data] : [];
-        await Promise.all(
-          records.map(async record => {
-            const form = record as Record<string, unknown>;
-            if (typeof form.id !== "string") return;
-            try {
-              // Count as system: whoever may read the form may see its
-              // submission volume without holding submission read rights.
-              form.submissionCount = await nextly.services.collections.count(
-                submissionSlug,
-                {
-                  where: {
-                    form: { equals: form.id },
-                    status: { not_equals: "spam" },
-                  },
-                },
-                { as: "system" }
-              );
-            } catch {
-              // A failed count must never break reading the form itself.
-              form.submissionCount = 0;
-            }
-          })
-        );
-      });
+      nextly.hooks.on("afterRead", formsSlug, (context: unknown) =>
+        injectSubmissionCount(context, submissionSlug, nextly)
+      );
     },
   });
 
@@ -1189,6 +1161,73 @@ async function handleSubmissionCreated(
 /**
  * Fetch the parent form document for a submission.
  */
+/**
+ * Put a real `submissionCount` on every form a read returned.
+ *
+ * Spam is excluded, because the number answers "how many people submitted", not
+ * "how many bots". `afterRead` fires for single reads and for list reads, so
+ * both shapes are handled; the counts run concurrently, and form lists are
+ * paginated, so this is a bounded fan-out of small indexed queries rather than
+ * a serial walk.
+ *
+ * A read that asked for the schema alone is left alone. A submission write
+ * reads its parent form only to check the payload against that form's fields,
+ * and counting there is presentation work nobody on that path reads. It also
+ * grows with the form's history, so every submission was paying for a count of
+ * every submission before it.
+ *
+ * The flag decides how much work to do and nothing else. Forged, the worst it
+ * can produce is a form read whose `submissionCount` is absent, and it cannot
+ * come from a request body in any case: the hook context is set by the
+ * server-side caller of the service.
+ */
+export async function injectSubmissionCount(
+  context: unknown,
+  submissionSlug: string,
+  nextly: NextlyInstance
+): Promise<void> {
+  const hook = context as {
+    data?: unknown;
+    context?: Record<string, unknown>;
+  };
+  if (hook.context?.[SCHEMA_ONLY_READ] === true) return;
+
+  const records = Array.isArray(hook.data)
+    ? hook.data
+    : hook.data
+      ? [hook.data]
+      : [];
+  await Promise.all(
+    records.map(async record => {
+      const form = record as Record<string, unknown>;
+      if (typeof form.id !== "string") return;
+      try {
+        // Count as system: whoever may read the form may see its submission
+        // volume without holding submission read rights.
+        form.submissionCount = await nextly.services.collections.count(
+          submissionSlug,
+          {
+            where: {
+              form: { equals: form.id },
+              status: { not_equals: "spam" },
+            },
+          },
+          { as: "system" }
+        );
+      } catch {
+        // A failed count must never break reading the form itself.
+        form.submissionCount = 0;
+      }
+    })
+  );
+}
+
+/**
+ * Tells the form's `afterRead` hook that this read wants the schema and nothing
+ * else, so it can skip work whose only purpose is to be displayed.
+ */
+const SCHEMA_ONLY_READ = "formBuilder.schemaOnlyRead";
+
 export async function fetchParentForm(
   formsSlug: string,
   formId: string,
@@ -1221,7 +1260,7 @@ export async function fetchParentForm(
     const form = await nextly.services.collections.findEntryById(
       formsSlug,
       formId,
-      { as: "system" }
+      { as: "system", context: { [SCHEMA_ONLY_READ]: true } }
     );
     return form;
   } catch (err) {


### PR DESCRIPTION
`ctx.services.collections` operations take an optional `context`, which reaches this operation's hooks as `ctx.context`. It is how a caller tells a hook something about the **call** that the row cannot say.

## Why this, and not a flag to skip hooks

My own filed finding proposed "a plugin-visible read that skips `afterRead`". Researching it, that is the wrong remedy, and Nextly already had the right one.

**Core has the channel end to end.** `listEntries`, `getEntry`, `createEntry`, `updateEntry` and `deleteEntry` all declare `context?: Record<string, unknown>`, and both read paths seed the shared hook context from it:

```ts
const sharedContext: Record<string, unknown> = { ...params.context };
```

`HookContext.context` is documented with exactly the pattern, set a flag in one hook and read it in another. **Two layers dropped it**: the plugin proxy rebuilds its trailing argument as a literal naming `user` and `overrideAccess`, so anything not named there is gone, and `CollectionService` forwarded the same two.

**It is also the industry answer.** Payload documents `context` on local API operations for precisely this: a caller passes `context: { skipHooks: true }` and hooks return early, used to prevent recursion and to avoid repeating expensive work. A blunt skip-hooks flag would also silence a host's own hooks, which may be load-bearing for correctness; telling a hook and letting it decide does not.

**It is data, not permission.** Nothing here bypasses access, validation or any hook. The worst a forged value can do is change how much work a hook chooses to perform.

## What it fixes today

A submission write reads its parent form only to check the payload against that form's fields. The form's `afterRead` hook counted that form's non-spam submissions on the way past: presentation work nobody on the write path reads, growing with the form's history, so **every submission paid for a count of every submission before it**. The write now says it wants the schema alone and the hook skips the count.

## Evidence

- 11,612 tests in `nextly`, 387 in the plugin, `check-types` clean over both configs, Fallow `new-only` zero introduced.
- The count moved into `injectSubmissionCount` so the skip is asserted rather than inferred, with a list-read control so a rule handling only one shape cannot pass.
- Controls both halves: the hook ignoring the flag fails one test, the proxy dropping the context fails two.