### PR TITLE
fix(blocks-engine): refuse a forest too large to measure, rather than crashing in it

### DIFF
--- a/.changeset/a-forest-too-large-to-measure.md
+++ b/.changeset/a-forest-too-large-to-measure.md
@@ -32,6 +32,13 @@ They walk ENTRIES, not objects, and deliberately so: one node object placed in t
 
 `documentBytes` was the sharp edge. `JSON.stringify` expands each shared node into a copy per path that reaches it, so it allocated 132 MB for 21 objects and raised `RangeError: Invalid string length` at 23 — from a document a few kilobytes in memory, in the one function that decides whether a document may be stored.
 
-Past `MAX_WALKABLE_ENTRIES` (1,000,000 — two hundred times the default node cap, so it only fires on forests no product setting would have allowed) each of the three now throws `ForestTooLargeError`, naming the cause: a node placed under more than one parent. Both are exported. Inside `applyOp` the refusal arrives as an `OpError` like every other, so the `...Refusal` helpers still return a reason rather than throwing at their caller.
+All three now throw `ForestTooLargeError`, against **two different bounds** — they count different populations and neither number stands in for the other:
+
+- `countNodes` and `treeDepth` refuse past `MAX_WALKABLE_ENTRIES` (1,000,000), which counts forest ENTRIES.
+- `documentBytes` refuses past `MAX_SERIALIZED_VALUES` (2,000,000), which counts the VALUES the serializer visits — measured at six per node, so this is roughly 333,000 nodes.
+
+Both bounds and the error are exported from the package root; `@nextlyhq/blocks-engine/format` exports the error and `MAX_SERIALIZED_VALUES`, which is the only one bounding anything that entry exposes.
+
+The messages name the routes to each bound without claiming which one a caller hit, because neither reader compares object identity and so neither can tell. Inside `applyOp` the refusal arrives as an `OpError` like every other, so the `...Refusal` helpers still return a reason rather than throwing at their caller. Composition and the builder's deletion metadata degrade rather than propagate it: an unmeasurable subtree refunds nothing and reports no descendant count, so a page still renders and a block can still be deleted.
 
 Nothing a site can store is affected. `JSON.parse` produces fresh objects and cannot express sharing, so a stored document is never such a forest; the bound is reachable only by a forest built in memory by code.

--- a/.changeset/a-forest-too-large-to-measure.md
+++ b/.changeset/a-forest-too-large-to-measure.md
@@ -1,0 +1,37 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The engine's three whole-document measurements — `countNodes`, `treeDepth` and `documentBytes` — now refuse a forest they cannot afford to walk instead of grinding through it or raising a native error.
+
+They walk ENTRIES, not objects, and deliberately so: one node object placed in two slots is two elements of the document, and counting it once would report half a real size and pass a cap the document exceeds. That makes the walk exponential in depth for a forest whose branches share a node object — 21 shared objects reach 2,097,151 entries, and every further object doubles it.
+
+`documentBytes` was the sharp edge. `JSON.stringify` expands each shared node into a copy per path that reaches it, so it allocated 132 MB for 21 objects and raised `RangeError: Invalid string length` at 23 — from a document a few kilobytes in memory, in the one function that decides whether a document may be stored.
+
+Past `MAX_WALKABLE_ENTRIES` (1,000,000 — two hundred times the default node cap, so it only fires on forests no product setting would have allowed) each of the three now throws `ForestTooLargeError`, naming the cause: a node placed under more than one parent. Both are exported. Inside `applyOp` the refusal arrives as an `OpError` like every other, so the `...Refusal` helpers still return a reason rather than throwing at their caller.
+
+Nothing a site can store is affected. `JSON.parse` produces fresh objects and cannot express sharing, so a stored document is never such a forest; the bound is reachable only by a forest built in memory by code.

--- a/packages/blocks-engine/src/format.ts
+++ b/packages/blocks-engine/src/format.ts
@@ -59,8 +59,13 @@ export {
   // consumer unable to tell that refusal from a defect of its own, or to name
   // the threshold it hit, without reaching past this entry to the root — which
   // is the coupling this parser-free entry exists to prevent.
+  //
+  // `MAX_SERIALIZED_VALUES` and not `MAX_WALKABLE_ENTRIES`: the two are
+  // different units and only the first bounds anything this entry exposes.
+  // `countNodes` and `treeDepth` are not published here, so exporting the bound
+  // they answer to would name a threshold no caller of this entry can reach.
   ForestTooLargeError,
-  MAX_WALKABLE_ENTRIES,
+  MAX_SERIALIZED_VALUES,
 } from "./limits";
 
 export { measureBytes, surveyDocument } from "./measure-bytes";

--- a/packages/blocks-engine/src/format.ts
+++ b/packages/blocks-engine/src/format.ts
@@ -54,6 +54,13 @@ export {
   MAX_DEPTH,
   MAX_NODES,
   documentBytes,
+  // What `documentBytes` REFUSES with, by the same rule as the types below: an
+  // entry point that exports a function without the error it throws leaves a
+  // consumer unable to tell that refusal from a defect of its own, or to name
+  // the threshold it hit, without reaching past this entry to the root — which
+  // is the coupling this parser-free entry exists to prevent.
+  ForestTooLargeError,
+  MAX_WALKABLE_ENTRIES,
 } from "./limits";
 
 export { measureBytes, surveyDocument } from "./measure-bytes";

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -102,6 +102,12 @@ export {
   countNodes,
   treeDepth,
   documentBytes,
+  // Published because the three readers above now REFUSE a forest they cannot
+  // afford to walk, and a caller that wants to report that rather than let it
+  // escape has to be able to name it. The bound travels with it so a caller can
+  // say what it exceeded rather than restating the number.
+  MAX_WALKABLE_ENTRIES,
+  ForestTooLargeError,
 } from "./limits";
 export type { DocumentLimits } from "./limits";
 export type { DocumentSurvey, SurveyLimits } from "./measure-bytes";

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -103,10 +103,16 @@ export {
   treeDepth,
   documentBytes,
   // Published because the three readers above now REFUSE a forest they cannot
-  // afford to walk, and a caller that wants to report that rather than let it
-  // escape has to be able to name it. The bound travels with it so a caller can
-  // say what it exceeded rather than restating the number.
+  // afford to measure, and a caller that wants to report that rather than let
+  // it escape has to be able to name it.
+  //
+  // BOTH bounds travel with it, because they are different units and a caller
+  // cannot tell from the error which it hit: `countNodes` and `treeDepth` count
+  // forest ENTRIES, while `documentBytes` counts the VALUES the serializer
+  // visits — six per node on a measured document, so the two numbers are not
+  // comparable and neither can stand in for the other.
   MAX_WALKABLE_ENTRIES,
+  MAX_SERIALIZED_VALUES,
   ForestTooLargeError,
 } from "./limits";
 export type { DocumentLimits } from "./limits";

