### PR TITLE
fix(release): close the frontmatter on the plugin-route changeset

### DIFF
--- a/.changeset/a-plugin-route-pins-its-request.md
+++ b/.changeset/a-plugin-route-pins-its-request.md
@@ -1,5 +1,4 @@
 ---
-
 "@nextlyhq/adapter-drizzle": patch
 "@nextlyhq/adapter-mysql": patch
 "@nextlyhq/adapter-postgres": patch
@@ -25,6 +24,7 @@
 "@nextlyhq/telemetry": patch
 "@nextlyhq/tsconfig": patch
 "@nextlyhq/ui": patch
+---
 
 A plugin-contributed route reached the collections through the managed facade
 without carrying the request it was serving, so a hook underneath one read a


### PR DESCRIPTION
Same defect as #1680, one hour later, in the changeset added by #1679: the package list is never terminated, so the file carries one `---` where it needs two and the parser reads the whole document as unterminated frontmatter.

`getReleasePlan` parses every entry in `.changeset/`, so one unparseable file fails `changeset status` for the whole repository and the release train stops behind it.

## What was measured

```
# on main, before this change
pnpm changeset status  -> exit 1
parsed ok: 1099   invalid: 1   (a-plugin-route-pins-its-request.md)

# after
pnpm changeset status  -> exit 0
```

## The gate is not missing — it had not run

Worth stating plainly, because the obvious conclusion after a second occurrence is that nothing checks this, and that is false. `scripts/release/check-changesets.mjs` catches it exactly as intended:

```
$ printf ".changeset/a-plugin-route-pins-its-request.md\n" | node scripts/release/check-changesets.mjs
✖ the frontmatter is missing or has a line this cannot read.        exit 1

$ printf ".changeset/a-layout-keeps-the-component-it-uses.md\n" | node scripts/release/check-changesets.mjs
Checked 1 changeset(s): all cover the group.                        exit 0
```

Both directions, so the check discriminates rather than merely refusing things.

It runs inside `Lint / Typecheck / Test / Build`. On #1679 that job was still `queued` at merge time — and is still queued as I write this. So the check had **not run**, rather than having run and passed. The same is true of #1667, which caused #1680.

That is a merge-timing observation rather than a code defect, and the remedy is not mine to choose. The two that would close it: waiting for that job before merging, or making it a required check so the merge button refuses. Flagging it because a third occurrence is otherwise a matter of time.

## Verification

- `pnpm changeset status` exits **0**, and the entry keeps the 25 packages and the summary #1679 gave it.
- No changeset of its own: this changes no published package.