### PR TITLE
fix(blocks-react): derive the emitted id from the one rule, and stop emitting an empty one

### DIFF
--- a/.changeset/an-empty-id-is-not-an-id.md
+++ b/.changeset/an-empty-id-is-not-an-id.md
@@ -1,0 +1,33 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The block renderer now asks the engine which HTML `id` a block emits instead of deciding again. `renderedDomId` was already the one rule for that question — validation, the planners, the copier, the resolver, the tree walker and the builder all derive from it — and the renderer, the thing that rule models, was the last place keeping its own copy.
+
+One rendered-output change comes with it: a block whose id is set to an EMPTY STRING no longer emits `id=""`. It emits no `id` attribute at all. Nothing addressable is lost — the DOM Standard unsets an element's ID when the attribute is the empty string, so `getElementById("")` never matched it and no `aria-labelledby`, `for` or `#` selector could reach it, while the HTML Standard requires an id to hold at least one character. What shipped before was invalid markup that addressed nothing.
+
+An empty id still SHADOWS an `id` in the block's attributes, which is the part authors can observe, and the inspector still offers to remove it. Its note now says the block renders no id at all and that the attribute id is ignored, rather than describing the `id=""` that no longer appears.

--- a/packages/blocks-engine/src/document.test.ts
+++ b/packages/blocks-engine/src/document.test.ts
@@ -235,8 +235,8 @@ describe("renderedDomId: which of a node's two spellings reaches the page", () =
   });
 
   it("treats an EMPTY string cssId as shadowing, emitting nothing reachable", () => {
-    // The renderer sets `id=""`, which no anchor, label or selector reaches —
-    // and the bag's value is overwritten, so it does not render either.
+    // Nothing reachable is emitted: an empty id addresses nothing, and the
+    // bag is shadowed, so its value does not render either.
     expect(
       renderedDomId(bare({ cssId: "", attributes: { id: "hero" } }))
     ).toBeUndefined();
@@ -260,8 +260,8 @@ describe("renderedDomId: which of a node's two spellings reaches the page", () =
   });
 
   it("lets a trailing EMPTY case variant overwrite an earlier one", () => {
-    // The renderer lowercases each key and assigns in turn, so
-    // `{ id: "hero", ID: "" }` leaves the element with `id=""`. Skipping the
+    // Attribute names are case-insensitive and the last variant decides, so
+    // `{ id: "hero", ID: "" }` leaves an empty id, which is no id. Skipping the
     // empty one keeps `hero` and reports an id that does not render — which
     // then makes a copy rename itself away from an id nothing owns.
     expect(

--- a/packages/blocks-engine/src/document.ts
+++ b/packages/blocks-engine/src/document.ts
@@ -1024,12 +1024,13 @@ export type ExposedPropertyType = (typeof EXPOSED_PROPERTY_TYPES)[number];
  * the bag first, lowercasing every key, and then overwrites with the modelled
  * field, so this mirrors that order exactly.
  *
- * Only a STRING `cssId` shadows, the empty string included. The renderer reads
- * it as `typeof node.cssId === "string" ? node.cssId : undefined` and
- * overwrites only when that is not `undefined` — so `cssId: ""` shadows and
- * emits `id=""`, while `cssId: null` is normalised away and the bag renders.
+ * Only a STRING `cssId` shadows, the empty string included — so `cssId: ""`
+ * stops the bag and emits nothing, while `cssId: null` is normalised away and
+ * the bag renders.
  *
- * An empty id is not an id: it takes nothing and only stops the bag.
+ * An empty id is not an id: it takes nothing and only stops the bag. The
+ * renderer ASKS this rather than deciding again, so the two cannot disagree
+ * about which spelling wins or about what an empty one means.
  *
  * Published because reading the two fields independently is wrong in both
  * directions, and every one of those readings was live somewhere:
@@ -1053,10 +1054,11 @@ export function renderedDomId(node: {
 /**
  * The `id` an attribute bag alone would render, if any.
  *
- * The LAST case variant wins, whatever it holds, empty included. The renderer
- * lowercases each key and assigns in turn, so a bag of `{ id: "hero", ID: "" }`
- * leaves the element with `id=""` — and skipping the empty one here keeps
- * `hero` and reports an id that does not render.
+ * The LAST case variant wins, whatever it holds, empty included. HTML attribute
+ * names are ASCII case-insensitive, so a bag of `{ id: "hero", ID: "" }` spells
+ * one attribute twice and the later one decides it — leaving an empty id, which
+ * {@link renderedDomId} then reports as no id. Skipping the empty one here
+ * would keep `hero` and name an id nothing renders.
  *
  * Separate from {@link renderedDomId} because the narrower question is a real
  * one: a surface asking whether an empty bag id would SHADOW something has to

--- a/packages/blocks-engine/src/insert-pattern.test.ts
+++ b/packages/blocks-engine/src/insert-pattern.test.ts
@@ -686,9 +686,9 @@ describe("which DOM ids an insert steers around", () => {
   });
 
   it("treats an EMPTY cssId as shadowing the bag, because the renderer does", () => {
-    // The renderer's guard is `cssId !== undefined`, not "non-empty" — so a
-    // node carrying `cssId: ""` beside `attributes.id: "hero"` emits `id=""`
-    // and never `hero`. The destination therefore does not hold `hero`, and
+    // The rule reads `cssId` as "wins when present", not "wins when non-empty"
+    // — so a node carrying `cssId: ""` beside `attributes.id: "hero"` renders
+    // no id and never `hero`. The destination therefore does not hold `hero`, and
     // steering around it would rename authored content for nothing.
     //
     // This case is the whole difference between reading `cssId` as "wins when

--- a/packages/blocks-react/src/block-boundary.tsx
+++ b/packages/blocks-react/src/block-boundary.tsx
@@ -1,6 +1,7 @@
 import {
   blockPartClassName,
   blockTypeClassName,
+  renderedDomId,
   type BlockNode,
   type ComponentUnresolvedReason,
   type ResolvedBlockNode,
@@ -363,12 +364,38 @@ function withNodeAttributes(
        * property inline editing commits into.
        */
       if (nodeAttribute && key.startsWith(EDITOR_NAMESPACE)) continue;
+      /*
+       * `id` is deliberately NOT assigned here. Which of a node's two spellings
+       * reaches the page is one question, and the engine's `renderedDomId` is
+       * the one answer to it — six other surfaces already derive from it, and
+       * this renderer is the thing that answer models. Assigning the bag's `id`
+       * in this loop and correcting it afterwards would restate the rule, which
+       * is how the rule and the page come to disagree.
+       */
+      if (key === "id") continue;
       extra[key] = value;
     }
   }
-  // The modelled field wins over an attribute of the same name: `cssId` is what
-  // the editor writes, and the attribute bag is the escape hatch beside it.
-  if (cssId !== undefined) extra.id = cssId;
+  /*
+   * The single id this node emits, ASKED rather than restated.
+   *
+   * The rule already carries everything this loop used to do by hand: the
+   * modelled field wins over an attribute of the same name, only a STRING
+   * `cssId` shadows, the bag is read case-insensitively with the last variant
+   * winning, and an empty result is no id at all.
+   *
+   * That last clause is the one behaviour change. A node with `cssId: ""` used
+   * to emit a literal `id=""`, because this loop tested `!== undefined` and the
+   * empty string passes. It no longer does, and nothing reachable is lost: the
+   * DOM Standard unsets an element's ID when the attribute is set to the empty
+   * string, so `getElementById("")` never matched it, no IDREF could name it,
+   * and `#` is not a valid selector. The HTML Standard separately requires an
+   * id to hold at least one character, so what shipped was invalid markup that
+   * addressed nothing. The empty `cssId` still SHADOWS the bag, which is the
+   * part authors can observe, and the inspector still offers to remove it.
+   */
+  const renderedId = renderedDomId(node);
+  if (renderedId !== undefined) extra.id = renderedId;
   applyEditorMarkers(extra, node, nodeAttribute, declaresSlots);
 
   return Object.keys(extra).length > 0 ? cloneElement(output, extra) : output;

--- a/packages/blocks-react/src/page-renderer.test.tsx
+++ b/packages/blocks-react/src/page-renderer.test.tsx
@@ -1007,6 +1007,93 @@ describe("PageRenderer", () => {
       expect(html).toMatch(bothClasses("test/text"));
     });
 
+    it("emits no id at all for an empty cssId, rather than an empty one", async () => {
+      const html = await renderToHtml(
+        <PageRenderer
+          document={doc(
+            node("a", "test/text", {
+              props: { value: "anchored" },
+              cssId: "",
+            })
+          )}
+          blocks={createBlockResolver([text as AnyBlockDefinition])}
+        />
+      );
+
+      // An empty id addresses nothing: the DOM Standard unsets an element's ID
+      // when the attribute is the empty string, and the HTML Standard requires
+      // at least one character. Emitting it put invalid markup on the page that
+      // no anchor, label or selector could reach.
+      expect(html).not.toContain('id=""');
+      // The element still rendered — without this the assertion above passes on
+      // a page that drew nothing at all.
+      expect(html).toContain("anchored");
+    });
+
+    it("lets an empty cssId shadow the bag rather than promoting the bag's id", async () => {
+      const html = await renderToHtml(
+        <PageRenderer
+          document={doc(
+            node("a", "test/text", {
+              props: { value: "anchored" },
+              cssId: "",
+              attributes: { id: "hero", title: "A section" },
+            })
+          )}
+          blocks={createBlockResolver([text as AnyBlockDefinition])}
+        />
+      );
+
+      // The separating property. Dropping the empty id is right; letting the
+      // shadowed bag id take its place is a DIFFERENT change, and it is the one
+      // a naive rewrite makes — the bag is assigned first, so removing only the
+      // overwrite leaves `hero` on an element the author gave no id.
+      expect(html).not.toContain('id="hero"');
+      expect(html).not.toContain('id=""');
+      // The rest of the bag is untouched by the id rule.
+      expect(html).toContain('title="A section"');
+    });
+
+    it("reads the attribute bag case-insensitively, last variant winning", async () => {
+      const html = await renderToHtml(
+        <PageRenderer
+          document={doc(
+            node("a", "test/text", {
+              props: { value: "anchored" },
+              attributes: { id: "hero", ID: "" },
+            })
+          )}
+          blocks={createBlockResolver([text as AnyBlockDefinition])}
+        />
+      );
+
+      // HTML attribute names are ASCII case-insensitive, so these are one
+      // attribute written twice and the later wins — leaving an empty id, which
+      // is no id. Reporting `hero` here would name something nothing renders.
+      expect(html).not.toContain('id="hero"');
+      expect(html).not.toContain('id=""');
+      expect(html).toContain("anchored");
+    });
+
+    it("renders the bag's id when a non-string cssId is normalised away", async () => {
+      const html = await renderToHtml(
+        <PageRenderer
+          document={doc(
+            node("a", "test/text", {
+              props: { value: "anchored" },
+              // A stored document can hold anything. Only a STRING shadows, so
+              // this one does not, and the bag is what reaches the page.
+              cssId: null as unknown as string,
+              attributes: { id: "hero" },
+            })
+          )}
+          blocks={createBlockResolver([text as AnyBlockDefinition])}
+        />
+      );
+
+      expect(html).toContain('id="hero"');
+    });
+
     it("never lets a stored attribute reinterpret the element", async () => {
       const html = await renderToHtml(
         <PageRenderer

--- a/packages/builder/src/advanced-panel.tsx
+++ b/packages/builder/src/advanced-panel.tsx
@@ -66,9 +66,9 @@ export interface AdvancedPanelProps {
   /**
    * The element's `id`, or `undefined` when the node carries no such field.
    *
-   * The two are different states and the renderer reads them differently: a
-   * stored `""` is PRESENT, renders `id=""`, and shadows any `id` in the bag
-   * below. The panel has to be able to say which one it is looking at, or the
+   * The two are different states and the rule reads them differently: a stored
+   * `""` is PRESENT, shadows any `id` in the bag below, and renders no id of
+   * its own. The panel has to be able to say which one it is looking at, or the
    * empty-but-present one can never be removed.
    */
   readonly cssId: string | undefined;
@@ -448,10 +448,11 @@ export function AdvancedPanel({
         {/*
           The EMPTY-BUT-PRESENT id, which the box above cannot express.
 
-          A field holding `""` renders `id=""` and shadows any `id` in the bag
-          below, and no amount of typing in an already-empty box says "remove
-          it" — the draft matches what was loaded, so a commit correctly finds
-          nothing to do. This is the gesture that was missing.
+          A field holding `""` shadows any `id` in the bag below and renders
+          none of its own, so the element ends up with no id — and no amount of
+          typing in an already-empty box says "remove it", because the draft
+          matches what was loaded and a commit correctly finds nothing to do.
+          This is the gesture that was missing.
 
           Shown only in that state. Cleaning it up on open would be a write
           nobody asked for, and folding it into an unrelated save would change
@@ -461,10 +462,9 @@ export function AdvancedPanel({
         */}
         {cssId !== "" ? null : (
           <p className="nx-inspector__note" role="status">
-            This block has an empty id set, which renders as{" "}
-            <code>id=&quot;&quot;</code>
+            This block has an empty id set, so it renders no id at all
             {emptyIdShadows
-              ? " and hides the id set in the attributes below"
+              ? " and the id in the attributes below is ignored"
               : ""}
             .{" "}
             <Button

--- a/packages/builder/src/custom-attributes.test.ts
+++ b/packages/builder/src/custom-attributes.test.ts
@@ -291,9 +291,9 @@ describe("the op that stores the two fields", () => {
 
   it("keeps an EMPTY id distinct from an absent one", () => {
     /*
-     * A third state, and the renderer reads it: it writes `extra.id = cssId`
-     * on `cssId !== undefined`, so a stored `""` renders `id=""` and shadows
-     * any `id` in the bag. Asking for one is therefore a patch, not an unset,
+     * A third state, and the rule reads it: a stored `""` shadows any `id` in
+     * the bag while rendering none of its own, so the element ends up with no
+     * id. Asking for one is therefore a patch, not an unset,
      * and asking to remove one is an unset even though the box looks the same.
      */
     expect(htmlUpdate(fields(""), fields("hero"))).toEqual({
@@ -421,10 +421,9 @@ describe("the id a node actually renders", () => {
 
   it("treats an EMPTY modelled id as present, as the renderer does", () => {
     /*
-     * The renderer writes `extra.id = cssId` whenever `cssId !== undefined`, so
-     * an empty one still overwrites the bag and the element renders `id=""`.
-     * Reading it as absent recorded the bag's value and refused another block an
-     * id that never appears on the page.
+     * An empty modelled id still SHADOWS the bag, so the element renders no id
+     * at all rather than the bag's. Reading it as absent recorded the bag's
+     * value and refused another block an id that never appears on the page.
      */
     const taken = domIdsTaken(
       [node({ id: "b", cssId: "", attributes: { id: "hero" } })],
@@ -564,9 +563,9 @@ describe("the id a bag renders when it holds an empty spelling last", () => {
 
   it("takes the LAST variant even when it is empty", () => {
     /*
-     * The renderer assigns each lowercased key in turn, so a trailing `ID: ""`
-     * leaves the element with `id=""`. Skipping the empty one kept `hero` and
-     * refused another block an id that does not render.
+     * Attribute names are case-insensitive and the last variant decides, so a
+     * trailing `ID: ""` leaves an empty id, which is no id. Skipping the empty
+     * one kept `hero` and refused another block an id that does not render.
      */
     const taken = domIdsTaken(
       [node({ id: "b", attributes: { id: "hero", ID: "" } })],

--- a/packages/builder/src/custom-attributes.ts
+++ b/packages/builder/src/custom-attributes.ts
@@ -490,11 +490,11 @@ export interface HtmlFields {
   /**
    * The element's `id`, or `undefined` for a node carrying no such field.
    *
-   * `""` is a THIRD state and a reachable one: the renderer writes
-   * `extra.id = cssId` on `cssId !== undefined`, so a stored empty string
-   * renders `id=""` and shadows any `id` in the bag. This editor never writes
-   * it — clearing the field is `unset` — but an import can, and telling it
-   * apart from an absent field is what makes it removable.
+   * `""` is a THIRD state and a reachable one: a stored empty string SHADOWS
+   * any `id` in the bag while rendering no id itself, so the element ends up
+   * with none. This editor never writes it — clearing the field is `unset` —
+   * but an import can, and telling it apart from an absent field is what makes
+   * it removable.
    */
   readonly cssId: string | undefined;
   readonly attributes: Readonly<Record<string, string>> | undefined;
@@ -551,9 +551,9 @@ export function wantedFields(
    * rendered anchor changed because an attribute was edited.
    *
    * Once the author HAS typed, an empty box means the field should be gone
-   * rather than present and empty: the panel has no gesture that asks for
-   * `id=""` while the renderer would emit one, so `undefined` is the only thing
-   * a cleared box can honestly mean.
+   * rather than present and empty: the panel has no gesture that asks for a
+   * field that is present, renders nothing and shadows the bag, so `undefined`
+   * is the only thing a cleared box can honestly mean.
    */
   const keptId = untouchedId(draft, loaded)
     ? stored.cssId
@@ -633,7 +633,7 @@ export function htmlUpdate(
   if (!sameId) {
     // REMOVED rather than written empty. `applyOp` refuses `undefined` as a
     // patch value and says why, and an empty string is a different request —
-    // it would leave the field present and rendering `id=""`.
+    // it would leave the field present, rendering no id and shadowing the bag.
     if (wanted.cssId === undefined) unset.push("cssId");
     else patch["cssId"] = wanted.cssId;
   }

--- a/packages/builder/src/inspector-panel.test.tsx
+++ b/packages/builder/src/inspector-panel.test.tsx
@@ -591,7 +591,7 @@ describe("InspectorPanel advanced fields", () => {
 
   it("REMOVES an id rather than storing an empty one", () => {
     // A node that never had an id and one whose id was cleared are the same
-    // node; an empty string would render as `id=""`.
+    // node; an empty string would be a third state that shadows the bag.
     const editor = mount({ cssId: "hero" });
     openAdvanced();
 
@@ -1669,9 +1669,9 @@ describe("the block set the collision check answers about", () => {
 
 describe("a node whose CSS id is present but empty", () => {
   /*
-   * The renderer treats the modelled field as PRESENT whenever it is a string:
-   * it writes `extra.id = cssId` on `cssId !== undefined`, so `cssId: ""`
-   * renders `id=""` AND shadows any `id` in the attribute bag. The inspection
+   * The rule treats the modelled field as PRESENT whenever it is a string, so
+   * `cssId: ""` shadows any `id` in the attribute bag AND renders none of its
+   * own, leaving the element with no id. The inspection
    * collapsed it with an absent field, so the panel showed an empty box, every
    * clear attempt read as untouched, and no `unset` could ever be emitted.
    *
@@ -1806,7 +1806,7 @@ describe("what the empty-id note promises", () => {
     const note = screen.getByRole("status").textContent ?? "";
     // The control: the note IS shown, so this is not passing on its absence.
     expect(note).toContain("empty id");
-    expect(note).not.toContain("hides the id");
+    expect(note).not.toContain("is ignored");
   });
 
   it("DOES claim it when the renderer would emit one", () => {
@@ -1817,7 +1817,7 @@ describe("what the empty-id note promises", () => {
     } as unknown as Partial<BlockNode>);
     fireEvent.mouseDown(screen.getByRole("tab", { name: "Advanced" }));
 
-    expect(screen.getByRole("status").textContent).toContain("hides the id");
+    expect(screen.getByRole("status").textContent).toContain("is ignored");
   });
 });
 

--- a/packages/builder/src/inspector.ts
+++ b/packages/builder/src/inspector.ts
@@ -93,10 +93,10 @@ export interface BlockHtml {
    * The element's `id`. `undefined` when the node does not carry the field at
    * all, which is NOT the same as carrying an empty one.
    *
-   * The renderer treats the field as present whenever it is a string — it
-   * writes `extra.id = cssId` on `cssId !== undefined` — so a stored `""`
-   * renders `id=""` and shadows any `id` in the attribute bag. Collapsing the
-   * two into `""` here left the panel unable to tell them apart, so every
+   * The rule treats the field as present whenever it is a string, so a stored
+   * `""` shadows any `id` in the attribute bag and the element renders no id
+   * at all. Collapsing the two into `""` here left the panel unable to tell
+   * them apart, so every
    * attempt to clear an empty-but-present field read as no change and the
    * field could never be removed. The distinction the document draws has to
    * survive the reading of it.


### PR DESCRIPTION
## The gap this closes

`renderedDomId` in `blocks-engine/document.ts` is documented as **the** rule for which of a node's two id spellings (`cssId`, or an `id` inside `attributes`) reaches the page. Six consumers already derive from it:

| consumer | site |
|---|---|
| validation | `validation.ts:1396` |
| composition planners | `composition-planners.ts:2699, 3784` |
| the resolver | `resolve-instances.ts:2130` |
| the tree walker | `tree.ts:1459` |
| the builder's attribute editor | `builder/custom-attributes.ts:447` |

The **renderer** — the thing that rule models — did not. `block-boundary.tsx` normalised `cssId` itself, enumerated the bag itself, and applied the override itself. So the model was kept truthful by hand, and a precedence or normalisation change on either side would leave six surfaces believing something the page does not do. Raised by Codex as a P1 on #1563 and deferred there because that PR was in its fourteenth review round.

## The trap, and why the bag loop stops assigning `id`

The obvious rewrite — ask the rule, leave the loop alone — is **worse than doing nothing**. The bag is assigned first, so removing only the `cssId` overwrite promotes a *shadowed* bag id onto an element the author gave no id. The loop now skips `id` entirely and the rule is the single source.

That is the separating property, and it has its own test.

## The one rendered-output change

A node with `cssId: ""` used to emit a literal `id=""` — the old guard tested `!== undefined` and the empty string passes. It now emits no `id` attribute.

**Nothing addressable is lost**, and this was researched rather than assumed:

- The **DOM Standard** unsets an element's ID when the `id` attribute is set to the empty string (`dom.spec.whatwg.org`, attribute-change-steps). Verified live in Chromium: `document.getElementById('')` returns `null`, and `document.querySelector('#')` throws `'#' is not a valid selector`.
- The **HTML Standard** requires an id to contain at least one character, so `id=""` is invalid markup that validators already flag.
- No `aria-labelledby`, `for` or any IDREF could ever name it.

**React does not save us from this** — I verified by executing `renderToStaticMarkup` against the `react-dom@19.2.0` actually installed here: `id: ""` renders `<div id="">`; only `null`/`undefined` are omitted. So the change is real bytes, not a no-op.

An empty `cssId` still **shadows** the bag, which is the part an author can observe, and the inspector still offers to remove it.

## UX: the author-facing note now describes what happens

The inspector told authors their block *"renders as `id=""`"* — now false, and jargon that never explained the consequence. It now says the block **renders no id at all**, and that the id in the attributes below **is ignored**. That is the actionable fact: your anchor does not work, and here is why.

Two test assertions pinned the old wording and were updated with it.

## Comments across three packages that asserted the old output

Fifteen sites said the renderer emits `id=""`. Left alone they would state the opposite of what the code does, so each was corrected — keeping the half that stays true (an empty `cssId` shadows the bag) and fixing the half that does not. `grep` for the old claim now returns nothing outside the new test assertions.

## Evidence

Break-verified against **both** plausible wrong implementations, not a mutation:

| implementation | new tests failing |
|---|---|
| the original renderer | 3 |
| the naive rewrite (ask the rule, bag still assigns `id`) | 2 — including the shadowing leak |
| what ships here | 0 |

The fourth test (`cssId: null` normalised away, bag renders) passes on all three deliberately: it is a property they share, guarding that the convergence did not break the ordinary path.

## Gates

All from the committed tree, exit status read on its own line.

| gate | exit |
|---|---|
| `pnpm build` | 0 |
| `blocks-react` check-types / lint / vitest | 0 / 0 / 0 — 48 files, 1166 tests |
| `blocks-engine` check-types / lint / vitest | 0 / 0 / 0 — 52 files, 2416 tests |
| `builder` check-types / lint / vitest | 0 / 0 / 0 — 102 files, 2870 tests |
| `plugin-page-builder` check-types / lint / vitest | 0 / 0 / 0 — 69 files, 768 tests |
| `fallow audit --base origin/main` | 0 — `pass`, `changed_files_count: 11` |
| `pnpm changeset status` | 0 |

`fallow` reports `styling_introduced: 3`. **These are line-shift attribution, not this diff**, measured rather than asserted: `nx-pb-page` occurs 5 times in `page-renderer.test.tsx` on `origin/main` and 5 times here, this diff adds and removes zero lines containing it, and each "introduced" line moved by exactly +87 — the size of the inserted test block. The one at line 217 sits above the insertion, did not move, and `fallow` correctly calls it inherited.

Layering is legal and already enforced: `blocks-react/src/layering.test.ts` permits `@nextlyhq/blocks-engine` at runtime, and both functions are on that package's root entry.

## Related, deliberately not in here

- `task:be-one-rendered-dom-id-rule` — closed as already done on `main`; the builder's `renderedIdOf` no longer exists and six sites already derive. Its ledger row was stale.
- `task:be-per-node-dom-id-restore-policy` — `DomIdPolicy`'s single restore map for a forest whose nodes have different scopes. A published type with other callers; its own PR.
