### PR TITLE
fix(admin): a card gated on a capability, and a placeholder that says so

### DIFF
--- a/.changeset/a-card-does-not-claim-a-meaning-it-lacks.md
+++ b/.changeset/a-card-does-not-claim-a-meaning-it-lacks.md
@@ -1,0 +1,44 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A dashboard card asserted a meaning its own data did not have. The status
+breakdown was generated for any collection carrying a field NAMED `status`, and
+the schema permits an ordinary field of that name with the publishing lifecycle
+switched off — so such a collection got a card titled "by status", describing
+the split "between draft and published", over a column holding whatever that
+author's field holds. It is now gated on the lifecycle capability itself, which
+is what the health card beside it already read.
+
+A chart's placeholder rows were told apart by styling alone. A bucket holding no
+value and one holding the literal text `(empty)` were drawn in different colours
+and announced identically, so the readers who most needed the distinction were
+the ones without it. A placeholder now says what it is — "no value stored" —
+rather than relying on italics. Exact separation is not achievable, because no
+string can be reserved from a column of arbitrary text; what is fixed is that
+the placeholder describes itself instead of depending on something a screen
+reader never sees.

--- a/packages/admin/src/components/features/widgets/archetypes/__tests__/bars.test.tsx
+++ b/packages/admin/src/components/features/widgets/archetypes/__tests__/bars.test.tsx
@@ -67,7 +67,7 @@ describe("the bars archetype", () => {
     expect(screen.getAllByText("(none)").length).toBeGreaterThan(0);
   });
 
