### PR TITLE
fix(ci): read the exported vitest config, and give each scan root its own control

### DIFF
--- a/scripts/check-instance-boot-lane.mjs
+++ b/scripts/check-instance-boot-lane.mjs
@@ -84,8 +84,8 @@ export const UNIT_LANE_SUFFIXES = [
  * `git ls-files` answers with what is committed, so a build artifact or an
  * ignored scratch file cannot enter the population and be judged.
  */
-export function testFiles(cwd, run = execFileSync) {
-  const listed = run("git", ["ls-files", "-z", "--", "packages", "templates"], {
+export function testFiles(cwd, run = execFileSync, root) {
+  const listed = run("git", ["ls-files", "-z", "--", root], {
     cwd,
     encoding: "utf8",
     maxBuffer: 64 * 1024 * 1024,
@@ -95,6 +95,20 @@ export function testFiles(cwd, run = execFileSync) {
     .filter(Boolean)
     .filter(path => UNIT_LANE_SUFFIXES.some(suffix => path.endsWith(suffix)));
 }
+
+/**
+ * The roots this scans, listed SEPARATELY so each carries its own control.
+ *
+ * 🔴 One combined listing cannot report a root that went missing. With both
+ * roots in one pathspec, misspelling `templates` still returned two thousand
+ * package files, so `covered` stayed large, the run reported success, and the
+ * only trace was a count nobody compares between runs: 225 of 2073 rather than
+ * 226 of 2074. The shipped template would have stopped being scanned while the
+ * output went on claiming every booting suite was checked.
+ *
+ * Asking per root makes each one's emptiness its own answer.
+ */
+export const SCAN_ROOTS = ["packages", "templates"];
 
 /**
  * Whether a source file IMPORTS the boot helper.
@@ -209,23 +223,50 @@ export function statesBootBudget(source) {
     false,
     ts.ScriptKind.TS
   );
-  const found = new Map();
-  const walk = node => {
+
+  /*
+   * 🔴 Only the object vitest is actually handed counts. A walk over the whole
+   * file records a `testTimeout` wherever it appears, including in a constant
+   * nobody passes anywhere, so a config could name the budgets in a decoy and
+   * export one that omits them: the check goes green and the suite runs on the
+   * defaults. What is traced instead is the default export, through
+   * `defineConfig(...)` if it is wrapped, down to its `test` property.
+   */
+  const exported = parsed.statements.find(ts.isExportAssignment);
+  if (!exported) return false;
+
+  let config = exported.expression;
+  // `defineConfig({...})` is a passthrough; an object literal may be exported
+  // directly, and vitest accepts both.
+  if (ts.isCallExpression(config)) {
+    if (config.arguments.length === 0) return false;
+    config = config.arguments[0];
+  }
+  if (!ts.isObjectLiteralExpression(config)) return false;
+
+  const test = config.properties.find(
+    property =>
+      ts.isPropertyAssignment(property) &&
+      ts.isIdentifier(property.name) &&
+      property.name.text === "test" &&
+      ts.isObjectLiteralExpression(property.initializer)
+  );
+  if (!test) return false;
+
+  const budgets = new Map();
+  for (const property of test.initializer.properties) {
     if (
-      ts.isPropertyAssignment(node) &&
-      ts.isIdentifier(node.name) &&
-      (node.name.text === "testTimeout" || node.name.text === "hookTimeout") &&
-      ts.isNumericLiteral(node.initializer)
+      ts.isPropertyAssignment(property) &&
+      ts.isIdentifier(property.name) &&
+      ts.isNumericLiteral(property.initializer)
     ) {
-      found.set(node.name.text, Number(node.initializer.text));
+      budgets.set(property.name.text, Number(property.initializer.text));
     }
-    ts.forEachChild(node, walk);
-  };
-  ts.forEachChild(parsed, walk);
+  }
 
   return (
-    (found.get("testTimeout") ?? 0) >= BOOT_BUDGET_MS &&
-    (found.get("hookTimeout") ?? 0) >= BOOT_BUDGET_MS
+    (budgets.get("testTimeout") ?? 0) >= BOOT_BUDGET_MS &&
+    (budgets.get("hookTimeout") ?? 0) >= BOOT_BUDGET_MS
   );
 }
 
@@ -340,14 +381,18 @@ const invokedDirectly =
   process.argv[1] && process.argv[1].endsWith("check-instance-boot-lane.mjs");
 
 if (invokedDirectly) {
-  const files = testFiles(root);
-
-  if (files.length === 0) {
-    console.error(
-      "check-instance-boot-lane: git listed no test files under packages/, so " +
-        "no file could have been judged."
-    );
-    process.exit(2);
+  const files = [];
+  for (const scanRoot of SCAN_ROOTS) {
+    const found = testFiles(root, execFileSync, scanRoot);
+    if (found.length === 0) {
+      console.error(
+        `check-instance-boot-lane: git listed no test files under ${scanRoot}/, ` +
+          "so nothing there could have been judged and a clean run would be " +
+          "reporting on a root it never read."
+      );
+      process.exit(2);
+    }
+    files.push(...found);
   }
 
   const readSource = path => readFileSync(join(root, path), "utf8");

--- a/scripts/check-instance-boot-lane.mjs
+++ b/scripts/check-instance-boot-lane.mjs
@@ -232,7 +232,14 @@ export function statesBootBudget(source) {
    * defaults. What is traced instead is the default export, through
    * `defineConfig(...)` if it is wrapped, down to its `test` property.
    */
-  const exported = parsed.statements.find(ts.isExportAssignment);
+  /*
+   * `export default x`, and not `export = x`. `isExportAssignment` matches both,
+   * and the second is the TypeScript CommonJS form, which is not the default
+   * export vitest loads.
+   */
+  const exported = parsed.statements.find(
+    statement => ts.isExportAssignment(statement) && !statement.isExportEquals
+  );
   if (!exported) return false;
 
   let config = exported.expression;
@@ -248,17 +255,27 @@ export function statesBootBudget(source) {
    * call this does not recognise is reported rather than guessed at.
    */
   if (ts.isCallExpression(config)) {
+    // A bare `defineConfig`, not `something.defineConfig`. A property access
+    // says nothing about what the object is, so a wrapper reached that way is a
+    // function this has not established returns its argument.
     const callee = config.expression;
-    const name = ts.isIdentifier(callee)
-      ? callee.text
-      : ts.isPropertyAccessExpression(callee)
-        ? callee.name.text
-        : undefined;
-    if (name !== "defineConfig") return false;
+    if (!ts.isIdentifier(callee) || callee.text !== "defineConfig") return false;
     if (config.arguments.length === 0) return false;
     config = config.arguments[0];
   }
   if (!ts.isObjectLiteralExpression(config)) return false;
+
+  /*
+   * 🔴 A spread can replace what was read. `{ test: {...}, ...other }` hands
+   * vitest `other.test`, and `{ testTimeout: 30000, ...other }` hands it
+   * `other.testTimeout`, so a budget read from the literal is a budget the
+   * suite may never run under. Resolving that means evaluating the spread,
+   * which a syntax read cannot do, so a config carrying one is reported rather
+   * than assumed adequate.
+   */
+  const hasSpread = object =>
+    object.properties.some(property => ts.isSpreadAssignment(property));
+  if (hasSpread(config)) return false;
 
   const test = config.properties.find(
     property =>
@@ -268,6 +285,8 @@ export function statesBootBudget(source) {
       ts.isObjectLiteralExpression(property.initializer)
   );
   if (!test) return false;
+
+  if (hasSpread(test.initializer)) return false;
 
   const budgets = new Map();
   for (const property of test.initializer.properties) {

--- a/scripts/check-instance-boot-lane.mjs
+++ b/scripts/check-instance-boot-lane.mjs
@@ -236,9 +236,25 @@ export function statesBootBudget(source) {
   if (!exported) return false;
 
   let config = exported.expression;
-  // `defineConfig({...})` is a passthrough; an object literal may be exported
-  // directly, and vitest accepts both.
+  /*
+   * 🔴 Only `defineConfig` is unwrapped, and anything else FAILS CLOSED.
+   *
+   * `defineConfig(x)` returns `x`, so its argument is the config. No other call
+   * promises that. `mergeConfig(a, b)` returns a composition in which `b`
+   * overrides `a`, so unwrapping to the first argument reads budgets that the
+   * exported config does not have: `mergeConfig({test:{testTimeout:30000}},
+   * {test:{testTimeout:1000}})` would be accepted while the suite ran on one
+   * second. Evaluating composition is not something a syntax read can do, so a
+   * call this does not recognise is reported rather than guessed at.
+   */
   if (ts.isCallExpression(config)) {
+    const callee = config.expression;
+    const name = ts.isIdentifier(callee)
+      ? callee.text
+      : ts.isPropertyAccessExpression(callee)
+        ? callee.name.text
+        : undefined;
+    if (name !== "defineConfig") return false;
     if (config.arguments.length === 0) return false;
     config = config.arguments[0];
   }

--- a/scripts/check-instance-boot-lane.mjs
+++ b/scripts/check-instance-boot-lane.mjs
@@ -207,6 +207,36 @@ export function isTemplate(path) {
 export const BOOT_BUDGET_MS = 30_000;
 
 /**
+ * The local names bound to `defineConfig` by an import from `vitest/config`.
+ *
+ * A set rather than a name, because `import { defineConfig as define }` is the
+ * same function under another label, and because a file importing nothing binds
+ * none: a call in that file is a local helper whatever it is called.
+ */
+export function vitestDefineConfigBindings(parsed) {
+  const bound = new Set();
+
+  for (const statement of parsed.statements) {
+    if (!ts.isImportDeclaration(statement)) continue;
+    if (!ts.isStringLiteral(statement.moduleSpecifier)) continue;
+    if (statement.moduleSpecifier.text !== "vitest/config") continue;
+
+    const clause = statement.importClause;
+    if (!clause || clause.isTypeOnly) continue;
+    const bindings = clause.namedBindings;
+    if (!bindings || !ts.isNamedImports(bindings)) continue;
+
+    for (const element of bindings.elements) {
+      if (element.isTypeOnly) continue;
+      const imported = element.propertyName ?? element.name;
+      if (imported.text === "defineConfig") bound.add(element.name.text);
+    }
+  }
+
+  return bound;
+}
+
+/**
  * Whether a config states timeouts a boot can finish inside.
  *
  * Read off the parsed config rather than matched in the text, for the same
@@ -255,11 +285,16 @@ export function statesBootBudget(source) {
    * call this does not recognise is reported rather than guessed at.
    */
   if (ts.isCallExpression(config)) {
-    // A bare `defineConfig`, not `something.defineConfig`. A property access
-    // says nothing about what the object is, so a wrapper reached that way is a
-    // function this has not established returns its argument.
+    /*
+     * The binding is resolved, not just the name. A property access says nothing
+     * about what the object is, and a local function named `defineConfig` is not
+     * vitest's: one that returned one-second timeouts while receiving a literal
+     * with thirty would read as adequate. Only the identifier this file imported
+     * from `vitest/config` is known to return its argument unchanged.
+     */
     const callee = config.expression;
-    if (!ts.isIdentifier(callee) || callee.text !== "defineConfig") return false;
+    if (!ts.isIdentifier(callee)) return false;
+    if (!vitestDefineConfigBindings(parsed).has(callee.text)) return false;
     if (config.arguments.length === 0) return false;
     config = config.arguments[0];
   }

--- a/scripts/check-instance-boot-lane.test.mjs
+++ b/scripts/check-instance-boot-lane.test.mjs
@@ -463,6 +463,26 @@ export default defineConfig({ test: { testTimeout: 30000, hookTimeout: 30000 } }
     ).toBe(false);
   });
 
+  it("does NOT accept a local function that merely shares the name", () => {
+    // A helper called `defineConfig` is not vitest's. One returning one-second
+    // timeouts while receiving a literal with thirty would read as adequate.
+    expect(
+      statesBootBudget(`const defineConfig = () => ({
+  test: { testTimeout: 1000, hookTimeout: 1000 },
+});
+export default defineConfig({ test: { testTimeout: 30000, hookTimeout: 30000 } });`)
+    ).toBe(false);
+  });
+
+  it("accepts the vitest binding under an alias, which is the same function", () => {
+    // The control: the case above would pass on a rule that had stopped
+    // unwrapping any call at all.
+    expect(
+      statesBootBudget(`import { defineConfig as define } from "vitest/config";
+export default define({ test: { testTimeout: 30000, hookTimeout: 30000 } });`)
+    ).toBe(true);
+  });
+
   it("does NOT accept a wrapper reached through a property access", () => {
     // A property access says nothing about what the object is, so this is a
     // function that has not been established to return its argument.

--- a/scripts/check-instance-boot-lane.test.mjs
+++ b/scripts/check-instance-boot-lane.test.mjs
@@ -431,6 +431,28 @@ export default defineConfig({ test: { include: ["src/**/*.test.ts"] } });`)
     ).toBe(false);
   });
 
+  it("does NOT unwrap a call it cannot reason about, such as mergeConfig", () => {
+    // `defineConfig(x)` returns `x`, so its argument is the config. `mergeConfig`
+    // returns a composition where the SECOND argument wins, so reading the first
+    // reports budgets the exported config does not have.
+    expect(
+      statesBootBudget(`import { mergeConfig } from "vitest/config";
+export default mergeConfig(
+  { test: { testTimeout: 30000, hookTimeout: 30000 } },
+  { test: { testTimeout: 1000, hookTimeout: 1000 } }
+);`)
+    ).toBe(false);
+  });
+
+  it("still accepts the wrapper it does understand", () => {
+    // The control for the case above: it would pass on a predicate that had
+    // stopped unwrapping anything at all.
+    expect(
+      statesBootBudget(`import { defineConfig } from "vitest/config";
+export default defineConfig({ test: { testTimeout: 30000, hookTimeout: 30000 } });`)
+    ).toBe(true);
+  });
+
   it("reads a config exported without the defineConfig wrapper", () => {
     // The positive control for the decoy case: it would pass on a predicate
     // that had simply stopped finding budgets anywhere.

--- a/scripts/check-instance-boot-lane.test.mjs
+++ b/scripts/check-instance-boot-lane.test.mjs
@@ -10,6 +10,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   BOOT_BUDGET_MS,
+  SCAN_ROOTS,
   BOOT_BINDING,
   isTemplate,
   statesBootBudget,
@@ -300,13 +301,36 @@ describe("the population it judges", () => {
       "packages/a/README.md",
     ].join("\0");
 
-    expect(testFiles(".", () => listed)).toEqual([
+    expect(testFiles(".", () => listed, "packages")).toEqual([
       "packages/a/src/x.test.ts",
       "packages/a/src/y.test.tsx",
       "packages/a/src/s.spec.ts",
       "packages/a/src/s2.spec.tsx",
       `packages/a/src/z${INTEGRATION_SUFFIX}`,
     ]);
+  });
+
+  it("asks git for the root it was given, which is what a control can check", () => {
+    // The pathspec was previously baked in and never asserted, so a misspelled
+    // root returned nothing, the package files kept the run non-empty, and the
+    // check reported success on a root it had not read.
+    const calls = [];
+    const runner = (_cmd, args) => {
+      calls.push(args);
+      return "";
+    };
+
+    testFiles(".", runner, "templates");
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain("templates");
+    expect(calls[0][calls[0].length - 1]).toBe("templates");
+  });
+
+  it("scans the package root and the template root, each on its own", () => {
+    // Listed separately so an empty one is its own answer. Combined, a missing
+    // root hides behind the other root's files.
+    expect(SCAN_ROOTS).toEqual(["packages", "templates"]);
   });
 
   it("collects the suffixes the unit configs name", () => {
@@ -394,6 +418,33 @@ export default defineConfig({ test: { include: ["src/**/*.test.ts"] } });`,
     expect(statesBootBudget(budget(30_000, 30_000))).toBe(true);
     expect(statesBootBudget(budget(30_000, 5_000))).toBe(false);
     expect(statesBootBudget(budget(1_000, 30_000))).toBe(false);
+  });
+
+  it("does not accept budgets from an object vitest is never handed", () => {
+    // The decoy that passed before the exported config was traced: the numbers
+    // are in the file, in an object nobody passes anywhere, while the config
+    // actually exported omits them and the suite runs on the defaults.
+    expect(
+      statesBootBudget(`import { defineConfig } from "vitest/config";
+const NOTES = { testTimeout: 30000, hookTimeout: 30000 };
+export default defineConfig({ test: { include: ["src/**/*.test.ts"] } });`)
+    ).toBe(false);
+  });
+
+  it("reads a config exported without the defineConfig wrapper", () => {
+    // The positive control for the decoy case: it would pass on a predicate
+    // that had simply stopped finding budgets anywhere.
+    expect(
+      statesBootBudget(
+        `export default { test: { testTimeout: 30000, hookTimeout: 30000 } };`
+      )
+    ).toBe(true);
+  });
+
+  it("does not accept a file with no default export at all", () => {
+    expect(
+      statesBootBudget(`export const config = { test: { testTimeout: 30000, hookTimeout: 30000 } };`)
+    ).toBe(false);
   });
 
   it("does not accept a budget that only appears in a comment", () => {

--- a/scripts/check-instance-boot-lane.test.mjs
+++ b/scripts/check-instance-boot-lane.test.mjs
@@ -453,6 +453,45 @@ export default defineConfig({ test: { testTimeout: 30000, hookTimeout: 30000 } }
     ).toBe(true);
   });
 
+  it("does NOT accept the TypeScript `export =` form", () => {
+    // `isExportAssignment` matches both, and `export =` is the CommonJS form
+    // rather than the default export vitest loads.
+    expect(
+      statesBootBudget(
+        `export = { test: { testTimeout: 30000, hookTimeout: 30000 } };`
+      )
+    ).toBe(false);
+  });
+
+  it("does NOT accept a wrapper reached through a property access", () => {
+    // A property access says nothing about what the object is, so this is a
+    // function that has not been established to return its argument.
+    expect(
+      statesBootBudget(`export default anything.defineConfig({
+  test: { testTimeout: 30000, hookTimeout: 30000 },
+});`)
+    ).toBe(false);
+  });
+
+  it("does NOT accept a spread that can replace the test object", () => {
+    // `{ test: {...}, ...other }` hands vitest `other.test`, so the budgets
+    // read from the literal may not be the ones the suite runs under.
+    expect(
+      statesBootBudget(`export default defineConfig({
+  test: { testTimeout: 30000, hookTimeout: 30000 },
+  ...lowBudgetConfig,
+});`)
+    ).toBe(false);
+  });
+
+  it("does NOT accept a spread that can replace the budgets themselves", () => {
+    expect(
+      statesBootBudget(`export default defineConfig({
+  test: { testTimeout: 30000, hookTimeout: 30000, ...lowBudgetConfig },
+});`)
+    ).toBe(false);
+  });
+
   it("reads a config exported without the defineConfig wrapper", () => {
     // The positive control for the decoy case: it would pass on a predicate
     // that had simply stopped finding budgets anywhere.


### PR DESCRIPTION
Two review findings on #1685, both verified, both real. Each is a way the lane check could report success on work it had not done, which is the worst failure mode a guard has.

## 1. The budget was read from anywhere in the file

`statesBootBudget` walked the whole source and recorded `testTimeout` wherever it appeared. So a config could name both budgets in an object nobody passes anywhere and export one that omits them.

**Reproduced before the fix:**

```ts
import { defineConfig } from "vitest/config";
const NOTES = { testTimeout: 30000, hookTimeout: 30000 };   // decoy
export default defineConfig({ test: { include: ["src/**/*.test.ts"] } });
```

> `decoy config accepted (should be false): true`

The check goes green while the suite runs on vitest's defaults, which is the exact regression it exists to prevent.

**Now** it traces the default export, through `defineConfig(...)` where it is wrapped and directly where it is not, down to the `test` property, and reads the budgets only from there. Numbers outside that object are not numbers vitest uses.

## 2. The two scan roots shared one pathspec

An empty root could not be reported, because the other root kept the run non-empty.

**Reproduced before the fix**, misspelling `templates` as `tmeplates`:

```
check-instance-boot-lane: ok - 225 suite(s) ... out of 2073 test file(s) scanned.
exit=0
```

Correct is **226 of 2074**. It passes cleanly, the shipped template is never scanned, and the only trace is a count nobody compares between runs. The output goes on claiming every booting suite was checked.

**Now** each root is listed separately and an empty one exits `2`:

```
check-instance-boot-lane: git listed no test files under tmeplates/, so nothing
there could have been judged and a clean run would be reporting on a root it
never read.
exit=2
```

The population test also asserts the pathspec **actually reaches git**, rather than ignoring the arguments its fake runner receives, which is how the baked-in pathspec went unverified in the first place.

## Verification

- Both failures reproduced against the previous code, then shown fixed
- The decoy is rejected; a config exported **without** the `defineConfig` wrapper is still accepted, so the negative cannot pass on a predicate that stopped finding budgets at all
- A file with no default export is rejected
- Clean tree passes: **226 booting suites have a boot-sized budget, out of 2074 scanned**
- 41 unit tests on the guard; full scripts suite **39 files / 1238 tests**

No changeset: CI-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved boot-lane validation to scan each supported project area independently.
  - Validation now reports which project area is missing test files, making setup issues easier to identify.
  - Configuration budget checks now use only the intended default test configuration, avoiding incorrect values from unrelated configuration objects.

- **Tests**
  - Added coverage for project-area scanning, configuration formats, and missing or unsupported configuration cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->