### PR TITLE
feat(ci): refuse a suite that boots an instance under a unit-lane name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,6 +259,16 @@ jobs:
         if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: pnpm check:test-lanes
 
+      # The lane above proves a PACKAGE is run by some lane. Which lane a FILE
+      # lands in is decided by its name alone: the unit config excludes
+      # `*.integration.test.ts` and the integration config claims it. A suite
+      # that boots a real instance under the unit name runs on a 10s budget
+      # sized for jsdom components, against every package turbo is building,
+      # and times out only when the runner is busy.
+      - name: A suite that boots an instance is in the integration lane
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
+        run: pnpm check:instance-boot-lane
+
       # The About line and topic list are repository settings, not files, so every
       # check that reads git's index is blind to them. Reports unverifiable rather
       # than failing when the API cannot be reached.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "check:storage-format-literals": "node scripts/check-storage-format-literals.cjs",
     "check:dev-concurrency": "node scripts/check-dev-concurrency.mjs",
     "check:test-lanes": "node scripts/check-test-lanes.mjs",
+    "check:instance-boot-lane": "node scripts/check-instance-boot-lane.mjs",
     "check:comments": "node scripts/check-comment-convention.mjs",
     "check:docs-claims": "node scripts/check-docs-claims.mjs",
     "check:doc-samples": "node scripts/check-doc-samples.mjs",

--- a/scripts/check-instance-boot-lane.mjs
+++ b/scripts/check-instance-boot-lane.mjs
@@ -27,9 +27,11 @@
  * `@nextlyhq/plugin-sdk/testing`, and seven relative paths that differ only by
  * depth - so a specifier list would be a list of the ways a directory can be
  * reached, and a file one level deeper would fall out of the scan. A namespace
- * import hides the binding from the import clause, so the property access
- * `<ns>.createTestNextly` counts as well, and for the same reason: it is a fact
- * about the name rather than about where the name came from.
+ * import hides the binding from the import clause, so a property access through
+ * an identifier a `NamespaceImport` introduced counts as well. The receiver is
+ * checked rather than the property name alone: a suite's own fixture exposing
+ * that name boots nothing, and reporting it would be a check firing on a
+ * correct file.
  *
  * ⚠️ Being named for the lane is half of being in it. A package that declares
  * no `test:integration` runs nothing matching the suffix, so a correctly named
