### PR TITLE
fix(release): wait for the registry, and read it uncached, before calling a release incomplete

### DIFF
--- a/.changeset/release-verification-waits-for-the-registry.md
+++ b/.changeset/release-verification-waits-for-the-registry.md
@@ -1,0 +1,52 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Release verification gave up on the registry after 24 seconds, so a complete
+release was recorded as incomplete and never got its git tag or its GitHub
+release.
+
+A publish is not one event. `changeset publish` returns once npm has accepted
+every tarball, and the packages become readable on the packument endpoint some
+time after that. Across a twenty-package train accepted within one second of
+itself, the last four became readable 47s, 125s, 179s and 186s later, against a
+verification budget of five attempts six seconds apart.
+
+The budget is now a deadline of ten minutes with backoff from 5s to 30s, sized
+against the measured settle rather than an assumption about it, and the two
+mistakes are not symmetric: publishing has already succeeded when this runs, so
+waiting longer spends CI minutes, while giving up early withholds the tag from a
+release npm accepted.
+
+The registry read now also revalidates rather than accepting a cached
+packument. Every caller asks what is true now, and a cached answer would have
+the verification spend its whole budget re-reading one stale copy.
+
+`verify.mjs` was the only script in the release directory with no tests. Its
+waiting and its verdict move to `lib.mjs` behind an injected clock, and nine
+cases cover them, including the control that a longer wait still reports a
+package the registry never received.

--- a/scripts/release/lib.mjs
+++ b/scripts/release/lib.mjs
@@ -268,7 +268,20 @@ export function isBootstrapPlaceholderOnly(state) {
  */
 export async function fetchRegistryState(name) {
   const response = await fetch(`${REGISTRY}/${name.replace("/", "%2F")}`, {
-    headers: { accept: "application/vnd.npm.install-v1+json" },
+    headers: {
+      accept: "application/vnd.npm.install-v1+json",
+      /*
+       * The registry sits behind a CDN, and every caller of this function is
+       * asking what is true NOW rather than what was true recently: the
+       * preflight decides what still needs publishing, the bootstrap check
+       * decides whether a package exists, and the verification decides whether
+       * a release is complete. A cached packument answers all three with the
+       * state before the publish, and the verification would then spend its
+       * whole budget re-reading one stale copy and conclude the packages never
+       * arrived. Revalidation is what makes waiting meaningful.
+       */
+      "cache-control": "no-cache",
+    },
   });
 
   if (response.status === 404) return null;
@@ -377,6 +390,132 @@ export async function fetchAllRegistryStates(manifest) {
     ])
   );
   return new Map(states);
