### PR TITLE
fix(nextly): one rule decides whether a key can be grouped, and null is not a key

### DIFF
--- a/.changeset/one-rule-decides-whether-a-key-can-be-grouped.md
+++ b/.changeset/one-rule-decides-whether-a-key-can-be-grouped.md
@@ -1,0 +1,48 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A `group` or `timeseries` read given a `null` key answered with an unclassified
+500 instead of naming the problem. The validator treated `null` as "no key
+given" while every read that consumes it decides absence with `=== undefined`,
+so the value it excused was still a key by the time it reached the column
+lookup, and the crash arrived through the one input the guard had waved past.
+Both API arguments are required strings, so nothing can mean "absent" by
+writing `null`; it is now refused by name.
+
+A localized date is refused by ONE rule rather than two. The read path and the
+widget validator each decided separately that a localized field cannot be
+grouped, and the day localized aggregation becomes supported they would have
+disagreed — the read accepting a key the validator still refused, leaving a
+path no author could reach. Both now ask the same leaf, which imports nothing
+so the validator can reach it.
+
+A widget source declaring a `bucketable` flag that is not a boolean is refused
+when it registers. Query validation rejects only the literal `false`, so the
+string `"false"` — legal in untyped JavaScript and in JSON — advertised a date
+the read then refused, and the widget failed on every load with nothing naming
+the cause.

--- a/packages/nextly/src/domains/collections/query/group-key-declaration.ts
+++ b/packages/nextly/src/domains/collections/query/group-key-declaration.ts
@@ -20,6 +20,8 @@ import type { FieldDefinition } from "../../../schemas/dynamic-collections";
 import { classifyFieldKind } from "../../schema/services/field-column-descriptor";
 import { isJsonFieldType } from "../services/collection-utils";
 
+import { localizedGroupKeyProblem } from "./localized-group-key";
+
 /**
  * Why a field's KIND cannot be grouped, if it cannot.
  *
@@ -76,8 +78,12 @@ export function groupKeyDeclarationProblem(
   // this table, so the column lookup finds nothing. Refusing it as "not a
   // column on this collection" reads as a typo for a field that is declared and
   // spelled correctly, which sends the reader looking in the wrong place.
-  if (declared.localized === true) {
-    return `"${groupBy}" is a localized field, so its values are stored per locale rather than on this collection. Grouping over a localized field is not supported yet.`;
+  //
+  // Asked of the shared leaf rather than tested here, because the widget
+  // validator needs the same answer and cannot import this module.
+  const localized = localizedGroupKeyProblem(declared);
+  if (localized !== undefined) {
+    return `"${groupBy}" ${localized}.`;
   }
   const ungroupable = ungroupableKind(declared);
   if (ungroupable !== undefined) {

--- a/packages/nextly/src/domains/collections/query/localized-group-key.ts
+++ b/packages/nextly/src/domains/collections/query/localized-group-key.ts
@@ -1,0 +1,41 @@
+/**
+ * Whether a field's LOCALIZATION stops it being a group key.
+ *
+ * A leaf module importing NOTHING, and that is the whole reason it exists.
+ * `group-key-declaration` owns the rest of the declaration-level decision, but
+ * it resolves a field's kind through the schema classifier — and
+ * `domains/widgets/query` is type-checked by the admin, whose project does not
+ * define the aliases that graph pulls in. So the one caller that most needs to
+ * agree with the read could not import the module that decides, and answered
+ * the localization question itself instead.
+ *
+ * Two implementations of one rule agree until one of them changes, and the
+ * direction this pair drifts in is the costly one: the day localized
+ * aggregation becomes supported, the read starts accepting a key the widget
+ * validator still refuses, leaving a supported path no author can reach and
+ * nothing failing to point at why.
+ *
+ * The REASON is returned rather than a boolean so that a caller can say why,
+ * and so a rule that later gains conditions carries them to every caller
+ * instead of to whichever one was remembered. Each caller words its own
+ * refusal around it: the read names a group key, the widget validator names a
+ * `dateField` on a source, and neither sentence would read correctly in the
+ * other's place.
+ *
+ * @module domains/collections/query/localized-group-key
+ */
+
+/**
+ * Why a localized field cannot be grouped, or `undefined` when it can.
+ *
+ * Takes the declaration STRUCTURALLY — only the property the rule reads — so
+ * that importing this pulls in no field-definition graph. A caller holding a
+ * full `FieldDefinition` satisfies it, and so does a widget source's field
+ * description, which is a different type carrying the same flag.
+ */
+export function localizedGroupKeyProblem(
+  declared: { localized?: boolean } | undefined
+): string | undefined {
+  if (declared?.localized !== true) return undefined;
+  return "is localized, so its values are stored per locale rather than on this collection, and grouping over a localized field is not supported yet";
+}

