### PR TITLE
feat(admin): a locked-out editor can ask for the document, and the holder is told

### DIFF
--- a/.changeset/a-locked-out-editor-can-say-so.md
+++ b/.changeset/a-locked-out-editor-can-say-so.md
@@ -1,0 +1,54 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+An author who opened a document somebody else was already editing had exactly
+one thing they could do about it: take the document over, displacing a colleague
+mid-sentence. The polite option was to close the tab and hope.
+
+The lock strip now offers "Request edit access" beside "Take over", and the
+holder is told — passively, in the same strip — that someone is waiting. Nothing
+else changes: the request moves no claim, asks the holder for no answer, cannot
+be refused, and the lease expiring stays the only thing that transfers a
+document. Every action the holder had, they keep, including the Save they are
+being given time to reach.
+
+The ask is a standing one rather than a single message. The editor that is
+locked out is already polling for the document on every beat, so the request
+rides that poll and is re-stated for as long as the person is still there and
+still waiting. Close the tab and it lapses, so a holder is never nudged on
+behalf of a colleague who has gone.
+
+Pressing the button is answered. The strip replaces it with "We have let Bob
+know you are waiting" — text, not a disabled button, because a control that
+stays on screen having stopped doing anything is what a broken one looks like.
+The confirmation is shown only when the SERVER has the ask on record, so a
+request that landed nowhere cannot be reported as delivered.
+
+The holder's notice is a `status` region and not a dialog. There is no APG basis
+for one here — that pattern is for urgent interruptions a person must answer —
+and it is spoken once when it appears rather than on every heartbeat.

--- a/packages/admin/src/components/features/entries/EntryForm/DocumentLockBanner.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/DocumentLockBanner.tsx
@@ -14,6 +14,16 @@
  * equally as a document this account lacks permission to change. So the sentence
  * names who has it and what can be done about it.
  *
+ * ## It also speaks to the HOLDER
+ *
+ * One strip, both sides of the same claim. A colleague who is locked out may
+ * leave word that they are waiting, and the holder is told here — passively,
+ * with nothing withheld and no answer required. Deliberately NOT a modal or an
+ * `alertdialog`: there is no APG basis for one, that pattern being for urgent
+ * interruptions a person must answer, and WCAG 2.2.4 asks that an interruption
+ * be postponable. The lease expiring stays the only thing that transfers a
+ * document, so there is nothing here to answer.
+ *
  * @module components/features/entries/EntryForm/DocumentLockBanner
  */
 
@@ -29,6 +39,8 @@ export interface DocumentLockBannerProps {
   notice: DocumentLockNotice | null;
   /** Claim the document, displacing whoever holds it. */
   onTakeOver: () => void;
+  /** Leave word with the holder that this editor is waiting. Displaces nobody. */
+  onRequestAccess: () => void;
   className?: string;
 }
 