+}
+
+
+/*
+ * How long to keep asking the registry before calling a package missing.
+ *
+ * A publish is not one event. `changeset publish` returns once npm has accepted
+ * every tarball, but a package becomes readable on the packument endpoint some
+ * time later, and for a train this size that lag is measured in minutes rather
+ * than in the "few seconds" a per-package view of it suggests: across twenty
+ * packages accepted within one second of each other, the last four became
+ * readable 47s, 125s, 179s and 186s afterwards. A budget shorter than that
+ * reports a complete release as incomplete.
+ *
+ * The cost of the two mistakes is not symmetric, which is what sets the size.
+ * Publishing has already succeeded by the time this runs, so waiting too long
+ * spends CI minutes and nothing else. Giving up too early withholds the tag and
+ * the GitHub release from a release npm accepted, leaving npm, git and the
+ * releases page describing different things, and it does so on a step whose red
+ * cross means "look again later" rather than "something is wrong" — which is
+ * the kind of red that teaches a reader to wave the next one through.
+ *
+ * Ten minutes is roughly three times the longest settle observed, and the job
+ * that runs it allows forty-five.
+ */
+const SETTLE_BUDGET_MS = 10 * 60 * 1000;
+
+/*
+ * Backoff rather than a fixed interval: a release that settles immediately is
+ * the common case and should not pay a long first wait, while one that needs
+ * minutes should not ask the registry a hundred times to find out.
+ */
+const FIRST_DELAY_MS = 5_000;
+const MAX_DELAY_MS = 30_000;
+
+/**
+ * Packages that are not yet fully released, each with the reason. A missing
+ * version and a stale dist-tag are reported separately because they need
+ * different fixes: the first is a failed publish, the second a tag that was
+ * never moved.
+ */
+export function collectProblems(manifest, registry, preState) {
+  const problems = [];
+
+  for (const entry of manifest) {
+    const state = registry.get(entry.name);
+
+    if (state === null) {
+      problems.push({
+        name: entry.name,
+        reason: "package not found on registry",
+      });
+      continue;
+    }
+
+    if (!state.versions.includes(entry.version)) {
+      problems.push({
+        name: entry.name,
+        reason: `version ${entry.version} not published`,
+      });
+      continue;
+    }
+
+    const expectedTag = getExpectedDistTag(state, preState);
+    const actual = state.distTags[expectedTag];
+    if (actual !== entry.version) {
+      problems.push({
+        name: entry.name,
+        reason:
+          `dist-tag "${expectedTag}" points at ${actual ?? "nothing"}, ` +
+          `so ${entry.name}@${expectedTag} does not resolve to ${entry.version}`,
+      });
+    }
+  }
+
+  return problems;
+}
+
+/**
+ * Ask the registry until it agrees the release is complete, or the budget runs out.
+ *
+ * The clock, the sleeper and the fetch are parameters so the waiting can be
+ * exercised without one: a test that actually slept would have to choose
+ * between a slow suite and a budget too small to describe the behaviour.
+ *
+ * Returns the last answer either way. A caller reports the problems; deciding
+ * that an incomplete release is a failure is not this function's job, because
+ * the same wait is the right one whether the caller exits or reports.
+ */
+export async function waitForCompleteRelease({
+  manifest,
+  preState,
+  fetchStates,
+  sleep: wait,
+  now,
+  budgetMs = SETTLE_BUDGET_MS,
+  firstDelayMs = FIRST_DELAY_MS,
+  maxDelayMs = MAX_DELAY_MS,
+}) {
+  const deadline = now() + budgetMs;
+  let delay = firstDelayMs;
+  let registry;
+  let problems;
+  let attempts = 0;
+
+  for (;;) {
+    registry = await fetchStates(manifest);
+    problems = collectProblems(manifest, registry, preState);
+    attempts += 1;
+    if (problems.length === 0) break;
+
+    // Measured against the deadline rather than counted, so the budget states a
+    // duration and stays true however long a registry round trip takes.
+    const remaining = deadline - now();
+    if (remaining <= 0) break;
+
+    const pause = Math.min(delay, remaining);
+    console.log(
+      `Waiting for ${problems.length} package(s) to settle on the registry ` +
+        `(attempt ${attempts}, ${Math.round(remaining / 1000)}s of budget left)...`
+    );
+    await wait(pause);
+    delay = Math.min(delay * 2, maxDelayMs);
+  }
+
+  return { registry, problems, attempts };
 }
 
 export { REGISTRY, REPO_ROOT };

--- a/scripts/release/verify.mjs
+++ b/scripts/release/verify.mjs
@@ -13,81 +13,25 @@
 
 import {
   fetchAllRegistryStates,
-  getExpectedDistTag,
   getReleaseManifest,
   readPreState,
+  waitForCompleteRelease,
 } from "./lib.mjs";
 
-// npm's read replicas trail a publish by a few seconds, so a package that is
-// genuinely live can 404 immediately afterwards. Retry before calling it missing.
-const ATTEMPTS = 5;
-const RETRY_DELAY_MS = 6000;
-
 const sleep = ms => new Promise(done => setTimeout(done, ms));
