### PR TITLE
feat(admin): a dashboard can draw what it counts

### DIFF
--- a/.changeset/a-dashboard-can-draw-what-it-counts.md
+++ b/.changeset/a-dashboard-can-draw-what-it-counts.md
@@ -1,0 +1,49 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A dashboard could count and group entries but had no way to show either as a
+picture. Every chart meant writing a React component, which is how a dashboard
+stops looking like one product.
+
+Two archetypes now draw from a query the way `metric` and `table` already do,
+so an author declares a chart instead of shipping code: `bars` compares the
+buckets of a `groupBy`, and `timeseries` plots the points of a window.
+
+They are drawn here rather than by a charting dependency. The popular one pulls
+eleven packages — a state-management stack in every install's admin bundle for
+two shapes — and renders `role="application"`, which puts a screen reader into
+forms mode over a graphic that has no keyboard interface. Owning the markup is
+what makes the right pattern reachable: each chart is a labelled graphic with a
+text alternative naming what it shows, beside the same numbers as a real table.
+
+The bars run horizontally because their labels are whatever the grouped column
+holds — author names, tags, statuses — and a column chart has only its own
+width for those, which forces rotation or truncation. A capped bucket set says
+so rather than presenting a partial comparison as the whole one, and a
+timeseries labels each point in UTC, the zone its buckets were computed in, so
+the axis cannot name a different day than the server did.

