### PR TITLE
refactor(blocks-engine): one ceiling on what anything will walk, not three

### DIFF
--- a/.changeset/a-forest-too-large-to-measure.md
+++ b/.changeset/a-forest-too-large-to-measure.md
@@ -32,9 +32,12 @@ They walk ENTRIES, not objects, and deliberately so: one node object placed in t
 
 `documentBytes` was the sharp edge. `JSON.stringify` expands each shared node into a copy per path that reaches it, so it allocated 132 MB for 21 objects and raised `RangeError: Invalid string length` at 23 — from a document a few kilobytes in memory, in the one function that decides whether a document may be stored.
 
-All three now throw `ForestTooLargeError` past `MAX_VALUE_PARTS` (4,194,304) — the ceiling the op layer's preflight **already** refused values at, now shared rather than duplicated.
+All three now throw `ForestTooLargeError`, against the ceiling that fits what each one actually spends:
 
-That reuse is the point. A second, lower number would let a dry run accept a document the apply then refuses, and would sit below `maxNodes` on a site that legitimately raised it — so a supported configuration would find one reader agreeing with it and another not. `MAX_VALUE_PARTS` is exported from the package root and from `@nextlyhq/blocks-engine/format` alongside the error.
+- `countNodes` and `treeDepth` refuse past `MAX_VALUE_PARTS` (4,194,304) — the ceiling the op layer's preflight **already** refused values at, now shared rather than duplicated.
+- `documentBytes` refuses past `MAX_SERIALIZED_VALUES`, which is derived from the byte cap it protects: every serialized value contributes at least one byte, so a document that has emitted more values than the cap has bytes cannot come in under it.
+
+Sharing the first number is the point: a second, lower ceiling for the structural readers would let a dry run accept a document the apply then refuses, and would sit below `maxNodes` on a site that legitimately raised it. The serializer keeps its own because it bounds a different resource — a structural walk reads, while serialization BUILDS as it goes, so one numeral buys different amounts of work in each. Both are exported from the package root, and `@nextlyhq/blocks-engine/format` exports the error with `MAX_SERIALIZED_VALUES`, the only one bounding anything that entry exposes.
 
 The messages name the routes to the ceiling without claiming which one a caller hit, because no reader compares object identity and so none can tell. Inside `applyOp` the refusal arrives as an `OpError` like every other, so the `...Refusal` helpers still return a reason rather than throwing at their caller. Composition and the builder's deletion metadata degrade rather than propagate it: an unmeasurable subtree refunds nothing and reports no descendant count, so a page still renders and a block can still be deleted.
 

--- a/.changeset/a-forest-too-large-to-measure.md
+++ b/.changeset/a-forest-too-large-to-measure.md
@@ -32,13 +32,10 @@ They walk ENTRIES, not objects, and deliberately so: one node object placed in t
 
 `documentBytes` was the sharp edge. `JSON.stringify` expands each shared node into a copy per path that reaches it, so it allocated 132 MB for 21 objects and raised `RangeError: Invalid string length` at 23 — from a document a few kilobytes in memory, in the one function that decides whether a document may be stored.
 
-All three now throw `ForestTooLargeError`, against **two different bounds** — they count different populations and neither number stands in for the other:
+All three now throw `ForestTooLargeError` past `MAX_VALUE_PARTS` (4,194,304) — the ceiling the op layer's preflight **already** refused values at, now shared rather than duplicated.
 
-- `countNodes` and `treeDepth` refuse past `MAX_WALKABLE_ENTRIES` (1,000,000), which counts forest ENTRIES.
-- `documentBytes` refuses past `MAX_SERIALIZED_VALUES` (2,000,000), which counts the VALUES the serializer visits — measured at six per node, so this is roughly 333,000 nodes.
+That reuse is the point. A second, lower number would let a dry run accept a document the apply then refuses, and would sit below `maxNodes` on a site that legitimately raised it — so a supported configuration would find one reader agreeing with it and another not. `MAX_VALUE_PARTS` is exported from the package root and from `@nextlyhq/blocks-engine/format` alongside the error.
 
