### PR TITLE
feat(nextly): a document lock can carry a standing request to edit

### DIFF
--- a/.changeset/somebody-is-waiting-for-this-document.md
+++ b/.changeset/somebody-is-waiting-for-this-document.md
@@ -1,0 +1,51 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A second author who opens a document somebody else is editing gets a read-only
+editor and no way to say anything about it. The only thing they can do is take
+the document over, which displaces a colleague mid-sentence — so the polite
+option was to close the tab and hope.
+
+The lock row can now carry a standing request to edit, and the holder is told
+about it on the heartbeat they were already making. It is a COURTESY and not a
+consent gate: it moves no claim, asks the holder for no answer, and cannot be
+refused. The lease expiring stays the only thing that transfers a document.
+
+The request is held on a lease of its own, the same length as a claim and
+refreshed on the same beat, because the useful fact is "somebody is waiting
+right now" rather than "somebody once asked". An editor that closed the tab
+stops refreshing it and the mark lapses, so a holder is never nudged on behalf
+of a colleague who has already gone. A claim changing hands clears it outright,
+since a request is about the claim it was made against.
+
+It rides the claim rather than travelling on a route of its own. The editor that
+is locked out is already asking for the document on every beat — that poll is
+how it learns the holder has left — so the standing "still waiting" is carried
+by a request that was going to be sent anyway, rather than doubling the traffic
+of a read-only tab. Winning the document records nothing, because a caller that
+holds a document is not waiting for one.

--- a/packages/nextly/src/api/__tests__/document-lock-route.test.ts
+++ b/packages/nextly/src/api/__tests__/document-lock-route.test.ts
@@ -57,6 +57,7 @@ const { readLock, acquireLock, renewLock, releaseLock } = await import(
 );
 
 const ref = { scopeKind: "collection", slug: "posts", entryId: "42" };
