### PR TITLE
fix(blocks-engine): refuse a render cap that removes the bound rather than sets one

### DIFF
--- a/.changeset/a-cap-that-is-not-a-number-is-refused.md
+++ b/.changeset/a-cap-that-is-not-a-number-is-refused.md
@@ -1,0 +1,37 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Rendering a page that embeds components now refuses a document-limits object
+whose `maxNodes` or `maxDepth` is not a number, instead of quietly rendering
+without that bound. A cap that arrives as `undefined` or `NaN` — a partial
+limits object, or one computed from an environment variable that is not set —
+did not fall back to the default: every comparison against it was false, so the
+walk had no stopping point and the guard that refuses to compose a document it
+could not survey whole never fired.
+
+Sites that pass a complete `limits` object, or none at all, are unaffected.

--- a/packages/blocks-engine/src/resolve-instances.test.ts
+++ b/packages/blocks-engine/src/resolve-instances.test.ts
@@ -2177,6 +2177,82 @@ describe("componentIdsIn", () => {
   });
 });
 
+describe("resolveComponentInstances under an unusable cap", () => {
+  // A host states `limits` in its own config, so a computed one — a cap read
+  // from an environment variable that is not set, say — arrives as `NaN`. That
+  // is not a loose bound but NO bound: `budget <= 0` is false against it, the
+  // survey never records that it stopped, and the refusal below it never
+  // fires. The document is then composed from a survey that read only part of
+  // it, which is the state that refusal exists to prevent.
+  const oversized = () => {
+    const nodes: BlockNode[] = [
+      ...Array.from({ length: DEFAULT_LIMITS.maxNodes + 10 }, (_, i) =>
+        node(`n${i}`)
+      ),
+      instance("i1", "def-1"),
+    ];
+    return { formatVersion: DOCUMENT_FORMAT_VERSION, kind: "page", nodes };
+  };
+  const definitions = {
+    get: () => ({
+      formatVersion: DOCUMENT_FORMAT_VERSION,
+      kind: "component" as const,
+      nodes: [node("d1")],
+    }),
+  };
+
+  it("refuses an oversized document under an ordinary cap", () => {
+    // The control. Without it the refusal below could be read as this function
+    // simply never composing anything in this fixture.
+    const doc = oversized() as BlockDocument;
+    const out = resolveComponentInstances(doc, definitions as never, {
+      limits: DEFAULT_LIMITS,
+    });
+
+    expect({
+      referenced: out.referenced,
+      composed: out.document !== doc,
+    }).toEqual({ referenced: [], composed: false });
+  });
+
+  it("refuses a cap that would remove the bound rather than set one", () => {
+    // Asserted through the helper's own message, which names both the subject
+    // and the field: a bare `toThrow()` would pass on any error this function
+    // might raise for another reason.
+    expect(() =>
+      resolveComponentInstances(
+        oversized() as BlockDocument,
+        definitions as never,
+        {
+          limits: { ...DEFAULT_LIMITS, maxNodes: Number.NaN },
+        }
+      )
+    ).toThrow(/resolveComponentInstances: maxNodes/);
+  });
+
+  it("reads each cap it uses exactly once", () => {
+    // The caller owns this object, so a member that answers differently
+    // between reads lets the survey validate under one cap and the composition
+    // run under another. One read cannot disagree with itself.
+    let reads = 0;
+    const counting = {
+      ...DEFAULT_LIMITS,
+      get maxNodes() {
+        reads += 1;
+        return DEFAULT_LIMITS.maxNodes;
+      },
+    };
+
+    resolveComponentInstances(
+      page([instance("i1", "def-1")]),
+      definitions as never,
+      { limits: counting }
+    );
+
+    expect(reads).toBe(1);
+  });
+});
+
 describe("componentUsageIn", () => {
   // Three entries exactly, so the budget can be set above, at and below the
   // size of the forest. The reference is the LAST of them, which is what makes

--- a/packages/blocks-engine/src/resolve-instances.ts
+++ b/packages/blocks-engine/src/resolve-instances.ts
@@ -387,7 +387,40 @@ export function resolveComponentInstances(
     return unchanged;
   }
 
-  const limits = options.limits ?? DEFAULT_LIMITS;
+  // Taken by name and validated once, rather than read from the caller's object
+  // wherever a cap is wanted. Two separate faults meet on this line.
+  //
+  // A `NaN` cap is not a loose bound, it is NO bound: `budget <= 0` is false
+  // against it, so the survey never stops and `survey.truncated` is never set —
+  // and the refusal directly below, which exists because composing from a
+  // partial survey is worse than not composing, silently never fires. Measured
+  // on a document of `maxNodes + 11` entries: under the default cap the
+  // resolver returns the document unchanged and references nothing, and under
+  // a `NaN` cap it composes it. `limits.maxNodes - survey.count` is NaN too,
+  // so the slot budget fails open as well.
+  //
+  // And `options.limits` is an object the CALLER owns, read four times here. A
+  // member that answers differently between reads lets the survey validate
+  // under one cap while the composition runs under another — the same fault
+  // this module's planner neighbour was fixed for.
+  //
+  // `maxBytes` is carried but NOT validated: nothing here reads it, and
+  // refusing a value this function never consults would reject callers it has
+  // always served. It is taken by name so the snapshot is whole.
+  const supplied = options.limits ?? DEFAULT_LIMITS;
+  const limits: DocumentLimits = {
+    maxDepth: boundedLimit(
+      supplied.maxDepth,
+      "maxDepth",
+      "resolveComponentInstances"
+    ),
+    maxNodes: boundedLimit(
+      supplied.maxNodes,
+      "maxNodes",
+      "resolveComponentInstances"
+    ),
+    maxBytes: supplied.maxBytes,
+  };
   const survey = surveyHost(document.nodes, limits.maxNodes);
   // A survey that stopped at the cap collected a PREFIX of the document's ids,
   // so every id minted afterwards would be checked against a set missing

--- a/packages/blocks-react/src/islands.test.tsx
+++ b/packages/blocks-react/src/islands.test.tsx
@@ -16,6 +16,7 @@
  */
 import { describe, expect, it } from "vitest";
 
+import { DEFAULT_LIMITS } from "@nextlyhq/blocks-engine";
 import type { BlockDocument } from "@nextlyhq/blocks-engine";
 
 import { coreBlocks } from "./blocks";
@@ -341,12 +342,21 @@ describe("the limits a site sets", () => {
     // A site that raised `maxDepth` renders deeper than the default allows. Read
     // against the defaults, an island the page DOES draw is truncated away and
     // the caller is told the page needs less JavaScript than it does.
+    //
+    // A WHOLE `DocumentLimits`, which is what the parameter asks for. This once
+    // passed `{ maxDepth: 40 } as never` — a partial object forced past the
+    // type — and the missing `maxNodes` did not fall back to a default: it
+    // removed the node bound entirely, because every `budget <= 0` test against
+    // `undefined` is false. The property under test is the raised depth, and it
+    // needs no help from that.
     const document = nested(14);
 
     expect(islandsFor(document, deep)).toEqual({});
     expect(
       Object.keys(
-        islandsFor(document, deep, { limits: { maxDepth: 40 } as never })
+        islandsFor(document, deep, {
+          limits: { ...DEFAULT_LIMITS, maxDepth: 40 },
+        })
       )
     ).toEqual(["test/ticker"]);
   });


### PR DESCRIPTION
A live defect on `main`, found while adding the component-usage derivation and
filed then as `finding:surveyhost-walks-unbounded-under-a-nan-budget`. It is
reachable through ordinary host configuration, and a real test in
`blocks-react` was relying on it.

## The defect

`resolveComponentInstances` takes `options.limits` from the caller and reads
`maxNodes` from it **four times** without validating it. A cap of `undefined`
or `NaN` is not a loose bound but **no bound** — every `budget <= 0` test
against it is false — so `surveyHost` never stops and never records that it
stopped. The refusal directly below it, which exists because composing from a
partial survey is worse than not composing, therefore **never fires**.

Measured on a document of `maxNodes + 11` entries, with a control:

| cap | `referenced` | document composed? |
|---|---|---|
| `DEFAULT_LIMITS` (control) | `[]` | **no** — correctly refused |
| `NaN` | `["def-1"]` | **yes** — composed unbounded |

`limits.maxNodes - survey.count` is `NaN` as well, so the slot budget fails
open too.

## It is reachable, and something was already relying on it

`limits` is a **host option** on the page-builder plugin that reaches the render
path, so a cap read from an unset environment variable arrives as `NaN`. And a
*partial* object leaves `maxNodes` undefined — which `boundedLimit`'s own
docblock already names as the case it exists to catch:

> A JavaScript caller omitting a bound therefore removed it and was told the
> document fitted.

**`blocks-react`'s `islands.test.tsx` was passing `{ maxDepth: 40 } as never`** —
a partial object forced past the type — and so was running with no node bound at
all. That test is the evidence this is not hypothetical.

## The fix

Guarded through `boundedLimit`, the published helper, and the caps are taken
**by name, once**, rather than read from the caller's object at each use. Both
faults meet on that line: `limits` is an object the caller owns, so a member
answering differently between reads lets the survey validate under one cap while
the composition runs under another — the same fault this module's planner
neighbour was fixed for two PRs ago.

`maxBytes` is carried but **not** validated: nothing here reads it, and refusing
a value this function never consults would reject callers it has always served.

## The test I changed, and why that is not moving the goalposts

`islands.test.tsx` now passes a whole `DocumentLimits`. Its subject — that a
raised `maxDepth` is honoured — needs no help from a missing `maxNodes`.

Verified that the edit preserved its meaning rather than merely making it pass:
handed the **default** depth instead of the raised one, it **fails**. So it
still measures the raised cap being honoured.

## Break-verification

| break | fails |
|---|---|
| remove the guard (main's state today) | `refuses a cap that would remove the bound rather than set one` **and** `reads each cap it uses exactly once` |

The third new test — that an oversized document is refused under an ordinary cap
— passes either way **by design**. It is the control that stops the refusal above
being read as "this fixture never composes anything", and it is labelled as such
in the file.

## Gates

| gate | result |
|---|---|
| `pnpm build` (after clearing every `dist` from the previous branch) | exit 0 |
| `blocks-engine` `check-types` / `lint` / tests | 0 / 0 / 52 files, 2416 tests |
| `blocks-react` `check-types` / `lint` / tests | 0 / 0 / 48 files, 1162 tests |
| `fallow audit --base origin/main` | `pass`, `changed_files_count: 4`, introduced 0 across all four categories |
| `pnpm changeset status` | parses; 25 packages |
