### PR TITLE
fix(nextly): a plugin route pins the request its handler is serving

### DIFF
--- a/.changeset/a-plugin-route-pins-its-request.md
+++ b/.changeset/a-plugin-route-pins-its-request.md
@@ -1,0 +1,37 @@
+---
+
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+
+A plugin-contributed route reached the collections through the managed facade
+without carrying the request it was serving, so a hook underneath one read a
+browser's write as background work. Every route written before that field
+existed names no request, which is all of them: the page-builder's save route
+and the form-builder's export routes among them. A request-scoped rule, a rate
+limit or an audit, stood down for exactly the traffic it exists to judge.
+
+The route dispatcher pins the request once, beside the caller scope it already
+pins, so a contributed route inherits it without naming it.

--- a/packages/nextly/src/plugins/routes/dispatch-request-scope.test.ts
+++ b/packages/nextly/src/plugins/routes/dispatch-request-scope.test.ts
@@ -1,0 +1,85 @@
+/**
+ * A plugin route pins the request its handler is serving.
+ *
+ * A contributed route reaches the collections through the managed facade, and
+ * that facade takes an explicit request only if the route names one. Routes
+ * written before the field existed do not, and a hook underneath them then
+ * reads a browser's write as background work: a rate limit stands down, an
+ * audit records nothing, a honeypot never runs. Pinning here is what makes the
+ * facts reach the hook without every contributed route remembering.
+ *
+ * Sibling of `dispatch-caller.test.ts`, which pins the other scope this opens
+ * for the same reason.
+ *
+ * @module plugins/routes/dispatch-request-scope
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../auth/middleware", () => ({
+  requireAuthentication: vi.fn(async () => ({
+    userId: "u1",
+    userEmail: "u1@x.com",
+    userName: "U",
+    permissions: [],
+    roles: [],
+    authMethod: "session" as const,
+  })),
+  requirePermission: vi.fn(async () => undefined),
+  isErrorResponse: (x: unknown) =>
+    !!x && typeof x === "object" && "statusCode" in x,
+}));
+
+import { currentRequest } from "../../hooks/request-scope";
+import type { PluginContext } from "../plugin-context";
+
+import { runPluginRoute } from "./dispatch";
+import type { RouteMatch } from "./route-registry";
+import type { PluginRoute } from "./route-types";
+
+const baseCtx = () =>
+  ({
+    self: { name: "@a/x", collections: {}, singles: {} },
+    logger: { info() {}, warn() {}, error() {}, debug() {} },
+    services: {},
+  }) as unknown as PluginContext;
+
+function match(handler: PluginRoute["handler"]): RouteMatch {
+  return {
+    pluginName: "@a/x",
+    route: { method: "GET", path: "/r", handler } as PluginRoute,
+    baseCtx: baseCtx(),
+    params: {},
+  };
+}
+
+describe("a plugin route pins the request", () => {
+  it("hands it to code that was told nothing", async () => {
+    let seen: Request | undefined;
+    const req = new Request("http://x/api/plugins/@a/x/r");
+    await runPluginRoute(
+      req,
+      match(() => {
+        // What a service several layers below the handler can reach. The
+        // handler's own argument is not the question: the facade underneath it
+        // is what reads this.
+        seen = currentRequest();
+        return Response.json({ ok: true });
+      })
+    );
+    expect(seen).toBe(req);
+  });
+
+  it("pins nothing outside a route", () => {
+    // The control. A scope that leaked would answer here too, and every job
+    // and seed write would be attributed to whichever route ran last.
+    expect(currentRequest()).toBeUndefined();
+  });
+
+  it("closes when the handler returns", async () => {
+    await runPluginRoute(
+      new Request("http://x/api/plugins/@a/x/r"),
+      match(() => Response.json({ ok: true }))
+    );
+    expect(currentRequest()).toBeUndefined();
+  });
+});

--- a/packages/nextly/src/plugins/routes/dispatch.ts
+++ b/packages/nextly/src/plugins/routes/dispatch.ts
@@ -9,6 +9,7 @@ import {
 } from "../../auth/middleware";
 import { toNextlyAuthError } from "../../auth/middleware/to-nextly-error";
 import { NextlyError } from "../../errors/nextly-error";
+import { runWithRequestScope } from "../../hooks/request-scope";
 import { currentFlattenedErrors } from "../../hooks/side-effect-warnings";
 import { SKIP_TIMEZONE_FORMAT_HEADER } from "../../shared/lib/date-formatting";
 import type { AuthUser } from "../../types/auth";
@@ -202,13 +203,16 @@ export async function runPluginRoute(
   );
 
   try {
-    // Pinned for the length of the handler so a service call inside it inherits
-    // the key's grants without the handler having to remember. Every route
-    // written before this field existed composes `{ as: "user", user }` by
-    // hand, and an opt-in field leaves all of them authorizing the key as its
-    // owner.
+    // Both scopes pinned for the length of the handler, so a service call
+    // inside it inherits the key's grants and the request without the handler
+    // having to remember either. Every route written before these fields
+    // existed composes `{ as: "user", user }` by hand: an opt-in field leaves
+    // all of them authorizing the key as its owner, and leaves every read and
+    // write they make looking like background work to a hook.
     return markPluginResponse(
-      await runWithCallerScope(auth.authenticatedScope, () => run(req, ctx)),
+      await runWithRequestScope(req, () =>
+        runWithCallerScope(auth.authenticatedScope, () => run(req, ctx))
+      ),
       matched.route
     );
   } catch (err) {


### PR DESCRIPTION
Follow-up to #1667, which merged while this commit was still in its pre-push run.

## The gap

#1667 pins the request at two boundaries: `withErrorHandler`, which covers the
handlers exported from `nextly/api/*`, and the service dispatcher, which covers
the dynamic routes. Plugin-contributed routes go through neither. They run
under `runPluginRoute`, which opens the caller scope and nothing else.

A contributed route reaches the collections through the managed facade, and
that facade carries a request only when the route names one in its
`ServiceOpts`. Every route written before that field existed names none, which
is all of them today: the page-builder's save route
(`save-pattern-route.ts:174-185`) and the form-builder's export routes
(`plugin.ts:271-310`) among them.

So a hook underneath one of those routes reads `ctx.req.http` as absent and
concludes no request produced the write. For a browser-initiated save that is
the wrong answer, and it is the answer a request-scoped rule acts on: a rate
limit stands down, an audit records nothing, a honeypot never runs.

## The fix

The route dispatcher pins the request once, beside the caller scope it already
pins. Its own comment gives the reason, one field over:

> an opt-in field leaves all of them authorizing the key as its owner

The same holds here. A field every contributed route has to remember is a field
most of them will not, and the failure is silent in both cases.

## Evidence

`dispatch-request-scope.test.ts`, the sibling of `dispatch-caller.test.ts`,
asserts a handler's ambient request rather than its argument, because the
argument is not what the facade underneath it reads.

Break-verified: removing the pin fails 1 of 3, and both controls (nothing
pinned outside a route, the scope closed when the handler returns) still pass.

Gates: both type configs, the plugin-route suites (9 files, 45 tests), lint,
`check:comments`.

## Why it is separate

It was the sixth review finding on #1667 and was pushed after the merge. It is
also a precondition for the form-builder's spam protection moving to the write
seam: that plugin's submit handler is a plugin route, so without this the rule
would attach and silently never run on the door it most needs to guard.
