### PR TITLE
refactor(ci): assert the scaffolded budget by evaluating it, not by reading it

### DIFF
--- a/packages/create-nextly-app/src/__tests__/scaffold-plugin.test.ts
+++ b/packages/create-nextly-app/src/__tests__/scaffold-plugin.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { mkdtemp, readdir, readFile, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -25,6 +25,55 @@ const exists = (p: string): Promise<boolean> =>
     () => true,
     () => false
   );
+
+/**
+ * What a freshly scaffolded suite must budget for a case and for a hook.
+ *
+ * A scaffolded project boots a real instance: `createTestNextly` builds a DI
+ * container, registers the schema and runs auto-sync over a real SQLite
+ * database. Vitest's defaults are sized for a unit test that touches none of
+ * that, and the first `pnpm test` in a new project is the least warm moment
+ * there is, so a timeout there reads as a broken scaffold rather than as a
+ * tight budget.
+ */
+const BOOT_BUDGET_MS = 30_000;
+
+type TestBudget = { testTimeout?: number; hookTimeout?: number };
+
+/**
+ * The `test` block vitest will actually apply, from a config file on disk.
+ *
+ * 🔴 The config is EVALUATED rather than parsed. Reading the source can only
+ * ever recognise the shapes someone thought of - a wrapper, a spread, a merge,
+ * an alias, a local helper of the same name - and each shape that is missed
+ * reports an adequate budget for a suite that does not have one.
+ *
+ * A config may export the object, a function returning it, or an async function
+ * returning it; vitest calls and awaits whichever it finds. `import()` hands
+ * back the export itself and does neither, so a functional config read straight
+ * off `default` has no `test` block at all, and an adequately budgeted project
+ * would be reported as having no budget.
+ */
+async function bootBudgetOf(
+  configPath: string
+): Promise<TestBudget | undefined> {
+  const module = (await import(/* @vite-ignore */ configPath)) as {
+    default: unknown;
+  };
+
+  const exported = module.default;
+  const resolved =
+    typeof exported === "function"
+      ? await (exported as (env: { mode: string; command: string }) => unknown)(
+          {
+            mode: "test",
+            command: "serve",
+          }
+        )
+      : await exported;
+
+  return (resolved as { test?: TestBudget } | undefined)?.test;
+}
 
 describe("scaffold --template plugin (D44/D45 smoke test)", () => {
   let workdir: string;
@@ -109,17 +158,12 @@ describe("scaffold --template plugin (D44/D45 smoke test)", () => {
      * Importing asks the runtime, which resolves all of them by construction,
      * and asserts the value the suite will really run under.
      */
-    const scaffoldedConfig = (await import(
-      /* @vite-ignore */ path.join(target, "vitest.config.ts")
-    )) as {
-      default: { test?: { testTimeout?: number; hookTimeout?: number } };
-    };
-    const budget = scaffoldedConfig.default.test;
+    const budget = await bootBudgetOf(path.join(target, "vitest.config.ts"));
 
     // Both, because the boot is in a hook and the case body is not, and vitest
     // budgets the two separately.
-    expect(budget?.testTimeout).toBeGreaterThanOrEqual(30_000);
-    expect(budget?.hookTimeout).toBeGreaterThanOrEqual(30_000);
+    expect(budget?.testTimeout).toBeGreaterThanOrEqual(BOOT_BUDGET_MS);
+    expect(budget?.hookTimeout).toBeGreaterThanOrEqual(BOOT_BUDGET_MS);
     expect(await exists(path.join(target, "pnpm-workspace.yaml"))).toBe(true);
     const workspaceYaml = await readFile(
       path.join(target, "pnpm-workspace.yaml"),
@@ -142,5 +186,48 @@ describe("scaffold --template plugin (D44/D45 smoke test)", () => {
     );
     expect(devConfig).toContain('"@acme/nextly-plugin-test"');
     expect(devConfig).not.toMatch(/\{\{\s*\w+\s*\}\}/);
+  });
+});
+
+/*
+ * 🔴 The population is DISCOVERED, so a template added later is covered without
+ * anyone remembering this file. The case above proves the scaffold pipeline
+ * carries the plugin template's budget through to a real project; on its own it
+ * says nothing about `base`, `blank`, `blog`, or whatever is added next, and
+ * naming the one template that exists today is how the gap reopens.
+ *
+ * The rule is deliberately broader than "templates whose suite boots": a
+ * template ships a vitest config or it does not, and that question has one
+ * answer per directory. Deciding instead which suites boot means reading their
+ * source for a call, which is the reading this whole check exists to avoid, and
+ * a template that boots through a helper would be missed. A generous timeout
+ * costs a passing suite nothing.
+ */
+describe("every scaffold template budgets for a boot", () => {
+  it("declares both timeouts in each template that ships a vitest config", async () => {
+    const entries = await readdir(templatesRoot, { withFileTypes: true });
+
+    const configs: string[] = [];
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const config = path.join(templatesRoot, entry.name, "vitest.config.ts");
+      if (await exists(config)) configs.push(config);
+    }
+
+    // An empty population would pass every assertion below without running one,
+    // so it is refused rather than reported as a clean sweep.
+    expect(configs.length).toBeGreaterThan(0);
+
+    for (const config of configs) {
+      const budget = await bootBudgetOf(config);
+      expect(
+        budget?.testTimeout,
+        `${path.relative(templatesRoot, config)} has no testTimeout`
+      ).toBeGreaterThanOrEqual(BOOT_BUDGET_MS);
+      expect(
+        budget?.hookTimeout,
+        `${path.relative(templatesRoot, config)} has no hookTimeout`
+      ).toBeGreaterThanOrEqual(BOOT_BUDGET_MS);
+    }
   });
 });

--- a/packages/create-nextly-app/src/__tests__/scaffold-plugin.test.ts
+++ b/packages/create-nextly-app/src/__tests__/scaffold-plugin.test.ts
@@ -90,6 +90,36 @@ describe("scaffold --template plugin (D44/D45 smoke test)", () => {
     // `pnpm` field (pnpm 11 ignores that field). Without this, `pnpm install` aborts
     // on better-sqlite3 (the dev playground's native dep) with ERR_PNPM_IGNORED_BUILDS.
     expect(pkg.pnpm).toBeUndefined();
+
+    /*
+     * The scaffolded suite boots a real instance, so its budget is asserted
+     * against what vitest will actually use rather than against the text of the
+     * config.
+     *
+     * `plugin.test.ts` calls `createTestNextly` in `beforeEach`, which builds a
+     * DI container, registers the plugin's schema and runs auto-sync over a real
+     * SQLite database. Vitest's defaults are sized for a unit test that touches
+     * none of that, and this is the first command a new plugin author runs, so a
+     * timeout there reads as a broken scaffold rather than a tight budget.
+     *
+     * 🔴 The config is IMPORTED rather than parsed. Reading the source can only
+     * ever recognise the shapes someone thought of - a wrapper, a spread, a
+     * merge, an alias, a local helper of the same name - and each one that is
+     * missed reports an adequate budget for a suite that does not have one.
+     * Importing asks the runtime, which resolves all of them by construction,
+     * and asserts the value the suite will really run under.
+     */
+    const scaffoldedConfig = (await import(
+      /* @vite-ignore */ path.join(target, "vitest.config.ts")
+    )) as {
+      default: { test?: { testTimeout?: number; hookTimeout?: number } };
+    };
+    const budget = scaffoldedConfig.default.test;
+
+    // Both, because the boot is in a hook and the case body is not, and vitest
+    // budgets the two separately.
+    expect(budget?.testTimeout).toBeGreaterThanOrEqual(30_000);
+    expect(budget?.hookTimeout).toBeGreaterThanOrEqual(30_000);
     expect(await exists(path.join(target, "pnpm-workspace.yaml"))).toBe(true);
     const workspaceYaml = await readFile(
       path.join(target, "pnpm-workspace.yaml"),

--- a/packages/create-nextly-app/src/__tests__/scaffold-plugin.test.ts
+++ b/packages/create-nextly-app/src/__tests__/scaffold-plugin.test.ts
@@ -54,9 +54,9 @@ type TestBudget = { testTimeout?: number; hookTimeout?: number };
  * off `default` has no `test` block at all, and an adequately budgeted project
  * would be reported as having no budget.
  */
-async function bootBudgetOf(
+async function resolvedConfigOf(
   configPath: string
-): Promise<TestBudget | undefined> {
+): Promise<{ test?: TestBudget; plugins?: unknown[] }> {
   const module = (await import(/* @vite-ignore */ configPath)) as {
     default: unknown;
   };
@@ -72,7 +72,32 @@ async function bootBudgetOf(
         )
       : await exported;
 
-  return (resolved as { test?: TestBudget } | undefined)?.test;
+  return (resolved ?? {}) as { test?: TestBudget; plugins?: unknown[] };
+}
+
+/** The budget a config declares, or nothing. */
+async function bootBudgetOf(
+  configPath: string
+): Promise<TestBudget | undefined> {
+  return (await resolvedConfigOf(configPath)).test;
+}
+
+/**
+ * Whether a directory contains any test file at all, ignoring installed
+ * packages and dot directories.
+ */
+async function shipsTests(dir: string): Promise<boolean> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.name === "node_modules" || entry.name.startsWith(".")) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (await shipsTests(full)) return true;
+      continue;
+    }
+    if (/\.(test|spec)\.[cm]?[jt]sx?$/.test(entry.name)) return true;
+  }
+  return false;
 }
 
 describe("scaffold --template plugin (D44/D45 smoke test)", () => {
@@ -196,37 +221,69 @@ describe("scaffold --template plugin (D44/D45 smoke test)", () => {
  * says nothing about `base`, `blank`, `blog`, or whatever is added next, and
  * naming the one template that exists today is how the gap reopens.
  *
- * The rule is deliberately broader than "templates whose suite boots": a
- * template ships a vitest config or it does not, and that question has one
- * answer per directory. Deciding instead which suites boot means reading their
- * source for a call, which is the reading this whole check exists to avoid, and
- * a template that boots through a helper would be missed. A generous timeout
- * costs a passing suite nothing.
+ * The rule turns on whether a template SHIPS TESTS, not on whether it ships a
+ * config. Keying on the config leaves the worse case uncovered: a template that
+ * adds a booting suite and no `vitest.config.ts` runs on vitest's 5s default,
+ * which is the exact defect this guard exists for, and a config-keyed filter
+ * would skip that directory silently while the one good template kept the
+ * population non-empty.
+ *
+ * It is deliberately broader than "templates whose suite boots". Deciding which
+ * suites boot means reading their source for a call, and a template that boots
+ * through a helper would be missed. A generous timeout costs a passing suite
+ * nothing, and every scaffold is a real project sooner or later.
  */
 describe("every scaffold template budgets for a boot", () => {
-  it("declares both timeouts in each template that ships a vitest config", async () => {
+  it("requires a budgeted vitest config in each template that ships tests", async () => {
     const entries = await readdir(templatesRoot, { withFileTypes: true });
 
-    const configs: string[] = [];
+    const withTests: string[] = [];
     for (const entry of entries) {
       if (!entry.isDirectory()) continue;
-      const config = path.join(templatesRoot, entry.name, "vitest.config.ts");
-      if (await exists(config)) configs.push(config);
+      const dir = path.join(templatesRoot, entry.name);
+      if (await shipsTests(dir)) withTests.push(dir);
     }
 
     // An empty population would pass every assertion below without running one,
     // so it is refused rather than reported as a clean sweep.
-    expect(configs.length).toBeGreaterThan(0);
+    expect(withTests.length).toBeGreaterThan(0);
 
-    for (const config of configs) {
-      const budget = await bootBudgetOf(config);
+    for (const dir of withTests) {
+      const name = path.basename(dir);
+      const configPath = path.join(dir, "vitest.config.ts");
+
       expect(
-        budget?.testTimeout,
-        `${path.relative(templatesRoot, config)} has no testTimeout`
+        await exists(configPath),
+        `templates/${name} ships tests but no vitest.config.ts, so its suite ` +
+          "runs on vitest's defaults"
+      ).toBe(true);
+
+      const config = await resolvedConfigOf(configPath);
+
+      /*
+       * ⚠️ The precondition that makes the budget above authoritative. A Vite
+       * plugin's `config` hook can contribute or override `test.testTimeout`,
+       * and vitest merges that before running, so with a plugin present the
+       * declared literal is no longer what the suite runs under. Resolving that
+       * properly means vitest's own config loader, and `vite` is not resolvable
+       * anywhere under this workspace's pnpm isolation. So the assertion states
+       * its precondition instead of hoping for it: no plugins, therefore no
+       * hook, therefore the declaration IS the resolved value. A template that
+       * genuinely needs one has to revisit this.
+       */
+      expect(
+        config.plugins ?? [],
+        `templates/${name} declares vitest plugins, and a plugin's config hook ` +
+          "can change the timeouts this asserts"
+      ).toHaveLength(0);
+
+      expect(
+        config.test?.testTimeout,
+        `templates/${name} has no testTimeout`
       ).toBeGreaterThanOrEqual(BOOT_BUDGET_MS);
       expect(
-        budget?.hookTimeout,
-        `${path.relative(templatesRoot, config)} has no hookTimeout`
+        config.test?.hookTimeout,
+        `templates/${name} has no hookTimeout`
       ).toBeGreaterThanOrEqual(BOOT_BUDGET_MS);
     }
   });

--- a/scripts/check-instance-boot-lane.mjs
+++ b/scripts/check-instance-boot-lane.mjs
@@ -99,16 +99,20 @@ export function testFiles(cwd, run = execFileSync, root) {
 /**
  * The roots this scans, listed SEPARATELY so each carries its own control.
  *
- * 🔴 One combined listing cannot report a root that went missing. With both
- * roots in one pathspec, misspelling `templates` still returned two thousand
- * package files, so `covered` stayed large, the run reported success, and the
- * only trace was a count nobody compares between runs: 225 of 2073 rather than
- * 226 of 2074. The shipped template would have stopped being scanned while the
- * output went on claiming every booting suite was checked.
+ * 🔴 Asked per root so an empty one is its own answer. A combined listing
+ * cannot report a root that went missing: the other root's files keep the
+ * population large, the run reports success, and the only trace is a count
+ * nobody compares between runs.
  *
- * Asking per root makes each one's emptiness its own answer.
+ * ⚠️ Scaffolded templates are deliberately NOT a root here. A template is a
+ * single-lane project whose budget is a runtime value, and reading that value
+ * out of the source is a syntax scan over arbitrary JavaScript: it can only
+ * recognise the shapes someone thought of, and each one missed reports an
+ * adequate budget for a suite that has none. `scaffold-plugin.test.ts` imports
+ * the scaffolded config instead and asserts what vitest will actually use,
+ * which resolves wrappers, merges and spreads by construction.
  */
-export const SCAN_ROOTS = ["packages", "templates"];
+export const SCAN_ROOTS = ["packages"];
 
 /**
  * Whether a source file IMPORTS the boot helper.
@@ -188,158 +192,6 @@ export function importsBootHelper(source, fileName = "test.ts") {
   return false;
 }
 
-/**
- * Whether a path is a scaffolded project rather than one of this repo's packages.
- *
- * The two are judged by different rules because they are different shapes. A
- * package here sits in a monorepo with two lanes and a build running beside it,
- * so a boot is routed to the lane sized for one. A template is a single-package
- * project a user receives with one vitest config, one test script and nothing
- * to contend with, so there is no second lane to route to and inventing one
- * would put monorepo machinery in someone's new plugin. What it can do is state
- * a budget, which is the thing the routing was buying.
- */
-export function isTemplate(path) {
-  return path.startsWith("templates/");
-}
-
-/** The vitest budget a boot needs, whichever mechanism supplies it. */
-export const BOOT_BUDGET_MS = 30_000;
-
-/**
- * The local names bound to `defineConfig` by an import from `vitest/config`.
- *
- * A set rather than a name, because `import { defineConfig as define }` is the
- * same function under another label, and because a file importing nothing binds
- * none: a call in that file is a local helper whatever it is called.
- */
-export function vitestDefineConfigBindings(parsed) {
-  const bound = new Set();
-
-  for (const statement of parsed.statements) {
-    if (!ts.isImportDeclaration(statement)) continue;
-    if (!ts.isStringLiteral(statement.moduleSpecifier)) continue;
-    if (statement.moduleSpecifier.text !== "vitest/config") continue;
-
-    const clause = statement.importClause;
-    if (!clause || clause.isTypeOnly) continue;
-    const bindings = clause.namedBindings;
-    if (!bindings || !ts.isNamedImports(bindings)) continue;
-
-    for (const element of bindings.elements) {
-      if (element.isTypeOnly) continue;
-      const imported = element.propertyName ?? element.name;
-      if (imported.text === "defineConfig") bound.add(element.name.text);
-    }
-  }
-
-  return bound;
-}
-
-/**
- * Whether a config states timeouts a boot can finish inside.
- *
- * Read off the parsed config rather than matched in the text, for the same
- * reason the imports are: a number in a comment explaining the defaults is not
- * a number vitest will use. Both budgets are required because a boot in
- * `beforeEach` is governed by `hookTimeout` and the case body by `testTimeout`,
- * and vitest's defaults for the two differ.
- */
-export function statesBootBudget(source) {
-  const parsed = ts.createSourceFile(
-    "vitest.config.ts",
-    source,
-    ts.ScriptTarget.Latest,
-    false,
-    ts.ScriptKind.TS
-  );
-
-  /*
-   * 🔴 Only the object vitest is actually handed counts. A walk over the whole
-   * file records a `testTimeout` wherever it appears, including in a constant
-   * nobody passes anywhere, so a config could name the budgets in a decoy and
-   * export one that omits them: the check goes green and the suite runs on the
-   * defaults. What is traced instead is the default export, through
-   * `defineConfig(...)` if it is wrapped, down to its `test` property.
-   */
-  /*
-   * `export default x`, and not `export = x`. `isExportAssignment` matches both,
-   * and the second is the TypeScript CommonJS form, which is not the default
-   * export vitest loads.
-   */
-  const exported = parsed.statements.find(
-    statement => ts.isExportAssignment(statement) && !statement.isExportEquals
-  );
-  if (!exported) return false;
-
-  let config = exported.expression;
-  /*
-   * 🔴 Only `defineConfig` is unwrapped, and anything else FAILS CLOSED.
-   *
-   * `defineConfig(x)` returns `x`, so its argument is the config. No other call
-   * promises that. `mergeConfig(a, b)` returns a composition in which `b`
-   * overrides `a`, so unwrapping to the first argument reads budgets that the
-   * exported config does not have: `mergeConfig({test:{testTimeout:30000}},
-   * {test:{testTimeout:1000}})` would be accepted while the suite ran on one
-   * second. Evaluating composition is not something a syntax read can do, so a
-   * call this does not recognise is reported rather than guessed at.
-   */
-  if (ts.isCallExpression(config)) {
-    /*
-     * The binding is resolved, not just the name. A property access says nothing
-     * about what the object is, and a local function named `defineConfig` is not
-     * vitest's: one that returned one-second timeouts while receiving a literal
-     * with thirty would read as adequate. Only the identifier this file imported
-     * from `vitest/config` is known to return its argument unchanged.
-     */
-    const callee = config.expression;
-    if (!ts.isIdentifier(callee)) return false;
-    if (!vitestDefineConfigBindings(parsed).has(callee.text)) return false;
-    if (config.arguments.length === 0) return false;
-    config = config.arguments[0];
-  }
-  if (!ts.isObjectLiteralExpression(config)) return false;
-
-  /*
-   * 🔴 A spread can replace what was read. `{ test: {...}, ...other }` hands
-   * vitest `other.test`, and `{ testTimeout: 30000, ...other }` hands it
-   * `other.testTimeout`, so a budget read from the literal is a budget the
-   * suite may never run under. Resolving that means evaluating the spread,
-   * which a syntax read cannot do, so a config carrying one is reported rather
-   * than assumed adequate.
-   */
-  const hasSpread = object =>
-    object.properties.some(property => ts.isSpreadAssignment(property));
-  if (hasSpread(config)) return false;
-
-  const test = config.properties.find(
-    property =>
-      ts.isPropertyAssignment(property) &&
-      ts.isIdentifier(property.name) &&
-      property.name.text === "test" &&
-      ts.isObjectLiteralExpression(property.initializer)
-  );
-  if (!test) return false;
-
-  if (hasSpread(test.initializer)) return false;
-
-  const budgets = new Map();
-  for (const property of test.initializer.properties) {
-    if (
-      ts.isPropertyAssignment(property) &&
-      ts.isIdentifier(property.name) &&
-      ts.isNumericLiteral(property.initializer)
-    ) {
-      budgets.set(property.name.text, Number(property.initializer.text));
-    }
-  }
-
-  return (
-    (budgets.get("testTimeout") ?? 0) >= BOOT_BUDGET_MS &&
-    (budgets.get("hookTimeout") ?? 0) >= BOOT_BUDGET_MS
-  );
-}
-
 /** The package directory a file belongs to, as `packages/<name>`. */
 /**
  * The name this file needs in order to be collected by the integration lane.
@@ -384,7 +236,6 @@ export function hasIntegrationLane(packageDir, readManifest) {
 export function classify(files, readSource) {
   const misrouted = [];
   const stranded = [];
-  const underBudget = [];
   const covered = [];
 
   for (const path of files) {
@@ -395,33 +246,6 @@ export function classify(files, readSource) {
       continue; // a file git lists and the disk cannot read is the linter's business
     }
     if (!importsBootHelper(source, path)) continue;
-
-    /*
-     * A template boots in the one lane it has, so the question is whether that
-     * lane states a budget a boot can finish inside. Demanding the integration
-     * suffix here would demand a second config and a second script in a project
-     * that ships with one test.
-     */
-    if (isTemplate(path)) {
-      const configPath = `${packageOf(path)}/vitest.config.ts`;
-      let config;
-      try {
-        config = readSource(configPath);
-      } catch {
-        underBudget.push({ path, configPath, reason: "has no vitest config" });
-        continue;
-      }
-      if (!statesBootBudget(config)) {
-        underBudget.push({
-          path,
-          configPath,
-          reason: `does not set testTimeout and hookTimeout to at least ${BOOT_BUDGET_MS}ms`,
-        });
-        continue;
-      }
-      covered.push(path);
-      continue;
-    }
 
     if (!path.endsWith(INTEGRATION_SUFFIX)) {
       misrouted.push(path);
@@ -444,7 +268,7 @@ export function classify(files, readSource) {
     covered.push(path);
   }
 
-  return { misrouted, stranded, underBudget, covered };
+  return { misrouted, stranded, covered };
 }
 
 const invokedDirectly =
@@ -466,7 +290,7 @@ if (invokedDirectly) {
   }
 
   const readSource = path => readFileSync(join(root, path), "utf8");
-  const { misrouted, stranded, underBudget, covered } = classify(files, readSource);
+  const { misrouted, stranded, covered } = classify(files, readSource);
 
   // The control, before the verdict. Every file failing to parse, or the
   // binding being renamed upstream, produces an empty `misrouted` that reads
@@ -480,20 +304,8 @@ if (invokedDirectly) {
     process.exit(2);
   }
 
-  if (misrouted.length > 0 || stranded.length > 0 || underBudget.length > 0) {
+  if (misrouted.length > 0 || stranded.length > 0) {
     console.error("check-instance-boot-lane: FAILED\n");
-
-    for (const { path, configPath, reason } of underBudget) {
-      console.error(
-        `  ${path}\n` +
-          `    boots an instance, and ${configPath} ${reason}.\n` +
-          `    A scaffolded project has one lane and nothing to contend with, so\n` +
-          `    it states the budget rather than routing around it: set\n` +
-          `    testTimeout and hookTimeout to ${BOOT_BUDGET_MS}. A boot in\n` +
-          "    `beforeEach` is governed by hookTimeout, the case body by\n" +
-          "    testTimeout, and vitest's defaults for the two differ.\n"
-      );
-    }
 
     for (const path of stranded) {
       console.error(
@@ -531,12 +343,8 @@ if (invokedDirectly) {
 
   console.log(
     `check-instance-boot-lane: ok - ${covered.length} suite(s) that boot an ` +
-      `instance have a budget sized for one, out of ${files.length} test ` +
-      "file(s) scanned."
-  );
-  console.log(
-    "  a package suite earns it by running in the integration lane; a " +
-      "scaffolded template by stating the timeouts, having only one lane."
+      `instance are named for the integration lane AND run by a package that ` +
+      `declares one, out of ${files.length} test file(s) scanned.`
   );
   // Said on the way past, so a reader taking this as proof of routing knows the
   // shape it did not judge.

--- a/scripts/check-instance-boot-lane.test.mjs
+++ b/scripts/check-instance-boot-lane.test.mjs
@@ -9,17 +9,14 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  BOOT_BUDGET_MS,
-  SCAN_ROOTS,
   BOOT_BINDING,
-  isTemplate,
-  statesBootBudget,
-  integrationName,
   INTEGRATION_SUFFIX,
+  SCAN_ROOTS,
   UNIT_LANE_SUFFIXES,
   classify,
   hasIntegrationLane,
   importsBootHelper,
+  integrationName,
   packageOf,
   testFiles,
 } from "./check-instance-boot-lane.mjs";
@@ -327,10 +324,15 @@ describe("the population it judges", () => {
     expect(calls[0][calls[0].length - 1]).toBe("templates");
   });
 
-  it("scans the package root and the template root, each on its own", () => {
-    // Listed separately so an empty one is its own answer. Combined, a missing
-    // root hides behind the other root's files.
-    expect(SCAN_ROOTS).toEqual(["packages", "templates"]);
+  it("scans the package root, and each root on its own", () => {
+    // Listed separately so an empty one is its own answer: combined, a missing
+    // root hides behind another root's files.
+    //
+    // Templates are deliberately absent. A template's budget is a runtime value,
+    // and `scaffold-plugin.test.ts` asserts it by importing the scaffolded
+    // config, which resolves wrappers, merges and spreads by construction. This
+    // check keeps to the rule it can decide completely: the filename.
+    expect(SCAN_ROOTS).toEqual(["packages"]);
   });
 
   it("collects the suffixes the unit configs name", () => {
@@ -364,192 +366,5 @@ describe("the population it judges", () => {
 
   it("uses the binding the repository actually imports", () => {
     expect(BOOT_BINDING).toBe("createTestNextly");
-  });
-});
-
-describe("a scaffolded template, which has only one lane", () => {
-  const BOOT = `import { createTestNextly } from "@nextlyhq/plugin-sdk/testing";`;
-  const budget = (t, h) =>
-    `import { defineConfig } from "vitest/config";
-export default defineConfig({ test: { testTimeout: ${t}, hookTimeout: ${h} } });`;
-
-  it("knows a template from a package", () => {
-    expect(isTemplate("templates/plugin/src/plugin.test.ts")).toBe(true);
-    expect(isTemplate("packages/nextly/src/x.test.ts")).toBe(false);
-  });
-
-  it("accepts a booting template whose config states both budgets", () => {
-    const files = {
-      "templates/plugin/vitest.config.ts": budget(30_000, 30_000),
-      "templates/plugin/src/plugin.test.ts": BOOT,
-    };
-    const { covered, underBudget, misrouted } = classify(
-      ["templates/plugin/src/plugin.test.ts"],
-      reader(files)
-    );
-
-    expect(covered).toEqual(["templates/plugin/src/plugin.test.ts"]);
-    expect(underBudget).toEqual([]);
-    // It is NOT reported as misrouted. Demanding the integration suffix here
-    // would demand a second config and script in a project shipping one test.
-    expect(misrouted).toEqual([]);
-  });
-
-  it("reports a booting template whose config states no budget", () => {
-    // The shape that shipped: vitest's defaults are 5s for a case and 10s for a
-    // hook, and the boot runs in `beforeEach`.
-    const files = {
-      "templates/plugin/vitest.config.ts":
-        `import { defineConfig } from "vitest/config";
-export default defineConfig({ test: { include: ["src/**/*.test.ts"] } });`,
-      "templates/plugin/src/plugin.test.ts": BOOT,
-    };
-    const { underBudget, covered } = classify(
-      ["templates/plugin/src/plugin.test.ts"],
-      reader(files)
-    );
-
-    expect(underBudget).toHaveLength(1);
-    expect(underBudget[0].path).toBe("templates/plugin/src/plugin.test.ts");
-    expect(covered).toEqual([]);
-  });
-
-  it("requires BOTH budgets, because the boot and the case are governed separately", () => {
-    expect(statesBootBudget(budget(30_000, 30_000))).toBe(true);
-    expect(statesBootBudget(budget(30_000, 5_000))).toBe(false);
-    expect(statesBootBudget(budget(1_000, 30_000))).toBe(false);
-  });
-
-  it("does not accept budgets from an object vitest is never handed", () => {
-    // The decoy that passed before the exported config was traced: the numbers
-    // are in the file, in an object nobody passes anywhere, while the config
-    // actually exported omits them and the suite runs on the defaults.
-    expect(
-      statesBootBudget(`import { defineConfig } from "vitest/config";
-const NOTES = { testTimeout: 30000, hookTimeout: 30000 };
-export default defineConfig({ test: { include: ["src/**/*.test.ts"] } });`)
-    ).toBe(false);
-  });
-
-  it("does NOT unwrap a call it cannot reason about, such as mergeConfig", () => {
-    // `defineConfig(x)` returns `x`, so its argument is the config. `mergeConfig`
-    // returns a composition where the SECOND argument wins, so reading the first
-    // reports budgets the exported config does not have.
-    expect(
-      statesBootBudget(`import { mergeConfig } from "vitest/config";
-export default mergeConfig(
-  { test: { testTimeout: 30000, hookTimeout: 30000 } },
-  { test: { testTimeout: 1000, hookTimeout: 1000 } }
-);`)
-    ).toBe(false);
-  });
-
-  it("still accepts the wrapper it does understand", () => {
-    // The control for the case above: it would pass on a predicate that had
-    // stopped unwrapping anything at all.
-    expect(
-      statesBootBudget(`import { defineConfig } from "vitest/config";
-export default defineConfig({ test: { testTimeout: 30000, hookTimeout: 30000 } });`)
-    ).toBe(true);
-  });
-
-  it("does NOT accept the TypeScript `export =` form", () => {
-    // `isExportAssignment` matches both, and `export =` is the CommonJS form
-    // rather than the default export vitest loads.
-    expect(
-      statesBootBudget(
-        `export = { test: { testTimeout: 30000, hookTimeout: 30000 } };`
-      )
-    ).toBe(false);
-  });
-
-  it("does NOT accept a local function that merely shares the name", () => {
-    // A helper called `defineConfig` is not vitest's. One returning one-second
-    // timeouts while receiving a literal with thirty would read as adequate.
-    expect(
-      statesBootBudget(`const defineConfig = () => ({
-  test: { testTimeout: 1000, hookTimeout: 1000 },
-});
-export default defineConfig({ test: { testTimeout: 30000, hookTimeout: 30000 } });`)
-    ).toBe(false);
-  });
-
-  it("accepts the vitest binding under an alias, which is the same function", () => {
-    // The control: the case above would pass on a rule that had stopped
-    // unwrapping any call at all.
-    expect(
-      statesBootBudget(`import { defineConfig as define } from "vitest/config";
-export default define({ test: { testTimeout: 30000, hookTimeout: 30000 } });`)
-    ).toBe(true);
-  });
-
-  it("does NOT accept a wrapper reached through a property access", () => {
-    // A property access says nothing about what the object is, so this is a
-    // function that has not been established to return its argument.
-    expect(
-      statesBootBudget(`export default anything.defineConfig({
-  test: { testTimeout: 30000, hookTimeout: 30000 },
-});`)
-    ).toBe(false);
-  });
-
-  it("does NOT accept a spread that can replace the test object", () => {
-    // `{ test: {...}, ...other }` hands vitest `other.test`, so the budgets
-    // read from the literal may not be the ones the suite runs under.
-    expect(
-      statesBootBudget(`export default defineConfig({
-  test: { testTimeout: 30000, hookTimeout: 30000 },
-  ...lowBudgetConfig,
-});`)
-    ).toBe(false);
-  });
-
-  it("does NOT accept a spread that can replace the budgets themselves", () => {
-    expect(
-      statesBootBudget(`export default defineConfig({
-  test: { testTimeout: 30000, hookTimeout: 30000, ...lowBudgetConfig },
-});`)
-    ).toBe(false);
-  });
-
-  it("reads a config exported without the defineConfig wrapper", () => {
-    // The positive control for the decoy case: it would pass on a predicate
-    // that had simply stopped finding budgets anywhere.
-    expect(
-      statesBootBudget(
-        `export default { test: { testTimeout: 30000, hookTimeout: 30000 } };`
-      )
-    ).toBe(true);
-  });
-
-  it("does not accept a file with no default export at all", () => {
-    expect(
-      statesBootBudget(`export const config = { test: { testTimeout: 30000, hookTimeout: 30000 } };`)
-    ).toBe(false);
-  });
-
-  it("does not accept a budget that only appears in a comment", () => {
-    // Same reason the imports are parsed: a number explaining the defaults is
-    // not a number vitest will use.
-    expect(
-      statesBootBudget(`import { defineConfig } from "vitest/config";
-// testTimeout: 30000 and hookTimeout: 30000 would be needed for a boot
-export default defineConfig({ test: {} });`)
-    ).toBe(false);
-  });
-
-  it("reports a booting template with no vitest config at all", () => {
-    const files = { "templates/plugin/src/plugin.test.ts": BOOT };
-    const { underBudget } = classify(
-      ["templates/plugin/src/plugin.test.ts"],
-      reader(files)
-    );
-
-    expect(underBudget).toHaveLength(1);
-    expect(underBudget[0].reason).toContain("no vitest config");
-  });
-
-  it("uses a budget the monorepo's own integration lane agrees with", () => {
-    expect(BOOT_BUDGET_MS).toBe(30_000);
   });
 });

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -502,6 +502,29 @@
       "cache": true // Cache test results (only re-run if inputs change)
     },
 
+    // create-nextly-app#test - the one package whose tests read files OUTSIDE it.
+    //
+    // 🔴 `scaffold-plugin.test.ts` scaffolds the real repo-root `templates/`,
+    // then imports the scaffolded `vitest.config.ts` and asserts the timeout a
+    // freshly scaffolded suite will boot under. Every input above is
+    // package-relative, and `globalDependencies` covers `packages/tsconfig` and
+    // `scripts` only, so a commit that changes ONLY `templates/plugin/
+    // vitest.config.ts` leaves this task's hash untouched: CI replays a cached
+    // pass and the budget assertion never executes, in precisely the commit
+    // that changed what it asserts.
+    //
+    // A package task REPLACES the shared definition rather than merging, which
+    // is why the comment above discourages one. `$TURBO_DEFAULT$` is what makes
+    // this safe to write anyway: it takes the package's own files without
+    // copying the curated list, so there is nothing here to drift out of step
+    // with it. `dependsOn` is restated because replacement drops that too.
+    "create-nextly-app#test": {
+      "dependsOn": ["^build", "build:surface-declarations"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/templates/**"],
+      "outputs": ["coverage/**"],
+      "cache": true
+    },
+
     // test:integration - Run integration tests against real DBs (F18).
     //
     // - Runs only *.integration.test.ts files via vitest.integration.config.ts.


### PR DESCRIPTION
Follows #1689. That PR took **eleven findings across four rounds**, and every one was the same class. This removes the thing that produced them.

## Why the previous approach kept failing

`statesBootBudget` read a timeout out of a vitest config's **source**. The shapes it was patched for, one round at a time:

| Round | Shape |
|---|---|
| 1 | budgets read from anywhere in the file, including a decoy object |
| 2 | `mergeConfig(a, b)` unwrapped to `a`, ignoring an override in `b` |
| 3 | `export =`, a property-access callee, a spread before `test`, a spread inside `test` |
| 4 | a local helper merely *named* `defineConfig` |

Each fix was correct. The next shape arrived anyway, because predicting what JavaScript evaluates to is not something a syntax read can do. `AGENTS.md:302-304` says it outright:

> *"A scan over syntax has an unbounded surface and can only ever be patched; a declared dependency graph, a type, or a manifest assertion is complete by construction."*

I should have recognised that three rounds earlier instead of patching six times.

## What replaces it

The budget is a runtime value, so it is taken from the runtime.

`scaffold-plugin.test.ts` already scaffolds the real bundled template, and asserted only that **files exist** (it never ran the suite and never looked at `vitest.config`, which is why the timeout defect shipped unnoticed). It now imports the **scaffolded** `vitest.config.ts` and asserts the budget vitest will actually use.

Wrappers, merges, aliases and spreads are all resolved by evaluation, so there are no shapes left to miss. It also tests the config **a user receives** rather than the one in the repository.

## What the lane check keeps

The rule it can decide completely: **filename routing** inside `packages/`. Templates leave its scan, `statesBootBudget` and its parsers are deleted.

**58 insertions, 405 deletions.** Config-parsing surface in that file: **zero**.

## Verification

Both proven by reverting the template and watching the scaffold test fail:

- **The config that shipped** (no budget at all) → fails
- **A spread lowering the budget past a literal** → fails with `expected 1000 to be greater than or equal to 30000`

That second one is the point: a parser would have read the 30000 literal and passed. The runtime resolved the spread.

Suites: 31 on the lane check, 1228 across `scripts/`, and the scaffold test green.

No changeset: CI and test-only.

---

## Round 2: three holes the first revision left

**The task hash did not include what the test reads (P1).** `scaffold-plugin.test.ts` scaffolds the repo-root `templates/`, but every input on turbo.jsonc's shared `test` task is package-relative and `globalDependencies` covers `packages/tsconfig` and `scripts` only. Measured: with `templates/plugin/vitest.config.ts` edited, the `create-nextly-app#test` hash stayed byte-identical at `2323af33a3c3ff85`. CI would replay a cached pass in exactly the commit that changed what the test asserts, which is the same class of defect this PR exists to remove. A package-scoped task now adds `$TURBO_ROOT$/templates/**`, and the same edit moves the hash to `18bbd020e5cc4393`. `$TURBO_DEFAULT$` keeps the curated input list out of the copy, so there is nothing to drift.

**The population was one hard-coded template (P2).** The scaffolded assertion proves the pipeline carries the plugin template's budget through to a real project. It says nothing about `base`, `blank`, `blog`, or whatever is added next. Templates that ship a vitest config are now discovered from disk and each is asserted, with an empty population refused rather than reported as a clean sweep. Proven with a probe template the code was never told about: `__probe/vitest.config.ts has no testTimeout`.

**A functional config read as no config at all (P2).** Vitest accepts `defineConfig(() => ({ ... }))` and async variants and calls and awaits whichever it finds; `import()` does neither. Measured directly: `typeof default: function | default.test: undefined`. An adequately budgeted functional config would have been failed. The export is now resolved before the budget is read, which is still evaluation rather than parsing.

The reviewer's suggested remedy for the third, loading through Vite's config path, is the approach this PR already rejected: `vite` is not resolvable anywhere under pnpm's isolation, at the root or from any package, and adding a root dependency for a guard is worse than the guard. Resolving the export keeps the evaluation without the dependency.
