### PR TITLE
docs: list the plugins that ship, and say what runs a queued job

### DIFF
--- a/docs/jobs/index.mdx
+++ b/docs/jobs/index.mdx
@@ -44,6 +44,38 @@ A job that is defined but not listed in `jobs` is absent from the registry. Rows
 its slug sit there with no handler to pick them up.
 </Callout>
 
+## Running the queue
+
+Defining a job queues it. **Nothing runs it on its own.** A pass over the queue happens
+when something calls the jobs route, so if nothing ever calls it, queued work waits
+forever.
+
+The scaffolded apps mount Nextly's handlers at `src/app/admin/api/[[...params]]/route.ts`,
+so the URL is:
+
+```
+POST /admin/api/jobs/run
+```
+
+<Callout type="warn">
+There is no general `/api` handler in a scaffolded app, so a scheduler pointed at
+`/api/jobs/run` gets a 404 and nothing in the queue ever runs. If you mounted the handlers
+somewhere else, use that path instead.
+</Callout>
+
+Point a cron job, a platform scheduler or an operator at it, authenticated, on whatever
+interval your soonest deadline allows.
+
+A pass is bounded: it claims at most 10 queued jobs, and it stops **starting** new ones
+after 20 seconds. That 20 seconds is a budget for starting work, not a hard ceiling on the
+request — the check happens before each claim, so a handler already running is awaited to
+completion and the call can overrun. Size any serverless timeout for the slowest handler,
+not for 20 seconds.
+
+A pass can also defer work past its deadline and still report success, so a job runs on the
+first pass that actually **reaches and completes** it, which is not always the first pass
+after it became due. Treat a due time as "not before", not as "at".
+
 ## Retries and backoff
 
 A failed job is retried with exponential backoff, starting at **1 second** and capped at

--- a/docs/plugins/index.mdx
+++ b/docs/plugins/index.mdx
@@ -14,6 +14,13 @@ Plugins extend Nextly with new functionality without modifying core code. A plug
 | Plugin | Package | Description |
 |--------|---------|-------------|
 | [Form Builder](/docs/plugins/form-builder) | `@nextlyhq/plugin-form-builder` | Visual drag-and-drop form builder with submission management, email notifications, spam protection, and export |
+| [Page Builder](/docs/page-builder) | `@nextlyhq/plugin-page-builder` | Let your team compose pages from blocks you define, rendered on the server with no client JavaScript by default |
+| SEO | [`@nextlyhq/plugin-seo`](https://www.npmjs.com/package/@nextlyhq/plugin-seo) | SEO fields on the collections you name, and a sitemap of published content served over plain HTTP. Framework-agnostic, so it is safe in a headless or admin-only project |
+
+Turning those SEO fields into `<meta>` tags is core rather than plugin work: use
+`buildMetadata` from `nextly/runtime`, described in
+[Routing and SEO](/docs/guides/routing-and-seo). The plugin supplies the fields and the
+sitemap; Open Graph, robots and hreflang come from core.
 
 ## Community Plugins
 

--- a/docs/releases/index.mdx
+++ b/docs/releases/index.mdx
@@ -42,34 +42,18 @@ Scheduling records when a release is due. The work is done by a `releases:drain`
 runs as part of the [background jobs](/docs/jobs) pass, triggered by calling the jobs route
 from a cron job, a platform scheduler, or an operator.
 
-The scaffolded apps mount Nextly's handlers at `src/app/admin/api/[[...params]]/route.ts`, so
-the URL is:
-
-```
-POST /admin/api/jobs/run
-```
-
-<Callout type="warn">
-There is no general `/api` handler in a scaffolded app, so a scheduler pointed at
-`/api/jobs/run` gets a 404 and your releases never publish. If you mounted the handlers
-somewhere else, use that path instead.
-</Callout>
+How to wire that call, the route it lives at, and what one pass is bounded by are all in
+[Running the queue](/docs/jobs#running-the-queue). Read it before you rely on scheduling.
 
 <Callout type="warn">
 **With no scheduler configured, a release stays scheduled forever.** Its due time passes and
-nothing happens, because nothing ran the sweep. Set up an authenticated periodic call to
-`/api/jobs/run` before you rely on scheduling.
+nothing happens, because nothing ran the sweep.
 </Callout>
 
-A pass is bounded: it claims at most 10 queued jobs, and it stops **starting** new ones after
-20 seconds. That 20 seconds is a budget for starting work, not a hard ceiling on the request —
-the check happens before each claim, so a handler already running is awaited to completion and
-the call can overrun. Size any serverless timeout for the slowest handler, not for 20 seconds.
-
-The sweep can also defer work past its deadline while still reporting success. So a release is
-applied on the first pass that actually **reaches and completes** it, which is not always the
-first pass after its due time. With a backlog, or several expensive releases due together,
-expect it a pass or two later. Treat the scheduled time as "not before", not as "at".
+Because a pass is bounded and can defer work past its deadline while still reporting success,
+a release is applied on the first pass that actually **reaches and completes** it, which is not
+always the first pass after its due time. With a backlog, or several expensive releases due
+together, expect it a pass or two later. Treat the scheduled time as "not before", not as "at".
 
 ## Blocking reasons
 


### PR DESCRIPTION
Three places where the docs did not describe the product.

## The Official Plugins table listed one of three

`docs/plugins/index.mdx` listed Form Builder alone, while the site claims three official plugins. Page Builder and SEO are there now, each pointing somewhere real:

- **Page Builder** at `/docs/page-builder`, which exists
- **SEO** at its package, because it has no docs page yet and a link to a 404 is worse than a link to a README

The Page Builder description is the destination page's own frontmatter rather than a fresh sentence. I wrote one first, claiming "live preview and per-block validation", then checked: the page claims neither. Taking the page's own words means the row cannot advertise something the page it links to does not.

The SEO row also says which half is core, because the plugin supplies fields and a sitemap while `buildMetadata` supplies the tags, and conflating the two is the confusion this item exists to end.

## `docs/jobs` never said how a queued job runs

It covered defining a job, retries and backoff, run-as identity, and retention. The page a person reads to wire jobs did not mention that **nothing runs them** unless something calls the jobs route. It has a **Running the queue** section now, with the route, the 404 trap, and what one pass is bounded by.

## `docs/releases` told the reader to do the thing it had just warned against

Two paragraphs after a callout saying a scheduler pointed at `/api/jobs/run` gets a 404 and your releases never publish, the remedy said:

> Set up an authenticated periodic call to `/api/jobs/run` before you rely on scheduling.

Following the page as written produced exactly the failure the callout above it exists to prevent. Verified against the scaffold: handlers mount at `src/app/admin/api/[[...params]]/route.ts`, and there is no general `/api` handler, only `/api/health` and `/api/media`.

The mechanics of a pass now live once, on the jobs page, with releases pointing at them and keeping only what is release-specific. They were duplicated onto the releases page while the jobs page had none, which is how the two drifted into contradicting each other.

## Checks

`pnpm check:doc-samples` passes. The fenced block added here carries no language tag, so it adds no counted sample and the ratchet baseline is unchanged.

## No changeset

Docs only. Nothing here ships inside a published package.