-  it("tells an EMPTY value apart from a missing one", () => {
+  it("tells an EMPTY value apart from a missing one, in BOTH mediums", () => {
     // Two different answers: the column holds nothing, and the column holds a
     // blank string. `??` catches only the first, so an empty string rendered as
     // an empty label -- a bar and a table row with no name at all.
@@ -78,12 +78,40 @@ describe("the bars archetype", () => {
       ])
     );
     const table = screen.getByRole("table");
+    // Addressed by ACCESSIBLE NAME, which is what a screen reader announces.
+    // Asserting the drawn text would pass while both rows spoke the same words.
     expect(
-      within(table).getByRole("row", { name: /\(none\)/ })
+      within(table).getByRole("row", { name: /no value stored/ })
     ).toBeInTheDocument();
     expect(
-      within(table).getByRole("row", { name: /\(empty\)/ })
+      within(table).getByRole("row", { name: /an empty value/ })
     ).toBeInTheDocument();
+  });
+
+  it("does not SPEAK a placeholder the same way as a value spelled like it", () => {
+    // 🔴 The distinction was carried by italic and muted colour, which a screen
+    // reader does not announce -- so an empty bucket and a stored "(empty)"
+    // were two rows with one spoken name, and the readers who most need the
+    // difference were the ones not given it.
+    //
+    // Exact separation is not achievable: no string can be reserved from a
+    // column of arbitrary text, so a value spelled like the description would
+    // still coincide. What is asserted is that the placeholder now SAYS what it
+    // is rather than relying on a colour.
+    draw(
+      grouped([
+        { value: "", count: 5 },
+        { value: "(empty)", count: 8 },
+      ])
+    );
+    const table = screen.getByRole("table");
+    const placeholder = within(table).getByRole("row", {
+      name: /an empty value/,
+    });
+    const literal = within(table).getByRole("row", { name: /\(empty\)/ });
+    expect(placeholder).not.toBe(literal);
+    expect(within(placeholder).getByText("5")).toBeInTheDocument();
+    expect(within(literal).getByText("8")).toBeInTheDocument();
   });
 
   it("keeps a stored value that READS like a placeholder as its own row", () => {

--- a/packages/admin/src/components/features/widgets/archetypes/bars.tsx
+++ b/packages/admin/src/components/features/widgets/archetypes/bars.tsx
@@ -19,7 +19,7 @@
  * @module components/features/widgets/archetypes/bars
  */
 
-import { ChartFrame } from "./chart-frame";
+import { ChartFrame, type ChartRow } from "./chart-frame";
 import { barFractions } from "./chart-scale";
 import type { ArchetypeAccepts, ArchetypeBody } from "./types";
 
@@ -43,15 +43,17 @@ import type { ArchetypeAccepts, ArchetypeBody } from "./types";
  * arbitrary text — so the placeholder rows are marked and drawn differently
  * instead of relying on their wording to separate them.
  */
-function bucketRow(
-  value: string | null,
-  count: number
-): { key: string; label: string; count: number; placeholder?: boolean } {
+function bucketRow(value: string | null, count: number): ChartRow {
   if (value === null) {
-    return { key: "null", label: "(none)", count, placeholder: true };
+    return { key: "null", label: "(none)", count, announce: "no value stored" };
   }
   if (value === "") {
-    return { key: "empty", label: "(empty)", count, placeholder: true };
+    return {
+      key: "empty",
+      label: "(empty)",
+      count,
+      announce: "an empty value",
+    };
   }
 
   return { key: `v${value}`, label: value, count };
@@ -135,7 +137,7 @@ export const barsBody: ArchetypeBody = (result, definition) => {
                       attribute keeps the whole string reachable on hover. */}
                   <span
                     className={
-                      row.placeholder
+                      row.announce
                         ? "truncate text-xs italic text-muted-foreground"
                         : "truncate text-xs text-foreground"
                     }

--- a/packages/admin/src/components/features/widgets/archetypes/chart-frame.tsx
+++ b/packages/admin/src/components/features/widgets/archetypes/chart-frame.tsx
@@ -45,14 +45,22 @@ export interface ChartRow {
   label: string;
   count: number;
   /**
-   * Whether the label STANDS IN for a value rather than being one.
+   * What a placeholder row is ANNOUNCED as, when it stands in for a value.
    *
-   * Rendered differently for that reason. No string can be reserved from a
-   * column of arbitrary text, so a row whose stored value happens to read
-   * "(none)" cannot be told apart from the null bucket BY ITS TEXT — the
-   * distinction has to be carried visually and structurally instead.
+   * Present only for a row whose label names the absence of a value rather than
+   * a value. Styling alone was not enough and reads as if it were: italic and
+   * muted separate the null bucket from a stored `(none)` on screen, and a
+   * screen reader announces both as "(none)" — so the readers who most need the
+   * distinction were the ones not given it.
+   *
+   * Spoken as a description instead — "no value stored" — which is a different
+   * utterance from any label a column is likely to hold. Not a guarantee: no
+   * string can be reserved from a column of arbitrary text, so a stored value
+   * spelled exactly like this description would still coincide. That case is
+   * accepted rather than papered over; what is fixed is that the placeholder
+   * now says what it is instead of relying on a colour.
    */
-  placeholder?: boolean;
+  announce?: string;
 }
 
 export interface ChartFrameProps {
@@ -147,12 +155,22 @@ export function ChartFrame({
                   <th
                     scope="row"
                     className={
-                      row.placeholder
+                      row.announce
                         ? "py-1 pr-2 text-left font-normal italic text-muted-foreground"
                         : "py-1 pr-2 text-left font-normal text-foreground"
                     }
                   >
-                    {row.label}
+                    {row.announce ? (
+                      <>
+                        {/* The drawn text is hidden from the reader and the
+                            spoken one from the screen, so the row has ONE name
+                            in each medium rather than both read in sequence. */}
+                        <span aria-hidden="true">{row.label}</span>
+                        <span className="sr-only">{row.announce}</span>
+                      </>
+                    ) : (
+                      row.label
+                    )}
                   </th>
                   <td className="py-1 text-right tabular-nums text-foreground">
                     {row.count.toLocaleString()}

--- a/packages/nextly/src/domains/widgets/__tests__/collection-widgets.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/collection-widgets.test.ts
@@ -592,12 +592,13 @@ describe("the cards that draw a picture", () => {
     expect(widgets.map(w => w.archetype)).not.toContain("timeseries");
   });
 
-  it("breaks down by status ONLY where the collection has one", () => {
+  it("breaks down by status ONLY where the LIFECYCLE is enabled", () => {
     const without = collectionWidgets([charting()]).map(w => w.archetype);
     expect(without).not.toContain("bars");
 
     const breakdown = collectionWidgets([
       charting({
+        lifecycleStatus: true,
         fields: [
           { name: "id", type: "string" },
           { name: "status", type: "string" },
@@ -611,6 +612,28 @@ describe("the cards that draw a picture", () => {
       groupBy: "status",
       status: "all",
     });
+  });
+
+  it("gives NO breakdown for an ordinary field that happens to be called status", () => {
+    // 🔴 The schema permits a user field named `status` with the lifecycle
+    // disabled. Read by NAME, this card was generated for it and titled "by
+    // status", described as the split "between draft and published", over a
+    // column holding whatever that author's field holds -- copy asserting a
+    // meaning the data does not have.
+    //
+    // The capability is the question; the field name is a proxy for it, and the
+    // cases that motivate the check are the ones that violate the proxy.
+    const widgets = collectionWidgets([
+      charting({
+        lifecycleStatus: false,
+        fields: [
+          { name: "id", type: "string" },
+          { name: "status", type: "string" },
+          { name: "createdAt", type: "date" },
+        ],
+      }),
+    ]);
+    expect(widgets.map(w => w.archetype)).not.toContain("bars");
   });
 
   it("gives NO breakdown to a source that does not answer groupBy", () => {

--- a/packages/nextly/src/domains/widgets/collection-widgets.ts
+++ b/packages/nextly/src/domains/widgets/collection-widgets.ts
@@ -405,10 +405,23 @@ function timelineWidget(source: WidgetSource): WidgetDefinition | undefined {
 /**
  * The breakdown card for a source: how the entries divide by status.
  *
- * Only for a collection that HAS a status column. Grouping by a column the
- * table does not carry is refused by the read, so offering the card would be
- * offering a card that cannot draw — and `status` is present on the source
- * exactly when the collection enabled the lifecycle that creates it.
+ * Gated on the LIFECYCLE CAPABILITY, not on a field called `status`. The two
+ * are not the same question: a collection may declare an ordinary field of that
+ * name with the lifecycle disabled, and the schema permits it. Read by name,
+ * this card was generated for such a collection and titled "by status",
+ * described as the split "between draft and published", over a column holding
+ * whatever that author's field holds — a card whose copy asserts a meaning its
+ * own data does not have.
+ *
+ * `lifecycleStatus` is what `statsWidget` beside it already reads, so the two
+ * cards that depend on the lifecycle now agree about when it is on. They
+ * disagreed while this asked a different question, which is the drift a second
+ * implementation of one question always produces.
+ *
+ * The column is still confirmed groupable afterwards. The capability says the
+ * lifecycle is enabled; whether the read can bucket that column is a separate
+ * fact, and offering a card whose query is then refused draws an error on every
+ * load rather than simply not being there.
  *
  * Status rather than an arbitrary field: it is the one column every
  * status-enabled collection shares, so the card means the same thing on each,
@@ -417,6 +430,7 @@ function timelineWidget(source: WidgetSource): WidgetDefinition | undefined {
  */
 function breakdownWidget(source: WidgetSource): WidgetDefinition | undefined {
   if (!source.supports.includes("groupBy")) return undefined;
+  if (source.lifecycleStatus !== true) return undefined;
   const status = source.fields.find(field => field.name === "status");
   if (status === undefined || status.bucketable === false) return undefined;
   const id = widgetId(source, "breakdown");


### PR DESCRIPTION
Two P2 findings raised on #1693 after it merged, so they come as a follow-up.
Both are the same shape: a proxy standing in for the question it was meant to
answer.

## The breakdown card claimed a meaning its data did not have

It was generated for any collection carrying a field **named** `status`. The
schema permits an ordinary user field of that name with the publishing
lifecycle disabled — so such a collection got a card titled "by status",
described as the split "between draft and published", over a column holding
whatever that author's field holds.

It now reads `lifecycleStatus`, the capability itself. That is what
`statsWidget` — directly beside it in the same file — already read, so the two
cards that depend on the lifecycle now agree about when it is on. They
disagreed for as long as this one asked a different question.

**The test had encoded the defect.** It declared a `status` field with the
lifecycle off and asserted the card appears, which is precisely the case that
must not generate one. Break-verifying the new gate is what exposed it: the
break killed nothing, and looking at why showed the fixture was asserting the
bug. Corrected, plus the missing case.

## A placeholder was distinguished by something a screen reader cannot hear

An empty bucket and a bucket holding the literal text `(empty)` were drawn in
italic-muted and plain — and announced identically. The distinction existed
only for readers who could see it, which is the wrong half.

A placeholder now carries its own spoken name describing what it is. The drawn
text is hidden from the reader and the spoken text from the screen, so the row
has **one** name in each medium rather than both read in sequence.

**What this does not claim.** Exact separation is not achievable: no string can
be reserved from a column of arbitrary text, so a stored value spelled like the
description would still coincide. That case is accepted rather than papered
over. What is fixed is that the placeholder describes itself instead of
depending on a colour.

## The status tracker, re-derived

`plans/WIDGETS-STATUS.md` still read **"Phase 3: 0 of 4, not started"** while
all four of its tasks are on `main`. It is re-derived here at
`ee01e5cef`: **21 of 35**, Phase 3 complete, and §6 row 7 retired — which was
the last row of the seven-row ordering, so every remaining task is now
phase-numbered only.

One residual is recorded rather than closed. Task 3.3 asks for the palette to
be *verified in both themes*; the colours are `--nx-*`-backed utilities with no
hardcoded value, so the tokens are right by construction, but no chart has been
looked at in dark mode. "Uses tokens" and "was checked in both themes" are
different claims and only the first has evidence.

## Gates

`check-types` 0 · lint clean · nextly 11,771 across 925 files · admin 4,162 ·
fallow `pass`, 0 introduced · changeset verified with `changeset status`.
Each fix break-verified by name: removing the lifecycle gate fails only
`gives NO breakdown for an ordinary field that happens to be called status`,
and removing the spoken name fails only the two announcement tests.