### PR TITLE
feat(plugin-form-builder): spam is judged where every door passes

### DIFF
--- a/.changeset/spam-is-judged-where-every-door-passes.md
+++ b/.changeset/spam-is-judged-where-every-door-passes.md
@@ -1,0 +1,49 @@
+---
+
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+
+Honeypot and rate limiting ran in the form route. The submissions collection
+grants public create on purpose, so a visitor can submit without an account,
+which makes the generic collection create a second public door and the Direct
+API a third. Submissions arriving that way were stored with no rule having
+looked at them.
+
+Both now run at the write seam every door passes through, and only when a
+request produced the write: a seed, an import or a scheduled job is not
+rate-limited by its own importer. A honeypot hit is still stored flagged rather
+than dropped, so a false positive stays reviewable. A submission over the limit
+is refused, and the form route still answers its own visitor with a success so
+a bot learns nothing from the difference.
+
+The rate-limit window moved out of a `Map` private to this package and into the
+deployment's own store, the one the REST and auth limiters already share.
+Configure `rateLimit.store` once and all three count together. A private Map
+counts per process: across several, the effective limit becomes the configured
+number times the number of instances, and it fails open under load.
+
+`cleanupRateLimitStore`, `getRateLimitStoreSize`, `clearRateLimitStore` and
+`isRateLimited` are no longer exported. They existed to manage that Map.

--- a/.changeset/spam-is-judged-where-every-door-passes.md
+++ b/.changeset/spam-is-judged-where-every-door-passes.md
@@ -1,5 +1,4 @@
 ---
-
 "@nextlyhq/adapter-drizzle": patch
 "@nextlyhq/adapter-mysql": patch
 "@nextlyhq/adapter-postgres": patch
@@ -25,6 +24,7 @@
 "@nextlyhq/telemetry": patch
 "@nextlyhq/tsconfig": patch
 "@nextlyhq/ui": patch
+---
 
 Honeypot and rate limiting ran in the form route. The submissions collection
 grants public create on purpose, so a visitor can submit without an account,