+const holder = { ownerId: "u2", ownerLabel: "Bob", expiresInSeconds: 90 };
 const post = (body: unknown, method = "POST") =>
   new Request("https://x.test/api/document-lock", {
     method,
@@ -85,7 +86,7 @@ describe("document lock route", () => {
     expect(service.acquire).toHaveBeenCalledWith(
       ref,
       { ownerId: "u1", ownerLabel: "Ada" },
-      { takeover: false }
+      { takeover: false, requestAccess: false }
     );
   });
 
@@ -95,12 +96,56 @@ describe("document lock route", () => {
     await acquireLock(post({ ...ref, takeover: true }));
     expect(service.acquire).toHaveBeenLastCalledWith(ref, expect.anything(), {
       takeover: true,
+      requestAccess: false,
     });
 
     // Anything other than the boolean is not a request to displace a colleague.
     await acquireLock(post({ ...ref, takeover: "yes" }));
     expect(service.acquire).toHaveBeenLastCalledWith(ref, expect.anything(), {
       takeover: false,
+      requestAccess: false,
+    });
+  });
+
+  it("forwards a request to edit, and never mistakes it for a takeover", async () => {
+    // The two intents share a call and are opposites: one displaces a
+    // colleague, the other leaves word and changes nothing. Read from separate
+    // keys so neither can be produced by asking for the other -- a body that
+    // asked to wait must not come out the far side as a steal.
+    service.acquire.mockResolvedValue({
+      status: "held",
+      holder,
+      waiting: true,
+    });
+
+    await acquireLock(post({ ...ref, requestAccess: true }));
+    expect(service.acquire).toHaveBeenLastCalledWith(ref, expect.anything(), {
+      takeover: false,
+      requestAccess: true,
+    });
+
+    // And the same reading rule: a truthy string is not a person asking.
+    await acquireLock(post({ ...ref, requestAccess: "yes" }));
+    expect(service.acquire).toHaveBeenLastCalledWith(ref, expect.anything(), {
+      takeover: false,
+      requestAccess: false,
+    });
+  });
+
+  it("hands the refused editor back the fact that its ask is on record", async () => {
+    // A control that silently does nothing is worse than no control: the
+    // interface can only confirm the ask if the answer carries it, and it must
+    // read the SERVER's answer rather than the click it just handled.
+    service.acquire.mockResolvedValue({
+      status: "held",
+      holder,
+      waiting: true,
+    });
+
+    const response = await acquireLock(post({ ...ref, requestAccess: true }));
+
+    expect(await response.json()).toMatchObject({
+      item: { status: "held", waiting: true },
     });
   });
 
@@ -108,7 +153,8 @@ describe("document lock route", () => {
     // Advisory: the second editor is told and not stopped.
     service.acquire.mockResolvedValue({
       status: "held",
-      holder: { ownerId: "u2", ownerLabel: "Bob", expiresInSeconds: 90 },
+      holder,
+      waiting: false,
     });
 
     const response = await acquireLock(post(ref));

--- a/packages/nextly/src/api/document-lock.ts
+++ b/packages/nextly/src/api/document-lock.ts
@@ -6,6 +6,13 @@
  * refused anywhere, so a claim left behind by a closed laptop costs a second
  * editor a dialog rather than access.
  *
+ * Claiming carries one optional extra rather than a fifth operation: a caller
+ * that is refused may say it is still waiting, which leaves a mark on the row
+ * for the holder's own heartbeat to find. It rides the claim because the
+ * locked-out editor is already sending one on every beat. It is a courtesy and
+ * not a consent gate — nothing about it moves the document, and the lease
+ * expiring stays the only thing that does.
+ *
  * The claimant is taken from the SESSION, never from the body. A caller that
  * could name its own owner id could claim a document as a colleague, and the
  * label shown to the next editor would be evidence of something that did not
@@ -243,7 +250,12 @@ export const acquireLock = withErrorHandler(async (req: Request) => {
       ownerId: auth.userId,
       ownerLabel: auth.userName ?? auth.userEmail ?? null,
     },
-    { takeover: body.takeover === true }
+    {
+      takeover: body.takeover === true,
+      // Read the same way `takeover` is, and for the same reason: anything
+      // other than the boolean is not a person asking for anything.
+      requestAccess: body.requestAccess === true,
+    }
   );
 
   // The canonical mutation envelope, so a client reads this with the same

--- a/packages/nextly/src/database/sqlite-core-tables.ts
+++ b/packages/nextly/src/database/sqlite-core-tables.ts
@@ -482,7 +482,8 @@ export function generateSqliteCoreTableStatements(): string[] {
       "claim_token" TEXT NOT NULL,
       "owner_label" TEXT,
       "acquired_at" INTEGER NOT NULL,
-      "expires_at" INTEGER NOT NULL
+      "expires_at" INTEGER NOT NULL,
+      "waiting_until" INTEGER
     )`,
     // Separate statements for the reason the ones above are: SQLite skips a
     // CREATE TABLE wholesale once the table exists, so an index folded into it

--- a/packages/nextly/src/domains/document-lock/__tests__/document-lock-repository.integration.test.ts
+++ b/packages/nextly/src/domains/document-lock/__tests__/document-lock-repository.integration.test.ts
@@ -18,6 +18,12 @@
  * no longer owns the row must change nothing, and that is a property of the
  * WHERE clause reaching a real row.
  *
+ * Fourth, that a request to edit lapses. It is held on a lease of its own in a
+ * nullable column, judged by a SQL comparison against a clock this code never
+ * reads — and a comparison that is `NULL` rather than false on one dialect
+ * would report somebody waiting on every document, forever, while every unit
+ * test passed.
+ *
  * Runs against whichever dialect the integration run configures; CI covers
  * SQLite, Postgres and MySQL.
  *
@@ -110,6 +116,27 @@ async function setRemaining(app: TestNextly, seconds: number): Promise<void> {
     await ctx.runStatement(
       sql`UPDATE ${sql.identifier(DOCUMENT_LOCK_TABLE)}
           SET ${sql.identifier("expires_at")} = ${futureExpression(dialect, seconds)}
+          WHERE ${sql.identifier("id")} = ${key}`
+    );
+  });
+}
+
+/**
+ * Push a standing request's own lease into the past.
+ *
+ * The requester going away is the case that matters and it cannot be staged any
+ * other way: it is the ABSENCE of the beat that would have refreshed this, and a
+ * test cannot wait 150 seconds for one not to arrive. Written with the same
+ * clock expression the repository stamps it with, given a negative offset, for
+ * the reason `expireClaim` gives.
+ */
+async function expireRequest(app: TestNextly): Promise<void> {
+  const dialect = app.adapter.getCapabilities().dialect;
+  const key = documentLockKey(DOC.scopeKind, DOC.slug, DOC.entryId);
+  await app.adapter.transaction(async ctx => {
+    await ctx.runStatement(
+      sql`UPDATE ${sql.identifier(DOCUMENT_LOCK_TABLE)}
+          SET ${sql.identifier("waiting_until")} = ${futureExpression(dialect, -600)}
           WHERE ${sql.identifier("id")} = ${key}`
     );
   });
@@ -332,6 +359,120 @@ describe.each(getConfiguredTestDialects())("document soft lock (%s)", d => {
     expect(await readDocumentLock(app.adapter, DOC)).toBeUndefined();
     const next = await acquireDocumentLock(app.adapter, DOC, GRACE);
     expect(next.status).toBe("acquired");
+  });
+
+  it("tells the holder somebody is waiting, once somebody asks", async () => {
+    const app = await boot(d);
+    const ada = await claim(app, ADA);
+
+    // The control, and the reason it is the first assertion: a column whose
+    // comparison came back NULL rather than false would report a waiting
+    // colleague here, on a document nobody has asked for.
+    const quiet = await renewDocumentLock(app.adapter, DOC, ada.token);
+    expect(quiet).toMatchObject({ status: "renewed", waiting: false });
+
+    // A refused poll on its own is NOT an ask. Every locked-out editor sends one
+    // every beat, so a stamp on this path would mean the holder is nudged by
+    // anybody who merely opened the document to read it.
+    await acquireDocumentLock(app.adapter, DOC, GRACE);
+    const still = await renewDocumentLock(app.adapter, DOC, ada.token);
+    expect(still).toMatchObject({ status: "renewed", waiting: false });
+
+    const asked = await acquireDocumentLock(app.adapter, DOC, GRACE, {
+      requestAccess: true,
+    });
+    // Held, still. The whole point is that asking moves nothing.
+    expect(asked).toMatchObject({ status: "held", waiting: true });
+    expect((await readDocumentLock(app.adapter, DOC))?.ownerId).toBe(
+      "user-ada"
+    );
+
+    const beat = await renewDocumentLock(app.adapter, DOC, ada.token);
+    expect(beat).toMatchObject({ status: "renewed", waiting: true });
+  });
+
+  it("stops telling the holder once the waiting editor has gone", async () => {
+    const app = await boot(d);
+    const ada = await claim(app, ADA);
+    await acquireDocumentLock(app.adapter, DOC, GRACE, { requestAccess: true });
+
+    // Grace closes the tab, so nothing refreshes the request. Without a lease of
+    // its own the mark would outlive her by as long as Ada keeps working, and
+    // Ada would be nudged indefinitely on behalf of somebody who left.
+    await expireRequest(app);
+
+    const beat = await renewDocumentLock(app.adapter, DOC, ada.token);
+    expect(beat).toMatchObject({ status: "renewed", waiting: false });
+  });
+
+  it("carries a still-waiting editor forward rather than refusing the repeat", async () => {
+    const app = await boot(d);
+    const ada = await claim(app, ADA);
+    await acquireDocumentLock(app.adapter, DOC, GRACE, { requestAccess: true });
+    await expireRequest(app);
+
+    // The same beat that would have kept it alive, arriving after it lapsed.
+    // A second ask has to be accepted for the mark to be refreshable at all --
+    // and "still waiting" is what every beat after the first one says.
+    const again = await acquireDocumentLock(app.adapter, DOC, GRACE, {
+      requestAccess: true,
+    });
+    expect(again).toMatchObject({ status: "held", waiting: true });
+
+    const beat = await renewDocumentLock(app.adapter, DOC, ada.token);
+    expect(beat).toMatchObject({ status: "renewed", waiting: true });
+  });
+
+  it("records no request against the editor that WINS the document", async () => {
+    const app = await boot(d);
+
+    // Nobody holds it, so this ask is answered by the document itself. Stamping
+    // the row on the way past would leave a fresh claim carrying a request
+    // against itself, and its holder told on the next beat that they are
+    // waiting for a document they are editing.
+    const got = await acquireDocumentLock(app.adapter, DOC, ADA, {
+      requestAccess: true,
+    });
+    expect(got.status).toBe("acquired");
+    if (got.status !== "acquired") throw new Error("unreachable");
+
+    const beat = await renewDocumentLock(app.adapter, DOC, got.claimToken);
+    expect(beat).toMatchObject({ status: "renewed", waiting: false });
+  });
+
+  it("clears a request when the document changes hands", async () => {
+    const app = await boot(d);
+    await claim(app, ADA);
+    await acquireDocumentLock(app.adapter, DOC, GRACE, { requestAccess: true });
+
+    // Grace stops waiting by taking it. A request is about the claim it was made
+    // against, so it must not survive into the next one -- otherwise the new
+    // holder is told on their first beat that somebody wants the document they
+    // just took, naming a queue that does not exist.
+    const stolen = await acquireDocumentLock(app.adapter, DOC, GRACE, {
+      takeover: true,
+    });
+    expect(stolen.status).toBe("acquired");
+    if (stolen.status !== "acquired") throw new Error("unreachable");
+
+    const beat = await renewDocumentLock(app.adapter, DOC, stolen.claimToken);
+    expect(beat).toMatchObject({ status: "renewed", waiting: false });
+  });
+
+  it("leaves no request behind on a document whose claim was swept", async () => {
+    const app = await boot(d);
+    await claim(app, ADA);
+    await acquireDocumentLock(app.adapter, DOC, GRACE, { requestAccess: true });
+    await expireClaim(app);
+    await sweepExpiredDocumentLocks(app.adapter);
+
+    // The row is gone, so the request went with it. Grace now takes the document
+    // outright, and her own beat must not report her as somebody waiting for it.
+    const got = await acquireDocumentLock(app.adapter, DOC, GRACE);
+    expect(got.status).toBe("acquired");
+    if (got.status !== "acquired") throw new Error("unreachable");
+    const beat = await renewDocumentLock(app.adapter, DOC, got.claimToken);
+    expect(beat).toMatchObject({ status: "renewed", waiting: false });
   });
 
   it("gives the document to exactly one of two simultaneous first claims", async () => {

--- a/packages/nextly/src/domains/document-lock/document-lock-repository.ts
+++ b/packages/nextly/src/domains/document-lock/document-lock-repository.ts
@@ -30,6 +30,17 @@
  * forever would mean a closed laptop locking a document until its lease runs
  * out with no way to ask for it back.
  *
+ * ## A request to edit is a lease too
+ *
+ * A second author locked out of a document may say they are waiting, and the
+ * holder is told so on their next heartbeat. It is a COURTESY and not a consent
+ * gate: it moves nothing, answers nothing and cannot be refused, and the lease
+ * expiring stays the only thing that transfers the document. It is held on a
+ * lease of its own for the same reason the claim is — so that "somebody is
+ * waiting" is a fact about right now rather than about the past, and a
+ * requester who closed the tab stops nudging a holder they are no longer
+ * waiting on.
+ *
  * ## No flush on takeover
  *
  * Taking a claim over does not move the ousted author's unsaved work anywhere.
@@ -86,6 +97,10 @@ export interface DocumentLockClaimant {
  * before its holder asks again", which is what a claimant needs before it starts
  * editing: a claim shorter than that is live now and gone before anything
  * re-checks it.
+ *
+ * `waiting` is the third time question, asked of the request rather than of the
+ * claim, and decided in the same statement on the same clock so it cannot
+ * disagree with them about what time it is.
  */
 interface LockRow {
   readonly ownerId: string;
@@ -94,6 +109,7 @@ interface LockRow {
   readonly expiresInSeconds: number;
   readonly live: boolean;
   readonly usable: boolean;
+  readonly waiting: boolean;
 }
 
 interface RawLockRow {
@@ -103,6 +119,7 @@ interface RawLockRow {
   readonly expires_in: unknown;
   readonly live: unknown;
   readonly usable: unknown;
+  readonly waiting: unknown;
 }
 
 /**
@@ -127,7 +144,9 @@ function lockRowQuery(dialect: SupportedDialect, key: string): SQL {
       CASE WHEN ${sql.identifier("expires_at")} > ${nowExpression(dialect)}
            THEN 1 ELSE 0 END AS ${sql.identifier("live")},
       CASE WHEN ${sql.identifier("expires_at")} > ${futureExpression(dialect, DOCUMENT_LOCK_RENEW_MARGIN_SECONDS)}
-           THEN 1 ELSE 0 END AS ${sql.identifier("usable")}
+           THEN 1 ELSE 0 END AS ${sql.identifier("usable")},
+      CASE WHEN ${sql.identifier("waiting_until")} > ${nowExpression(dialect)}
+           THEN 1 ELSE 0 END AS ${sql.identifier("waiting")}
       FROM ${sql.identifier(DOCUMENT_LOCK_TABLE)}
       WHERE ${sql.identifier("id")} = ${key}`;
 }
@@ -145,6 +164,10 @@ function toLockRow(row: RawLockRow | undefined): LockRow | undefined {
     expiresInSeconds: Math.trunc(Number(row.expires_in)),
     live: Number(row.live) === 1,
     usable: Number(row.usable) === 1,
+    // A NULL column takes the CASE's ELSE branch on every dialect, so "nobody
+    // has asked" and "the ask has lapsed" arrive here as the same 0 — which is
+    // right, because neither is somebody waiting.
+    waiting: Number(row.waiting) === 1,
   };
 }
 
@@ -265,7 +288,15 @@ function isTakeable(
   );
 }
 
-/** Replace whatever claim the row carries with this one. */
+/**
+ * Replace whatever claim the row carries with this one.
+ *
+ * Clears any standing request, because a request is about the claim it was made
+ * against and this is a different claim. Nothing is lost by that: an editor
+ * still waiting re-states it on its next beat, and a holder who reopens their
+ * own document in a second tab does not inherit a nudge aimed at the claim they
+ * just replaced.
+ */
 function writeClaim(
   dialect: SupportedDialect,
   key: string,
@@ -277,8 +308,58 @@ function writeClaim(
           ${sql.identifier("claim_token")} = ${claimToken},
           ${sql.identifier("owner_label")} = ${claimant.ownerLabel ?? null},
           ${sql.identifier("acquired_at")} = ${nowExpression(dialect)},
-          ${sql.identifier("expires_at")} = ${futureExpression(dialect, DOCUMENT_LOCK_TTL_SECONDS)}
+          ${sql.identifier("expires_at")} = ${futureExpression(dialect, DOCUMENT_LOCK_TTL_SECONDS)},
+          ${sql.identifier("waiting_until")} = NULL
       WHERE ${sql.identifier("id")} = ${key}`;
+}
+
+/**
+ * Record that somebody is waiting for this document, on a lease of its own.
+ *
+ * Written as a FUTURE instant rather than as "when they asked", so the question
+ * the holder's heartbeat asks has the same shape as the one a claim answers: is
+ * this still true right now. The locked-out editor re-states it on every beat of
+ * its own, so a requester who closed the tab stops refreshing it and the mark
+ * lapses instead of nudging the holder forever on behalf of somebody who left.
+ *
+ * The SAME TTL as a claim, deliberately, and not a number chosen here. Both
+ * answer "has this party confirmed itself recently" and both are refreshed on
+ * the same beat, so two figures picked side by side for one question would only
+ * drift apart the first time either was tuned.
+ *
+ * Unconditional beyond the key: a request that is already on record is pushed
+ * forward rather than refused, which is what "still waiting" means. It does not
+ * restart a queue or displace an earlier asker, because there is no queue —
+ * nothing here decides who gets the document next.
+ */
+function markWaiting(dialect: SupportedDialect, key: string): SQL {
+  return sql`UPDATE ${sql.identifier(DOCUMENT_LOCK_TABLE)}
+      SET ${sql.identifier("waiting_until")} = ${futureExpression(dialect, DOCUMENT_LOCK_TTL_SECONDS)}
+      WHERE ${sql.identifier("id")} = ${key}`;
+}
+
+/**
+ * Report that somebody else has the document — and, when this caller asked,
+ * leave the fact that they are waiting on the row first.
+ *
+ * The stamp is not read back, unlike the claim above it. That read-back exists
+ * because a claim's outcome is a statement about WHO WON, which only the row can
+ * settle. This UPDATE matches on `id` alone, on a row this transaction has
+ * already locked and read, so it has no condition that can fail to match and no
+ * other writer that can intervene.
+ */
+async function refuse(
+  ctx: Pick<TransactionContext, "runStatement">,
+  dialect: SupportedDialect,
+  key: string,
+  row: LockRow,
+  requestAccess: boolean
+): Promise<AcquireDocumentLockOutcome> {
+  if (!requestAccess) {
+    return { status: "held", holder: toHolder(row), waiting: row.waiting };
+  }
+  await ctx.runStatement(markWaiting(dialect, key));
+  return { status: "held", holder: toHolder(row), waiting: true };
 }
 
 /**
@@ -293,16 +374,33 @@ function writeClaim(
  * that no caller can take a document over by accident: an editor opening a
  * document and a person pressing "take over anyway" are different intents and
  * the server can tell them apart.
+ *
+ * `requestAccess` is the opposite intent, and the weakest one here: leave word
+ * that this caller would like the document, and change nothing else. It rides
+ * the claim rather than travelling on a call of its own because the editor that
+ * is locked out is ALREADY asking for the document on every beat — that poll is
+ * how it learns the holder has left — so the standing "still waiting" is carried
+ * by the request that was going to be sent anyway. A separate endpoint would add
+ * a second request per beat to say something the first one is in a position to
+ * say.
+ *
+ * 🔴 It is recorded only where the answer is `held`. A caller that WINS the
+ * document is not waiting for it, and stamping the row on the way past would
+ * leave every fresh claim carrying a request against itself.
  */
 export async function acquireDocumentLock(
   adapter: DrizzleAdapter,
   ref: DocumentRef,
   claimant: DocumentLockClaimant,
-  options?: { readonly takeover?: boolean }
+  options?: {
+    readonly takeover?: boolean;
+    readonly requestAccess?: boolean;
+  }
 ): Promise<AcquireDocumentLockOutcome> {
   const dialect = adapter.getCapabilities().dialect;
   const key = keyFor(ref);
   const claimToken = randomUUID();
+  const requestAccess = options?.requestAccess === true;
 
   return adapter.transaction(async ctx => {
     // 🔴 INSERT FIRST, then lock. `lockRow` issues `SELECT ... FOR UPDATE`, and
@@ -326,7 +424,7 @@ export async function acquireDocumentLock(
 
     if (existing === undefined) lockRowVanished(key);
     if (!isTakeable(existing, claimant, options?.takeover === true)) {
-      return { status: "held", holder: toHolder(existing) };
+      return await refuse(ctx, dialect, key, existing, requestAccess);
     }
 
     await ctx.runStatement(writeClaim(dialect, key, claimant, claimToken));
@@ -341,7 +439,7 @@ export async function acquireDocumentLock(
     // author writes a different token, so comparing owners would report both
     // callers as holders of one claim and let either release the other's.
     if (after.claimToken !== claimToken || !after.usable) {
-      return { status: "held", holder: toHolder(after) };
+      return await refuse(ctx, dialect, key, after, requestAccess);
     }
     return { status: "acquired", holder: toHolder(after), claimToken };
   });
@@ -386,7 +484,14 @@ export async function renewDocumentLock(
     if (after.claimToken !== claimToken || !after.usable) {
       return { status: "lost", holder: toHolder(after) };
     }
-    return { status: "renewed", holder: toHolder(after) };
+    // The courtesy notice rides the answer the holder was already waiting for.
+    // Nothing here acts on it: a request does not shorten this lease, cannot
+    // refuse this renewal, and is not a step in any handover.
+    return {
+      status: "renewed",
+      holder: toHolder(after),
+      waiting: after.waiting,
+    };
   });
 }
 

--- a/packages/nextly/src/domains/document-lock/document-lock-service.ts
+++ b/packages/nextly/src/domains/document-lock/document-lock-service.ts
@@ -52,11 +52,19 @@ export class DocumentLockService {
    * repository implements by replacing the claim rather than by deleting and
    * re-taking it, so the displaced holder's next renew reports `lost` with the
    * new holder attached and their editor can name who took over.
+   *
+   * `requestAccess` is the courtesy at the other end of that scale: leave word
+   * that this caller is waiting, and change nothing. It is answered only when
+   * the document is held, it moves no claim, and the holder learns of it on the
+   * heartbeat they were already making.
    */
   async acquire(
     ref: DocumentRef,
     claimant: DocumentLockClaimant,
-    options?: { readonly takeover?: boolean }
+    options?: {
+      readonly takeover?: boolean;
+      readonly requestAccess?: boolean;
+    }
   ): Promise<AcquireDocumentLockOutcome> {
     return await acquireDocumentLock(this.adapter, ref, claimant, options);
   }

--- a/packages/nextly/src/domains/document-lock/types.ts
+++ b/packages/nextly/src/domains/document-lock/types.ts
@@ -47,7 +47,24 @@ export type AcquireDocumentLockOutcome =
       readonly holder: DocumentLockHolder;
       readonly claimToken: string;
     }
-  | { readonly status: "held"; readonly holder: DocumentLockHolder };
+  | {
+      readonly status: "held";
+      readonly holder: DocumentLockHolder;
+      /**
+       * Whether an unlapsed request to edit this document is on record.
+       *
+       * The same fact `renewed` carries, read from the other side: here it is
+       * how a refused editor learns its own ask was written down, and there it
+       * is how the holder learns somebody is waiting. Deliberately not "your
+       * request was accepted" — nothing accepts one, and nothing about it moves
+       * the document.
+       *
+       * A caller that did not ask still gets an honest answer, which is that
+       * somebody is waiting. It is the interface that knows whether the person
+       * in front of it is that somebody.
+       */
+      readonly waiting: boolean;
+    };
 
 /**
  * The outcome of confirming a claim you believe you hold.
@@ -56,7 +73,28 @@ export type AcquireDocumentLockOutcome =
  * took over rather than only that something did. It is absent when the claim
  * simply lapsed and nobody has taken it — the distinction decides whether the
  * interface offers "request access" or "resume editing".
+ *
+ * `renewed` is also the channel the holder learns about a colleague on. The
+ * heartbeat is the one call a holder already makes on an interval, so a
+ * courtesy notice that rides it needs no second transport, no second poll and
+ * no push channel — and it arrives at the cadence a person can act on rather
+ * than the cadence a countdown ticks at.
  */
 export type RenewDocumentLockOutcome =
-  | { readonly status: "renewed"; readonly holder: DocumentLockHolder }
+  | {
+      readonly status: "renewed";
+      readonly holder: DocumentLockHolder;
+      /**
+       * Whether somebody is waiting to edit this document.
+       *
+       * A courtesy, and nothing more: it does not shorten the lease, does not
+       * ask the holder to answer, and is not a step in any handover. The lease
+       * expiring remains the only thing that transfers the document.
+       *
+       * False again once the request lapses, because the editor that made it
+       * re-states it on its own beat. So a holder is never told about somebody
+       * who has already gone.
+       */
+      readonly waiting: boolean;
+    }
   | { readonly status: "lost"; readonly holder?: DocumentLockHolder };

--- a/packages/nextly/src/schemas/document-lock/mysql.ts
+++ b/packages/nextly/src/schemas/document-lock/mysql.ts
@@ -25,6 +25,9 @@ export const nextlyDocumentLock = mysqlTable(
     // would otherwise disagree about when this claim ends by five hours.
     acquiredAt: datetime("acquired_at").notNull(),
     expiresAt: datetime("expires_at").notNull(),
+    // See `./postgres.ts` for what this is. Written from `UTC_TIMESTAMP()` like
+    // the two above, and for the same reason.
+    waitingUntil: datetime("waiting_until"),
   },
   t => [
     index("ndl_expires_at_idx").on(t.expiresAt),

--- a/packages/nextly/src/schemas/document-lock/postgres.ts
+++ b/packages/nextly/src/schemas/document-lock/postgres.ts
@@ -62,6 +62,19 @@ export const nextlyDocumentLock = pgTable(
     ownerLabel: varchar("owner_label", { length: 255 }),
     acquiredAt: timestamp("acquired_at", { withTimezone: true }).notNull(),
     expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+    // A standing request to edit, held on a lease of its own.
+    //
+    // Null while nobody is asking. The editor that is locked out re-states it on
+    // the SAME heartbeat the holder renews the claim on, so this column answers
+    // "is somebody waiting right now" rather than "did somebody once ask": a
+    // requester who closed the tab stops refreshing it and the mark lapses
+    // within one TTL, instead of nudging the holder forever on behalf of a
+    // colleague who left. Cleared outright whenever the claim changes hands,
+    // because a request is about the claim it was made against.
+    //
+    // Not indexed. It is only ever read through the primary key, on the row the
+    // heartbeat has already fetched.
+    waitingUntil: timestamp("waiting_until", { withTimezone: true }),
   },
   t => [
     index("ndl_expires_at_idx").on(t.expiresAt),

--- a/packages/nextly/src/schemas/document-lock/sqlite.ts
+++ b/packages/nextly/src/schemas/document-lock/sqlite.ts
@@ -24,6 +24,8 @@ export const nextlyDocumentLock = sqliteTable(
     // `unixepoch()` rather than interval arithmetic.
     acquiredAt: integer("acquired_at", { mode: "timestamp" }).notNull(),
     expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
+    // See `./postgres.ts` for what this is. Unix seconds, like the two above.
+    waitingUntil: integer("waiting_until", { mode: "timestamp" }),
   },
   t => [
     index("ndl_expires_at_idx").on(t.expiresAt),


### PR DESCRIPTION
Server half of the soft-lock courtesy notice (`task:pb-softlock-request-access-ui`,
per `decision:pb-softlock-courtesy-notice-not-consent`). The admin half — the
button and the two notices — follows in a second PR once this is on `main`; the
split is deliberate, because three dialect schemas plus the domain plus the UI in
one diff is not reviewable.

## What this is

A second author who opens a document somebody else is editing gets a read-only
editor and no way to say anything about it. The only thing on offer is taking the
document over, which displaces a colleague mid-sentence — so the polite option
was to close the tab.

The lock row gains **one nullable column**, and the holder learns that somebody
is waiting on the heartbeat they were already making.

**It is a courtesy, not a consent gate.** It moves no claim, asks the holder for
no answer, and cannot be refused. The lease expiring stays the only thing that
transfers a document. That is the founder's re-scope of 2026-09-10, and it is
also what the prior art supports: WordPress, Payload and Strapi all make takeover
unilateral precisely to avoid the walked-away deadlock, and Figma's "Ask to edit"
and Google Docs' "Request access" are ACL grants answered by email rather than
live-session handovers.

## The three decisions worth reviewing

**1. A request is held on a lease of its own.** `waiting_until` is a future
instant, not "when they asked", and the locked-out editor re-states it on every
beat. So the column answers *is somebody waiting right now*, not *did somebody
once ask*: an editor that closed the tab stops refreshing it and the mark lapses
within one TTL, instead of nudging the holder forever on behalf of a colleague
who left. A claim changing hands clears it outright, because a request is about
the claim it was made against.

Same TTL as a claim, and not a number chosen here — both answer "has this party
confirmed itself recently" and both are refreshed on the same 15s beat, so two
figures picked side by side for one question would drift the first time either
was tuned.

**2. It rides the claim rather than a route of its own.** The locked-out editor
is *already* asking for the document on every beat — that poll is how it learns
the holder has gone — so the standing "still waiting" is carried by a request
that was going to be sent anyway. A separate endpoint would add a second request
per beat to say something the first one is in a position to say. It also means no
new authorization branch: asking rides the same `claim` gate, so only somebody
who could edit the document may ask for it.

**3. Recorded only where the answer is `held`.** A caller that WINS the document
is not waiting for one; stamping on the way past would leave every fresh claim
carrying a request against itself, and its holder told on the next beat that they
are waiting for a document they are editing.

## Evidence

Six integration tests, run in **all three dialects** (23 cases per dialect):

| Test | What it pins |
|---|---|
| tells the holder somebody is waiting, once somebody asks | opens with the control — a refused poll on its own is not an ask |
| stops telling the holder once the waiting editor has gone | the lease on the request; staged by expiring it, because the case IS the absence of a beat |
| carries a still-waiting editor forward rather than refusing the repeat | a lapsed mark is refreshable, which is what every beat after the first says |
| records no request against the editor that WINS the document | decision 3 |
| clears a request when the document changes hands | `writeClaim` sets it NULL |
| leaves no request behind on a document whose claim was swept | the row going takes the request with it |

**Break-verified — the wrong implementation written, not a mutation.** Each break
killed exactly one named test and no others:

- `writeClaim` stops clearing the mark → *clears a request when the document changes hands*
- every refused poll stamps the row → *tells the holder somebody is waiting, once somebody asks*
- `waiting_until IS NOT NULL` instead of `> now` → *stops telling the holder once the waiting editor has gone*
- the bootstrap DDL omits the column → the existing `sqlite-core-tables` guard, by name

The liveness comparison is a SQL expression the database evaluates on its own
clock, like every other one in this module — a `CASE` returning 1/0 rather than a
boolean, because the three dialects return booleans as `true`, `1` and `"1"`.

## Gates

`pnpm build` 0 · `pnpm check-types` 0 · `pnpm lint` 0 · `npx vitest run` 0
(925 files, 11773 passed) · integration sqlite/postgres17/mysql 0 ·
`fallow audit` verdict `pass`, 11 changed files, every `*_introduced` 0 ·
`pnpm changeset status` 0. Re-run after committing, since the hook reformats.

## Migration

`nextly_document_lock` is a core table, so the column reaches an existing
database through the ordinary `nextly migrate:create` / `nextly migrate` path
(core tables are in `getDialectTables`, which is what the migration CLI diffs
against). The bootstrap DDL in `sqlite-core-tables.ts` is updated alongside the
three Drizzle schemas, and the existing drift guard fails if they disagree.