-
-/**
- * Packages that are not yet fully released, each with the reason. A missing
- * version and a stale dist-tag are reported separately because they need
- * different fixes: the first is a failed publish, the second a tag that was
- * never moved.
- */
-function collectProblems(manifest, registry, preState) {
-  const problems = [];
-
-  for (const entry of manifest) {
-    const state = registry.get(entry.name);
-
-    if (state === null) {
-      problems.push({
-        name: entry.name,
-        reason: "package not found on registry",
-      });
-      continue;
-    }
-
-    if (!state.versions.includes(entry.version)) {
-      problems.push({
-        name: entry.name,
-        reason: `version ${entry.version} not published`,
-      });
-      continue;
-    }
-
-    const expectedTag = getExpectedDistTag(state, preState);
-    const actual = state.distTags[expectedTag];
-    if (actual !== entry.version) {
-      problems.push({
-        name: entry.name,
-        reason:
-          `dist-tag "${expectedTag}" points at ${actual ?? "nothing"}, ` +
-          `so ${entry.name}@${expectedTag} does not resolve to ${entry.version}`,
-      });
-    }
-  }
-
-  return problems;
-}
 
 async function main() {
   const manifest = getReleaseManifest();
   const preState = readPreState();
   const expectedVersion = manifest[0].version;
 
-  let problems = [];
-  let registry;
-
-  for (let attempt = 1; attempt <= ATTEMPTS; attempt += 1) {
-    registry = await fetchAllRegistryStates(manifest);
-    problems = collectProblems(manifest, registry, preState);
-    if (problems.length === 0) break;
-    if (attempt < ATTEMPTS) {
-      console.log(
-        `Waiting for ${problems.length} package(s) to settle on the registry ` +
-          `(attempt ${attempt}/${ATTEMPTS})...`
-      );
-      await sleep(RETRY_DELAY_MS);
-    }
-  }
+  const { registry, problems } = await waitForCompleteRelease({
+    manifest,
+    preState,
+    fetchStates: fetchAllRegistryStates,
+    sleep,
+    now: () => Date.now(),
+  });
 
   console.log(`Release verification for ${expectedVersion}`);
   console.log(`  expected packages: ${manifest.length}`);

--- a/scripts/release/verify.test.mjs
+++ b/scripts/release/verify.test.mjs
@@ -1,0 +1,254 @@
+/**
+ * The wait that decides whether a release is complete.
+ *
+ * `changeset publish` accepts every tarball and returns, and the packages
+ * become readable on the packument endpoint some time afterwards. Everything
+ * here is about that gap: how long it is worth waiting for, and what must still
+ * be reported when the wait ends with packages genuinely absent.
+ *
+ * The clock and the sleeper are injected, so a budget measured in minutes runs
+ * in microseconds and the assertions can be about elapsed time rather than
+ * about call counts standing in for it.
+ */
+import { describe, expect, it } from "vitest";
+
+import { collectProblems, waitForCompleteRelease } from "./lib.mjs";
+
+const VERSION = "0.0.2-alpha.64";
+
+/** A manifest of `count` packages, all at the same version, as `fixed[]` produces. */
+function manifestOf(count) {
+  return Array.from({ length: count }, (_, index) => ({
+    name: `@nextlyhq/pkg-${index}`,
+    version: VERSION,
+  }));
+}
+
+/*
+ * The `0.0.0` bootstrap placeholder is in every fixture's version list because
+ * it is load-bearing rather than leftover: `getExpectedDistTag` treats a package
+ * whose versions are ALL prereleases of the active tag as one that should take
+ * `latest`, so a fixture listing alphas alone would expect `latest` and describe
+ * a package this repository does not have.
+ */
+const PLACEHOLDER = "0.0.0";
+const PREVIOUS = "0.0.2-alpha.62";
+
+/** A registry entry that has the version and points the channel tag at it. */
+function live(version = VERSION, tag = "alpha") {
+  return {
+    versions: [PLACEHOLDER, version],
+    distTags: { [tag]: version, latest: PLACEHOLDER },
+  };
+}
+
+/** A registry entry from before the publish: the previous version only. */
+function stale(tag = "alpha") {
+  return {
+    versions: [PLACEHOLDER, PREVIOUS],
+    distTags: { [tag]: PREVIOUS, latest: PLACEHOLDER },
+  };
+}
+
+const PRE_STATE = { mode: "pre", tag: "alpha" };
+
+/**
+ * A fake clock and sleeper. `sleep` advances the clock instead of waiting, so
+ * the elapsed time the loop sees is exactly the time it asked for.
+ */
+function fakeClock() {
+  let current = 0;
+  return {
+    now: () => current,
+    sleep: async ms => {
+      current += ms;
+    },
+    elapsed: () => current,
+  };
+}
+
+/**
+ * A registry that answers `stale` for the first `settleAfter` polls and `live`
+ * from then on, which is the shape of a publish the CDN has not caught up with.
+ */
+function registrySettlingAfter(settleAfter, manifest) {
+  let polls = 0;
+  return {
+    fetchStates: async () => {
+      polls += 1;
+      const entry = polls > settleAfter ? live() : stale();
+      return new Map(manifest.map(({ name }) => [name, entry]));
+    },
+    polls: () => polls,
+  };
+}
+
+describe("waiting for a release to settle on the registry", () => {
+  it("keeps asking past the point a 24s budget would have given up", async () => {
+    // The measured case. Twenty packages were accepted within one second of
+    // each other and the last became readable 186s later, so a wait that ends
+    // at 24s reports a complete release as incomplete.
+    const manifest = manifestOf(20);
+    const clock = fakeClock();
+    const registry = registrySettlingAfter(8, manifest);
+
+    const { problems } = await waitForCompleteRelease({
+      manifest,
+      preState: PRE_STATE,
+      fetchStates: registry.fetchStates,
+      sleep: clock.sleep,
+      now: clock.now,
+    });
+
+    expect(problems).toEqual([]);
+    expect(clock.elapsed()).toBeGreaterThan(24_000);
+  });
+
+  it("gives up at a 24s budget on the same registry, which is why the budget moved", async () => {
+    // The control for the case above. Without it that test would pass on a loop
+    // that never waited at all, because a registry answering `live` on the first
+    // poll also returns no problems. This pins the difference to the budget.
+    const manifest = manifestOf(20);
+    const clock = fakeClock();
+    const registry = registrySettlingAfter(8, manifest);
+
+    const { problems } = await waitForCompleteRelease({
+      manifest,
+      preState: PRE_STATE,
+      fetchStates: registry.fetchStates,
+      sleep: clock.sleep,
+      now: clock.now,
+      budgetMs: 24_000,
+    });
+
+    expect(problems).not.toEqual([]);
+    expect(clock.elapsed()).toBeLessThanOrEqual(24_000);
+  });
+
+  it("returns on the first answer when the registry is already caught up", async () => {
+    // A release that settles immediately is the common case and must not pay a
+    // first delay for the slow one's sake.
+    const manifest = manifestOf(3);
+    const clock = fakeClock();
+    const registry = registrySettlingAfter(0, manifest);
+
+    const { problems, attempts } = await waitForCompleteRelease({
+      manifest,
+      preState: PRE_STATE,
+      fetchStates: registry.fetchStates,
+      sleep: clock.sleep,
+      now: clock.now,
+    });
+
+    expect(problems).toEqual([]);
+    expect(attempts).toBe(1);
+    expect(clock.elapsed()).toBe(0);
+  });
+
+  it("still reports a package the registry never receives", async () => {
+    // The anti-vacuity control, and the one that matters most: a longer wait
+    // must not turn a genuinely failed publish into a pass. This registry never
+    // settles, so the budget runs out and the problems survive it.
+    const manifest = manifestOf(4);
+    const clock = fakeClock();
+    const registry = registrySettlingAfter(Number.POSITIVE_INFINITY, manifest);
+
+    const { problems } = await waitForCompleteRelease({
+      manifest,
+      preState: PRE_STATE,
+      fetchStates: registry.fetchStates,
+      sleep: clock.sleep,
+      now: clock.now,
+    });
+
+    expect(problems).toHaveLength(4);
+    expect(problems[0].reason).toContain(VERSION);
+  });
+
+  it("never waits longer than the budget it was given", async () => {
+    const manifest = manifestOf(2);
+    const clock = fakeClock();
+    const registry = registrySettlingAfter(Number.POSITIVE_INFINITY, manifest);
+
+    await waitForCompleteRelease({
+      manifest,
+      preState: PRE_STATE,
+      fetchStates: registry.fetchStates,
+      sleep: clock.sleep,
+      now: clock.now,
+      budgetMs: 70_000,
+    });
+
+    expect(clock.elapsed()).toBeLessThanOrEqual(70_000);
+  });
+
+  it("backs off up to a cap rather than asking at a fixed interval", async () => {
+    // A fixed short interval spends the whole budget on requests; an
+    // ever-doubling one overshoots the end of it. The cap is what keeps a long
+    // wait to a bounded number of polls without a single long final sleep.
+    const manifest = manifestOf(1);
+    const clock = fakeClock();
+    const waits = [];
+    const registry = registrySettlingAfter(Number.POSITIVE_INFINITY, manifest);
+
+    await waitForCompleteRelease({
+      manifest,
+      preState: PRE_STATE,
+      fetchStates: registry.fetchStates,
+      sleep: async ms => {
+        waits.push(ms);
+        await clock.sleep(ms);
+      },
+      now: clock.now,
+      budgetMs: 200_000,
+      firstDelayMs: 5_000,
+      maxDelayMs: 30_000,
+    });
+
+    expect(waits.slice(0, 4)).toEqual([5_000, 10_000, 20_000, 30_000]);
+    expect(Math.max(...waits)).toBe(30_000);
+  });
+});
+
+describe("what counts as an incomplete release", () => {
+  it("separates a missing version from a dist-tag that never moved", async () => {
+    // The two need different fixes, so they are reported differently: the first
+    // is a publish that did not happen, the second a publish that did while
+    // `pkg@alpha` still resolves to the release before it.
+    const manifest = manifestOf(2);
+    const registry = new Map([
+      [manifest[0].name, stale()],
+      [
+        manifest[1].name,
+        {
+          versions: [PLACEHOLDER, VERSION],
+          distTags: { alpha: PREVIOUS, latest: PLACEHOLDER },
+        },
+      ],
+    ]);
+
+    const problems = collectProblems(manifest, registry, PRE_STATE);
+
+    expect(problems).toHaveLength(2);
+    expect(problems[0].reason).toContain("not published");
+    expect(problems[1].reason).toContain("dist-tag");
+  });
+
+  it("reports a package the registry has never heard of", async () => {
+    const manifest = manifestOf(1);
+    const registry = new Map([[manifest[0].name, null]]);
+
+    expect(collectProblems(manifest, registry, PRE_STATE)).toEqual([
+      { name: manifest[0].name, reason: "package not found on registry" },
+    ]);
+  });
+
+  it("is empty when every package is live on the channel", async () => {
+    // The positive control for this group: the three above would all pass
+    // against a `collectProblems` that reported a problem for everything.
+    const manifest = manifestOf(5);
+    const registry = new Map(manifest.map(({ name }) => [name, live()]));
+
+    expect(collectProblems(manifest, registry, PRE_STATE)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What was wrong

The `Release` job on `12523acb8` failed at **Verify every package reached the registry**, so `v0.0.2-alpha.64` got **no git tag and no GitHub Release**. npm, git and the releases page have disagreed since.

The release itself was fine. Running the verifier today against the live registry:

```
Complete release: all 20 packages are live at 0.0.2-alpha.64 on the alpha channel.
```

## Root cause

A publish is not one event. `changeset publish` returns once npm accepts every tarball; a package becomes readable on the packument endpoint later. From npm's own `time` field for that run, against a verification that began at 14:55:42 and gave up at 14:56:07:

| Package | Readable at | Past the deadline by |
|---|---|---|
| `admin-css` | 14:56:28 | 21s |
| `plugin-form-builder` | 14:57:46 | 99s |
| `blocks-engine` | 14:58:40 | 153s |
| `plugin-sdk` | 14:58:47 | 160s |

The budget was `ATTEMPTS = 5`, `RETRY_DELAY_MS = 6000`, and the sleep only runs *between* attempts: **24 seconds**, against a comment assuming npm "trails a publish by a few seconds".

## The fix

**A deadline, not a count.** Ten minutes with backoff from 5s to 30s, sized against the measured settle. The costs are asymmetric and that is what sets the size: publishing has already succeeded when this runs, so waiting spends CI minutes, while giving up early withholds the tag from a release npm accepted — on a red cross that means "look again later", which is the kind that teaches a reader to wave the next one through.

**The registry read revalidates.** `fetchRegistryState` sent no cache header. Every caller (preflight, bootstrap, verify) asks what is true *now*, and a cached packument would have the wait re-read one stale copy for its whole budget. Waiting is only meaningful if the read is fresh.

**The tests it never had.** `verify.mjs` was the only script in `scripts/release/` with none. The wait and the verdict move into `lib.mjs` behind an injected clock — which is how this directory already tests `preflight` — and gain 9 cases.

## Verification

- `scripts/release/`: **5 files, 120 tests, all passing**
- **Mutation tested**: setting the budget back to 24s fails exactly one test, *"keeps asking past the point a 24s budget would have given up"*, and restoring it passes
- The suite carries its own control: the same slow registry with a 24s budget **must** give up, so the first test cannot pass on a loop that never waits
- The anti-vacuity control: a registry that never settles **still reports all 4 packages missing**, so a longer wait cannot turn a genuinely failed publish into a pass

## Not in this PR

The finalize steps are gated on `hasChangesets == 'false'`. Two minutes after this failure a commit with new changesets landed, so every later run takes the version-PR path and **skips verification and finalization permanently** — `34366671802` shows both as `skipped`. That is the same outcome the gate's comment was written to prevent, reached by another route.

Fixing it is not a one-line gate change: `getReleaseManifest()` reads the **working tree**, and on the version path the changesets action has already bumped it, so an unconditional verify would compare a version that is deliberately unpublished. It needs a separate job with its own clean checkout, which deserves its own review.