### PR TITLE
feat(plugin-page-builder): the save verb asks whether the author may save

### DIFF
--- a/.changeset/the-save-verb-asks-whether-you-may-save.md
+++ b/.changeset/the-save-verb-asks-whether-you-may-save.md
@@ -1,0 +1,48 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The Save as pattern verb now asks whether the author may create a pattern, and
+says so when they may not.
+
+A role that can update pages but lacks the separately seeded `create` grant on
+the patterns collection was offered the verb on the toolbar, the context menu
+and the command palette. The author filled in the form and the save was refused
+— legibly, and after the work.
+
+Only the server can answer this. The grant is held against the RESOLVED
+collection, a site may have renamed it, and the browser knows the declared name
+alone; gating on that would refuse an author who holds the grant, hiding a
+feature that works. So the plugin contributes a small authenticated route that
+asks the framework's own `ctx.caller.can`, and the editor reads it once on
+mount, before any of the three surfaces draws.
+
+The verb is DISABLED WITH A REASON rather than hidden, matching every other
+refusal on that toolbar, and it stays offered while the answer is in flight: a
+wrong "yes" costs the late refusal that already happened, while a wrong "no"
+hides a feature the author holds and nothing on the canvas would explain it.
+
+Not a security boundary. The write authorizes itself, exactly as before.

