### PR TITLE
feat(plugin-page-builder): record which documents embed which components

### DIFF
--- a/.changeset/the-builder-records-where-components-are-used.md
+++ b/.changeset/the-builder-records-where-components-are-used.md
@@ -39,3 +39,10 @@ read rather than the document being read twice.
 A page too large to read whole records that fact rather than recording nothing,
 because "embeds no components" is the answer that would make deleting one look
 safe.
+
+Repairing the indexes is now one call, `rebuildUsageIndexes`, which takes every
+index a site maintains. `rebuildClassUsageIndex` still works and still repairs
+the class index alone; it is deprecated for one release because that narrowness
+is exactly the trap — a site that upgraded and ran it would have left its
+component index empty, and an empty index reports every component as used
+nowhere.

--- a/.changeset/the-builder-records-where-components-are-used.md
+++ b/.changeset/the-builder-records-where-components-are-used.md
@@ -40,9 +40,11 @@ A page too large to read whole records that fact rather than recording nothing,
 because "embeds no components" is the answer that would make deleting one look
 safe.
 
-Repairing the indexes is now one call, `rebuildUsageIndexes`, which takes every
-index a site maintains. `rebuildClassUsageIndex` still works and still repairs
-the class index alone; it is deprecated for one release because that narrowness
-is exactly the trap — a site that upgraded and ran it would have left its
-component index empty, and an empty index reports every component as used
-nowhere.
+Repairing the indexes is now one call, `rebuildPageBuilderUsageIndexes`, which
+takes the document store and both index stores and repairs every index the
+plugin maintains — it names the set itself, so an index added in a later
+version is repaired without a caller having to know it exists.
+`rebuildClassUsageIndex` still works and still repairs the class index alone;
+it is deprecated for one release because that narrowness is exactly the trap —
+a site that upgraded and ran it would have left its component index empty, and
+an empty index reports every component as used nowhere.

--- a/.changeset/the-builder-records-where-components-are-used.md
+++ b/.changeset/the-builder-records-where-components-are-used.md
@@ -1,0 +1,41 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The page builder now records which documents embed which components, in a
+`nx_pb_component_usage` collection maintained automatically as pages are saved
+and deleted. Nothing surfaces it yet; it is what will let the library say a
+component is used on N pages, and let deleting one tell you what still embeds
+it instead of quietly breaking those pages.
+
+It is maintained by the same write-path pass that already keeps the class usage
+index, so a save reads each document once and both indexes derive from that
+read rather than the document being read twice.
+
+A page too large to read whole records that fact rather than recording nothing,
+because "embeds no components" is the answer that would make deleting one look
+safe.

--- a/packages/plugin-page-builder/src/class-usage-hook.test.ts
+++ b/packages/plugin-page-builder/src/class-usage-hook.test.ts
@@ -18,6 +18,16 @@ import {
 } from "./class-usage-hook";
 
 const INDEX = "nx_pb_class_usage";