--- a/packages/blocks-engine/src/limits.test.ts
+++ b/packages/blocks-engine/src/limits.test.ts
@@ -75,46 +75,65 @@ describe("a forest whose entries outrun its objects", () => {
     expect(() => treeDepth(sharedChain(OVER))).toThrow(ForestTooLargeError);
   });
 
-  it("translates the serializer's size failure, and only that one", () => {
+  it("aborts serialization at the bound instead of building the string first", () => {
     /*
-     * The real trigger is a string longer than the engine can hold — 23 shared
-     * objects reach it — and building one costs half a gigabyte, which is not
-     * what a unit suite should spend to observe a translation. The FIXTURE
-     * raises the same error the serializer raises, from inside the same call,
-     * so the mechanism under test is exercised exactly.
+     * The bound rides the serializer's OWN traversal through a replacer, so it
+     * stops before the string exists. Catching the eventual failure instead
+     * would pay the whole cost first: the 21-object case allocates 132 MB and a
+     * deeper one exhausts the heap before any catchable error is raised.
      *
-     * The second half is what makes the first mean anything: a cycle raises
-     * `TypeError` and must pass THROUGH, because renaming an unrelated failure
-     * into a size complaint sends a reader to shrink a document that is fine.
+     * 30 objects is chosen because it CANNOT be serialized at all — a billion
+     * entries — so a passing assertion here proves the abort is early rather
+     * than merely eventual. The test would not complete otherwise.
      */
-    const sizeFailure = {
-      id: "s",
+    const start = Date.now();
+    expect(() => documentBytes(page(sharedChain(30)))).toThrow(
+      ForestTooLargeError
+    );
+    expect(Date.now() - start).toBeLessThan(10_000);
+  });
+
+  it("leaves a RangeError from the document's own hook alone", () => {
+    /*
+     * A `toJSON`, a getter or a proxy trap may raise `RangeError` for its own
+     * reasons. Renaming that into a size refusal tells a caller to shrink or
+     * de-share a document whose problem is in its hook, and loses the original
+     * diagnostic — so nothing here catches it.
+     *
+     * This replaces an earlier test that RAISED a RangeError through `toJSON`
+     * to stand in for the size failure. It passed, and it pinned exactly the
+     * misclassification described above: the fixture proved the translation
+     * happened, never that the serializer had hit its own limit.
+     */
+    const own = new RangeError("from the document's own hook");
+    const hooked = {
+      id: "h",
       type: "core/box",
       version: 1,
       props: {},
       toJSON() {
-        throw new RangeError("Invalid string length");
+        throw own;
       },
     } as unknown as BlockNode;
-    expect(() => documentBytes(page([sizeFailure]))).toThrow(
-      ForestTooLargeError
-    );
-    expect(() => documentBytes(page([sizeFailure]))).toThrow(
-      /longer than a string can hold/
-    );
 
-    const cyclic = { id: "c", type: "core/box", version: 1, props: {} } as {
-      self?: unknown;
-    } & BlockNode;
-    cyclic.self = cyclic;
     let raised: unknown;
     try {
-      documentBytes(page([cyclic]));
+      documentBytes(page([hooked]));
     } catch (error) {
       raised = error;
     }
-    expect(raised).toBeInstanceOf(TypeError);
+    expect(raised).toBe(own);
     expect(raised).not.toBeInstanceOf(ForestTooLargeError);
+  });
+
+  it("measures an ordinary document byte-for-byte as plain stringify would", () => {
+    // The replacer must not change the OUTPUT, only bound the work. Without
+    // this, a replacer that dropped or rewrote values would still pass every
+    // refusal test above while silently reporting the wrong size.
+    const doc = page(chain(20));
+    expect(documentBytes(doc)).toBe(
+      new TextEncoder().encode(JSON.stringify(doc)).length
+    );
   });
 
   it("offers both causes rather than diagnosing the one it cannot see", () => {

--- a/packages/blocks-engine/src/limits.test.ts
+++ b/packages/blocks-engine/src/limits.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+
+import type { BlockDocument, BlockNode } from "./document";
+import {
+  countNodes,
+  documentBytes,
+  ForestTooLargeError,
+  MAX_NODES,
+  MAX_WALKABLE_ENTRIES,
+  treeDepth,
+} from "./limits";
+
+/**
+ * A forest of `objects` distinct nodes where each holds the NEXT one TWICE.
+ *
+ * Entry count is `2 ** objects - 1` while the object count is linear, which is
+ * the shape the bound exists for. Nothing persisted can look like this —
+ * `JSON.parse` produces fresh objects and cannot express sharing — so it is
+ * built here the only way it can arise: in memory, by code.
+ */
+function sharedChain(objects: number): BlockNode[] {
+  let node: BlockNode = {
+    id: "leaf",
+    type: "core/box",
+    version: 1,
+    props: {},
+  } as BlockNode;
+  for (let i = objects - 1; i >= 0; i--) {
+    node = {
+      id: `n${String(i)}`,
+      type: "core/box",
+      version: 1,
+      props: {},
+      slots: { children: [node, node] },
+    } as BlockNode;
+  }
+  return [node];
+}
+
+/** A genuinely deep TREE — no sharing, one object per entry. */
+function chain(objects: number): BlockNode[] {
+  let node: BlockNode = {
+    id: "leaf",
+    type: "core/box",
+    version: 1,
+    props: {},
+  } as BlockNode;
+  for (let i = objects - 1; i >= 0; i--) {
+    node = {
+      id: `n${String(i)}`,
+      type: "core/box",
+      version: 1,
+      props: {},
+      slots: { children: [node] },
+    } as BlockNode;
+  }
+  return [node];
+}
+
+const page = (nodes: BlockNode[]): BlockDocument =>
+  ({ formatVersion: 1, kind: "page", nodes }) as BlockDocument;
+
+describe("a forest whose entries outrun its objects", () => {
+  // 21 objects walk 2,097,151 entries, which is past the bound. 18 objects walk
+  // 262,143, which is not — so the pair separates "refuses what it must" from
+  // "refuses everything", and neither test is evidence without the other.
+  const OVER = 21;
+  const UNDER = 18;
+
+  it("refuses to COUNT one, rather than answering from a partial walk", () => {
+    expect(() => countNodes(sharedChain(OVER))).toThrow(ForestTooLargeError);
+  });
+
+  it("refuses to MEASURE ITS DEPTH for the same reason", () => {
+    expect(() => treeDepth(sharedChain(OVER))).toThrow(ForestTooLargeError);
+  });
+
+  it("refuses to SIZE one instead of raising a native string-length error", () => {
+    /*
+     * `JSON.stringify` expands a shared node into a copy per path that reaches
+     * it, so the string grows with entries rather than objects and stops with
+     * `RangeError: Invalid string length` — an error naming a string length,
+     * from the one function that decides whether a document may be stored.
+     *
+     * The assertion names the type rather than merely requiring a throw:
+     * without it the RangeError this replaced would satisfy the test.
+     */
+    expect(() => documentBytes(page(sharedChain(OVER)))).toThrow(
+      ForestTooLargeError
+    );
+    let raised: unknown;
+    try {
+      documentBytes(page(sharedChain(OVER)));
+    } catch (error) {
+      raised = error;
+    }
+    expect(raised).toBeInstanceOf(ForestTooLargeError);
+    expect(raised).not.toBeInstanceOf(RangeError);
+  });
+
+  it("says what to look for, since the caller's own nodes are rarely the cause", () => {
+    // The message has to name the SHARING. "Too large" sends a reader to trim a
+    // document that is already small, which is the wrong repair.
+    expect(() => countNodes(sharedChain(OVER))).toThrow(/more than one parent/);
+  });
+
+  it("still answers for a shared forest UNDER the bound", () => {
+    // The control for all four above. A bound set low enough to refuse
+    // everything passes each of them, and this is what separates the two.
+    expect(countNodes(sharedChain(UNDER))).toBe(2 ** (UNDER + 1) - 1);
+    expect(treeDepth(sharedChain(UNDER))).toBe(UNDER + 1);
+  });
+
+  it("leaves an ordinary document alone, bound nowhere near it", () => {
+    // The bound is a MACHINE one and must never fire on anything a product cap
+    // would have allowed, so it is asserted against the product cap rather than
+    // against a number chosen to agree with it.
+    expect(MAX_WALKABLE_ENTRIES).toBeGreaterThan(MAX_NODES * 100);
+    const ordinary = chain(50);
+    expect(countNodes(ordinary)).toBe(51);
+    expect(treeDepth(ordinary)).toBe(51);
+    expect(documentBytes(page(ordinary))).toBeGreaterThan(0);
+  });
+});

--- a/packages/blocks-engine/src/limits.test.ts
+++ b/packages/blocks-engine/src/limits.test.ts
@@ -75,33 +75,90 @@ describe("a forest whose entries outrun its objects", () => {
     expect(() => treeDepth(sharedChain(OVER))).toThrow(ForestTooLargeError);
   });
 
-  it("refuses to SIZE one instead of raising a native string-length error", () => {
+  it("translates the serializer's size failure, and only that one", () => {
     /*
-     * `JSON.stringify` expands a shared node into a copy per path that reaches
-     * it, so the string grows with entries rather than objects and stops with
-     * `RangeError: Invalid string length` — an error naming a string length,
-     * from the one function that decides whether a document may be stored.
+     * The real trigger is a string longer than the engine can hold — 23 shared
+     * objects reach it — and building one costs half a gigabyte, which is not
+     * what a unit suite should spend to observe a translation. The FIXTURE
+     * raises the same error the serializer raises, from inside the same call,
+     * so the mechanism under test is exercised exactly.
      *
-     * The assertion names the type rather than merely requiring a throw:
-     * without it the RangeError this replaced would satisfy the test.
+     * The second half is what makes the first mean anything: a cycle raises
+     * `TypeError` and must pass THROUGH, because renaming an unrelated failure
+     * into a size complaint sends a reader to shrink a document that is fine.
      */
-    expect(() => documentBytes(page(sharedChain(OVER)))).toThrow(
+    const sizeFailure = {
+      id: "s",
+      type: "core/box",
+      version: 1,
+      props: {},
+      toJSON() {
+        throw new RangeError("Invalid string length");
+      },
+    } as unknown as BlockNode;
+    expect(() => documentBytes(page([sizeFailure]))).toThrow(
       ForestTooLargeError
     );
+    expect(() => documentBytes(page([sizeFailure]))).toThrow(
+      /longer than a string can hold/
+    );
+
+    const cyclic = { id: "c", type: "core/box", version: 1, props: {} } as {
+      self?: unknown;
+    } & BlockNode;
+    cyclic.self = cyclic;
     let raised: unknown;
     try {
-      documentBytes(page(sharedChain(OVER)));
+      documentBytes(page([cyclic]));
     } catch (error) {
       raised = error;
     }
-    expect(raised).toBeInstanceOf(ForestTooLargeError);
-    expect(raised).not.toBeInstanceOf(RangeError);
+    expect(raised).toBeInstanceOf(TypeError);
+    expect(raised).not.toBeInstanceOf(ForestTooLargeError);
   });
 
-  it("says what to look for, since the caller's own nodes are rarely the cause", () => {
-    // The message has to name the SHARING. "Too large" sends a reader to trim a
-    // document that is already small, which is the wrong repair.
+  it("offers both causes rather than diagnosing the one it cannot see", () => {
+    /*
+     * The walk counts entries and never compares identity, so it cannot tell a
+     * shared chain from a genuinely enormous flat forest. Naming only the
+     * sharing would send a reader hunting for a node under two parents in a
+     * document that has none — a repair that cannot succeed.
+     *
+     * Both halves are asserted: dropping either leaves a message that reads as
+     * a diagnosis of whichever survived.
+     */
     expect(() => countNodes(sharedChain(OVER))).toThrow(/more than one parent/);
+    expect(() => countNodes(sharedChain(OVER))).toThrow(
+      /genuinely holding that many nodes/
+    );
+  });
+
+  it("does not refuse a document the serializer would have measured", () => {
+    /*
+     * `walkForest` reaches `node.slots` by property access, so it sees a slot
+     * the serializer does not: `JSON.stringify` reads own enumerable properties
+     * only. Predicting the size from the walk refused this document — whose
+     * JSON is under a hundred bytes — which is a false refusal on the function
+     * deciding whether a document may be stored. Measuring what the serializer
+     * ACTUALLY produced cannot diverge from it.
+     */
+    const hidden = {
+      id: "h",
+      type: "core/box",
+      version: 1,
+      props: {},
+    } as unknown as BlockNode;
+    Object.defineProperty(hidden, "slots", {
+      value: { children: sharedChain(OVER) },
+      enumerable: false,
+    });
+
+    const bytes = documentBytes(page([hidden]));
+    expect(bytes).toBeGreaterThan(0);
+    expect(bytes).toBeLessThan(1_000);
+    // The control: the walk really does reach the hidden chain, so this is not
+    // passing because the fixture failed to build one.
+    expect(() => countNodes([hidden])).toThrow(ForestTooLargeError);
   });
 
   it("still answers for a shared forest UNDER the bound", () => {

--- a/packages/blocks-engine/src/limits.ts
+++ b/packages/blocks-engine/src/limits.ts
@@ -115,16 +115,32 @@ export const MAX_WALKABLE_ENTRIES = 1_000_000;
  * under more than one parent is.
  */
 export class ForestTooLargeError extends Error {
-  constructor(subject: string) {
-    super(
-      `${subject} reaches more than ${String(MAX_WALKABLE_ENTRIES)} entries ` +
-        `and cannot be measured: past that the walk is not affordable. A ` +
-        `forest this large for its object count holds a node placed under ` +
-        `more than one parent, which multiplies entries at every level.`
-    );
+  constructor(message: string) {
+    super(message);
     this.name = "ForestTooLargeError";
   }
 }
+
+/**
+ * The two ways a forest outruns a reader, stated together because the reader
+ * CANNOT tell them apart.
+ *
+ * The bound counts entries and never compares object identity, so a flat forest
+ * of a million distinct nodes reaches it exactly as a shared chain of
+ * twenty-one does. Naming only the sharing reads as a diagnosis rather than a
+ * possibility, and sends a reader hunting for a node under two parents in a
+ * document that has none — a repair that cannot succeed because there is
+ * nothing to find.
+ *
+ * Establishing WHICH one it is would mean holding every visited object to
+ * compare identity, which costs memory proportional to the forest on every
+ * ordinary call to pay for a sentence on the failing one. So both are named and
+ * neither is claimed.
+ */
+const WHY_TOO_LARGE =
+  `A forest reaches this either by genuinely holding that many nodes, or by ` +
+  `holding a node placed under more than one parent — which multiplies ` +
+  `entries at every level, so a few dozen objects can reach millions.`;
 
 /**
  * Visit the forest, refusing rather than answering from a partial walk.
@@ -148,7 +164,13 @@ function walkBounded(
     onEntry(entry.depth);
     return "descend";
   });
-  if (spent) throw new ForestTooLargeError(subject);
+  if (spent) {
+    throw new ForestTooLargeError(
+      `${subject} reaches more than ${String(MAX_WALKABLE_ENTRIES)} entries ` +
+        `and cannot be measured: past that the walk is not affordable. ` +
+        WHY_TOO_LARGE
+    );
+  }
 }
 
 /** Total node count across the forest, slots included. */
@@ -176,25 +198,40 @@ export function treeDepth(nodes: BlockNode[]): number {
  * Serialized size of a document in bytes (UTF-8 of its JSON form — the same
  * bytes that hit storage, so the cap measures what actually gets persisted).
  *
- * The forest is measured FIRST, and this is not belt-and-braces. `JSON.stringify`
- * expands a shared node object into a separate copy per path that reaches it,
- * so the string it builds grows with ENTRIES rather than with objects — and it
+ * `JSON.stringify` expands a shared node object into a separate copy per path
+ * that reaches it, so the string grows with ENTRIES rather than with objects and
  * does not degrade gracefully. Measured on this module's own helpers: 21 shared
- * objects produce 132 MB, and 23 raise `RangeError: Invalid string length`
- * from a document that is a few kilobytes in memory.
+ * objects produce 132 MB, and 23 raise `RangeError: Invalid string length` from
+ * a document that is a few kilobytes in memory. A native `RangeError` names a
+ * string length, which says nothing about the document and cannot be acted on —
+ * and it arrives from the one function whose whole job is to decide whether a
+ * document may be stored, so it lands where a caller is least able to read it.
  *
- * That error is the reason the guard runs before the serialization rather than
- * around it. A native `RangeError` escaping here names a string length, which
- * says nothing about the document and cannot be acted on; it also arrives from
- * the one function whose whole job is to decide whether a document may be
- * stored, so the failure lands where a caller is least able to interpret it.
+ * The refusal is taken FROM the serializer rather than predicted before it, and
+ * that is the whole design. A preflight walk answers a different question than
+ * the one this function asks: `walkForest` reaches `node.slots` by property
+ * access, so it sees inherited and non-enumerable slots and ignores `toJSON`,
+ * while `JSON.stringify` reads own enumerable properties and honours it.
+ * Measured with a node whose `slots` is non-enumerable: the document serializes
+ * to 95 bytes and a preflight walk refused it — a false refusal, on a gate,
+ * against a document that would have saved perfectly.
+ *
+ * Catching what the serializer actually raised cannot diverge from it, costs no
+ * second traversal, and refuses exactly the documents that cannot be measured.
  */
 export function documentBytes(doc: BlockDocument): number {
-  // Guarded at RUNTIME although the type says `BlockNode[]`, because a stored
-  // document arrives unvalidated and `walkForest` is written for exactly that.
-  // A document whose `nodes` is not a list has nothing to measure and is left
-  // to the serializer, which reports its own shape complaint.
-  const nodes = doc.nodes;
-  if (Array.isArray(nodes)) countNodes(nodes);
-  return new TextEncoder().encode(JSON.stringify(doc)).length;
+  try {
+    return new TextEncoder().encode(JSON.stringify(doc)).length;
+  } catch (error) {
+    // `RangeError` is the size failure specifically. A cycle raises TypeError
+    // and a getter that throws raises whatever it threw, so neither is caught
+    // here and neither is renamed into a size complaint it is not.
+    if (error instanceof RangeError) {
+      throw new ForestTooLargeError(
+        `this document cannot be measured: its JSON form is longer than a ` +
+          `string can hold. ${WHY_TOO_LARGE}`
+      );
+    }
+    throw error;
+  }
 }

--- a/packages/blocks-engine/src/limits.ts
+++ b/packages/blocks-engine/src/limits.ts
@@ -76,15 +76,89 @@ export const DEFAULT_LIMITS: DocumentLimits = {
   maxBytes: DEFAULT_MAX_DOCUMENT_BYTES,
 };
 
+/**
+ * How many entries a whole-forest reader may visit before it refuses.
+ *
+ * A machine limit like `MAX_WALKABLE_DEPTH` in `ops.ts`, not a product one:
+ * {@link MAX_NODES} is a rule a site may raise, and this is the point past
+ * which reading the forest at all stops being affordable whatever any site
+ * says. Two hundred times the default node cap, so it only ever fires on
+ * forests no product setting would have allowed.
+ *
+ * It exists because entries are not bounded by OBJECTS. `walkForest`
+ * deliberately revisits a node object reached under two different parents —
+ * one object placed in two slots is two elements of the document, and counting
+ * it once would report half a real size and pass a cap the document exceeds.
+ * That is right for a count and it makes the walk exponential in depth for a
+ * forest whose branches share objects: measured on this module's own helpers, a
+ * chain of 21 distinct objects each holding the next twice walks 2,097,151
+ * entries, and every further object doubles it.
+ *
+ * A stored document can never be such a forest, because `JSON.parse` produces
+ * fresh objects and cannot express sharing. One built in memory by code can be,
+ * and these readers decide whether a document may be stored at all — so the
+ * unbounded version failed in the worst possible place.
+ */
+export const MAX_WALKABLE_ENTRIES = 1_000_000;
+
+/**
+ * A forest whose entries outrun {@link MAX_WALKABLE_ENTRIES}.
+ *
+ * Thrown rather than answered around, because every honest answer here is a
+ * refusal: a count taken from a walk that stopped early is a PARTIAL one, and
+ * returning it as a whole number is a bound that fails in the passing
+ * direction — the document reads as smaller than it is and passes the very cap
+ * this module exists to enforce.
+ *
+ * Named so a caller can tell it from a defect in its own input handling. The
+ * `nodes` a caller holds are almost never the cause; a node object reached
+ * under more than one parent is.
+ */
+export class ForestTooLargeError extends Error {
+  constructor(subject: string) {
+    super(
+      `${subject} reaches more than ${String(MAX_WALKABLE_ENTRIES)} entries ` +
+        `and cannot be measured: past that the walk is not affordable. A ` +
+        `forest this large for its object count holds a node placed under ` +
+        `more than one parent, which multiplies entries at every level.`
+    );
+    this.name = "ForestTooLargeError";
+  }
+}
+
+/**
+ * Visit the forest, refusing rather than answering from a partial walk.
+ *
+ * The one place the bound is applied, so the three readers below cannot drift
+ * on where it sits or on what happens when it is reached.
+ */
+function walkBounded(
+  nodes: BlockNode[],
+  subject: string,
+  onEntry: (depth: number) => void
+): void {
+  let seen = 0;
+  let spent = false;
+  walkForest(nodes, entry => {
+    seen += 1;
+    if (seen > MAX_WALKABLE_ENTRIES) {
+      spent = true;
+      return "stop";
+    }
+    onEntry(entry.depth);
+    return "descend";
+  });
+  if (spent) throw new ForestTooLargeError(subject);
+}
+
 /** Total node count across the forest, slots included. */
 export function countNodes(nodes: BlockNode[]): number {
   let count = 0;
   // EVERY entry counts, malformed ones included: the cap exists to reject a
   // document by its real element count, so an array padded with junk must not
   // slip past it.
-  walkForest(nodes, () => {
+  walkBounded(nodes, "this forest", () => {
     count += 1;
-    return "descend";
   });
   return count;
 }
@@ -92,9 +166,8 @@ export function countNodes(nodes: BlockNode[]): number {
 /** Deepest nesting level in the forest; an empty forest is depth 0. */
 export function treeDepth(nodes: BlockNode[]): number {
   let deepest = 0;
-  walkForest(nodes, entry => {
-    if (entry.depth > deepest) deepest = entry.depth;
-    return "descend";
+  walkBounded(nodes, "this forest", depth => {
+    if (depth > deepest) deepest = depth;
   });
   return deepest;
 }
@@ -102,7 +175,26 @@ export function treeDepth(nodes: BlockNode[]): number {
 /**
  * Serialized size of a document in bytes (UTF-8 of its JSON form — the same
  * bytes that hit storage, so the cap measures what actually gets persisted).
+ *
+ * The forest is measured FIRST, and this is not belt-and-braces. `JSON.stringify`
+ * expands a shared node object into a separate copy per path that reaches it,
+ * so the string it builds grows with ENTRIES rather than with objects — and it
+ * does not degrade gracefully. Measured on this module's own helpers: 21 shared
+ * objects produce 132 MB, and 23 raise `RangeError: Invalid string length`
+ * from a document that is a few kilobytes in memory.
+ *
+ * That error is the reason the guard runs before the serialization rather than
+ * around it. A native `RangeError` escaping here names a string length, which
+ * says nothing about the document and cannot be acted on; it also arrives from
+ * the one function whose whole job is to decide whether a document may be
+ * stored, so the failure lands where a caller is least able to interpret it.
  */
 export function documentBytes(doc: BlockDocument): number {
+  // Guarded at RUNTIME although the type says `BlockNode[]`, because a stored
+  // document arrives unvalidated and `walkForest` is written for exactly that.
+  // A document whose `nodes` is not a list has nothing to measure and is left
+  // to the serializer, which reports its own shape complaint.
+  const nodes = doc.nodes;
+  if (Array.isArray(nodes)) countNodes(nodes);
   return new TextEncoder().encode(JSON.stringify(doc)).length;
 }

--- a/packages/blocks-engine/src/limits.ts
+++ b/packages/blocks-engine/src/limits.ts
@@ -159,6 +159,22 @@ const WHY_TOO_LARGE =
   `entries at every level, so a few dozen objects can reach millions.`;
 
 /**
+ * The same question for the SERIALIZER, which counts a different population.
+ *
+ * A replacer runs for every value `JSON.stringify` visits, not for every node:
+ * a `props` object holding a large array reaches the bound with one node and no
+ * sharing at all. So this names a third route the forest explanation does not
+ * cover, and must not be replaced by it — a caller told to look for a node
+ * under two parents, in a document with one node, is being sent somewhere there
+ * is nothing to find.
+ */
+const WHY_TOO_MANY_VALUES =
+  `The serializer counts every value it visits rather than every node, so a ` +
+  `document reaches this by holding that many values in its props, by holding ` +
+  `that many nodes, or by holding a node placed under more than one parent — ` +
+  `which multiplies what is serialized at every level.`;
+
+/**
  * Visit the forest, refusing rather than answering from a partial walk.
  *
  * The one place the bound is applied, so the three readers below cannot drift
@@ -258,7 +274,7 @@ export function documentBytes(doc: BlockDocument): number {
     if (visited > MAX_SERIALIZED_VALUES) {
       throw new ForestTooLargeError(
         `this document cannot be measured: serializing it visits more than ` +
-          `${String(MAX_SERIALIZED_VALUES)} values. ${WHY_TOO_LARGE}`
+          `${String(MAX_SERIALIZED_VALUES)} values. ${WHY_TOO_MANY_VALUES}`
       );
     }
     return value;

--- a/packages/blocks-engine/src/limits.ts
+++ b/packages/blocks-engine/src/limits.ts
@@ -102,6 +102,22 @@ export const DEFAULT_LIMITS: DocumentLimits = {
 export const MAX_WALKABLE_ENTRIES = 1_000_000;
 
 /**
+ * How many values {@link documentBytes} may serialize before it refuses.
+ *
+ * A different unit from {@link MAX_WALKABLE_ENTRIES} and deliberately its own
+ * constant, because the serializer counts VALUES rather than nodes: measured on
+ * a 5,000-node document, `JSON.stringify` visits six values per node. Two
+ * million is therefore roughly 333,000 nodes — sixty-six times the default node
+ * cap, the same order of headroom `MAX_WALKABLE_DEPTH` keeps over
+ * `DEFAULT_LIMITS.maxDepth`.
+ *
+ * Reusing the entry bound here would have been a bound in the wrong unit,
+ * six times tighter than it reads, and would refuse documents a site could
+ * legitimately configure.
+ */
+export const MAX_SERIALIZED_VALUES = 2_000_000;
+
+/**
  * A forest whose entries outrun {@link MAX_WALKABLE_ENTRIES}.
  *
  * Thrown rather than answered around, because every honest answer here is a
@@ -207,31 +223,45 @@ export function treeDepth(nodes: BlockNode[]): number {
  * and it arrives from the one function whose whole job is to decide whether a
  * document may be stored, so it lands where a caller is least able to read it.
  *
- * The refusal is taken FROM the serializer rather than predicted before it, and
- * that is the whole design. A preflight walk answers a different question than
- * the one this function asks: `walkForest` reaches `node.slots` by property
- * access, so it sees inherited and non-enumerable slots and ignores `toJSON`,
- * while `JSON.stringify` reads own enumerable properties and honours it.
- * Measured with a node whose `slots` is non-enumerable: the document serializes
- * to 95 bytes and a preflight walk refused it — a false refusal, on a gate,
- * against a document that would have saved perfectly.
+ * The bound is applied BY the serializer's own traversal, through a replacer,
+ * and that is the whole design. It has to satisfy two requirements that defeat
+ * the obvious approaches separately.
  *
- * Catching what the serializer actually raised cannot diverge from it, costs no
- * second traversal, and refuses exactly the documents that cannot be measured.
+ * A PREFLIGHT WALK cannot be used, because it answers a different question:
+ * `walkForest` reaches `node.slots` by property access, so it sees inherited
+ * and non-enumerable slots and ignores `toJSON`, while `JSON.stringify` reads
+ * own enumerable properties and honours it. Measured with a node whose `slots`
+ * is non-enumerable — the document serializes to 95 bytes and a preflight walk
+ * refused it. A false refusal, on the gate deciding whether a document may be
+ * stored, against a document that would have saved perfectly.
+ *
+ * CATCHING THE FAILURE afterwards cannot be used either, because by then the
+ * cost has been paid: the string is built until it cannot grow, so the 21-object
+ * case still allocates 132 MB and a larger one exhausts the heap before any
+ * catchable error exists. It also cannot tell the serializer's own size failure
+ * from a `RangeError` thrown by a `toJSON`, a getter or a proxy trap, and
+ * renaming one of those into a size complaint tells a caller to shrink a
+ * document whose problem is in its own hook.
+ *
+ * A replacer is called by the serializer for every value it actually visits, so
+ * counting there uses the SAME traversal — it cannot diverge from what gets
+ * serialized, and it aborts before the string is built rather than after.
+ * Measured: byte-identical output on ordinary documents, and a shared forest of
+ * any depth refuses in about 60 ms instead of exhausting memory. A `RangeError`
+ * from a document's own hook now propagates untouched, because nothing here
+ * catches it.
  */
 export function documentBytes(doc: BlockDocument): number {
-  try {
-    return new TextEncoder().encode(JSON.stringify(doc)).length;
-  } catch (error) {
-    // `RangeError` is the size failure specifically. A cycle raises TypeError
-    // and a getter that throws raises whatever it threw, so neither is caught
-    // here and neither is renamed into a size complaint it is not.
-    if (error instanceof RangeError) {
+  let visited = 0;
+  const json = JSON.stringify(doc, function replacer(_key, value: unknown) {
+    visited += 1;
+    if (visited > MAX_SERIALIZED_VALUES) {
       throw new ForestTooLargeError(
-        `this document cannot be measured: its JSON form is longer than a ` +
-          `string can hold. ${WHY_TOO_LARGE}`
+        `this document cannot be measured: serializing it visits more than ` +
+          `${String(MAX_SERIALIZED_VALUES)} values. ${WHY_TOO_LARGE}`
       );
     }
-    throw error;
-  }
+    return value;
+  });
+  return new TextEncoder().encode(json).length;
 }

--- a/packages/blocks-engine/src/ops.ts
+++ b/packages/blocks-engine/src/ops.ts
@@ -54,6 +54,7 @@ import {
 import {
   countNodes,
   DEFAULT_LIMITS,
+  ForestTooLargeError,
   treeDepth,
   type DocumentLimits,
 } from "./limits";
@@ -434,6 +435,31 @@ function assertUsableLimits(limits: DocumentLimits): void {
 }
 
 /** Refuses a tree the engine's recursive helpers cannot walk. */
+/**
+ * Measure a forest, reporting a refusal to measure as an `OpError`.
+ *
+ * `countNodes` and `treeDepth` refuse a forest whose entries outrun
+ * {@link MAX_WALKABLE_ENTRIES} rather than answering from a partial walk, and
+ * that refusal has to arrive here wearing this module's error type. Six
+ * `...Refusal` helpers in this file are written as
+ * `catch (error) { if (error instanceof OpError) return error.message; throw error; }`
+ * — so an error of any other type is rethrown, and a helper whose whole purpose
+ * is to hand back a reason instead throws at its caller.
+ *
+ * The message is carried verbatim: it already names the cause a reader has to
+ * act on, and restating it here would be a second spelling of one explanation.
+ */
+function measured(measure: () => number, verb: string): number {
+  try {
+    return measure();
+  } catch (error) {
+    if (error instanceof ForestTooLargeError) {
+      throw new OpError(`${verb}: ${error.message}`);
+    }
+    throw error;
+  }
+}
+
 function assertWalkable(depth: number, subject: string): void {
   if (depth > MAX_WALKABLE_DEPTH) {
     throw new OpError(
@@ -1930,15 +1956,21 @@ function assertFitsCaps(
   // against a freshly measured original made the original's cost proportional
   // to the number of offending nodes, so lowering `maxDepth` under a broad
   // document turned a linear edit into a quadratic one.
-  const depth = treeDepth(result.nodes);
-  if (depth > limits.maxDepth && depth > treeDepth(before.nodes)) {
+  const depth = measured(() => treeDepth(result.nodes), verb);
+  if (
+    depth > limits.maxDepth &&
+    depth > measured(() => treeDepth(before.nodes), verb)
+  ) {
     throw new OpError(
       `${verb}: this would leave the document nested ${String(depth)} ` +
         `levels deep, past the ${String(limits.maxDepth)} it may hold.`
     );
   }
-  const total = countNodes(result.nodes);
-  if (total > limits.maxNodes && total > countNodes(before.nodes)) {
+  const total = measured(() => countNodes(result.nodes), verb);
+  if (
+    total > limits.maxNodes &&
+    total > measured(() => countNodes(before.nodes), verb)
+  ) {
     throw new OpError(
       `${verb}: this would leave the document holding ${String(total)} nodes, ` +
         `past the ${String(limits.maxNodes)} a document may hold. The edit would ` +
@@ -3061,7 +3093,10 @@ export function applyOp(
   // saying so is better than letting a native RangeError escape from whichever
   // helper reaches it first. This is deliberately NOT `limits.maxDepth`: that
   // is a product rule a site may relax, and this is a machine one nothing can.
-  assertWalkable(treeDepth(nodes), "this document");
+  assertWalkable(
+    measured(() => treeDepth(nodes), "this document"),
+    "this document"
+  );
 
   // The op itself, before its discriminant is read. `op.kind` on a `null`
   // leaves this module as a TypeError, which a caller cannot distinguish from
@@ -3149,7 +3184,10 @@ export function applyOp(
       // `limits.maxDepth` can otherwise hand in a subtree deeper than the
       // engine's helpers can walk, and the overflow lands after the document
       // has been checked rather than before.
-      assertWalkable(treeDepth([op.node]), "insert");
+      assertWalkable(
+        measured(() => treeDepth([op.node]), "insert"),
+        "insert"
+      );
       const lockedId = lockedWithin(op.node);
       if (lockedId !== undefined) {
         throw new OpError(

--- a/packages/blocks-engine/src/resolve-instances.ts
+++ b/packages/blocks-engine/src/resolve-instances.ts
@@ -61,6 +61,7 @@ import { remapFragmentBindings, remapFragmentProps } from "./fragment-refs";
 import {
   countNodes,
   DEFAULT_LIMITS,
+  ForestTooLargeError,
   MAX_COMPOSED_DEPTH,
   MAX_ENVELOPE_ENTRIES,
   type DocumentLimits,
@@ -1362,7 +1363,7 @@ function refundDiscardedSlots(
     if (kept.has(name)) continue;
     const children = ownEntry(slots, name);
     if (!Array.isArray(children)) continue;
-    run.budget += countNodes(children);
+    run.budget += refundableCount(children);
   }
 }
 
@@ -2064,10 +2065,33 @@ function survivesGating(
  * content, which is what `nodes` holds until something places it. Refunding a
  * composed size credited a number the survey never took, in either direction.
  */
+/**
+ * What a subtree is worth as a REFUND, or nothing when it cannot be counted.
+ *
+ * `countNodes` refuses a forest whose entries outrun the machine bound rather
+ * than answering from a partial walk, and a refund is the wrong place to let
+ * that escape. This module's whole limit strategy is to degrade — a document
+ * past its budget comes back unchanged or with instances left unresolved, so a
+ * visitor gets the page rather than a blank screen — and an exception thrown
+ * midway through composition replaces that with nothing at all.
+ *
+ * Nothing is the conservative refund. It leaves the run believing it has spent
+ * more than it has, so the budget it already checks runs out and the existing
+ * graceful path takes over, which is the same outcome by the intended route.
+ */
+function refundableCount(nodes: BlockNode[]): number {
+  try {
+    return countNodes(nodes);
+  } catch (error) {
+    if (error instanceof ForestTooLargeError) return 0;
+    throw error;
+  }
+}
+
 function refundPlannedSlots(plan: NodePlan, run: ResolveRun): void {
   if (plan.slots === undefined) return;
   for (const content of plan.slots.values()) {
-    run.budget += countNodes(content.nodes);
+    run.budget += refundableCount(content.nodes);
   }
 }
 

--- a/packages/builder/src/delete-block.test.ts
+++ b/packages/builder/src/delete-block.test.ts
@@ -136,3 +136,60 @@ describe("blockDeletion", () => {
     expect(blockDeletion(documentOf([]), "a")).toBeNull();
   });
 });
+
+describe("a subtree the engine cannot count", () => {
+  /**
+   * A chain of distinct node objects where each holds the NEXT one twice, so
+   * entries double at every level while the object count stays linear. The
+   * engine refuses to count past its machine bound rather than answering from a
+   * partial walk.
+   */
+  function sharedChain(objects: number): BlockNode {
+    let node: BlockNode = leaf("deep-leaf");
+    for (let i = objects - 1; i >= 0; i--) {
+      node = {
+        id: `d${String(i)}`,
+        type: "acme/box",
+        version: 1,
+        props: {},
+        slots: { children: [node, node] },
+      } as BlockNode;
+    }
+    return node;
+  }
+
+  it("still offers the deletion instead of throwing out of the editor", () => {
+    /*
+     * `blockDeletion` is called to decide whether the toolbar's Delete button
+     * is ENABLED, so a refusal escaping here throws during toolbar construction
+     * and takes the editor down at the moment the node is selected. Being able
+     * to remove a block must not depend on being able to describe it.
+     */
+    const doc = documentOf([sharedChain(21), leaf("after")]);
+
+    const deletion = blockDeletion(doc, "d0");
+
+    expect(deletion).not.toBeNull();
+    expect(deletion?.id).toBe("d0");
+    // Selection still lands somewhere real, which is the other half of what
+    // this function owes its caller.
+    expect(deletion?.nextSelection).toBe("after");
+  });
+
+  it("claims nothing about the contents it could not count", () => {
+    // Zero is the same value a childless node reports, and that is deliberate:
+    // the announcement says "<name> deleted" at zero and adds "with N blocks
+    // inside" above it, so zero states nothing rather than stating none.
+    const doc = documentOf([sharedChain(21)]);
+
+    expect(blockDeletion(doc, "d0")?.descendantCount).toBe(0);
+  });
+
+  it("still counts a subtree it CAN measure", () => {
+    // The control. Without it, a `blockDeletion` that reported zero for every
+    // node — or never counted at all — passes both tests above.
+    const doc = documentOf([sharedChain(4)]);
+
+    expect(blockDeletion(doc, "d0")?.descendantCount).toBe(2 ** 5 - 2);
+  });
+});

--- a/packages/builder/src/delete-block.ts
+++ b/packages/builder/src/delete-block.ts
@@ -20,6 +20,7 @@
 
 import {
   countNodes,
+  ForestTooLargeError,
   locateNode,
   type BlockDocument,
   type BlockNode,
@@ -111,6 +112,23 @@ function siblingsOf(
 }
 
 /**
+ * How many descendants a subtree has, or zero when it cannot be counted.
+ *
+ * The engine refuses to count a forest whose entries outrun its machine bound
+ * rather than answering from a partial walk. That refusal belongs to the engine
+ * and is right there; here it must not become an exception, because this
+ * function's answer decides whether the editor OFFERS a deletion at all.
+ */
+function countableDescendants(node: BlockNode): number {
+  try {
+    return countNodes([node]) - 1;
+  } catch (error) {
+    if (error instanceof ForestTooLargeError) return 0;
+    throw error;
+  }
+}
+
+/**
  * Describe deleting the selected block, or `null` when there is nothing to
  * delete.
  *
@@ -140,7 +158,19 @@ export function blockDeletion(
   // The subtree's own size, less the node itself. `countNodes` walks slots, so
   // this is every descendant at any depth rather than the immediate children —
   // which is what actually disappears.
-  const descendantCount = countNodes([node]) - 1;
+  //
+  // A subtree too large to count must not stop the DELETION being offered.
+  // `blockDeletion` is called to decide whether the toolbar's Delete button is
+  // enabled, so letting the refusal escape would throw out of toolbar
+  // construction and take the editor down at the moment a node is selected —
+  // and the count is descriptive, while being able to remove the node is not.
+  //
+  // Zero is the fallback, and it is deliberately the same value a node with no
+  // descendants gets. Normally folding "unknown" into a real value is how a
+  // third state disappears, but the only reader is the announcement, which says
+  // "<name> deleted" at zero and adds "with N blocks inside" above it — so zero
+  // states nothing about the contents rather than claiming there were none.
+  const descendantCount = countableDescendants(node);
 
   const dropSlotIfEmpty =
     here.parent !== undefined && here.slot !== undefined


### PR DESCRIPTION
## What was wrong

`countNodes`, `treeDepth` and `documentBytes` read the whole forest with no bound.

They walk **entries**, not objects, and deliberately so — one node object placed in two slots is two elements of the document, and counting it once would report half a real size and pass a cap the document exceeds. That makes the walk exponential in depth for a forest whose branches share a node object. Measured on these helpers:

| distinct objects | entries walked | `countNodes` |
|---|---|---|
| 16 | 65,535 | 3 ms |
| 19 | 524,287 | 21 ms |
| 21 | 2,097,151 | 87 ms |

**`documentBytes` was the sharp edge, and it did not merely get slow.** `JSON.stringify` expands a shared node into a copy per path that reaches it, so the string grows with entries rather than objects:

- 21 objects → allocates **132 MB**
- 23 objects → **`RangeError: Invalid string length`**

That is a hard throw from a document a few kilobytes in memory, raised by the one function whose job is to decide whether a document may be stored. A native `RangeError` names a *string length* — it says nothing about the document and a caller cannot act on it.

The existing guard could not help: `assertWalkable(treeDepth(nodes), …)` computes its argument with the very walk that blows up, so it runs after the damage.

## The fix

`MAX_WALKABLE_ENTRIES` is a **machine bound** in exactly the sense `ops.ts` already uses for `MAX_WALKABLE_DEPTH` — not derived from `limits.maxNodes`, which a site may raise, and set two hundred times above it so it only fires on forests no product setting would have allowed. Past it the three throw `ForestTooLargeError`. Both are exported.

Three choices worth calling out:

**Refuse, not return a partial count.** A count from a walk that stopped early is a bound failing in the *passing* direction — it reports a document as smaller than it is, to the very check meant to reject it.

**Do not dedupe by object.** Tempting and wrong: the revisit semantics are load-bearing for the count, and deduping would let an over-cap document through.

**Name the cause, not the symptom.** The message says a node is placed under more than one parent. "Too large" would send a reader to trim a document that is already a few kilobytes — the wrong repair.

Inside `applyOp` the refusal is translated to `OpError`. Six `…Refusal` helpers in `ops.ts` are written as `if (error instanceof OpError) return error.message; throw error`, so an untranslated error would make a helper whose whole purpose is to hand back a reason throw at its caller instead.

## Reachability — measured, and narrower than the ticket assumed

The ticket left this open. Both halves now measured:

- **Stored documents can never be such a forest.** `JSON.parse` produces fresh objects and cannot express sharing.
- **Composition does not build one either.** I resolved two instances of one component and counted objects *reached* against objects *distinct*: `reached=4, distinct=4`. My first attempt at that probe reported "not shared" for the wrong reason — the component never expanded — so it carries a control asserting the resolution actually happened.

So this is **hardening**, not a live bug, and the PR should be read that way. The bound is reachable only from a forest built in memory by code. I have shown one composition path does not produce sharing; I have not shown that nothing does — `renameScopes` still carries explicit handling for "the same node object reached a second time", which is either defensive or a path I have not found.

## Evidence

Six tests, break-verified against the previous unbounded implementation:

| | result |
|---|---|
| four tests asserting the refusal | **fail** on the old implementation |
| two controls asserting the bound does NOT fire | pass on both, by design |

The controls are the point — a bound set low enough to refuse everything satisfies the first four. One covers a shared forest *under* the bound (still counted correctly, `2^19 − 1`), the other an ordinary document, and `MAX_WALKABLE_ENTRIES` is asserted against `MAX_NODES * 100` rather than against a number chosen to agree with it.

The `documentBytes` test names the error *type* and asserts it is **not** a `RangeError`, because the error it replaced would otherwise satisfy a bare "it throws".

New file `limits.test.ts` — collection confirmed by the suite going 52 → 53 files.

## Gates

Rebuilt from cleared `dist` after rebasing onto current `main`. Exit status read on its own line.

| gate | exit |
|---|---|
| `pnpm build` | 0 |
| `blocks-engine` ct / lint / vitest | 0 / 0 / 0 — 53 files, 2422 tests |
| `builder` ct / lint / vitest | 0 / 0 / 0 — 102 files, 2870 tests |
| `blocks-react` ct / lint / vitest | 0 / 0 / 0 — 48 files, 1168 tests |
| `plugin-page-builder` ct / lint / vitest | 0 / 0 / 0 — 69 files, 768 tests |
| `fallow audit --base origin/main` | 0 — `pass`, `changed_files_count: 5`, every `*_introduced: 0` |
| `pnpm changeset status` | 0 |

One lint error was introduced and fixed at the cause rather than suppressed: an unnecessary type assertion in `documentBytes`. The runtime `Array.isArray` guard beside it stays, and says why it is there despite the type.
