### PR TITLE
test(root): budget the repository-scanning suites for the work they do

### DIFF
--- a/packages/ui/src/styles/contrast/__tests__/alpha-utilities.test.ts
+++ b/packages/ui/src/styles/contrast/__tests__/alpha-utilities.test.ts
@@ -343,7 +343,22 @@ function worstRatio(combo: string): { ratio: number; need: number } {
   return { ratio: worst, need };
 }
 
-describe("alpha-opacity color utilities", () => {
+/*
+ * 🔴 Budgeted for a repository scan, because that is what these cases do.
+ *
+ * `scanCombos` walks every scanned package's source for colour utilities, and
+ * two cases then measure each match against both themes. On an idle machine
+ * they take 2818ms and 2695ms, against vitest's 5000ms default: more than half
+ * the budget with nothing else running. Under `pnpm turbo test`, which runs
+ * every package's suite at once, one of them crossed it and failed a push with
+ * "Test timed out in 5000ms" while passing on its own moments earlier.
+ *
+ * A timeout that only fires when the machine is busy reports a contrast defect
+ * that does not exist, and teaches the next person to re-run rather than to
+ * read it. The budget is stated on the block so a case added here inherits it,
+ * and it is sized for contention rather than for the measured time.
+ */
+describe("alpha-opacity color utilities", { timeout: 30_000 }, () => {
   const combos = scanCombos();
 
   it("finds utilities to scan (guards against a broken scan)", () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from "vitest/config";
+
+/*
+ * The lane `pnpm test:scripts` runs, and the only vitest run rooted here.
+ *
+ * 🔴 Budgeted, because these are not unit tests. `check-doc-samples` compiles
+ * every documentation sample with the TypeScript compiler, and the guards
+ * beside it walk the whole workspace. Their cost swings with how warm the
+ * compiler's caches are: measured cold on an idle machine, one case takes
+ * 1545ms and another 5479ms, against vitest's 5000ms default. Under a
+ * concurrent build the first crossed it and failed with "Test timed out in
+ * 5000ms", having passed on its own moments earlier. A budget has to cover the
+ * cold, contended run, not the warm one that is easy to measure.
+ *
+ * ⚠️ The 5479ms one passes today only because it never yields. Vitest cannot
+ * interrupt synchronous work, so its budget is met by accident, and making that
+ * case async would fail it immediately at a length it already has. Stating the
+ * budget is what removes the accident.
+ *
+ * Sized for contention rather than for the measured time. A guard that fails
+ * when the machine is busy teaches everyone to re-run rather than to read it,
+ * and the next failure that is real gets the same treatment.
+ */
+export default defineConfig({
+  test: {
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+  },
+});


### PR DESCRIPTION
## The flake

`packages/ui`'s contrast suite scans every scanned package's source for colour utilities, then measures each match against both themes. Two of its cases do that work:

| case | idle machine | busy machine | budget |
|---|---|---|---|
| `scans every package that uses these alpha utilities` | 2818ms | 5185ms | 5000ms |
| `puts no alpha on the control boundary, in any utility` | 2695ms | 6778ms | 5000ms |

`packages/ui/vitest.config.ts` states no `testTimeout`, so vitest's 5000ms default governs them. More than half the budget is spent on an idle machine with nothing else running.

Under `pnpm turbo test`, which runs every package's suite at once, that is not enough. A push failed with:

```
FAIL src/styles/contrast/__tests__/alpha-utilities.test.ts > alpha-opacity color utilities
     > puts no alpha on the control boundary, in any utility
Error: Test timed out in 5000ms.
```

The same file had passed standalone minutes earlier, and passed standalone again straight after.

## Why it matters more than a re-run

The failure names a contrast rule, so it reads as an accessibility defect. It is not one. A timeout that fires only when the machine is busy trains everyone who sees it to re-run rather than to read it, and the next time the message is real it gets the same treatment.

## The fix

The budget is stated on the `describe` block rather than on the two cases, so a case added beside them inherits it, and it is sized for contention rather than for the measured time.

Verified applied rather than assumed. Set to 1000ms, the heavy case fails and the four light ones still pass:

```
× puts no alpha on the control boundary, in any utility 3304ms
Error: Test timed out in 1000ms.
Tests  1 failed | 4 passed (5)
```

That rules out the option being silently ignored, which is the way this kind of change usually fails.

## No changeset

One test file. Nothing here ships in a published package.


---

## The same defect in the other scanning lane

`pnpm test:scripts` is the only vitest run rooted at the repository, and there was **no config for it at all**, so every guard in `scripts/` ran on bare defaults.

`check-doc-samples` compiles every documentation sample with the TypeScript compiler, and the guards beside it walk the whole workspace:

| case | cold, idle | budget |
|---|---|---|
| `would be counted as compiled while checking nothing, if it were compiled` | 1545ms | 5000ms |
| `knows what this workspace publishes and what it does not` | 5479ms | 5000ms |

Running that suite beside a build, the first one crossed it:

```
FAIL scripts/check-doc-samples.test.mjs
     > would be counted as compiled while checking nothing, if it were compiled
Error: Test timed out in 5000ms.
```

The second is the more interesting half. It is **already over the default** and passes only because it never yields, so vitest cannot interrupt it. Its budget is met by accident, and making that case async would fail it at a length it already has.

## How this one was verified

A timing-based control is worthless here: these tests get several times faster on a warm compiler cache, so the same budget passes or fails depending on what ran before it. I tried one and it gave both answers.

Deterministic instead:

```
testTimeout: 1        -> Error: Test timed out in 1ms.   (config governs the lane)
no config at all      -> 103 passed                      (nothing else was setting it)
```

Test discovery is unchanged either way, at 33 files, so the config adds a budget and nothing else.
