### PR TITLE
fix(release): close the frontmatter on the visitor-hook changeset

### DIFF
--- a/.changeset/a-hook-can-tell-a-visitor-from-a-server.md
+++ b/.changeset/a-hook-can-tell-a-visitor-from-a-server.md
@@ -1,5 +1,4 @@
 ---
-
 "@nextlyhq/adapter-drizzle": patch
 "@nextlyhq/adapter-mysql": patch
 "@nextlyhq/adapter-postgres": patch
@@ -25,6 +24,7 @@
 "@nextlyhq/telemetry": patch
 "@nextlyhq/tsconfig": patch
 "@nextlyhq/ui": patch
+---
 
 A hook could not tell whether the write it was running on came from a browser
 or from a seed script, so a rule that only makes sense for a visitor, a rate


### PR DESCRIPTION
The changeset added by #1667 opens its frontmatter and never closes it — the file carries one `---` where it needs two, so the parser reads the whole document as unterminated frontmatter and rejects it.

**This is not local to that file.** `getReleasePlan` parses every entry in `.changeset/`, so one unparseable file fails `pnpm changeset status` for the whole repository and the release train stops behind it.

## What was measured

```
# before, on main
pnpm changeset status  -> exit 1
  error could not parse changeset - missing or invalid frontmatter.

# every changeset, through the real parser
parsed ok: 1097   invalid: 1
```

The `1097 ok / 1 invalid` line matters: it says the defect is one file rather than a convention the repository has drifted away from.

## The fix, and one wrong turn worth recording

The closing `---` after the last package entry. That is the whole defect.

I first read the blank line on line 2 as the cause and removed it — the parse error names frontmatter, and a blank line inside it looks like the problem. It was not: restoring that blank line and re-parsing still succeeds, so it was never required. Only re-running the gate after the first "fix" caught it, and the diff here is what prettier settled on once the file became parseable.

## Verification

- `pnpm changeset status` exits **0**, and lists 25 packages to bump at patch.
- The parsed result carries 25 releases and the original summary, so the entry keeps the meaning #1667 gave it.
- No changeset of its own: this changes no published package, it makes an existing one readable.