--- a/packages/nextly/src/auth/middleware/rate-limiter.ts
+++ b/packages/nextly/src/auth/middleware/rate-limiter.ts
@@ -37,6 +37,15 @@ export interface RateLimitCheckResult {
  * Holds no state of its own — every window lives in the store — so
  * constructing one per request is free, and two limiters over the same store
  * enforce one shared limit.
+ *
+ * @public
+ *
+ * Distinct from `createRateLimiter`, which builds REST middleware that reads a
+ * request and answers with a `Response`. This is the limiter underneath that
+ * decision, driven directly with a key, a limit and a window, for a caller that
+ * already knows what it is counting. Both run over the same
+ * {@link RateLimitStore}, so a deployment that configures one store has one
+ * shared window whichever drives it.
  */
 export class RateLimiter {
   constructor(

--- a/packages/nextly/src/index.ts
+++ b/packages/nextly/src/index.ts
@@ -871,11 +871,20 @@ export {
   createRateLimiter,
   createRateLimitHeaders,
   InMemoryRateLimitStore,
+  resolveRateLimitStore,
   type RateLimitConfig,
   type RateLimitStore,
   type RateLimitResult,
   type RateLimitRecord,
 } from "./middleware";
+
+// The limiter a caller drives directly, over the same store the middleware
+// uses. Exported so a plugin limiting something of its own counts in the same
+// window as the REST and auth limiters rather than in one of its own.
+export {
+  RateLimiter,
+  type RateLimitCheckResult,
+} from "./auth/middleware/rate-limiter";
 
 // Security middleware types
 export { type SecurityHeadersConfig, type CorsConfig } from "./middleware";

--- a/packages/nextly/src/middleware/index.ts
+++ b/packages/nextly/src/middleware/index.ts
@@ -13,6 +13,7 @@ export {
   createRateLimitHeaders,
   getDefaultStore,
   resetDefaultStore,
+  resolveRateLimitStore,
   InMemoryRateLimitStore,
   type RateLimitConfig,
   type RateLimitStore,

--- a/packages/nextly/src/middleware/rate-limit.ts
+++ b/packages/nextly/src/middleware/rate-limit.ts
@@ -27,6 +27,7 @@
  * ```
  */
 
+import { container } from "../di/container";
 import { getTrustedClientIp } from "../utils/get-trusted-client-ip";
 
 // ============================================================================
@@ -608,6 +609,34 @@ export function getDefaultStore(): InMemoryRateLimitStore {
     _defaultStore = new InMemoryRateLimitStore();
   }
   return _defaultStore;
+}
+
+/**
+ * The rate-limit store this deployment is using.
+ *
+ * @public
+ *
+ * One store, three consumers: the REST limiter, the auth limiter, and any
+ * plugin that limits something of its own. A consumer that reaches for its own
+ * store instead counts in isolation, and on a deployment that spans processes
+ * the effective limit becomes `configured x instances` -- a number the operator
+ * never chose and cannot see. Configure `rateLimit.store` once, in
+ * `nextly.config.ts`, and every limiter shares the window.
+ *
+ * Falls back to the in-memory default when nothing is configured, which is
+ * correct for a single process and wrong for several. That is the same default
+ * the REST and auth limiters take, so the three agree about what they are
+ * counting whether or not a store is configured.
+ */
+export function resolveRateLimitStore(): RateLimitStore {
+  try {
+    const config = container.has("config")
+      ? container.get<{ rateLimit?: { store?: RateLimitStore } }>("config")
+      : undefined;
+    return config?.rateLimit?.store ?? getDefaultStore();
+  } catch {
+    return getDefaultStore();
+  }
 }
 
 /**

--- a/packages/plugin-form-builder/src/__tests__/spam-at-the-write-seam.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/spam-at-the-write-seam.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Spam is judged at the seam every door passes through, not in one route.
+ *
+ * The submissions collection grants public create on purpose, so a visitor can
+ * submit without an account. That makes the generic collection create a second
+ * public door and the Direct API a third, and a rule that lives in the form
+ * route guards the form route. These drive the write-seam hook directly, which
+ * is what the other two doors reach and what `submitForm` also passes through.
+ *
+ * @module __tests__/spam-at-the-write-seam
+ */
+import { NextlyError } from "nextly";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { asPluginSubmission } from "../handlers/prepare-submission";
+import { prepareSubmissionForWrite } from "../plugin";
+
+const FIELDS = [{ name: "email", label: "Email", type: "text" }];
+
+function nextlyWith(spamProtection: Record<string, unknown>): never {
+  return {
+    __formBuilderConfig: { spamProtection },
+  } as never;
+}
+
+/**
+ * A create as the other two doors make it: a row, and a request behind it.
+ *
+ * `form` is per-case rather than shared. The rate-limit window is keyed by form
+ * and address, and the store outlives one test, so a shared id would let one
+ * case spend another's budget and the failure would look like the limiter
+ * working.
+ *
+ * `ip` is read by presence, not by `??`: the case that matters most passes
+ * `null`, which is what the core answers when no address can be trusted, and
+ * `??` would quietly turn it back into an address.
+ */
+function writeOf(
+  payload: Record<string, unknown>,
+  opts: {
+    form?: string;
+    ip?: string | null;
+    request?: boolean;
+    fields?: unknown[];
+  } = {}
+) {
+  const form = opts.form ?? "f1";
+  const ip = "ip" in opts ? opts.ip : "203.0.113.7";
+  const row = asPluginSubmission(
+    { form, data: payload },
+    { form: { id: form, fields: (opts.fields ?? FIELDS) as never } }
+  );
+  return {
+    data: row,
+    operation: "create",
+    ...(opts.request === false
+      ? {}
+      : { req: { http: { ip, method: "POST" } } }),
+  };
+}
+
+const run = (ctx: unknown, spam: Record<string, unknown>) =>
+  prepareSubmissionForWrite(ctx, "forms", nextlyWith(spam));
+
+afterEach(() => {
+  delete process.env.TRUSTED_PROXY_IPS;
+});
+
+describe("the write seam judges a submission", () => {
+  it("flags a honeypot hit rather than dropping it", async () => {
+    const ctx = writeOf({ email: "a@b.test", website: "http://spam.example" });
+    await run(ctx, { honeypot: true });
+    // Stored, flagged: a false positive stays reviewable and recoverable.
+    expect(ctx.data.status).toBe("spam");
+    expect(ctx.data.spamReason).toBe("honeypot");
+  });
+
+  it("leaves a clean submission alone", async () => {
+    // The control. A seam that flagged everything would satisfy the case above
+    // while making the Spam view the only view.
+    const ctx = writeOf({ email: "a@b.test" });
+    await run(ctx, { honeypot: true });
+    expect(ctx.data.status).toBeUndefined();
+  });
+
+  it("does not trip on a field the form actually declares", async () => {
+    // `website` is both a stock honeypot name and an ordinary form field. The
+    // trap is set among the keys the form does NOT declare, so a form that
+    // asks for a website is not a form whose every submission is bot traffic.
+    const ctx = writeOf(
+      { email: "a@b.test", website: "http://mysite.example" },
+      { fields: [...FIELDS, { name: "website", label: "Site", type: "text" }] }
+    );
+    await run(ctx, { honeypot: true });
+    expect(ctx.data.status).toBeUndefined();
+  });
+
+  it("says nothing about a write no request produced", async () => {
+    // A seed, an import, a job. The whole reason the core carries the request:
+    // a rule aimed at a visitor must not judge a server importing rows as one.
+    const ctx = writeOf(
+      { email: "a@b.test", website: "http://spam.example" },
+      { request: false }
+    );
+    await run(ctx, { honeypot: true });
+    expect(ctx.data.status).toBeUndefined();
+  });
+
+  it("refuses a submission over the limit, and refuses it as a rate limit", async () => {
+    const spam = {
+      honeypot: false,
+      rateLimit: { maxSubmissions: 1, windowMs: 60_000 },
+    };
+    await run(writeOf({ email: "a@b.test" }, { form: "limited" }), spam);
+    // The second one is over.
+    await expect(
+      run(writeOf({ email: "c@d.test" }, { form: "limited" }), spam)
+    ).rejects.toSatisfy((error: unknown) => NextlyError.isRateLimited(error));
+  });
+
+  it("counts an unidentifiable client as nobody rather than as everybody", async () => {
+    // `ip: null` is what the resolver answers when no address can be trusted.
+    // Keying a window on that would put every such visitor in one bucket, where
+    // the first bot to fill it locks out the rest.
+    const spam = {
+      honeypot: false,
+      rateLimit: { maxSubmissions: 1, windowMs: 60_000 },
+    };
+    await run(writeOf({ email: "a@b.test" }, { form: "anon", ip: null }), spam);
+    await expect(
+      run(writeOf({ email: "c@d.test" }, { form: "anon", ip: null }), spam)
+    ).resolves.toBeDefined();
+  });
+});

--- a/packages/plugin-form-builder/src/handlers/index.ts
+++ b/packages/plugin-form-builder/src/handlers/index.ts
@@ -21,10 +21,6 @@ export {
 // Spam detection utilities
 export {
   checkSpam,
-  cleanupRateLimitStore,
-  getRateLimitStoreSize,
-  clearRateLimitStore,
-  isRateLimited,
   type SpamCheckConfig,
   type SpamCheckOptions,
   type SpamCheckResult,

--- a/packages/plugin-form-builder/src/handlers/spam-detection.ts
+++ b/packages/plugin-form-builder/src/handlers/spam-detection.ts
@@ -1,12 +1,22 @@
 /**
  * Spam Detection
  *
- * Implements honeypot and rate limiting spam protection for form submissions.
- * Provides a pluggable approach to spam detection that can be extended.
+ * Honeypot and rate limiting for form submissions.
+ *
+ * The honeypot is a pure read of the submitted payload. The rate limit is not:
+ * it counts, and where the count lives decides whether the limit means
+ * anything. It lives in the deployment's own {@link RateLimitStore}, the one
+ * the REST and auth limiters already share, so `rateLimit.store` is configured
+ * once and all three agree about what they are counting. A store private to
+ * this module would count per process, and on a deployment that spans several
+ * the effective limit becomes `configured x instances` -- a number the operator
+ * never chose, that fails open, and only under load.
  *
  * @module handlers/spam-detection
  * @since 0.1.0
  */
+
+import { RateLimiter, resolveRateLimitStore } from "nextly";
 
 // ============================================================
 // Types
@@ -74,24 +84,6 @@ export interface SpamCheckResult {
 }
 
 // ============================================================
-// Rate Limit Store
-// ============================================================
-
-/**
- * In-memory rate limit store.
- *
- * Note: For multi-instance deployments (serverless, load-balanced),
- * consider using Redis or a database-backed store instead.
- * This in-memory implementation works well for single-instance deployments.
- */
-interface RateLimitEntry {
-  count: number;
-  timestamp: number;
-}
-
-const rateLimitStore = new Map<string, RateLimitEntry>();
-
-// ============================================================
 // Main Spam Check Function
 // ============================================================
 
@@ -124,7 +116,6 @@ const rateLimitStore = new Map<string, RateLimitEntry>();
  * }
  * ```
  */
-// eslint-disable-next-line @typescript-eslint/require-await -- public API: declared return type is `Promise<SpamCheckResult>` and callers `await` it; removing `async` would force a return-type change
 export async function checkSpam(
   options: SpamCheckOptions
 ): Promise<SpamCheckResult> {
@@ -140,7 +131,7 @@ export async function checkSpam(
 
   // 2. Rate limiting check
   if (config.rateLimit && ipAddress) {
-    const rateLimitResult = checkRateLimit(
+    const rateLimitResult = await checkRateLimit(
       ipAddress,
       formSlug,
       config.rateLimit
@@ -213,141 +204,34 @@ function checkHoneypot(data: Record<string, unknown>): SpamCheckResult {
 // ============================================================
 
 /**
- * Check rate limit for a given IP and form combination.
+ * Whether this address has submitted this form too often, recording the attempt.
  *
- * Uses a sliding window approach where submissions are counted
- * within a time window. If the count exceeds the maximum,
- * further submissions are blocked.
+ * Keyed by form and address together, so a burst against one form does not
+ * lock a visitor out of another. The window lives in the deployment's shared
+ * store, so two processes serving the same visitor count once.
  *
- * @param ipAddress - Submitter's IP address
- * @param formSlug - Form identifier
- * @param config - Rate limit configuration
- * @returns Spam check result
+ * An address of `unknown` is not a bucket to key on: every client whose address
+ * could not be resolved would share one window, and the first bot to fill it
+ * would lock out every visitor behind an untrusted proxy. The caller decides
+ * what to do about an unidentifiable client; this counts only identified ones.
  */
-function checkRateLimit(
+async function checkRateLimit(
   ipAddress: string,
   formSlug: string,
   config: { maxSubmissions: number; windowMs: number }
-): SpamCheckResult {
-  const key = `${formSlug}:${ipAddress}`;
-  const now = Date.now();
-  const entry = rateLimitStore.get(key);
-
-  if (entry) {
-    // Check if window has expired
-    if (now - entry.timestamp > config.windowMs) {
-      // Reset counter for new window
-      rateLimitStore.set(key, { count: 1, timestamp: now });
-      return { isSpam: false };
-    }
-
-    // Check if limit exceeded
-    if (entry.count >= config.maxSubmissions) {
-      return {
-        isSpam: true,
-        reason: "rate_limit",
-        details: `Rate limit exceeded: ${entry.count}/${config.maxSubmissions} in ${config.windowMs}ms`,
-      };
-    }
-
-    // Increment counter
-    rateLimitStore.set(key, {
-      count: entry.count + 1,
-      timestamp: entry.timestamp,
-    });
-  } else {
-    // First submission from this IP/form
-    rateLimitStore.set(key, { count: 1, timestamp: now });
-  }
-
-  return { isSpam: false };
-}
-
-// ============================================================
-// Utility Functions
-// ============================================================
-
-/**
- * Clean up expired rate limit entries.
- *
- * Call this periodically (e.g., every 5 minutes) to prevent
- * memory leaks from accumulated rate limit entries.
- *
- * @param maxAgeMs - Maximum age of entries to keep (default: 5 minutes)
- * @returns Number of entries removed
- *
- * @example
- * ```typescript
- * // Set up periodic cleanup
- * setInterval(() => {
- *   const removed = cleanupRateLimitStore();
- *   console.log(`Cleaned up ${removed} expired rate limit entries`);
- * }, 5 * 60 * 1000); // Every 5 minutes
- * ```
- */
-export function cleanupRateLimitStore(
-  maxAgeMs: number = 5 * 60 * 1000
-): number {
-  const now = Date.now();
-  let removed = 0;
-
-  for (const [key, entry] of rateLimitStore.entries()) {
-    if (now - entry.timestamp > maxAgeMs) {
-      rateLimitStore.delete(key);
-      removed++;
-    }
-  }
-
-  return removed;
-}
-
-/**
- * Get the current size of the rate limit store.
- *
- * Useful for monitoring and debugging.
- *
- * @returns Number of entries in the store
- */
-export function getRateLimitStoreSize(): number {
-  return rateLimitStore.size;
-}
-
-/**
- * Clear all rate limit entries.
- *
- * Useful for testing or resetting state.
- */
-export function clearRateLimitStore(): void {
-  rateLimitStore.clear();
-}
-
-/**
- * Check if a specific IP/form is currently rate limited.
- *
- * @param ipAddress - IP address to check
- * @param formSlug - Form slug
- * @param config - Rate limit configuration
- * @returns Whether the IP is currently rate limited
- */
-export function isRateLimited(
-  ipAddress: string,
-  formSlug: string,
-  config: { maxSubmissions: number; windowMs: number }
-): boolean {
-  const key = `${formSlug}:${ipAddress}`;
-  const now = Date.now();
-  const entry = rateLimitStore.get(key);
-
-  if (!entry) {
-    return false;
-  }
-
-  // Check if window has expired
-  if (now - entry.timestamp > config.windowMs) {
-    return false;
-  }
-
-  return entry.count >= config.maxSubmissions;
+): Promise<SpamCheckResult> {
+  const limiter = new RateLimiter(resolveRateLimitStore());
+  const result = await limiter.check(
+    `form-submit:${formSlug}:${ipAddress}`,
+    config.maxSubmissions,
+    config.windowMs
+  );
+  if (result.allowed) return { isSpam: false };
+  return {
+    isSpam: true,
+    reason: "rate_limit",
+    details: `Rate limit exceeded: ${config.maxSubmissions} per ${config.windowMs}ms`,
+  };
 }
 
 // ============================================================

--- a/packages/plugin-form-builder/src/handlers/submit-form.ts
+++ b/packages/plugin-form-builder/src/handlers/submit-form.ts
@@ -51,6 +51,21 @@ export interface SubmitFormOptions {
     /** Submitter's user agent string */
     userAgent?: string;
   };
+
+  /**
+   * The HTTP request this submission arrived on.
+   *
+   * A route calling this helper is its own route, outside everything Nextly
+   * pins a request around, so nothing else can supply it. Without it the write
+   * reaches the submissions hooks looking like a seed or a job, and every rule
+   * scoped to a visitor stands down: the rate limit above all.
+   *
+   * The request rather than an address, because the core resolves the client
+   * from it under this deployment's proxy-trust settings. `metadata.ipAddress`
+   * is a string the caller chose, which is the right shape for the audit column
+   * it fills and the wrong shape for deciding who to throttle.
+   */
+  request?: Request;
 }
 
 /**
@@ -133,7 +148,7 @@ export async function submitForm(
   options: SubmitFormOptions,
   context: SubmitFormContext
 ): Promise<SubmitFormResult> {
-  const { formSlug, data, metadata } = options;
+  const { formSlug, data, metadata, request } = options;
   const { pluginContext, pluginConfig } = context;
   const { collections } = pluginContext.services;
   const { logger } = pluginContext;
@@ -304,14 +319,22 @@ export async function submitForm(
         }),
         // Public form submission — create as system. No ambient user; an
         // empty context already resolves to system, but be explicit.
-        { as: "system" }
+        //
+        // The request travels with it so the seam judges this submission on the
+        // same facts as one arriving through a Nextly route. Omitted by a caller
+        // that has none, and then the seam correctly reads the write as
+        // server-side work.
+        { as: "system", ...(request ? { request } : {}) }
       );
     } catch (error) {
       // The seam refuses a submission over the limit, and refuses it the same
-      // way at every door. This one answers its VISITOR with a success anyway:
-      // a bot that is told it was limited learns the rate to sit under, and a
-      // form is the one door where the caller is a browser. The other doors are
-      // machine-facing and get the 429 the seam threw.
+      // way at every door. This helper answers its own caller with a success
+      // anyway: a host route calls it to serve a browser, and a bot told it was
+      // limited learns the rate to sit under.
+      //
+      // This is NOT the built-in `POST /api/forms/:slug/submit`, which core's
+      // form dispatcher serves without calling this at all. That endpoint
+      // returns the refusal as a 429.
       //
       // Nothing is stored. A limiter that wrote a row per refusal would hand an
       // attacker a way to fill the database with the very volume it exists to

--- a/packages/plugin-form-builder/src/handlers/submit-form.ts
+++ b/packages/plugin-form-builder/src/handlers/submit-form.ts
@@ -8,7 +8,7 @@
  * @since 0.1.0
  */
 
-import { formAvailability, NO_SUCH_FORM } from "nextly";
+import { formAvailability, NextlyError, NO_SUCH_FORM } from "nextly";
 import type { PluginContext } from "nextly";
 
 import { asFormDocument, asSubmissionDocument } from "../document-shapes";
@@ -226,35 +226,20 @@ export async function submitForm(
       Object.entries(data).filter(([key]) => !declaredFieldNames.has(key))
     );
 
+    // The honeypot only, and only to decide whether to validate. It is a pure
+    // read of the payload, so running it here and again at the write seam
+    // costs nothing and cannot disagree. The RATE LIMIT is not asked here: it
+    // counts, and a check with a side effect run twice counts one submission
+    // twice. The seam owns that one, and owns the verdict written to the row.
     const spamResult = await checkSpam({
       data: undeclaredData,
-      ipAddress: metadata?.ipAddress,
       formSlug,
       config: {
         // Per-form overrides win where set; blank inherits the plugin config.
         honeypot:
           settings.honeypotEnabled ?? pluginConfig.spamProtection.honeypot,
-        rateLimit: pluginConfig.spamProtection.rateLimit,
-        recaptcha: {
-          ...pluginConfig.spamProtection.recaptcha,
-          enabled:
-            settings.captchaEnabled ??
-            pluginConfig.spamProtection.recaptcha?.enabled ??
-            false,
-        },
       },
     });
-
-    // Rate-limit hits are pure volume — storing them would turn the limiter
-    // into a database DoS, so they are rejected without a trace (still with
-    // fake success so the client learns nothing).
-    if (spamResult.isSpam && spamResult.reason === "rate_limit") {
-      logger.info?.("Spam submission rejected (rate limit)", {
-        formSlug,
-        ipAddress: metadata?.ipAddress,
-      });
-      return { success: true };
-    }
 
     const isContentSpam = spamResult.isSpam;
 
@@ -309,16 +294,34 @@ export async function submitForm(
     // is evidence this handler chose to keep rather than a caller asking for
     // validation to be skipped. The form goes with it so the seam does not read
     // it a second time.
-    const submission = await collections.createEntry(
-      pluginConfig.formSubmissionOverrides.slug,
-      asPluginSubmission(submissionData, {
-        keepAsEvidence: isContentSpam,
-        form: { id: form.id, fields: form.fields },
-      }),
-      // Public form submission — create as system. No ambient user; an
-      // empty context already resolves to system, but be explicit.
-      { as: "system" }
-    );
+    let submission: Awaited<ReturnType<typeof collections.createEntry>>;
+    try {
+      submission = await collections.createEntry(
+        pluginConfig.formSubmissionOverrides.slug,
+        asPluginSubmission(submissionData, {
+          keepAsEvidence: isContentSpam,
+          form: { id: form.id, fields: form.fields },
+        }),
+        // Public form submission — create as system. No ambient user; an
+        // empty context already resolves to system, but be explicit.
+        { as: "system" }
+      );
+    } catch (error) {
+      // The seam refuses a submission over the limit, and refuses it the same
+      // way at every door. This one answers its VISITOR with a success anyway:
+      // a bot that is told it was limited learns the rate to sit under, and a
+      // form is the one door where the caller is a browser. The other doors are
+      // machine-facing and get the 429 the seam threw.
+      //
+      // Nothing is stored. A limiter that wrote a row per refusal would hand an
+      // attacker a way to fill the database with the very volume it exists to
+      // refuse.
+      if (NextlyError.isRateLimited(error)) {
+        logger.info?.("Form submission refused (rate limit)", { formSlug });
+        return { success: true };
+      }
+      throw error;
+    }
 
     logger.info?.("Form submission created successfully", {
       formSlug,

--- a/packages/plugin-form-builder/src/index.ts
+++ b/packages/plugin-form-builder/src/index.ts
@@ -245,10 +245,6 @@ export {
 // Spam detection utilities
 export {
   checkSpam,
-  cleanupRateLimitStore,
-  getRateLimitStoreSize,
-  clearRateLimitStore,
-  isRateLimited,
   type SpamCheckConfig,
   type SpamCheckOptions,
   type SpamCheckResult,

--- a/packages/plugin-form-builder/src/plugin.ts
+++ b/packages/plugin-form-builder/src/plugin.ts
@@ -31,6 +31,7 @@ import {
   type SubmissionOriginMarks,
   prepareSubmission,
 } from "./handlers/prepare-submission";
+import { checkSpam, type SpamCheckResult } from "./handlers/spam-detection";
 import type {
   AnyFormField,
   BeforeEmailFilterContext,
@@ -932,6 +933,7 @@ export async function prepareSubmissionForWrite(
     operation?: string;
     originalData?: Record<string, unknown>;
     user?: { id?: string };
+    req?: { http?: { ip: string | null; method: string } };
   };
   const submission = ctx.data;
   if (!submission || typeof submission !== "object") return ctx.data;
@@ -954,7 +956,29 @@ export async function prepareSubmissionForWrite(
   // Read off the row itself, so it describes this write and no other.
   const marks = submissionMarks(submission);
 
-  const fields = await fieldsToCheckAgainst(marks, formsSlug, formId, nextly);
+  const form = await formToCheckAgainst(marks, formsSlug, formId, nextly);
+  const fields = form.fields as AnyFormField[];
+
+  // Spam is judged HERE, at the seam every door passes through, rather than in
+  // the route: the submissions collection grants public create, so the generic
+  // collection create is a second public door and the Direct API a third. A
+  // rule that lives in one of them guards one of them.
+  //
+  // Only when a request produced this write. `ctx.req.http` is absent for a
+  // seed, an import or a job, and a rule aimed at a visitor must not judge a
+  // server that is importing ten thousand rows as one.
+  const spam =
+    ctx.operation === "create" && ctx.req?.http
+      ? await judgeSubmission(incoming, form, ctx.req.http, nextly)
+      : undefined;
+
+  if (spam?.reason === "rate_limit") {
+    // Refused, not stored: a limiter that wrote a row per refusal would turn
+    // volume into a database it fills for the attacker. The plugin's own route
+    // answers its visitor with a success anyway, so a bot learns nothing from
+    // it; the other doors are machine-facing and get the honest 429.
+    throw NextlyError.rateLimited();
+  }
 
   // Content spam keeps its evidence. The handler stores a honeypot or reCAPTCHA
   // hit flagged rather than dropping it, so a false positive stays recoverable,
@@ -967,7 +991,7 @@ export async function prepareSubmissionForWrite(
   const prepared = prepareSubmission({
     data: incoming,
     fields,
-    validate: marks?.keepAsEvidence !== true,
+    validate: marks?.keepAsEvidence !== true && spam === undefined,
   });
 
   if (prepared.validationErrors) {
@@ -979,6 +1003,14 @@ export async function prepareSubmissionForWrite(
   }
 
   ctx.data = { ...submission, data: prepared.data };
+  if (spam) {
+    // Flagged, never dropped: a false positive stays reviewable in the Spam
+    // view and recoverable through "Not spam". Written here rather than trusted
+    // from the payload, because the collection grants public create and nothing
+    // restricts these fields, so a caller could otherwise mark its own row.
+    ctx.data.status = "spam";
+    ctx.data.spamReason = spam.reason ?? null;
+  }
   if (ctx.operation !== "create" && submission.data === undefined) {
     stampDerivedEdit(ctx.data, ctx.user, incoming, prepared.data);
   }
@@ -995,12 +1027,12 @@ export async function prepareSubmissionForWrite(
  * write before it. Only ever the form this row names, because the id has to
  * match.
  */
-async function fieldsToCheckAgainst(
+async function formToCheckAgainst(
   marks: SubmissionOriginMarks | undefined,
   formsSlug: string,
   formId: string,
   nextly: NextlyInstance
-): Promise<AnyFormField[]> {
+): Promise<Record<string, unknown>> {
   const handedOver = marks?.form?.id === formId ? marks.form : null;
   const form = handedOver ?? (await fetchParentForm(formsSlug, formId, nextly));
   if (!form || !Array.isArray(form.fields)) {
@@ -1015,7 +1047,61 @@ async function fieldsToCheckAgainst(
       ],
     });
   }
-  return form.fields as AnyFormField[];
+  return form;
+}
+
+/**
+ * The part of a rate-limit key that names the form.
+ *
+ * Only a string identifies a form; anything else shares a key with everything
+ * else that is not a string, and one form's burst would then limit another.
+ * Falls back to a constant that is explicit about naming no form, so a row
+ * whose slug and id are both unusable is limited as its own bucket rather than
+ * silently joining a neighbour's.
+ */
+function rateLimitKeyFor(form: Record<string, unknown>): string {
+  const { slug, id } = form;
+  if (typeof slug === "string" && slug.length > 0) return slug;
+  if (typeof id === "string" && id.length > 0) return id;
+  return "unidentified-form";
+}
+
+/**
+ * Whether this submission looks like a bot's, and why.
+ *
+ * `undefined` means nothing was detected, which is not the same as "no rule
+ * ran": a form that disables the honeypot and a deployment that configures no
+ * rate limit both answer that way, and both mean the submission is stored as an
+ * ordinary one.
+ *
+ * The address comes from the core, resolved under the deployment's proxy-trust
+ * settings, so it is the closest untrusted hop rather than whatever the sender
+ * put in `x-forwarded-for`. `null` means no address could be trusted, and the
+ * rate limit does not run: keying it on a placeholder would put every
+ * unidentifiable client in one window, where the first bot to fill it locks out
+ * every visitor behind an untrusted proxy. The honeypot still applies, because
+ * it reads the payload rather than the caller.
+ */
+async function judgeSubmission(
+  payload: Record<string, unknown>,
+  form: Record<string, unknown>,
+  http: { ip: string | null; method: string },
+  nextly: NextlyInstance
+): Promise<SpamCheckResult | undefined> {
+  const config = getFormBuilderConfig(nextly);
+  if (!config) return undefined;
+
+  const settings = (form.settings ?? {}) as { honeypotEnabled?: boolean };
+  const verdict = await checkSpam({
+    data: payload,
+    ipAddress: http.ip ?? undefined,
+    formSlug: rateLimitKeyFor(form),
+    config: {
+      honeypot: settings.honeypotEnabled ?? config.spamProtection.honeypot,
+      rateLimit: config.spamProtection.rateLimit,
+    },
+  });
+  return verdict.isSpam ? verdict : undefined;
 }
 
 /**

--- a/packages/plugin-form-builder/src/plugin.ts
+++ b/packages/plugin-form-builder/src/plugin.ts
@@ -1091,9 +1091,22 @@ async function judgeSubmission(
   const config = getFormBuilderConfig(nextly);
   if (!config) return undefined;
 
+  // The trap is set among the keys the form does NOT declare. Several honeypot
+  // names are ones a real form might use -- `website`, `url_field` -- so
+  // probing the whole payload would flag every submission to a form that
+  // declares one, and flag it as bot traffic.
+  const declared = new Set(
+    (Array.isArray(form.fields) ? form.fields : [])
+      .map(field => (field as { name?: unknown }).name)
+      .filter((name): name is string => typeof name === "string")
+  );
+  const undeclared = Object.fromEntries(
+    Object.entries(payload).filter(([key]) => !declared.has(key))
+  );
+
   const settings = (form.settings ?? {}) as { honeypotEnabled?: boolean };
   const verdict = await checkSpam({
-    data: payload,
+    data: undeclared,
     ipAddress: http.ip ?? undefined,
     formSlug: rateLimitKeyFor(form),
     config: {

--- a/packages/plugin-form-builder/src/plugin.ts
+++ b/packages/plugin-form-builder/src/plugin.ts
@@ -1053,17 +1053,17 @@ async function formToCheckAgainst(
 /**
  * The part of a rate-limit key that names the form.
  *
- * Only a string identifies a form; anything else shares a key with everything
- * else that is not a string, and one form's burst would then limit another.
- * Falls back to a constant that is explicit about naming no form, so a row
- * whose slug and id are both unusable is limited as its own bucket rather than
- * silently joining a neighbour's.
+ * The ID, never the slug. A door that hands the seam the form it already read
+ * carries `{ id, fields }`, and a door that makes the seam fetch it carries the
+ * whole row: keyed on whatever each happens to have, one form gets one window
+ * per door and a caller alternating between two doors spends two budgets.
+ *
+ * Only a string identifies a form. A row whose id is unusable is limited as its
+ * own bucket rather than silently joining a neighbour's.
  */
 function rateLimitKeyFor(form: Record<string, unknown>): string {
-  const { slug, id } = form;
-  if (typeof slug === "string" && slug.length > 0) return slug;
-  if (typeof id === "string" && id.length > 0) return id;
-  return "unidentified-form";
+  const { id } = form;
+  return typeof id === "string" && id.length > 0 ? id : "unidentified-form";
 }
 
 /**


### PR DESCRIPTION
Completes the work #1667 and #1679 made possible.

## The problem

There are three public doors into the form submissions table, not one. The
collection grants public create on purpose (`submissions.ts:246`) because a
visitor submits without an account, which makes the generic collection create a
second public door and the Direct API a third.

Honeypot and rate limiting lived in the form route, so submissions arriving
through the other two were stored with no rule having looked at them. Removing
the built-in route would not have closed that; it would have moved the hole.

The objection that kept this in the route was real: a honeypot and a rate limit
are facts about a REQUEST, and a trusted server importing ten thousand
submissions would have been rate-limited by its own importer. #1667 answered it
by letting a hook see whether a request produced the write at all.

## What this does

Both checks run at the `beforeChange` seam every door passes through, and only
when `ctx.req.http` is present. A seed, an import or a scheduled job is not
judged as a visitor.

- **A honeypot hit is stored flagged**, not dropped, so a false positive stays
  reviewable in the Spam view and recoverable through "Not spam". The verdict is
  written by the seam rather than trusted from the payload: the collection
  grants public create and nothing restricts `status`, so a caller could
  otherwise mark its own row.
- **A submission over the limit is refused** as `RATE_LIMITED`. The `submitForm`
  helper catches that one error and answers its own caller with a success,
  because a host calls it to serve a browser and a bot told it was limited
  learns the rate to sit under. Every other door surfaces the 429. Nothing is
  stored either way: a limiter that wrote a row per refusal would hand an
  attacker a way to fill the database with the volume it exists to refuse.

## The rate-limit window moved out of this package

It lived in a `Map` private to `spam-detection.ts`. That counts per process, so
on any deployment that runs more than one the effective limit became
`configured x instances` -- a number the operator never chose, cannot see, and
which fails open exactly under load.

It now lives in the deployment's own `RateLimitStore`, the one the REST and auth
limiters already share (`config.rateLimit.store`). Configure it once and all
three count together. Core publishes `resolveRateLimitStore()` for that, and
exports the `RateLimiter` the auth path already uses, so this package does not
re-implement the atomicity reasoning that store's contract documents at length.

**Breaking, alpha:** `cleanupRateLimitStore`, `getRateLimitStoreSize`,
`clearRateLimitStore` and `isRateLimited` are no longer exported. They existed
to manage the private Map.

## What `submitForm` still does

It keeps the honeypot read, because it decides whether to validate before
writing and that is what gives a real person their validation errors. It no
longer asks for the rate limit: that check COUNTS, and a counting check run in
two places counts one submission twice.

## Evidence

The package's 384 existing tests all passed with the seam's judgement disabled
entirely, because every one of them drives `submitForm`, which still does its
own honeypot read. Six new cases drive the hook the other two doors reach; the
same mutation fails two of them.

They also cover the case that made this worth checking: `website` and
`url_field` are stock honeypot names AND plausible real inputs, so the trap is
read among the keys a form does NOT declare. Probing the whole payload would
flag every submission to a form that asks for a website.

Gates: both type configs, core suite 11,734 across 923 files, plugin-form-builder
390, lint, `check:comments`.

## Four doors, not three, and what this does NOT cover

`submitForm` is a public helper for a host's own route. It has no internal
caller: the built-in `POST /api/forms/:slug/submit` is served by core's form
dispatcher, which never reaches it. That is a fourth door, and this PR's earlier
description had it wrong.

So on the built-in endpoint two things still hold, both consequences of core
owning a form endpoint that duplicates plugin logic:

- a refusal surfaces as a 429 rather than the silent success the helper gives;
- core validates required fields before the write, so a bot that fills a
  honeypot AND omits a required field gets a validation error and never reaches
  the seam, storing no evidence.

Neither is a regression. That endpoint has no spam protection at all today, and
`docs/plugins/form-builder.mdx` already tells readers so. Both resolve by
retiring core's form endpoint in favour of a plugin-owned route, which is the
direction #1636's research pointed at (Payload and Strapi ship no form endpoint)
and is agreed as separate work: it changes a documented public URL and needs a
deprecation cycle.

## Known, and not changed here

`verifyRecaptcha` is defined and never called, while the admin offers a per-form
`captchaEnabled` toggle. That control promises protection it does not deliver.
Pre-existing, and its own decision.
