### PR TITLE
fix(create-nextly-app): size the scaffolded plugin suite for the boot it performs

### DIFF
--- a/.changeset/scaffolded-plugin-suite-is-sized-for-its-boot.md
+++ b/.changeset/scaffolded-plugin-suite-is-sized-for-its-boot.md
@@ -1,0 +1,44 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The plugin scaffold's own test could time out on a first run.
+
+`plugin.test.ts` boots a real Nextly instance in `beforeEach`, building a DI
+container, registering the plugin's schema and running auto-sync against a real
+SQLite database. Its vitest config stated no budget, so it inherited the
+defaults: 5 seconds for the case and 10 for the hook, both sized for a unit test
+that touches none of that.
+
+A boot is about a second and a half on a warm machine, and the first run of a
+freshly scaffolded project is the least warm moment there is: a cold install, no
+build cache, whatever else the laptop or CI container is doing. It is also the
+first command a new plugin author runs, so a timeout there reads as a broken
+scaffold rather than a tight budget.
+
+Both budgets are now 30 seconds, matching what this repository's own integration
+lane gives a suite that boots.

--- a/scripts/check-instance-boot-lane.mjs
+++ b/scripts/check-instance-boot-lane.mjs
@@ -85,7 +85,7 @@ export const UNIT_LANE_SUFFIXES = [
  * ignored scratch file cannot enter the population and be judged.
  */
 export function testFiles(cwd, run = execFileSync) {
-  const listed = run("git", ["ls-files", "-z", "--", "packages"], {
+  const listed = run("git", ["ls-files", "-z", "--", "packages", "templates"], {
     cwd,
     encoding: "utf8",
     maxBuffer: 64 * 1024 * 1024,
@@ -174,6 +174,61 @@ export function importsBootHelper(source, fileName = "test.ts") {
   return false;
 }
 
+/**
+ * Whether a path is a scaffolded project rather than one of this repo's packages.
+ *
+ * The two are judged by different rules because they are different shapes. A
+ * package here sits in a monorepo with two lanes and a build running beside it,
+ * so a boot is routed to the lane sized for one. A template is a single-package
+ * project a user receives with one vitest config, one test script and nothing
+ * to contend with, so there is no second lane to route to and inventing one
+ * would put monorepo machinery in someone's new plugin. What it can do is state
+ * a budget, which is the thing the routing was buying.
+ */
+export function isTemplate(path) {
+  return path.startsWith("templates/");
+}
+
+/** The vitest budget a boot needs, whichever mechanism supplies it. */
+export const BOOT_BUDGET_MS = 30_000;
+
+/**
+ * Whether a config states timeouts a boot can finish inside.
+ *
+ * Read off the parsed config rather than matched in the text, for the same
+ * reason the imports are: a number in a comment explaining the defaults is not
+ * a number vitest will use. Both budgets are required because a boot in
+ * `beforeEach` is governed by `hookTimeout` and the case body by `testTimeout`,
+ * and vitest's defaults for the two differ.
+ */
+export function statesBootBudget(source) {
+  const parsed = ts.createSourceFile(
+    "vitest.config.ts",
+    source,
+    ts.ScriptTarget.Latest,
+    false,
+    ts.ScriptKind.TS
+  );
+  const found = new Map();
+  const walk = node => {
+    if (
+      ts.isPropertyAssignment(node) &&
+      ts.isIdentifier(node.name) &&
+      (node.name.text === "testTimeout" || node.name.text === "hookTimeout") &&
+      ts.isNumericLiteral(node.initializer)
+    ) {
+      found.set(node.name.text, Number(node.initializer.text));
+    }
+    ts.forEachChild(node, walk);
+  };
+  ts.forEachChild(parsed, walk);
+
+  return (
+    (found.get("testTimeout") ?? 0) >= BOOT_BUDGET_MS &&
+    (found.get("hookTimeout") ?? 0) >= BOOT_BUDGET_MS
+  );
+}
+
 /** The package directory a file belongs to, as `packages/<name>`. */
 /**
  * The name this file needs in order to be collected by the integration lane.
@@ -187,8 +242,8 @@ export function integrationName(path) {
 }
 
 export function packageOf(path) {
-  const [, name] = path.split("/");
-  return name ? `packages/${name}` : undefined;
+  const [root, name] = path.split("/");
+  return name ? `${root}/${name}` : undefined;
 }
 
 /**
@@ -218,6 +273,7 @@ export function hasIntegrationLane(packageDir, readManifest) {
 export function classify(files, readSource) {
   const misrouted = [];
   const stranded = [];
+  const underBudget = [];
   const covered = [];
 
   for (const path of files) {
@@ -228,6 +284,33 @@ export function classify(files, readSource) {
       continue; // a file git lists and the disk cannot read is the linter's business
     }
     if (!importsBootHelper(source, path)) continue;
+
+    /*
+     * A template boots in the one lane it has, so the question is whether that
+     * lane states a budget a boot can finish inside. Demanding the integration
+     * suffix here would demand a second config and a second script in a project
+     * that ships with one test.
+     */
+    if (isTemplate(path)) {
+      const configPath = `${packageOf(path)}/vitest.config.ts`;
+      let config;
+      try {
+        config = readSource(configPath);
+      } catch {
+        underBudget.push({ path, configPath, reason: "has no vitest config" });
+        continue;
+      }
+      if (!statesBootBudget(config)) {
+        underBudget.push({
+          path,
+          configPath,
+          reason: `does not set testTimeout and hookTimeout to at least ${BOOT_BUDGET_MS}ms`,
+        });
+        continue;
+      }
+      covered.push(path);
+      continue;
+    }
 
     if (!path.endsWith(INTEGRATION_SUFFIX)) {
       misrouted.push(path);
@@ -250,7 +333,7 @@ export function classify(files, readSource) {
     covered.push(path);
   }
 
-  return { misrouted, stranded, covered };
+  return { misrouted, stranded, underBudget, covered };
 }
 
 const invokedDirectly =
@@ -268,7 +351,7 @@ if (invokedDirectly) {
   }
 
   const readSource = path => readFileSync(join(root, path), "utf8");
-  const { misrouted, stranded, covered } = classify(files, readSource);
+  const { misrouted, stranded, underBudget, covered } = classify(files, readSource);
 
   // The control, before the verdict. Every file failing to parse, or the
   // binding being renamed upstream, produces an empty `misrouted` that reads
@@ -282,8 +365,20 @@ if (invokedDirectly) {
     process.exit(2);
   }
 
-  if (misrouted.length > 0 || stranded.length > 0) {
+  if (misrouted.length > 0 || stranded.length > 0 || underBudget.length > 0) {
     console.error("check-instance-boot-lane: FAILED\n");
+
+    for (const { path, configPath, reason } of underBudget) {
+      console.error(
+        `  ${path}\n` +
+          `    boots an instance, and ${configPath} ${reason}.\n` +
+          `    A scaffolded project has one lane and nothing to contend with, so\n` +
+          `    it states the budget rather than routing around it: set\n` +
+          `    testTimeout and hookTimeout to ${BOOT_BUDGET_MS}. A boot in\n` +
+          "    `beforeEach` is governed by hookTimeout, the case body by\n" +
+          "    testTimeout, and vitest's defaults for the two differ.\n"
+      );
+    }
 
     for (const path of stranded) {
       console.error(
@@ -321,8 +416,12 @@ if (invokedDirectly) {
 
   console.log(
     `check-instance-boot-lane: ok - ${covered.length} suite(s) that boot an ` +
-      `instance are named for the integration lane AND run by a package that ` +
-      `declares one, out of ${files.length} test file(s) scanned.`
+      `instance have a budget sized for one, out of ${files.length} test ` +
+      "file(s) scanned."
+  );
+  console.log(
+    "  a package suite earns it by running in the integration lane; a " +
+      "scaffolded template by stating the timeouts, having only one lane."
   );
   // Said on the way past, so a reader taking this as proof of routing knows the
   // shape it did not judge.

--- a/scripts/check-instance-boot-lane.test.mjs
+++ b/scripts/check-instance-boot-lane.test.mjs
@@ -9,7 +9,10 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  BOOT_BUDGET_MS,
   BOOT_BINDING,
+  isTemplate,
+  statesBootBudget,
   integrationName,
   INTEGRATION_SUFFIX,
   UNIT_LANE_SUFFIXES,
@@ -337,5 +340,84 @@ describe("the population it judges", () => {
 
   it("uses the binding the repository actually imports", () => {
     expect(BOOT_BINDING).toBe("createTestNextly");
+  });
+});
+
+describe("a scaffolded template, which has only one lane", () => {
+  const BOOT = `import { createTestNextly } from "@nextlyhq/plugin-sdk/testing";`;
+  const budget = (t, h) =>
+    `import { defineConfig } from "vitest/config";
+export default defineConfig({ test: { testTimeout: ${t}, hookTimeout: ${h} } });`;
+
+  it("knows a template from a package", () => {
+    expect(isTemplate("templates/plugin/src/plugin.test.ts")).toBe(true);
+    expect(isTemplate("packages/nextly/src/x.test.ts")).toBe(false);
+  });
+
+  it("accepts a booting template whose config states both budgets", () => {
+    const files = {
+      "templates/plugin/vitest.config.ts": budget(30_000, 30_000),
+      "templates/plugin/src/plugin.test.ts": BOOT,
+    };
+    const { covered, underBudget, misrouted } = classify(
+      ["templates/plugin/src/plugin.test.ts"],
+      reader(files)
+    );
+
+    expect(covered).toEqual(["templates/plugin/src/plugin.test.ts"]);
+    expect(underBudget).toEqual([]);
+    // It is NOT reported as misrouted. Demanding the integration suffix here
+    // would demand a second config and script in a project shipping one test.
+    expect(misrouted).toEqual([]);
+  });
+
+  it("reports a booting template whose config states no budget", () => {
+    // The shape that shipped: vitest's defaults are 5s for a case and 10s for a
+    // hook, and the boot runs in `beforeEach`.
+    const files = {
+      "templates/plugin/vitest.config.ts":
+        `import { defineConfig } from "vitest/config";
+export default defineConfig({ test: { include: ["src/**/*.test.ts"] } });`,
+      "templates/plugin/src/plugin.test.ts": BOOT,
+    };
+    const { underBudget, covered } = classify(
+      ["templates/plugin/src/plugin.test.ts"],
+      reader(files)
+    );
+
+    expect(underBudget).toHaveLength(1);
+    expect(underBudget[0].path).toBe("templates/plugin/src/plugin.test.ts");
+    expect(covered).toEqual([]);
+  });
+
+  it("requires BOTH budgets, because the boot and the case are governed separately", () => {
+    expect(statesBootBudget(budget(30_000, 30_000))).toBe(true);
+    expect(statesBootBudget(budget(30_000, 5_000))).toBe(false);
+    expect(statesBootBudget(budget(1_000, 30_000))).toBe(false);
+  });
+
+  it("does not accept a budget that only appears in a comment", () => {
+    // Same reason the imports are parsed: a number explaining the defaults is
+    // not a number vitest will use.
+    expect(
+      statesBootBudget(`import { defineConfig } from "vitest/config";
+// testTimeout: 30000 and hookTimeout: 30000 would be needed for a boot
+export default defineConfig({ test: {} });`)
+    ).toBe(false);
+  });
+
+  it("reports a booting template with no vitest config at all", () => {
+    const files = { "templates/plugin/src/plugin.test.ts": BOOT };
+    const { underBudget } = classify(
+      ["templates/plugin/src/plugin.test.ts"],
+      reader(files)
+    );
+
+    expect(underBudget).toHaveLength(1);
+    expect(underBudget[0].reason).toContain("no vitest config");
+  });
+
+  it("uses a budget the monorepo's own integration lane agrees with", () => {
+    expect(BOOT_BUDGET_MS).toBe(30_000);
   });
 });

--- a/templates/plugin/vitest.config.ts
+++ b/templates/plugin/vitest.config.ts
@@ -4,5 +4,24 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["src/**/*.test.ts"],
+    /*
+     * Sized for an instance boot, because that is what this suite does.
+     *
+     * `plugin.test.ts` calls `createTestNextly` in `beforeEach`, which builds a
+     * DI container, registers the plugin's schema and runs auto-sync against a
+     * real SQLite database. Vitest's defaults are sized for a unit test that
+     * touches none of that: 5s for a case and 10s for a hook. A boot is about a
+     * second and a half on a warm machine, and the first run of a freshly
+     * scaffolded project is the least warm moment there is - a cold install, no
+     * build cache, whatever the laptop or CI container is doing.
+     *
+     * This is the first command a new plugin author runs, so a timeout here
+     * reads as "the scaffold ships a broken test" rather than "the budget was
+     * tight". The monorepo solves the same problem by routing boots to a lane
+     * with a 30s budget; a single-package project has one lane and nothing to
+     * contend with, so it states the budget instead.
+     */
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
   },
 });


### PR DESCRIPTION
Follows a review finding on #1675. The diagnosis was right; the remedy differs, and the reason is in "Why not an integration lane" below.

## The defect, in shipped code

`templates/plugin/src/plugin.test.ts` calls `createTestNextly` in `beforeEach`, which builds a DI container, registers the plugin's schema and runs auto-sync against a real SQLite database.

Its config stated **no budget at all**:

```ts
export default defineConfig({
  test: { environment: "node", include: ["src/**/*.test.ts"] },
});
```

So it inherited vitest's defaults: **5s for the case, 10s for the hook**, both sized for a unit test that touches none of that. The boot runs in the hook; the two DB round-trips run in the case.

**This ships.** `tsup.config.ts` copies the monorepo templates into the package, `plugin` is one of the bundled three, and `files` includes `templates`. It reaches every scaffolded plugin project.

A boot is about 1.5s warm, and the first run of a freshly scaffolded project is the least warm moment there is: cold install, no build cache, whatever the machine is doing. It is also **the first command a new plugin author runs**, where a timeout reads as "the scaffold ships a broken test".

Both budgets are now **30s**, matching what this repo's own integration lane gives a boot.

## Why not an integration lane

The review suggested extending the check to templates and validating their generated lane configuration. Extending the scan is right and is done. Requiring an *integration lane* there is not.

A template is a **single-package project** a user receives, with one vitest config and one `test` script. There is no second lane to route to, and adding one would put monorepo machinery into someone's new plugin: two configs, two scripts, for one test file with nothing to contend with.

The rule the lane split actually buys is **"a suite that boots gets a budget sized for a boot"**. The monorepo satisfies it by routing; a single-lane project satisfies it by stating the timeouts. Same invariant, two mechanisms, each fitting its context.

## The guard, extended

`check-instance-boot-lane` now scans `templates/` and judges a booting template on its budget rather than its filename:

- Both `testTimeout` **and** `hookTimeout` are required, because a boot in `beforeEach` is governed by one and the case body by the other, and vitest's defaults differ.
- Read off the **parsed** config, for the same reason imports are parsed: a number in a comment explaining the defaults is not a number vitest will use. There is a test for exactly that.
- A booting template with no config at all is reported too.

## Verification

- **Reverting the template config to what shipped on `main` fails the check**, naming the file and both timeouts.
- Clean tree passes: **225 booting suites have a boot-sized budget, out of 2064 scanned** (was 223 of 2048 before templates were in scope).
- 36 unit tests on the guard; full scripts suite **39 files / 1233 tests**.

## Changeset

Included, because this is **not** CI-only: the template config ships inside `create-nextly-app`. Generated from `.changeset/config.json` rather than copied from a neighbour, after `check-changesets.mjs` caught that a copied header was missing `@nextlyhq/eslint-plugin` (24 of 25).