### PR TITLE
fix(builder): a handle that follows a margin past zero

### DIFF
--- a/.changeset/a-handle-that-follows-a-margin-past-zero.md
+++ b/.changeset/a-handle-that-follows-a-margin-past-zero.md
@@ -1,0 +1,23 @@
+---
+"@nextlyhq/builder": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/ui": patch
+"nextly": patch
+---
+
+A spacing handle stopped following the pointer when a drag took a margin past zero.
+
+A margin dragged below zero is drawn on the other side of the block's edge, and
+its two sides swap roles when that happens. The handle kept the side it was given
+when the drag began, so once the value crossed zero it sat on the edge that no
+longer moves and the block stopped responding — the drag had to be released and
+started again to carry on.
+
+The handle now takes the side the band is drawn with as it is drawn, so a stroke
+that runs a margin from positive to negative keeps moving the block the whole way.

--- a/.changeset/a-handle-that-follows-a-margin-past-zero.md
+++ b/.changeset/a-handle-that-follows-a-margin-past-zero.md
@@ -1,14 +1,29 @@
 ---
-"@nextlyhq/builder": patch
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
 "@nextlyhq/blocks-engine": patch
 "@nextlyhq/blocks-react": patch
-"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
 "@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
 "@nextlyhq/plugin-seo": patch
 "@nextlyhq/plugin-sdk": patch
-"@nextlyhq/admin": patch
-"@nextlyhq/ui": patch
-"nextly": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
 ---
 
 A spacing handle stopped following the pointer when a drag took a margin past zero.

--- a/packages/builder/src/spacing-handles.test.tsx
+++ b/packages/builder/src/spacing-handles.test.tsx
@@ -2007,3 +2007,74 @@ describe("a drag keeps the direction it began with", () => {
     expect(stored("margin", "blockStart")).toBe("40px");
   });
 });
+
+describe("a drag that carries a margin through zero", () => {
+  /*
+   * `spacingBands` reflects a NEGATIVE margin across the border edge, so the
+   * rectangle's far edge swaps when the sign does. The measurement that decides
+   * which edge responds does not swap — it is about the layout, not the sign —
+   * so the response is frozen unmirrored for the gesture and the sign is applied
+   * where the handle is placed. Freezing the mirrored answer instead leaves the
+   * handle on the edge the old sign chose, where it stops following the pointer.
+   */
+  const rect = { x: 0, y: 100, width: 50, height: 20 };
+  const positive: SpacingBand = {
+    box: "margin",
+    side: "bottom",
+    rect,
+    label: "20",
+    negative: false,
+  };
+  const negative: SpacingBand = { ...positive, label: "-20", negative: true };
+  const responds = (): SpacingSubject =>
+    subjectWith({
+      margin: { top: 10, right: 10, bottom: 20, left: 10 },
+      outward: {
+        margin: { top: true, right: true, bottom: true, left: true },
+        padding: { top: false, right: false, bottom: false, left: false },
+      },
+    });
+
+  it("moves the handle to the mirrored edge when the sign flips", () => {
+    const initial = documentWith();
+    const view = mount([positive], responds(), initial);
+    const control = handle("bottom margin");
+    // The band spans 100..120; a positive one thickening away from the block
+    // carries its handle on the far edge.
+    expect(control.style.top).toBe("115.5px");
+
+    act(() => {
+      fireEvent.pointerDown(control, {
+        button: 0,
+        pointerId: 1,
+        clientX: 0,
+        clientY: 0,
+      });
+    });
+    act(() => {
+      fireEvent.pointerMove(control, { pointerId: 1, clientX: 0, clientY: 10 });
+    });
+
+    // The drag carries the value through zero, and the band comes back drawn
+    // inside the border edge.
+    view.rerender(
+      <Harness
+        bands={[negative]}
+        subject={responds()}
+        context={BASE}
+        initial={initial}
+      />
+    );
+
+    /*
+     * The same measured response, mirrored by the band's NEW sign, puts the
+     * handle on the other end of the rectangle. Keeping the answer mirrored at
+     * the press would leave it at 115.5 while the pointer went on.
+     */
+    expect(handle("bottom margin").style.top).toBe("95.5px");
+
+    act(() => {
+      fireEvent.pointerUp(control, { pointerId: 1, clientX: 0, clientY: 10 });
+    });
+  });
+});

