### PR TITLE
fix(admin): restore the two chart commits that did not land

### DIFF
--- a/.changeset/a-dashboard-can-draw-what-it-counts.md
+++ b/.changeset/a-dashboard-can-draw-what-it-counts.md
@@ -47,3 +47,10 @@ width for those, which forces rotation or truncation. A capped bucket set says
 so rather than presenting a partial comparison as the whole one, and a
 timeseries labels each point in UTC, the zone its buckets were computed in, so
 the axis cannot name a different day than the server did.
+
+Every collection that can answer them now generates the two cards, beside the
+count, list and table it already generated — so the charts are something an
+install has rather than something a plugin author could build. A timeline is
+withheld from a collection whose only dates the read cannot bucket, and a
+status breakdown from one with no status column, because offering a card whose
+query is then refused is a card that draws an error on every load.

--- a/packages/admin/src/components/features/widgets/archetypes/__tests__/bars.test.tsx
+++ b/packages/admin/src/components/features/widgets/archetypes/__tests__/bars.test.tsx
@@ -9,7 +9,7 @@
  * alternative and a real table.
  */
 import { render, screen, within } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import type {
   DashboardWidget,
@@ -65,6 +65,59 @@ describe("the bars archetype", () => {
     // an empty label would read as a rendering fault rather than as a group.
     draw(grouped([{ value: null, count: 4 }]));
     expect(screen.getAllByText("(none)").length).toBeGreaterThan(0);
+  });
+
+  it("tells an EMPTY value apart from a missing one", () => {
+    // Two different answers: the column holds nothing, and the column holds a
+    // blank string. `??` catches only the first, so an empty string rendered as
+    // an empty label -- a bar and a table row with no name at all.
+    draw(
+      grouped([
+        { value: null, count: 4 },
+        { value: "", count: 2 },
+      ])
+    );
+    const table = screen.getByRole("table");
+    expect(
+      within(table).getByRole("row", { name: /\(none\)/ })
+    ).toBeInTheDocument();
+    expect(
+      within(table).getByRole("row", { name: /\(empty\)/ })
+    ).toBeInTheDocument();
+  });
+
+  it("keeps a stored value that READS like a placeholder as its own row", () => {
+    // A grouped column holds arbitrary text, so a row whose value is literally
+    // "(none)" is a real group that happens to share the null bucket's wording.
+    //
+    // Keyed by that wording the two shared a React key. A single render cannot
+    // see it -- React renders duplicate-keyed siblings and only WARNS -- so the
+    // warning is the observable, and asserting the rows exist would pass either
+    // way. The defect it prevents is across re-renders, where React keeps one
+    // child per key and a count is left drawn beside a group it does not
+    // belong to.
+    const warnings: unknown[][] = [];
+    const spy = vi
+      .spyOn(console, "error")
+      .mockImplementation((...args: unknown[]) => {
+        warnings.push(args);
+      });
+    try {
+      draw(
+        grouped([
+          { value: "(none)", count: 7 },
+          { value: null, count: 3 },
+        ])
+      );
+    } finally {
+      spy.mockRestore();
+    }
+
+    const table = screen.getByRole("table");
+    expect(within(table).getAllByRole("row")).toHaveLength(3); // header + 2
+    expect(warnings.some(args => String(args[0]).includes("same key"))).toBe(
+      false
+    );
   });
 
   it("carries a text alternative naming the largest bucket", () => {

--- a/packages/admin/src/components/features/widgets/archetypes/bars.tsx
+++ b/packages/admin/src/components/features/widgets/archetypes/bars.tsx
@@ -24,14 +24,38 @@ import { barFractions } from "./chart-scale";
 import type { ArchetypeAccepts, ArchetypeBody } from "./types";
 
 /**
- * What a bucket with no value is called.
+ * What a bucket that stores no readable value is called, and how it is keyed.
  *
  * A null bucket is a real answer — "how many entries have no author" — and the
- * result carries it as a bucket in its own right rather than dropping it. It
- * needs a NAME to be drawn and to appear in the table, and an empty label would
- * read as a rendering fault.
+ * result carries it as a bucket in its own right rather than dropping it. So is
+ * an EMPTY STRING, which is a different answer: the column holds a value and
+ * that value is blank. They are named apart, because folding them together
+ * would report two groups as one.
+ *
+ * The identity is derived from the bucket rather than from what it is called.
+ * A grouped column holds arbitrary text, so a row whose stored value reads
+ * `(none)` would otherwise share both its label and its React key with the null
+ * bucket. The prefixes make that impossible: `null` and `empty` carry no
+ * payload, and every stored value is prefixed `v`, so no two distinct buckets
+ * can collide however they are spelled.
+ *
+ * Their LABELS can still coincide — no string can be reserved from a column of
+ * arbitrary text — so the placeholder rows are marked and drawn differently
+ * instead of relying on their wording to separate them.
  */
-const NO_VALUE_LABEL = "(none)";
+function bucketRow(
+  value: string | null,
+  count: number
+): { key: string; label: string; count: number; placeholder?: boolean } {
+  if (value === null) {
+    return { key: "null", label: "(none)", count, placeholder: true };
+  }
+  if (value === "") {
+    return { key: "empty", label: "(empty)", count, placeholder: true };
+  }
+
+  return { key: `v${value}`, label: value, count };
+}
 
 export const barsAccepts: ArchetypeAccepts = definition => {
   if (definition.query) return undefined;
@@ -47,10 +71,9 @@ export const barsBody: ArchetypeBody = (result, definition) => {
     };
   }
 
-  const rows = result.buckets.map(bucket => ({
-    label: bucket.value ?? NO_VALUE_LABEL,
-    count: bucket.count,
-  }));
+  const rows = result.buckets.map(bucket =>
+    bucketRow(bucket.value, bucket.count)
+  );
 
   if (rows.length === 0) {
     return {
@@ -105,13 +128,17 @@ export const barsBody: ArchetypeBody = (result, definition) => {
               {text}
             </span>
             {rows.map((row, index) => (
-              <div key={row.label} className="flex flex-col gap-0.5">
+              <div key={row.key} className="flex flex-col gap-0.5">
                 <div className="flex min-w-0 items-baseline justify-between gap-2">
                   {/* Truncated with an accessible full value: a long author
                       name must not push the count off the card, and the title
                       attribute keeps the whole string reachable on hover. */}
                   <span
-                    className="truncate text-xs text-foreground"
+                    className={
+                      row.placeholder
+                        ? "truncate text-xs italic text-muted-foreground"
+                        : "truncate text-xs text-foreground"
+                    }
                     title={row.label}
                   >
                     {row.label}

--- a/packages/admin/src/components/features/widgets/archetypes/chart-frame.tsx
+++ b/packages/admin/src/components/features/widgets/archetypes/chart-frame.tsx
@@ -29,6 +29,32 @@
 
 import { useId, type ReactNode } from "react";
 
+/**
+ * One row behind a chart: its identity, its label, and its number.
+ *
+ * `key` is kept APART from `label` because a grouped column holds arbitrary
+ * strings, so no label is safe to identify a row by. A bucket whose value is
+ * literally the placeholder text would share a React key with the null bucket,
+ * and two rows under one key is a reconciliation defect rather than a cosmetic
+ * one — React keeps one of them and the counts stop belonging to the rows they
+ * are drawn beside.
+ */
+export interface ChartRow {
+  /** Unique within one result, derived from the bucket rather than its text. */
+  key: string;
+  label: string;
+  count: number;
+  /**
+   * Whether the label STANDS IN for a value rather than being one.
+   *
+   * Rendered differently for that reason. No string can be reserved from a
+   * column of arbitrary text, so a row whose stored value happens to read
+   * "(none)" cannot be told apart from the null bucket BY ITS TEXT — the
+   * distinction has to be carried visually and structurally instead.
+   */
+  placeholder?: boolean;
+}
+
 export interface ChartFrameProps {
   /** What the chart shows, announced in place of the shapes. */
   title: string;
@@ -37,7 +63,7 @@ export interface ChartFrameProps {
   /** Heading for the label column of the table. */
   labelHeading: string;
   /** The rows behind the picture, in the order they are drawn. */
-  rows: ReadonlyArray<{ label: string; count: number }>;
+  rows: ReadonlyArray<ChartRow>;
   /** Said above the table when the series is not the whole answer. */
   note?: string;
   /**
@@ -115,12 +141,16 @@ export function ChartFrame({
             </thead>
             <tbody>
               {rows.map(row => (
-                <tr key={row.label} className="border-b border-border/50">
+                <tr key={row.key} className="border-b border-border/50">
                   {/* A row header, so a screen reader announces which row a
                       number belongs to when reading the count cell. */}
                   <th
                     scope="row"
-                    className="py-1 pr-2 text-left font-normal text-foreground"
+                    className={
+                      row.placeholder
+                        ? "py-1 pr-2 text-left font-normal italic text-muted-foreground"
+                        : "py-1 pr-2 text-left font-normal text-foreground"
+                    }
                   >
                     {row.label}
                   </th>

--- a/packages/admin/src/components/features/widgets/archetypes/timeseries.tsx
+++ b/packages/admin/src/components/features/widgets/archetypes/timeseries.tsx
@@ -75,6 +75,9 @@ export const timeseriesBody: ArchetypeBody = (result, definition) => {
   }
 
   const rows = result.points.map(point => ({
+    // The instant, not the label: two intervals can format identically at a
+    // coarse label while being different points.
+    key: point.start,
     label: pointLabel(point.start, result.interval),
     count: point.count,
   }));

--- a/packages/nextly/src/domains/widgets/__tests__/collection-widgets.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/collection-widgets.test.ts
@@ -512,3 +512,117 @@ describe("which collection a generated card is about", () => {
     ).toBeUndefined();
   });
 });
+
+describe("the cards that draw a picture", () => {
+  const charting = (patch: Partial<WidgetSource> = {}): WidgetSource =>
+    source({
+      supports: ["count", "list", "groupBy", "timeseries"],
+      fields: [
+        { name: "id", type: "string" },
+        { name: "title", type: "string" },
+        { name: "createdAt", type: "date" },
+        { name: "updatedAt", type: "date" },
+      ],
+      ...patch,
+    });
+
+  it("derives a timeline over the date the collection actually has", () => {
+    const timeline = collectionWidgets([charting()]).find(
+      w => w.archetype === "timeseries"
+    );
+    expect(timeline?.id).toBe("collection/posts-timeline");
+    expect(timeline?.query).toMatchObject({
+      op: "timeseries",
+      dateField: "createdAt",
+      interval: "day",
+      // Drafts included, so the curve agrees with the collection's own list.
+      status: "all",
+    });
+  });
+
+  it("prefers createdAt over a date the author happened to declare first", () => {
+    // "When did these arrive" is the question a timeline is asked. A declared
+    // date could be an event, an expiry or a reminder, whose curve says nothing
+    // about the collection's cadence.
+    const timeline = collectionWidgets([
+      charting({
+        fields: [
+          { name: "id", type: "string" },
+          { name: "eventOn", type: "date" },
+          { name: "createdAt", type: "date" },
+        ],
+      }),
+    ]).find(w => w.archetype === "timeseries");
+    expect(timeline?.query).toMatchObject({ dateField: "createdAt" });
+  });
+
+  it("still draws a timeline for a collection with no timestamps", () => {
+    // `timestamps: false` means no created_at column at all. The card falls
+    // back to whatever date IS declared rather than being withheld.
+    const timeline = collectionWidgets([
+      charting({
+        fields: [
+          { name: "id", type: "string" },
+          { name: "eventOn", type: "date" },
+        ],
+      }),
+    ]).find(w => w.archetype === "timeseries");
+    expect(timeline?.query).toMatchObject({ dateField: "eventOn" });
+  });
+
+  it("gives NO timeline when every date is one the read cannot bucket", () => {
+    // 🔴 A localized date is still a date, so a check reading only `type` mints
+    // a card whose query the read then refuses -- an error on every load rather
+    // than a card that was never offered. The source's own marking is asked.
+    const widgets = collectionWidgets([
+      charting({
+        fields: [
+          { name: "id", type: "string" },
+          { name: "translatedAt", type: "date", bucketable: false },
+        ],
+      }),
+    ]);
+    expect(widgets.map(w => w.archetype)).not.toContain("timeseries");
+  });
+
+  it("gives NO timeline to a source that does not answer timeseries", () => {
+    const widgets = collectionWidgets([
+      charting({ supports: ["count", "list"] }),
+    ]);
+    expect(widgets.map(w => w.archetype)).not.toContain("timeseries");
+  });
+
+  it("breaks down by status ONLY where the collection has one", () => {
+    const without = collectionWidgets([charting()]).map(w => w.archetype);
+    expect(without).not.toContain("bars");
+
+    const breakdown = collectionWidgets([
+      charting({
+        fields: [
+          { name: "id", type: "string" },
+          { name: "status", type: "string" },
+          { name: "createdAt", type: "date" },
+        ],
+      }),
+    ]).find(w => w.archetype === "bars");
+    expect(breakdown?.id).toBe("collection/posts-breakdown");
+    expect(breakdown?.query).toMatchObject({
+      op: "groupBy",
+      groupBy: "status",
+      status: "all",
+    });
+  });
+
+  it("gives NO breakdown to a source that does not answer groupBy", () => {
+    const widgets = collectionWidgets([
+      charting({
+        supports: ["count", "list"],
+        fields: [
+          { name: "id", type: "string" },
+          { name: "status", type: "string" },
+        ],
+      }),
+    ]);
+    expect(widgets.map(w => w.archetype)).not.toContain("bars");
+  });
+});

--- a/packages/nextly/src/domains/widgets/collection-widgets.ts
+++ b/packages/nextly/src/domains/widgets/collection-widgets.ts
@@ -63,7 +63,7 @@ const TABLE_ROWS = 5;
  */
 function widgetId(
   source: WidgetSource,
-  kind: "count" | "recent" | "table" | "stats"
+  kind: "count" | "recent" | "table" | "stats" | "timeline" | "breakdown"
 ): string | undefined {
   // 🔴 An underscore is legal in a collection slug (`SLUG_PATTERN` permits it)
   // and illegal in a widget id, so `customer_notes` produced an id the registry
@@ -346,6 +346,97 @@ function tableWidget(source: WidgetSource): WidgetDefinition | undefined {
 }
 
 /**
+ * The date a timeline buckets by, or `undefined` when the collection has none.
+ *
+ * ASKED of the source's own fields rather than assumed. A collection declaring
+ * `timestamps: false` has no `created_at` column at all, and a localized date
+ * keeps its values in the companion table — so naming a field here would mint a
+ * card whose query the read path then refuses, which is a card that draws an
+ * error on every load rather than a card that was never offered.
+ *
+ * `bucketable === false` is the source's own marking, decided by the same rule
+ * the read consults. Reading the coarse `type` instead would approve a
+ * localized date, because a localized date is still a date.
+ *
+ * `createdAt` is PREFERRED where it is bucketable, because "when did these
+ * arrive" is the question a timeline on a content collection is asked, and a
+ * user-declared date could be anything — an event date, an expiry, a
+ * reminder — whose curve says nothing about the collection's cadence. It is a
+ * preference and not a requirement: a collection without timestamps still gets
+ * a timeline over whatever date it does declare.
+ */
+function bucketableDate(source: WidgetSource): string | undefined {
+  const dates = source.fields.filter(
+    field => field.type === "date" && field.bucketable !== false
+  );
+  const preferred = dates.find(field => field.name === "createdAt");
+  return (preferred ?? dates[0])?.name;
+}
+
+/**
+ * The timeline card for a source: how many entries arrived per day.
+ *
+ * `status: "all"` for the reason the count card states: a curve that silently
+ * excluded drafts would disagree with the collection's own list, and nothing on
+ * the card would say which question it answered.
+ */
+function timelineWidget(source: WidgetSource): WidgetDefinition | undefined {
+  if (!source.supports.includes("timeseries")) return undefined;
+  const dateField = bucketableDate(source);
+  if (dateField === undefined) return undefined;
+  const id = widgetId(source, "timeline");
+  if (id === undefined) return undefined;
+  return {
+    id,
+    title: `${source.label} over time`,
+    description: `How many ${source.label} entries there are per day`,
+    archetype: "timeseries",
+    defaultSize: "md",
+    query: {
+      source: source.id,
+      op: "timeseries",
+      status: "all",
+      dateField,
+      interval: "day",
+    },
+  };
+}
+
+/**
+ * The breakdown card for a source: how the entries divide by status.
+ *
+ * Only for a collection that HAS a status column. Grouping by a column the
+ * table does not carry is refused by the read, so offering the card would be
+ * offering a card that cannot draw — and `status` is present on the source
+ * exactly when the collection enabled the lifecycle that creates it.
+ *
+ * Status rather than an arbitrary field: it is the one column every
+ * status-enabled collection shares, so the card means the same thing on each,
+ * and its buckets are few enough to compare at a glance. A breakdown over a
+ * free-text column would be a different card with a different bound.
+ */
+function breakdownWidget(source: WidgetSource): WidgetDefinition | undefined {
+  if (!source.supports.includes("groupBy")) return undefined;
+  const status = source.fields.find(field => field.name === "status");
+  if (status === undefined || status.bucketable === false) return undefined;
+  const id = widgetId(source, "breakdown");
+  if (id === undefined) return undefined;
+  return {
+    id,
+    title: `${source.label} by status`,
+    description: `How ${source.label} entries divide between draft and published`,
+    archetype: "bars",
+    defaultSize: "md",
+    query: {
+      source: source.id,
+      op: "groupBy",
+      status: "all",
+      groupBy: "status",
+    },
+  };
+}
+
+/**
  * Every generated card the given sources support, in source order.
  *
  * Pure, so the derivation can be asserted without a container: the refresh
@@ -370,6 +461,8 @@ export function collectionWidgets(
       statsWidget(source),
       recentWidget(source),
       tableWidget(source),
+      timelineWidget(source),
+      breakdownWidget(source),
     ]) {
       if (!widget) continue;
       claimed.set(widget.id, (claimed.get(widget.id) ?? 0) + 1);


### PR DESCRIPTION
**PR #1683 merged from its opening commit, so two of its three commits never
reached `main`.** This restores them. Nothing here is new work; it is the
content that was already reviewed and gated, re-applied on top of current
`main`.

Confirmed by content rather than by the merge's own report, with a control:

| marker | branch head | `main` |
|---|---|---|
| `barsBody` (control — must be found) | present | **present** |
| `function timelineWidget(` | present | **absent** |
| `function breakdownWidget(` | present | **absent** |
| `function bucketRow(` | present | **absent** |
| `NO_VALUE_LABEL` (the pre-fix code) | gone | **still there** |

The control matters: `git grep` exits 1 both for "no match" and for "the
pathspec matched no files", so an absent marker proves nothing until the search
is shown to find something in that file.

## What was missing from `main`

**The charts were unreachable.** The `bars` and `timeseries` archetypes landed,
and nothing declared either — so a plugin author could use them and no install
drew a chart. That is the same shape as a supported read path with nothing
offering it. Every collection now generates a timeline and a status breakdown
beside the count, list and table it already generated, each withheld where the
read would refuse it: a timeline needs a date the read can bucket, a breakdown
needs the status column the lifecycle creates.

**A P2 review finding was live.** `??` catches only a null value, so a bucket
whose column holds an empty string drew a bar and a table row with no name at
all. And the React key came from the drawn label, so a bucket whose stored
value reads `(none)` shared a key with the null bucket — React keeps one child
per key, so across a refetch a count is left drawn beside a group it does not
belong to. Identity is now derived from the bucket rather than from its text.

## Re-verified against current `main`, not assumed

`main` has moved since — #1686 rewrote `sources.ts` and the
`group-key-declaration` module these cards read. Both commits cherry-picked
without conflict, and the guard was re-broken to confirm it still
discriminates on the new base: removing the `bucketable` check fails exactly
`gives NO timeline when every date is one the read cannot bucket`, and nothing
else.

## Gates

`check-types` 0 · lint clean · nextly 11,758 across 924 files · admin 4,161 ·
fallow `pass`, 0 introduced · changeset verified with `changeset status`.