### PR TITLE
fix(blocks-react): say what an empty node id does to a block's own root id

### DIFF
--- a/packages/blocks-react/src/block-boundary.tsx
+++ b/packages/blocks-react/src/block-boundary.tsx
@@ -384,15 +384,30 @@ function withNodeAttributes(
    * `cssId` shadows, the bag is read case-insensitively with the last variant
    * winning, and an empty result is no id at all.
    *
-   * That last clause is the one behaviour change. A node with `cssId: ""` used
-   * to emit a literal `id=""`, because this loop tested `!== undefined` and the
-   * empty string passes. It no longer does, and nothing reachable is lost: the
-   * DOM Standard unsets an element's ID when the attribute is set to the empty
-   * string, so `getElementById("")` never matched it, no IDREF could name it,
-   * and `#` is not a valid selector. The HTML Standard separately requires an
-   * id to hold at least one character, so what shipped was invalid markup that
-   * addressed nothing. The empty `cssId` still SHADOWS the bag, which is the
-   * part authors can observe, and the inspector still offers to remove it.
+   * That last clause changes what an empty id does, in two ways.
+   *
+   * A node with `cssId: ""` used to emit a literal `id=""`, because this loop
+   * tested `!== undefined` and the empty string passes. It no longer does, and
+   * nothing reachable is lost: the DOM Standard unsets an element's ID when the
+   * attribute is set to the empty string, so `getElementById("")` never matched
+   * it, no IDREF could name it, and `#` is not a valid selector. The HTML
+   * Standard separately requires an id to hold at least one character, so what
+   * shipped was invalid markup that addressed nothing. The empty `cssId` still
+   * SHADOWS the bag, which is the part authors can observe, and the inspector
+   * still offers to remove it.
+   *
+   * And a node contributing no id now leaves a BLOCK-OWNED root id alone, so
+   * the two ways of contributing none — the field absent, and the field present
+   * but empty — agree. Only the empty one moved: an absent `cssId` always left
+   * a block's own id in place. Assigning the empty string overwrote it and left
+   * the element reachable by nothing, which was collateral of the assignment
+   * rather than a rule anything stated, and it is the harmful direction — an
+   * empty `cssId` arrives by import and never from the editor, and a block
+   * whose root id is the target of its own `aria-labelledby` or `htmlFor` lost
+   * that wiring to a value its author never typed.
+   *
+   * What this rule decides is which of the NODE's two spellings reaches the
+   * page, never whether the block may keep an id of its own.
    */
   const renderedId = renderedDomId(node);
   if (renderedId !== undefined) extra.id = renderedId;

--- a/packages/blocks-react/src/page-renderer.test.tsx
+++ b/packages/blocks-react/src/page-renderer.test.tsx
@@ -129,6 +129,26 @@ const text = defineBlock<{ value: string }>({
 });
 
 /**
+ * A block whose own root element carries an `id` the BLOCK chose.
+ *
+ * Nothing in the first-party library does this today — `form` puts ids on its
+ * inner controls, which this boundary never touches — but a plugin's block may,
+ * and the node's id rule has to say what happens when both want the attribute.
+ */
+const ownedId = defineBlock<{ value: string }>({
+  name: "test/owned-id",
+  version: 1,
+  description: "Renders a root carrying its own id.",
+  example: { props: { value: "hi" } },
+  defaultProps: { value: "" },
+  render: ({ props, className }) => (
+    <p className={className} id="block-owned">
+      {props.value}
+    </p>
+  ),
+});
+
+/**
  * A block that answers whether these props make it draw, so one document can
  * hold an instance on each side of the declaration.
  */
@@ -1092,6 +1112,59 @@ describe("PageRenderer", () => {
       );
 
       expect(html).toContain('id="hero"');
+    });
+
+    it("leaves a block's OWN root id alone when the node supplies none", async () => {
+      // Two node states mean "this node contributes no id": the field absent,
+      // and the field present but empty. They now behave the SAME — the block's
+      // id survives both — where an empty one used to overwrite it with `id=""`
+      // and leave the element addressable by nothing.
+      //
+      // Suppressing it was collateral of assigning the empty string rather than
+      // a rule anything stated. It is also the harmful direction: an empty
+      // `cssId` arrives by import, never from this editor, and a block whose
+      // root id is the target of its own `aria-labelledby` or `htmlFor` would
+      // lose that wiring because of a value the author did not type.
+      for (const nodeFields of [
+        {},
+        { cssId: "" },
+        { attributes: { id: "" } },
+      ]) {
+        const html = await renderToHtml(
+          <PageRenderer
+            document={doc(
+              node("a", "test/owned-id", {
+                props: { value: "anchored" },
+                ...nodeFields,
+              })
+            )}
+            blocks={createBlockResolver([ownedId as AnyBlockDefinition])}
+          />
+        );
+
+        expect(html).toContain('id="block-owned"');
+        expect(html).not.toContain('id=""');
+      }
+    });
+
+    it("lets the node's id win over a block's own root id", async () => {
+      // The other half, and the one that must not regress: when the node DOES
+      // name an id, it is the node's that reaches the page. Without this the
+      // test above passes on a renderer that ignores the node entirely.
+      const html = await renderToHtml(
+        <PageRenderer
+          document={doc(
+            node("a", "test/owned-id", {
+              props: { value: "anchored" },
+              cssId: "author-chose",
+            })
+          )}
+          blocks={createBlockResolver([ownedId as AnyBlockDefinition])}
+        />
+      );
+
+      expect(html).toContain('id="author-chose"');
+      expect(html).not.toContain('id="block-owned"');
     });
 
     it("never lets a stored attribute reinterpret the element", async () => {


### PR DESCRIPTION
## Why this is a separate PR

This is the response to Codex's P2 on **#1662**. That PR merged at `16:33:04Z` on head `6311330ec`, and this commit was written twelve minutes later — so it is **stranded off `main`** rather than part of it. Verified by content, not ancestry: the marker `leaves a block's OWN root id alone` is absent from `origin/main` and present here.

So `main` currently has the convergence **without** the tests and documentation for one of the two behaviour changes it made. This closes that.

No changeset: `block-boundary.tsx` is comment-only here and the rest is tests, which the repo's rule exempts.

## The finding was correct, and I had missed it

Codex flagged that when a block's own root element carries an `id` the *block* chose, an empty node id no longer suppresses it. I probed both implementations rather than reasoning about it:

| node state | before #1662 | after #1662 |
|---|---|---|
| `cssId` absent | `id="block-owned"` | `id="block-owned"` |
| **`cssId: ""`** | **`id=""`** | **`id="block-owned"`** |
| `cssId: "set"` | `id="set"` | `id="set"` |
| **bag `id: ""`** | **`id=""`** | **`id="block-owned"`** |

#1662 claimed *one* rendered-output change. There were two. That is exactly the failure mode a convergence invites, and the review caught it.

## Why the behaviour is kept rather than restored

Only the two empty-id rows moved, and they moved **into agreement with the first row**, not away from it. An absent `cssId` never suppressed a block-owned id; nothing documented that an empty one did; the suppression was collateral of assigning the empty string.

Restoring it is the harmful direction and costs the convergence:

- An empty `cssId` **arrives by import and never from the editor** — the builder writes `unset`, and the inspector actively offers "Remove the empty id". A block whose root id is the target of its own `aria-labelledby` or `htmlFor` would lose that wiring to a value its author never typed.
- Implementing the restore means the renderer re-deriving *"the node spelled an id but it was empty"* — splitting apart the exact question #1662 unified — and it makes an empty id a **stronger** suppressor than an absent one, which nothing argues for.

## Evidence

Two tests, break-verified: `leaves a block's OWN root id alone when the node supplies none` **fails on the previous implementation**. Beside it is the positive control — `lets the node's id win over a block's own root id` — which passes on both, so the pair cannot be satisfied by a renderer that ignores the node entirely.

## What this does NOT fix, filed instead

`finding:be-rendered-dom-id-cannot-see-block-owned-ids`.

Underneath the P2 is a real gap: `renderedDomId`'s docblock calls it *"The single HTML id a node actually renders"*, but for a node with no `cssId` it answers `undefined` while the page emits the block's own id. So it answers for the **node**, not for the element, and neither `domIdsTaken` nor `validateDomIds` can see a block-owned root id.

That is true on **both sides** of #1662 and of the common case, so it is not something that change introduced. Closing it is a decision between two coherent answers — narrow the rule's documented claim, or make the renderer clear block-owned root ids so the rule is true by construction — and the second alters the common case and needs every block audited first. Not smuggled in here.

## Gates

Rebuilt from cleared `dist` after the branch switch. Exit status read on its own line.

| gate | exit |
|---|---|
| `pnpm build` | 0 |
| `blocks-react` ct / lint / vitest | 0 / 0 / 0 — 48 files, 1168 tests |
| `blocks-engine` ct / lint / vitest | 0 / 0 / 0 — 52 files, 2416 tests |
| `builder` ct / lint / vitest | 0 / 0 / 0 — 102 files, 2870 tests |
| `plugin-page-builder` ct / lint / vitest | 0 / 0 / 0 — 69 files, 768 tests |
| `fallow audit --base origin/main` | 0 — `pass`, `changed_files_count: 2` |
| `pnpm changeset status` | 0 |

`fallow`'s `styling_introduced: 4` is line-shift attribution, measured: `nx-pb-page` occurs 5 times in `page-renderer.test.tsx` on both sides, this diff adds and removes zero lines containing it, and each flagged line moved by exactly the size of the inserted block.