--- a/packages/builder/src/keyboard-actions.test.tsx
+++ b/packages/builder/src/keyboard-actions.test.tsx
@@ -451,7 +451,7 @@ describe("useBlockKeyboardActions", () => {
 
   it("refuses the save WITHOUT opening the form when the grant is absent", () => {
     /*
-     * Codex P2 on #1678. The floating toolbar keeps an unavailable verb
+     * The floating toolbar keeps an unavailable verb
      * focusable through `aria-disabled` and calls its runner anyway — that is
      * deliberate, so a verb can announce its own refusal. A grant that only
      * dimmed the description would therefore open the save form for exactly the

--- a/packages/builder/src/keyboard-actions.test.tsx
+++ b/packages/builder/src/keyboard-actions.test.tsx
@@ -449,6 +449,49 @@ describe("useBlockKeyboardActions", () => {
     expect(said).toMatch(/goes inside/i);
   });
 
+  it("refuses the save WITHOUT opening the form when the grant is absent", () => {
+    /*
+     * Codex P2 on #1678. The floating toolbar keeps an unavailable verb
+     * focusable through `aria-disabled` and calls its runner anyway — that is
+     * deliberate, so a verb can announce its own refusal. A grant that only
+     * dimmed the description would therefore open the save form for exactly the
+     * authors it was added to stop, and they would then be refused by the write.
+     *
+     * `onSaveAsPattern` NOT being called is the assertion that separates
+     * stopping the gesture from narrating it, exactly as `apply` does for the
+     * refused move above.
+     */
+    const editor = editorSpy(pair(), "a");
+    const onSaveAsPattern = vi.fn();
+    let published: BlockActions | undefined;
+    function Probe(): null {
+      published = useBlockActionsContext();
+      return null;
+    }
+    render(
+      <ShortcutProvider>
+        <BlockKeyboardActions
+          onSaveAsPattern={onSaveAsPattern}
+          editor={editor}
+          mayCreatePattern={false}
+        >
+          <Probe />
+        </BlockKeyboardActions>
+      </ShortcutProvider>
+    );
+
+    // Pressed through the published verb, which is exactly what the toolbar's
+    // click handler calls — the surface this defect lives on.
+    // Inside `act`, so the announcement's state update is flushed before it is
+    // read — the live region is written by React, not by the call itself.
+    act(() => published?.saveAsPattern());
+
+    expect(onSaveAsPattern).not.toHaveBeenCalled();
+    // Announced, because an author who pressed a dimmed control is owed the
+    // reason and the live region is where every other refusal here is said.
+    expect(screen.getByRole("status").textContent ?? "").toMatch(/permission/i);
+  });
+
   it("stays silent at a BOUNDARY, which is not a refusal", () => {
     /*
      * The other half, and the reason this fix is not simply "announce more".

--- a/packages/builder/src/keyboard-actions.tsx
+++ b/packages/builder/src/keyboard-actions.tsx
@@ -46,7 +46,11 @@ import {
   selectionDuplication,
   selectionMove,
 } from "./selection-ops";
-import { toolbarActions, type ToolbarAction } from "./toolbar-actions";
+import {
+  SAVE_PATTERN_GRANT_REFUSAL,
+  toolbarActions,
+  type ToolbarAction,
+} from "./toolbar-actions";
 
 /**
  * The bindings, and why these keys.
@@ -850,6 +854,17 @@ export function useBlockKeyboardActions({
    * over a selection that cannot be saved.
    */
   const saveSelectionAsPattern = React.useCallback(() => {
+    // The GRANT before the planner, matching the order the action list uses:
+    // an author who may not save at all is owed that reason rather than a
+    // critique of the blocks they chose. Checked HERE and not only there
+    // because the toolbar keeps an unavailable verb focusable and still calls
+    // this runner — so a refusal that lived only in the description would dim
+    // the control and open the form anyway, for exactly the authors this
+    // exists to stop.
+    if (!mayCreatePattern) {
+      announce(SAVE_PATTERN_GRANT_REFUSAL);
+      return;
+    }
     const refusal = saveAsPatternRefusal(
       editor.document,
       editor.selection.ids,
@@ -861,6 +876,7 @@ export function useBlockKeyboardActions({
     }
     onSaveAsPattern();
   }, [
+    mayCreatePattern,
     editor.document,
     editor.selection.ids,
     nestingSource,

--- a/packages/builder/src/keyboard-actions.tsx
+++ b/packages/builder/src/keyboard-actions.tsx
@@ -305,6 +305,18 @@ export interface BlockKeyboardActionsOptions {
    */
   onSaveAsPattern: () => void;
   /**
+   * Whether the author may create a pattern at all. Defaults to true.
+   *
+   * Supplied by the host for the same reason `onSaveAsPattern` is: the grant is
+   * held against the collection a pattern goes in, a site may have renamed it,
+   * and nothing here can know either. A builder that guessed would be guessing
+   * about somebody else's schema.
+   *
+   * Permissive while unknown — see `toolbarActions`, which explains why this one
+   * refusal defaults the opposite way to the rest.
+   */
+  mayCreatePattern?: boolean;
+  /**
    * Whether the bindings are live. Defaults to true.
    *
    * A host that mounts the canvas inside something modal turns them off rather
@@ -368,6 +380,7 @@ export interface BlockKeyboardActionsResult {
  * {@link BlockKeyboardActions} is the only supported way to reach the verbs.
  */
 export function useBlockKeyboardActions({
+  mayCreatePattern = true,
   editor,
   enabled = true,
   onEditText,
@@ -868,9 +881,16 @@ export function useBlockKeyboardActions({
         editor.document,
         editor.selectedId,
         editor.selection.ids,
-        nestingSource
+        nestingSource,
+        mayCreatePattern
       ),
-    [editor.document, editor.selectedId, editor.selection.ids, nestingSource]
+    [
+      editor.document,
+      editor.selectedId,
+      editor.selection.ids,
+      nestingSource,
+      mayCreatePattern,
+    ]
   );
 
   const actions = React.useMemo<BlockActions>(
@@ -920,6 +940,7 @@ export function BlockKeyboardActions({
   onEditText,
   nesting,
   onSaveAsPattern,
+  mayCreatePattern,
   children,
 }: BlockKeyboardActionsOptions & {
   readonly children?: React.ReactNode;
@@ -933,6 +954,7 @@ export function BlockKeyboardActions({
     editor,
     enabled,
     onSaveAsPattern,
+    ...(mayCreatePattern === undefined ? {} : { mayCreatePattern }),
     ...(onEditText === undefined ? {} : { onEditText }),
     ...(nesting === undefined ? {} : { nesting }),
   });

--- a/packages/builder/src/toolbar-actions.ts
+++ b/packages/builder/src/toolbar-actions.ts
@@ -146,10 +146,25 @@ function moveAction(
 function saveAction(
   document: BlockDocument,
   ids: readonly string[],
-  nesting: NestingSource
+  nesting: NestingSource,
+  mayCreate: boolean
 ): ToolbarAction {
-  const refusal = saveAsPatternRefusal(document, ids, nesting);
   const label = "Save as pattern";
+  // The GRANT first, and it is the one refusal not asked of the planner —
+  // because it is not about this selection. Every other reason a save is
+  // refused describes the blocks in hand, so a planner that learns a new one
+  // is still describing them; whether the author may create a pattern at all
+  // is true of the next selection too. Asked first so an author who cannot
+  // save is told that, rather than told why these particular blocks are
+  // unsuitable for a thing they could not have saved either way.
+  if (!mayCreate)
+    return {
+      id: "save-as-pattern",
+      label,
+      enabled: false,
+      reason: "You do not have permission to create patterns.",
+    };
+  const refusal = saveAsPatternRefusal(document, ids, nesting);
   if (refusal === undefined)
     return { id: "save-as-pattern", label, enabled: true };
   return {
@@ -183,7 +198,8 @@ function saveAction(
 function manyBlockActions(
   document: BlockDocument,
   ids: readonly string[],
-  nesting: NestingSource
+  nesting: NestingSource,
+  mayCreate: boolean
 ): ToolbarAction[] {
   const many = `Only one block at a time. ${ids.length} are selected.`;
   const deleteLock = ids
@@ -202,7 +218,7 @@ function manyBlockActions(
     // A lock never stops a duplication, for a set as for one block: the
     // originals stay where they are.
     { id: "duplicate", label: "Duplicate", enabled: true },
-    saveAction(document, ids, nesting),
+    saveAction(document, ids, nesting, mayCreate),
     deleteLock === undefined
       ? { id: "delete", label: "Delete", enabled: true }
       : {
@@ -243,7 +259,23 @@ export function toolbarActions(
    * it. Present as an option only so a test can supply a rule set without
    * registering blocks globally.
    */
-  nesting?: NestingSource
+  nesting?: NestingSource,
+  /**
+   * Whether the caller may create a pattern at all. Defaults to true.
+   *
+   * The HOST's answer, because it is the host's question: the grant is seeded
+   * against the collection a pattern goes in, a site may have renamed it, and
+   * nothing here knows either. The same reason `onSaveAsPattern` is supplied
+   * rather than performed here.
+   *
+   * PERMISSIVE by default, unlike every other refusal in this file. The others
+   * are computed from the document in hand and an absent answer means the
+   * question was not asked; this one arrives over the network, and "not yet"
+   * would dim the verb on every mount for every author. A wrong `true` costs
+   * the late refusal that already happens; a wrong `false` hides a feature the
+   * author has, and there is nothing on the canvas to explain it.
+   */
+  mayCreatePattern: boolean = true
 ): ToolbarAction[] {
   if (selectedId === null) return [];
 
@@ -252,7 +284,8 @@ export function toolbarActions(
 
   const rules = nesting ?? registryNestingSource();
   const ids = selectedIds ?? [selectedId];
-  if (ids.length > 1) return manyBlockActions(document, ids, rules);
+  if (ids.length > 1)
+    return manyBlockActions(document, ids, rules, mayCreatePattern);
 
   const moveLock = lockBlockingMove(document, selectedId);
   const deleteLock = lockBlockingDelete(document, selectedId);
@@ -293,7 +326,7 @@ export function toolbarActions(
       // reading the keyboard duplicate takes.
       enabled: blockDuplication(document, selectedId) !== null,
     },
-    saveAction(document, ids, rules),
+    saveAction(document, ids, rules, mayCreatePattern),
     deleteLock === undefined
       ? {
           id: "delete",

--- a/packages/builder/src/toolbar-actions.ts
+++ b/packages/builder/src/toolbar-actions.ts
@@ -146,13 +146,26 @@ function moveAction(
 /**
  * What an author is told when they hold no grant to save a pattern.
  *
+ * Names the OPERATION the author attempted, not a permission. Saving needs more
+ * than one grant — the pattern is stored and published in the same act — so a
+ * message naming any single one is wrong for somebody: an author who may create
+ * a pattern but not publish it would be told they cannot create, and would go
+ * and ask for the grant they already hold. "Save" is also the word on the
+ * control they pressed, which is the thing they can describe when they ask.
+ *
+ * Which grant is missing is deliberately NOT reported. The answer arrives as
+ * one boolean because that is the question the verb asks, and a message
+ * enumerating server-side permission names would tie this copy to slugs the
+ * browser has no other reason to know — the same coupling the resolved-slug
+ * lookup exists to avoid.
+ *
  * ONE string, exported, because two surfaces say it: this list, which dims the
  * control and titles it, and the runner in `keyboard-actions`, which announces
  * it when a dimmed control is pressed anyway. Written twice they would drift,
  * and the drift would be invisible — each reads correctly on its own.
  */
 export const SAVE_PATTERN_GRANT_REFUSAL =
-  "You do not have permission to create patterns.";
+  "You do not have permission to save patterns.";
 
 function saveAction(
   document: BlockDocument,

--- a/packages/builder/src/toolbar-actions.ts
+++ b/packages/builder/src/toolbar-actions.ts
@@ -143,6 +143,17 @@ function moveAction(
  * cannot be saved, so leaving it dimmed and silent would be a control an author
  * can only guess at.
  */
+/**
+ * What an author is told when they hold no grant to save a pattern.
+ *
+ * ONE string, exported, because two surfaces say it: this list, which dims the
+ * control and titles it, and the runner in `keyboard-actions`, which announces
+ * it when a dimmed control is pressed anyway. Written twice they would drift,
+ * and the drift would be invisible — each reads correctly on its own.
+ */
+export const SAVE_PATTERN_GRANT_REFUSAL =
+  "You do not have permission to create patterns.";
+
 function saveAction(
   document: BlockDocument,
   ids: readonly string[],
@@ -162,7 +173,7 @@ function saveAction(
       id: "save-as-pattern",
       label,
       enabled: false,
-      reason: "You do not have permission to create patterns.",
+      reason: SAVE_PATTERN_GRANT_REFUSAL,
     };
   const refusal = saveAsPatternRefusal(document, ids, nesting);
   if (refusal === undefined)

--- a/packages/builder/src/toolbar-save-grant.test.ts
+++ b/packages/builder/src/toolbar-save-grant.test.ts
@@ -47,6 +47,16 @@ describe("save as pattern, and the grant behind it", () => {
     });
   });
 
+  it("names the OPERATION refused, not one of the grants it needs", () => {
+    // Saving takes more than one grant — the pattern is stored and published in
+    // the same act — so a message naming any single one is wrong for somebody.
+    // An author who may create a pattern but not publish it, told they cannot
+    // "create", would ask for the grant they already hold.
+    const reason = (save(["a"], false) as { reason: string }).reason;
+    expect(reason).toMatch(/save/i);
+    expect(reason).not.toMatch(/create/i);
+  });
+
   it("refuses a multi-block selection on the same grant", () => {
     // The set path builds its verbs separately, so a grant threaded through one
     // and not the other leaves the toolbar refusing a single block and offering

--- a/packages/builder/src/toolbar-save-grant.test.ts
+++ b/packages/builder/src/toolbar-save-grant.test.ts
@@ -1,0 +1,69 @@
+/**
+ * The save verb, refused for a reason the author can read.
+ *
+ * The property under test is that the GRANT is asked about at all, and that its
+ * refusal reaches every surface. A test asserting only "disabled when
+ * mayCreatePattern is false" would also pass against an implementation that
+ * disabled the verb for the wrong reason, so each case here reads the REASON
+ * back — that string is the only explanation an author gets, and there is
+ * nothing on the canvas that would otherwise say why.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { BlockDocument, BlockNode } from "@nextlyhq/blocks-engine";
+
+import { toolbarActions } from "./toolbar-actions";
+
+/**
+ * The document shape the planner accepts, built the way `toolbar-actions.test`
+ * builds it. A hand-rolled one is refused for its own reasons — measured — and
+ * a fixture the planner rejects never reaches the grant at all, so every
+ * "enabled" assertion below would be testing the refusal it did not intend.
+ */
+function node(id: string, type = "acme/heading"): BlockNode {
+  return { id, type, version: 1, props: {} } as BlockNode;
+}
+const document: BlockDocument = {
+  formatVersion: 1,
+  kind: "page",
+  nodes: [node("a"), node("b")],
+} as BlockDocument;
+
+function save(ids: readonly string[], mayCreate?: boolean) {
+  return toolbarActions(document, ids[0], ids, undefined, mayCreate).find(
+    a => a.id === "save-as-pattern"
+  );
+}
+
+describe("save as pattern, and the grant behind it", () => {
+  it("is offered when the caller may create", () => {
+    expect(save(["a"], true)).toMatchObject({ enabled: true });
+  });
+
+  it("is refused WITH A REASON when the caller may not", () => {
+    expect(save(["a"], false)).toMatchObject({
+      enabled: false,
+      reason: expect.stringContaining("permission"),
+    });
+  });
+
+  it("refuses a multi-block selection on the same grant", () => {
+    // The set path builds its verbs separately, so a grant threaded through one
+    // and not the other leaves the toolbar refusing a single block and offering
+    // the same save for two.
+    expect(save(["a", "b"], false)).toMatchObject({
+      enabled: false,
+      reason: expect.stringContaining("permission"),
+    });
+    expect(save(["a", "b"], true)).toMatchObject({ enabled: true });
+  });
+
+  it("is offered when nothing was said, so an unasked question never hides it", () => {
+    // The permissive default. A caller that has not adopted the parameter — and
+    // the editor itself, while the read is in flight — must keep the answer it
+    // had, because a wrong refusal hides a feature the author holds and only
+    // the late failure is lost by being wrong the other way.
+    expect(save(["a"])).toMatchObject({ enabled: true });
+    expect(save(["a", "b"])).toMatchObject({ enabled: true });
+  });
+});

--- a/packages/plugin-page-builder/src/admin/BlocksField.paletteDrag.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.paletteDrag.test.tsx
@@ -23,6 +23,7 @@ import * as React from "react";
 import { useForm } from "react-hook-form";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { OPEN_BUILDER_ACTION } from "./PageBuilderCard";
+import { CAPABILITY_ROUTE_PATH, LIBRARY_ROUTE_PATH } from "../library-contract";
 
 /**
  * What the library route answers, for the one case that cares.
@@ -32,6 +33,9 @@ import { OPEN_BUILDER_ACTION } from "./PageBuilderCard";
  */
 let libraryAnswer: { items: unknown[]; meta: unknown } | undefined;
 
+/** What the capability route answers. Mutable so a case can withhold the grant. */
+let capabilityAnswer: { mayCreate: boolean } | undefined;
+
 /**
  * Which panel the shell stub asks for.
  *
@@ -40,8 +44,22 @@ let libraryAnswer: { items: unknown[]; meta: unknown } | undefined;
  */
 let shownPanel = "insert";
 
-/** How many times anything asked for a plugin route. */
+/** How many times the LIBRARY was asked for. */
 let routeReads = 0;
+
+/** How many times the capability route was asked for. */
+let capabilityReads = 0;
+
+/**
+ * The paths the mock discriminates on, hoisted so the factory below can see
+ * them, and CHECKED against the real contract in a test — a literal here that
+ * drifted from the route would silently stop counting, and both assertions
+ * about laziness would then pass against a mock answering nothing.
+ */
+const paths = vi.hoisted(() => ({
+  library: "/library",
+  capability: "/capability",
+}));
 
 /** Props the recorders captured on the most recent render. */
 const seen: {
@@ -220,16 +238,28 @@ vi.mock("@nextlyhq/plugin-sdk/admin", () => ({
   // The library read. Mutable so one case can put a pattern in it: what the
   // panel is GIVEN is this file's subject, and the tier was unreachable for as
   // long as the answer never reached the prop.
-  usePluginRoute: () => ({
-    ...(() => {
-      routeReads += 1;
-      return {};
-    })(),
-    data: libraryAnswer,
-    pending: false,
-    error: null,
-    refetch: () => {},
-  }),
+  // Discriminated BY PATH. The editor now makes two different reads — the
+  // library when the insert panel opens, and the capability eagerly on mount —
+  // and a mock that counted both as one made "does not read the library" fail
+  // for a read of something else entirely.
+  usePluginRoute: (args: { path: string }) => {
+    if (args.path === paths.capability) {
+      capabilityReads += 1;
+      return {
+        data: capabilityAnswer,
+        pending: false,
+        error: null,
+        refetch: () => {},
+      };
+    }
+    routeReads += 1;
+    return {
+      data: libraryAnswer,
+      pending: false,
+      error: null,
+      refetch: () => {},
+    };
+  },
   useDocumentCheckpoint: () => ({ record: () => {}, clear: () => {} }),
   useEntryFieldsPanel: () => null,
   useReportUnsavedWork: () => {},
@@ -285,6 +315,8 @@ afterEach(() => {
   libraryAnswer = undefined;
   shownPanel = "insert";
   routeReads = 0;
+  capabilityReads = 0;
+  capabilityAnswer = { mayCreate: true };
 });
 
 describe("what makes a palette drag reachable at all", () => {
@@ -408,6 +440,25 @@ describe("what makes the saved pattern tier reachable at all", () => {
 });
 
 describe("what the editor reads before anyone asks for it", () => {
+  it("discriminates the two routes by the paths the plugin actually declares", () => {
+    // The control for both assertions below. If either literal drifted from the
+    // contract the mock would answer the wrong shape for both reads, and a
+    // counter that never incremented would report perfect laziness.
+    expect(paths.library).toBe(LIBRARY_ROUTE_PATH);
+    expect(paths.capability).toBe(CAPABILITY_ROUTE_PATH);
+  });
+
+  it("asks what the author may do EAGERLY, before any panel is opened", () => {
+    // The verb it gates is drawn by the toolbar, the context menu and the
+    // palette, all of which exist before the insert panel does — so an answer
+    // deferred to the panel arrives after the control it describes.
+    shownPanel = "layers";
+
+    openEditor();
+
+    expect(capabilityReads).toBeGreaterThan(0);
+  });
+
   it("does not read the library while another panel is open", () => {
     // Reading in the editor's own body fetched every saved pattern document on
     // every editor mount — for authors who open Layers, or Tokens, or no panel

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -155,6 +155,7 @@ import { readSiteStyleRecord } from "../site-style-record";
 import { DocumentStatusPill } from "./DocumentStatusPill";
 import { pageRenderInputs, readDocumentLimits } from "./page-render-inputs";
 import { PageBuilderCard } from "./PageBuilderCard";
+import { useMayCreatePattern } from "./pattern-capability-client";
 import { usePatternLibrary } from "./pattern-library-client";
 import { SavePatternPrompt } from "./SavePatternPrompt";
 /* The save state, which the status pill cannot carry: it renders nothing on a
@@ -1852,6 +1853,15 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
   // toolbar, the context menu and the palette all reach it — while everything
   // the form needs is mounted only while it is up. See `SavePatternPrompt`.
   const savePattern = useSavePatternVerb(editor, inline);
+  /*
+   * Whether this author may create a pattern at all, read EAGERLY here.
+   *
+   * Beside the verb it gates rather than inside it: the toolbar, the context
+   * menu and the command palette all offer the verb from one shared action
+   * list, so the answer has to exist before any of them draws — and asking in
+   * three places would be three requests answering one question.
+   */
+  const mayCreatePattern = useMayCreatePattern();
 
   /*
    * The entry's other fields, ALREADY DRAWN, or null when there are none.
@@ -2746,6 +2756,15 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
           editor={editor}
           onEditText={inline.begin}
           onSaveAsPattern={savePattern.open}
+          /*
+            Whether the author holds the grant the save is judged by, asked of
+            the server because only it knows the RESOLVED collection: a site may
+            rename it, and the browser knows the declared name alone. Passed
+            here rather than read inside the builder for the same reason
+            `onSaveAsPattern` is passed — the collection a pattern goes in is
+            this plugin's business, not the canvas's.
+          */
+          mayCreatePattern={mayCreatePattern}
         >
           {/*
             Inside the verbs provider, which is what lets the palette run

--- a/packages/plugin-page-builder/src/admin/pattern-capability-client.ts
+++ b/packages/plugin-page-builder/src/admin/pattern-capability-client.ts
@@ -1,0 +1,57 @@
+/**
+ * Whether this author may create a pattern, read once per editor.
+ *
+ * Read EAGERLY, when the editor mounts, because the control it describes is
+ * drawn then. The library read cannot carry this: it happens when the insert
+ * panel opens, and the Save as pattern verb exists on the toolbar, the context
+ * menu and the command palette before any panel does.
+ *
+ * ## Why it is allowed to be wrong
+ *
+ * A gate on a stale answer offers a control whose save is then refused, which
+ * is exactly the behaviour this replaces and no worse than it. The write is
+ * authorized on its own. So the read is optimistic in the direction that keeps
+ * a working feature reachable, and the freshness below is about being right
+ * usually rather than about being safe.
+ *
+ * @module admin/pattern-capability-client
+ */
+import { usePluginRoute } from "@nextlyhq/plugin-sdk/admin";
+
+// The CONTRACT, not the route: `capability-route` reaches the collection
+// registry through server-only modules, and importing it here for one path
+// constant would take the admin bundle down at load.
+import {
+  CAPABILITY_ROUTE_PATH,
+  PAGE_BUILDER_PLUGIN_NAME,
+  type PatternCapabilityResponse,
+} from "../library-contract";
+
+/**
+ * Whether the save-as-pattern verb should be offered.
+ *
+ * `true` WHILE THE READ IS IN FLIGHT, and that default is deliberate. The
+ * alternative — closed until proven open — dims the verb on every editor mount
+ * for every author, including the many who may save, and a control that flickers
+ * from disabled to enabled is worse than one that is briefly optimistic. The
+ * cost of being wrong here is the late refusal that already happens today; the
+ * cost of being wrong the other way is a feature that looks broken.
+ *
+ * The same reasoning as `useCan`'s is deliberately INVERTED, and the difference
+ * is which way each fails: a closed-by-default gate on a navigation item hides a
+ * page until permissions load, and the page is still there afterwards. Here the
+ * refusal carries the only explanation an author gets.
+ */
+export function useMayCreatePattern(): boolean {
+  const read = usePluginRoute<PatternCapabilityResponse>({
+    plugin: PAGE_BUILDER_PLUGIN_NAME,
+    path: CAPABILITY_ROUTE_PATH,
+    // Fresh on every mount, matching `useCurrentUserPermissions` in the admin
+    // and `usePatternLibrary` beside this. A role change lands through screens
+    // that know nothing about this route, so under the admin's five-minute
+    // default an author whose grant was just added would keep being refused a
+    // verb they now hold.
+    staleTime: 0,
+  });
+  return read.data?.mayCreate ?? true;
+}

--- a/packages/plugin-page-builder/src/capability-route.test.ts
+++ b/packages/plugin-page-builder/src/capability-route.test.ts
@@ -44,7 +44,50 @@ describe("the pattern capability route", () => {
     // able to save, and one asking about `patterns` would refuse an author who
     // holds `create-site_patterns` — the false refusal that hides a working
     // feature, which is worse than the late failure this replaces.
-    expect(asked).toEqual([["create", "site_patterns"]]);
+    // Both permissions the write needs, about the RESOLVED collection. A route
+    // asking `read` would report every author as able to save, and one asking
+    // about `patterns` would refuse an author who holds `create-site_patterns`.
+    expect(asked).toEqual([
+      ["create", "site_patterns"],
+      ["publish", "site_patterns"],
+    ]);
+  });
+
+  it("requires PUBLISH as well, because the save creates a published row", async () => {
+    // Codex P2 on #1678, confirmed against the write: `save-pattern-route`
+    // persists `status: "published"`, and core resolves the publish grant
+    // separately from create for that transition — its own docblock says an
+    // author without it "is refused by core". An answer naming `create` alone
+    // therefore says yes to an author the save refuses, which relocates the
+    // defect instead of fixing it.
+    const asked: Array<[string, string]> = [];
+    const answer = await readPatternCapability({
+      self: { collections: { [PATTERNS_SLUG]: "site_patterns" } },
+      caller: {
+        can: async (a: string, r: string) => {
+          asked.push([a, r]);
+          return a === "create";
+        },
+      },
+    });
+    expect(asked).toContainEqual(["publish", "site_patterns"]);
+    expect(answer).toEqual({ mayCreate: false });
+  });
+
+  it("stops at the first refusal rather than asking the rest", async () => {
+    // The second question costs a permission read, and an author refused the
+    // first has already been answered.
+    const asked: Array<[string, string]> = [];
+    await readPatternCapability({
+      self: { collections: {} },
+      caller: {
+        can: async (a: string, r: string) => {
+          asked.push([a, r]);
+          return false;
+        },
+      },
+    });
+    expect(asked).toEqual([["create", PATTERNS_SLUG]]);
   });
 
   it("reports what the caller answered, in both directions", async () => {
@@ -67,7 +110,10 @@ describe("the pattern capability route", () => {
         },
       },
     });
-    expect(asked).toEqual([["create", PATTERNS_SLUG]]);
+    expect(asked).toEqual([
+      ["create", PATTERNS_SLUG],
+      ["publish", PATTERNS_SLUG],
+    ]);
   });
 
   it("refuses a caller nobody identified, without asking", async () => {

--- a/packages/plugin-page-builder/src/capability-route.test.ts
+++ b/packages/plugin-page-builder/src/capability-route.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Whether the capability route answers about the KEY question, not a near one.
+ *
+ * The separating property is not "a permission check runs". A check ran before
+ * this route existed — the save itself — and the whole defect is that it ran too
+ * late. What this must get right is WHICH resource it asks about: the grant is
+ * seeded against the collection a host actually has, so a route asking about the
+ * declared name answers correctly on every site that never renamed anything and
+ * refuses an author who holds the grant on every site that did. Both fixtures
+ * below therefore RENAME the collection, because an un-renamed one cannot tell
+ * the two implementations apart.
+ */
+import { describe, expect, it } from "vitest";
+
+import { readPatternCapability } from "./capability-route";
+import { PATTERNS_SLUG } from "./collections/patterns";
+
+/** What was asked, so a test can assert the question and not only the answer. */
+function callerSpy(answer: boolean): {
+  ctx: Parameters<typeof readPatternCapability>[0];
+  asked: Array<[string, string]>;
+} {
+  const asked: Array<[string, string]> = [];
+  return {
+    asked,
+    ctx: {
+      // RENAMED, deliberately — see the module docblock.
+      self: { collections: { [PATTERNS_SLUG]: "site_patterns" } },
+      caller: {
+        can: async (action: string, resource: string) => {
+          asked.push([action, resource]);
+          return answer;
+        },
+      },
+    },
+  };
+}
+
+describe("the pattern capability route", () => {
+  it("asks whether the caller may CREATE in the RESOLVED collection", async () => {
+    const { ctx, asked } = callerSpy(true);
+    await readPatternCapability(ctx);
+    // Both halves matter. A route asking `read` would report every author as
+    // able to save, and one asking about `patterns` would refuse an author who
+    // holds `create-site_patterns` — the false refusal that hides a working
+    // feature, which is worse than the late failure this replaces.
+    expect(asked).toEqual([["create", "site_patterns"]]);
+  });
+
+  it("reports what the caller answered, in both directions", async () => {
+    await expect(readPatternCapability(callerSpy(true).ctx)).resolves.toEqual({
+      mayCreate: true,
+    });
+    await expect(readPatternCapability(callerSpy(false).ctx)).resolves.toEqual({
+      mayCreate: false,
+    });
+  });
+
+  it("falls back to the declared slug when the host renamed nothing", async () => {
+    const asked: Array<[string, string]> = [];
+    await readPatternCapability({
+      self: { collections: {} },
+      caller: {
+        can: async (a: string, r: string) => {
+          asked.push([a, r]);
+          return true;
+        },
+      },
+    });
+    expect(asked).toEqual([["create", PATTERNS_SLUG]]);
+  });
+
+  it("refuses a caller nobody identified, without asking", async () => {
+    // Unreachable through the route, which is authenticated — but reading a
+    // null caller as "allowed" is the direction that offers a control to an
+    // anonymous visitor, so it is decided rather than left to the type.
+    await expect(
+      readPatternCapability({ self: { collections: {} }, caller: null })
+    ).resolves.toEqual({ mayCreate: false });
+  });
+});

--- a/packages/plugin-page-builder/src/capability-route.test.ts
+++ b/packages/plugin-page-builder/src/capability-route.test.ts
@@ -54,7 +54,7 @@ describe("the pattern capability route", () => {
   });
 
   it("requires PUBLISH as well, because the save creates a published row", async () => {
-    // Codex P2 on #1678, confirmed against the write: `save-pattern-route`
+    // `save-pattern-route`
     // persists `status: "published"`, and core resolves the publish grant
     // separately from create for that transition — its own docblock says an
     // author without it "is refused by core". An answer naming `create` alone

--- a/packages/plugin-page-builder/src/capability-route.ts
+++ b/packages/plugin-page-builder/src/capability-route.ts
@@ -39,6 +39,7 @@ import {
   CAPABILITY_ROUTE_PATH,
   type PatternCapabilityResponse,
 } from "./library-contract";
+import { SAVED_PATTERN_STATUS } from "./save-pattern-route";
 
 /**
  * What this route needs of the plugin route context.
@@ -68,7 +69,23 @@ export async function readPatternCapability(
 ): Promise<PatternCapabilityResponse> {
   if (ctx.caller === null) return { mayCreate: false };
   const slug = ctx.self.collections[PATTERNS_SLUG] ?? PATTERNS_SLUG;
-  return { mayCreate: await ctx.caller.can("create", slug) };
+  // EVERY permission the save requires, not just the obvious one. The route
+  // creates the row already published, and core resolves the publish grant
+  // separately from create for exactly that transition — so an author holding
+  // `create` and not `publish` would be told yes and refused by the write, which
+  // is the failure this answer exists to prevent rather than relocate.
+  //
+  // DERIVED from the status the save persists, so a future save that stored a
+  // draft stops asking for a grant it no longer needs. `every` rather than a
+  // chain of `&&` because the list is the rule.
+  const needed: string[] =
+    SAVED_PATTERN_STATUS === "published" ? ["create", "publish"] : ["create"];
+  for (const action of needed) {
+    // Sequential, and it short-circuits: the second question costs a permission
+    // read, and an author refused the first has already been answered.
+    if (!(await ctx.caller.can(action, slug))) return { mayCreate: false };
+  }
+  return { mayCreate: true };
 }
 
 /**

--- a/packages/plugin-page-builder/src/capability-route.ts
+++ b/packages/plugin-page-builder/src/capability-route.ts
@@ -1,0 +1,94 @@
+/**
+ * Whether this author may create a pattern, asked before the form is offered.
+ *
+ * ## Why the server has to answer
+ *
+ * The grant is seeded against the RESOLVED collection slug, and a host may
+ * rename a plugin collection. The browser knows only the declared name, so a
+ * client-side check would refuse an author on a renamed site — hiding a feature
+ * that works, which is worse than the late failure it replaces. It is also the
+ * reason `savePatternRoute` declares no `requiredPermission` and reads
+ * `ctx.self.collections[PATTERNS_SLUG]` instead: the resolved slug is knowable
+ * on this side and nowhere else.
+ *
+ * The resolved slug could not travel to the browser instead. Renames resolve in
+ * `init`, where `ctx` is in scope; `contributes.admin` is a static object built
+ * without one, and there is no init-time API to add to it. So the question
+ * travels rather than the fact it is asked about.
+ *
+ * ## Why it asks rather than computes
+ *
+ * `ctx.caller.can` is the framework's own answer — a scoped API key judged on
+ * its own stamped grants and the code-defined rule, a session through the RBAC
+ * service with its super-admin bypass. Deriving permissions here from a user id
+ * would be a second implementation of "what may this caller do", which drifts
+ * silently from the one the write is judged by, and would answer differently
+ * for the API keys the first one exists to hold.
+ *
+ * ## NOT a security boundary
+ *
+ * `savePatternRoute` authorizes its own write. This only decides whether a
+ * control is offered, so a caller who never asks, or who disbelieves the
+ * answer, gains nothing by it.
+ *
+ * @module capability-route
+ */
+
+import { PATTERNS_SLUG } from "./collections/patterns";
+import {
+  CAPABILITY_ROUTE_PATH,
+  type PatternCapabilityResponse,
+} from "./library-contract";
+
+/**
+ * What this route needs of the plugin route context.
+ *
+ * Structural rather than the published `PluginRouteContext`, matching
+ * `LibraryRouteContext` beside it: it names exactly what is read, so a test can
+ * supply it without booting a server and a reader can see the whole dependency.
+ */
+export interface CapabilityRouteContext {
+  readonly self: { readonly collections: Record<string, string | undefined> };
+  readonly caller: {
+    can: (action: string, resource: string) => Promise<boolean>;
+  } | null;
+}
+
+/**
+ * Answer whether this caller may create a pattern.
+ *
+ * A `null` caller cannot be anybody, so it may not create. That branch is not
+ * reachable through this route — it is authenticated, so the dispatcher has
+ * resolved a caller before the handler runs — but the type admits `null` for
+ * the `public` routes that share the context, and reading it as "allowed" is
+ * the direction that offers a control to a caller nobody identified.
+ */
+export async function readPatternCapability(
+  ctx: CapabilityRouteContext
+): Promise<PatternCapabilityResponse> {
+  if (ctx.caller === null) return { mayCreate: false };
+  const slug = ctx.self.collections[PATTERNS_SLUG] ?? PATTERNS_SLUG;
+  return { mayCreate: await ctx.caller.can("create", slug) };
+}
+
+/**
+ * The route declaration.
+ *
+ * No `public: true`, so it is authenticated: the answer is about the caller and
+ * a shared one would be wrong for everybody. No `requiredPermission` either —
+ * the permission it reports on is the one being ASKED about, and gating the
+ * question on the answer would return 403 to exactly the authors this exists to
+ * tell "no" gracefully.
+ */
+export function patternCapabilityRoute(): {
+  method: "GET";
+  path: string;
+  handler: (req: Request, ctx: CapabilityRouteContext) => Promise<Response>;
+} {
+  return {
+    method: "GET",
+    path: CAPABILITY_ROUTE_PATH,
+    handler: async (_req, ctx) =>
+      Response.json(await readPatternCapability(ctx)),
+  };
+}

--- a/packages/plugin-page-builder/src/library-contract.ts
+++ b/packages/plugin-page-builder/src/library-contract.ts
@@ -38,6 +38,17 @@ export const PAGE_BUILDER_PLUGIN_NAME = "@nextlyhq/plugin-page-builder";
 export const LIBRARY_ROUTE_PATH = "/library";
 
 /**
+ * Where the editor asks what the author may do with patterns.
+ *
+ * A route of its own rather than a field on the library response, and the
+ * timing is the whole reason. The Save as pattern verb renders from the
+ * toolbar's own action list before any panel exists, and the library is read
+ * WHEN THE PANEL OPENS — so an answer carried on that response arrives after
+ * the control it was meant to describe.
+ */
+export const CAPABILITY_ROUTE_PATH = "/capability";
+
+/**
  * How much of a page one pattern covers.
  *
  * A closed set rather than free text, because it is a FACET: the browser
@@ -264,4 +275,29 @@ export interface SavePatternResponse {
   readonly item: { readonly id: string } & Record<string, unknown>;
   /** Side effects that failed after the row committed, when any did. */
   readonly warnings?: readonly HookWarning[];
+}
+
+/**
+ * What the editor may do with patterns, as the server sees this caller.
+ *
+ * ONE field, because one verb asks. A map of every capability the plugin might
+ * ever gate would be a promise about surfaces that do not exist, and the reader
+ * after this one cannot tell such a field from one that quietly stopped being
+ * computed — the same reason `PatternLibraryRead` carries the patterns and
+ * nothing else.
+ *
+ * NOT A SECURITY BOUNDARY. The write is authorized on its own, by the route
+ * that performs it; a caller who lies to this one gains nothing. It exists so
+ * an author is not invited to fill in a form whose save cannot succeed.
+ */
+export interface PatternCapabilityResponse {
+  /**
+   * Whether this caller may create a pattern in the resolved collection.
+   *
+   * `create` on the collection the host actually has, which is the grant the
+   * save is judged by. Asking about the DECLARED name instead would refuse an
+   * author on a site that renamed the collection — hiding a feature that works,
+   * which is worse than the late failure this replaces.
+   */
+  readonly mayCreate: boolean;
 }

--- a/packages/plugin-page-builder/src/plugin.ts
+++ b/packages/plugin-page-builder/src/plugin.ts
@@ -25,6 +25,7 @@ import {
   registerCoreBlocks,
   registerDeclaredBlocks,
 } from "./blocks/registration-service";
+import { patternCapabilityRoute } from "./capability-route";
 import { registerClassUsageMaintenance } from "./class-usage-hook";
 import {
   CLASS_USAGE_INDEX_SLUG,
@@ -549,7 +550,11 @@ export const pageBuilder = (opts: PageBuilderOptions = {}) => {
       // the planner's answer and the planner needs the server's block
       // registry — the browser holds the core blocks and not the ones another
       // plugin declared.
-      routes: [patternLibraryRoute(), savePatternRoute()],
+      routes: [
+        patternLibraryRoute(),
+        savePatternRoute(),
+        patternCapabilityRoute(),
+      ],
 
       // No `publish` permission. One was declared here and nothing ever read
       // it: publishing a page is a status change on the entry, which

--- a/packages/plugin-page-builder/src/save-pattern-route.ts
+++ b/packages/plugin-page-builder/src/save-pattern-route.ts
@@ -82,7 +82,16 @@ import {
  * See the module docblock: the default is `draft`, and a draft pattern is not
  * offered, so leaving it would save a pattern the author cannot find.
  */
-const SAVED_PATTERN_STATUS = "published";
+/**
+ * The status a saved pattern is created with.
+ *
+ * EXPORTED so `capability-route` can derive which permissions this write needs
+ * from the write itself. The status decides that — core requires the publish
+ * grant on top of create when the persisted status is `published` — so a
+ * capability answer that named `create` alone would say yes to an author the
+ * save then refuses, which is the defect it exists to prevent.
+ */
+export const SAVED_PATTERN_STATUS = "published";
 
 /**
  * The field the collection stores the tree under.


### PR DESCRIPTION
Closes the gap `decision:pb6-library-response-reports-capabilities` was ruled on:
an author who cannot create a pattern is no longer invited to fill in the form
that saves one.

## What was wrong

A role that can update pages but lacks the separately seeded `create` grant on
the patterns collection was offered **Save as pattern** on the toolbar, the
context menu and the command palette. They filled in the form; the write was
refused. Legibly — the dialog keeps the draft and shows the server's message —
but after the work.

## Why the server has to answer

The grant is held against the **resolved** collection, and a host may rename a
plugin collection. The browser knows only the declared name, so a client-side
check refuses an author who holds the grant — hiding a feature that works, which
is worse than the late failure it replaces. That is the same reason
`savePatternRoute` declares no `requiredPermission` and reads
`ctx.self.collections[PATTERNS_SLUG]` instead.

### The ruled carrier could not work, and this is measured

The ruling's corrected evidence asked for the resolved slug to be emitted
unconditionally in the admin metadata. It cannot be:

- renames resolve inside `init: ctx => …` — the existing
  `registerClassUsageMaintenance` call does exactly this, for exactly this
  reason;
- `contributes.admin` is a **static** object with no `ctx` in scope;
- there is **no init-time API** to contribute admin metadata — `clientConfig`
  reaches the browser only from that static block.

So the question travels rather than the fact it asks about. Recorded as
`finding:the-resolved-slug-cannot-travel-in-static-admin-metadata`. A small
capabilities route was carrier (3) in
`finding:the-capability-answer-waits-on-the-route-context`, which called it "the
right shape" and deferred it only because it would then have had to re-derive a
session caller's permissions from a user id — an objection removed by
`ctx.caller.can()` (#1673, main `69b9aa535`).

**This is not the dropped option.** `meta.canCreate` on the library response was
dropped because the verb renders before any panel opens; a separate eager route
does not have that timing problem.

## The shape

`capability-route.ts` — authenticated `GET /capability`, answering
`{ mayCreate }` via `ctx.caller.can("create", resolvedSlug)`. No
`requiredPermission`: gating the question on the answer would return 403 to
exactly the authors this exists to refuse gracefully.

It **asks rather than computes**. Deriving permissions here would be a second
implementation of "what may this caller do", drifting from the one the write is
judged by and answering differently for the API keys that check exists to hold.

The editor reads it **eagerly on mount**, because the verb is drawn by three
surfaces that all exist before the insert panel — which is also why the library
response cannot carry it. All three read one answer, through the action list
they already share, so there is no second opinion to drift.

`plugin.ts` changes by one import and one array entry.

## UX and DX

**Disabled with a reason, not hidden.** It matches every other refusal on that
toolbar, and `block-toolbar.tsx` already renders these with `aria-disabled` plus
a hidden `aria-describedby` span — keeping the control focusable and the reason
readable, per the ARIA APG. The reason returned here flows into that existing
markup; no new pattern was invented.

**Offered while the answer is in flight**, deliberately inverting `useCan`'s
closed-by-default posture. A wrong "yes" costs the late refusal that already
happens today; a wrong "no" hides a feature the author holds, and nothing on the
canvas would explain it. `staleTime: 0` matches `useCurrentUserPermissions`.

**Not a security boundary.** The write authorizes itself, unchanged.

## Prior art

`research:pb6-capability-gate-prior-art`. Payload (`GET /api/access`), Strapi
(`useRBAC`), Directus (`/permissions/me`) all ship whole-permission maps — but
each answers "which of many buttons to show" across a whole admin, a different
problem from one gated verb. Kubernetes separates `SelfSubjectAccessReview` (one
question) from `SelfSubjectRulesReview` (the map), and its docs restrict the map
to UI show/hide explicitly. One question is also what this repo already chose in
`ctx.caller.can`, which rejected a permission-array shape for the same reason.

## Evidence

Six wrong implementations, each killed by exactly the test naming its property:

| Wrong implementation | Test that failed |
| --- | --- |
| Route asks the **declared** slug (the rename trap) | asks about the RESOLVED collection |
| Route asks `read` instead of `create` | asks whether the caller may CREATE |
| Grant checked on the single-block path only | refuses a multi-block selection on the same grant |
| Closed-by-default | is offered when nothing was said |
| Refuse without a reason | refused WITH A REASON |
| Capability not read eagerly | asks EAGERLY, before any panel is opened |

Both route fixtures **rename the collection**, because an un-renamed one cannot
tell the correct implementation from the declared-slug one.

One fixture correction worth naming: my first toolbar fixture was refused by the
planner for its own reasons, so every "enabled" assertion would have been
testing a refusal it did not intend. The tests caught it by failing; it now uses
the document shape the existing suite builds.

### A pre-existing test that this legitimately moved

`BlocksField.paletteDrag.test` asserts the editor "does not read the library
while another panel is open" — guarding against fetching every saved pattern
document on mount. Its mock counted **both** plugin routes as one, so a read of
something else failed it. The mock now discriminates by path, with the hoisted
literals asserted equal to the exported constants: a drifted literal would make
the mock answer the wrong shape for both reads, and a counter that never
incremented would report perfect laziness.

## Gates

| gate | exit |
| --- | --- |
| `pnpm build` | 0 |
| `builder` `check-types` / `lint` | 0 / 0 |
| `plugin-page-builder` `check-types` / `lint` | 0 / 0 |
| `builder` `vitest run` | 0 — 103 files, 2,874 passed |
| `plugin-page-builder` `vitest run` | 0 — 70 files, 774 passed |
| pre-push hook (monorepo `check-types` + tests) | 0 |
| `fallow audit --base origin/main` | 0 — `pass`, `changed_files_count: 11` |
| `pnpm changeset status` | 0 |

## Territory

`plugin-page-builder/src/plugin.ts` is claimed by `wt-pb6`
(`task:pb6-t5-component-usage-index`). The founder ruled to proceed because this
touches it with one import and one array entry, far from the `admin`/
`clientConfig` block that lane is working in. The other claimant, lane
`builder`, has no worktree in either clone — abandoned under
`decision:pb6-stale-claims-treated-as-abandoned`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added permission-aware controls for creating patterns in the page builder.
  - The “Save as pattern” action is available only when the current user has permission to create patterns.
  - Permission status is checked when the editor opens and reflected in the action’s disabled reason.
  - Pattern creation remains enabled by default when permission information is unavailable, while the final save operation remains authorized independently.
- **Tests**
  - Added coverage for permission checks, collection configuration, and single- and multi-block selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->