--- a/packages/nextly/src/domains/widgets/__tests__/sources.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/sources.test.ts
@@ -111,6 +111,45 @@ describe("registerSource validation (M8)", () => {
     );
   });
 
+  it("refuses a bucketable flag that is not a boolean", () => {
+    // The flag decides whether a timeline read is REFUSED, and query
+    // validation refuses only the literal `false`. A source declaring the
+    // STRING `"false"` — legal in untyped JavaScript, and what a serialized
+    // source carries — would therefore advertise a date the read rejects, and
+    // the widget would fail on every load with nothing naming the cause.
+    expect(() =>
+      registerSource({
+        ...VALID_SOURCE,
+        fields: [
+          {
+            name: "publishedAt",
+            type: "date",
+            bucketable: "false" as unknown as boolean,
+          },
+        ],
+      })
+    ).toThrow(/bucketable flag that is not a boolean/);
+  });
+
+  it("CONTROL: accepts the flag when it IS a boolean, and when it is absent", () => {
+    // Without this, a check that refused every source carrying the flag would
+    // satisfy the case above while making the derived marking unusable.
+    expect(() =>
+      registerSource({
+        ...VALID_SOURCE,
+        id: "collection:marked",
+        fields: [{ name: "publishedAt", type: "date", bucketable: false }],
+      })
+    ).not.toThrow();
+    expect(() =>
+      registerSource({
+        ...VALID_SOURCE,
+        id: "collection:unmarked",
+        fields: [{ name: "publishedAt", type: "date" }],
+      })
+    ).not.toThrow();
+  });
+
   it("refuses an unknown kind", () => {
     expect(() =>
       registerSource({

--- a/packages/nextly/src/domains/widgets/query.ts
+++ b/packages/nextly/src/domains/widgets/query.ts
@@ -15,6 +15,7 @@ import {
   parseNearQuery,
   parseWithinQuery,
 } from "../collections/query/geo-utils";
+import { localizedGroupKeyProblem } from "../collections/query/localized-group-key";
 import {
   GEO_OPERATORS,
   isValidOperator,
@@ -712,14 +713,19 @@ function assertDateFieldBucketable(
     );
   }
   const declaredField = source.fields.find(field => field.name === dateField);
-  // A localized field's values live in the `_locales` companion, so the read
-  // cannot bucket them. Refused HERE as well, because the coarse type says
-  // "date" either way and approving it would register a widget that fails on
-  // every load with nothing pointing at the declaration that caused it.
-  if (declaredField?.localized === true) {
-    fail(
-      `dateField "${dateField}" on "${source.id}" is localized, so its values are stored per locale and cannot be placed on a timeline`
-    );
+  // ONE rule, asked rather than repeated. The read refuses a localized group
+  // key through `localizedGroupKeyProblem`, and this asks the same leaf — so
+  // the day localized aggregation becomes supported, both start accepting it
+  // together instead of this one refusing a read the engine now allows.
+  //
+  // Still refused HERE rather than left to the `bucketable` flag below: that
+  // flag is derived by the collection source builder, and a plugin registering
+  // its own source through the SDK carries `localized` without it. Validating
+  // from the flag alone would approve exactly those sources and leave a widget
+  // that fails on every load.
+  const localizedProblem = localizedGroupKeyProblem(declaredField);
+  if (localizedProblem !== undefined) {
+    fail(`dateField "${dateField}" on "${source.id}" ${localizedProblem}`);
   }
   // Read off the DESCRIPTION rather than asked of the read's own guard. That
   // guard reaches the field-level registry, and this module is type-checked by
@@ -727,6 +733,14 @@ function assertDateFieldBucketable(
   // pulls in -- importing it here reported a hundred errors about code the
   // admin never touches. The source builder runs server-side and marks each
   // date it publishes, so the answer still comes from one place.
+  //
+  // ONE decision, not two. Localization is one of the reasons a date cannot be
+  // bucketed, and `groupKeyDeclarationProblem` is where that list lives — so
+  // the source builder already marks a localized date `bucketable: false` and a
+  // second `localized` test beside this one was the same question answered
+  // twice. They agree today; the day localized aggregation becomes supported
+  // they would not, and the parallel test would keep refusing a read the engine
+  // had started accepting.
   if (declaredField?.bucketable === false) {
     fail(
       `dateField "${dateField}" on "${source.id}" cannot be grouped, so its rows cannot be placed on a timeline`

--- a/packages/nextly/src/domains/widgets/sources.ts
+++ b/packages/nextly/src/domains/widgets/sources.ts
@@ -290,6 +290,68 @@ function validateSourceSupports(s: Partial<WidgetSource>): void {
 }
 
 /**
+ * Refuses a field whose IDENTITY a source cannot be used with.
+ *
+ * Name and type: what the field IS. Separated from the optional annotations
+ * below because the two answer different questions — this one decides whether
+ * there is a usable field at all, and that one whether the extras attached to
+ * it are well-formed.
+ */
+function validateFieldIdentity(
+  sourceId: string,
+  field: Partial<WidgetSourceField> | null | undefined
+): string {
+  if (typeof field?.name !== "string" || field.name.trim() === "") {
+    fail(`${sourceId}: every field requires a non-empty name`);
+  }
+  if (
+    !WIDGET_SOURCE_FIELD_TYPES.includes(field.type as WidgetSourceFieldType)
+  ) {
+    fail(
+      `${sourceId}: field "${field.name}" has an unknown type "${String(field.type)}"`
+    );
+  }
+  return field.name;
+}
+
+/**
+ * Refuses an ANNOTATION that is present and unusable.
+ *
+ * Both are optional, and absence is legal for each — so what is checked is the
+ * shape of a value that IS there. They are refused HERE, where every source
+ * passes, rather than only on the path that computes them: the collection
+ * builder derives both and can only produce well-formed ones, while a plugin
+ * registering its own source through the SDK, or a source restored from a
+ * stored snapshot, reaches this untouched by that path.
+ *
+ * A blank label is refused rather than trimmed away, because it is a mistake in
+ * the plugin's config and silently dropping it leaves the author wondering why
+ * their heading never appears. A non-boolean `bucketable` is refused because
+ * query validation rejects only the literal `false` — so the string `"false"`,
+ * legal in untyped JavaScript and in JSON, would advertise a date the read then
+ * refuses, and the widget would fail on every load with nothing naming why.
+ */
+function validateFieldAnnotations(
+  sourceId: string,
+  name: string,
+  field: Partial<WidgetSourceField>
+): void {
+  if (
+    field.label !== undefined &&
+    (typeof field.label !== "string" || field.label.trim() === "")
+  ) {
+    fail(
+      `${sourceId}: field "${name}" has a label that is empty or not a string`
+    );
+  }
+  if (field.bucketable !== undefined && typeof field.bucketable !== "boolean") {
+    fail(
+      `${sourceId}: field "${name}" has a bucketable flag that is not a boolean`
+    );
+  }
+}
+
+/**
  * Confirms `fields` is a non-empty array of well-formed, uniquely-named
  * fields. A duplicate field name would make `validateWidgetQuery`'s
  * declared-field set silently collapse two fields into one entry, so it is
@@ -303,36 +365,12 @@ function validateSourceFields(s: Partial<WidgetSource>): void {
   const seen = new Set<string>();
   for (const raw of s.fields as unknown[]) {
     const field = raw as Partial<WidgetSourceField> | null | undefined;
-    if (typeof field?.name !== "string" || field.name.trim() === "") {
-      fail(`${s.id}: every field requires a non-empty name`);
+    const name = validateFieldIdentity(String(s.id), field);
+    validateFieldAnnotations(String(s.id), name, field as WidgetSourceField);
+    if (seen.has(name)) {
+      fail(`${s.id}: field "${name}" is declared more than once`);
     }
-    if (
-      !WIDGET_SOURCE_FIELD_TYPES.includes(field.type as WidgetSourceFieldType)
-    ) {
-      fail(
-        `${s.id}: field "${field.name}" has an unknown type "${String(field.type)}"`
-      );
-    }
-    if (seen.has(field.name)) {
-      fail(`${s.id}: field "${field.name}" is declared more than once`);
-    }
-    // A label that is present but unusable is refused HERE, where every source
-    // passes, rather than only on the path that builds one from a collection.
-    // A plugin registering its own source through the SDK reaches the stored
-    // snapshot untouched by that path, and `"   "` is legal TypeScript -- so
-    // the empty column head this field exists to prevent arrived through the
-    // one channel that had no normalisation. Refused rather than trimmed away,
-    // because a blank label is a mistake in the plugin's config and silently
-    // dropping it leaves the author wondering why their heading never appears.
-    if (
-      field.label !== undefined &&
-      (typeof field.label !== "string" || field.label.trim() === "")
-    ) {
-      fail(
-        `${s.id}: field "${field.name}" has a label that is empty or not a string`
-      );
-    }
-    seen.add(field.name);
+    seen.add(name);
   }
 }
 

--- a/packages/nextly/src/shared/lib/__tests__/groupable-fields.test.ts
+++ b/packages/nextly/src/shared/lib/__tests__/groupable-fields.test.ts
@@ -75,6 +75,39 @@ describe("grouping by a field that carries a read rule", () => {
     ).not.toThrow();
   });
 
+  it("refuses a NULL key rather than reading it as no key at all", () => {
+    // The seam this closes: every read that consumes this decision tests
+    // `groupBy === undefined` for absence, so a `null` excused here was still a
+    // key by the time it reached `toSnakeCase`, whose `.replace` threw a raw
+    // `TypeError` the service reports as an unclassified 500 — the exact
+    // outcome this validator exists to replace, arriving through the one value
+    // it waved through.
+    // Asserted on the SERIALIZED error for the reason the cases above are:
+    // `NextlyError.validation` carries a generic public message and puts the
+    // reason in `errors`.
+    registerVaults();
+    try {
+      assertGroupableField("collection", SLUG, null as unknown as string);
+      expect.unreachable("should have refused");
+    } catch (error) {
+      expect(JSON.stringify(error)).toMatch(/must be given as a string/i);
+    }
+  });
+
+  it("refuses the other FALSY non-strings for the same reason", () => {
+    // `0`, `false` and `NaN` are falsy AND wrong. A falsy test alone reads them
+    // as absent, which is how they reached the crash.
+    registerVaults();
+    for (const bad of [0, false, Number.NaN]) {
+      try {
+        assertGroupableField("collection", SLUG, bad as unknown as string);
+        expect.unreachable(`should have refused ${String(bad)}`);
+      } catch (error) {
+        expect(JSON.stringify(error)).toMatch(/must be given as a string/i);
+      }
+    }
+  });
+
   it("judges the field that OWNS the rule for a nested path", () => {
     registerVaults();
     expect(() =>

--- a/packages/nextly/src/shared/lib/filterable-fields.ts
+++ b/packages/nextly/src/shared/lib/filterable-fields.ts
@@ -298,14 +298,24 @@ export function groupableFieldProblem(
   groupBy: unknown,
   opts: { overrideAccess?: boolean; frameworkFilter?: boolean } = {}
 ): Array<{ path: string; code: string; message: string }> | undefined {
-  // `undefined` and `null` both mean "no group key was given", and an empty
-  // string is the same absence spelled differently. Anything else non-string is
-  // MALFORMED, and is refused here rather than reaching `.split` or
-  // `toSnakeCase` -- whose `.replace` throws a raw `TypeError` the calling
-  // service catches as an unclassified 500. Checked BEFORE the absence test,
-  // because `0`, `false` and `NaN` are falsy AND wrong: treating them as absent
-  // let them through to exactly the crash this exists to replace.
-  if (groupBy === undefined || groupBy === null) return undefined;
+  // `undefined` means "no group key was given", and an empty string is the same
+  // absence spelled differently. Anything else non-string is MALFORMED, and is
+  // refused here rather than reaching `.split` or `toSnakeCase` -- whose
+  // `.replace` throws a raw `TypeError` the calling service catches as an
+  // unclassified 500. Checked BEFORE the absence test, because `0`, `false` and
+  // `NaN` are falsy AND wrong: treating them as absent let them through to
+  // exactly the crash this exists to replace.
+  //
+  // `null` is MALFORMED here rather than absent, and the difference is not a
+  // preference. Every read that consumes this decides absence with
+  // `groupBy === undefined`, so a `null` this waved through as "no key given"
+  // was still a key as far as they were concerned, and it reached `toSnakeCase`
+  // -- the crash this function exists to replace, arriving through the one
+  // value it excused. The API asks for a required string on both paths
+  // (`GroupArgs.groupBy`, `TimeseriesArgs.dateField`), so no caller can mean
+  // "absent" by writing `null`; only an untyped one reaches here with it, and a
+  // named refusal is what it should get.
+  if (groupBy === undefined) return undefined;
   if (typeof groupBy !== "string") {
     return [
       {


### PR DESCRIPTION
Follow-up to #1665, which merged with 11 unresolved review threads. Each was checked against current `main` before being acted on, because "unresolved" and "still true" are different facts.

## What the audit found

| | |
|---|---|
| **7 threads** | **Already fixed on main** during the review — the derived `READS` list, the MySQL spanning-window (`timeseriesWindowIsStorable`, which I confirmed is *called* at `collection-query-service.ts:440`, not merely defined), the release-visibility clock (`requestNow` is kept separate from the caller`s `anchor`), and the falsy-key check |
| **1 thread** | **Not a defect.** The report says `canBucket` independently rejects `localized`; it delegates to `isGroupKeyDeclaration` → `groupKeyDeclarationProblem`, which owns that rule. Nothing to change |
| **3 threads** | **Live, and fixed here** |

## The three fixes

**A `null` key answered with an unclassified 500.** `groupableFieldProblem` read `null` as "no key given", while `resolveReadPlan` and `validatedGroupKey` both decide absence with `=== undefined`. So the one value the validator excused was still a key downstream, reached `toSnakeCase`, and threw a raw `TypeError` — the exact outcome that validator exists to replace, arriving through the input it waved past. `GroupArgs.groupBy` and `TimeseriesArgs.dateField` are required strings, so nothing can mean "absent" by writing `null`.

**A localized date was refused by two rules.** They agreed only by coincidence, and the divergence has a direction: the day localized aggregation is supported, the read starts accepting a key the widget validator still refuses, leaving a supported path no author can reach. `group-key-declaration` could not be imported by `domains/widgets/query` — it resolves field kinds through the schema classifier, and that module is type-checked by the admin, whose project lacks those aliases. So the localization rule moves to a leaf that **imports nothing**, and both sides ask it.

**I did not take the suggested remedy for that one, and the reason is measured.** The review asked me to delete the validator`s `localized` check and rely on the derived `bucketable` flag. Doing so makes `query.test.ts``s localized case pass — its fixture is a plugin-registered source carrying `localized` with **no** `bucketable`, which is every source registered through the SDK rather than built from a collection. The flag is derived by `collectionSource`; a hand-registered source never passes through it. Validating from the flag alone would approve exactly those and leave a widget failing on every load.

**A `bucketable` flag that is not a boolean is now refused at registration.** Query validation rejects only the literal `false`, so the string `"false"` — legal in untyped JavaScript and in JSON — advertised a date the read then refused.

## Verification

- **Break-verified**, each fix separately: restoring the `null`-as-absent test, deleting the shared localization call, and removing the flag check each kill exactly their own test, and the control passes on restore.
- Full `nextly` suite: **11748 passed, 42 skipped**. `check-types` 0. `lint` 0. `changeset status` 0.
- **`fallow` refused this twice and was right twice.** The new flag check pushed `validateSourceFields` over the gate (cognitive 17, CRAP 56.3), and my first split left the extracted function still over it (CC 10). The seam that resolves it is real rather than cosmetic: what a field **is** (name, type) and the optional **annotations** attached to it are two jobs. Final verdict `pass`, `complexity_introduced: 0`.

Controls included where a check could pass by refusing everything: the flag test asserts a boolean flag and an absent flag are both accepted, and the localized test keeps its non-localized control.