+/**
+ * The COMPONENT index's collection, wired like the plugin wires it.
+ *
+ * Omitting it left the registration with `undefined`, so the re-entry guard
+ * excluded a collection that does not exist, the delete loop asked a store for
+ * one, and the fake below — keyed on "is this the class index" — answered the
+ * component store with the DOCUMENT payload. Every test here then exercised a
+ * configuration the plugin never creates.
+ */
+const COMPONENT_INDEX = "nx_pb_component_usage";
 
 /** A document whose single node applies the given classes. */
 const documentUsing = (...classes: string[]) => ({
@@ -66,7 +76,10 @@ function harness(
     // bare document, and every test passed while no index row was ever found
     // and no classes were ever derived.
     find: vi.fn(async (a: { collection?: string }) =>
-      a.collection !== INDEX
+      // EITHER index collection answers as an index, not as a document read.
+      // Keying on the class index alone made the component store receive the
+      // document payload and read pages as though they were its own rows.
+      a.collection !== INDEX && a.collection !== COMPONENT_INDEX
         ? {
             items: [{ id: "p1", content: documentUsing("hero") }],
             meta: { hasNext: false },
@@ -89,6 +102,7 @@ function harness(
   registerClassUsageMaintenance({
     ctx,
     indexCollection: INDEX,
+    componentIndexCollection: COMPONENT_INDEX,
     draftSplit: options.draftSplit ?? (async () => ({ eligible: false })),
     locales: () => options.locales ?? [],
     limits: () => DEFAULT_LIMITS,
@@ -248,6 +262,39 @@ describe("a document that was deleted", () => {
     await fireDelete({ collection: "single:site-style" });
 
     expect(api.find).not.toHaveBeenCalled();
+  });
+
+  it("cleans the OTHER index when one of them cannot be reached", async () => {
+    // The class index is asked first. Letting its failure end the loop stranded
+    // the healthy index's rows too — and the document is already gone, so no
+    // later save revisits them: only a rebuild nobody knows to run would.
+    const { fireDelete, api } = harness();
+    api.find.mockImplementation(async (a: { collection?: string }) => {
+      if (a.collection === INDEX) throw new Error("class index unreachable");
+      return {
+        items: [
+          {
+            id: "k1",
+            scope: "collection",
+            entity: "pages",
+            entityKey: "p1",
+            field: "content",
+            locale: "",
+            variant: "published",
+            kind: "reference",
+            componentId: "header",
+          },
+        ],
+        meta: { hasNext: false },
+      };
+    });
+
+    // Still raises, because one index genuinely failed.
+    await expect(fireDelete()).rejects.toThrow(/could not forget/);
+    // And the reachable index's row was removed anyway, which is the property.
+    expect(api.delete).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "k1" })
+    );
   });
 
   it("RAISES when the rows cannot be removed, so the caller is told", async () => {

--- a/packages/plugin-page-builder/src/class-usage-hook.ts
+++ b/packages/plugin-page-builder/src/class-usage-hook.ts
@@ -231,21 +231,40 @@ async function forget(
   });
   if (target === null) return;
 
-  try {
-    // Every index, because a document's rows survive it in each of them and
-    // nothing later reconciles rows naming a document that no longer exists.
-    for (const indexCollection of [
-      args.indexCollection,
-      args.componentIndexCollection,
-    ]) {
+  // Every index, because a document's rows survive it in each of them and
+  // nothing later reconciles rows naming a document that no longer exists.
+  //
+  // EACH ONE ATTEMPTED, whatever the ones before it did. The document is
+  // already gone, so a store that cannot be reached now will not be revisited
+  // by any later save — only a rebuild reaches those rows. Letting the first
+  // failure end the loop would strand the healthy indexes' rows too, for a
+  // document that no longer exists, and they would count towards their
+  // references until somebody ran a rebuild nobody knew was needed.
+  const failures: unknown[] = [];
+  for (const indexCollection of [
+    args.indexCollection,
+    args.componentIndexCollection,
+  ]) {
+    try {
       await forgetDeletedDocument({
         store: classUsageIndexStore(target.nextly, indexCollection),
         scope: "collection",
         entity: target.slug,
         entityKey: target.documentId,
       });
+    } catch (thrown) {
+      failures.push(thrown);
     }
-  } catch (failure) {
+  }
+
+  if (failures.length > 0) {
+    const failure =
+      failures.length === 1
+        ? failures[0]
+        : new AggregateError(
+            failures,
+            "more than one usage index could not forget a deleted document"
+          );
     // Raised for the same reason maintenance raises: `after*` is a side-effect
     // phase whose throw the registry converts into a warning the caller
     // receives, and the delete itself is already committed. Swallowing would

--- a/packages/plugin-page-builder/src/class-usage-hook.ts
+++ b/packages/plugin-page-builder/src/class-usage-hook.ts
@@ -26,6 +26,31 @@
  * hook runs BEFORE the caller commits, where a throw would mean something else
  * entirely, and maintenance does not run there.
  *
+ * ## What running post-commit does NOT give, stated rather than implied
+ *
+ * Serialisation with the write. The mutation service releases its transaction
+ * before these hooks run, so two concurrent saves of one document can each read
+ * the index before either has written it, and the loser's diff describes a
+ * document that is no longer the live one — removing rows the winning document
+ * still justifies. `class-usage-reconcile` records the same window from the
+ * reconciler's side and says there that soundness is the write path's to
+ * establish; this is the write path, and it does not establish it.
+ *
+ * Every index maintained here shares the window, because they share the read.
+ * The direction it fails in is the costly one: rows go missing, so a document
+ * that still references something reads as referencing nothing.
+ *
+ * An in-process lock keyed by document is not the fix and is worse than none. A
+ * second application instance is not serialised by it, so it would close the
+ * window on one machine and leave it open on the deployments most likely to see
+ * concurrent saves — a mitigation that fails in the direction of looking
+ * effective. Closing it needs a boundary the writes share, which is the
+ * mutation service's to offer.
+ *
+ * The consequence for callers is the same as the one this whole module is
+ * built around: the index is EVENTUALLY consistent, a rebuild is what repairs
+ * it, and a decision that destroys data must not read it as exact.
+ *
  * @module class-usage-hook
  */
 import type { DocumentLimits } from "@nextlyhq/blocks-engine";

--- a/packages/plugin-page-builder/src/class-usage-hook.ts
+++ b/packages/plugin-page-builder/src/class-usage-hook.ts
@@ -33,12 +33,14 @@ import type { HookContext } from "nextly";
 
 import { blocksFieldsOf } from "./class-usage-blocks-fields";
 import { forgetDeletedDocument } from "./class-usage-maintenance";
+import { classUsageIndex } from "./class-usage-reconcile";
 import {
   classUsageDocumentReader,
   classUsageIndexStore,
   type ClassUsageDirectApi,
 } from "./class-usage-runtime";
-import { reconcileWrittenDocument } from "./class-usage-write";
+import { reconcileWrittenDocument, usageTarget } from "./class-usage-write";
+import { componentUsageIndex } from "./component-usage";
 import { requestContextFor, writeTargetOf } from "./write-target";
 
 /**
@@ -112,8 +114,17 @@ export interface DraftSplitResolver {
  */
 export function registerClassUsageMaintenance(args: {
   ctx: ClassUsagePluginContext;
-  /** The collection whose rows this maintains. */
+  /** The collection the CLASS index's rows live in. */
   indexCollection: string;
+  /**
+   * The collection the COMPONENT index's rows live in.
+   *
+   * A second index, not a second hook. One registration reads the written
+   * collection's configuration, resolves its draft split and reads each locale
+   * and variant of the document ONCE, and every index derives from that read —
+   * where a second wildcard registration would repeat all of it on every save.
+   */
+  componentIndexCollection: string;
   /** Resolves whether a collection keeps a working draft beside its published row. */
   draftSplit: DraftSplitResolver;
   /** The site's configured locales, read per call. */
@@ -188,17 +199,27 @@ async function forget(
   context: UnknownRecord
 ): Promise<void> {
   const target = writeTargetOf<ClassUsageDirectApi>(context, {
-    excluded: [args.indexCollection],
+    // BOTH, because the hook is on the wildcard: a write to either index would
+    // otherwise re-enter this handler and maintain an index against its own
+    // bookkeeping rows.
+    excluded: [args.indexCollection, args.componentIndexCollection],
   });
   if (target === null) return;
 
   try {
-    await forgetDeletedDocument({
-      store: classUsageIndexStore(target.nextly, args.indexCollection),
-      scope: "collection",
-      entity: target.slug,
-      entityKey: target.documentId,
-    });
+    // Every index, because a document's rows survive it in each of them and
+    // nothing later reconciles rows naming a document that no longer exists.
+    for (const indexCollection of [
+      args.indexCollection,
+      args.componentIndexCollection,
+    ]) {
+      await forgetDeletedDocument({
+        store: classUsageIndexStore(target.nextly, indexCollection),
+        scope: "collection",
+        entity: target.slug,
+        entityKey: target.documentId,
+      });
+    }
   } catch (failure) {
     // Raised for the same reason maintenance raises: `after*` is a side-effect
     // phase whose throw the registry converts into a warning the caller
@@ -233,7 +254,10 @@ async function planMaintenance(
   context: UnknownRecord
 ): Promise<Parameters<typeof reconcileWrittenDocument>[0] | null> {
   const target = writeTargetOf<ClassUsageDirectApi>(context, {
-    excluded: [args.indexCollection],
+    // BOTH, because the hook is on the wildcard: a write to either index would
+    // otherwise re-enter this handler and maintain an index against its own
+    // bookkeeping rows.
+    excluded: [args.indexCollection, args.componentIndexCollection],
   });
   if (target === null) return null;
 
@@ -248,6 +272,16 @@ async function planMaintenance(
 
   return {
     store: classUsageIndexStore(target.nextly, args.indexCollection),
+    targets: [
+      usageTarget(
+        classUsageIndex,
+        classUsageIndexStore(target.nextly, args.indexCollection)
+      ),
+      usageTarget(
+        componentUsageIndex,
+        classUsageIndexStore(target.nextly, args.componentIndexCollection)
+      ),
+    ],
     read: classUsageDocumentReader(target.nextly),
     collection: {
       slug: target.slug,

--- a/packages/plugin-page-builder/src/class-usage-index-rebuild.test.ts
+++ b/packages/plugin-page-builder/src/class-usage-index-rebuild.test.ts
@@ -700,6 +700,107 @@ describe("repairing every index a site maintains", () => {
     },
   });
 
+  /** An index store holding fixed rows and recording its deletes. */
+  function storeHolding(rows: Record<string, unknown>[]) {
+    const deleted: string[] = [];
+    const store: ClassUsageIndexStore = {
+      find: async args => {
+        const key = args.where.entityKey?.equals;
+        // The sweep asks WITHOUT an entityKey; maintenance asks with one.
+        return {
+          items:
+            key === undefined ? rows : rows.filter(r => r.entityKey === key),
+          meta: { hasNext: false },
+        };
+      },
+      create: async () => ({}),
+      delete: async args => {
+        deleted.push(args.id);
+        return {};
+      },
+    };
+    return { store, deleted };
+  }
+
+  it("keeps the DEPRECATED entry point raising rather than reporting", async () => {
+    // Code written against the published signature puts the call in a `try`
+    // and cannot inspect a field that did not exist when it was written. The
+    // walk behind it now reports failures instead of raising them, so the
+    // wrapper restores the contract its callers compiled against: reporting
+    // here would turn a failed repair into a silent success for every one.
+    const docs = documentStore([onePage("page-1", "hero")]);
+
+    await expect(
+      rebuildClassUsageIndex({
+        limits: DEFAULT_LIMITS,
+        documents: docs.store,
+        index: unavailableStore("class index unavailable"),
+        collection: "pages",
+        field: "content",
+        locale: "",
+        variant: "published",
+      })
+    ).rejects.toThrow("class index unavailable");
+  });
+
+  it("sweeps the COMPONENT index's orphan rows, not only the class index's", async () => {
+    // The sweep decodes rows through an index descriptor, and one index's
+    // reader answers null for another's rows. Swept through the class reader,
+    // every component row is skipped for having no `classId` — so the sweep
+    // examines nothing, removes nothing, and reports a clean pass. The rows of
+    // a document deleted outside the hook then count for ever.
+    const docs = documentStore([onePage("page-1", "hero")]);
+    const classes = storeHolding([
+      {
+        id: "c-orphan",
+        scope: "collection",
+        entity: "pages",
+        entityKey: "deleted-page",
+        field: "content",
+        locale: "",
+        variant: "published",
+        classId: "ghost",
+      },
+    ]);
+    const components = storeHolding([
+      {
+        id: "k-orphan",
+        scope: "collection",
+        entity: "pages",
+        entityKey: "deleted-page",
+        field: "content",
+        locale: "",
+        variant: "published",
+        kind: "reference",
+        componentId: "ghost-component",
+      },
+    ]);
+
+    const report = await rebuildPageBuilderUsageIndexes({
+      limits: DEFAULT_LIMITS,
+      documents: docs.store,
+      classIndex: classes.store,
+      componentIndex: components.store,
+      collection: "pages",
+      field: "content",
+      locale: "",
+      variant: "published",
+    });
+
+    // BOTH asserted: the class half is the control. Without it a sweep that
+    // removed nothing at all would fail this test for the wrong reason, and
+    // one that removed everything would pass it for the wrong reason.
+    expect({
+      classOrphan: classes.deleted.includes("c-orphan"),
+      componentOrphan: components.deleted.includes("k-orphan"),
+      orphansRemoved: report.orphansRemoved,
+    }).toEqual({
+      classOrphan: true,
+      componentOrphan: true,
+      orphansRemoved: 2,
+    });
+  });
+
   it("repairs the OTHER indexes when one of them cannot be reached", async () => {
     // The rebuild is the remedy for a stale index, so abandoning the walk at
     // the first store that cannot answer means the repair path fails in

--- a/packages/plugin-page-builder/src/class-usage-index-rebuild.test.ts
+++ b/packages/plugin-page-builder/src/class-usage-index-rebuild.test.ts
@@ -106,6 +106,7 @@ describe("rebuilding the class-usage index", () => {
       scanned: 2,
       repaired: 2,
       undetermined: 0,
+      unrepaired: 0,
       orphansRemoved: 0,
     });
     expect(index.calls).toEqual([
@@ -174,6 +175,7 @@ describe("rebuilding the class-usage index", () => {
       scanned: 1,
       repaired: 0,
       undetermined: 0,
+      unrepaired: 0,
       orphansRemoved: 0,
     });
     expect(index.calls).toEqual([]);
@@ -212,6 +214,7 @@ describe("rebuilding the class-usage index", () => {
       scanned: 1,
       repaired: 1,
       undetermined: 1,
+      unrepaired: 0,
       orphansRemoved: 0,
     });
   });
@@ -242,6 +245,7 @@ describe("rebuilding the class-usage index", () => {
       scanned: 1,
       repaired: 1,
       undetermined: 0,
+      unrepaired: 0,
       orphansRemoved: 0,
     });
     expect(index.calls).toEqual(["create:published:page-1:hero"]);
@@ -440,6 +444,7 @@ describe("rows whose document no longer exists", () => {
       scanned: 1,
       repaired: 0,
       undetermined: 0,
+      unrepaired: 0,
       orphansRemoved: 1,
     });
     expect(calls).toEqual(["delete:r9"]);
@@ -659,6 +664,126 @@ describe("repairing every index a site maintains", () => {
     };
     return { store, written };
   }
+
+  /** A store that cannot answer at all, as an unavailable index table reads. */
+  function unavailableStore(message: string): ClassUsageIndexStore {
+    return {
+      find: async () => {
+        throw new Error(message);
+      },
+      create: async () => ({}),
+      delete: async () => ({}),
+    };
+  }
+
+  /**
+   * A page carrying a reference for BOTH indexes.
+   *
+   * A class alone would leave the component index with nothing to derive, so a
+   * test asserting the sibling was repaired would fail on a fixture that never
+   * gave it anything to write rather than on the behaviour it names.
+   */
+  const onePage = (id: string, klass: string) => ({
+    id,
+    content: {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        { id: "a", type: "core/text", version: 1, props: {}, classes: [klass] },
+        {
+          id: `${id}-i`,
+          type: "nextly/component-instance",
+          version: 1,
+          props: { componentId: "header" },
+        },
+      ],
+    },
+  });
+
+  it("repairs the OTHER indexes when one of them cannot be reached", async () => {
+    // The rebuild is the remedy for a stale index, so abandoning the walk at
+    // the first store that cannot answer means the repair path fails in
+    // exactly the circumstances it exists for — and it abandoned every
+    // remaining DOCUMENT too, not merely the failing index.
+    const docs = documentStore([onePage("page-1", "hero")]);
+    const healthy = recordingStore();
+
+    const report = await rebuildPageBuilderUsageIndexes({
+      limits: DEFAULT_LIMITS,
+      documents: docs.store,
+      classIndex: unavailableStore("class index unavailable"),
+      componentIndex: healthy.store,
+      collection: "pages",
+      field: "content",
+      locale: "",
+      variant: "published",
+    });
+
+    expect({
+      // The sibling was repaired anyway, which is the property.
+      sibling: healthy.written.length > 0,
+      // And the report SAYS it was not a whole repair, rather than reading as
+      // a clean rebuild that happened to write less.
+      unrepaired: report.unrepaired,
+      cause: (report.failure as Error).message,
+      scanned: report.scanned,
+    }).toEqual({
+      sibling: true,
+      unrepaired: 1,
+      cause: "class index unavailable",
+      scanned: 1,
+    });
+  });
+
+  it("walks the documents AFTER one that could not be repaired", async () => {
+    // The costly half of aborting: every later document keeps rows that
+    // disagree with it, and the later ones are the ones nobody knows to check.
+    const docs = documentStore([
+      onePage("page-1", "hero"),
+      onePage("page-2", "banner"),
+    ]);
+    const healthy = recordingStore();
+
+    const report = await rebuildPageBuilderUsageIndexes({
+      limits: DEFAULT_LIMITS,
+      documents: docs.store,
+      classIndex: unavailableStore("class index unavailable"),
+      componentIndex: healthy.store,
+      collection: "pages",
+      field: "content",
+      locale: "",
+      variant: "published",
+    });
+
+    expect({ scanned: report.scanned, unrepaired: report.unrepaired }).toEqual({
+      scanned: 2,
+      unrepaired: 2,
+    });
+  });
+
+  it("reports a rebuild that repaired everything as carrying NO failure", async () => {
+    // The control. Without it, a report that always carried a failure would
+    // satisfy both assertions above.
+    const docs = documentStore([onePage("page-1", "hero")]);
+    const classes = recordingStore();
+    const components = recordingStore();
+
+    const report = await rebuildPageBuilderUsageIndexes({
+      limits: DEFAULT_LIMITS,
+      documents: docs.store,
+      classIndex: classes.store,
+      componentIndex: components.store,
+      collection: "pages",
+      field: "content",
+      locale: "",
+      variant: "published",
+    });
+
+    expect({
+      failure: report.failure,
+      unrepaired: report.unrepaired,
+    }).toEqual({ failure: undefined, unrepaired: 0 });
+  });
 
   it("fills BOTH indexes from one walk, through the entry point a host can reach", async () => {
     // The upgrade case, and the reason this entry point exists. An installation

--- a/packages/plugin-page-builder/src/class-usage-index-rebuild.test.ts
+++ b/packages/plugin-page-builder/src/class-usage-index-rebuild.test.ts
@@ -12,10 +12,14 @@ import { describe, expect, it } from "vitest";
 
 import { DEFAULT_LIMITS } from "@nextlyhq/blocks-engine";
 
+import { classUsageIndex } from "./class-usage-reconcile";
+import { usageTarget } from "./class-usage-write";
 import {
   rebuildClassUsageIndex,
+  rebuildUsageIndexes,
   type ClassUsageDocumentStore,
 } from "./class-usage-index-rebuild";
+import { componentUsageIndex } from "./component-usage";
 import type { ClassUsageIndexStore } from "./class-usage-maintenance";
 
 const documentUsing = (...classes: string[]) => ({
@@ -638,5 +642,75 @@ describe("the coordinates an existence check is asked in", () => {
     });
 
     expect(asked).toEqual(["gone-page:fr:draft"]);
+  });
+});
+
+describe("repairing every index a site maintains", () => {
+  /** A store that keeps whole rows, so each index's own columns are visible. */
+  function recordingStore() {
+    const written: Record<string, unknown>[] = [];
+    const store: ClassUsageIndexStore = {
+      find: async () => ({ items: [], meta: { hasNext: false } }),
+      create: async args => {
+        written.push(args.data);
+        return {};
+      },
+      delete: async () => ({}),
+    };
+    return { store, written };
+  }
+
+  it("fills BOTH indexes from one walk", async () => {
+    // The upgrade case, and the reason this entry point exists. An installation
+    // that already held pages gets an empty component index and it fills only
+    // for pages saved AFTER the upgrade, so every stored reference stays
+    // invisible until somebody resaves the page. An empty index answers
+    // "references nothing" — the answer a delete check acts on.
+    const docs = documentStore([
+      {
+        id: "page-1",
+        content: {
+          formatVersion: 1,
+          kind: "page",
+          nodes: [
+            {
+              id: "a",
+              type: "core/text",
+              version: 1,
+              props: {},
+              classes: ["hero"],
+            },
+            {
+              id: "i1",
+              type: "nextly/component-instance",
+              version: 1,
+              props: { componentId: "header" },
+            },
+          ],
+        },
+      },
+    ]);
+    const classes = recordingStore();
+    const components = recordingStore();
+
+    await rebuildUsageIndexes({
+      limits: DEFAULT_LIMITS,
+      documents: docs.store,
+      targets: [
+        usageTarget(classUsageIndex, classes.store),
+        usageTarget(componentUsageIndex, components.store),
+      ],
+      collection: "pages",
+      field: "content",
+      locale: "",
+      variant: "published",
+    });
+
+    // Both asserted together: either alone passes on a rebuild that repaired
+    // one index and silently skipped the other, which is the defect itself.
+    expect({
+      classes: classes.written.map(r => r.classId),
+      components: components.written.map(r => r.componentId),
+    }).toEqual({ classes: ["hero"], components: ["header"] });
   });
 });

--- a/packages/plugin-page-builder/src/class-usage-index-rebuild.test.ts
+++ b/packages/plugin-page-builder/src/class-usage-index-rebuild.test.ts
@@ -16,7 +16,7 @@ import { classUsageIndex } from "./class-usage-reconcile";
 import { usageTarget } from "./class-usage-write";
 import {
   rebuildClassUsageIndex,
-  rebuildUsageIndexes,
+  rebuildPageBuilderUsageIndexes,
   type ClassUsageDocumentStore,
 } from "./class-usage-index-rebuild";
 import { componentUsageIndex } from "./component-usage";
@@ -660,12 +660,18 @@ describe("repairing every index a site maintains", () => {
     return { store, written };
   }
 
-  it("fills BOTH indexes from one walk", async () => {
+  it("fills BOTH indexes from one walk, through the entry point a host can reach", async () => {
     // The upgrade case, and the reason this entry point exists. An installation
     // that already held pages gets an empty component index and it fills only
     // for pages saved AFTER the upgrade, so every stored reference stays
     // invisible until somebody resaves the page. An empty index answers
     // "references nothing" — the answer a delete check acts on.
+    //
+    // Exercised through `rebuildPageBuilderUsageIndexes` rather than by handing
+    // a targets list to the walk, because the targets list names
+    // package-internal descriptors: a test that builds one proves the WALK
+    // repairs what it is given, and says nothing about whether a host can name
+    // both indexes in the first place.
     const docs = documentStore([
       {
         id: "page-1",
@@ -693,21 +699,21 @@ describe("repairing every index a site maintains", () => {
     const classes = recordingStore();
     const components = recordingStore();
 
-    await rebuildUsageIndexes({
+    await rebuildPageBuilderUsageIndexes({
       limits: DEFAULT_LIMITS,
       documents: docs.store,
-      targets: [
-        usageTarget(classUsageIndex, classes.store),
-        usageTarget(componentUsageIndex, components.store),
-      ],
+      classIndex: classes.store,
+      componentIndex: components.store,
       collection: "pages",
       field: "content",
       locale: "",
       variant: "published",
     });
 
-    // Both asserted together: either alone passes on a rebuild that repaired
-    // one index and silently skipped the other, which is the defect itself.
+    // Both asserted together, and each against the rows only ITS descriptor
+    // produces: either alone passes on a rebuild that repaired one index and
+    // silently skipped the other, which is the defect itself, and comparing
+    // row counts would pass on the two stores wired to the same descriptor.
     expect({
       classes: classes.written.map(r => r.classId),
       components: components.written.map(r => r.componentId),

--- a/packages/plugin-page-builder/src/class-usage-index-rebuild.ts
+++ b/packages/plugin-page-builder/src/class-usage-index-rebuild.ts
@@ -39,9 +39,10 @@ import { isPlainRecord } from "@nextlyhq/blocks-engine";
 
 import {
   forgetAbsentDocuments,
-  maintainClassUsage,
   type ClassUsageIndexStore,
 } from "./class-usage-maintenance";
+import { classUsageIndex } from "./class-usage-reconcile";
+import { usageTarget, type UsageTarget } from "./class-usage-write";
 import type { ClassUsageVariant } from "./collections/class-usage-index";
 import { walkPages } from "./paged-walk";
 
@@ -188,15 +189,15 @@ interface PageTally {
  * are the ones nobody knows to look at.
  */
 async function rebuildOnePage(
-  items: readonly unknown[],
   args: {
-    index: ClassUsageIndexStore;
+    targets: readonly UsageTarget[];
     collection: string;
     field: string;
     locale: string;
     variant: ClassUsageVariant;
     limits: DocumentLimits;
   },
+  items: readonly unknown[],
   visited: Set<string>
 ): Promise<PageTally> {
   let scanned = 0;
@@ -208,19 +209,34 @@ async function rebuildOnePage(
     scanned += 1;
     visited.add(item.id);
 
-    const report = await maintainClassUsage({
-      store: args.index,
-      subject: {
-        scope: "collection",
-        entity: args.collection,
-        entityKey: item.id,
-        field: args.field,
-        locale: args.locale,
-        variant: args.variant,
-      },
-      document: item[args.field],
-      limits: args.limits,
-    });
+    const subject = {
+      scope: "collection" as const,
+      entity: args.collection,
+      entityKey: item.id,
+      field: args.field,
+      locale: args.locale,
+      variant: args.variant,
+    };
+
+    // Every index, from ONE document. A rebuild that repaired only some of them
+    // is the shape this whole slice exists to avoid: the unrepaired index reads
+    // as "references nothing", which is the answer a delete check acts on.
+    let changed = false;
+    let unread = false;
+    for (const target of args.targets) {
+      const report = await target.maintain({
+        subject,
+        document: item[args.field],
+        limits: args.limits,
+      });
+      if (report.undetermined) unread = true;
+      if (report.inserted > 0 || report.removed > 0) changed = true;
+    }
+    const report = {
+      undetermined: unread,
+      inserted: changed ? 1 : 0,
+      removed: 0,
+    };
 
     if (report.undetermined) undetermined += 1;
     // Repaired means the rows CHANGED, which is a different question from
@@ -247,9 +263,19 @@ async function rebuildOnePage(
  * or its next rebuild, and holding every document still would cost more than
  * the thing it prevents.
  */
-export async function rebuildClassUsageIndex(args: {
+export async function rebuildUsageIndexes(args: {
   documents: ClassUsageDocumentStore;
-  index: ClassUsageIndexStore;
+  /**
+   * Every index to repair from this one walk.
+   *
+   * Required, and a list rather than one store, because that is what makes
+   * leaving an index out a DECISION rather than an omission. An index absent
+   * from a rebuild is not merely unrepaired: for every document the walk
+   * visited it answers "references nothing", which cannot be told from a
+   * document that genuinely references none — and that is the answer a delete
+   * check acts on.
+   */
+  targets: readonly UsageTarget[];
   /** The collection whose documents are walked. */
   collection: string;
   /** The blocks field on those documents. */
@@ -317,6 +343,9 @@ export async function rebuildClassUsageIndex(args: {
   // Collected during the SAME walk that reconciles, rather than by reading the
   // documents again. Two reads would let a document created between them be
   // read as absent, and lose rows it should keep.
+  // Resolved ONCE. A default that allocated per page would build a target for
+  // every page of the walk, and a caller's own list would be re-read as often.
+  const resolvedTargets = args.targets;
   const visited = new Set<string>();
 
   await walkPages({
@@ -336,7 +365,11 @@ export async function rebuildClassUsageIndex(args: {
         variant: args.variant,
       }),
     onPage: async items => {
-      const tally = await rebuildOnePage(items, args, visited);
+      const tally = await rebuildOnePage(
+        { ...args, targets: resolvedTargets },
+        items,
+        visited
+      );
       scanned += tally.scanned;
       repaired += tally.repaired;
       undetermined += tally.undetermined;
@@ -346,30 +379,65 @@ export async function rebuildClassUsageIndex(args: {
   // AFTER the walk, and only after it completed: the sweep decides absence from
   // the set of documents actually seen, so running it against a partial walk
   // would delete the rows of every document the walk had not reached yet.
-  const { removed } = await forgetAbsentDocuments({
-    store: args.index,
-    scope: "collection",
-    entity: args.collection,
-    field: args.field,
-    locale: args.locale,
-    variant: args.variant,
-    visited,
-    // Asked only about a document the walk did not see, so a stable collection
-    // costs nothing. A row survives unless the document is confirmed GONE —
-    // failing towards keeping a row, because a kept stale row over-counts and
-    // blocks a delete, while a wrongly removed one under-counts and permits
-    // deleting a class the live document still renders.
-    stillExists: id =>
-      args.documents.exists({
-        collection: args.collection,
-        id,
-        // The subject's own coordinates, not the document's id alone. A row is
-        // filed under all of them, so the question that decides whether to
-        // remove it has to be asked in all of them.
-        locale: args.locale,
-        variant: args.variant,
-      }),
-  });
+  // EVERY index, for the reason the maintenance loop covers every index: a
+  // sweep that skipped one leaves rows naming documents that no longer exist,
+  // and nothing later reconciles a row whose document is gone.
+  let removed = 0;
+  for (const target of resolvedTargets) {
+    const swept = await forgetAbsentDocuments({
+      store: target.store,
+      scope: "collection",
+      entity: args.collection,
+      field: args.field,
+      locale: args.locale,
+      variant: args.variant,
+      visited,
+      // Asked only about a document the walk did not see, so a stable collection
+      // costs nothing. A row survives unless the document is confirmed GONE —
+      // failing towards keeping a row, because a kept stale row over-counts and
+      // blocks a delete, while a wrongly removed one under-counts and permits
+      // deleting a class the live document still renders.
+      stillExists: id =>
+        args.documents.exists({
+          collection: args.collection,
+          id,
+          // The subject's own coordinates, not the document's id alone. A row is
+          // filed under all of them, so the question that decides whether to
+          // remove it has to be asked in all of them.
+          locale: args.locale,
+          variant: args.variant,
+        }),
+    });
+    removed += swept.removed;
+  }
 
   return { scanned, repaired, undetermined, orphansRemoved: removed };
+}
+
+/**
+ * Repair the class index alone.
+ *
+ * @deprecated Use {@link rebuildUsageIndexes} and pass every index the site
+ * maintains. Kept for one release because the name is published, and it keeps
+ * exactly the behaviour it had: a repair of the CLASS index and no other.
+ *
+ * That narrowness is the reason for the rename rather than an accident of it.
+ * A site that upgraded and ran this would have left its component index empty,
+ * and an empty index answers "references nothing" for every document — which
+ * is the answer a delete check acts on.
+ */
+export async function rebuildClassUsageIndex(args: {
+  documents: ClassUsageDocumentStore;
+  index: ClassUsageIndexStore;
+  collection: string;
+  field: string;
+  locale: string;
+  variant: ClassUsageVariant;
+  limits: DocumentLimits;
+}): Promise<ClassUsageRebuildReport> {
+  const { index, ...rest } = args;
+  return rebuildUsageIndexes({
+    ...rest,
+    targets: [usageTarget(classUsageIndex, index)],
+  });
 }

--- a/packages/plugin-page-builder/src/class-usage-index-rebuild.ts
+++ b/packages/plugin-page-builder/src/class-usage-index-rebuild.ts
@@ -44,6 +44,7 @@ import {
 import { classUsageIndex } from "./class-usage-reconcile";
 import { usageTarget, type UsageTarget } from "./class-usage-write";
 import type { ClassUsageVariant } from "./collections/class-usage-index";
+import { componentUsageIndex } from "./component-usage";
 import { walkPages } from "./paged-walk";
 
 /** How many documents one query asks for. */
@@ -434,11 +435,57 @@ export async function rebuildUsageIndexes(args: {
 }
 
 /**
+ * Repair EVERY usage index this plugin maintains, from one walk.
+ *
+ * The entry point a host reaches for. It names the stores rather than the
+ * targets, because the set of indexes is the PLUGIN's to know: a caller asked
+ * to list them can only list the ones that existed when its code was written,
+ * so an index added in a later version would go unrepaired on every upgraded
+ * site — and an index that is never repaired answers "references nothing" for
+ * every document, which is the answer a delete check acts on.
+ *
+ * That is the same reasoning `rebuildUsageIndexes` applies from the other side.
+ * There the list is required so that omitting one is a decision; here the
+ * decision has already been taken, by the code that knows the whole set.
+ *
+ * Both stores are required for the same reason. A host holding one of them and
+ * not the other is repairing half its derived state, and the half it skips is
+ * indistinguishable afterwards from one that genuinely records nothing.
+ */
+export async function rebuildPageBuilderUsageIndexes(args: {
+  documents: ClassUsageDocumentStore;
+  /** Where the CLASS index's rows live. */
+  classIndex: ClassUsageIndexStore;
+  /** Where the COMPONENT index's rows live. */
+  componentIndex: ClassUsageIndexStore;
+  /** The collection whose documents are walked. */
+  collection: string;
+  /** The blocks field on those documents. */
+  field: string;
+  /** The locale being rebuilt, or `""` when the field is not localized. */
+  locale: string;
+  /** Which stored variant is being rebuilt. */
+  variant: ClassUsageVariant;
+  /** The bounds the documents are rendered under. */
+  limits: DocumentLimits;
+}): Promise<ClassUsageRebuildReport> {
+  const { classIndex, componentIndex, ...rest } = args;
+  return rebuildUsageIndexes({
+    ...rest,
+    targets: [
+      usageTarget(classUsageIndex, classIndex),
+      usageTarget(componentUsageIndex, componentIndex),
+    ],
+  });
+}
+
+/**
  * Repair the class index alone.
  *
- * @deprecated Use {@link rebuildUsageIndexes} and pass every index the site
- * maintains. Kept for one release because the name is published, and it keeps
- * exactly the behaviour it had: a repair of the CLASS index and no other.
+ * @deprecated Use {@link rebuildPageBuilderUsageIndexes}, which repairs every
+ * index the plugin maintains. Kept for one release because the name is
+ * published, and it keeps exactly the behaviour it had: a repair of the CLASS
+ * index and no other.
  *
  * That narrowness is the reason for the rename rather than an accident of it.
  * A site that upgraded and ran this would have left its component index empty,

--- a/packages/plugin-page-builder/src/class-usage-index-rebuild.ts
+++ b/packages/plugin-page-builder/src/class-usage-index-rebuild.ts
@@ -37,10 +37,7 @@
 import type { DocumentLimits } from "@nextlyhq/blocks-engine";
 import { isPlainRecord } from "@nextlyhq/blocks-engine";
 
-import {
-  forgetAbsentDocuments,
-  type ClassUsageIndexStore,
-} from "./class-usage-maintenance";
+import { type ClassUsageIndexStore } from "./class-usage-maintenance";
 import { classUsageIndex } from "./class-usage-reconcile";
 import { usageTarget, type UsageTarget } from "./class-usage-write";
 import type { ClassUsageVariant } from "./collections/class-usage-index";
@@ -462,8 +459,7 @@ export async function rebuildUsageIndexes(args: {
     // holding rows for documents that no longer exist, and nothing later
     // reconciles a row whose document is gone.
     try {
-      const swept = await forgetAbsentDocuments({
-        store: target.store,
+      const swept = await target.forgetAbsent({
         scope: "collection",
         entity: args.collection,
         field: args.field,
@@ -565,6 +561,14 @@ export async function rebuildPageBuilderUsageIndexes(args: {
  * A site that upgraded and ran this would have left its component index empty,
  * and an empty index answers "references nothing" for every document — which
  * is the answer a delete check acts on.
+ *
+ * It also RAISES a failure rather than reporting one, which the walk behind it
+ * no longer does. That difference is the point of this wrapper rather than an
+ * oversight: code written against the published signature puts the call in a
+ * `try` and cannot inspect a field that did not exist when it was written, so
+ * reporting instead of raising would turn a failed repair into a silent
+ * success for every existing caller. A caller that wants the partial report
+ * moves to the new entry point, where the field is part of the contract.
  */
 export async function rebuildClassUsageIndex(args: {
   documents: ClassUsageDocumentStore;
@@ -576,8 +580,23 @@ export async function rebuildClassUsageIndex(args: {
   limits: DocumentLimits;
 }): Promise<ClassUsageRebuildReport> {
   const { index, ...rest } = args;
-  return rebuildUsageIndexes({
+  const report = await rebuildUsageIndexes({
     ...rest,
     targets: [usageTarget(classUsageIndex, index)],
   });
+  if (report.failure !== undefined) {
+    // The ORIGINAL value where it is one, so a caller's existing `catch` sees
+    // what it always saw. A store that rejects with something other than an
+    // error is wrapped rather than rethrown, because a non-error rejection
+    // reaching a caller is what makes a failure unreadable at the point it is
+    // finally logged.
+    throw report.failure instanceof Error
+      ? report.failure
+      : new Error(
+          "[page-builder] the class-usage rebuild failed, and the store " +
+            "rejected with a value that is not an error",
+          { cause: report.failure }
+        );
+  }
+  return report;
 }

--- a/packages/plugin-page-builder/src/class-usage-index-rebuild.ts
+++ b/packages/plugin-page-builder/src/class-usage-index-rebuild.ts
@@ -181,6 +181,52 @@ interface PageTally {
 }
 
 /**
+ * Bring ONE document's rows into agreement, across every index.
+ *
+ * Its own function rather than a loop inside the page walk. The walk COUNTS and
+ * this REPAIRS, and folding both into one body put that function over the
+ * complexity gate — which is the gate reporting, correctly, that a reader now
+ * had to hold two jobs at once to follow it.
+ *
+ * A rebuild that repaired only some indexes is the shape this whole slice
+ * exists to avoid: an unrepaired index answers "references nothing" for every
+ * document the walk visited, and that is the answer a delete check acts on.
+ */
+async function repairOneDocument(
+  args: {
+    targets: readonly UsageTarget[];
+    collection: string;
+    field: string;
+    locale: string;
+    variant: ClassUsageVariant;
+    limits: DocumentLimits;
+  },
+  item: { id: string } & Record<string, unknown>
+): Promise<{ changed: boolean; unread: boolean }> {
+  const subject = {
+    scope: "collection" as const,
+    entity: args.collection,
+    entityKey: item.id,
+    field: args.field,
+    locale: args.locale,
+    variant: args.variant,
+  };
+
+  let changed = false;
+  let unread = false;
+  for (const target of args.targets) {
+    const report = await target.maintain({
+      subject,
+      document: item[args.field],
+      limits: args.limits,
+    });
+    if (report.undetermined) unread = true;
+    if (report.inserted > 0 || report.removed > 0) changed = true;
+  }
+  return { changed, unread };
+}
+
+/**
  * Bring one query's worth of documents into agreement with their rows.
  *
  * An item this cannot read an id out of is SKIPPED rather than counted.
@@ -209,40 +255,13 @@ async function rebuildOnePage(
     scanned += 1;
     visited.add(item.id);
 
-    const subject = {
-      scope: "collection" as const,
-      entity: args.collection,
-      entityKey: item.id,
-      field: args.field,
-      locale: args.locale,
-      variant: args.variant,
-    };
+    const outcome = await repairOneDocument(args, item);
 
-    // Every index, from ONE document. A rebuild that repaired only some of them
-    // is the shape this whole slice exists to avoid: the unrepaired index reads
-    // as "references nothing", which is the answer a delete check acts on.
-    let changed = false;
-    let unread = false;
-    for (const target of args.targets) {
-      const report = await target.maintain({
-        subject,
-        document: item[args.field],
-        limits: args.limits,
-      });
-      if (report.undetermined) unread = true;
-      if (report.inserted > 0 || report.removed > 0) changed = true;
-    }
-    const report = {
-      undetermined: unread,
-      inserted: changed ? 1 : 0,
-      removed: 0,
-    };
-
-    if (report.undetermined) undetermined += 1;
+    if (outcome.unread) undetermined += 1;
     // Repaired means the rows CHANGED, which is a different question from
     // whether the document was read. A document already in agreement issues no
     // writes and is scanned without being repaired.
-    if (report.inserted > 0 || report.removed > 0) repaired += 1;
+    if (outcome.changed) repaired += 1;
   }
 
   return { scanned, repaired, undetermined };

--- a/packages/plugin-page-builder/src/class-usage-index-rebuild.ts
+++ b/packages/plugin-page-builder/src/class-usage-index-rebuild.ts
@@ -163,6 +163,30 @@ export interface ClassUsageRebuildReport {
    * scanned document answered, and one of these did not.
    */
   undetermined: number;
+  /**
+   * Documents for which at least one index could not be brought into agreement.
+   *
+   * Separate from `undetermined`, which is a document this walk could not read
+   * WHOLE. Both make a count untrustworthy and they have different causes and
+   * different remedies, so folding them together would report an unavailable
+   * index store as a collection full of unreadable documents.
+   */
+  unrepaired: number;
+  /**
+   * The first failure this rebuild met, or absent when it met none.
+   *
+   * PRESENT means the rebuild did not repair everything it walked, so the index
+   * must not be read as exact until one returns without it. `unrepaired` gives
+   * the scale; a sweep that could not run leaves orphan rows behind without
+   * moving that count at all, which is why this field rather than the count is
+   * the one to check.
+   *
+   * The FIRST rather than every one: a store that is unavailable fails
+   * identically for every document it is asked about, so keeping them all would
+   * grow with the collection while saying one thing many times. A caller needs
+   * one cause to act on and a number for how far it spread.
+   */
+  failure?: unknown;
 }
 
 /** Whether a stored item is something a document can be read out of. */
@@ -179,6 +203,8 @@ interface PageTally {
   scanned: number;
   repaired: number;
   undetermined: number;
+  unrepaired: number;
+  failure?: unknown;
 }
 
 /**
@@ -203,7 +229,7 @@ async function repairOneDocument(
     limits: DocumentLimits;
   },
   item: { id: string } & Record<string, unknown>
-): Promise<{ changed: boolean; unread: boolean }> {
+): Promise<{ changed: boolean; unread: boolean; failure?: unknown }> {
   const subject = {
     scope: "collection" as const,
     entity: args.collection,
@@ -215,16 +241,31 @@ async function repairOneDocument(
 
   let changed = false;
   let unread = false;
+  let failure: unknown;
   for (const target of args.targets) {
-    const report = await target.maintain({
-      subject,
-      document: item[args.field],
-      limits: args.limits,
-    });
-    if (report.undetermined) unread = true;
-    if (report.inserted > 0 || report.removed > 0) changed = true;
+    // Each index on its own. A rejection here used to leave the walk entirely,
+    // so one unavailable store abandoned the repair of every OTHER index and
+    // every document after this one — turning the routine that exists to fix a
+    // stale index into one that stops at the first sign that it is stale.
+    //
+    // Continuing is safe for the sweep that follows: this document is marked
+    // visited before the repair is attempted, so its rows are never mistaken
+    // for a deleted document's and removed.
+    try {
+      const report = await target.maintain({
+        subject,
+        document: item[args.field],
+        limits: args.limits,
+      });
+      if (report.undetermined) unread = true;
+      if (report.inserted > 0 || report.removed > 0) changed = true;
+    } catch (thrown) {
+      failure ??= thrown;
+    }
   }
-  return { changed, unread };
+  return failure === undefined
+    ? { changed, unread }
+    : { changed, unread, failure };
 }
 
 /**
@@ -250,6 +291,8 @@ async function rebuildOnePage(
   let scanned = 0;
   let repaired = 0;
   let undetermined = 0;
+  let unrepaired = 0;
+  let failure: unknown;
 
   for (const item of items) {
     if (!isStoredDocument(item)) continue;
@@ -258,6 +301,10 @@ async function rebuildOnePage(
 
     const outcome = await repairOneDocument(args, item);
 
+    if (outcome.failure !== undefined) {
+      unrepaired += 1;
+      failure ??= outcome.failure;
+    }
     if (outcome.unread) undetermined += 1;
     // Repaired means the rows CHANGED, which is a different question from
     // whether the document was read. A document already in agreement issues no
@@ -265,7 +312,9 @@ async function rebuildOnePage(
     if (outcome.changed) repaired += 1;
   }
 
-  return { scanned, repaired, undetermined };
+  return failure === undefined
+    ? { scanned, repaired, undetermined, unrepaired }
+    : { scanned, repaired, undetermined, unrepaired, failure };
 }
 
 /**
@@ -360,6 +409,8 @@ export async function rebuildUsageIndexes(args: {
   let scanned = 0;
   let repaired = 0;
   let undetermined = 0;
+  let unrepaired = 0;
+  let failure: unknown;
   // Collected during the SAME walk that reconciles, rather than by reading the
   // documents again. Two reads would let a document created between them be
   // read as absent, and lose rows it should keep.
@@ -393,6 +444,8 @@ export async function rebuildUsageIndexes(args: {
       scanned += tally.scanned;
       repaired += tally.repaired;
       undetermined += tally.undetermined;
+      unrepaired += tally.unrepaired;
+      failure ??= tally.failure;
     },
   });
 
@@ -404,34 +457,55 @@ export async function rebuildUsageIndexes(args: {
   // and nothing later reconciles a row whose document is gone.
   let removed = 0;
   for (const target of resolvedTargets) {
-    const swept = await forgetAbsentDocuments({
-      store: target.store,
-      scope: "collection",
-      entity: args.collection,
-      field: args.field,
-      locale: args.locale,
-      variant: args.variant,
-      visited,
-      // Asked only about a document the walk did not see, so a stable collection
-      // costs nothing. A row survives unless the document is confirmed GONE —
-      // failing towards keeping a row, because a kept stale row over-counts and
-      // blocks a delete, while a wrongly removed one under-counts and permits
-      // deleting a class the live document still renders.
-      stillExists: id =>
-        args.documents.exists({
-          collection: args.collection,
-          id,
-          // The subject's own coordinates, not the document's id alone. A row is
-          // filed under all of them, so the question that decides whether to
-          // remove it has to be asked in all of them.
-          locale: args.locale,
-          variant: args.variant,
-        }),
-    });
-    removed += swept.removed;
+    // Each index's sweep on its own, for the reason the repair loop above is:
+    // one store that cannot answer would otherwise leave every OTHER index
+    // holding rows for documents that no longer exist, and nothing later
+    // reconciles a row whose document is gone.
+    try {
+      const swept = await forgetAbsentDocuments({
+        store: target.store,
+        scope: "collection",
+        entity: args.collection,
+        field: args.field,
+        locale: args.locale,
+        variant: args.variant,
+        visited,
+        // Asked only about a document the walk did not see, so a stable collection
+        // costs nothing. A row survives unless the document is confirmed GONE —
+        // failing towards keeping a row, because a kept stale row over-counts and
+        // blocks a delete, while a wrongly removed one under-counts and permits
+        // deleting a class the live document still renders.
+        stillExists: id =>
+          args.documents.exists({
+            collection: args.collection,
+            id,
+            // The subject's own coordinates, not the document's id alone. A row
+            // is filed under all of them, so the question that decides whether
+            // to remove it has to be asked in all of them.
+            locale: args.locale,
+            variant: args.variant,
+          }),
+      });
+      removed += swept.removed;
+    } catch (thrown) {
+      // Not counted in `unrepaired`, which counts DOCUMENTS. A sweep failure
+      // leaves orphan rows rather than a document unreconciled, which is why
+      // `failure` and not the count is the field that says a rebuild was
+      // incomplete.
+      failure ??= thrown;
+    }
   }
 
-  return { scanned, repaired, undetermined, orphansRemoved: removed };
+  return failure === undefined
+    ? { scanned, repaired, undetermined, unrepaired, orphansRemoved: removed }
+    : {
+        scanned,
+        repaired,
+        undetermined,
+        unrepaired,
+        orphansRemoved: removed,
+        failure,
+      };
 }
 
 /**

--- a/packages/plugin-page-builder/src/class-usage-maintenance.ts
+++ b/packages/plugin-page-builder/src/class-usage-maintenance.ts
@@ -64,18 +64,19 @@ import { isPlainRecord } from "@nextlyhq/blocks-engine";
 import type { DocumentLimits } from "@nextlyhq/blocks-engine";
 
 import {
-  deriveClassUsageRows,
-  reconcileClassUsage,
+  classUsageIndex,
+  deriveUsageRows,
+  reconcileUsage,
   type ClassUsageSubject,
   type StoredClassUsageRow,
 } from "./class-usage-reconcile";
 import {
-  type ClassUsageRow,
   type ClassUsageScope,
   type ClassUsageVariant,
 } from "./collections/class-usage-index";
 import { walkPages } from "./paged-walk";
 import { readStoredJson } from "./stored-json";
+import type { UsageIndex, UsageSubject } from "./usage-index";
 
 /**
  * The store operations maintenance needs, declared structurally.
@@ -145,14 +146,14 @@ export function looksLikeBlockDocument(value: unknown): boolean {
   return isPlainRecord(document) && Array.isArray(document.nodes);
 }
 
-/** The columns of a stored row that must each be a string. */
-const ROW_STRING_COLUMNS = [
-  "id",
-  "entity",
-  "entityKey",
-  "field",
-  "classId",
-] as const;
+/**
+ * The columns EVERY stored row must carry as a string.
+ *
+ * The row's own columns are not here: an index reads those itself, through
+ * `readOwn`, because a bare list of names cannot validate a closed set — and
+ * the component index carries one beside its reference.
+ */
+const ROW_STRING_COLUMNS = ["id", "entity", "entityKey", "field"] as const;
 
 /**
  * Read every named key as a string, or nothing if any is not one.
@@ -204,7 +205,23 @@ function readVariant(value: unknown): ClassUsageVariant | null {
  * data arrives unvalidated, one unreadable row must not stop the subject being
  * reconciled, and nothing here knows enough about it to remove it.
  */
-function readStoredRow(item: unknown): StoredClassUsageRow | null {
+function storedRowReader<TRow extends UsageSubject>(
+  index: UsageIndex<TRow>
+): (item: unknown) => (TRow & { id: string }) | null {
+  return item => readStoredRow(index, item);
+}
+
+/**
+ * One stored row under any index, or null when it cannot be read as one.
+ *
+ * The subject columns and the row id are read here because every index has
+ * them; whatever else a row carries is the index's own and it reads that
+ * itself. See {@link UsageIndex.readOwn}.
+ */
+function readStoredRow<TRow extends UsageSubject>(
+  index: UsageIndex<TRow>,
+  item: unknown
+): (TRow & { id: string }) | null {
   if (!isPlainRecord(item)) return null;
 
   const scope = readScope(item.scope);
@@ -223,9 +240,26 @@ function readStoredRow(item: unknown): StoredClassUsageRow | null {
 
   const parts = readStrings(item, ROW_STRING_COLUMNS);
   if (parts === null) return null;
-  const [id, entity, entityKey, field, classId] = parts;
+  const own = index.readOwn(item);
+  if (own === null) return null;
+  const [id, entity, entityKey, field] = parts;
 
-  return { id, scope, entity, entityKey, field, locale, variant, classId };
+  // Asserted because TypeScript cannot see that the subject columns plus the
+  // index's own columns are exactly `TRow`: `Omit` erased the relationship it
+  // would need to check the spread. The two halves are each checked above —
+  // every subject column against its own rule, and `own` by the index — so
+  // what is unchecked here is only that they SUM to the row, which the
+  // descriptor's type states.
+  return {
+    id,
+    scope,
+    entity,
+    entityKey,
+    field,
+    locale,
+    variant,
+    ...own,
+  } as TRow & { id: string };
 }
 
 /**
@@ -243,7 +277,7 @@ async function storedRowsWhere(
   where: Record<string, { equals: string }>,
   describe: string
 ): Promise<StoredClassUsageRow[]> {
-  return rowsWhere(store, where, describe, readStoredRow);
+  return rowsWhere(store, where, describe, storedRowReader(classUsageIndex));
 }
 
 /**
@@ -392,15 +426,24 @@ function describeSubject(subject: ClassUsageSubject): string {
   return `${subject.scope}:${subject.entity}:${subject.entityKey}:${subject.field}`;
 }
 
-/** The rows the index currently holds for one subject. */
-async function storedRowsFor(
+/**
+ * The rows an index currently holds for one subject.
+ *
+ * Kept as the one place that knows how a subject becomes a query, rather than
+ * inlined at each caller: the six predicates have to be bound TOGETHER, and a
+ * caller that assembled its own could bind five and silently read another
+ * document's rows — which the reconciler would then return as removals.
+ */
+async function storedRowsFor<TRow extends UsageSubject>(
+  index: UsageIndex<TRow>,
   store: ClassUsageIndexStore,
-  subject: ClassUsageSubject
-): Promise<StoredClassUsageRow[]> {
-  return storedRowsWhere(
+  subject: UsageSubject
+): Promise<(TRow & { id: string })[]> {
+  return rowsWhere(
     store,
     subjectWhere(subject),
-    describeSubject(subject)
+    describeSubject(subject),
+    storedRowReader(index)
   );
 }
 
@@ -424,19 +467,43 @@ export async function maintainClassUsage(args: {
   document: unknown;
   limits: DocumentLimits;
 }): Promise<ClassUsageMaintenanceReport> {
+  return maintainUsage(classUsageIndex, args);
+}
+
+/**
+ * Bring one subject's rows into agreement with its document, under any index.
+ *
+ * The generic beneath {@link maintainClassUsage}, which is a call to it. The
+ * named function keeps its signature so its tests stay the oracle for this
+ * refactor rather than being edited alongside the code they check.
+ */
+export async function maintainUsage<TRow extends UsageSubject>(
+  index: UsageIndex<TRow>,
+  args: {
+    store: ClassUsageIndexStore;
+    subject: UsageSubject;
+    document: unknown;
+    limits: DocumentLimits;
+  }
+): Promise<ClassUsageMaintenanceReport> {
   const { store, subject } = args;
-  const derivation = deriveClassUsageRows(subject, args.document, args.limits);
+  const derivation = deriveUsageRows(
+    index,
+    subject,
+    args.document,
+    args.limits
+  );
 
   // An incomplete read contributes its marker and nothing else. Reconciling
   // against the prefix it managed to read would remove the rows for every
   // reference past the bound, which is the answer that licences deleting a
   // class the document still applies.
-  const derived: ClassUsageRow[] = derivation.complete
+  const derived: TRow[] = derivation.complete
     ? derivation.rows
     : [derivation.undetermined];
 
-  const stored = await storedRowsFor(store, subject);
-  const { insert, remove } = reconcileClassUsage(subject, derived, stored);
+  const stored = await storedRowsFor(index, store, subject);
+  const { insert, remove } = reconcileUsage(index, subject, derived, stored);
 
   // Inserts before removals. Between the two statements the index reports the
   // subject as referencing both what it did and what it now does — an

--- a/packages/plugin-page-builder/src/class-usage-maintenance.ts
+++ b/packages/plugin-page-builder/src/class-usage-maintenance.ts
@@ -68,7 +68,6 @@ import {
   deriveUsageRows,
   reconcileUsage,
   type ClassUsageSubject,
-  type StoredClassUsageRow,
 } from "./class-usage-reconcile";
 import {
   type ClassUsageScope,
@@ -272,12 +271,13 @@ function readStoredRow<TRow extends UsageSubject>(
  * expected values onto whatever came back is precisely the operation that hides
  * that. Its removals would then delete another document's rows.
  */
-async function storedRowsWhere(
+async function storedRowsWhere<TRow extends UsageSubject>(
+  index: UsageIndex<TRow>,
   store: ClassUsageIndexStore,
   where: Record<string, { equals: string }>,
   describe: string
-): Promise<StoredClassUsageRow[]> {
-  return rowsWhere(store, where, describe, storedRowReader(classUsageIndex));
+): Promise<(TRow & { id: string })[]> {
+  return rowsWhere(store, where, describe, storedRowReader(index));
 }
 
 /**
@@ -599,7 +599,16 @@ export async function forgetDeletedDocument(args: {
  * Scoped to one entity, field and locale, so a rebuild of one blocks field
  * cannot remove rows belonging to another.
  */
-export async function forgetAbsentDocuments(args: {
+export async function forgetAbsentDocuments<TRow extends UsageSubject>(args: {
+  /**
+   * The index whose rows are being swept.
+   *
+   * Required, and not inferable from the store. Rows are decoded through this
+   * descriptor, and one index's reader answers null for another's rows — the
+   * class reader needs a `classId`, so sweeping the component index through it
+   * examines no rows at all and reports a clean pass having removed nothing.
+   */
+  index: UsageIndex<TRow>;
   store: ClassUsageIndexStore;
   scope: ClassUsageScope;
   entity: string;
@@ -631,6 +640,7 @@ export async function forgetAbsentDocuments(args: {
     variant: { equals: args.variant },
   };
   const rows = await storedRowsWhere(
+    args.index,
     args.store,
     where,
     `${args.scope}:${args.entity}:*:${args.field}`

--- a/packages/plugin-page-builder/src/class-usage-reconcile.ts
+++ b/packages/plugin-page-builder/src/class-usage-reconcile.ts
@@ -183,7 +183,8 @@ export function deriveClassUsageRows(
 export const classUsageIndex: UsageIndex<ClassUsageRow> = {
   readOwn: item =>
     typeof item.classId === "string" ? { classId: item.classId } : null,
-  referenceOf: row => row.classId,
+  // The class row carries nothing beside its reference, so the key IS the id.
+  reconcileKeyOf: row => row.classId,
   rowFor: (subject, referenceId) => ({ ...subject, classId: referenceId }),
   markerFor: subject => ({ ...subject, classId: UNDETERMINED_CLASS_ID }),
   isMarker: row => row.classId === UNDETERMINED_CLASS_ID,
@@ -281,7 +282,7 @@ export function reconcileUsage<TRow extends UsageSubject>(
     }
   }
 
-  const wanted = new Set(derived.map(row => index.referenceOf(row)));
+  const wanted = new Set(derived.map(row => index.reconcileKeyOf(row)));
   // Which classes a SURVIVING stored row records. A class reaches this set only
   // by having a row that is both wanted and the first of its class, which is
   // what makes it the right thing to subtract the inserts from: a class whose
@@ -309,16 +310,16 @@ export function reconcileUsage<TRow extends UsageSubject>(
     // re-derives from the row that won. That is a property of the write path,
     // which cannot be established here, and this comment is where it is
     // recorded rather than assumed.
-    const duplicate = kept.has(index.referenceOf(row));
-    if (duplicate || !wanted.has(index.referenceOf(row))) {
+    const duplicate = kept.has(index.reconcileKeyOf(row));
+    if (duplicate || !wanted.has(index.reconcileKeyOf(row))) {
       remove.push(row.id);
       continue;
     }
-    kept.add(index.referenceOf(row));
+    kept.add(index.reconcileKeyOf(row));
   }
 
   return {
-    insert: derived.filter(row => !kept.has(index.referenceOf(row))),
+    insert: derived.filter(row => !kept.has(index.reconcileKeyOf(row))),
     remove,
   };
 }

--- a/packages/plugin-page-builder/src/class-usage-reconcile.ts
+++ b/packages/plugin-page-builder/src/class-usage-reconcile.ts
@@ -181,7 +181,8 @@ export function deriveClassUsageRows(
  * marker becomes indistinguishable from a reference nobody noticed was legal.
  */
 export const classUsageIndex: UsageIndex<ClassUsageRow> = {
-  referenceColumn: "classId",
+  readOwn: item =>
+    typeof item.classId === "string" ? { classId: item.classId } : null,
   referenceOf: row => row.classId,
   rowFor: (subject, referenceId) => ({ ...subject, classId: referenceId }),
   markerFor: subject => ({ ...subject, classId: UNDETERMINED_CLASS_ID }),

--- a/packages/plugin-page-builder/src/class-usage-write.test.ts
+++ b/packages/plugin-page-builder/src/class-usage-write.test.ts
@@ -14,8 +14,11 @@ import { DEFAULT_LIMITS } from "@nextlyhq/blocks-engine";
 import { describe, expect, it } from "vitest";
 
 import type { ClassUsageIndexStore } from "./class-usage-maintenance";
-import type { ClassUsageSubject } from "./class-usage-reconcile";
-import { reconcileWrittenDocument } from "./class-usage-write";
+import {
+  classUsageIndex,
+  type ClassUsageSubject,
+} from "./class-usage-reconcile";
+import { reconcileWrittenDocument, usageTarget } from "./class-usage-write";
 
 /** A document whose single node applies the given classes. */
 const documentUsing = (...classes: string[]) => ({
@@ -309,6 +312,89 @@ describe("a subject that fails", () => {
     expect(report.failures[0]?.subject.locale).toBe("en");
     // The two locales after the failure were still written.
     expect(calls).toEqual(["create:hero", "create:hero"]);
+  });
+
+  it("maintains the sibling indexes after one of them fails", async () => {
+    // The content save has already committed, so a failure isolated to one
+    // derived store has no reason to leave the others stale as well. The
+    // persistent case is what makes this matter: every save fails at the same
+    // target first, so a sibling index never records anything at all — and an
+    // empty index answers "references nothing" for every document, which is
+    // the answer a delete check acts on.
+    const failing: ClassUsageIndexStore = {
+      find: async () => {
+        throw new Error("class index unavailable");
+      },
+      create: async () => ({}),
+      delete: async () => ({}),
+    };
+    const healthy = recordingStore();
+
+    const report = await reconcileWrittenDocument({
+      store: failing,
+      read: async () => documentUsing("hero"),
+      collection: {
+        slug: "pages",
+        fields: [{ type: "blocks", name: "content" }],
+        hasDrafts: false,
+      },
+      documentId: "p1",
+      locales: [],
+      limits: DEFAULT_LIMITS,
+      // The order the hook registers them in: the class target is always
+      // first, so a loop that stops at the first throw never reaches this one.
+      targets: [
+        usageTarget(classUsageIndex, failing),
+        usageTarget(classUsageIndex, healthy.store),
+      ],
+    });
+
+    expect({
+      failures: report.failures.length,
+      cause: (report.failures[0]?.failure as Error).message,
+      // The second target ran anyway, which is the whole property.
+      sibling: healthy.calls,
+    }).toEqual({
+      failures: 1,
+      cause: "class index unavailable",
+      sibling: ["create:hero"],
+    });
+  });
+
+  it("reports EVERY target that failed, not only the first", async () => {
+    // Separate indexes fail for separate reasons — a missing table is not a
+    // lost connection — and reducing them to the first hides the one nobody
+    // has diagnosed yet.
+    const failing = (message: string): ClassUsageIndexStore => ({
+      find: async () => {
+        throw new Error(message);
+      },
+      create: async () => ({}),
+      delete: async () => ({}),
+    });
+
+    const report = await reconcileWrittenDocument({
+      store: failing("first"),
+      read: async () => documentUsing("hero"),
+      collection: {
+        slug: "pages",
+        fields: [{ type: "blocks", name: "content" }],
+        hasDrafts: false,
+      },
+      documentId: "p1",
+      locales: [],
+      limits: DEFAULT_LIMITS,
+      targets: [
+        usageTarget(classUsageIndex, failing("first")),
+        usageTarget(classUsageIndex, failing("second")),
+      ],
+    });
+
+    const failure = report.failures[0]?.failure as AggregateError;
+    expect(failure.errors.map((e: Error) => e.message)).toEqual([
+      "first",
+      "second",
+    ]);
   });
 
   it("reports a reconciliation failure the same way as a read failure", async () => {

--- a/packages/plugin-page-builder/src/class-usage-write.test.ts
+++ b/packages/plugin-page-builder/src/class-usage-write.test.ts
@@ -361,6 +361,39 @@ describe("a subject that fails", () => {
     });
   });
 
+  it("still reports a target that rejected without a reason", async () => {
+    // `Promise.reject()` and `throw undefined` both carry no value. Callers
+    // identify a failed subject by `failure !== undefined`, so passing that
+    // value straight through would report the subject as reconciled while its
+    // index stayed stale — the failure erased by the field that exists to
+    // carry it.
+    const silent: ClassUsageIndexStore = {
+      find: async () => {
+        throw undefined;
+      },
+      create: async () => ({}),
+      delete: async () => ({}),
+    };
+
+    const report = await reconcileWrittenDocument({
+      store: silent,
+      read: async () => documentUsing("hero"),
+      collection: {
+        slug: "pages",
+        fields: [{ type: "blocks", name: "content" }],
+        hasDrafts: false,
+      },
+      documentId: "p1",
+      locales: [],
+      limits: DEFAULT_LIMITS,
+    });
+
+    expect({
+      counted: report.failures.length,
+      reported: report.failures[0]?.failure !== undefined,
+    }).toEqual({ counted: 1, reported: true });
+  });
+
   it("reports EVERY target that failed, not only the first", async () => {
     // Separate indexes fail for separate reasons — a missing table is not a
     // lost connection — and reducing them to the first hides the one nobody

--- a/packages/plugin-page-builder/src/class-usage-write.ts
+++ b/packages/plugin-page-builder/src/class-usage-write.ts
@@ -85,7 +85,15 @@ export interface ClassUsageSubjectOutcome {
   removed: number;
   /** True when the document could not be read whole and a marker was written. */
   undetermined: boolean;
-  /** Absent on success. Present, and the subject is unchanged, on failure. */
+  /**
+   * Absent on success.
+   *
+   * Present when any index for this subject could not be brought into
+   * agreement with the document. The others may still have been, and
+   * `inserted` and `removed` count what actually landed — a failing index does
+   * not stop its siblings, so this is not a claim that the subject is
+   * unchanged.
+   */
   failure?: unknown;
   /** True when no document exists in this locale and variant. */
   absent: boolean;
@@ -110,21 +118,6 @@ export interface ClassUsageWriteReport {
   outcomes: ClassUsageSubjectOutcome[];
 }
 
-/**
- * Reconcile every subject a written document owns.
- *
- * Returns an empty report for the collections this index does not track, which
- * is most of them: `blocksFieldsOf` finds no field, so the document owns no
- * subject and nothing is read. That filter reads the collection configuration
- * passed in rather than a list captured when the plugin was wired, so a
- * collection created after that moment is tracked rather than missed.
- *
- * A failure against one subject does not stop the others. Each subject's rows
- * are independent, and stopping would leave the subjects after the failure
- * stale as well as the one that failed — turning one recoverable disagreement
- * into several for no gain, since reconciliation is idempotent and a rerun
- * repairs whatever this pass could not.
- */
 /**
  * One index and the store its rows live in.
  *
@@ -170,6 +163,21 @@ export function usageTarget<TRow extends UsageSubject>(
   };
 }
 
+/**
+ * Reconcile every subject a written document owns.
+ *
+ * Returns an empty report for the collections this index does not track, which
+ * is most of them: `blocksFieldsOf` finds no field, so the document owns no
+ * subject and nothing is read. That filter reads the collection configuration
+ * passed in rather than a list captured when the plugin was wired, so a
+ * collection created after that moment is tracked rather than missed.
+ *
+ * A failure against one subject does not stop the others. Each subject's rows
+ * are independent, and stopping would leave the subjects after the failure
+ * stale as well as the one that failed — turning one recoverable disagreement
+ * into several for no gain, since reconciliation is idempotent and a rerun
+ * repairs whatever this pass could not.
+ */
 export async function reconcileWrittenDocument(args: {
   store: ClassUsageIndexStore;
   read: ClassUsageDocumentReader;
@@ -232,6 +240,71 @@ export async function reconcileWrittenDocument(args: {
  * separating them would suggest a caller could respond to one differently,
  * which after the write has committed it cannot.
  */
+/**
+ * Maintain EVERY index from one read, whatever any single one of them does.
+ *
+ * A target that throws does not stop the ones after it. The content save has
+ * already committed, so a failure isolated to one derived store has no reason
+ * to leave the others stale as well — and a failure that PERSISTS would
+ * otherwise mean a sibling index never records anything at all: every save
+ * fails at the same target first, so the sibling stays empty, and an empty
+ * index answers "references nothing" for every document. That is the answer a
+ * delete check acts on.
+ *
+ * This is the rule `reconcileWrittenDocument` already applies ACROSS SUBJECTS,
+ * applied across the indexes of one subject for the same reason: stopping
+ * turns one recoverable disagreement into several, for no gain, since
+ * maintenance is idempotent and a rebuild repairs whatever did not land.
+ *
+ * The subject still FAILS when any target did. A caller cannot act on "one of
+ * your indexes is stale" differently from "this subject is stale", and the
+ * remedy is the same rebuild either way.
+ */
+async function maintainEvery(
+  targets: readonly UsageTarget[],
+  args: { subject: UsageSubject; document: unknown; limits: DocumentLimits }
+): Promise<{
+  inserted: number;
+  removed: number;
+  undetermined: boolean;
+  failure?: unknown;
+}> {
+  let inserted = 0;
+  let removed = 0;
+  let undetermined = false;
+  const failures: unknown[] = [];
+
+  for (const target of targets) {
+    try {
+      const report = await target.maintain(args);
+      inserted += report.inserted;
+      removed += report.removed;
+      undetermined = undetermined || report.undetermined;
+    } catch (failure) {
+      failures.push(failure);
+    }
+  }
+
+  if (failures.length === 0) return { inserted, removed, undetermined };
+  return {
+    inserted,
+    removed,
+    undetermined,
+    // A lone failure is reported AS ITSELF. Wrapping one error in an aggregate
+    // would put a wrapper in front of the cause for every consumer that
+    // already reads this field. Several are aggregated rather than reduced to
+    // the first, because separate targets fail for separate reasons and only
+    // one of them would ever be seen.
+    failure:
+      failures.length === 1
+        ? failures[0]
+        : new AggregateError(
+            failures,
+            "more than one usage index failed for this subject"
+          ),
+  };
+}
+
 async function reconcileOne(
   args: {
     read: ClassUsageDocumentReader;
@@ -270,25 +343,14 @@ async function reconcileOne(
       };
     }
 
-    // Every index derives from THIS read. A failure in one is the subject's
-    // failure — the catch below turns it into a reported outcome — because a
-    // caller cannot act on "one of your indexes is stale" any differently, and
-    // the hook's remedy, a rebuild, repairs both.
-    let inserted = 0;
-    let removed = 0;
-    let undetermined = false;
-    for (const target of args.targets) {
-      const report = await target.maintain({
-        subject,
-        document,
-        limits: args.limits,
-      });
-      inserted += report.inserted;
-      removed += report.removed;
-      undetermined = undetermined || report.undetermined;
-    }
+    // Every index derives from THIS read.
+    const maintained = await maintainEvery(args.targets, {
+      subject,
+      document,
+      limits: args.limits,
+    });
 
-    return { subject, inserted, removed, undetermined, absent: false };
+    return { subject, ...maintained, absent: false };
   } catch (failure) {
     return {
       subject,

--- a/packages/plugin-page-builder/src/class-usage-write.ts
+++ b/packages/plugin-page-builder/src/class-usage-write.ts
@@ -36,6 +36,7 @@ import {
   type BlocksFieldsCollection,
 } from "./class-usage-blocks-fields";
 import {
+  forgetAbsentDocuments,
   maintainUsage,
   type ClassUsageIndexStore,
   type ClassUsageMaintenanceReport,
@@ -45,6 +46,7 @@ import {
   type ClassUsageSubject,
 } from "./class-usage-reconcile";
 import { classUsageSubjectsFor } from "./class-usage-subjects";
+import type { ClassUsageVariant } from "./collections/class-usage-index";
 import type { UsageIndex, UsageSubject } from "./usage-index";
 
 /**
@@ -128,19 +130,33 @@ export interface ClassUsageWriteReport {
  * save — the write amplification the design names in as many words.
  */
 export interface UsageTarget {
-  /**
-   * The store this index's rows live in.
-   *
-   * Exposed beside `maintain` because a rebuild's SWEEP — removing the rows of
-   * documents the walk never saw — addresses rows by subject columns and needs
-   * no knowledge of the row's own shape. Only the row type has to stay hidden.
-   */
-  readonly store: ClassUsageIndexStore;
   maintain(args: {
     subject: UsageSubject;
     document: unknown;
     limits: DocumentLimits;
   }): Promise<ClassUsageMaintenanceReport>;
+  /**
+   * Remove this index's rows for documents a rebuild's walk never saw.
+   *
+   * A METHOD rather than an exposed store, because the sweep decodes rows
+   * through the index's own descriptor and one index's reader answers null for
+   * another's rows. Handing a caller the bare store let it sweep the component
+   * index through the class reader, which examined no rows at all and reported
+   * a clean pass having removed nothing — a sweep that cannot see its own rows
+   * fails silently and in the direction that keeps them.
+   *
+   * Behind the method the row type stays erased, exactly as `maintain` keeps
+   * it, so a list of targets can still hold indexes whose rows differ.
+   */
+  forgetAbsent(args: {
+    scope: "collection";
+    entity: string;
+    field: string;
+    locale: string;
+    variant: ClassUsageVariant;
+    visited: ReadonlySet<string>;
+    stillExists: (entityKey: string) => Promise<boolean>;
+  }): Promise<{ removed: number }>;
 }
 
 /**
@@ -158,8 +174,8 @@ export function usageTarget<TRow extends UsageSubject>(
   store: ClassUsageIndexStore
 ): UsageTarget {
   return {
-    store,
     maintain: args => maintainUsage(index, { ...args, store }),
+    forgetAbsent: args => forgetAbsentDocuments({ ...args, index, store }),
   };
 }
 
@@ -260,6 +276,28 @@ export async function reconcileWrittenDocument(args: {
  * your indexes is stale" differently from "this subject is stale", and the
  * remedy is the same rebuild either way.
  */
+/**
+ * The value that will be carried as a subject's failure.
+ *
+ * Never `undefined` when there was a failure, whatever was thrown. A rejection
+ * carries any value at all — `Promise.reject()` supplies none — and the field
+ * this feeds is read as "did this fail", so an undefined cause and no cause at
+ * all would be the same answer.
+ */
+function reportableFailure(failures: readonly unknown[]): unknown {
+  const named = failures.map(failure =>
+    failure === undefined
+      ? new Error("a usage index rejected without a reason")
+      : failure
+  );
+  return named.length === 1
+    ? named[0]
+    : new AggregateError(
+        named,
+        "more than one usage index failed for this subject"
+      );
+}
+
 async function maintainEvery(
   targets: readonly UsageTarget[],
   args: { subject: UsageSubject; document: unknown; limits: DocumentLimits }
@@ -290,18 +328,19 @@ async function maintainEvery(
     inserted,
     removed,
     undetermined,
-    // A lone failure is reported AS ITSELF. Wrapping one error in an aggregate
-    // would put a wrapper in front of the cause for every consumer that
-    // already reads this field. Several are aggregated rather than reduced to
-    // the first, because separate targets fail for separate reasons and only
-    // one of them would ever be seen.
-    failure:
-      failures.length === 1
-        ? failures[0]
-        : new AggregateError(
-            failures,
-            "more than one usage index failed for this subject"
-          ),
+    // A lone failure is reported AS ITSELF, so a consumer already reading this
+    // field gets the cause rather than a wrapper around it. Several are
+    // aggregated rather than reduced to the first, because separate targets
+    // fail for separate reasons and only one would ever be seen.
+    //
+    // Except when the thrown value IS `undefined`, which `Promise.reject()`
+    // and `throw undefined` both produce. Callers identify a failed subject by
+    // `failure !== undefined`, so passing that value through would report the
+    // subject as reconciled while its index stayed stale — the failure erased
+    // by the very field that exists to carry it. A stand-in error is
+    // substituted, because "a target rejected and said nothing" is still a
+    // failure and must read as one.
+    failure: reportableFailure(failures),
   };
 }
 

--- a/packages/plugin-page-builder/src/class-usage-write.ts
+++ b/packages/plugin-page-builder/src/class-usage-write.ts
@@ -135,6 +135,14 @@ export interface ClassUsageWriteReport {
  * save — the write amplification the design names in as many words.
  */
 export interface UsageTarget {
+  /**
+   * The store this index's rows live in.
+   *
+   * Exposed beside `maintain` because a rebuild's SWEEP — removing the rows of
+   * documents the walk never saw — addresses rows by subject columns and needs
+   * no knowledge of the row's own shape. Only the row type has to stay hidden.
+   */
+  readonly store: ClassUsageIndexStore;
   maintain(args: {
     subject: UsageSubject;
     document: unknown;
@@ -157,6 +165,7 @@ export function usageTarget<TRow extends UsageSubject>(
   store: ClassUsageIndexStore
 ): UsageTarget {
   return {
+    store,
     maintain: args => maintainUsage(index, { ...args, store }),
   };
 }

--- a/packages/plugin-page-builder/src/class-usage-write.ts
+++ b/packages/plugin-page-builder/src/class-usage-write.ts
@@ -36,11 +36,16 @@ import {
   type BlocksFieldsCollection,
 } from "./class-usage-blocks-fields";
 import {
-  maintainClassUsage,
+  maintainUsage,
   type ClassUsageIndexStore,
+  type ClassUsageMaintenanceReport,
 } from "./class-usage-maintenance";
-import type { ClassUsageSubject } from "./class-usage-reconcile";
+import {
+  classUsageIndex,
+  type ClassUsageSubject,
+} from "./class-usage-reconcile";
 import { classUsageSubjectsFor } from "./class-usage-subjects";
+import type { UsageIndex, UsageSubject } from "./usage-index";
 
 /**
  * How the caller obtains the document behind one subject.
@@ -120,6 +125,42 @@ export interface ClassUsageWriteReport {
  * into several for no gain, since reconciliation is idempotent and a rerun
  * repairs whatever this pass could not.
  */
+/**
+ * One index and the store its rows live in.
+ *
+ * A LIST of these rather than one store, because a written document is read
+ * ONCE and every index derives from that read. Maintaining a second index by
+ * registering a second hook would re-read the collection config, re-resolve the
+ * draft split and re-read every locale and variant of the document on every
+ * save — the write amplification the design names in as many words.
+ */
+export interface UsageTarget {
+  maintain(args: {
+    subject: UsageSubject;
+    document: unknown;
+    limits: DocumentLimits;
+  }): Promise<ClassUsageMaintenanceReport>;
+}
+
+/**
+ * A target for one index against one store.
+ *
+ * The index's row type is captured here and does not escape. A list of
+ * `UsageTarget<TRow>` could not hold two indexes with different rows —
+ * `UsageIndex` is invariant in its row — and widening the list to the shared
+ * subject would make every member accept rows belonging to another index,
+ * which is precisely the confusion the reconciler's mismatch guard exists to
+ * catch. Erasing the row behind one method keeps both properties.
+ */
+export function usageTarget<TRow extends UsageSubject>(
+  index: UsageIndex<TRow>,
+  store: ClassUsageIndexStore
+): UsageTarget {
+  return {
+    maintain: args => maintainUsage(index, { ...args, store }),
+  };
+}
+
 export async function reconcileWrittenDocument(args: {
   store: ClassUsageIndexStore;
   read: ClassUsageDocumentReader;
@@ -130,6 +171,14 @@ export async function reconcileWrittenDocument(args: {
   locales: readonly string[];
   /** The bounds the rows are derived under. Required, never defaulted here. */
   limits: DocumentLimits;
+  /**
+   * Every index to maintain from this one read.
+   *
+   * Defaults to the class index alone, against `store`, which is what this
+   * function did before a second index existed — so a caller that knows about
+   * one keeps working, and its tests stay the oracle for that behaviour.
+   */
+  targets?: readonly UsageTarget[];
 }): Promise<ClassUsageWriteReport> {
   // No early return for an untracked collection, deliberately. `blocksFieldsOf`
   // answers `[]` for one, `classUsageSubjectsFor` answers `[]` for no fields,
@@ -145,10 +194,15 @@ export async function reconcileWrittenDocument(args: {
     hasDrafts: args.collection.hasDrafts,
   });
 
+  // Resolved once, here, rather than per subject: the default allocates a
+  // target and a caller that supplied its own should not have the list rebuilt
+  // for every locale and variant of the document.
+  const targets = args.targets ?? [usageTarget(classUsageIndex, args.store)];
+
   const outcomes: ClassUsageSubjectOutcome[] = [];
 
   for (const subject of subjects) {
-    outcomes.push(await reconcileOne(args, subject));
+    outcomes.push(await reconcileOne({ ...args, targets }, subject));
   }
 
   return {
@@ -171,9 +225,9 @@ export async function reconcileWrittenDocument(args: {
  */
 async function reconcileOne(
   args: {
-    store: ClassUsageIndexStore;
     read: ClassUsageDocumentReader;
     limits: DocumentLimits;
+    targets: readonly UsageTarget[];
   },
   subject: ClassUsageSubject
 ): Promise<ClassUsageSubjectOutcome> {
@@ -207,20 +261,25 @@ async function reconcileOne(
       };
     }
 
-    const report = await maintainClassUsage({
-      store: args.store,
-      subject,
-      document,
-      limits: args.limits,
-    });
+    // Every index derives from THIS read. A failure in one is the subject's
+    // failure — the catch below turns it into a reported outcome — because a
+    // caller cannot act on "one of your indexes is stale" any differently, and
+    // the hook's remedy, a rebuild, repairs both.
+    let inserted = 0;
+    let removed = 0;
+    let undetermined = false;
+    for (const target of args.targets) {
+      const report = await target.maintain({
+        subject,
+        document,
+        limits: args.limits,
+      });
+      inserted += report.inserted;
+      removed += report.removed;
+      undetermined = undetermined || report.undetermined;
+    }
 
-    return {
-      subject,
-      inserted: report.inserted,
-      removed: report.removed,
-      undetermined: report.undetermined,
-      absent: false,
-    };
+    return { subject, inserted, removed, undetermined, absent: false };
   } catch (failure) {
     return {
       subject,

--- a/packages/plugin-page-builder/src/collections/class-usage-index.ts
+++ b/packages/plugin-page-builder/src/collections/class-usage-index.ts
@@ -62,7 +62,7 @@ export type ClassUsageScope = UsageScope;
 export type ClassUsageVariant = UsageVariant;
 
 /** One reference: this document, through this field, uses this class. */
-export interface ClassUsageRow extends UsageSubject {
+export type ClassUsageRow = UsageSubject & {
   /**
    * The named class's id, as stored in `node.classes`, or the marker id on a
    * marker row.
@@ -83,7 +83,7 @@ export interface ClassUsageRow extends UsageSubject {
    * usable class id and a document can genuinely reference one.
    */
   classId: string;
-}
+};
 
 /**
  * The index collection.

--- a/packages/plugin-page-builder/src/collections/component-usage-index.ts
+++ b/packages/plugin-page-builder/src/collections/component-usage-index.ts
@@ -1,0 +1,148 @@
+/**
+ * Where the record of "which documents embed which component" lives.
+ *
+ * One row per reference: a page embedding three components contributes three
+ * rows. The question the library asks is "which documents use THIS component",
+ * and a row per pair answers it with a lookup rather than a scan over every
+ * stored document — which is what makes "used on N pages" affordable beside
+ * every tile at once, rather than once per delete.
+ *
+ * Everything about the SUBJECT half — why a scope is stored rather than
+ * inferred, why `entityKey` and `locale` are empty strings rather than null,
+ * why the draft and published variants are counted separately — is the shared
+ * `UsageSubject` and is documented there. This file carries only what is this
+ * index's own.
+ *
+ * ## Why a second collection rather than a `kind` column on the class index
+ *
+ * The two record different things about the same documents, and deleting a
+ * class and deleting a component are different jobs with different blast
+ * radii. One table would make a defect in either sweep able to remove the
+ * other's rows. Design section 6.2 names `nx-pb-component-usage` for this
+ * reason, and the machinery is shared instead — which is where sharing
+ * belongs, since it is the RULES that are common and not the records.
+ *
+ * @module collections/component-usage-index
+ */
+import { defineCollection, text } from "nextly/config";
+
+import type { UsageSubject } from "../usage-index";
+
+/** The slug this plugin's component index is stored under. */
+export const COMPONENT_USAGE_INDEX_SLUG = "nx_pb_component_usage";
+
+/**
+ * What a row IS: a reference the document holds, or the record that the
+ * document could not be read whole.
+ *
+ * A COLUMN rather than a sentinel id, and this is the one place the component
+ * index cannot copy the class one. A class marker is disjoint by LENGTH —
+ * `UNDETERMINED_CLASS_ID` exceeds the cap a class id is held to, and length is
+ * the only lever the rule offers. A component id has no such lever: the
+ * validator asks only that it be a nonempty string, so EVERY nonempty string
+ * is a legal reference and the sole value disjoint from all of them is the
+ * empty string — which is exactly what a reader takes for "no reference at
+ * all", making it the worst available way to say "I could not read this".
+ *
+ * Saying what the row is, in its own column, keeps `componentId` free to hold
+ * whatever the document held.
+ */
+export type ComponentUsageKind = "reference" | "unreadable";
+
+/** One row: this document, through this field, embeds this component. */
+export type ComponentUsageRow = UsageSubject & {
+  kind: ComponentUsageKind;
+  /**
+   * The component definition's id, as stored in the instance node's
+   * `props.componentId` — or empty on an `"unreadable"` row, where there is no
+   * reference to name.
+   *
+   * Empty rather than absent for the reason every other column is: the values
+   * form a total key, and a nullable member of a uniqueness constraint
+   * compares as unknown on most dialects. Nothing here relies on the empty
+   * string being distinguishable from a real id, because `kind` is what
+   * distinguishes them.
+   */
+  componentId: string;
+};
+
+/**
+ * The index collection.
+ *
+ * Every column is `text`, as the class index's are and for the same reason:
+ * these are identifiers arriving from stored documents, and none of them is a
+ * number, a date, or a relationship this plugin may assume exists. A
+ * relationship to `pages` in particular would be wrong twice over — the index
+ * spans every collection that mounts a blocks field, and a single has no row
+ * to relate to.
+ */
+export function componentUsageIndexCollection() {
+  return defineCollection({
+    slug: COMPONENT_USAGE_INDEX_SLUG,
+    labels: { singular: "Component usage", plural: "Component usage" },
+    // Bookkeeping the plugin maintains, never authored. `internal` keeps it out
+    // of the admin's navigation and nothing else — measured on the class index,
+    // it sets `admin.hidden` and stops there — so the access rules below are
+    // what keep it out of everything else.
+    internal: true,
+    fields: [
+      text({ name: "scope", label: "Scope" }),
+      text({ name: "entity", label: "Entity" }),
+      // Indexed because every maintenance pass filters on it and it is the most
+      // selective column in that filter: `scope` has two values and `entity`
+      // one per collection, while a document id is unique. A composite index
+      // over the whole subject would be better and cannot be declared — a
+      // collection's `indexes` never reach the schema pipeline, which builds a
+      // table's indexes from its FIELDS.
+      text({ name: "entityKey", label: "Entity key", index: true }),
+      text({ name: "field", label: "Field" }),
+      text({ name: "locale", label: "Locale" }),
+      text({ name: "variant", label: "Variant" }),
+      text({ name: "kind", label: "Kind" }),
+      // Indexed because this is the column the library filters on: the count is
+      // shown beside every component tile, so "which documents use this one" is
+      // asked once per component per render. Declared on the FIELD rather than
+      // as a collection-level index, which is the form the pipeline
+      // materialises.
+      text({ name: "componentId", label: "Component id", index: true }),
+    ],
+    access: {
+      // Derived from documents on every write and rebuilt from them on demand.
+      // Nothing outside this plugin has a reason to author a row, and one
+      // authored by hand would disagree with the document it claims to describe
+      // until a rebuild replaced it.
+      //
+      // Functions returning a constant rather than bare `false`: access rules
+      // are validated as callables, and a boolean is rejected at config time
+      // rather than read as "never". The plugin's own maintenance runs through
+      // the Direct API, which overrides access, so these close the wire API
+      // without closing the path that maintains the rows. A super-admin session
+      // bypasses them entirely; the rebuild is what repairs a table written
+      // that way.
+      create: () => false,
+      update: () => false,
+      delete: () => false,
+      // Read is closed for that reason and one more: the rows enumerate which
+      // documents exist and what they embed, which is a map of the site's
+      // content to anyone who can list them.
+      read: () => false,
+    },
+    // No webhook recording. An omitted option RECORDS — the registry reads
+    // `webhooks?.record !== false` — so a site with an endpoint subscribed to
+    // `entry.*` would receive every row this table writes, and access rules are
+    // not consulted for outbox delivery. Reconciliation writes on every save,
+    // so recording would also put an event on the outbox per changed reference.
+    webhooks: false,
+    admin: {
+      description:
+        "Which documents embed which components. Maintained automatically; editing it cannot change what any page renders.",
+    },
+    // A row is a fact derived from a document, not an event. `createdAt` and
+    // `updatedAt` invite exactly the question they cannot answer — when the
+    // REFERENCE appeared, which is a property of the document's history rather
+    // than of this row's. Declared even though the pipeline injects both
+    // columns regardless, because it is the correct statement for this
+    // collection and a pipeline that learns to read it should apply it here.
+    timestamps: false,
+  });
+}

--- a/packages/plugin-page-builder/src/component-usage.test.ts
+++ b/packages/plugin-page-builder/src/component-usage.test.ts
@@ -1,0 +1,80 @@
+import { DEFAULT_LIMITS } from "@nextlyhq/blocks-engine";
+import { describe, expect, it } from "vitest";
+
+import { componentUsageOf } from "./component-usage";
+
+const COMPONENT_INSTANCE_TYPE = "nextly/component-instance";
+
+const box = (id: string) => ({ id, type: "core/box", version: 1, props: {} });
+const instance = (id: string, componentId: string) => ({
+  id,
+  type: COMPONENT_INSTANCE_TYPE,
+  version: 1,
+  props: { componentId },
+});
+const doc = (nodes: unknown[]) => ({ formatVersion: 1, kind: "page", nodes });
+
+describe("what a stored document says about the components it embeds", () => {
+  it("names each component once, and reports a whole read", () => {
+    const stored = doc([
+      instance("i1", "header"),
+      { ...box("wrap"), slots: { children: [instance("i2", "header")] } },
+      instance("i3", "footer"),
+    ]);
+
+    expect(componentUsageOf(stored, DEFAULT_LIMITS)).toEqual({
+      ids: ["header", "footer"],
+      complete: true,
+    });
+  });
+
+  it("reads a document stored as JSON text", () => {
+    // The column can hold either, and a reader that handled only the object
+    // would answer "references nothing" for every site whose adapter stores
+    // JSON as text — the direction that permits deleting a component in use.
+    const stored = JSON.stringify(doc([instance("i1", "header")]));
+
+    expect(componentUsageOf(stored, DEFAULT_LIMITS)).toEqual({
+      ids: ["header"],
+      complete: true,
+    });
+  });
+
+  it("says it could NOT read a document past the node cap", () => {
+    // Both halves asserted together: `ids: []` on its own is also what a
+    // document holding no instances answers, and separating those two is the
+    // entire reason this returns a pair.
+    const stored = doc([
+      ...Array.from({ length: DEFAULT_LIMITS.maxNodes + 10 }, (_, i) =>
+        box(`n${i}`)
+      ),
+      instance("i1", "header"),
+    ]);
+
+    expect(componentUsageOf(stored, DEFAULT_LIMITS)).toEqual({
+      ids: [],
+      complete: false,
+    });
+  });
+
+  it("treats a value that is not a document as referencing nothing, READABLY", () => {
+    // `complete: true`, deliberately. Reporting these as unreadable would put a
+    // marker row against a subject whose document is simply absent, and no
+    // rebuild could ever clear it — the row would count towards its components
+    // for ever.
+    for (const stored of [
+      undefined,
+      null,
+      42,
+      "not json at all",
+      {},
+      { nodes: "not an array" },
+      doc([]),
+    ]) {
+      expect({
+        stored,
+        usage: componentUsageOf(stored, DEFAULT_LIMITS),
+      }).toEqual({ stored, usage: { ids: [], complete: true } });
+    }
+  });
+});

--- a/packages/plugin-page-builder/src/component-usage.test.ts
+++ b/packages/plugin-page-builder/src/component-usage.test.ts
@@ -1,7 +1,8 @@
 import { DEFAULT_LIMITS } from "@nextlyhq/blocks-engine";
 import { describe, expect, it } from "vitest";
 
-import { componentUsageOf } from "./component-usage";
+import { reconcileUsage } from "./class-usage-reconcile";
+import { componentUsageIndex, componentUsageOf } from "./component-usage";
 
 const COMPONENT_INSTANCE_TYPE = "nextly/component-instance";
 
@@ -76,5 +77,64 @@ describe("what a stored document says about the components it embeds", () => {
         usage: componentUsageOf(stored, DEFAULT_LIMITS),
       }).toEqual({ stored, usage: { ids: [], complete: true } });
     }
+  });
+});
+
+describe("a stored row that contradicts itself", () => {
+  const subject = {
+    scope: "collection" as const,
+    entity: "pages",
+    entityKey: "p1",
+    field: "content",
+    locale: "",
+    variant: "published" as const,
+  };
+
+  it("does not let a malformed marker suppress the real reference", () => {
+    // A row can say it could not read the page AND name a component — after a
+    // restore, a hand edit, or a super-admin write. Keyed on the component id
+    // alone, that row and a genuine reference to the same component look like
+    // ONE record: the malformed one is kept, the real one is never inserted,
+    // and no later save can tell them apart to repair it.
+    //
+    // With the kind in the key it is simply a row no derivation claims, so the
+    // next save removes it and inserts the reference.
+    const malformed = {
+      ...subject,
+      kind: "unreadable" as const,
+      componentId: "header",
+      id: "row-1",
+    };
+    const derived = [componentUsageIndex.rowFor(subject, "header")];
+
+    const { insert, remove } = reconcileUsage(
+      componentUsageIndex,
+      subject,
+      derived,
+      [malformed]
+    );
+
+    expect({
+      inserted: insert.map(r => `${r.kind}:${r.componentId}`),
+      removed: remove,
+    }).toEqual({ inserted: ["reference:header"], removed: ["row-1"] });
+  });
+
+  it("keeps a well-formed marker while the page still cannot be read", () => {
+    // The control. Without it, a key that simply never matched anything would
+    // satisfy the case above by removing every stored row and re-inserting.
+    const marker = { ...componentUsageIndex.markerFor(subject), id: "row-1" };
+
+    const { insert, remove } = reconcileUsage(
+      componentUsageIndex,
+      subject,
+      [componentUsageIndex.markerFor(subject)],
+      [marker]
+    );
+
+    expect({ inserted: insert.length, removed: remove }).toEqual({
+      inserted: 0,
+      removed: [],
+    });
   });
 });

--- a/packages/plugin-page-builder/src/component-usage.ts
+++ b/packages/plugin-page-builder/src/component-usage.ts
@@ -95,7 +95,18 @@ export const componentUsageIndex: UsageIndex<ComponentUsageRow> = {
     if (typeof componentId !== "string") return null;
     return { kind, componentId };
   },
-  referenceOf: row => row.componentId,
+  // The KIND is part of the key, not only the id. A stored row can contradict
+  // itself — `kind: "unreadable"` beside a real component id, after a restore
+  // or a hand edit — and keying on the id alone makes that row and the genuine
+  // reference to the same component look like one record: the malformed one is
+  // kept, the real one is never inserted, and reconciliation cannot tell them
+  // apart to repair it. With the kind in the key the contradiction is simply a
+  // row no derivation claims, so the next save removes it.
+  //
+  // Rejecting it in `readOwn` instead was the other option and is worse: a row
+  // the parser skips is not reconciled either, so the contradiction would
+  // survive every save rather than being cleared by the next one.
+  reconcileKeyOf: row => `${row.kind}:${row.componentId}`,
   rowFor: (subject, referenceId) => ({
     ...subject,
     kind: "reference",

--- a/packages/plugin-page-builder/src/component-usage.ts
+++ b/packages/plugin-page-builder/src/component-usage.ts
@@ -1,0 +1,113 @@
+/**
+ * What a stored document says about the components it embeds.
+ *
+ * The component half of what `class-usage.ts` answers for named classes, and
+ * deliberately the same two-valued shape: an empty list and an unreadable
+ * document are different answers, and the whole point of the record is to
+ * decide whether a component may be DELETED. A delete check reads absence as
+ * evidence, so an absence produced by a BOUND rather than by the document has
+ * to be visible, or it is indistinguishable from "not used".
+ *
+ * ## Which walk, and why it is not this module's own
+ *
+ * `componentUsageIn` is the resolver's, published from the engine. The question
+ * is which components this page RESOLVES, and a reader that stopped anywhere
+ * else would answer about a different document than the one being served —
+ * which is the mistake `research:pb6-t4c3-reachability` records: discovery must
+ * ask the resolver what it reaches rather than predict it.
+ *
+ * That matters more here than the same rule does for classes, because the two
+ * engine walks genuinely differ. The class reader selects level-order through
+ * `selectNodes`; the resolver walks depth-first. At one and the same cap they
+ * reach different nodes — measured, a first root larger than the cap hides an
+ * instance on a later sibling from the depth-first walk while the level-order
+ * one sees it immediately. Only one of those answers describes the page.
+ *
+ * @module component-usage
+ */
+import { componentUsageIn } from "@nextlyhq/blocks-engine";
+import type { DocumentLimits } from "@nextlyhq/blocks-engine";
+
+import type { ComponentUsageRow } from "./collections/component-usage-index";
+import { readStoredJson } from "./stored-json";
+import type { UsageDerivation, UsageIndex } from "./usage-index";
+
+/**
+ * The components a stored document references, and whether it could all be read.
+ *
+ * Total by construction. This reads persisted data that nothing is guaranteed
+ * to have validated — the blocks field admits any value whose `nodes` is an
+ * array, so a malformed tree reaches storage intact — and a shape it cannot
+ * read contributes nothing rather than raising.
+ *
+ * `limits` is REQUIRED, unlike its class-side sibling's optional one. There the
+ * omission is neutral because the engine's own default is the same answer; here
+ * the caller is the index, which must derive under the bounds the page is drawn
+ * with or record a document the renderer never sees.
+ */
+export function componentUsageOf(
+  stored: unknown,
+  limits: DocumentLimits
+): UsageDerivation {
+  const document = readStoredJson(stored);
+  if (!isRecordWithNodes(document)) return { ids: [], complete: true };
+  return componentUsageIn(document.nodes, limits.maxNodes);
+}
+
+/**
+ * Whether a stored value carries a forest this can walk at all.
+ *
+ * Both halves matter and neither is redundant. A non-record is not a document;
+ * a record whose `nodes` is not an array is one the engine's own walk answers
+ * nothing for, and letting it through would spend the walk to learn that.
+ *
+ * Answering `{ ids: [], complete: true }` for both is deliberate rather than an
+ * oversight: a value that is not a document references nothing, and saying it
+ * could not be READ would put a marker row against a subject whose document is
+ * simply absent — which no rebuild could ever clear.
+ */
+function isRecordWithNodes(value: unknown): value is { nodes: unknown[] } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    Array.isArray((value as { nodes?: unknown }).nodes)
+  );
+}
+
+/**
+ * The component index, as the shared machinery sees it.
+ *
+ * One place builds a row and chooses the marker, because the two have to agree
+ * about what a marker IS — and here they agree through the `kind` column
+ * rather than through a value no reference can wear, which is what the class
+ * index has to do and what a component id cannot support.
+ */
+export const componentUsageIndex: UsageIndex<ComponentUsageRow> = {
+  readOwn: item => {
+    // Validated against the closed set rather than accepted as any string, for
+    // the reason `scope` and `variant` are: `kind` partitions the rows into
+    // families, and a value outside the set belongs to a family no real query
+    // names — neither reconciled nor swept, and counting towards its component
+    // for ever. A typo does not fail here, it accumulates.
+    const kind = item.kind;
+    if (kind !== "reference" && kind !== "unreadable") return null;
+    const componentId = item.componentId;
+    if (typeof componentId !== "string") return null;
+    return { kind, componentId };
+  },
+  referenceOf: row => row.componentId,
+  rowFor: (subject, referenceId) => ({
+    ...subject,
+    kind: "reference",
+    componentId: referenceId,
+  }),
+  markerFor: subject => ({
+    ...subject,
+    kind: "unreadable",
+    // Nothing reads this on a marker row — `kind` is what says the row is one —
+    // and it is empty rather than absent because the columns form a total key.
+    componentId: "",
+  }),
+  isMarker: row => row.kind === "unreadable",
+  derive: (document, limits) => componentUsageOf(document, limits),
+};

--- a/packages/plugin-page-builder/src/index.ts
+++ b/packages/plugin-page-builder/src/index.ts
@@ -107,9 +107,17 @@ export type { SiteStyleReader } from "./site-style-storage";
 // second.
 export { classUsageOf } from "./class-usage";
 export type { ClassUsage } from "./class-usage";
+// `rebuildPageBuilderUsageIndexes` rather than the general
+// `rebuildUsageIndexes` behind it. The general one takes the list of indexes to
+// repair, and that list is not a caller's to write: it names package-internal
+// descriptors, and a host that could write it could only ever name the indexes
+// that existed when its code was written — so an index added later would go
+// unrepaired on every upgraded site, which is the undercount this whole export
+// exists to prevent. The preconfigured entry point takes the STORES and knows
+// the set itself.
 export {
   rebuildClassUsageIndex,
-  rebuildUsageIndexes,
+  rebuildPageBuilderUsageIndexes,
   type ClassUsageDocumentStore,
   type ClassUsageRebuildReport,
 } from "./class-usage-index-rebuild";

--- a/packages/plugin-page-builder/src/index.ts
+++ b/packages/plugin-page-builder/src/index.ts
@@ -109,6 +109,7 @@ export { classUsageOf } from "./class-usage";
 export type { ClassUsage } from "./class-usage";
 export {
   rebuildClassUsageIndex,
+  rebuildUsageIndexes,
   type ClassUsageDocumentStore,
   type ClassUsageRebuildReport,
 } from "./class-usage-index-rebuild";

--- a/packages/plugin-page-builder/src/plugin-class-usage-wiring.test.ts
+++ b/packages/plugin-page-builder/src/plugin-class-usage-wiring.test.ts
@@ -13,6 +13,9 @@
  */
 import { describe, expect, it, vi } from "vitest";
 
+import { CLASS_USAGE_INDEX_SLUG } from "./collections/class-usage-index";
+import { COMPONENT_USAGE_INDEX_SLUG } from "./collections/component-usage-index";
+
 import { UNDETERMINED_CLASS_ID } from "./class-usage-reconcile";
 import { pageBuilder } from "./plugin";
 
@@ -114,7 +117,7 @@ describe("an integrator who renamed the index collection", () => {
   });
 });
 
-describe("the document limits maintenance derives under", () => {
+describe("what one save derives, and writes to each index", () => {
   /** A document with two nodes, each applying one class. */
   const twoNodes = {
     formatVersion: 1,
@@ -126,9 +129,13 @@ describe("the document limits maintenance derives under", () => {
   };
 
   /** Drive one save through the plugin's own wiring and collect index writes. */
-  async function savedUnder(options: Parameters<typeof pageBuilder>[0]) {
+  async function savedUnder(
+    options: Parameters<typeof pageBuilder>[0],
+    document: unknown = twoNodes
+  ) {
     const { ctx, handlers } = initContext();
     const created: string[] = [];
+    const componentRows: { kind?: string; componentId?: string }[] = [];
     ctx.services.collections.getCollection = (async () => ({
       fields: [{ type: "blocks", name: "content" }],
     })) as never;
@@ -144,23 +151,40 @@ describe("the document limits maintenance derives under", () => {
           // reader currently uses: the document read moves from `findByID` to
           // `find` with a lifecycle filter in a parallel change, and this
           // assertion is about LIMITS either way.
-          findByID: async () => ({ id: "p1", content: twoNodes }),
+          findByID: async () => ({ id: "p1", content: document }),
           find: async (a: { collection: string }) =>
             a.collection === "pages"
               ? {
-                  items: [{ id: "p1", content: twoNodes }],
+                  items: [{ id: "p1", content: document }],
                   meta: { hasNext: false },
                 }
               : { items: [], meta: { hasNext: false } },
-          create: async (a: { data: { classId: string } }) => {
-            created.push(a.data.classId);
+          // Scoped to the CLASS index. One save now maintains both indexes
+          // from one read, so an unscoped collector also catches the component
+          // index's row — whose `classId` is `undefined`, which reads as this
+          // wiring having produced a second, malformed class row. This test is
+          // about the limits the CLASS derivation runs under; the component
+          // index has its own.
+          create: async (a: {
+            collection: string;
+            data: { classId?: string };
+          }) => {
+            if (a.collection === CLASS_USAGE_INDEX_SLUG) {
+              created.push(a.data.classId as string);
+            }
+            if (a.collection === COMPONENT_USAGE_INDEX_SLUG) {
+              componentRows.push({
+                kind: (a.data as { kind?: string }).kind,
+                componentId: (a.data as { componentId?: string }).componentId,
+              });
+            }
             return {};
           },
           delete: async () => ({}),
         },
       },
     });
-    return created;
+    return { created, componentRows };
   }
 
   it("uses the limits the HOST configured, not the engine defaults", async () => {
@@ -172,7 +196,7 @@ describe("the document limits maintenance derives under", () => {
     //
     // Observed through the undetermined marker, which is what a document that
     // could not be read whole contributes.
-    const created = await savedUnder({
+    const { created } = await savedUnder({
       limits: { maxDepth: 1, maxNodes: 1, maxBytes: 100_000 },
     });
 
@@ -182,8 +206,55 @@ describe("the document limits maintenance derives under", () => {
   it("records the real classes when the host configures nothing", async () => {
     // The control: without it, a wiring that always produced the marker would
     // satisfy the case above.
-    const created = await savedUnder({});
+    const { created } = await savedUnder({});
 
     expect(created).toEqual(["one", "two"]);
+  });
+
+  describe("the component index, maintained from the same read", () => {
+    const withInstance = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        { id: "a", type: "core/text", version: 1, props: {}, classes: ["one"] },
+        {
+          id: "i1",
+          type: "nextly/component-instance",
+          version: 1,
+          props: { componentId: "header" },
+        },
+      ],
+    };
+
+    it("writes a row for a component the saved page embeds", async () => {
+      // The feature's own evidence. The class assertions above pass whether or
+      // not a second index exists, so without this the wiring could maintain
+      // nothing and every other test in the file would stay green.
+      const { componentRows } = await savedUnder({}, withInstance);
+
+      expect(componentRows).toEqual([
+        { kind: "reference", componentId: "header" },
+      ]);
+    });
+
+    it("writes NO component row for a page that embeds none", async () => {
+      // The control. Without it, a wiring that wrote a row unconditionally —
+      // recording a reference no document holds — would satisfy the case above.
+      const { componentRows } = await savedUnder({});
+
+      expect(componentRows).toEqual([]);
+    });
+
+    it("marks a page it could not read whole, rather than calling it empty", async () => {
+      // A cap of one node stops the walk before the instance. The row that
+      // records THAT is what stops "could not read" being stored as "references
+      // nothing" — the answer that would let the component be deleted.
+      const { componentRows } = await savedUnder(
+        { limits: { maxDepth: 1, maxNodes: 1, maxBytes: 100_000 } },
+        withInstance
+      );
+
+      expect(componentRows).toEqual([{ kind: "unreadable", componentId: "" }]);
+    });
   });
 });

--- a/packages/plugin-page-builder/src/plugin.ts
+++ b/packages/plugin-page-builder/src/plugin.ts
@@ -31,6 +31,10 @@ import {
   classUsageIndexCollection,
 } from "./collections/class-usage-index";
 import {
+  COMPONENT_USAGE_INDEX_SLUG,
+  componentUsageIndexCollection,
+} from "./collections/component-usage-index";
+import {
   COMPONENTS_SLUG,
   componentsCollection,
 } from "./collections/components";
@@ -459,6 +463,13 @@ export const pageBuilder = (opts: PageBuilderOptions = {}) => {
         indexCollection:
           ctx.self.collections[CLASS_USAGE_INDEX_SLUG] ??
           CLASS_USAGE_INDEX_SLUG,
+        // Resolved the same way and for the same reason: an integrator may
+        // rename it, and a hook holding the declared name would write every row
+        // to a collection that does not exist and fail to recognise its own
+        // writes, so the wildcard would re-enter itself.
+        componentIndexCollection:
+          ctx.self.collections[COMPONENT_USAGE_INDEX_SLUG] ??
+          COMPONENT_USAGE_INDEX_SLUG,
         // The registry record, projected. `getCollection` is declared to
         // return a shape that promises none of the properties this question
         // reads, while returning an object that carries all of them.
@@ -503,6 +514,7 @@ export const pageBuilder = (opts: PageBuilderOptions = {}) => {
         componentsCollection(),
         layoutsCollection(),
         classUsageIndexCollection(),
+        componentUsageIndexCollection(),
       ],
       // The Site Style global: one versioned, access-controlled document the
       // stored style tier lives in. Registered whether or not the host stated

--- a/packages/plugin-page-builder/src/usage-index.ts
+++ b/packages/plugin-page-builder/src/usage-index.ts
@@ -160,8 +160,19 @@ export interface UsageIndex<TRow extends UsageSubject> {
    */
   readOwn(item: Record<string, unknown>): Omit<TRow, keyof UsageSubject> | null;
 
-  /** The reference a row records. */
-  referenceOf(row: TRow): string;
+  /**
+   * The key a row is reconciled by: two rows sharing one are the same record.
+   *
+   * NOT simply "the reference id", though for an index whose rows carry
+   * nothing else it is exactly that. Reconciliation matches derived rows
+   * against stored ones through this and removes what no derived row claims,
+   * so anything that distinguishes two rows an index must keep apart has to be
+   * IN it. An index whose rows carry a second column that changes their meaning
+   * — a marker flag, say — includes it, or a stored row contradicting itself
+   * suppresses the real one and no reconciliation can repair it, because the
+   * two look like the same record.
+   */
+  reconcileKeyOf(row: TRow): string;
 
   /** A row recording that `subject` references `referenceId`. */
   rowFor(subject: UsageSubject, referenceId: string): TRow;

--- a/packages/plugin-page-builder/src/usage-index.ts
+++ b/packages/plugin-page-builder/src/usage-index.ts
@@ -64,7 +64,7 @@ export type UsageVariant = "published" | "draft";
  * enforces that key today — a collection's declared indexes do not reach the
  * schema pipeline — so the reconciler is what keeps rows unique instead.
  */
-export interface UsageSubject {
+export type UsageSubject = {
   scope: UsageScope;
   /** The collection's or single's slug. */
   entity: string;
@@ -118,7 +118,7 @@ export interface UsageSubject {
    * draft applies breaks that draft the moment somebody publishes it.
    */
   variant: UsageVariant;
-}
+};
 
 /** What a document references, and whether the whole of it could be read. */
 export interface UsageDerivation {
@@ -144,13 +144,21 @@ export interface UsageDerivation {
  */
 export interface UsageIndex<TRow extends UsageSubject> {
   /**
-   * The stored column the reference id lives in.
+   * A stored row's OWN columns, read from unvalidated data, or `null` when any
+   * of them cannot be read as what it must be.
    *
-   * A string because the row PARSER validates columns by name against data
-   * that arrives unvalidated. Everywhere a row is built or read as a value,
-   * the typed members below are used instead.
+   * The shared parser reads the six subject columns and the row id, which every
+   * index has; this reads what only this index has. Returning `null` SKIPS the
+   * row rather than counting or deleting it: persisted data arrives
+   * unvalidated, one unreadable row must not stop a subject being reconciled,
+   * and nothing here knows enough about it to remove it.
+   *
+   * This replaced a `referenceColumn: string` written a slice earlier, which
+   * named the column and was never read by anything — the parser needs more
+   * than a name, because an index may carry a closed set beside its reference
+   * and a bare column list cannot validate one.
    */
-  readonly referenceColumn: string;
+  readOwn(item: Record<string, unknown>): Omit<TRow, keyof UsageSubject> | null;
 
   /** The reference a row records. */
   referenceOf(row: TRow): string;


### PR DESCRIPTION
Plan 06 **T-5**, the index that makes a component's deletion answerable: which
pages still embed it. Nothing surfaces it yet — that is the next slice — but it
is maintained from this point on.

## One read, two indexes

Maintained by the pass that already keeps the class usage index, so a save reads
each document **once** and both indexes derive from that read. A second wildcard
registration would re-read the collection's configuration, re-resolve its draft
split and re-read every locale and variant on every save — the write
amplification the design names in as many words.

## The marker is a column, and that is forced rather than preferred

A document too large to read whole must record **that**, not nothing: "embeds no
components" is the answer that makes deleting one look safe.

The class index makes its marker disjoint by **length** — its sentinel exceeds
the cap a class id is held to. A component id has no such lever: the validator
asks only that it be a nonempty string, so **every** nonempty string is a legal
reference and the only value disjoint from all of them is the empty string —
which is precisely what a reader takes for "no reference at all".

So a `kind` column says what the row **is**, leaving `componentId` free to hold
whatever the document held. The class index keeps its own arrangement: it works,
a test pins it against the engine's length rule, and rewriting a live index's
sentinel as a side effect of adding a second one is not a thing to do.

## What slice 2a got wrong, corrected here

`UsageIndex.referenceColumn` was **declared, set, and never read** — surface
added in anticipation. Building the real second index showed what the parser
actually needs: it validates columns against unvalidated data, and a bare column
*name* cannot validate a closed set, which the component row carries beside its
reference. It is replaced by `readOwn`, which reads and validates whatever is
that index's own. The subject columns and the row id stay in the shared parser,
because every index has them.

The row types became type **aliases** rather than interfaces so a row can be
handed to a store that takes data — TypeScript gives an alias an implicit index
signature and an interface none. That **removed** a cast rather than adding one.

## Break-verification

| break | fails |
|---|---|
| drop the component target from the hook | `writes a row for a component the saved page embeds` **and** `marks a page it could not read whole` |

The third new wiring test — *no* component row for a page that embeds none —
passes either way **by design**, and says so in the file. It is the control that
stops the other two reading as "this wiring writes a row unconditionally".

The derivation has its own three breaks, each killing a different test: not
decoding stored JSON text, always claiming a complete read, and reporting an
absent document as unreadable.

## The one existing test I edited, and why it is not widening an expectation

`plugin-class-usage-wiring.test.ts` collected **every** create regardless of
collection, so it caught the component row too and saw two writes where it
expected one. It is now scoped to the class index — which is what that test is
about — rather than having its count widened to accommodate a row it was never
measuring.

Every other class test passes untouched.

## Gates

| gate | result |
|---|---|
| `pnpm build` | exit 0 |
| `plugin-page-builder` `check-types` | exit 0 (both `tsc` invocations) |
| `plugin-page-builder` `lint` | exit 0 |
| `plugin-page-builder` tests | 70 files, **775 tests**, exit 0 |
| `fallow audit --base origin/main` | `pass`, `changed_files_count: 12`, introduced 0 across all four categories |
| `pnpm changeset status` | parses; 25 packages |

## Next

The read API — "used on N pages" as `COUNT(DISTINCT documentId)` — then the
rebuild, then delete-as-a-job, which closes the unimplemented class-usage
delete-as-job at the same time per design §9.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added component usage tracking alongside existing class usage tracking.
  - Component references are identified from nested page content, including unreadable or malformed documents.
  - Added safeguards for document size limits and duplicate component references.
  - Added support for rebuilding class and component usage data together.
- **Bug Fixes**
  - Usage maintenance now updates both indexes consistently when documents are created, changed, or deleted.
- **Tests**
  - Added coverage for embedded components, empty pages, unreadable documents, nested content, and node-count limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->