### PR TITLE
fix(docs): bind the route samples to their names, and tell the coverage baseline

### DIFF
--- a/docs/plugins/routes.mdx
+++ b/docs/plugins/routes.mdx
@@ -66,6 +66,12 @@ the scope's arrays are frozen, so editing them is refused:
 
 ```ts
 import { narrowScope } from "@nextlyhq/plugin-sdk";
+import type { PluginRouteContext } from "@nextlyhq/plugin-sdk";
+
+// The `ctx` your handler received, and the values it read from the request.
+declare const ctx: PluginRouteContext;
+declare const id: string;
+declare const data: Record<string, unknown>;
 
 const readOnly = narrowScope(ctx.authenticatedScope!, g => g.action === "read");
 
@@ -131,15 +137,21 @@ Two rules for the function:
   never falls back to "no permission required".
 
 ```ts
-{
+import type { PluginRouteContext } from "@nextlyhq/plugin-sdk";
+
+declare const buildSitemap: (
+  services: PluginRouteContext["services"]
+) => Promise<string>;
+
+const sitemapRoute = {
   method: "GET",
   path: "/sitemap.xml",
   public: true, // no auth — public derived data
-  handler: async (_req, ctx) => {
+  handler: async (_req: Request, ctx: PluginRouteContext) => {
     const xml = await buildSitemap(ctx.services); // use { as: "system" } inside
     return new Response(xml, { headers: { "content-type": "application/xml" } });
   },
-}
+};
 ```
 
 Pair `public: true` with `{ as: "system" }` service calls only for genuinely public,
@@ -168,7 +180,15 @@ NARROW them before a particularly sensitive call. Passing it explicitly wins ove
 ambient one:
 
 ```ts
-{ as: "user", user: ctx.user ?? undefined, authenticatedScope: ctx.authenticatedScope }
+import type { PluginRouteContext } from "@nextlyhq/plugin-sdk";
+
+declare const ctx: PluginRouteContext;
+
+const callOptions = {
+  as: "user",
+  user: ctx.user ?? undefined,
+  authenticatedScope: ctx.authenticatedScope,
+} as const;
 ```
 
 A session caller carries no scope at all, and resolves exactly as it always has —
@@ -180,6 +200,8 @@ Routes support an ordered, typed middleware chain (onion model). Each middleware
 `next()` to continue or returns a `Response` to short-circuit:
 
 ```ts
+import type { Middleware } from "@nextlyhq/plugin-sdk";
+
 const timing: Middleware = async (req, ctx, next) => {
   const res = await next();
   res.headers.set("x-handler", "reports");

--- a/packages/ui/src/styles/contrast/__tests__/alpha-utilities.test.ts
+++ b/packages/ui/src/styles/contrast/__tests__/alpha-utilities.test.ts
@@ -132,6 +132,13 @@ const ALLOWED_DECORATIVE = new Set<string>([
   "text-muted/10", // chart ring-track backing
   "border-warning-200/50", // soft border on a light tint badge (fill+text identify it)
   "border-success-900/50", // dark tonal badge border (fill+text identify it)
+  // Row separators INSIDE a data table, lighter than the header rule above them
+  // on purpose. The structural boundary — header from body — is drawn at full
+  // strength with `border-border`; these divide rows that a screen reader
+  // already separates by `<tr>` and `<th scope="row">`, and that a sighted
+  // reader separates by alignment and spacing. Losing the line loses no
+  // information, which is what makes it supplementary rather than a state cue.
+  "border-border/50",
   // Decorative accent rings: supplementary emphasis around a badge, dot, or
   // card that is already identified by its fill and text, not a focus indicator
   // (all focus rings are full-strength) nor a sole state cue.

--- a/scripts/doc-samples-baseline.json
+++ b/scripts/doc-samples-baseline.json
@@ -1,8 +1,8 @@
 {
   "coverage": {
     "pages": 49,
-    "samples": 335,
-    "compiled": 202
+    "samples": 336,
+    "compiled": 207
   },
   "samplesPerPage": {
     "docs/admin/branding.mdx": {
@@ -174,8 +174,8 @@
       "compiled": 1
     },
     "docs/plugins/routes.mdx": {
-      "samples": 6,
-      "compiled": 0
+      "samples": 7,
+      "compiled": 5
     },
     "docs/plugins/schema.mdx": {
       "samples": 3,


### PR DESCRIPTION
## `main` is red, and every open PR inherits it

Measured on **clean `origin/main` with no change of mine present**, properly installed and rebuilt:

| gate | on `main` |
|---|---|
| `pnpm check:doc-samples` | **exit 1** |
| `@nextlyhq/ui` contrast test | **exit 1** — `border-border/50 = 1.11:1 (needs 3:1)` |

Both reproduce identically on the branch that found them, so neither is caused by that work.

**Why nobody noticed.** The other open PRs show that gate green — from runs at **13:59, 15:11 and 21:44**. `main` gained **eleven commits** after those. A finished run never re-evaluates when `main` moves, so every PR looks fine while `main` is broken underneath it. Mine was simply the first run afterwards.

My first attempt at that control was worthless, and I mention it because the result looked convincing: I made a fresh worktree with no `node_modules`, so it failed on a missing `typescript`. A red that appears with **and** without the change proves nothing. Redone by switching an installed worktree to `main`.

## The docs gate

**#1692** added a `narrowScope` sample to `docs/plugins/routes.mdx` and wrote a baseline already one sample behind its own final edit. The gate refused — and refused to be rewritten:

> *these diagnostics are new. A sample a reader copies has to run, so fix the finding rather than recording it.*

**It was right to refuse.** The sample referenced `ctx`, `id` and `data` from nowhere, so a reader copying it got five errors. Binding them made the page compile — which surfaced two more fragments that had been masked while the whole page failed: a bare route object and a bare options object, neither of which parses as a statement.

All four now bind their names with `declare const` and the SDK's own exported types (`PluginRouteContext`, `Middleware`) — the idiom **six other doc pages already use**, so this follows the convention rather than inventing one. `Middleware` was simply never imported, which is also why its three parameters were implicitly `any`.

Recording the findings instead was available via `--allow-new-findings`. The script's own header calls that *"how this gate was defeated once already, from the inside"*, so I didn't.

The baseline is written by its **sanctioned flag**, not by hand, and every number moved **up**:

| | before | after |
|---|---|---|
| samples | 335 | **336** |
| compiled | 202 | **207** |
| `routes.mdx` compiled | 0 | **5** |

The findings section is untouched — the diff is 4 lines. A ratchet that only rises refuses *more* next time, not less.

## The contrast test

**#1683**'s dashboard table draws row separators with `border-border/50` — **1.11:1** against a 3:1 requirement.

Allowlisted rather than restyled, because the value is deliberate and the design is sound: the same table draws its **header rule at full strength** with `border-border`, so the structural boundary already meets contrast. Only the intra-body separators are light, and those divide rows a screen reader already separates by `<tr>` and `<th scope="row">`, and a sighted reader by alignment and spacing.

Losing that line loses no information — which is the test's own definition of decorative, and the reasoning its existing entries give (`"soft border on a light tint badge (fill+text identify it)"`). Restyling to full strength would flatten a deliberate hierarchy to satisfy a check that offers this exact escape hatch.

## Gates

| gate | exit |
|---|---|
| `pnpm check:doc-samples` | **0** (was 1 on `main`) |
| `@nextlyhq/ui` full suite | **0** — 49 files, 1164 tests (was 1 failing) |
| `ui` / `admin` check-types + lint | 0 / 0 |
| `fallow audit --base origin/main` | 0 — `pass`, 3 files, every `*_introduced: 0` |
| `pnpm changeset status` | 0 |

No changeset: documentation and a test allowlist, which the repo exempts.

## Territory

Neither area is mine. I checked first: no worktree holds the contrast test or the baseline. `nextly-wt-forms` has a commit touching `routes.mdx` on its own branch — unmerged, so it will rebaseline on merge as any docs change does. I flagged that rather than assuming it away.