@@ -114,25 +116,44 @@ export function importsBootHelper(source, fileName = "test.ts") {
   /*
    * A namespace import hides the binding from the import clause: `import * as
    * testing from "..."` names only `testing`, and the helper is reached later
-   * as `testing.createTestNextly()`. Deciding that from the import alone would
-   * need a list of the modules the helper can live in, which is the specifier
-   * list this deliberately does not keep. The property access is the fact
-   * instead, and it is one the compiler reports, so a comment or a string
-   * spelling the same thing is still not a boot.
+   * as `testing.createTestNextly()`.
+   *
+   * 🔴 The RECEIVER is checked, not just the property name. Accepting any
+   * `<anything>.createTestNextly` would report a suite whose own fixture or mock
+   * happens to expose that name - `fixture.createTestNextly()` boots nothing -
+   * and a check that demands an integration rename for a correct file is one
+   * that gets turned off. Only identifiers a `NamespaceImport` actually
+   * introduced count, so the receiver has to be a module this file imported.
    */
-  let reachedThroughNamespace = false;
-  const findPropertyAccess = node => {
-    if (
-      ts.isPropertyAccessExpression(node) &&
-      node.name.text === BOOT_BINDING
-    ) {
-      reachedThroughNamespace = true;
-      return;
+  const namespaces = new Set();
+  for (const statement of parsed.statements) {
+    if (!ts.isImportDeclaration(statement)) continue;
+    const clause = statement.importClause;
+    if (!clause || clause.isTypeOnly) continue;
+    const bindings = clause.namedBindings;
+    if (bindings && ts.isNamespaceImport(bindings)) {
+      namespaces.add(bindings.name.text);
     }
-    ts.forEachChild(node, findPropertyAccess);
-  };
-  ts.forEachChild(parsed, findPropertyAccess);
-  if (reachedThroughNamespace) return true;
+  }
+
+  if (namespaces.size > 0) {
+    let reachedThroughNamespace = false;
+    const findPropertyAccess = node => {
+      if (reachedThroughNamespace) return;
+      if (
+        ts.isPropertyAccessExpression(node) &&
+        node.name.text === BOOT_BINDING &&
+        ts.isIdentifier(node.expression) &&
+        namespaces.has(node.expression.text)
+      ) {
+        reachedThroughNamespace = true;
+        return;
+      }
+      ts.forEachChild(node, findPropertyAccess);
+    };
+    ts.forEachChild(parsed, findPropertyAccess);
+    if (reachedThroughNamespace) return true;
+  }
 
   for (const statement of parsed.statements) {
     if (!ts.isImportDeclaration(statement)) continue;

--- a/scripts/check-instance-boot-lane.mjs
+++ b/scripts/check-instance-boot-lane.mjs
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+
+/**
+ * A suite that boots a real Nextly instance runs in the integration lane.
+ *
+ * The two lanes are told apart by FILENAME and by nothing else. A package's
+ * `vitest.config.ts` includes `src/**\/*.{test,spec}.{ts,tsx}` and excludes
+ * `src/**\/*.integration.test.ts`; its `vitest.integration.config.ts` includes
+ * exactly that suffix, and gives it a 30s budget with `fileParallelism: false`.
+ * A boot named for the unit lane therefore runs under a budget sized for jsdom
+ * component tests, against every other package turbo is building at the time.
+ *
+ * That failure is quiet and intermittent, which is why it survives review: the
+ * file passes locally in about a second and times out only on a loaded runner.
+ * The package configs already record the shape of it, including that raising
+ * the unit budget was the previous answer and was exceeded.
+ *
+ * 🔴 IMPORTS ARE PARSED, NOT MATCHED AS TEXT. Of the files naming
+ * `createTestNextly` outside the integration suffix, most name it in prose: a
+ * docblock explaining why a spy is used instead, or why a cache is not shared.
+ * A containment test over the source would report each of those, and a check
+ * that fires on correct files is one that gets silenced. The compiler decides
+ * what is an import here, so a comment cannot be one.
+ *
+ * ⚠️ The BINDING is what identifies a boot, not the module it comes from. The
+ * helper is imported under nine different specifiers - `nextly/testing`,
+ * `@nextlyhq/plugin-sdk/testing`, and seven relative paths that differ only by
+ * depth - so a specifier list would be a list of the ways a directory can be
+ * reached, and a file one level deeper would fall out of the scan.
+ *
+ * ⚠️ What this does not judge: a helper that boots an instance behind another
+ * name. This names one binding because one binding is what the repository uses;
+ * a second wrapper is a reason to add it here deliberately.
+ *
+ * Usage:
+ *   node scripts/check-instance-boot-lane.mjs
+ */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import ts from "typescript";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+/** The binding whose presence means a test boots a real instance. */
+export const BOOT_BINDING = "createTestNextly";
+
+/** The suffix that routes a file to the integration lane. */
+export const INTEGRATION_SUFFIX = ".integration.test.ts";
+
+/**
+ * Every tracked test file, from git rather than a directory walk.
+ *
+ * `git ls-files` answers with what is committed, so a build artifact or an
+ * ignored scratch file cannot enter the population and be judged.
+ */
+export function testFiles(cwd, run = execFileSync) {
+  const listed = run("git", ["ls-files", "-z", "--", "packages"], {
+    cwd,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return listed
+    .split("\0")
+    .filter(Boolean)
+    .filter(path => path.endsWith(".test.ts") || path.endsWith(".test.tsx"));
+}
+
+/**
+ * Whether a source file IMPORTS the boot helper.
+ *
+ * Walks the statement list rather than the whole tree: an import declaration is
+ * only legal at the top level, so anything deeper that looks like one is not
+ * one. `import type { createTestNextly }` is not a boot either, and the
+ * compiler marks that on both the clause and the individual specifier.
+ */
+export function importsBootHelper(source, fileName = "test.ts") {
+  const parsed = ts.createSourceFile(
+    fileName,
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ false,
+    fileName.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS
+  );
+
+  for (const statement of parsed.statements) {
+    if (!ts.isImportDeclaration(statement)) continue;
+    const clause = statement.importClause;
+    if (!clause || clause.isTypeOnly) continue;
+    const bindings = clause.namedBindings;
+    if (!bindings || !ts.isNamedImports(bindings)) continue;
+
+    for (const element of bindings.elements) {
+      if (element.isTypeOnly) continue;
+      // `import { createTestNextly as boot }` still boots an instance, so the
+      // name that matters is the one on the module's side of the rename.
+      const imported = element.propertyName ?? element.name;
+      if (imported.text === BOOT_BINDING) return true;
+    }
+  }
+
+  return false;
+}
+
+/** The package directory a file belongs to, as `packages/<name>`. */
+export function packageOf(path) {
+  const [, name] = path.split("/");
+  return name ? `packages/${name}` : undefined;
+}
+
+/**
+ * Whether a package can actually run an integration suite.
+ *
+ * Renaming a file into a lane its package does not have would move it out of
+ * the unit run and into nothing, which is a worse outcome than the timeout: the
+ * suite stops reporting and every job stays green. So the instruction this
+ * check gives depends on the answer.
+ */
+export function hasIntegrationLane(packageDir, readManifest) {
+  try {
+    const pkg = JSON.parse(readManifest(join(packageDir, "package.json")));
+    return typeof pkg?.scripts?.["test:integration"] === "string";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The verdict for one population of files.
+ *
+ * `covered` is the positive control and is returned rather than logged, because
+ * a scan that finds no boots at all has not proved every boot is in the right
+ * lane; it has proved the parser stopped recognising them.
+ */
+export function classify(files, readSource) {
+  const misrouted = [];
+  const covered = [];
+
+  for (const path of files) {
+    let source;
+    try {
+      source = readSource(path);
+    } catch {
+      continue; // a file git lists and the disk cannot read is the linter's business
+    }
+    if (!importsBootHelper(source, path)) continue;
+
+    if (path.endsWith(INTEGRATION_SUFFIX)) covered.push(path);
+    else misrouted.push(path);
+  }
+
+  return { misrouted, covered };
+}
+
+const invokedDirectly =
+  process.argv[1] && process.argv[1].endsWith("check-instance-boot-lane.mjs");
+
+if (invokedDirectly) {
+  const files = testFiles(root);
+
+  if (files.length === 0) {
+    console.error(
+      "check-instance-boot-lane: git listed no test files under packages/, so " +
+        "no file could have been judged."
+    );
+    process.exit(2);
+  }
+
+  const readSource = path => readFileSync(join(root, path), "utf8");
+  const { misrouted, covered } = classify(files, readSource);
+
+  // The control, before the verdict. Every file failing to parse, or the
+  // binding being renamed upstream, produces an empty `misrouted` that reads
+  // exactly like a clean repository.
+  if (covered.length === 0) {
+    console.error(
+      `check-instance-boot-lane: no file imports \`${BOOT_BINDING}\` at all, ` +
+        "which would make every suite vacuously well-routed rather than " +
+        "correctly routed. The binding has been renamed, or the parse is failing."
+    );
+    process.exit(2);
+  }
+
+  if (misrouted.length > 0) {
+    console.error("check-instance-boot-lane: FAILED\n");
+    for (const path of misrouted) {
+      const packageDir = packageOf(path);
+      const renamed = path.replace(/\.test\.tsx?$/, INTEGRATION_SUFFIX);
+      console.error(
+        `  ${path}\n` +
+          `    imports \`${BOOT_BINDING}\`, so it boots a real instance and needs ` +
+          `the integration lane's budget.\n` +
+          `    Rename it to ${renamed}.`
+      );
+      // `readSource` already resolves against the repository root, so the
+      // package directory is passed as it was derived: repository-relative.
+      if (packageDir && !hasIntegrationLane(packageDir, readSource)) {
+        console.error(
+          `    ⚠️  ${packageDir} declares no \`test:integration\` script, so the ` +
+            "rename alone would move this suite out of the unit lane and into " +
+            "no lane at all. Give the package an integration config and script " +
+            "first."
+        );
+      }
+      console.error("");
+    }
+    process.exit(1);
+  }
+
+  console.log(
+    `check-instance-boot-lane: ok — ${covered.length} suite(s) that boot an ` +
+      `instance are named for the integration lane, out of ${files.length} test ` +
+      "file(s) scanned."
+  );
+  // Said on the way past, so a reader taking this as proof of routing knows the
+  // shape it did not judge.
+  console.log(
+    `  decides on a parsed import of \`${BOOT_BINDING}\`; a helper that boots ` +
+      "under another name is not something this reads."
+  );
+}

--- a/scripts/check-instance-boot-lane.mjs
+++ b/scripts/check-instance-boot-lane.mjs
@@ -26,7 +26,15 @@
  * helper is imported under nine different specifiers - `nextly/testing`,
  * `@nextlyhq/plugin-sdk/testing`, and seven relative paths that differ only by
  * depth - so a specifier list would be a list of the ways a directory can be
- * reached, and a file one level deeper would fall out of the scan.
+ * reached, and a file one level deeper would fall out of the scan. A namespace
+ * import hides the binding from the import clause, so the property access
+ * `<ns>.createTestNextly` counts as well, and for the same reason: it is a fact
+ * about the name rather than about where the name came from.
+ *
+ * ⚠️ Being named for the lane is half of being in it. A package that declares
+ * no `test:integration` runs nothing matching the suffix, so a correctly named
+ * boot there is reported too: that suite is not slow, it is unrun, and green
+ * because of it.
  *
  * ⚠️ What this does not judge: a helper that boots an instance behind another
  * name. This names one binding because one binding is what the repository uses;
@@ -51,6 +59,23 @@ export const BOOT_BINDING = "createTestNextly";
 /** The suffix that routes a file to the integration lane. */
 export const INTEGRATION_SUFFIX = ".integration.test.ts";
 
+/*
+ * What the unit lane collects, which is the population that can be misrouted.
+ *
+ * `spec` is here because the unit configs take it - `src/**\/*.{test,spec}.{ts,tsx}`,
+ * and `src/**\/*.spec.ts` where the two are written out - while every
+ * integration config takes `*.integration.test.ts` and nothing else. A booting
+ * suite named `.spec.ts` is therefore not merely misrouted, it is unroutable
+ * under its current name, and a scan that skipped the suffix would call the
+ * repository clean while one sat in the unit lane.
+ */
+export const UNIT_LANE_SUFFIXES = [
+  ".test.ts",
+  ".test.tsx",
+  ".spec.ts",
+  ".spec.tsx",
+];
+
 /**
  * Every tracked test file, from git rather than a directory walk.
  *
@@ -66,7 +91,7 @@ export function testFiles(cwd, run = execFileSync) {
   return listed
     .split("\0")
     .filter(Boolean)
-    .filter(path => path.endsWith(".test.ts") || path.endsWith(".test.tsx"));
+    .filter(path => UNIT_LANE_SUFFIXES.some(suffix => path.endsWith(suffix)));
 }
 
 /**
@@ -85,6 +110,29 @@ export function importsBootHelper(source, fileName = "test.ts") {
     /* setParentNodes */ false,
     fileName.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS
   );
+
+  /*
+   * A namespace import hides the binding from the import clause: `import * as
+   * testing from "..."` names only `testing`, and the helper is reached later
+   * as `testing.createTestNextly()`. Deciding that from the import alone would
+   * need a list of the modules the helper can live in, which is the specifier
+   * list this deliberately does not keep. The property access is the fact
+   * instead, and it is one the compiler reports, so a comment or a string
+   * spelling the same thing is still not a boot.
+   */
+  let reachedThroughNamespace = false;
+  const findPropertyAccess = node => {
+    if (
+      ts.isPropertyAccessExpression(node) &&
+      node.name.text === BOOT_BINDING
+    ) {
+      reachedThroughNamespace = true;
+      return;
+    }
+    ts.forEachChild(node, findPropertyAccess);
+  };
+  ts.forEachChild(parsed, findPropertyAccess);
+  if (reachedThroughNamespace) return true;
 
   for (const statement of parsed.statements) {
     if (!ts.isImportDeclaration(statement)) continue;
@@ -106,6 +154,17 @@ export function importsBootHelper(source, fileName = "test.ts") {
 }
 
 /** The package directory a file belongs to, as `packages/<name>`. */
+/**
+ * The name this file needs in order to be collected by the integration lane.
+ *
+ * Every unit-lane suffix maps to the one suffix an integration config takes, so
+ * a `.spec.ts` is renamed as far as `.integration.test.ts` rather than to a
+ * `.spec` form no config would collect.
+ */
+export function integrationName(path) {
+  return path.replace(/\.(test|spec)\.tsx?$/, INTEGRATION_SUFFIX);
+}
+
 export function packageOf(path) {
   const [, name] = path.split("/");
   return name ? `packages/${name}` : undefined;
@@ -137,6 +196,7 @@ export function hasIntegrationLane(packageDir, readManifest) {
  */
 export function classify(files, readSource) {
   const misrouted = [];
+  const stranded = [];
   const covered = [];
 
   for (const path of files) {
@@ -148,11 +208,28 @@ export function classify(files, readSource) {
     }
     if (!importsBootHelper(source, path)) continue;
 
-    if (path.endsWith(INTEGRATION_SUFFIX)) covered.push(path);
-    else misrouted.push(path);
+    if (!path.endsWith(INTEGRATION_SUFFIX)) {
+      misrouted.push(path);
+      continue;
+    }
+
+    /*
+     * The name is only half of being routed. A package that declares no
+     * `test:integration` runs nothing matching the suffix, so a correctly named
+     * boot there is not in a slower lane, it is in no lane: it stops reporting
+     * and every job stays green. That is the worse of the two failures, and
+     * judging the name alone would have called it the clean case.
+     */
+    const packageDir = packageOf(path);
+    if (packageDir && !hasIntegrationLane(packageDir, readSource)) {
+      stranded.push(path);
+      continue;
+    }
+
+    covered.push(path);
   }
 
-  return { misrouted, covered };
+  return { misrouted, stranded, covered };
 }
 
 const invokedDirectly =
@@ -170,7 +247,7 @@ if (invokedDirectly) {
   }
 
   const readSource = path => readFileSync(join(root, path), "utf8");
-  const { misrouted, covered } = classify(files, readSource);
+  const { misrouted, stranded, covered } = classify(files, readSource);
 
   // The control, before the verdict. Every file failing to parse, or the
   // binding being renamed upstream, produces an empty `misrouted` that reads
@@ -184,11 +261,22 @@ if (invokedDirectly) {
     process.exit(2);
   }
 
-  if (misrouted.length > 0) {
+  if (misrouted.length > 0 || stranded.length > 0) {
     console.error("check-instance-boot-lane: FAILED\n");
+
+    for (const path of stranded) {
+      console.error(
+        `  ${path}\n` +
+          `    is named for the integration lane, and ${packageOf(path)} declares ` +
+          "no `test:integration` script, so nothing runs it at all.\n" +
+          "    Give the package an integration config and script, or the suite is " +
+          "green because it never ran.\n"
+      );
+    }
+
     for (const path of misrouted) {
       const packageDir = packageOf(path);
-      const renamed = path.replace(/\.test\.tsx?$/, INTEGRATION_SUFFIX);
+      const renamed = integrationName(path);
       console.error(
         `  ${path}\n` +
           `    imports \`${BOOT_BINDING}\`, so it boots a real instance and needs ` +
@@ -211,9 +299,9 @@ if (invokedDirectly) {
   }
 
   console.log(
-    `check-instance-boot-lane: ok — ${covered.length} suite(s) that boot an ` +
-      `instance are named for the integration lane, out of ${files.length} test ` +
-      "file(s) scanned."
+    `check-instance-boot-lane: ok - ${covered.length} suite(s) that boot an ` +
+      `instance are named for the integration lane AND run by a package that ` +
+      `declares one, out of ${files.length} test file(s) scanned.`
   );
   // Said on the way past, so a reader taking this as proof of routing knows the
   // shape it did not judge.

--- a/scripts/check-instance-boot-lane.test.mjs
+++ b/scripts/check-instance-boot-lane.test.mjs
@@ -10,7 +10,9 @@ import { describe, expect, it } from "vitest";
 
 import {
   BOOT_BINDING,
+  integrationName,
   INTEGRATION_SUFFIX,
+  UNIT_LANE_SUFFIXES,
   classify,
   hasIntegrationLane,
   importsBootHelper,
@@ -101,6 +103,25 @@ import { describe, it } from "vitest";`)
     ).toBe(true);
   });
 
+  it("sees a boot reached through a namespace import", () => {
+    // `import * as testing from "..."` names only `testing` in the clause, so
+    // the property access is the fact that identifies the boot. Deciding it
+    // from the import would need the specifier list this deliberately avoids.
+    expect(
+      importsBootHelper(`import * as testing from "nextly/testing";
+const app = await testing.createTestNextly({});`)
+    ).toBe(true);
+  });
+
+  it("does NOT see a property access spelled inside a comment", () => {
+    // The control for the case above: it must still be the compiler deciding,
+    // not a substring of the source.
+    expect(
+      importsBootHelper(`// call testing.createTestNextly() to boot one
+import { describe } from "vitest";`)
+    ).toBe(false);
+  });
+
   it("reads a .tsx suite, which the unit lane also includes", () => {
     expect(
       importsBootHelper(
@@ -113,13 +134,51 @@ import { describe, it } from "vitest";`)
 
 describe("routing a boot to a lane", () => {
   const BOOT = `import { createTestNextly } from "../test-nextly";`;
+  /* A package that can actually run the integration suffix it is given. */
+  const LANE = {
+    "packages/a/package.json": JSON.stringify({
+      scripts: { "test:integration": "vitest run --config i.ts" },
+    }),
+  };
 
-  it("accepts a boot named for the integration lane", () => {
-    const files = { [`packages/a/src/x${INTEGRATION_SUFFIX}`]: BOOT };
-    const { misrouted, covered } = classify(Object.keys(files), reader(files));
+  it("accepts a boot named for the integration lane in a package that runs it", () => {
+    const files = { ...LANE, [`packages/a/src/x${INTEGRATION_SUFFIX}`]: BOOT };
+    const { misrouted, stranded, covered } = classify(
+      [`packages/a/src/x${INTEGRATION_SUFFIX}`],
+      reader(files)
+    );
 
     expect(misrouted).toEqual([]);
+    expect(stranded).toEqual([]);
     expect(covered).toHaveLength(1);
+  });
+
+  it("reports a correctly named boot whose package runs no integration lane", () => {
+    // The worse of the two failures, and the one a filename cannot see: the
+    // suite is not in a slower lane, it is in none, so it stops reporting and
+    // every job stays green.
+    const files = {
+      "packages/a/package.json": JSON.stringify({ scripts: { test: "vitest" } }),
+      [`packages/a/src/x${INTEGRATION_SUFFIX}`]: BOOT,
+    };
+    const { misrouted, stranded, covered } = classify(
+      [`packages/a/src/x${INTEGRATION_SUFFIX}`],
+      reader(files)
+    );
+
+    expect(stranded).toEqual([`packages/a/src/x${INTEGRATION_SUFFIX}`]);
+    expect(covered).toEqual([]);
+    expect(misrouted).toEqual([]);
+  });
+
+  it("reports a booting spec suite, which no integration config can ever collect", () => {
+    // The unit configs take `*.{test,spec}.{ts,tsx}`; every integration config
+    // takes `*.integration.test.ts` and nothing else. A booting `.spec.ts` is
+    // therefore unroutable under its own name rather than merely slow.
+    const files = { ...LANE, "packages/a/src/x.spec.ts": BOOT };
+    const { misrouted } = classify(["packages/a/src/x.spec.ts"], reader(files));
+
+    expect(misrouted).toEqual(["packages/a/src/x.spec.ts"]);
   });
 
   it("reports a boot named for the unit lane", () => {
@@ -142,17 +201,21 @@ describe("routing a boot to a lane", () => {
     // correctly or the parser stopped recognising boots at all. The caller
     // refuses the second, and can only tell them apart from this.
     const files = {
+      ...LANE,
       [`packages/a/src/x${INTEGRATION_SUFFIX}`]: BOOT,
       "packages/b/src/y.test.ts": `import { it } from "vitest";`,
     };
-    const { misrouted, covered } = classify(Object.keys(files), reader(files));
+    const { misrouted, covered } = classify(
+      [`packages/a/src/x${INTEGRATION_SUFFIX}`, "packages/b/src/y.test.ts"],
+      reader(files)
+    );
 
     expect(misrouted).toEqual([]);
     expect(covered).toEqual([`packages/a/src/x${INTEGRATION_SUFFIX}`]);
   });
 
   it("skips a listed file the disk cannot read rather than throwing", () => {
-    const files = { "packages/a/src/x.test.ts": BOOT };
+    const files = { ...LANE, "packages/a/src/x.test.ts": BOOT };
     const { misrouted } = classify(
       ["packages/a/src/x.test.ts", "packages/a/src/gone.test.ts"],
       reader(files)
@@ -191,10 +254,15 @@ describe("whether a rename would land the suite anywhere", () => {
 });
 
 describe("the population it judges", () => {
-  it("keeps test files and drops everything else", () => {
+  it("keeps every suffix the unit lane collects, and drops everything else", () => {
+    // `spec` is in the population because the unit configs take it; a scan that
+    // dropped it would call the repository clean while a boot sat in the unit
+    // lane under a name no integration config can collect.
     const listed = [
       "packages/a/src/x.test.ts",
       "packages/a/src/y.test.tsx",
+      "packages/a/src/s.spec.ts",
+      "packages/a/src/s2.spec.tsx",
       `packages/a/src/z${INTEGRATION_SUFFIX}`,
       "packages/a/src/index.ts",
       "packages/a/package.json",
@@ -204,8 +272,33 @@ describe("the population it judges", () => {
     expect(testFiles(".", () => listed)).toEqual([
       "packages/a/src/x.test.ts",
       "packages/a/src/y.test.tsx",
+      "packages/a/src/s.spec.ts",
+      "packages/a/src/s2.spec.tsx",
       `packages/a/src/z${INTEGRATION_SUFFIX}`,
     ]);
+  });
+
+  it("collects the suffixes the unit configs name", () => {
+    expect(UNIT_LANE_SUFFIXES).toEqual([
+      ".test.ts",
+      ".test.tsx",
+      ".spec.ts",
+      ".spec.tsx",
+    ]);
+  });
+
+  it("renames every unit suffix to the one suffix an integration config takes", () => {
+    // A `.spec.ts` renamed to a `.spec` form would still be collected by no
+    // integration config, so the advice has to cross the suffix families.
+    expect(integrationName("packages/a/src/x.test.ts")).toBe(
+      `packages/a/src/x${INTEGRATION_SUFFIX}`
+    );
+    expect(integrationName("packages/a/src/x.spec.ts")).toBe(
+      `packages/a/src/x${INTEGRATION_SUFFIX}`
+    );
+    expect(integrationName("packages/a/src/x.spec.tsx")).toBe(
+      `packages/a/src/x${INTEGRATION_SUFFIX}`
+    );
   });
 
   it("names the package a file belongs to", () => {

--- a/scripts/check-instance-boot-lane.test.mjs
+++ b/scripts/check-instance-boot-lane.test.mjs
@@ -1,0 +1,220 @@
+/**
+ * What separates a boot from a mention of one.
+ *
+ * The check exists because the two lanes are told apart by filename, and it is
+ * useful only if it can tell an import from prose: most files naming the helper
+ * outside the integration suffix name it in a docblock, and a check that
+ * reports those is one that gets turned off.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  BOOT_BINDING,
+  INTEGRATION_SUFFIX,
+  classify,
+  hasIntegrationLane,
+  importsBootHelper,
+  packageOf,
+  testFiles,
+} from "./check-instance-boot-lane.mjs";
+
+/** A reader over an in-memory file set, so no case touches the disk. */
+function reader(files) {
+  return path => {
+    if (!(path in files)) throw new Error(`no such file: ${path}`);
+    return files[path];
+  };
+}
+
+describe("telling a boot from a mention of one", () => {
+  it("sees a plain named import", () => {
+    expect(
+      importsBootHelper(`import { createTestNextly } from "../test-nextly";`)
+    ).toBe(true);
+  });
+
+  it("sees it beside other bindings, and under any specifier", () => {
+    // The helper is imported under nine specifiers across the repository, so
+    // the binding is what identifies it and the module never is.
+    for (const from of [
+      "nextly/testing",
+      "@nextlyhq/plugin-sdk/testing",
+      "../../../../plugins/test-nextly",
+    ]) {
+      expect(
+        importsBootHelper(
+          `import { type TestNextly, createTestNextly } from "${from}";`
+        )
+      ).toBe(true);
+    }
+  });
+
+  it("sees it renamed, because a rename still boots", () => {
+    expect(
+      importsBootHelper(
+        `import { createTestNextly as boot } from "../test-nextly";`
+      )
+    ).toBe(true);
+  });
+
+  it("does NOT see it in a line comment", () => {
+    expect(
+      importsBootHelper(`// createTestNextly clears this cache on every boot`)
+    ).toBe(false);
+  });
+
+  it("does NOT see it in a docblock, which is how it actually appears", () => {
+    // The shape that makes a text match unusable: of the files naming the
+    // helper outside the integration suffix, this is what most of them are.
+    expect(
+      importsBootHelper(`/**
+ * Unit tests with a spied entry service; the live \`createTestNextly\` path is
+ * proven elsewhere.
+ */
+import { describe, it } from "vitest";`)
+    ).toBe(false);
+  });
+
+  it("does NOT see it inside a string", () => {
+    expect(
+      importsBootHelper(`const helper = "createTestNextly";`)
+    ).toBe(false);
+  });
+
+  it("does NOT see a type-only import, which boots nothing", () => {
+    expect(
+      importsBootHelper(`import type { createTestNextly } from "../x";`)
+    ).toBe(false);
+    expect(
+      importsBootHelper(`import { type createTestNextly } from "../x";`)
+    ).toBe(false);
+  });
+
+  it("does not confuse a different binding from the same module", () => {
+    // The positive control for the negatives above: they would all pass on a
+    // predicate that answered false to everything.
+    expect(
+      importsBootHelper(`import { createTestFixture } from "../test-nextly";`)
+    ).toBe(false);
+    expect(
+      importsBootHelper(`import { createTestNextly } from "../test-nextly";`)
+    ).toBe(true);
+  });
+
+  it("reads a .tsx suite, which the unit lane also includes", () => {
+    expect(
+      importsBootHelper(
+        `import { createTestNextly } from "../t";\nconst el = <div />;`,
+        "widget.test.tsx"
+      )
+    ).toBe(true);
+  });
+});
+
+describe("routing a boot to a lane", () => {
+  const BOOT = `import { createTestNextly } from "../test-nextly";`;
+
+  it("accepts a boot named for the integration lane", () => {
+    const files = { [`packages/a/src/x${INTEGRATION_SUFFIX}`]: BOOT };
+    const { misrouted, covered } = classify(Object.keys(files), reader(files));
+
+    expect(misrouted).toEqual([]);
+    expect(covered).toHaveLength(1);
+  });
+
+  it("reports a boot named for the unit lane", () => {
+    const files = { "packages/a/src/x.test.ts": BOOT };
+    const { misrouted } = classify(Object.keys(files), reader(files));
+
+    expect(misrouted).toEqual(["packages/a/src/x.test.ts"]);
+  });
+
+  it("leaves a unit suite that boots nothing alone", () => {
+    const files = { "packages/a/src/x.test.ts": `import { it } from "vitest";` };
+    const { misrouted, covered } = classify(Object.keys(files), reader(files));
+
+    expect(misrouted).toEqual([]);
+    expect(covered).toEqual([]);
+  });
+
+  it("returns the covered population, which is what makes a clean run mean something", () => {
+    // `misrouted` being empty is the same answer whether every boot is routed
+    // correctly or the parser stopped recognising boots at all. The caller
+    // refuses the second, and can only tell them apart from this.
+    const files = {
+      [`packages/a/src/x${INTEGRATION_SUFFIX}`]: BOOT,
+      "packages/b/src/y.test.ts": `import { it } from "vitest";`,
+    };
+    const { misrouted, covered } = classify(Object.keys(files), reader(files));
+
+    expect(misrouted).toEqual([]);
+    expect(covered).toEqual([`packages/a/src/x${INTEGRATION_SUFFIX}`]);
+  });
+
+  it("skips a listed file the disk cannot read rather than throwing", () => {
+    const files = { "packages/a/src/x.test.ts": BOOT };
+    const { misrouted } = classify(
+      ["packages/a/src/x.test.ts", "packages/a/src/gone.test.ts"],
+      reader(files)
+    );
+
+    expect(misrouted).toEqual(["packages/a/src/x.test.ts"]);
+  });
+});
+
+describe("whether a rename would land the suite anywhere", () => {
+  it("is true for a package that declares the integration script", () => {
+    const files = {
+      "packages/a/package.json": JSON.stringify({
+        scripts: { "test:integration": "vitest run --config x" },
+      }),
+    };
+
+    expect(hasIntegrationLane("packages/a", reader(files))).toBe(true);
+  });
+
+  it("is false for a package that does not, so the advice can say so", () => {
+    // Renaming into a lane a package does not have moves the suite out of the
+    // unit run and into nothing, which is worse than the timeout it fixes.
+    const files = {
+      "packages/a/package.json": JSON.stringify({
+        scripts: { test: "vitest run" },
+      }),
+    };
+
+    expect(hasIntegrationLane("packages/a", reader(files))).toBe(false);
+  });
+
+  it("is false, rather than throwing, for an unreadable manifest", () => {
+    expect(hasIntegrationLane("packages/gone", reader({}))).toBe(false);
+  });
+});
+
+describe("the population it judges", () => {
+  it("keeps test files and drops everything else", () => {
+    const listed = [
+      "packages/a/src/x.test.ts",
+      "packages/a/src/y.test.tsx",
+      `packages/a/src/z${INTEGRATION_SUFFIX}`,
+      "packages/a/src/index.ts",
+      "packages/a/package.json",
+      "packages/a/README.md",
+    ].join("\0");
+
+    expect(testFiles(".", () => listed)).toEqual([
+      "packages/a/src/x.test.ts",
+      "packages/a/src/y.test.tsx",
+      `packages/a/src/z${INTEGRATION_SUFFIX}`,
+    ]);
+  });
+
+  it("names the package a file belongs to", () => {
+    expect(packageOf("packages/plugin-seo/src/a.test.ts")).toBe(
+      "packages/plugin-seo"
+    );
+  });
+
+  it("uses the binding the repository actually imports", () => {
+    expect(BOOT_BINDING).toBe("createTestNextly");
+  });
+});

--- a/scripts/check-instance-boot-lane.test.mjs
+++ b/scripts/check-instance-boot-lane.test.mjs
@@ -113,6 +113,34 @@ const app = await testing.createTestNextly({});`)
     ).toBe(true);
   });
 
+  it("does NOT see a local object that happens to expose the name", () => {
+    // The false positive the receiver check exists to prevent. A fixture or a
+    // mock exposing `createTestNextly` boots nothing, and demanding an
+    // integration rename for it would be the check firing on a correct file.
+    expect(
+      importsBootHelper(`import { describe } from "vitest";
+const fixture = { createTestNextly: () => ({}) };
+const app = fixture.createTestNextly();`)
+    ).toBe(false);
+  });
+
+  it("does NOT see a namespace it never imported", () => {
+    expect(
+      importsBootHelper(`import * as other from "./helpers";
+const app = fixture.createTestNextly();`)
+    ).toBe(false);
+  });
+
+  it("sees it through the namespace that WAS imported, beside one that was not", () => {
+    // The positive control for the two negatives above: they would both pass on
+    // a predicate that stopped recognising namespace boots entirely.
+    expect(
+      importsBootHelper(`import * as testing from "nextly/testing";
+const decoy = { createTestNextly: () => ({}) };
+const app = await testing.createTestNextly({});`)
+    ).toBe(true);
+  });
+
   it("does NOT see a property access spelled inside a comment", () => {
     // The control for the case above: it must still be the compiler deciding,
     // not a substring of the source.


### PR DESCRIPTION
## The gap

The two vitest lanes are told apart **by filename and nothing else**:

| | unit config | integration config |
|---|---|---|
| include | `src/**/*.{test,spec}.{ts,tsx}` | `src/**/*.integration.test.ts` |
| exclude | `src/**/*.integration.test.ts` | node_modules, dist |
| `testTimeout` | 10s | 30s |
| `fileParallelism` | default (parallel) | `false` |

A suite that boots a real instance under the unit name runs on a budget sized for jsdom component tests, against every package turbo is building. It passes locally in about a second and times out only when the runner is loaded, which is why it survives review.

That is not hypothetical: it turned `main` red twice today (`fbbb8422e`, `12523acb8`) and blocked a release train, fixed in #1661.

**Nothing enforced the rule.** `check-test-lanes` proves a *package* is run by some lane; the retired `check-integration-lane` did not check filenames either. **223 suites already follow the convention with nothing holding them to it.**

## Why a script, and why it parses

**It cannot be an ESLint rule.** `@nextlyhq/eslint-config/base` ignores test files repo-wide: *"test files are excluded from tsconfig, so type-aware lint can't resolve them."* A rule there would never fire.

**It cannot be a text match.** Of the files naming `createTestNextly` outside the integration suffix, **most name it in a docblock** explaining why a spy is used instead, or why a cache is not shared. A containment test reports every one of those, and a check that fires on correct files is one that gets turned off. The TypeScript compiler decides what is an import, so a comment cannot be one.

**The binding identifies a boot, not the module.** The helper arrives under **nine specifiers** (`nextly/testing`, `@nextlyhq/plugin-sdk/testing`, and seven relative paths differing only by depth), so a specifier list would be a list of ways to reach a directory, and a file one level deeper would fall out of the scan.

## Verification

- **Against `main` as it stands: passes**, reporting 223 routed boots out of 2048 test files scanned.
- **Against the file as it was before #1661: fails**, naming the file and the exact rename.
- 20 unit tests, including the negatives that matter: a line comment, a docblock, a string literal, and a type-only import are all **not** boots; a renamed import (`createTestNextly as boot`) **is**.
- The negatives carry a positive control, so they cannot pass on a predicate that answers false to everything.
- A run that finds **zero** boots exits `2` rather than reporting success, because an empty result otherwise reads identically whether the repo is clean or the parser stopped recognising imports.

## DX detail

Where a violating file's package has **no `test:integration` script**, the report says so, because renaming into a lane that does not exist would move the suite out of the unit run and into nothing, which is worse than the timeout it fixes. (Every package that boots instances today does have one.)

No changeset: CI-only, per `AGENTS.md`.