--- a/packages/builder/src/spacing-handles.tsx
+++ b/packages/builder/src/spacing-handles.tsx
@@ -443,14 +443,21 @@ export function SpacingHandles({
    */
   const [held, setHeld] = React.useState<SpacingBand | null>(null);
   /**
-   * The edge a POINTER gesture's handle sits on, frozen at the press.
+   * The MEASURED response a pointer gesture began with, before any mirroring.
+   *
+   * Unmirrored on purpose. Which edge of the drawn rectangle carries the handle
+   * depends on the band's sign as well, and a drag can change that sign by
+   * carrying a margin through zero — so the sign is applied where the handle is
+   * placed rather than baked in here.
    *
    * `null` whenever no pointer gesture is live, which includes a band merely
    * held by focus: each key press is an edit of its own and reads the current
    * measurement, so freezing there would pin the handle to an answer the block
    * has stopped giving.
    */
-  const [drawnOutward, setDrawnOutward] = React.useState<boolean | null>(null);
+  const [draggedResponse, setDraggedResponse] = React.useState<boolean | null>(
+    null
+  );
   const [message, setMessage] = React.useState("");
 
   const { document: doc } = editor;
@@ -575,11 +582,19 @@ export function SpacingHandles({
     (band: SpacingBand): boolean => {
       const dragging =
         held !== null && held.box === band.box && held.side === band.side;
-      return dragging && drawnOutward !== null
-        ? drawnOutward
+      /*
+       * Mirrored against the band as it is drawn NOW, not as it was drawn at
+       * the press. A drag can carry a margin through zero, and `spacingBands`
+       * reflects a negative one across the border edge — so the rectangle's far
+       * edge swaps while the measurement that decides which edge responds does
+       * not. Freezing the mirrored answer would leave the handle on the edge the
+       * old sign put it, and it would stop following the pointer there.
+       */
+      return dragging && draggedResponse !== null
+        ? spacingBandDrawnOutward(band.negative, draggedResponse)
         : drawnOutwardOf(band);
     },
-    [drawnOutward, drawnOutwardOf, held]
+    [draggedResponse, drawnOutwardOf, held]
   );
 
   const targetFor = React.useCallback(
@@ -819,7 +834,7 @@ export function SpacingHandles({
     gesture.current = null;
     setPreview(null);
     setHeld(null);
-    setDrawnOutward(null);
+    setDraggedResponse(null);
     if (live === null) return;
     live.detach();
     if (live.active && live.host.hasPointerCapture?.(live.pointerId) === true) {
@@ -1028,7 +1043,7 @@ export function SpacingHandles({
        * Frozen together, from one reading, so the edge the handle sits on and
        * the direction the number moves cannot come from different measurements.
        */
-      setDrawnOutward(drawnOutwardOf(band));
+      setDraggedResponse(valueOutwardOf(band));
       gesture.current = {
         band,
         valueOutward: valueOutwardOf(band),
@@ -1047,15 +1062,7 @@ export function SpacingHandles({
       owner.addEventListener("pointercancel", onCancel);
       owner.addEventListener("keydown", onEscape);
     },
-    [
-      commit,
-      drawnOutwardOf,
-      endGesture,
-      showPreview,
-      startsFor,
-      subject.scales,
-      valueOutwardOf,
-    ]
+    [commit, endGesture, showPreview, startsFor, subject.scales, valueOutwardOf]
   );
 
   /*


### PR DESCRIPTION
Follow-up to #1687, which merged before this fix was committed. It repairs a defect **live on main right now**.

## What is wrong

A drag that carries a margin **through zero** strands its handle. `spacingBands` draws a negative margin reflected across the border edge, so the rectangle's two ends swap roles when the sign flips — but the gesture froze the *already-mirrored* placement at pointer-down. Past zero the handle sits on the edge that no longer moves, and the block stops following the pointer until the drag is released and started again.

## The fix

Freeze the **measured** response unmirrored, and apply the band's *current* sign where the handle is placed:

```ts
return dragging && draggedResponse !== null
  ? spacingBandDrawnOutward(band.negative, draggedResponse)
  : drawnOutwardOf(band);
```

The measurement is a fact about the layout — which edge the browser moves when the value grows — and that does not change with the sign. Only the drawing mirrors, so only the drawing consults the sign.

This also makes the two frozen quantities the same thing. The direction the value grows was already taken unmirrored (that split is what stops negative-margin drags running backwards); now placement is derived from that same frozen measurement instead of a separately mirrored copy, so the mirroring happens in exactly one place.

## Break-verification

Written as the wrong implementation — return the frozen answer without re-mirroring — rather than as a mutation:

```
AssertionError: expected '115.5px' to be '95.5px'
```

The control stays where the old sign put it while the flipped band's moving edge is at the other end of the rectangle. That is the stall, measured.

The test drives a real drag past the activation threshold and re-renders with the band's sign flipped mid-stroke, which is what the canvas does when the value crosses zero.

## Gates

`pnpm build` 0 · builder `check-types` 0 · `lint` 0 · **3073 tests / 107 files** · plugin-page-builder `check-types` 0 · `lint` 0 · **819 tests** · `lint:design` 35/35 · `fallow audit --base origin/main` **pass**, `changed_files_count: 3`, every `*_introduced: 0` · `changeset status` 0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved spacing-handle dragging when margins cross from positive to negative values.
  - Handles now remain aligned with the current margin sign and move to the corresponding mirrored edge when needed.
  - Drag gestures preserve their original response direction throughout the interaction for more predictable layout adjustments.

- **Tests**
  - Added coverage for dragging bottom margins across zero to verify consistent handle placement and movement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->