--- a/packages/admin/src/components/features/widgets/archetypes/__tests__/bars.test.tsx
+++ b/packages/admin/src/components/features/widgets/archetypes/__tests__/bars.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * What a `bars` card shows, and what it says to a reader who cannot see it.
+ *
+ * The lengths themselves are not asserted here — jsdom performs no layout, so a
+ * bar's rendered width is not observable and `chart-scale.test.ts` asks that
+ * question of the arithmetic directly. What IS observable, and what these cover,
+ * is everything a chart can get wrong without being visibly broken: refusing the
+ * wrong payload, naming a null bucket, disclosing a cap, and carrying a text
+ * alternative and a real table.
+ */
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type {
+  DashboardWidget,
+  WidgetResult,
+} from "@admin/types/dashboard/widgets";
+
+import { barsAccepts, barsBody } from "../bars";
+
+const widget = (): DashboardWidget =>
+  ({
+    id: "acme/by-status",
+    title: "Entries by status",
+    archetype: "bars",
+    size: "md",
+    query: { source: "collection:posts", op: "groupBy", groupBy: "status" },
+  }) as DashboardWidget;
+
+const grouped = (
+  buckets: { value: string | null; count: number }[],
+  truncated?: boolean
+): WidgetResult => ({
+  op: "groupBy",
+  buckets,
+  ...(truncated && { truncated }),
+});
+
+function draw(result: WidgetResult, definition = widget()) {
+  const outcome = barsBody(result, definition);
+  if (!outcome.ok) throw new Error(`expected a body, got: ${outcome.message}`);
+  render(<>{outcome.node}</>);
+}
+
+describe("the bars archetype", () => {
+  it("refuses a payload that is not grouped buckets", () => {
+    // A count carries a single number, and the tempting coercion -- drawing one
+    // bar of it -- invents a comparison the query never asked for.
+    const outcome = barsBody({ op: "count", total: 12 }, widget());
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) expect(outcome.message).toContain("count");
+  });
+
+  it("needs a query, and says so by name", () => {
+    expect(barsAccepts({ archetype: "bars", title: "By status" })).toContain(
+      "By status"
+    );
+    expect(
+      barsAccepts({ archetype: "bars", query: { op: "groupBy" } })
+    ).toBeUndefined();
+  });
+
+  it("names the bucket for rows whose value is null", () => {
+    // A null bucket is a real answer -- "how many entries have no author" -- and
+    // an empty label would read as a rendering fault rather than as a group.
+    draw(grouped([{ value: null, count: 4 }]));
+    expect(screen.getAllByText("(none)").length).toBeGreaterThan(0);
+  });
+
+  it("carries a text alternative naming the largest bucket", () => {
+    // What a screen reader is given INSTEAD of the shapes. Without it the card
+    // announces a title and then a run of unlabelled elements.
+    draw(
+      grouped([
+        { value: "Published", count: 128 },
+        { value: "Draft", count: 57 },
+      ])
+    );
+    const graphic = screen.getByRole("img");
+    expect(graphic).toHaveAccessibleName(/Entries by status/);
+    expect(graphic).toHaveAccessibleDescription(/Largest: Published, 128/);
+  });
+
+  it("puts every bucket in a real table, with the count beside it", () => {
+    draw(
+      grouped([
+        { value: "Published", count: 128 },
+        { value: "Draft", count: 57 },
+      ])
+    );
+    const table = screen.getByRole("table");
+    // Addressed by ROW rather than by a bare text match: a count that rendered
+    // against the wrong label would satisfy two independent `getByText` calls
+    // while telling the reader the opposite of the truth.
+    const row = within(table).getByRole("row", { name: /Draft/ });
+    expect(within(row).getByText("57")).toBeInTheDocument();
+  });
+
+  it("discloses a cap rather than quietly showing a partial picture", () => {
+    draw(grouped([{ value: "Published", count: 9 }], true));
+    expect(screen.getByText(/some are not listed/i)).toBeInTheDocument();
+  });
+
+  it("says nothing was matched rather than drawing an empty frame", () => {
+    draw(grouped([]));
+    expect(screen.getByText(/no rows matched/i)).toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+});

--- a/packages/admin/src/components/features/widgets/archetypes/__tests__/chart-scale.test.ts
+++ b/packages/admin/src/components/features/widgets/archetypes/__tests__/chart-scale.test.ts
@@ -1,0 +1,126 @@
+/**
+ * The chart arithmetic, asked the questions a rendered SVG cannot answer.
+ *
+ * jsdom performs no layout, so a chart drawn upside down, one that overflows
+ * its own viewBox, and one that divides by zero all render identically to a
+ * correct one. These assertions are on the numbers for that reason.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  areaPath,
+  barFractions,
+  linePath,
+  linePoints,
+  type ChartBox,
+} from "../chart-scale";
+
+const BOX: ChartBox = { width: 100, height: 40, padding: 4 };
+
+describe("bar lengths", () => {
+  it("gives the largest bucket the full track", () => {
+    expect(barFractions([5, 10, 1])).toEqual([0.5, 1, 0.1]);
+  });
+
+  it("draws nothing rather than dividing by zero when every bucket is empty", () => {
+    // A real first-day dashboard: the collection exists and has no rows. The
+    // defect this catches is `0/0`, which is NaN and reaches the DOM as a
+    // width of "NaN%" -- a bar of unpredictable length rather than none.
+    expect(barFractions([0, 0, 0])).toEqual([0, 0, 0]);
+  });
+
+  it("keeps a bar inside its track whatever arrives", () => {
+    // Every fraction is a width, so one above 1 overflows the card and one
+    // below 0 inverts the bar. Neither can come from a count today, which is
+    // exactly why nothing else would catch it.
+    for (const fraction of barFractions([-4, 0, 7, Number.NaN, Infinity])) {
+      expect(fraction).toBeGreaterThanOrEqual(0);
+      expect(fraction).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("has no bars for no buckets", () => {
+    expect(barFractions([])).toEqual([]);
+  });
+});
+
+describe("line geometry", () => {
+  it("puts a LARGER count higher up the chart", () => {
+    // SVG's y axis grows downward, so the correct chart and the upside-down one
+    // differ by a single minus sign and both look like charts.
+    const [low, high] = linePoints([1, 9], BOX);
+    expect(high.y).toBeLessThan(low.y);
+  });
+
+  it("measures from zero rather than from the smallest value", () => {
+    // A baseline at the minimum turns 100 vs 102 into a cliff. For counts, zero
+    // is meaningful and reachable, so it is the floor.
+    const [a, b] = linePoints([100, 102], BOX);
+    const span = Math.abs(a.y - b.y);
+    expect(span).toBeLessThan(BOX.height / 10);
+  });
+
+  it("spans the full width and stays inside the padding", () => {
+    const points = linePoints([1, 2, 3, 4], BOX);
+    expect(points[0].x).toBe(BOX.padding);
+    expect(points[points.length - 1].x).toBe(BOX.width - BOX.padding);
+    for (const point of points) {
+      expect(point.y).toBeGreaterThanOrEqual(BOX.padding);
+      expect(point.y).toBeLessThanOrEqual(BOX.height - BOX.padding);
+    }
+  });
+
+  it("draws an all-zero window as a flat line on the baseline", () => {
+    // Zero means NO ROWS, never unknown -- the whole window was read. So this
+    // is a real answer to draw, not a reason to render nothing.
+    const points = linePoints([0, 0, 0], BOX);
+    const baseline = BOX.height - BOX.padding;
+    expect(points.map(p => p.y)).toEqual([baseline, baseline, baseline]);
+  });
+
+  it("places a single interval without dividing by a zero span", () => {
+    // One interval is a legal window. The span between points is `n - 1`, so
+    // this is the input that divides by zero.
+    const points = linePoints([3], BOX);
+    expect(points).toHaveLength(1);
+    expect(Number.isFinite(points[0].x)).toBe(true);
+    expect(Number.isFinite(points[0].y)).toBe(true);
+  });
+
+  it("has no points for an empty window", () => {
+    expect(linePoints([], BOX)).toEqual([]);
+  });
+});
+
+describe("path strings", () => {
+  it("moves once and then draws", () => {
+    const path = linePath(linePoints([0, 1], BOX));
+    expect(path.startsWith("M ")).toBe(true);
+    expect(path.match(/M /g)).toHaveLength(1);
+    expect(path).toContain("L ");
+  });
+
+  it("emits no path at all for an empty series", () => {
+    // "" is falsy, so the component can decline to render the element rather
+    // than emitting a `<path d="">` that some engines warn about.
+    expect(linePath([])).toBe("");
+  });
+
+  it("rounds coordinates so a path can be compared and stays small", () => {
+    // A third of a span produces 31.999999999999996 without this.
+    const path = linePath(linePoints([1, 2, 3, 4], { ...BOX, width: 100 }));
+    expect(path).not.toMatch(/\d\.\d{3,}/);
+  });
+
+  it("closes an area down to the baseline", () => {
+    const points = linePoints([1, 2], BOX);
+    const area = areaPath(points, BOX.height - BOX.padding);
+    expect(area.endsWith("Z")).toBe(true);
+    expect(area).toContain(`,${BOX.height - BOX.padding}`);
+  });
+
+  it("fills nothing when a single point encloses no area", () => {
+    expect(areaPath(linePoints([5], BOX), 36)).toBe("");
+  });
+});

--- a/packages/admin/src/components/features/widgets/archetypes/__tests__/timeseries.test.tsx
+++ b/packages/admin/src/components/features/widgets/archetypes/__tests__/timeseries.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * What a `timeseries` card shows, and which instant each point is called.
+ *
+ * The labelling is the part with a real defect in it. The server buckets in
+ * UTC, so a point IS a UTC calendar day; rendering that instant in another zone
+ * renames the bucket, and the axis would then disagree with both the table
+ * beside it and the server that produced it.
+ */
+import { render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { setGlobalDateTimeConfig } from "@admin/lib/dates/format";
+import type {
+  DashboardWidget,
+  WidgetResult,
+} from "@admin/types/dashboard/widgets";
+
+import { timeseriesAccepts, timeseriesBody } from "../timeseries";
+
+const widget = (): DashboardWidget =>
+  ({
+    id: "acme/over-time",
+    title: "Entries over time",
+    archetype: "timeseries",
+    size: "lg",
+    query: {
+      source: "collection:posts",
+      op: "timeseries",
+      dateField: "createdAt",
+      interval: "day",
+    },
+  }) as DashboardWidget;
+
+const series = (
+  points: { start: string; count: number }[],
+  interval = "day"
+): WidgetResult =>
+  ({ op: "timeseries", points, interval }) as unknown as WidgetResult;
+
+function draw(result: WidgetResult, definition = widget()) {
+  const outcome = timeseriesBody(result, definition);
+  if (!outcome.ok) throw new Error(`expected a body, got: ${outcome.message}`);
+  render(<>{outcome.node}</>);
+}
+
+afterEach(() => {
+  setGlobalDateTimeConfig({});
+});
+
+describe("the timeseries archetype", () => {
+  it("refuses a payload that is not a timeline", () => {
+    const outcome = timeseriesBody(
+      { op: "groupBy", buckets: [{ value: "a", count: 1 }] },
+      widget()
+    );
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) expect(outcome.message).toContain("groupBy");
+  });
+
+  it("needs a query, and says so by name", () => {
+    expect(
+      timeseriesAccepts({ archetype: "timeseries", title: "Over time" })
+    ).toContain("Over time");
+    expect(
+      timeseriesAccepts({
+        archetype: "timeseries",
+        query: { op: "timeseries" },
+      })
+    ).toBeUndefined();
+  });
+
+  it("labels a bucket by its UTC date whatever zone the install is set to", () => {
+    // The defect this exists for: a UTC day begins at midnight, which is 19:00
+    // the PREVIOUS day at UTC-5. Formatted in the install's zone, March 4th's
+    // rows would be labelled "Mar 3" while the server and the table call them
+    // the 4th.
+    setGlobalDateTimeConfig({ timezone: "America/New_York", locale: "en-US" });
+    draw(series([{ start: "2026-03-04T00:00:00.000Z", count: 3 }]));
+
+    const table = screen.getByRole("table");
+    expect(within(table).getByText(/Mar 4/)).toBeInTheDocument();
+    expect(within(table).queryByText(/Mar 3/)).not.toBeInTheDocument();
+  });
+
+  it("still honours the install's locale for how that date is written", () => {
+    // The zone is pinned; the FORMAT is not. Pinning both would make these
+    // cards the only dates in the admin that ignore the configured preference.
+    setGlobalDateTimeConfig({ timezone: "UTC", locale: "de-DE" });
+    draw(series([{ start: "2026-03-04T00:00:00.000Z", count: 3 }]));
+
+    const table = screen.getByRole("table");
+    // German abbreviates March as "Mär"; the assertion is that the locale
+    // reached the formatter at all, not the exact spelling.
+    expect(within(table).queryByText(/Mar 4/)).not.toBeInTheDocument();
+  });
+
+  it("carries a text alternative naming the busiest interval and the total", () => {
+    draw(
+      series([
+        { start: "2026-03-04T00:00:00.000Z", count: 2 },
+        { start: "2026-03-05T00:00:00.000Z", count: 9 },
+      ])
+    );
+    const graphic = screen.getByRole("img");
+    expect(graphic).toHaveAccessibleName(/Entries over time/);
+    expect(graphic).toHaveAccessibleDescription(/11 in total/);
+    expect(graphic).toHaveAccessibleDescription(/Busiest/);
+  });
+
+  it("keeps an empty interval as a zero row rather than dropping it", () => {
+    // Zero means NO ROWS, never unknown -- the whole window was read. A missing
+    // row would let a reader infer the interval was not measured.
+    draw(
+      series([
+        { start: "2026-03-04T00:00:00.000Z", count: 0 },
+        { start: "2026-03-05T00:00:00.000Z", count: 4 },
+      ])
+    );
+    const table = screen.getByRole("table");
+    expect(within(table).getAllByRole("row")).toHaveLength(3); // header + 2
+    expect(within(table).getByText("0")).toBeInTheDocument();
+  });
+
+  it("marks a single interval instead of drawing an invisible line", () => {
+    // One point is a legal window and produces no line segment, so without a
+    // marker the card renders an empty box that reads as a failure.
+    const { container } = render(
+      <>
+        {(() => {
+          const outcome = timeseriesBody(
+            series([{ start: "2026-03-04T00:00:00.000Z", count: 5 }]),
+            widget()
+          );
+          if (!outcome.ok) throw new Error(outcome.message);
+          return outcome.node;
+        })()}
+      </>
+    );
+    expect(container.querySelector("circle")).not.toBeNull();
+  });
+
+  it("says the window is empty rather than drawing nothing at all", () => {
+    draw(series([]));
+    expect(screen.getByText(/no intervals/i)).toBeInTheDocument();
+  });
+});

--- a/packages/admin/src/components/features/widgets/archetypes/bars.tsx
+++ b/packages/admin/src/components/features/widgets/archetypes/bars.tsx
@@ -1,0 +1,141 @@
+/**
+ * The `bars` archetype: how many rows fall in each bucket, as lengths.
+ *
+ * HORIZONTAL, and that is the load-bearing choice. The labels are whatever the
+ * grouped column holds — author names, tag names, statuses — so they are text of
+ * arbitrary length. A vertical column chart has only the column's own width to
+ * put those in, which forces rotation or truncation; rotated text is measurably
+ * slower to read, and truncation removes the very thing that identifies the bar.
+ * Running the bars left-to-right gives every label a full line of its own.
+ *
+ * Length encodes the count, because length is judged accurately at a glance.
+ * Nothing is encoded by colour: this is one series, so a second hue would carry
+ * no information while excluding the readers who cannot separate it.
+ *
+ * Drawn with layout rather than SVG. A bar here is a `<div>` whose width is a
+ * percentage, which wraps, reflows and respects the reader's font size for
+ * free — none of which an SVG of the same picture does without being told.
+ *
+ * @module components/features/widgets/archetypes/bars
+ */
+
+import { ChartFrame } from "./chart-frame";
+import { barFractions } from "./chart-scale";
+import type { ArchetypeAccepts, ArchetypeBody } from "./types";
+
+/**
+ * What a bucket with no value is called.
+ *
+ * A null bucket is a real answer — "how many entries have no author" — and the
+ * result carries it as a bucket in its own right rather than dropping it. It
+ * needs a NAME to be drawn and to appear in the table, and an empty label would
+ * read as a rendering fault.
+ */
+const NO_VALUE_LABEL = "(none)";
+
+export const barsAccepts: ArchetypeAccepts = definition => {
+  if (definition.query) return undefined;
+  const name = definition.title ?? "This bars widget";
+  return `"${name}" is drawn from a query, and this widget declares none.`;
+};
+
+export const barsBody: ArchetypeBody = (result, definition) => {
+  if (result.op !== "groupBy") {
+    return {
+      ok: false,
+      message: `"${definition.title}" expected grouped buckets, but the query returned a ${result.op}.`,
+    };
+  }
+
+  const rows = result.buckets.map(bucket => ({
+    label: bucket.value ?? NO_VALUE_LABEL,
+    count: bucket.count,
+  }));
+
+  if (rows.length === 0) {
+    return {
+      ok: true,
+      node: (
+        <p className="text-sm text-muted-foreground">
+          Nothing to compare yet — no rows matched this query.
+        </p>
+      ),
+    };
+  }
+
+  const fractions = barFractions(rows.map(row => row.count));
+  const largest = rows[0];
+  // Composed ONCE and handed to both the frame and the graphic. Written twice,
+  // the two drifted immediately: one pluralised "category" for a single bucket
+  // and the other did not, so the table's caption and the chart's own
+  // description disagreed about the same data.
+  const description = `${rows.length} ${rows.length === 1 ? "category" : "categories"}. Largest: ${largest.label}, ${largest.count.toLocaleString()}.`;
+
+  return {
+    ok: true,
+    node: (
+      <ChartFrame
+        title={definition.title ?? "Comparison"}
+        // The shape in words, for a reader who cannot see the lengths. Naming
+        // the biggest bucket is what the picture communicates first.
+        description={description}
+        labelHeading="Value"
+        rows={rows}
+        note={
+          result.truncated
+            ? "Showing the largest groups only; some are not listed."
+            : undefined
+        }
+      >
+        {({ titleId, descId, title, description: text }) => (
+          // A list rather than a bare stack of divs: the bars ARE a list of
+          // labelled values, and `role="img"` on the wrapper prunes the
+          // children anyway, so the semantics cost nothing and survive if the
+          // role is ever removed.
+          <div
+            role="img"
+            aria-labelledby={titleId}
+            aria-describedby={descId}
+            className="flex flex-col gap-1.5"
+          >
+            <span id={titleId} className="sr-only">
+              {title}
+            </span>
+            <span id={descId} className="sr-only">
+              {text}
+            </span>
+            {rows.map((row, index) => (
+              <div key={row.label} className="flex flex-col gap-0.5">
+                <div className="flex min-w-0 items-baseline justify-between gap-2">
+                  {/* Truncated with an accessible full value: a long author
+                      name must not push the count off the card, and the title
+                      attribute keeps the whole string reachable on hover. */}
+                  <span
+                    className="truncate text-xs text-foreground"
+                    title={row.label}
+                  >
+                    {row.label}
+                  </span>
+                  <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+                    {row.count.toLocaleString()}
+                  </span>
+                </div>
+                {/* The track is always full width, so the bars share one
+                    baseline and their lengths are comparable by eye. */}
+                <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+                  <div
+                    className="h-full rounded-full bg-primary"
+                    // design-lint-ok: the width IS the datum, so it cannot come
+                    // from a utility class -- there is no Tailwind scale for
+                    // "this bucket's share of the largest one".
+                    style={{ width: `${fractions[index] * 100}%` }}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </ChartFrame>
+    ),
+  };
+};

--- a/packages/admin/src/components/features/widgets/archetypes/chart-frame.tsx
+++ b/packages/admin/src/components/features/widgets/archetypes/chart-frame.tsx
@@ -1,0 +1,138 @@
+/**
+ * The chrome every core-drawn chart shares: a labelled graphic and its table.
+ *
+ * A chart is a picture of numbers, and a picture is not readable by everyone
+ * looking at the card. Two things carry the same data, and both are needed
+ * because neither replaces the other:
+ *
+ * - The SVG is `role="img"` with a `<title>` and a `<desc>`, so a screen reader
+ *   announces WHAT the chart shows and its headline shape instead of walking
+ *   into a bag of unlabelled `<path>` elements. `role="img"` also prunes the
+ *   children from the accessibility tree, which is the point: the shapes are
+ *   decoration once the text alternative exists.
+ * - The DISCLOSURE holds the real numbers as an HTML table, which is the only
+ *   form that can be navigated cell by cell, compared, and copied.
+ *
+ * The table is behind a disclosure rather than always shown so a dashboard of
+ * several cards stays scannable — a 30-point window would otherwise add thirty
+ * rows under one chart. That is a presentation choice and not an access one:
+ * `<details>` is operated identically by a mouse, a keyboard and a screen
+ * reader, so nobody is asked to take a longer route to the numbers. The `<desc>`
+ * is what keeps the chart itself meaningful while the table is closed.
+ *
+ * `role="img"` and not `role="application"`, which is what the popular chart
+ * libraries emit: `application` puts a screen reader into forms mode and hands
+ * every keystroke to a widget that has no keyboard interface to receive them.
+ *
+ * @module components/features/widgets/archetypes/chart-frame
+ */
+
+import { useId, type ReactNode } from "react";
+
+export interface ChartFrameProps {
+  /** What the chart shows, announced in place of the shapes. */
+  title: string;
+  /** The headline the picture makes, in words. Read after the title. */
+  description: string;
+  /** Heading for the label column of the table. */
+  labelHeading: string;
+  /** The rows behind the picture, in the order they are drawn. */
+  rows: ReadonlyArray<{ label: string; count: number }>;
+  /** Said above the table when the series is not the whole answer. */
+  note?: string;
+  /**
+   * The graphic, handed the ids it must reference AND the strings they hold.
+   *
+   * The text comes back through this callback rather than being composed again
+   * inside the graphic: written twice, the two drifted on their first outing —
+   * one pluralised a single bucket as "categories" and the frame did not — so
+   * the caption and the chart's own description described the same data
+   * differently.
+   */
+  children: (chart: {
+    titleId: string;
+    descId: string;
+    title: string;
+    description: string;
+  }) => ReactNode;
+}
+
+export function ChartFrame({
+  title,
+  description,
+  labelHeading,
+  rows,
+  note,
+  children,
+}: ChartFrameProps) {
+  const base = useId();
+  const titleId = `${base}-title`;
+  const descId = `${base}-desc`;
+
+  return (
+    <figure className="m-0 flex min-w-0 flex-col gap-2">
+      {children({ titleId, descId, title, description })}
+
+      {/* A cap is DISCLOSED rather than silently applied. A chart drawn from a
+          capped set is not the whole picture, and a reader comparing bars has
+          no way to tell unless the card says so. */}
+      {note ? (
+        <p className="text-xs leading-tight text-muted-foreground">{note}</p>
+      ) : null}
+
+      <details className="group">
+        <summary className="inline-flex cursor-pointer list-none items-center gap-1 rounded-sm text-xs font-medium text-muted-foreground outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring">
+          {/* Rotated with the disclosure's own open state rather than with
+              React state, so the marker cannot disagree with the element. */}
+          <span
+            aria-hidden="true"
+            className="transition-transform group-open:rotate-90"
+          >
+            ▸
+          </span>
+          View as table
+        </summary>
+        {/* Its own scroll container: a long window must not make the card the
+            thing that scrolls sideways. */}
+        <div className="mt-2 max-h-48 overflow-auto">
+          <table className="w-full border-collapse text-xs">
+            <caption className="sr-only">{title}</caption>
+            <thead>
+              <tr className="border-b border-border">
+                <th
+                  scope="col"
+                  className="py-1 pr-2 text-left font-medium text-muted-foreground"
+                >
+                  {labelHeading}
+                </th>
+                <th
+                  scope="col"
+                  className="py-1 text-right font-medium text-muted-foreground"
+                >
+                  Count
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map(row => (
+                <tr key={row.label} className="border-b border-border/50">
+                  {/* A row header, so a screen reader announces which row a
+                      number belongs to when reading the count cell. */}
+                  <th
+                    scope="row"
+                    className="py-1 pr-2 text-left font-normal text-foreground"
+                  >
+                    {row.label}
+                  </th>
+                  <td className="py-1 text-right tabular-nums text-foreground">
+                    {row.count.toLocaleString()}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </details>
+    </figure>
+  );
+}

--- a/packages/admin/src/components/features/widgets/archetypes/chart-scale.ts
+++ b/packages/admin/src/components/features/widgets/archetypes/chart-scale.ts
@@ -1,0 +1,137 @@
+/**
+ * The arithmetic behind a chart, with no SVG and no React in it.
+ *
+ * Separate from the components so the parts that can be WRONG can be tested
+ * directly. A path string rendered into jsdom tells you nothing — jsdom does no
+ * layout, so a chart that overflows its box, inverts its axis or divides by
+ * zero renders exactly as one that does not. The numbers are where the defects
+ * live, so they are asked questions here instead.
+ *
+ * Every function is total: a count of zero, a single point and an all-zero
+ * series are ordinary inputs a real dashboard produces on its first day, not
+ * edge cases to guard at the call site.
+ *
+ * @module components/features/widgets/archetypes/chart-scale
+ */
+
+/**
+ * Each value as a fraction of the largest, in `0..1`.
+ *
+ * Scaled to the largest value rather than to a fixed ceiling, because a bar
+ * chart's job is comparison between its own bars — a fixed ceiling would draw
+ * every bar as a sliver whenever the counts happen to be small.
+ *
+ * A largest value of zero answers all zeros rather than dividing by it. That is
+ * the honest picture: every bucket is empty, so no bar has any length, and the
+ * reader sees an empty chart rather than a full one drawn from `0/0`.
+ *
+ * A negative count cannot come from a `count(*)`, and clamping rather than
+ * rendering one keeps a bar inside its track if some other source ever produces
+ * one.
+ */
+export function barFractions(counts: readonly number[]): number[] {
+  const usable = counts.map(count =>
+    Number.isFinite(count) && count > 0 ? count : 0
+  );
+  const largest = Math.max(0, ...usable);
+  if (largest === 0) return usable.map(() => 0);
+  return usable.map(count => count / largest);
+}
+
+/** The box a line chart is drawn inside, in user units. */
+export interface ChartBox {
+  width: number;
+  height: number;
+  /** Kept clear on every side so a stroke is not clipped by the viewBox. */
+  padding: number;
+}
+
+/**
+ * The points of a line chart, in SVG user units.
+ *
+ * The x axis is the INDEX rather than the timestamp, because a timeseries
+ * answers with one point per interval including the empty ones — the spacing is
+ * already uniform, and reading the dates to re-derive that would introduce a
+ * second opinion about a series the server already made regular.
+ *
+ * The y axis is inverted, as SVG's is: a larger count is a SMALLER y. Getting
+ * this backwards produces a chart that is upside down and otherwise perfectly
+ * plausible, which is why it is asserted rather than eyeballed.
+ *
+ * The baseline is always zero rather than the smallest value. A line starting
+ * at the minimum exaggerates variation — counts of 100 and 102 become a cliff —
+ * and for count data, where zero is meaningful and reachable, that is a
+ * misreading the chart itself invites.
+ */
+export function linePoints(
+  counts: readonly number[],
+  box: ChartBox
+): Array<{ x: number; y: number }> {
+  const usable = counts.map(count =>
+    Number.isFinite(count) && count > 0 ? count : 0
+  );
+  if (usable.length === 0) return [];
+
+  const innerWidth = Math.max(0, box.width - box.padding * 2);
+  const innerHeight = Math.max(0, box.height - box.padding * 2);
+  const largest = Math.max(0, ...usable);
+  const bottom = box.padding + innerHeight;
+
+  // A single point has no span to divide, and one interval is a legitimate
+  // window. It is placed at the LEFT edge rather than the centre so the marker
+  // sits where the next point would extend from.
+  const step = usable.length > 1 ? innerWidth / (usable.length - 1) : 0;
+
+  return usable.map((count, index) => ({
+    x: box.padding + step * index,
+    // An all-zero series sits on the baseline rather than dividing by its own
+    // maximum. Every interval was read and every one was empty, which is a
+    // flat line at zero -- not an absent chart and not a full one.
+    y: largest === 0 ? bottom : bottom - (count / largest) * innerHeight,
+  }));
+}
+
+/** `M x,y L x,y …` for a set of points, or `""` when there is nothing to draw. */
+export function linePath(points: ReadonlyArray<{ x: number; y: number }>) {
+  if (points.length === 0) return "";
+  const [first, ...rest] = points;
+  const head = `M ${round(first.x)},${round(first.y)}`;
+  if (rest.length === 0) return head;
+  return `${head} ${rest.map(p => `L ${round(p.x)},${round(p.y)}`).join(" ")}`;
+}
+
+/**
+ * The same line, closed down to the baseline so it can be filled.
+ *
+ * Drawn from the line's own points rather than recomputed, so the fill cannot
+ * describe a different series than the stroke above it.
+ *
+ * A single point encloses no area, so it answers empty: a fill built from one
+ * point would be a zero-width sliver that reads as a rendering fault.
+ */
+export function areaPath(
+  points: ReadonlyArray<{ x: number; y: number }>,
+  baselineY: number
+): string {
+  if (points.length < 2) return "";
+  const last = points[points.length - 1];
+  const first = points[0];
+  return [
+    linePath(points),
+    `L ${round(last.x)},${round(baselineY)}`,
+    `L ${round(first.x)},${round(baselineY)}`,
+    "Z",
+  ].join(" ");
+}
+
+/**
+ * Coordinates are rounded to two decimals before they reach the DOM.
+ *
+ * A float division produces values like `31.999999999999996`, and a path full
+ * of them is both larger over the wire and impossible to compare in a test
+ * without an epsilon. Two decimals is finer than a physical pixel at any
+ * viewport this renders in.
+ */
+function round(value: number): number {
+  return Math.round(value * 100) / 100;
+}

--- a/packages/admin/src/components/features/widgets/archetypes/timeseries.tsx
+++ b/packages/admin/src/components/features/widgets/archetypes/timeseries.tsx
@@ -1,0 +1,174 @@
+/**
+ * The `timeseries` archetype: a count per interval, as a line.
+ *
+ * A line, because 2D position along a shared baseline is read accurately and
+ * because the intervals are ORDERED — bars would draw the same numbers while
+ * saying nothing about the sequence, which is the whole question a timeline
+ * asks. A soft fill under the line gives the shape a body without encoding a
+ * second thing in colour.
+ *
+ * `preserveAspectRatio="none"` with a fixed viewBox, so the chart stretches to
+ * whatever width the card has. The stroke is drawn with
+ * `vector-effect="non-scaling-stroke"` for that reason: without it a stretched
+ * viewBox scales the stroke horizontally too, and the line thins and thickens
+ * with the card's width.
+ *
+ * @module components/features/widgets/archetypes/timeseries
+ */
+
+import { formatGlobalDateTime } from "@admin/lib/dates/format";
+
+import { ChartFrame } from "./chart-frame";
+import { areaPath, linePath, linePoints, type ChartBox } from "./chart-scale";
+import type { ArchetypeAccepts, ArchetypeBody } from "./types";
+
+/**
+ * The user units the line is drawn in.
+ *
+ * Arbitrary, and deliberately so: the SVG scales to the card, so these decide
+ * the shape's proportions rather than its size. The padding keeps a 2px stroke
+ * off the edges of the viewBox, which would otherwise clip it in half.
+ */
+const BOX: ChartBox = { width: 240, height: 64, padding: 3 };
+
+/**
+ * How each interval's start is written.
+ *
+ * Pinned to UTC, and this is the correctness point rather than a preference.
+ * The server buckets in UTC, so a point IS a UTC calendar hour, day, week,
+ * month or year. Rendering that instant in another zone renames the bucket: a
+ * UTC day beginning at midnight is 19:00 the PREVIOUS day at UTC-5, so the axis
+ * would label March 4th's rows "Mar 3" while the table beside it and the
+ * server both call it the 4th.
+ *
+ * The install's locale and date-format preferences still apply, because this
+ * goes through the same formatter every other admin date does — only the zone
+ * is fixed.
+ */
+const LABEL_OPTIONS: Record<string, Intl.DateTimeFormatOptions> = {
+  hour: { day: "numeric", month: "short", hour: "2-digit", minute: "2-digit" },
+  day: { day: "numeric", month: "short" },
+  week: { day: "numeric", month: "short" },
+  month: { month: "short", year: "numeric" },
+  year: { year: "numeric" },
+};
+
+function pointLabel(start: string, interval: string): string {
+  const options = LABEL_OPTIONS[interval] ?? LABEL_OPTIONS.day;
+  // The raw value is the fallback, so an unparseable instant reaches the reader
+  // as evidence rather than as an em dash claiming the interval has nothing.
+  return formatGlobalDateTime(start, { ...options, timeZone: "UTC" }, start);
+}
+
+export const timeseriesAccepts: ArchetypeAccepts = definition => {
+  if (definition.query) return undefined;
+  const name = definition.title ?? "This timeseries widget";
+  return `"${name}" is drawn from a query, and this widget declares none.`;
+};
+
+export const timeseriesBody: ArchetypeBody = (result, definition) => {
+  if (result.op !== "timeseries") {
+    return {
+      ok: false,
+      message: `"${definition.title}" expected a timeline, but the query returned a ${result.op}.`,
+    };
+  }
+
+  const rows = result.points.map(point => ({
+    label: pointLabel(point.start, result.interval),
+    count: point.count,
+  }));
+
+  if (rows.length === 0) {
+    return {
+      ok: true,
+      node: (
+        <p className="text-sm text-muted-foreground">
+          Nothing to plot yet — this window has no intervals.
+        </p>
+      ),
+    };
+  }
+
+  const counts = result.points.map(point => point.count);
+  const points = linePoints(counts, BOX);
+  const line = linePath(points);
+  const area = areaPath(points, BOX.height - BOX.padding);
+  const total = counts.reduce((sum, count) => sum + count, 0);
+  const busiest = rows.reduce((best, row) =>
+    row.count > best.count ? row : best
+  );
+
+  // Only the ends are labelled on the axis. Thirty labels do not fit under a
+  // card-width chart, and thinning them to every nth point makes which dates
+  // appear depend on the window length. The table carries every one.
+  const first = rows[0];
+  const last = rows[rows.length - 1];
+
+  // Composed ONCE and handed to both the frame and the graphic, so the table's
+  // caption and the chart's own description cannot describe different data.
+  const description = `${rows.length} ${result.interval} intervals, ${total.toLocaleString()} in total. Busiest: ${busiest.label}, ${busiest.count.toLocaleString()}.`;
+
+  return {
+    ok: true,
+    node: (
+      <ChartFrame
+        title={definition.title ?? "Over time"}
+        description={description}
+        labelHeading="Interval"
+        rows={rows}
+      >
+        {({ titleId, descId, title, description: text }) => (
+          <div className="flex flex-col gap-1">
+            <svg
+              role="img"
+              aria-labelledby={titleId}
+              aria-describedby={descId}
+              viewBox={`0 0 ${BOX.width} ${BOX.height}`}
+              preserveAspectRatio="none"
+              className="h-16 w-full text-primary"
+            >
+              <title id={titleId}>{title}</title>
+              <desc id={descId}>{text}</desc>
+              {area ? (
+                <path d={area} fill="currentColor" className="opacity-10" />
+              ) : null}
+              {line ? (
+                <path
+                  d={line}
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  vectorEffect="non-scaling-stroke"
+                />
+              ) : null}
+              {/* A single interval draws no line, so it is marked instead --
+                  otherwise a one-point window renders as an empty box. */}
+              {points.length === 1 ? (
+                <circle
+                  cx={points[0].x}
+                  cy={points[0].y}
+                  r="2.5"
+                  fill="currentColor"
+                  vectorEffect="non-scaling-stroke"
+                />
+              ) : null}
+            </svg>
+            {/* Hidden from assistive tech: the `<desc>` above already names the
+                span, and these two would otherwise be read as bare dates with
+                nothing saying what they bound. */}
+            <div
+              aria-hidden="true"
+              className="flex justify-between text-[10px] leading-none text-muted-foreground"
+            >
+              <span>{first.label}</span>
+              {rows.length > 1 ? <span>{last.label}</span> : null}
+            </div>
+          </div>
+        )}
+      </ChartFrame>
+    ),
+  };
+};

--- a/packages/admin/src/components/features/widgets/outcome.ts
+++ b/packages/admin/src/components/features/widgets/outcome.ts
@@ -32,10 +32,12 @@ import type {
 } from "@admin/types/dashboard/widgets";
 
 import { actionsBody } from "./archetypes/actions";
+import { barsAccepts, barsBody } from "./archetypes/bars";
 import { listAccepts, listBody } from "./archetypes/list";
 import { metricAccepts, metricBody } from "./archetypes/metric";
 import { statsAccepts, statsBody } from "./archetypes/stats";
 import { tableAccepts, tableBody } from "./archetypes/table";
+import { timeseriesAccepts, timeseriesBody } from "./archetypes/timeseries";
 import type {
   ArchetypeOutcome,
   ArchetypeRenderer,
@@ -54,6 +56,8 @@ const ARCHETYPE_BODIES: Partial<Record<WidgetArchetype, ArchetypeRenderer>> = {
   metric: { accepts: metricAccepts, body: metricBody },
   list: { accepts: listAccepts, body: listBody },
   table: { accepts: tableAccepts, body: tableBody },
+  bars: { accepts: barsAccepts, body: barsBody },
+  timeseries: { accepts: timeseriesAccepts, body: timeseriesBody },
   actions: { declared: actionsBody },
   stats: { accepts: statsAccepts, cells: statsBody },
 };

--- a/packages/nextly/src/domains/widgets/definition.ts
+++ b/packages/nextly/src/domains/widgets/definition.ts
@@ -77,6 +77,16 @@ export const WIDGET_ARCHETYPES = [
   "stats",
   "table",
   "list",
+  // A categorical comparison, drawn as bars. Named for the SHAPE rather than
+  // for `groupBy`, the op behind it: an archetype is a way of drawing, and a
+  // name taken from the query would have to change if the same picture were
+  // ever drawn from a different one.
+  "bars",
+  // A count per interval, drawn as a line. This one DOES share its name with
+  // its op, and that is not the near-miss `stats` avoids: `metric`/`metrics`
+  // are two different pictures one keystroke apart, while an archetype and an
+  // op called `timeseries` are the same idea named once.
+  "timeseries",
   "text",
   "actions",
   "custom",
@@ -93,7 +103,13 @@ export type WidgetArchetype = (typeof WIDGET_ARCHETYPES)[number];
  * implementation; a narrower view is derived from this rather than computed
  * beside it.
  */
-export const DATA_ARCHETYPES = ["metric", "table", "list"] as const;
+export const DATA_ARCHETYPES = [
+  "metric",
+  "table",
+  "list",
+  "bars",
+  "timeseries",
+] as const;
 
 /**
  * Archetypes drawn from MANY queries, declared as `cells`.
@@ -147,6 +163,8 @@ const ARCHETYPE_RESULTS: ReadonlyMap<
   ["metric", new Set<WidgetOp>(["count"])],
   ["table", new Set<WidgetOp>(["list"])],
   ["list", new Set<WidgetOp>(["list"])],
+  ["bars", new Set<WidgetOp>(["groupBy"])],
+  ["timeseries", new Set<WidgetOp>(["timeseries"])],
 ]);
 
 /**

--- a/packages/nextly/src/domains/widgets/widget-exports.test-d.ts
+++ b/packages/nextly/src/domains/widgets/widget-exports.test-d.ts
@@ -57,7 +57,15 @@ assertType<
 assertType<
   Exact<
     WidgetArchetype,
-    "metric" | "stats" | "table" | "list" | "text" | "actions" | "custom"
+    | "metric"
+    | "stats"
+    | "table"
+    | "list"
+    | "bars"
+    | "timeseries"
+    | "text"
+    | "actions"
+    | "custom"
   >
 >(true);
 


### PR DESCRIPTION
A dashboard could count and group entries but had no way to show either as a
picture. Every chart meant writing a React component, which is how a dashboard
stops looking like one product.

Two archetypes core draws from a query result, the way `metric` and `table`
already are:

- **`bars`** — compares the buckets of a `groupBy`.
- **`timeseries`** — plots the points of a window.

Both take the singular `query` the other data archetypes take, and each
declares the one op it can draw, so a mismatch is refused at registration —
where an author can still be told — rather than discovered by a card that
renders an error on every load.

## Why no charting dependency

Measured rather than assumed:

- `recharts@3.10.1` declares **11 dependencies**, among them
  `@reduxjs/toolkit`, `react-redux`, `immer` and `reselect` — a
  state-management stack in every install's admin bundle, for two shapes.
- `packages/admin` and `packages/ui` declare **zero** charting dependencies
  today, and two hand-rolled SVG components (`RingChart`, `Sparkline`) already
  set the precedent.

Accessibility settles it. The library renders `role="application"`, which puts
a screen reader into forms mode over a graphic that has no keyboard interface
to receive the keystrokes. Owning the markup is what makes the right pattern
reachable.

## What a reader who cannot see the chart gets

Each chart is `role="img"` with a text alternative naming what it shows and its
headline shape — the largest bucket, or the busiest interval and the total —
beside the same numbers as a real HTML table.

The table sits behind a `View as table` disclosure so a dashboard of several
cards stays scannable; a 30-point window would otherwise add thirty rows under
one chart. That is a presentation choice and not an access one: `<details>` is
operated identically by a mouse, a keyboard and a screen reader, so the numbers
are no further away for anyone, and the description keeps the chart meaningful
while the table is closed.

## Two choices worth naming

**The bars run horizontally.** Their labels are whatever the grouped column
holds — author names, tags, statuses — so they are text of arbitrary length. A
column chart has only its own width for those, which forces rotation or
truncation, and rotated labels are read measurably more slowly. Nothing is
encoded in colour: one series has nothing to distinguish, so a second hue would
carry no information while excluding the readers who cannot separate it.

**A timeseries labels each point in UTC**, the zone its buckets were computed
in. Rendering that instant in the install's zone renames the bucket — a UTC day
begins at 19:00 the previous day at UTC-5 — so the axis would disagree with
both the table beside it and the server that produced it. The install's locale
and date format still apply, because the label goes through the same formatter
every other admin date does.

## Testing

The arithmetic is its own module with no SVG in it, because **jsdom performs no
layout**: a chart drawn upside down, one that overflows its viewBox and one
that divides by zero all render identically to a correct one. So the numbers
are asked directly — the y axis is inverted, the baseline is zero rather than
the minimum, bars stay within their track, and a zero count, a single interval
and an all-zero window are answered rather than guarded at the call site.

The rendering tests cover what a chart can get wrong without looking broken:
refusing the wrong payload, naming a null bucket, disclosing a cap, and
carrying both a text alternative and a real table. The table assertions address
rows by name rather than matching bare text, because a count rendered against
the wrong label would satisfy two independent text matches while telling the
reader the opposite of the truth.

Break-verified: inverting the y axis fails exactly the axis test and nothing
else. The `aria-describedby` defect in the first draft — two ids on
`aria-labelledby` concatenate into the *name*, leaving the description empty —
was caught by the test that asserts it.

## Gates

`check-types` 0 · lint clean · admin 4,159 · nextly 11,734 across 923 files ·
plugin-sdk 22 · fallow `pass`, 0 introduced.

## Not built, deliberately

No pie or donut archetype: angle and area are misread, and the existing
`RingChart` keeps the single status-breakdown case it already serves rather
than being generalised.