-Both bounds and the error are exported from the package root; `@nextlyhq/blocks-engine/format` exports the error and `MAX_SERIALIZED_VALUES`, which is the only one bounding anything that entry exposes.
-
-The messages name the routes to each bound without claiming which one a caller hit, because neither reader compares object identity and so neither can tell. Inside `applyOp` the refusal arrives as an `OpError` like every other, so the `...Refusal` helpers still return a reason rather than throwing at their caller. Composition and the builder's deletion metadata degrade rather than propagate it: an unmeasurable subtree refunds nothing and reports no descendant count, so a page still renders and a block can still be deleted.
+The messages name the routes to the ceiling without claiming which one a caller hit, because no reader compares object identity and so none can tell. Inside `applyOp` the refusal arrives as an `OpError` like every other, so the `...Refusal` helpers still return a reason rather than throwing at their caller. Composition and the builder's deletion metadata degrade rather than propagate it: an unmeasurable subtree refunds nothing and reports no descendant count, so a page still renders and a block can still be deleted.
 
 Nothing a site can store is affected. `JSON.parse` produces fresh objects and cannot express sharing, so a stored document is never such a forest; the bound is reachable only by a forest built in memory by code.

--- a/packages/blocks-engine/src/format.ts
+++ b/packages/blocks-engine/src/format.ts
@@ -59,13 +59,8 @@ export {
   // consumer unable to tell that refusal from a defect of its own, or to name
   // the threshold it hit, without reaching past this entry to the root — which
   // is the coupling this parser-free entry exists to prevent.
-  //
-  // `MAX_SERIALIZED_VALUES` and not `MAX_WALKABLE_ENTRIES`: the two are
-  // different units and only the first bounds anything this entry exposes.
-  // `countNodes` and `treeDepth` are not published here, so exporting the bound
-  // they answer to would name a threshold no caller of this entry can reach.
   ForestTooLargeError,
-  MAX_SERIALIZED_VALUES,
+  MAX_VALUE_PARTS,
 } from "./limits";
 
 export { measureBytes, surveyDocument } from "./measure-bytes";

--- a/packages/blocks-engine/src/format.ts
+++ b/packages/blocks-engine/src/format.ts
@@ -60,7 +60,11 @@ export {
   // the threshold it hit, without reaching past this entry to the root — which
   // is the coupling this parser-free entry exists to prevent.
   ForestTooLargeError,
-  MAX_VALUE_PARTS,
+  // `MAX_SERIALIZED_VALUES` and not `MAX_VALUE_PARTS`: `countNodes` and
+  // `treeDepth` are not published here, so the structural ceiling bounds nothing
+  // a caller of this entry can reach, and naming it would advertise a threshold
+  // they cannot hit.
+  MAX_SERIALIZED_VALUES,
 } from "./limits";
 
 export { measureBytes, surveyDocument } from "./measure-bytes";

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -110,6 +110,7 @@ export {
   // value with more parts than this, so a second number here would let a dry run
   // accept what the apply then refuses.
   MAX_VALUE_PARTS,
+  MAX_SERIALIZED_VALUES,
   ForestTooLargeError,
 } from "./limits";
 export type { DocumentLimits } from "./limits";

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -102,17 +102,14 @@ export {
   countNodes,
   treeDepth,
   documentBytes,
-  // Published because the three readers above now REFUSE a forest they cannot
-  // afford to measure, and a caller that wants to report that rather than let
-  // it escape has to be able to name it.
+  // Published because the three readers above now REFUSE a structure they
+  // cannot afford to walk, and a caller that wants to report that rather than
+  // let it escape has to be able to name it and to say what it exceeded.
   //
-  // BOTH bounds travel with it, because they are different units and a caller
-  // cannot tell from the error which it hit: `countNodes` and `treeDepth` count
-  // forest ENTRIES, while `documentBytes` counts the VALUES the serializer
-  // visits — six per node on a measured document, so the two numbers are not
-  // comparable and neither can stand in for the other.
-  MAX_WALKABLE_ENTRIES,
-  MAX_SERIALIZED_VALUES,
+  // ONE ceiling, which is the point: the op layer's preflight already refused a
+  // value with more parts than this, so a second number here would let a dry run
+  // accept what the apply then refuses.
+  MAX_VALUE_PARTS,
   ForestTooLargeError,
 } from "./limits";
 export type { DocumentLimits } from "./limits";