@@ -43,11 +55,16 @@ const TONE_SURFACE: Record<DocumentLockNotice["tone"], string> = {
   held: "border-border bg-muted/50",
   surrendered: "border-primary bg-primary/5",
   unchecked: "border-border bg-muted/50",
+  // The reader has lost nothing and is being asked for nothing, so it is the
+  // quietest surface of the four. Dressed as a warning it would read as a
+  // demand, which is the one thing a courtesy notice must not do.
+  awaited: "border-border bg-muted/50",
 };
 
 export function DocumentLockBanner({
   notice,
   onTakeOver,
+  onRequestAccess,
   className,
 }: DocumentLockBannerProps) {
   // Answered here rather than at each call site: two editors mount this, and a
@@ -76,6 +93,27 @@ export function DocumentLockBanner({
     >
       <Lock className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
       <p className="flex-1 text-foreground">{notice.message}</p>
+      {/*
+        The confirmation is TEXT and not a disabled button. A control that stays
+        on screen having stopped doing anything is the thing a reader cannot
+        tell from one that is broken, and a disabled button announces itself as
+        unavailable rather than as done. It sits inside the same `status`
+        region, so replacing the button with it is announced -- which is the
+        whole answer the person gets, since nothing else about the page changes.
+      */}
+      {notice.accessRequest?.kind === "sent" ? (
+        <p className="text-muted-foreground">{notice.accessRequest.message}</p>
+      ) : null}
+      {notice.accessRequest?.kind === "offer" ? (
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          onClick={onRequestAccess}
+        >
+          {notice.accessRequest.label}
+        </Button>
+      ) : null}
       {notice.takeOverLabel ? (
         <Button type="button" size="sm" variant="outline" onClick={onTakeOver}>
           {notice.takeOverLabel}

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -770,6 +770,7 @@ export function EntryForm({
             <DocumentLockBanner
               notice={lock.notice}
               onTakeOver={lock.takeOver}
+              onRequestAccess={lock.requestAccess}
             />
             {/* Error summary at top of form */}
             <FormErrorSummary errors={errors} submitCount={submitCount} />
@@ -990,6 +991,7 @@ export function EntryForm({
                             <DocumentLockBanner
                               notice={lock.notice}
                               onTakeOver={lock.takeOver}
+                              onRequestAccess={lock.requestAccess}
                             />
                             {/* Above the fields and below the header: the reader sees
                       the document it refers to without the offer covering it. */}

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/DocumentLockBanner.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/DocumentLockBanner.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * DocumentLockBanner — one strip, spoken to both sides of a claim.
+ *
+ * Every negative assertion carries its positive control in the same render: the
+ * strip itself is queried first, so "the button is absent" can never pass
+ * because nothing rendered at all.
+ */
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import type { DocumentLockNotice } from "../document-lock-affordances";
+import { DocumentLockBanner } from "../DocumentLockBanner";
+
+function strip() {
+  return screen.getByTestId("document-lock-banner");
+}
+
+const HELD: DocumentLockNotice = {
+  tone: "held",
+  message: "Bob is editing this document. You can read it, or take over.",
+  takeOverLabel: "Take over",
+  accessRequest: { kind: "offer", label: "Request edit access" },
+};
+
+function show(notice: DocumentLockNotice) {
+  const onTakeOver = vi.fn();
+  const onRequestAccess = vi.fn();
+  render(
+    <DocumentLockBanner
+      notice={notice}
+      onTakeOver={onTakeOver}
+      onRequestAccess={onRequestAccess}
+    />
+  );
+  return { onTakeOver, onRequestAccess };
+}
+
+describe("what a locked-out editor is offered", () => {
+  it("offers the polite option beside the one that displaces a colleague", async () => {
+    const { onRequestAccess, onTakeOver } = show(HELD);
+
+    expect(strip()).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Request edit access" })
+    );
+
+    expect(onRequestAccess).toHaveBeenCalledTimes(1);
+    // 🔴 And nothing else. The two intents sit next to each other and are
+    // opposites: one leaves word, the other takes the document out from under
+    // somebody mid-sentence.
+    expect(onTakeOver).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Take over" })).toBeVisible();
+  });
+
+  it("replaces the button with a sentence once the ask is on record", () => {
+    show({
+      ...HELD,
+      accessRequest: {
+        kind: "sent",
+        message: "We have let Bob know you are waiting.",
+      },
+    });
+
+    expect(strip()).toBeInTheDocument();
+    expect(
+      screen.getByText("We have let Bob know you are waiting.")
+    ).toBeVisible();
+    // 🔴 REPLACES, and is not a disabled button. A control still on screen
+    // having stopped doing anything is what a broken one looks like, and a
+    // disabled button announces itself as unavailable rather than as done.
+    //
+    // Asserted as the WHOLE set of buttons, not as the absence of one label. A
+    // render that kept the control but lost its text leaves a nameless button
+    // in the strip, which "no button called Request edit access" reports as a
+    // clean replacement -- the exact shape the ask is being replaced to avoid.
+    expect(screen.getAllByRole("button").map(b => b.textContent)).toEqual([
+      "Take over",
+    ]);
+  });
+
+  it("shows no ask where the notice offers none", () => {
+    show({ ...HELD, accessRequest: null });
+
+    expect(strip()).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Take over" })).toBeVisible();
+    expect(
+      screen.queryByRole("button", { name: "Request edit access" })
+    ).toBeNull();
+  });
+});
+
+describe("what the HOLDER is told", () => {
+  const AWAITED: DocumentLockNotice = {
+    tone: "awaited",
+    message: "Someone is waiting to edit this document.",
+    takeOverLabel: null,
+    accessRequest: null,
+  };
+
+  it("says it in the polite region, and asks the holder for nothing", () => {
+    show(AWAITED);
+
+    const el = strip();
+    // 🔴 `status`, never `alert` or `alertdialog`. There is no APG basis for a
+    // dialog here -- that pattern is for urgent interruptions a person must
+    // answer -- and WCAG 2.2.4 asks that an interruption be postponable. A
+    // request moves nothing, so there is nothing to answer.
+    expect(el).toHaveAttribute("role", "status");
+    expect(el).toHaveTextContent("Someone is waiting to edit this document.");
+    // Not one button: nothing here is a step in a handover.
+    expect(screen.queryAllByRole("button")).toHaveLength(0);
+  });
+
+  it("renders nothing at all when there is nothing to say", () => {
+    render(
+      <DocumentLockBanner
+        notice={null}
+        onTakeOver={vi.fn()}
+        onRequestAccess={vi.fn()}
+      />
+    );
+
+    // The control for every "the strip says X" above: a banner that always
+    // rendered would sit permanently over every document its author opens.
+    expect(screen.queryByTestId("document-lock-banner")).toBeNull();
+  });
+});

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/document-lock-affordances.test.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/document-lock-affordances.test.ts
@@ -15,7 +15,7 @@ describe("what a lock state means for the editor", () => {
   it.each<DocumentLockState>([
     { status: "idle" },
     { status: "acquiring" },
-    { status: "held-by-me" },
+    { status: "held-by-me", someoneWaiting: false },
   ])("leaves the editor alone while $status", state => {
     expect(documentLockAffordances(state)).toEqual({
       readOnly: false,
@@ -37,11 +37,108 @@ describe("what a lock state means for the editor", () => {
     const affordances = documentLockAffordances({
       status: "held-by-other",
       holder: bob,
+      requestSent: false,
     });
     expect(affordances.readOnly).toBe(true);
     expect(affordances.actionsDisabled).toBe(true);
     expect(affordances.notice?.message).toContain("Bob");
     expect(affordances.notice?.takeOverLabel).toBe("Take over");
+  });
+
+  it("offers the polite option beside the one that displaces a colleague", () => {
+    // Both, and never only the steal. Taking over is the loudest thing this
+    // interface can do, and until now it was the only thing a locked-out editor
+    // could do at all.
+    const affordances = documentLockAffordances({
+      status: "held-by-other",
+      holder: bob,
+      requestSent: false,
+    });
+    expect(affordances.notice?.accessRequest).toEqual({
+      kind: "offer",
+      label: "Request edit access",
+    });
+    expect(affordances.notice?.takeOverLabel).toBe("Take over");
+  });
+
+  it("replaces the offer with a confirmation once the ask is on record", () => {
+    // 🔴 REPLACES. A control that stays put having stopped doing anything is
+    // what a broken one looks like, and the sentence is the entire answer the
+    // person gets -- nothing else about the page changes, by design.
+    const affordances = documentLockAffordances({
+      status: "held-by-other",
+      holder: bob,
+      requestSent: true,
+    });
+    expect(affordances.notice?.accessRequest).toEqual({
+      kind: "sent",
+      message: "We have let Bob know you are waiting.",
+    });
+    // Still offered: asking politely does not spend the option of not asking.
+    expect(affordances.notice?.takeOverLabel).toBe("Take over");
+  });
+
+  it("says the colleague was told without naming one the server did not", () => {
+    // A claim carries no label when the account had no name to record, and
+    // "We have let null know" is worse than the unnamed sentence.
+    const affordances = documentLockAffordances({
+      status: "held-by-other",
+      holder: { ...bob, ownerLabel: null },
+      requestSent: true,
+    });
+    expect(affordances.notice?.accessRequest).toEqual({
+      kind: "sent",
+      message: "We have let them know you are waiting.",
+    });
+  });
+
+  it("tells the holder somebody is waiting, and withholds nothing for it", () => {
+    // 🔴 The courtesy notice is the whole feature: a request moves no claim,
+    // demands no answer and cannot be refused, so anything withheld here would
+    // be a consent gate wearing a courtesy notice's words. The holder keeps
+    // every action they had -- including the Save they are being given time for.
+    const affordances = documentLockAffordances({
+      status: "held-by-me",
+      someoneWaiting: true,
+    });
+    expect(affordances.readOnly).toBe(false);
+    expect(affordances.actionsDisabled).toBe(false);
+    expect(affordances.notice?.tone).toBe("awaited");
+    expect(affordances.notice?.message).toBe(
+      "Someone is waiting to edit this document."
+    );
+    // Nothing to press. The lease expiring is what transfers a document.
+    expect(affordances.notice?.takeOverLabel).toBeNull();
+    expect(affordances.notice?.accessRequest).toBeNull();
+  });
+
+  it("says nothing to a holder nobody is waiting on", () => {
+    // The control for the case above: a notice that rendered either way would
+    // put a permanent strip over every document its author opens.
+    const affordances = documentLockAffordances({
+      status: "held-by-me",
+      someoneWaiting: false,
+    });
+    expect(affordances.notice).toBeNull();
+  });
+
+  it("offers no ask where the beat has stopped or never reached the server", () => {
+    // A button that asks a server this editor is not talking to is exactly the
+    // silent control the confirmation exists to rule out. `taken-over` and
+    // `lost` have stopped polling; `unavailable` did not reach it this beat.
+    const cases: [DocumentLockState, DocumentLockHolder | null][] = [
+      [{ status: "taken-over", holder: bob }, null],
+      [{ status: "lost" }, null],
+      [{ status: "unavailable" }, bob],
+      [{ status: "unavailable" }, null],
+    ];
+    for (const [state, known] of cases) {
+      const affordances = documentLockAffordances(state, known);
+      expect(
+        affordances.notice?.accessRequest ?? null,
+        state.status
+      ).toBeNull();
+    }
   });
 
   it("says the work is still there when someone takes over", () => {
@@ -106,7 +203,7 @@ describe("what a lock state means for the editor", () => {
     // A read-only document with no affordance is a dead end, and the reader
     // cannot tell it from one they lack permission for.
     const cases: [DocumentLockState, DocumentLockHolder | null][] = [
-      [{ status: "held-by-other", holder: bob }, null],
+      [{ status: "held-by-other", holder: bob, requestSent: false }, null],
       [{ status: "taken-over", holder: bob }, null],
       [{ status: "taken-over" }, null],
       [{ status: "lost" }, null],
@@ -123,7 +220,7 @@ describe("what a lock state means for the editor", () => {
     // 🔴 Read-only fields with live Save is the worst of both: the banner says the
     // document is somebody else's and the editor can still overwrite them.
     const cases: DocumentLockState[] = [
-      { status: "held-by-other", holder: bob },
+      { status: "held-by-other", holder: bob, requestSent: false },
       { status: "taken-over", holder: bob },
       { status: "lost" },
     ];

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/useDocumentLockSurface.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/useDocumentLockSurface.test.tsx
@@ -14,6 +14,7 @@ const bob: DocumentLockHolder = {
   expiresInSeconds: 90,
 };
 const takeOver = vi.fn();
+const requestAccess = vi.fn();
 const options = {
   scopeKind: "collection" as const,
   slug: "posts",
@@ -30,8 +31,9 @@ describe("remembering who held the document", () => {
     // was reported. Forgetting them hands the document to a second editor while
     // the last confirmed fact is that somebody holds an unexpired lease.
     useDocumentLock.mockReturnValue({
-      state: { status: "held-by-other", holder: bob },
+      state: { status: "held-by-other", holder: bob, requestSent: false },
       takeOver,
+      requestAccess,
     });
     const { result, rerender } = renderHook(() =>
       useDocumentLockSurface(options)
@@ -41,6 +43,7 @@ describe("remembering who held the document", () => {
     useDocumentLock.mockReturnValue({
       state: { status: "unavailable" },
       takeOver,
+      requestAccess,
     });
     rerender();
 
@@ -53,8 +56,9 @@ describe("remembering who held the document", () => {
     // document announces itself as `acquiring`. Carrying the last one's holder
     // into it renders a document read-only over a colleague who was never in it.
     useDocumentLock.mockReturnValue({
-      state: { status: "held-by-other", holder: bob },
+      state: { status: "held-by-other", holder: bob, requestSent: false },
       takeOver,
+      requestAccess,
     });
     const { result, rerender } = renderHook(() =>
       useDocumentLockSurface(options)
@@ -64,11 +68,13 @@ describe("remembering who held the document", () => {
     useDocumentLock.mockReturnValue({
       state: { status: "acquiring" },
       takeOver,
+      requestAccess,
     });
     rerender();
     useDocumentLock.mockReturnValue({
       state: { status: "unavailable" },
       takeOver,
+      requestAccess,
     });
     rerender();
 
@@ -78,24 +84,44 @@ describe("remembering who held the document", () => {
 
   it("forgets them once this editor holds it", () => {
     useDocumentLock.mockReturnValue({
-      state: { status: "held-by-other", holder: bob },
+      state: { status: "held-by-other", holder: bob, requestSent: false },
       takeOver,
+      requestAccess,
     });
     const { result, rerender } = renderHook(() =>
       useDocumentLockSurface(options)
     );
 
     useDocumentLock.mockReturnValue({
-      state: { status: "held-by-me" },
+      state: { status: "held-by-me", someoneWaiting: false },
       takeOver,
+      requestAccess,
     });
     rerender();
     useDocumentLock.mockReturnValue({
       state: { status: "unavailable" },
       takeOver,
+      requestAccess,
     });
     rerender();
 
     expect(result.current.readOnly).toBe(false);
+  });
+
+  it("republishes the polite ask, so an editor is not left with only the steal", () => {
+    // The surface is what both editors render from. Publishing `takeOver` and
+    // not this would leave a locked-out author one option -- displacing a
+    // colleague -- which is the dead end this whole change exists to remove.
+    useDocumentLock.mockReturnValue({
+      state: { status: "held-by-other", holder: bob, requestSent: false },
+      takeOver,
+      requestAccess,
+    });
+    const { result } = renderHook(() => useDocumentLockSurface(options));
+
+    result.current.requestAccess();
+
+    expect(requestAccess).toHaveBeenCalledTimes(1);
+    expect(takeOver).not.toHaveBeenCalled();
   });
 });

--- a/packages/admin/src/components/features/entries/EntryForm/document-lock-affordances.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/document-lock-affordances.ts
@@ -13,14 +13,50 @@ import type { DocumentLockHolder } from "nextly/document-lock";
 
 import type { DocumentLockState } from "@admin/hooks/queries/useDocumentLock";
 
+/**
+ * What this editor may do about a colleague's claim, short of taking it.
+ *
+ * 🔴 A union rather than a label and a flag. "Nothing to offer", "a button" and
+ * "we told them" are three states, and carrying them as a nullable label beside
+ * a boolean admits a fourth that means nothing — a confirmation with a button
+ * still under it, which is what a control that silently re-arms looks like.
+ */
+export type DocumentAccessRequest =
+  /** Not asked yet: the button, and what it says. */
+  | { readonly kind: "offer"; readonly label: string }
+  /**
+   * Asked, and the server has it on record.
+   *
+   * A whole sentence rather than a tick, because this is the entire answer the
+   * person gets: nothing else in the interface changes, by design. A control
+   * that silently does nothing is worse than no control.
+   */
+  | { readonly kind: "sent"; readonly message: string };
+
 /** What the strip above the document says, and what it offers. */
 export interface DocumentLockNotice {
-  /** Distinguishes "someone has it" from "we cannot vouch for yours". */
-  readonly tone: "held" | "surrendered" | "unchecked";
+  /**
+   * Distinguishes "someone has it" from "we cannot vouch for yours" — and
+   * `awaited`, which is the only one that is not about a loss at all: the reader
+   * holds the document and is simply being told a colleague would like it.
+   */
+  readonly tone: "held" | "surrendered" | "unchecked" | "awaited";
   /** A whole sentence: the banner is read on its own, without the chrome. */
   readonly message: string;
   /** Present when the editor may claim the document. */
   readonly takeOverLabel: string | null;
+  /**
+   * Present only where asking means something: a colleague holds the document
+   * and this editor is polling for it.
+   *
+   * Null everywhere the ask could not be carried. On `taken-over` and `lost`
+   * the beat has stopped polling and the offer is already "take it back", so a
+   * button here would ask a server this editor is no longer talking to — which
+   * is exactly the silent control the `sent` state exists to avoid. On
+   * `unavailable` the last beat did not reach the server at all, and on
+   * `unchecked` nobody has been reported to ask.
+   */
+  readonly accessRequest: DocumentAccessRequest | null;
 }
 
 export interface DocumentLockAffordances {
@@ -55,17 +91,62 @@ const UNLOCKED: DocumentLockAffordances = {
   notice: null,
 };
 
+/**
+ * The holder, told that a colleague is waiting.
+ *
+ * 🔴 Withholds NOTHING, and that is the whole design rather than an oversight.
+ * It is a courtesy notice and not a consent gate: the reader is not asked a
+ * question, is not interrupted, and keeps every action they had. The lease
+ * expiring stays the only thing that transfers a document, so a notice that
+ * disabled Save would take away the very thing the holder is being given time
+ * to finish.
+ */
+const AWAITED: DocumentLockAffordances = {
+  readOnly: false,
+  actionsDisabled: false,
+  notice: {
+    tone: "awaited",
+    // Unnamed on purpose. The server records THAT somebody is waiting and not
+    // who, so naming one would be a claim about a colleague — and the request
+    // is a standing one that any locked-out editor refreshes, so there may be
+    // more than one of them.
+    message: "Someone is waiting to edit this document.",
+    takeOverLabel: null,
+    accessRequest: null,
+  },
+};
+
 /** Everything a colleague's claim withholds, with the sentence that explains it. */
 function withheld(
   tone: DocumentLockNotice["tone"],
   message: string,
-  takeOverLabel: string
+  takeOverLabel: string,
+  accessRequest: DocumentAccessRequest | null = null
 ): DocumentLockAffordances {
   return {
     readOnly: true,
     actionsDisabled: true,
-    notice: { tone, message, takeOverLabel },
+    notice: { tone, message, takeOverLabel, accessRequest },
   };
+}
+
+/** What a locked-out editor may say to the colleague holding the document. */
+function accessRequestFor(
+  holder: DocumentLockHolder,
+  requestSent: boolean
+): DocumentAccessRequest {
+  return requestSent
+    ? {
+        kind: "sent",
+        // Named when the server named them, because the point of the sentence
+        // is that a PERSON was told. Honest when it could not: a claim carries
+        // no label when the account had no name to record.
+        message:
+          holder.ownerLabel === null
+            ? "We have let them know you are waiting."
+            : `We have let ${holder.ownerLabel} know you are waiting.`,
+      }
+    : { kind: "offer", label: "Request edit access" };
 }
 
 /**
@@ -94,6 +175,12 @@ function withheld(
  * because a colleague holds the row now. Clearing the form would be the one
  * unrecoverable thing this could do.
  *
+ * 🔴 **Holding the document is no longer always silent.** It gains a notice, and
+ * only a notice: `held-by-me` with a colleague waiting keeps every action the
+ * holder had. A request moves nothing, cannot be refused, and is not a step in
+ * any handover — so anything withheld here would be a consent gate wearing a
+ * courtesy notice's words.
+ *
  * 🔴 **Autosave is NOT stopped, and this is worth stating because the opposite
  * looks obviously right.** `useDocumentAutosave` does not write the document: it
  * upserts a recovery row keyed by document AND author, marked `isAutosave`,
@@ -114,14 +201,17 @@ export function documentLockAffordances(
   switch (state.status) {
     case "idle":
     case "acquiring":
-    case "held-by-me":
       return UNLOCKED;
+
+    case "held-by-me":
+      return state.someoneWaiting ? AWAITED : UNLOCKED;
 
     case "held-by-other":
       return withheld(
         "held",
         `${state.holder.ownerLabel} is editing this document. You can read it, or take over.`,
-        "Take over"
+        "Take over",
+        accessRequestFor(state.holder, state.requestSent)
       );
 
     case "taken-over":
@@ -155,6 +245,7 @@ export function documentLockAffordances(
               message:
                 "We could not check whether anyone else is editing this document. You can keep working, but a colleague may be in it too.",
               takeOverLabel: null,
+              accessRequest: null,
             },
           }
         : withheld(

--- a/packages/admin/src/components/features/entries/EntryForm/useDocumentLockSurface.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/useDocumentLockSurface.ts
@@ -28,12 +28,20 @@ import {
 export interface DocumentLockSurface extends DocumentLockAffordances {
   /** Claim the document, displacing whoever holds it. */
   readonly takeOver: () => void;
+  /**
+   * Leave word with the holder that this editor is waiting.
+   *
+   * The opposite intent to `takeOver` and the weakest thing here: it displaces
+   * nobody, is answered by nobody, and moves no claim. A standing ask — every
+   * beat re-states it until this editor has the document or leaves.
+   */
+  readonly requestAccess: () => void;
 }
 
 export function useDocumentLockSurface(
   options: UseDocumentLockOptions
 ): DocumentLockSurface {
-  const { state, takeOver } = useDocumentLock(options);
+  const { state, takeOver, requestAccess } = useDocumentLock(options);
 
   // 🔴 The colleague outlives a failed refresh. Every beat re-asks, so a
   // transient rejection arrives as `unavailable` long after a holder was
@@ -59,5 +67,6 @@ export function useDocumentLockSurface(
   return {
     ...documentLockAffordances(state, lastKnownHolder.current),
     takeOver,
+    requestAccess,
   };
 }

--- a/packages/admin/src/components/features/singles/SingleForm.tsx
+++ b/packages/admin/src/components/features/singles/SingleForm.tsx
@@ -1007,6 +1007,7 @@ export function SingleForm({
                             <DocumentLockBanner
                               notice={lock.notice}
                               onTakeOver={lock.takeOver}
+                              onRequestAccess={lock.requestAccess}
                               className="mx-6 mt-3"
                             />
                             {/* The recovery offer restores work into the LIVE

--- a/packages/admin/src/hooks/queries/__tests__/useDocumentLock.test.tsx
+++ b/packages/admin/src/hooks/queries/__tests__/useDocumentLock.test.tsx
@@ -29,13 +29,19 @@ const acquired = {
   message: "",
   item: { status: "acquired", claimToken: "t1" },
 };
-const held = { message: "", item: { status: "held", holder: other } };
+const held = {
+  message: "",
+  item: { status: "held", holder: other, waiting: false },
+};
 
 beforeEach(() => {
   vi.clearAllMocks();
   vi.useFakeTimers({ shouldAdvanceTime: true });
   post.mockResolvedValue(acquired);
-  patch.mockResolvedValue({ message: "", item: { status: "renewed" } });
+  patch.mockResolvedValue({
+    message: "",
+    item: { status: "renewed", waiting: false },
+  });
   del.mockResolvedValue(undefined);
 });
 
@@ -51,6 +57,7 @@ describe("useDocumentLock", () => {
     expect(post).toHaveBeenCalledWith("/document-lock", {
       ...ref,
       takeover: false,
+      requestAccess: false,
     });
   });
 
@@ -79,6 +86,7 @@ describe("useDocumentLock", () => {
       expect(result.current.state).toEqual({
         status: "held-by-other",
         holder: other,
+        requestSent: false,
       })
     );
   });
@@ -202,7 +210,235 @@ describe("useDocumentLock", () => {
     expect(post).toHaveBeenLastCalledWith("/document-lock", {
       ...ref,
       takeover: true,
+      requestAccess: false,
     });
+  });
+
+  it("asks for nothing until the person asks for it", async () => {
+    // The control, and the reason it comes first: every locked-out editor polls
+    // on every beat, so a flag that rode the poll unconditionally would nudge
+    // the holder on behalf of anybody who merely opened the document to read it.
+    post.mockResolvedValue(held);
+    const { result } = renderHook(() => useDocumentLock(ref));
+    await waitFor(() =>
+      expect(result.current.state.status).toBe("held-by-other")
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS);
+    });
+
+    for (const call of post.mock.calls) {
+      expect(call[1]).toMatchObject({ requestAccess: false });
+    }
+  });
+
+  it("asks at once, and keeps asking on every beat afterwards", async () => {
+    // 🔴 A STANDING ask. The server holds it on a lease, so one request would
+    // lapse under a holder who keeps working -- and the person pressed once.
+    // Asking at once rather than at the next beat is what answers the press.
+    post.mockResolvedValue({
+      message: "",
+      item: { status: "held", holder: other, waiting: true },
+    });
+    const { result } = renderHook(() => useDocumentLock(ref));
+    await waitFor(() =>
+      expect(result.current.state.status).toBe("held-by-other")
+    );
+
+    await act(async () => {
+      result.current.requestAccess();
+    });
+    expect(post).toHaveBeenLastCalledWith("/document-lock", {
+      ...ref,
+      takeover: false,
+      requestAccess: true,
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS);
+    });
+    expect(post).toHaveBeenLastCalledWith("/document-lock", {
+      ...ref,
+      takeover: false,
+      requestAccess: true,
+    });
+  });
+
+  it("confirms the ask only when the SERVER says it is on record", async () => {
+    // 🔴 Not the click. A server that ignored the flag -- an older deployment,
+    // a dropped field -- would otherwise have this editor promise a colleague
+    // was told by a request that landed nowhere.
+    post.mockResolvedValue(held);
+    const { result } = renderHook(() => useDocumentLock(ref));
+    await waitFor(() =>
+      expect(result.current.state.status).toBe("held-by-other")
+    );
+
+    await act(async () => {
+      result.current.requestAccess();
+    });
+
+    expect(result.current.state).toEqual({
+      status: "held-by-other",
+      holder: other,
+      requestSent: false,
+    });
+
+    post.mockResolvedValue({
+      message: "",
+      item: { status: "held", holder: other, waiting: true },
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS);
+    });
+
+    await waitFor(() =>
+      expect(result.current.state).toEqual({
+        status: "held-by-other",
+        holder: other,
+        requestSent: true,
+      })
+    );
+  });
+
+  it("does not report a THIRD colleague's ask as this editor's own", async () => {
+    // `waiting` says somebody is waiting, which is also true when it is not the
+    // person in front of this editor. Only the conjunction says "we told them,
+    // for you", and this is the half a click-driven flag cannot see.
+    post.mockResolvedValue({
+      message: "",
+      item: { status: "held", holder: other, waiting: true },
+    });
+    const { result } = renderHook(() => useDocumentLock(ref));
+
+    await waitFor(() =>
+      expect(result.current.state).toEqual({
+        status: "held-by-other",
+        holder: other,
+        requestSent: false,
+      })
+    );
+  });
+
+  it("re-renders when the ask lands, though the holder has not changed", async () => {
+    // 🔴 Nobody changes holder when somebody asks for their document. A poll
+    // that stayed quiet on an unchanged HOLDER would leave the button on screen
+    // after the request that replaced it landed.
+    post.mockResolvedValue(held);
+    const { result } = renderHook(() => useDocumentLock(ref));
+    await waitFor(() =>
+      expect(result.current.state.status).toBe("held-by-other")
+    );
+
+    post.mockResolvedValue({
+      message: "",
+      item: { status: "held", holder: other, waiting: true },
+    });
+    await act(async () => {
+      result.current.requestAccess();
+    });
+
+    await waitFor(() =>
+      expect(result.current.state).toMatchObject({ requestSent: true })
+    );
+  });
+
+  it("stops asking once this editor has the document", async () => {
+    // Nobody waits for what they hold. The server clears its own mark on the
+    // same event, so neither side is left saying this editor queues for its own
+    // claim.
+    post.mockResolvedValue({
+      message: "",
+      item: { status: "held", holder: other, waiting: true },
+    });
+    const { result } = renderHook(() => useDocumentLock(ref));
+    await waitFor(() =>
+      expect(result.current.state.status).toBe("held-by-other")
+    );
+    await act(async () => {
+      result.current.requestAccess();
+    });
+
+    post.mockResolvedValue(acquired);
+    await act(async () => {
+      vi.advanceTimersByTime(DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS);
+    });
+    await waitFor(() =>
+      expect(result.current.state).toEqual({
+        status: "held-by-me",
+        someoneWaiting: false,
+      })
+    );
+
+    // Then lose it to nobody, and take it back. That second acquisition is what
+    // makes the cleared intent OBSERVABLE: uncleared, a person taking a document
+    // back would be recorded as somebody waiting for the document they now hold,
+    // and their own next beat would tell them so.
+    patch.mockResolvedValue({ message: "", item: { status: "lost" } });
+    await act(async () => {
+      vi.advanceTimersByTime(DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS);
+    });
+    await waitFor(() => expect(result.current.state.status).toBe("taken-over"));
+
+    await act(async () => {
+      result.current.takeOver();
+    });
+    expect(post).toHaveBeenLastCalledWith("/document-lock", {
+      ...ref,
+      takeover: true,
+      requestAccess: false,
+    });
+  });
+
+  it("tells the holder somebody is waiting, on the beat they already make", async () => {
+    const { result } = renderHook(() => useDocumentLock(ref));
+    await waitFor(() => expect(result.current.state.status).toBe("held-by-me"));
+    expect(result.current.state).toEqual({
+      status: "held-by-me",
+      someoneWaiting: false,
+    });
+
+    patch.mockResolvedValue({
+      message: "",
+      item: { status: "renewed", waiting: true },
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS);
+    });
+
+    await waitFor(() =>
+      expect(result.current.state).toEqual({
+        status: "held-by-me",
+        someoneWaiting: true,
+      })
+    );
+  });
+
+  it("says it once, not once per beat", async () => {
+    // 🔴 The notice lives in a live region, so re-rendering it on an unchanged
+    // answer would read the same sentence to somebody every fifteen seconds.
+    // State identity is the instrument: a new object IS the re-announcement.
+    patch.mockResolvedValue({
+      message: "",
+      item: { status: "renewed", waiting: true },
+    });
+    const { result } = renderHook(() => useDocumentLock(ref));
+    await waitFor(() => expect(result.current.state.status).toBe("held-by-me"));
+
+    await act(async () => {
+      vi.advanceTimersByTime(DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS);
+    });
+    await waitFor(() =>
+      expect(result.current.state).toMatchObject({ someoneWaiting: true })
+    );
+    const spoken = result.current.state;
+
+    await act(async () => {
+      vi.advanceTimersByTime(DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS * 3);
+    });
+
+    expect(result.current.state).toBe(spoken);
   });
 
   it("reports the claim unavailable when it cannot be asked for, and retries", async () => {
@@ -333,6 +569,7 @@ describe("useDocumentLock", () => {
       expect(post).toHaveBeenLastCalledWith("/document-lock", {
         ...ref,
         takeover: true,
+        requestAccess: false,
       })
     );
 
@@ -362,6 +599,7 @@ describe("useDocumentLock", () => {
     expect(post).toHaveBeenLastCalledWith("/document-lock", {
       ...ref,
       takeover: false,
+      requestAccess: false,
     });
   });
 
@@ -436,6 +674,7 @@ describe("useDocumentLock", () => {
     expect(post).toHaveBeenLastCalledWith("/document-lock", {
       ...ref,
       takeover: true,
+      requestAccess: false,
     });
   });
 
@@ -482,7 +721,10 @@ describe("useDocumentLock", () => {
       message: "",
       item: { status: "acquired", claimToken: "t2" },
     });
-    patch.mockResolvedValue({ message: "", item: { status: "renewed" } });
+    patch.mockResolvedValue({
+      message: "",
+      item: { status: "renewed", waiting: false },
+    });
     await act(async () => {
       result.current.takeOver();
     });
@@ -540,6 +782,7 @@ describe("useDocumentLock", () => {
     expect(post).toHaveBeenLastCalledWith("/document-lock", {
       ...ref,
       takeover: true,
+      requestAccess: false,
     });
   });
 
@@ -719,6 +962,7 @@ describe("useDocumentLock", () => {
       expect(result.current.state).toEqual({
         status: "held-by-other",
         holder: other,
+        requestSent: false,
       })
     );
   });
@@ -1024,6 +1268,7 @@ describe("useDocumentLock", () => {
     expect(post).toHaveBeenLastCalledWith("/document-lock", {
       ...ref,
       takeover: true,
+      requestAccess: false,
     });
     const sent = post.mock.calls.length;
 
@@ -1036,6 +1281,7 @@ describe("useDocumentLock", () => {
     expect(post).toHaveBeenLastCalledWith("/document-lock", {
       ...ref,
       takeover: true,
+      requestAccess: false,
     });
   });
 

--- a/packages/admin/src/hooks/queries/useDocumentLock.ts
+++ b/packages/admin/src/hooks/queries/useDocumentLock.ts
@@ -53,6 +53,20 @@
  * slot is re-asked as a take-over. Losing it turns the decision into a poll that
  * politely declines to displace anyone.
  *
+ * ## A request to edit rides the beat that was already going
+ *
+ * 🔴 An editor that is locked out polls for the document on every beat -- that
+ * poll is how it learns the holder has left -- so a person asking for the
+ * document is carried as a flag on the claim that was going to be sent anyway,
+ * not on a call of its own. That is also what makes the ask a STANDING one:
+ * every beat re-states it, the server holds it on a lease, and closing the tab
+ * stops refreshing it. A colleague is therefore never told that somebody is
+ * waiting when nobody is still there.
+ *
+ * 🔴 The intent is remembered in the effect, like the claim, and cleared by
+ * WINNING the document rather than by the request that carried it. A person
+ * presses once; the beat says it again until they have it or they leave.
+ *
  * ## The beat outlives the claim
  *
  * 🔴 The interval is cleared by cleanup and by nothing else. An editor who takes
@@ -97,10 +111,29 @@ export type DocumentLockState =
   | { status: "idle" }
   /** Asked for, no answer yet. */
   | { status: "acquiring" }
-  /** This editor holds it. */
-  | { status: "held-by-me" }
-  /** Someone else holds it, and can be named. */
-  | { status: "held-by-other"; holder: DocumentLockHolder }
+  /**
+   * This editor holds it.
+   *
+   * `someoneWaiting` is the courtesy notice, and the server's answer rather
+   * than this editor's guess: a colleague has asked for the document and has
+   * not stopped asking. It withholds nothing and demands nothing -- the lease
+   * expiring stays the only thing that transfers a document.
+   */
+  | { status: "held-by-me"; someoneWaiting: boolean }
+  /**
+   * Someone else holds it, and can be named.
+   *
+   * `requestSent` is true once THIS editor has asked for the document and the
+   * server has confirmed the ask is on record. Both halves are required: the
+   * click alone would let the interface promise a colleague was told by a
+   * request that never landed, and the server's answer alone names any waiting
+   * editor rather than this one.
+   */
+  | {
+      status: "held-by-other";
+      holder: DocumentLockHolder;
+      requestSent: boolean;
+    }
   /**
    * This editor held it and the server said someone took over. The holder is
    * absent when the claim simply lapsed and nobody took it, which is what
@@ -162,6 +195,11 @@ export function useDocumentLock({
   const takeOverRef = useRef<() => void>(() => {});
   const takeOver = useCallback(() => takeOverRef.current(), []);
 
+  // Published the same way and for the same reason: the intent belongs to the
+  // effect that owns the claim, and the consumer gets a stable reference.
+  const requestAccessRef = useRef<() => void>(() => {});
+  const requestAccess = useCallback(() => requestAccessRef.current(), []);
+
   // 🔴 The cross-RUN half of the fencing, which the token fence cannot cover. A
   // run whose cleanup has already happened can still have a request in flight,
   // and the server treats a claim from the same owner as takeable, so that late
@@ -201,6 +239,15 @@ export function useDocumentLock({
     // because the very thing it reports is that the token just installed may
     // already be dead. Collapsing them lets a win swallow the repair.
     let repairNeeded = false;
+    // 🔴 A STANDING ask, not a one-shot request. `requesting` is what the person
+    // decided and every beat re-states it; `requestSent` is what the server has
+    // confirmed is on record, and only the pair may be shown as "they know".
+    let requesting = false;
+    let requestSent = false;
+    // What the holder was last told about a colleague waiting. Kept so an
+    // unchanged answer on every beat does not re-render the editor, and does not
+    // re-announce a sentence the reader has already heard.
+    let awaited = false;
     // Set when this editor stops being a contender: displaced by the server, or
     // past its own deadline. The beat then waits for the person rather than
     // re-taking a claim they were just told they had lost.
@@ -253,18 +300,27 @@ export function useDocumentLock({
       // very token may already be dead and the following plain claim would come
       // back `held`, losing the click for good.
       if (!repairNeeded) pending = null;
-      setState({ status: "held-by-me" });
+      // Winning the document ends the ask: nobody waits for what they hold. The
+      // server clears its own mark on the same event, so neither side is left
+      // telling somebody that this editor is queueing for its own claim.
+      requesting = false;
+      requestSent = false;
+      awaited = false;
+      setState({ status: "held-by-me", someoneWaiting: false });
     };
 
-    /** Store a refusal, quietly when the holder has not changed. */
-    const installHeld = (current: DocumentLockHolder) => {
+    /** Store a refusal, quietly when neither the holder nor the ask has moved. */
+    const installHeld = (current: DocumentLockHolder, sent: boolean) => {
       token = null;
-      // This runs every beat while a colleague holds the document, and a fresh
-      // object each time re-renders the editor for no news.
-      if (holder === null || !sameHolder(holder, current)) {
-        holder = current;
-        setState({ status: "held-by-other", holder: current });
-      }
+      // 🔴 The ask is part of what this state SAYS, so it is part of what decides
+      // whether to re-render. Comparing holders alone would leave the button on
+      // screen after the request that replaced it landed -- the holder does not
+      // change when somebody asks for their document.
+      const news = holder === null || !sameHolder(holder, current);
+      if (!news && sent === requestSent) return;
+      holder = current;
+      requestSent = sent;
+      setState({ status: "held-by-other", holder: current, requestSent: sent });
     };
 
     /** Report that the server could not be asked, and forget what it last said. */
@@ -275,6 +331,10 @@ export function useDocumentLock({
       // editor stays on `unavailable` while the server is answering perfectly
       // well — which is plausible whenever the holder renews on this cadence.
       holder = null;
+      // The ask itself is NOT forgotten -- `requesting` is the person's decision
+      // and outlives a failed beat -- but its confirmation is, because what the
+      // server has on record is exactly what this beat failed to learn.
+      requestSent = false;
       setState({ status: "unavailable" });
     };
 
@@ -325,6 +385,45 @@ export function useDocumentLock({
       reacquireRef.current(key);
     };
 
+    /**
+     * Decide what one acquisition's answer means for this editor.
+     *
+     * Separate from sending it because the two halves answer different
+     * questions. `acquire` owns the SLOT — who has a request outstanding, and
+     * what is queued behind it — while this owns the CLAIM the answer carries.
+     * The slot question has to be settled first and independently: a reply the
+     * slot has moved on from is a duplicate whatever it says, including when it
+     * says this editor won the document.
+     *
+     * `asked` is what THIS request carried, not what the person has since
+     * pressed, which is why it is passed in rather than read here.
+     */
+    const settle = (
+      item: AcquireDocumentLockOutcome,
+      seq: number,
+      sentAt: number,
+      asked: boolean
+    ) => {
+      // The slot moved on without this request, so whatever it won is a
+      // duplicate: a later acquisition has already replaced it server-side, or
+      // is about to.
+      const superseded = inFlight !== seq;
+      if (!superseded) inFlight = null;
+
+      if (cancelled || superseded) {
+        discardDuplicate(item);
+        if (superseded) drain();
+        return;
+      }
+
+      if (item.status === "acquired") installAcquired(item.claimToken, sentAt);
+      // 🔴 Both halves. `item.waiting` says somebody is waiting, which is also
+      // true when the person in front of this editor has asked for nothing and a
+      // THIRD colleague has. Only the conjunction says "we told them, for you".
+      else installHeld(item.holder, asked && item.waiting);
+      drain();
+    };
+
     async function acquire(takeover: boolean): Promise<void> {
       const intent: ClaimIntent = takeover ? "takeover" : "claim";
       if (inFlight !== null) {
@@ -341,32 +440,22 @@ export function useDocumentLock({
       );
 
       let item: AcquireDocumentLockOutcome;
+      // Read once, here, so the answer is judged against what THIS request
+      // carried. Read again at the reply, a request sent before the person
+      // pressed would report their ask as landed on the strength of a beat that
+      // never mentioned it.
+      const asked = requesting;
       try {
         ({ item } = await protectedApi.post<
           MutationResponse<AcquireDocumentLockOutcome>
-        >("/document-lock", { ...ref, takeover }));
+        >("/document-lock", { ...ref, takeover, requestAccess: asked }));
       } catch {
         clearTimeout(slotExpiry);
         failClaim(seq, intent);
         return;
       }
       clearTimeout(slotExpiry);
-
-      // The slot moved on without this request, so whatever it won is a
-      // duplicate: a later acquisition has already replaced it server-side, or
-      // is about to.
-      const superseded = inFlight !== seq;
-      if (!superseded) inFlight = null;
-
-      if (cancelled || superseded) {
-        discardDuplicate(item);
-        if (superseded) drain();
-        return;
-      }
-
-      if (item.status === "acquired") installAcquired(item.claimToken, sentAt);
-      else installHeld(item.holder);
-      drain();
+      settle(item, seq, sentAt, asked);
     }
 
     /** Give the claim up, and hand back whatever the server may still be holding. */
@@ -383,6 +472,14 @@ export function useDocumentLock({
     };
 
     takeOverRef.current = () => void acquire(true);
+    requestAccessRef.current = () => {
+      // Set first, then ask NOW rather than at the next beat, so the person sees
+      // their press answered. A claim already in flight is not overtaken: the
+      // flag is read where a request is BUILT, so whatever the slot admits next
+      // carries it, and every beat after that re-states it.
+      requesting = true;
+      void acquire(false);
+    };
     reacquireRef.current = (forDocument: string) => {
       if (cancelled || forDocument !== key) return;
       // Queued rather than asked directly: the live run may have a claim of its
@@ -441,6 +538,16 @@ export function useDocumentLock({
             // renewal landing after a newer one would shorten a lease the newer
             // one already extended — firing the deadline several beats early.
             confirmedAt = Math.max(confirmedAt, renewSentAt);
+            // 🔴 Coarse by construction, and that is the accessibility
+            // requirement rather than a happy accident: the beat is the only
+            // thing that can move this, so the notice appears and disappears at
+            // the heartbeat's granularity instead of ticking at a reader.
+            // Rendered only on a CHANGE, so an unchanged answer every 15 seconds
+            // is not a live region repeating itself.
+            if (item.waiting !== awaited) {
+              awaited = item.waiting;
+              setState({ status: "held-by-me", someoneWaiting: item.waiting });
+            }
             return;
           }
           surrender({ status: "taken-over", holder: item.holder });
@@ -453,6 +560,7 @@ export function useDocumentLock({
     return () => {
       cancelled = true;
       takeOverRef.current = () => {};
+      requestAccessRef.current = () => {};
       // `reacquireRef` is left for the run that replaces this one to overwrite,
       // and refuses a document it does not own, so a late reply cannot wake an
       // editor that has gone or one looking at something else.
@@ -461,5 +569,5 @@ export function useDocumentLock({
     };
   }, [active, ref]);
 
-  return { state, takeOver };
+  return { state, takeOver, requestAccess };
 }

--- a/packages/admin/src/pages/dashboard/entries/[slug]/[id]/index.tsx
+++ b/packages/admin/src/pages/dashboard/entries/[slug]/[id]/index.tsx
@@ -549,11 +549,14 @@ export default function EditEntryPage({
             onDefaultLocale={!isNonDefaultLocale}
           />
           {/* Said for the same reason, about the other fact a second editor
-              needs: who has this document open. The strip renders nothing while
-              the claim is this editor's own. */}
+              needs: who has this document open. The strip is silent while the
+              claim is this editor's own AND nobody is waiting for it; a
+              colleague who asks for the document is spoken here too, since this
+              is the one live region the lock uses. */}
           <DocumentLockBanner
             notice={customViewLock.notice}
             onTakeOver={customViewLock.takeOver}
+            onRequestAccess={customViewLock.requestAccess}
           />
           {/* Boxed for the same reason the injection slots are: under the
               measured frame this is a direct child of a CSS grid, and the rule


### PR DESCRIPTION
The client half of the soft-lock courtesy notice. #1703 gave the lock row a
standing request; this is the interface that raises one and the one that reads it.

## What a person sees

**Locked out.** The banner already named the holder and offered "Take over". It
now offers **Request edit access** beside it, and once the server has the ask on
record the button is *replaced* by a sentence — "We have let Dev User know you
are waiting." A control that silently does nothing is worse than no control, so
the confirmation is the point, not a nicety.

**Holding the document.** A line appears above the document: *"Someone is waiting
to edit this document."* No buttons, nothing to answer, nothing withheld — Save,
Publish and every field stay exactly as they were. The lease expiring is still
the only thing that transfers the document.

Verified end-to-end in a real browser with two accounts (D-04.10): the ask lands,
the holder is told on the next heartbeat, and the notice **disappears on its own**
once the person waiting closes the tab.

## Three decisions worth reviewing

**The ask rides the poll it was going to send anyway.** A locked-out editor
already re-acquires every 15s — that poll is how it learns the holder left. So
"still waiting" is carried by that request rather than by a second one, which is
also what makes the mark self-expiring: stop polling, and it lapses.

**The confirmation is a conjunction, not either half.** `item.waiting` is true
whenever *somebody* is waiting, including a third colleague this editor has never
heard of. Only `asked && item.waiting` says "we told them, for you". Reading
either half alone is a claim the editor cannot support, and there is a test for
each direction.

**One live region, and it does not chatter.** The banner keeps `role="status"`
rather than becoming an `alert` — nothing here is urgent enough to cut across a
screen reader, and WCAG 2.2.4 wants an interruption a person can postpone. The
holder's line is announced once when it appears and not re-announced on every
beat, because the state is only re-set when the answer actually changes.

## What is NOT here

No modal, no consent gate, no queue, and nothing that can refuse the holder —
per `decision:pb-softlock-courtesy-notice-not-consent`. The handover path never
reaches `useReportUnsavedWork`, which reports one boolean and cannot save.

## Gates

`pnpm build` 0 · admin `check-types` 0 `lint` 0 `vitest` 0 (417 files, 4182 tests)
· plugin-sdk 0/0/0 · `fallow audit` pass, every `*_introduced` 0 over 12 changed
files · `changeset status` 0.

Eight mechanisms break-verified: each was rewritten wrong, the named test failed,
the original restored. `acquire` was split into send/settle when fallow flagged
the complexity it had gained, and two of the breaks were re-run afterwards to
prove the split left no uncovered path.