--- a/packages/blocks-engine/src/limits.test.ts
+++ b/packages/blocks-engine/src/limits.test.ts
@@ -6,7 +6,7 @@ import {
   documentBytes,
   ForestTooLargeError,
   MAX_NODES,
-  MAX_WALKABLE_ENTRIES,
+  MAX_VALUE_PARTS,
   treeDepth,
 } from "./limits";
 
@@ -61,10 +61,11 @@ const page = (nodes: BlockNode[]): BlockDocument =>
   ({ formatVersion: 1, kind: "page", nodes }) as BlockDocument;
 
 describe("a forest whose entries outrun its objects", () => {
-  // 21 objects walk 2,097,151 entries, which is past the bound. 18 objects walk
-  // 262,143, which is not — so the pair separates "refuses what it must" from
-  // "refuses everything", and neither test is evidence without the other.
-  const OVER = 21;
+  // 23 objects walk 8,388,607 entries, which is past the shared ceiling of
+  // 4,194,304. 18 objects walk 524,287, which is not — so the pair separates
+  // "refuses what it must" from "refuses everything", and neither test is
+  // evidence without the other.
+  const OVER = 23;
   const UNDER = 18;
 
   it("refuses to COUNT one, rather than answering from a partial walk", () => {
@@ -188,10 +189,16 @@ describe("a forest whose entries outrun its objects", () => {
   });
 
   it("leaves an ordinary document alone, bound nowhere near it", () => {
-    // The bound is a MACHINE one and must never fire on anything a product cap
-    // would have allowed, so it is asserted against the product cap rather than
-    // against a number chosen to agree with it.
-    expect(MAX_WALKABLE_ENTRIES).toBeGreaterThan(MAX_NODES * 100);
+    /*
+     * The bound is a MACHINE one and must never fire on anything a product cap
+     * would have allowed, so it is asserted against the product cap rather than
+     * against a number chosen to agree with it.
+     *
+     * It is also the SAME ceiling the op layer's preflight refuses at, which is
+     * what stops a dry run accepting a document the apply then rejects. A second
+     * number here, however well chosen, reintroduces that disagreement.
+     */
+    expect(MAX_VALUE_PARTS).toBeGreaterThan(MAX_NODES * 100);
     const ordinary = chain(50);
     expect(countNodes(ordinary)).toBe(51);
     expect(treeDepth(ordinary)).toBe(51);

--- a/packages/blocks-engine/src/limits.test.ts
+++ b/packages/blocks-engine/src/limits.test.ts
@@ -60,13 +60,49 @@ function chain(objects: number): BlockNode[] {
 const page = (nodes: BlockNode[]): BlockDocument =>
   ({ formatVersion: 1, kind: "page", nodes }) as BlockDocument;
 
+/** Entries a `sharedChain(wrappers)` walks: one leaf plus `wrappers` doublings. */
+function chainEntries(wrappers: number): number {
+  return 2 ** (wrappers + 1) - 1;
+}
+
+/** The smallest chain whose entries exceed `ceiling`. */
+function smallestChainOver(ceiling: number): number {
+  let wrappers = 1;
+  while (chainEntries(wrappers) <= ceiling) wrappers += 1;
+  return wrappers;
+}
+
 describe("a forest whose entries outrun its objects", () => {
-  // 23 objects walk 8,388,607 entries, which is past the shared ceiling of
-  // 4,194,304. 18 objects walk 524,287, which is not — so the pair separates
-  // "refuses what it must" from "refuses everything", and neither test is
-  // evidence without the other.
-  const OVER = 23;
-  const UNDER = 18;
+  /*
+   * DERIVED from the ceiling, not chosen against it. `sharedChain(w)` builds one
+   * leaf plus `w` wrappers, so its entries are `2 ** (w + 1) - 1` — a number
+   * that was stated by hand and was wrong by a factor of two, which left the
+   * fixture four times over the ceiling instead of just over it. A fixture with
+   * that much slack keeps passing while the ceiling moves underneath it, which
+   * is the drift these tests exist to expose.
+   *
+   * OVER is the SMALLEST chain that exceeds the ceiling and UNDER is the largest
+   * that does not, so the pair brackets it: move the ceiling either way and one
+   * of them fails.
+   */
+  const OVER = smallestChainOver(MAX_VALUE_PARTS);
+  const UNDER = OVER - 1;
+
+  it("brackets the ceiling, so neither fixture can drift away from it", () => {
+    /*
+     * The property that makes every test below mean something. A fixture sized
+     * by hand sits at whatever multiple of the ceiling it happened to be written
+     * at, and keeps passing when the ceiling moves — the earlier one was four
+     * times over, from an entry count stated wrongly by a factor of two.
+     *
+     * Asserted rather than assumed, because the derivation is arithmetic that
+     * can be got wrong exactly as the hand-written number was.
+     */
+    expect(chainEntries(UNDER)).toBeLessThanOrEqual(MAX_VALUE_PARTS);
+    expect(chainEntries(OVER)).toBeGreaterThan(MAX_VALUE_PARTS);
+    // And OVER is the SMALLEST such chain: one step down is under the ceiling.
+    expect(OVER).toBe(UNDER + 1);
+  });
 
   it("refuses to COUNT one, rather than answering from a partial walk", () => {
     expect(() => countNodes(sharedChain(OVER))).toThrow(ForestTooLargeError);
@@ -184,7 +220,7 @@ describe("a forest whose entries outrun its objects", () => {
   it("still answers for a shared forest UNDER the bound", () => {
     // The control for all four above. A bound set low enough to refuse
     // everything passes each of them, and this is what separates the two.
-    expect(countNodes(sharedChain(UNDER))).toBe(2 ** (UNDER + 1) - 1);
+    expect(countNodes(sharedChain(UNDER))).toBe(chainEntries(UNDER));
     expect(treeDepth(sharedChain(UNDER))).toBe(UNDER + 1);
   });
 

--- a/packages/blocks-engine/src/limits.ts
+++ b/packages/blocks-engine/src/limits.ts
@@ -121,6 +121,28 @@ export const DEFAULT_LIMITS: DocumentLimits = {
 export const MAX_VALUE_PARTS = 4 * 1024 * 1024;
 
 /**
+ * How many values {@link documentBytes} may serialize before it refuses.
+ *
+ * SEPARATE from {@link MAX_VALUE_PARTS}, and the separation is the point rather
+ * than an oversight. That ceiling bounds a structural walk, which reads and
+ * allocates nothing; this one bounds a walk that BUILDS as it goes, so the same
+ * numeral buys a different amount of work. Measured on a forest of shared
+ * objects, refusing at 4,194,304 callbacks takes 498ms against 145ms at this
+ * value — sharing one number there was arithmetic, not a derivation.
+ *
+ * DERIVED from the byte cap it exists to protect, so it moves when that moves.
+ * Every serialized value contributes at least one byte to the output, so a
+ * document that has already emitted more values than the cap has bytes cannot
+ * come in under it, and the exact size of something that far over is not a
+ * number any caller needs.
+ *
+ * A site that raises `maxBytes` past this is choosing a document larger than the
+ * editor will edit, which is the stance {@link MAX_VALUE_PARTS} already takes
+ * for the same reason.
+ */
+export const MAX_SERIALIZED_VALUES = DEFAULT_MAX_DOCUMENT_BYTES;
+
+/**
  * A structure with more parts than {@link MAX_VALUE_PARTS}.
  *
  * Thrown rather than answered around, because every honest answer here is a
@@ -274,10 +296,10 @@ export function documentBytes(doc: BlockDocument): number {
   let visited = 0;
   const json = JSON.stringify(doc, function replacer(_key, value: unknown) {
     visited += 1;
-    if (visited > MAX_VALUE_PARTS) {
+    if (visited > MAX_SERIALIZED_VALUES) {
       throw new ForestTooLargeError(
         `this document cannot be measured: serializing it visits more than ` +
-          `${String(MAX_VALUE_PARTS)} values. ${WHY_TOO_MANY_VALUES}`
+          `${String(MAX_SERIALIZED_VALUES)} values. ${WHY_TOO_MANY_VALUES}`
       );
     }
     return value;

--- a/packages/blocks-engine/src/limits.ts
+++ b/packages/blocks-engine/src/limits.ts
@@ -77,48 +77,51 @@ export const DEFAULT_LIMITS: DocumentLimits = {
 };
 
 /**
- * How many entries a whole-forest reader may visit before it refuses.
+ * How many parts of a structure anything in this engine will walk.
  *
- * A machine limit like `MAX_WALKABLE_DEPTH` in `ops.ts`, not a product one:
- * {@link MAX_NODES} is a rule a site may raise, and this is the point past
- * which reading the forest at all stops being affordable whatever any site
- * says. Two hundred times the default node cap, so it only ever fires on
- * forests no product setting would have allowed.
+ * A machine limit, not a product one, and the ONE answer to that question. The
+ * op layer's preflight refuses a value with more parts than this, and the three
+ * readers below refuse a forest or a serialization that reaches it. Two numbers
+ * for one question is how a dry run comes to accept what the apply then refuses,
+ * and how a site that legitimately raises `maxNodes` finds one reader agreeing
+ * with its configuration while another does not.
  *
- * It exists because entries are not bounded by OBJECTS. `walkForest`
- * deliberately revisits a node object reached under two different parents —
- * one object placed in two slots is two elements of the document, and counting
- * it once would report half a real size and pass a cap the document exceeds.
- * That is right for a count and it makes the walk exponential in depth for a
- * forest whose branches share objects: measured on this module's own helpers, a
- * chain of 21 distinct objects each holding the next twice walks 2,097,151
- * entries, and every further object doubles it.
+ * The walks visit every key and every element, so a shallow object with millions
+ * of enumerable properties costs a full traversal — and an in-process or
+ * agent-written op can carry one. The byte cap would refuse such a value, but
+ * only after these walks have already paid for it, which is the wrong order for
+ * a guard whose job is to reject.
  *
- * A stored document can never be such a forest, because `JSON.parse` produces
- * fresh objects and cannot express sharing. One built in memory by code can be,
- * and these readers decide whether a document may be stored at all — so the
- * unbounded version failed in the worst possible place.
+ * ENTRIES are not bounded by OBJECTS, which is the other reason a bound is
+ * needed here. `walkForest` deliberately revisits a node object reached under
+ * two different parents — one object placed in two slots is two elements of the
+ * document, and counting it once would report half a real size and pass a cap
+ * the document exceeds. That is right for a count, and it makes the walk
+ * exponential in depth for a forest whose branches share objects: measured on
+ * this module's own helpers, a chain of 21 distinct objects each holding the
+ * next twice walks 2,097,151 entries, and every further object doubles it. A
+ * stored document can never be one — `JSON.parse` produces fresh objects and
+ * cannot express sharing — but one built in memory by code can.
+ *
+ * Set well above `DEFAULT_LIMITS.maxBytes`, which is 2 MiB: every part
+ * contributes at least one byte to serialized JSON, so a structure with more
+ * parts than this has more bytes than any default-configured document may hold,
+ * and refusing it unexamined agrees with the answer a full walk would have
+ * reached. A site that raises `maxBytes` past this is choosing a document larger
+ * than the editor will edit, which the machine caps already say elsewhere.
+ *
+ * What this bounds, precisely: the descriptor lookups, the nested traversal and
+ * the value reads, which are the costs that grow with what the value CONTAINS.
+ * It does not bound `Reflect.ownKeys` itself, which materialises the key list in
+ * one call before any loop can stop — and it cannot, because there is no way to
+ * enumerate own keys including non-enumerable and symbol ones without building
+ * that list. The op is already in memory by then, so this doubles a cost the
+ * caller has paid rather than admitting an unbounded new one.
  */
-export const MAX_WALKABLE_ENTRIES = 1_000_000;
+export const MAX_VALUE_PARTS = 4 * 1024 * 1024;
 
 /**
- * How many values {@link documentBytes} may serialize before it refuses.
- *
- * A different unit from {@link MAX_WALKABLE_ENTRIES} and deliberately its own
- * constant, because the serializer counts VALUES rather than nodes: measured on
- * a 5,000-node document, `JSON.stringify` visits six values per node. Two
- * million is therefore roughly 333,000 nodes — sixty-six times the default node
- * cap, the same order of headroom `MAX_WALKABLE_DEPTH` keeps over
- * `DEFAULT_LIMITS.maxDepth`.
- *
- * Reusing the entry bound here would have been a bound in the wrong unit,
- * six times tighter than it reads, and would refuse documents a site could
- * legitimately configure.
- */
-export const MAX_SERIALIZED_VALUES = 2_000_000;
-
-/**
- * A forest whose entries outrun {@link MAX_WALKABLE_ENTRIES}.
+ * A structure with more parts than {@link MAX_VALUE_PARTS}.
  *
  * Thrown rather than answered around, because every honest answer here is a
  * refusal: a count taken from a walk that stopped early is a PARTIAL one, and
@@ -189,7 +192,7 @@ function walkBounded(
   let spent = false;
   walkForest(nodes, entry => {
     seen += 1;
-    if (seen > MAX_WALKABLE_ENTRIES) {
+    if (seen > MAX_VALUE_PARTS) {
       spent = true;
       return "stop";
     }
@@ -198,7 +201,7 @@ function walkBounded(
   });
   if (spent) {
     throw new ForestTooLargeError(
-      `${subject} reaches more than ${String(MAX_WALKABLE_ENTRIES)} entries ` +
+      `${subject} reaches more than ${String(MAX_VALUE_PARTS)} entries ` +
         `and cannot be measured: past that the walk is not affordable. ` +
         WHY_TOO_LARGE
     );
@@ -271,10 +274,10 @@ export function documentBytes(doc: BlockDocument): number {
   let visited = 0;
   const json = JSON.stringify(doc, function replacer(_key, value: unknown) {
     visited += 1;
-    if (visited > MAX_SERIALIZED_VALUES) {
+    if (visited > MAX_VALUE_PARTS) {
       throw new ForestTooLargeError(
         `this document cannot be measured: serializing it visits more than ` +
-          `${String(MAX_SERIALIZED_VALUES)} values. ${WHY_TOO_MANY_VALUES}`
+          `${String(MAX_VALUE_PARTS)} values. ${WHY_TOO_MANY_VALUES}`
       );
     }
     return value;

--- a/packages/blocks-engine/src/ops.ts
+++ b/packages/blocks-engine/src/ops.ts
@@ -55,6 +55,7 @@ import {
   countNodes,
   DEFAULT_LIMITS,
   ForestTooLargeError,
+  MAX_VALUE_PARTS,
   treeDepth,
   type DocumentLimits,
 } from "./limits";
@@ -351,33 +352,6 @@ function describe(value: unknown): string {
 const MAX_VALUE_DEPTH = 512;
 
 /**
- * How many parts a value may have before it is refused unexamined.
- *
- * A machine limit like {@link MAX_WALKABLE_DEPTH}, not a product one. The domain
- * walks below visit every key and every element, so a shallow object with
- * millions of enumerable properties costs a full traversal — and an in-process
- * or agent-written op can carry one. The byte cap would refuse such a value, but
- * only after these walks have already paid for it, which is the wrong order for
- * a guard whose job is to reject.
- *
- * Set well above `DEFAULT_LIMITS.maxBytes`, which is 2 MiB: every part
- * contributes at least one byte to serialized JSON, so a value with more parts
- * than this has more bytes than any default-configured document may hold, and
- * refusing it unexamined agrees with the answer a full walk would have reached.
- * A site that raises `maxBytes` past this is choosing a document larger than the
- * editor will edit, which the machine caps already say elsewhere.
- *
- * What this bounds, precisely: the descriptor lookups, the nested traversal and
- * the value reads, which are the costs that grow with what the value CONTAINS.
- * It does not bound `Reflect.ownKeys` itself, which materialises the key list in
- * one call before any loop can stop — and it cannot, because there is no way to
- * enumerate own keys including non-enumerable and symbol ones without building
- * that list. The op is already in memory by then, so this doubles a cost the
- * caller has paid rather than admitting an unbounded new one.
- */
-const MAX_VALUE_PARTS = 4 * 1024 * 1024;
-
-/**
  * How deep a node TREE may nest before the engine's helpers cannot walk it.
  *
  * A machine limit, not a product one: `limits.maxDepth` is a rule a site may
@@ -439,7 +413,7 @@ function assertUsableLimits(limits: DocumentLimits): void {
  * Measure a forest, reporting a refusal to measure as an `OpError`.
  *
  * `countNodes` and `treeDepth` refuse a forest whose entries outrun
- * {@link MAX_WALKABLE_ENTRIES} rather than answering from a partial walk, and
+ * {@link MAX_VALUE_PARTS} rather than answering from a partial walk, and
  * that refusal has to arrive here wearing this module's error type. Six
  * `...Refusal` helpers in this file are written as
  * `catch (error) { if (error instanceof OpError) return error.message; throw error; }`

--- a/packages/builder/src/delete-block.test.ts
+++ b/packages/builder/src/delete-block.test.ts
@@ -11,6 +11,7 @@
  */
 import { describe, expect, it } from "vitest";
 
+import { MAX_VALUE_PARTS } from "@nextlyhq/blocks-engine";
 import type { BlockDocument, BlockNode } from "@nextlyhq/blocks-engine";
 
 import { blockDeletion } from "./delete-block";
@@ -144,11 +145,26 @@ describe("a subtree the engine cannot count", () => {
    * engine refuses to count past its machine ceiling rather than answering from
    * a partial walk.
    *
-   * 23 objects reach 8,388,607 entries, past the shared `MAX_VALUE_PARTS`
-   * ceiling of 4,194,304. The number is tied to that ceiling rather than chosen:
-   * when it moved, this fixture stopped being refused and the tests below went
-   * green while asserting nothing.
+   * DERIVED from the ceiling rather than written beside it. `sharedChain(w)`
+   * builds one leaf plus `w` wrappers, so its entries are `2 ** (w + 1) - 1`;
+   * stating that number by hand got it wrong by a factor of two, and a fixture
+   * with that much slack keeps passing while the ceiling moves underneath it.
+   *
+   * The smallest chain that exceeds the ceiling is the sensitive one: raise the
+   * ceiling and this stops being refused, which is the drift worth catching.
    */
+  /** Entries a chain of `wrappers` doublings walks, over one leaf. */
+  function chainEntries(wrappers: number): number {
+    return 2 ** (wrappers + 1) - 1;
+  }
+
+  /** The smallest chain whose entries exceed the engine's ceiling. */
+  function overCeiling(): number {
+    let wrappers = 1;
+    while (chainEntries(wrappers) <= MAX_VALUE_PARTS) wrappers += 1;
+    return wrappers;
+  }
+
   function sharedChain(objects: number): BlockNode {
     let node: BlockNode = leaf("deep-leaf");
     for (let i = objects - 1; i >= 0; i--) {
@@ -170,7 +186,7 @@ describe("a subtree the engine cannot count", () => {
      * and takes the editor down at the moment the node is selected. Being able
      * to remove a block must not depend on being able to describe it.
      */
-    const doc = documentOf([sharedChain(23), leaf("after")]);
+    const doc = documentOf([sharedChain(overCeiling()), leaf("after")]);
 
     const deletion = blockDeletion(doc, "d0");
 
@@ -185,7 +201,7 @@ describe("a subtree the engine cannot count", () => {
     // Zero is the same value a childless node reports, and that is deliberate:
     // the announcement says "<name> deleted" at zero and adds "with N blocks
     // inside" above it, so zero states nothing rather than stating none.
-    const doc = documentOf([sharedChain(23)]);
+    const doc = documentOf([sharedChain(overCeiling())]);
 
     expect(blockDeletion(doc, "d0")?.descendantCount).toBe(0);
   });

--- a/packages/builder/src/delete-block.test.ts
+++ b/packages/builder/src/delete-block.test.ts
@@ -141,8 +141,13 @@ describe("a subtree the engine cannot count", () => {
   /**
    * A chain of distinct node objects where each holds the NEXT one twice, so
    * entries double at every level while the object count stays linear. The
-   * engine refuses to count past its machine bound rather than answering from a
-   * partial walk.
+   * engine refuses to count past its machine ceiling rather than answering from
+   * a partial walk.
+   *
+   * 23 objects reach 8,388,607 entries, past the shared `MAX_VALUE_PARTS`
+   * ceiling of 4,194,304. The number is tied to that ceiling rather than chosen:
+   * when it moved, this fixture stopped being refused and the tests below went
+   * green while asserting nothing.
    */
   function sharedChain(objects: number): BlockNode {
     let node: BlockNode = leaf("deep-leaf");
@@ -165,7 +170,7 @@ describe("a subtree the engine cannot count", () => {
      * and takes the editor down at the moment the node is selected. Being able
      * to remove a block must not depend on being able to describe it.
      */
-    const doc = documentOf([sharedChain(21), leaf("after")]);
+    const doc = documentOf([sharedChain(23), leaf("after")]);
 
     const deletion = blockDeletion(doc, "d0");
 
@@ -180,7 +185,7 @@ describe("a subtree the engine cannot count", () => {
     // Zero is the same value a childless node reports, and that is deliberate:
     // the announcement says "<name> deleted" at zero and adds "with N blocks
     // inside" above it, so zero states nothing rather than stating none.
-    const doc = documentOf([sharedChain(21)]);
+    const doc = documentOf([sharedChain(23)]);
 
     expect(blockDeletion(doc, "d0")?.descendantCount).toBe(0);
   });


### PR DESCRIPTION
## Why this exists

This is the root fix for two findings on **#1677**, which merged at `20:53:30Z` while the fix was being written — so it is stranded off `main` rather than part of it. Verified by content: the one-ceiling marker is absent from `origin/main`, and `MAX_WALKABLE_ENTRIES` is still there with 5 occurrences.

**So `main` currently carries the flawed design.** That is the reason this is not deferred.

## The premise that was wrong

In #1677 I introduced `MAX_WALKABLE_ENTRIES = 1_000_000` and justified it by copying `MAX_WALKABLE_DEPTH`'s reasoning — *"well beyond `DEFAULT_LIMITS.maxDepth`, so it only ever fires on documents no product setting would have allowed."*

**That reasoning does not transfer.** `MAX_WALKABLE_DEPTH` is where the machine *actually* fails — the stack overflows "whatever any site says". Mine was a work budget I picked. And raising `maxNodes` is a supported, documented configuration, stated in five places across the packages.

So the new ceiling sat **below a value sites are told they may set**, and every symptom followed from that one inversion:

| finding | symptom | same cause |
|---|---|---|
| round 2 | composition threw mid-resolution | ceiling < configured cap |
| round 4 | composition lost budget it had already charged | ceiling < configured cap |
| round 4 | the dry run accepted what the apply refused | two ceilings, one lower |

I patched four sites before recognising the shape. That is what this replaces.

## The engine already had this ceiling

`ops.ts` declared `MAX_VALUE_PARTS = 4_194_304` for exactly this question, applied it in the forest preflight, and justified it against the **byte** cap rather than the node cap:

> every part contributes at least one byte to serialized JSON, so a value with more parts than this has more bytes than any default-configured document may hold … A site that raises `maxBytes` past this is choosing a document larger than the editor will edit.

That argument covers a forest's entries and a serializer's values as well as an op's payload. I had invented a second and a third answer to a question this codebase had already answered once.

There is now **one** ceiling, moved into `limits.ts` where the caps live and shared by the preflight, the three readers and the serializer. `MAX_WALKABLE_ENTRIES` and `MAX_SERIALIZED_VALUES` are gone.

## Why that fixes both findings rather than patching them

- **The dry run cannot disagree with the apply**, because they read the same number. Not "they are kept in step" — there is one number.
- **The refund case counts exactly.** 1,048,575 entries is under 4,194,304, so the exact refund happens; it was only over the invented 1,000,000.

The graceful fallbacks in composition and the builder's deletion stay. They are no longer covering a self-inflicted disagreement, but a subtree genuinely past the ceiling still must not throw out of toolbar construction or abort a composition midway.

## A fixture that stopped asserting anything

Raising the ceiling silently disarmed a test. The builder's shared-chain fixture was 21 objects — over the old 1,000,000, under the new 4,194,304 — so `countNodes` began succeeding and the degradation tests went green **while asserting nothing**.

It surfaced as a real failure only because one test pinned the count. Both fixtures are now sized against the constant (23 objects → 8,388,607 entries) with a comment tying the number to it, so the next move breaks them loudly instead of quietly.

## Gates

Rebuilt from cleared `dist` after branching off current `main`. Exit status read on its own line.

| gate | exit |
|---|---|
| `pnpm build` | 0 |
| `blocks-engine` ct / lint / vitest | 0 / 0 / 0 — 53 files |
| `builder` ct / lint / vitest | 0 / 0 / 0 — 106 files |
| `blocks-react` ct / lint / vitest | 0 / 0 / 0 — 48 files |
| `plugin-page-builder` ct / lint / vitest | 0 / 0 / 0 — 73 files |
| `plugin-sdk` ct / lint / vitest | 0 / 0 / 0 — 4 files |
| `fallow audit --base origin/main` | 0 — `pass`, `changed_files_count: 7`, every `*_introduced: 0` |
| `pnpm changeset status` | 0 |

The changeset from #1677 is amended rather than added to, since it has not been released — it now names the shared ceiling and the reason for the reuse.
