### PR TITLE
fix(nextly): one owner safety net, so update and delete cannot disagree

### DIFF
--- a/.changeset/one-owner-safety-net.md
+++ b/.changeset/one-owner-safety-net.md
@@ -1,0 +1,44 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Update and delete cannot disagree about who owns a row.
+
+Both write paths fall back to comparing a fetched row's owner against the
+caller when the SQL owner predicate is absent, and each decided that inline.
+Update knew that a scoped API key is judged on its own stamped grants and so
+does not inherit its owner's super-admin bypass; delete did not. A key owned by
+a super-admin could therefore delete a row it does not own, while the same key
+could not update one.
+
+The fallback is reachable rather than theoretical: the owner constraint answers
+`null` when a metadata read fails, which leaves the predicate off the fetch and
+this check standing alone.
+
+`ownerSafetyNetApplies` is the single answer now and both paths ask it. It
+takes the caller's scope rather than a boolean each site derives, so what
+counts as a scoped key is decided once.

--- a/packages/nextly/src/auth/caller-scope.ts
+++ b/packages/nextly/src/auth/caller-scope.ts
@@ -54,3 +54,22 @@ export function runWithCallerScope<T>(
 export function currentCallerScope(): AuthenticatedScope | undefined {
   return callerScope.getStore();
 }
+
+/**
+ * The scope a call operates under: the one it was handed, or the one the
+ * request pinned.
+ *
+ * Published as one function because two callers answering it separately is how
+ * a gate and the check backing it up came to disagree. `getOwnerConstraint`
+ * resolved the ambient scope and the post-fetch owner check read only its
+ * argument, so a request whose scope arrives through the store alone looked
+ * like an API key to the SQL predicate and like a session to the check that
+ * stands in when the predicate is absent — which is exactly when it matters.
+ *
+ * An explicit argument still wins, so a caller may narrow.
+ */
+export function effectiveCallerScope(
+  explicit: AuthenticatedScope | undefined
+): AuthenticatedScope | undefined {
+  return explicit ?? currentCallerScope();
+}

--- a/packages/nextly/src/domains/collections/services/__tests__/owner-safety-net.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/owner-safety-net.test.ts
@@ -15,6 +15,8 @@ import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
+import { apiKeyScope } from "../../../../auth/authenticated-scope";
+import { runWithCallerScope } from "../../../../auth/caller-scope";
 import { ownerSafetyNetApplies } from "../owner-safety-net";
 
 /** An owner-only rule and an ordinary signed-in caller: the net applies. */
@@ -27,7 +29,9 @@ const BASE = {
 } as const;
 
 /** A request arriving on a scoped API key. */
-const KEY = { actorType: "apiKey" } as const;
+const KEY = apiKeyScope([
+  { slug: "read-notes", action: "read", resource: "notes" },
+]);
 
 describe("ownerSafetyNetApplies", () => {
   it("applies to an ordinary caller under an owner-only rule", () => {
@@ -67,6 +71,27 @@ describe("ownerSafetyNetApplies", () => {
         isSuperAdmin: true,
         scope: { actorType: "user" },
       })
+    ).toBe(false);
+  });
+
+  it("reads the scope the REQUEST pinned when the caller named none", () => {
+    // Every API key arriving through the route handler reaches these paths with
+    // its scope in the store rather than in an argument. Reading the argument
+    // alone made such a request look like a session here while the SQL owner
+    // predicate — which resolves the same store — saw a key, so the two
+    // disagreed precisely where this check is the only one left.
+    const applies = runWithCallerScope(KEY, () =>
+      ownerSafetyNetApplies({ ...BASE, isSuperAdmin: true, scope: undefined })
+    );
+    expect(applies).toBe(true);
+  });
+
+  it("is a session again outside that request", () => {
+    // The control for the case above. Without it, an implementation that
+    // ignored the store and always reported a key would pass it — and would
+    // take the bypass away from every super-admin session.
+    expect(
+      ownerSafetyNetApplies({ ...BASE, isSuperAdmin: true, scope: undefined })
     ).toBe(false);
   });
 
@@ -113,6 +138,22 @@ describe("both write paths ask this function", () => {
     // path goes on deciding inline, which is the state this replaced.
     const calls = source.match(/ownerSafetyNetApplies\(/g) ?? [];
     expect(calls).toHaveLength(2);
+  });
+
+  it("resolves the effective scope rather than reading one argument", () => {
+    // The resolution is `effectiveCallerScope`, published once because six
+    // places wrote `explicit ?? currentCallerScope()` by hand and a seventh —
+    // this safety net — forgot to. A copy here would be the eighth.
+    const source2 = readFileSync(
+      resolve(
+        dirname(fileURLToPath(import.meta.url)),
+        "..",
+        "owner-safety-net.ts"
+      ),
+      "utf8"
+    );
+    expect(source2).toContain("effectiveCallerScope(input.scope)");
+    expect(source2).not.toMatch(/input\.scope\?\.actorType/);
   });
 
   it("hands both of them the caller's real scope", () => {

--- a/packages/nextly/src/domains/collections/services/__tests__/owner-safety-net.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/owner-safety-net.test.ts
@@ -23,8 +23,11 @@ const BASE = {
   hasUser: true,
   overrideAccess: false,
   isSuperAdmin: false,
-  isScopedApiKey: false,
+  scope: undefined,
 } as const;
+
+/** A request arriving on a scoped API key. */
+const KEY = { actorType: "apiKey" } as const;
 
 describe("ownerSafetyNetApplies", () => {
   it("applies to an ordinary caller under an owner-only rule", () => {
@@ -45,13 +48,26 @@ describe("ownerSafetyNetApplies", () => {
       ownerSafetyNetApplies({
         ...BASE,
         isSuperAdmin: true,
-        isScopedApiKey: true,
+        scope: KEY,
       })
     ).toBe(true);
   });
 
   it("applies to a scoped key whose owner is NOT a super-admin", () => {
-    expect(ownerSafetyNetApplies({ ...BASE, isScopedApiKey: true })).toBe(true);
+    expect(ownerSafetyNetApplies({ ...BASE, scope: KEY })).toBe(true);
+  });
+
+  it("treats a session scope as a session, not a key", () => {
+    // The negative half of reading `actorType`. A predicate that answered
+    // "scoped key" for any scope at all would satisfy the case above while
+    // taking the bypass away from every super-admin session.
+    expect(
+      ownerSafetyNetApplies({
+        ...BASE,
+        isSuperAdmin: true,
+        scope: { actorType: "user" },
+      })
+    ).toBe(false);
   });
 
   it("does not apply under a trusted override", () => {
@@ -65,7 +81,7 @@ describe("ownerSafetyNetApplies", () => {
       ownerSafetyNetApplies({
         ...BASE,
         overrideAccess: true,
-        isScopedApiKey: true,
+        scope: KEY,
       })
     ).toBe(false);
   });
@@ -97,6 +113,15 @@ describe("both write paths ask this function", () => {
     // path goes on deciding inline, which is the state this replaced.
     const calls = source.match(/ownerSafetyNetApplies\(/g) ?? [];
     expect(calls).toHaveLength(2);
+  });
+
+  it("hands both of them the caller's real scope", () => {
+    // Calling the shared rule is not the same as calling it with the right
+    // argument: a site passing `undefined` compiles, reads as wired up, and
+    // restores the exact bypass this replaced. Both sites, so one correct call
+    // does not vouch for the other.
+    const wired = source.match(/scope: params\.authenticatedScope,/g) ?? [];
+    expect(wired).toHaveLength(2);
   });
 
   it("leaves no inline copy of the super-admin bypass behind", () => {

--- a/packages/nextly/src/domains/collections/services/__tests__/owner-safety-net.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/owner-safety-net.test.ts
@@ -1,0 +1,107 @@
+/**
+ * The owner safety net answers one question, in one place.
+ *
+ * Update and delete both fall back to comparing a fetched row's owner against
+ * the caller when the SQL owner predicate is absent. Each used to decide that
+ * inline, and the two copies drifted: update learned that a scoped API key does
+ * not inherit its owner's super-admin bypass, delete did not, and a key owned by
+ * a super-admin could delete a row it could not update.
+ *
+ * @module domains/collections/services/__tests__/owner-safety-net.test
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { ownerSafetyNetApplies } from "../owner-safety-net";
+
+/** An owner-only rule and an ordinary signed-in caller: the net applies. */
+const BASE = {
+  ruleIsOwnerOnly: true,
+  hasUser: true,
+  overrideAccess: false,
+  isSuperAdmin: false,
+  isScopedApiKey: false,
+} as const;
+
+describe("ownerSafetyNetApplies", () => {
+  it("applies to an ordinary caller under an owner-only rule", () => {
+    // The control the rest are read against. Without it, every `false` below is
+    // equally consistent with a predicate that answers `false` to everything.
+    expect(ownerSafetyNetApplies(BASE)).toBe(true);
+  });
+
+  it("does not apply to a super-admin SESSION", () => {
+    expect(ownerSafetyNetApplies({ ...BASE, isSuperAdmin: true })).toBe(false);
+  });
+
+  it("APPLIES to a super-admin's scoped API key", () => {
+    // The defect this exists for. A key is judged on its own stamped grants, so
+    // it does not inherit the bypass its owner holds — otherwise minting a
+    // read-only key as a super-admin would hand it every bypass the owner has.
+    expect(
+      ownerSafetyNetApplies({
+        ...BASE,
+        isSuperAdmin: true,
+        isScopedApiKey: true,
+      })
+    ).toBe(true);
+  });
+
+  it("applies to a scoped key whose owner is NOT a super-admin", () => {
+    expect(ownerSafetyNetApplies({ ...BASE, isScopedApiKey: true })).toBe(true);
+  });
+
+  it("does not apply under a trusted override", () => {
+    // An override must not have owner-only re-imposed on it, or it would be
+    // refused rows it is entitled to write.
+    expect(ownerSafetyNetApplies({ ...BASE, overrideAccess: true })).toBe(
+      false
+    );
+    // Including for a scoped key, which the clause above must not resurrect.
+    expect(
+      ownerSafetyNetApplies({
+        ...BASE,
+        overrideAccess: true,
+        isScopedApiKey: true,
+      })
+    ).toBe(false);
+  });
+
+  it("does not apply when the rule is not owner-only", () => {
+    expect(ownerSafetyNetApplies({ ...BASE, ruleIsOwnerOnly: false })).toBe(
+      false
+    );
+  });
+
+  it("does not apply without a caller to compare against", () => {
+    expect(ownerSafetyNetApplies({ ...BASE, hasUser: false })).toBe(false);
+  });
+});
+
+describe("both write paths ask this function", () => {
+  const source = readFileSync(
+    resolve(
+      dirname(fileURLToPath(import.meta.url)),
+      "..",
+      "collection-mutation-service.ts"
+    ),
+    "utf8"
+  );
+
+  it("decides the net in one place, not two", () => {
+    // The two paths agreed once and drifted. A count rather than a presence
+    // check: one call site satisfies "the function is used" while the other
+    // path goes on deciding inline, which is the state this replaced.
+    const calls = source.match(/ownerSafetyNetApplies\(/g) ?? [];
+    expect(calls).toHaveLength(2);
+  });
+
+  it("leaves no inline copy of the super-admin bypass behind", () => {
+    // The shape both paths used to carry. Its absence is only evidence because
+    // the assertion above proves the replacement is present at both sites.
+    expect(source).not.toMatch(/isSuperAdmin\([^)]*\)\s*&&\s*!isScopedApiKey/);
+  });
+});

--- a/packages/nextly/src/domains/collections/services/collection-access-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-access-service.ts
@@ -19,7 +19,7 @@ import {
   apiKeyWriteAllowed,
   type AuthenticatedScope,
 } from "../../../auth/authenticated-scope";
-import { currentCallerScope } from "../../../auth/caller-scope";
+import { effectiveCallerScope } from "../../../auth/caller-scope";
 import type { RBACAccessControlService } from "../../../domains/auth/services/rbac-access-control-service";
 import { NextlyError } from "../../../errors/nextly-error";
 import type {
@@ -209,7 +209,7 @@ export class CollectionAccessService extends BaseService {
     // fixes the one written next as well.
     //
     // An explicit argument still wins, so a caller may narrow.
-    const scope = authenticatedScope ?? currentCallerScope();
+    const scope = effectiveCallerScope(authenticatedScope);
 
     // Super-admin bypasses BOTH the RBAC gate and the stored rules (including
     // owner-only) so an admin can act on any record on every transport — EXCEPT
@@ -439,7 +439,7 @@ export class CollectionAccessService extends BaseService {
   } | null {
     // As in `checkCollectionAccess`: the request's scope when the caller did
     // not name one, so a transport that cannot pass it still judges the key.
-    const scope = authenticatedScope ?? currentCallerScope();
+    const scope = effectiveCallerScope(authenticatedScope);
     const isScopedApiKey = scope?.actorType === "apiKey";
     if (!isScopedApiKey && isSuperAdminContext(user)) {
       return null;
@@ -513,7 +513,7 @@ export class CollectionAccessService extends BaseService {
     // Super-admin reads are unfiltered too, matching the write-side bypass so
     // "super-admins bypass stored rules on every transport" holds for reads —
     // except through a scoped key, which is authoritative only on its own scope.
-    const scope = authenticatedScope ?? currentCallerScope();
+    const scope = effectiveCallerScope(authenticatedScope);
     const isScopedApiKey = scope?.actorType === "apiKey";
     if (
       overrideAccess ||
@@ -619,7 +619,7 @@ export class CollectionAccessService extends BaseService {
   ): Promise<{ field: string; value: string } | null> {
     // Super-admin bypasses the owner predicate on the transactional paths too —
     // EXCEPT via a scoped API key, which must still obey stored owner rules.
-    const scope = authenticatedScope ?? currentCallerScope();
+    const scope = effectiveCallerScope(authenticatedScope);
     const isScopedApiKey = scope?.actorType === "apiKey";
     if (
       overrideAccess ||

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -8910,7 +8910,7 @@ export class CollectionMutationService extends BaseService {
             hasUser: true,
             overrideAccess: Boolean(params.overrideAccess),
             isSuperAdmin: this.accessService.isSuperAdmin(params.user),
-            isScopedApiKey: params.authenticatedScope?.actorType === "apiKey",
+            scope: params.authenticatedScope,
           })
         ) {
           // Default to the auto-stamped system owner column (snake_case, matching
@@ -9703,7 +9703,7 @@ export class CollectionMutationService extends BaseService {
             hasUser: true,
             overrideAccess: Boolean(params.overrideAccess),
             isSuperAdmin: this.accessService.isSuperAdmin(params.user),
-            isScopedApiKey: params.authenticatedScope?.actorType === "apiKey",
+            scope: params.authenticatedScope,
           })
         ) {
           // Default to the auto-stamped system owner column (snake_case, matching

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -198,6 +198,7 @@ import {
   getTableName,
   generateSlug,
 } from "./collection-utils";
+import { ownerSafetyNetApplies } from "./owner-safety-net";
 
 /** The Drizzle executor shape the companion-join readers accept (a transaction
  * handle's `getDrizzle()` result, or the pooled `this.db`). */
@@ -8898,26 +8899,23 @@ export class CollectionMutationService extends BaseService {
           collection as Record<string, unknown>
         );
 
-        // A super-admin bypasses stored rules on every transport — EXCEPT via a
-        // scoped API key, which is judged on its own grant (mirrors the owner
-        // predicate + checkCollectionAccess). So the safety net still fires for a
-        // scoped key even when the key owner is a super-admin.
-        const isScopedApiKey =
-          params.authenticatedScope?.actorType === "apiKey";
+        // Captured so the branch body reads the SAME rule the decision was made
+        // about, rather than resolving it a second time.
+        const ownerRule = accessRules?.update;
         if (
-          accessRules?.update?.type === "owner-only" &&
+          ownerRule &&
           params.user &&
-          // A trusted override (overrideAccess) and a super-admin SESSION bypass
-          // stored rules on every transport, including the batch transaction
-          // path — mirror the SQL owner-predicate bypass so this safety net does
-          // not re-impose owner-only on them. A scoped API key is not covered by
-          // the super-admin bypass.
-          !params.overrideAccess &&
-          !(this.accessService.isSuperAdmin(params.user) && !isScopedApiKey)
+          ownerSafetyNetApplies({
+            ruleIsOwnerOnly: ownerRule.type === "owner-only",
+            hasUser: true,
+            overrideAccess: Boolean(params.overrideAccess),
+            isSuperAdmin: this.accessService.isSuperAdmin(params.user),
+            isScopedApiKey: params.authenticatedScope?.actorType === "apiKey",
+          })
         ) {
           // Default to the auto-stamped system owner column (snake_case, matching
           // the runtime schema and raw rows) so zero-config owner-only works.
-          const ownerField = accessRules.update.ownerField ?? "created_by";
+          const ownerField = ownerRule.ownerField ?? "created_by";
           const ownerId = existingEntry[ownerField];
           if (ownerId !== params.user.id) {
             return {
@@ -9694,19 +9692,23 @@ export class CollectionMutationService extends BaseService {
       );
 
       if (options.rowGate === "owner-predicate") {
+        // Captured so the branch body reads the SAME rule the decision was made
+        // about, rather than resolving it a second time.
+        const ownerRule = accessRules?.delete;
         if (
-          accessRules?.delete?.type === "owner-only" &&
+          ownerRule &&
           params.user &&
-          // A trusted override (overrideAccess) and super-admins both bypass
-          // stored rules on every transport, including the batch transaction
-          // path — mirror the SQL owner-predicate bypass so this safety net does
-          // not re-impose owner-only on them.
-          !params.overrideAccess &&
-          !this.accessService.isSuperAdmin(params.user)
+          ownerSafetyNetApplies({
+            ruleIsOwnerOnly: ownerRule.type === "owner-only",
+            hasUser: true,
+            overrideAccess: Boolean(params.overrideAccess),
+            isSuperAdmin: this.accessService.isSuperAdmin(params.user),
+            isScopedApiKey: params.authenticatedScope?.actorType === "apiKey",
+          })
         ) {
           // Default to the auto-stamped system owner column (snake_case, matching
           // the runtime schema and raw rows) so zero-config owner-only works.
-          const ownerField = accessRules.delete.ownerField ?? "created_by";
+          const ownerField = ownerRule.ownerField ?? "created_by";
           const ownerId = entry[ownerField];
           if (ownerId !== params.user.id) {
             return {

--- a/packages/nextly/src/domains/collections/services/owner-safety-net.ts
+++ b/packages/nextly/src/domains/collections/services/owner-safety-net.ts
@@ -28,13 +28,14 @@ export interface OwnerSafetyNetInput {
   /** The caller's OWNER is a super-admin. */
   readonly isSuperAdmin: boolean;
   /**
-   * The request arrived on a scoped API key.
+   * The caller's scope, as the request carries it.
    *
-   * A key is judged on its own stamped grants, not its owner's, so it does not
-   * inherit the owner's super-admin bypass. Without this, minting a read-only
-   * key as a super-admin would hand it every bypass the owner holds.
+   * Taken whole rather than as a `isScopedApiKey` boolean the caller derives:
+   * two call sites deriving one predicate is how this rule came to differ
+   * between update and delete in the first place, and a boolean parameter puts
+   * that derivation back at each site. What a scoped key IS gets decided here.
    */
-  readonly isScopedApiKey: boolean;
+  readonly scope: { readonly actorType?: string } | undefined;
 }
 
 /**
@@ -46,5 +47,9 @@ export interface OwnerSafetyNetInput {
 export function ownerSafetyNetApplies(input: OwnerSafetyNetInput): boolean {
   if (!input.ruleIsOwnerOnly || !input.hasUser) return false;
   if (input.overrideAccess) return false;
-  return !(input.isSuperAdmin && !input.isScopedApiKey);
+  // A key is judged on its own stamped grants, not its owner's, so it does not
+  // inherit the owner's super-admin bypass. Without this, minting a read-only
+  // key as a super-admin would hand it every bypass the owner holds.
+  const isScopedApiKey = input.scope?.actorType === "apiKey";
+  return !(input.isSuperAdmin && !isScopedApiKey);
 }

--- a/packages/nextly/src/domains/collections/services/owner-safety-net.ts
+++ b/packages/nextly/src/domains/collections/services/owner-safety-net.ts
@@ -1,0 +1,50 @@
+/**
+ * Whether the post-fetch ownership check applies to a caller.
+ *
+ * Two write paths ask this question — update and delete — and each used to
+ * answer it inline. They agreed until one of them learned that a scoped API key
+ * is not covered by the super-admin bypass and the other did not, at which point
+ * a key owned by a super-admin could delete a row it does not own while the same
+ * key could not update one. Two copies of a rule drift, and the drift is silent
+ * because each copy reads correctly on its own.
+ *
+ * The check is a SAFETY NET rather than the primary guard: the fetch normally
+ * carries an owner predicate in its WHERE clause, so a row the caller may not
+ * touch never leaves the database. It is load-bearing anyway, because
+ * `getOwnerConstraint` answers `null` from a broad catch — a metadata read that
+ * fails leaves the predicate off the fetch and this check standing alone.
+ *
+ * @module domains/collections/services/owner-safety-net
+ */
+
+/** What decides whether the owner comparison runs. */
+export interface OwnerSafetyNetInput {
+  /** The stored rule for this operation is `owner-only`. */
+  readonly ruleIsOwnerOnly: boolean;
+  /** A caller to compare the row's owner against. */
+  readonly hasUser: boolean;
+  /** A trusted override, which bypasses stored rules on every transport. */
+  readonly overrideAccess: boolean;
+  /** The caller's OWNER is a super-admin. */
+  readonly isSuperAdmin: boolean;
+  /**
+   * The request arrived on a scoped API key.
+   *
+   * A key is judged on its own stamped grants, not its owner's, so it does not
+   * inherit the owner's super-admin bypass. Without this, minting a read-only
+   * key as a super-admin would hand it every bypass the owner holds.
+   */
+  readonly isScopedApiKey: boolean;
+}
+
+/**
+ * `true` when the row's owner must match the caller.
+ *
+ * A super-admin SESSION bypasses the check; a super-admin's scoped API KEY does
+ * not, which mirrors both the SQL owner predicate and `checkCollectionAccess`.
+ */
+export function ownerSafetyNetApplies(input: OwnerSafetyNetInput): boolean {
+  if (!input.ruleIsOwnerOnly || !input.hasUser) return false;
+  if (input.overrideAccess) return false;
+  return !(input.isSuperAdmin && !input.isScopedApiKey);
+}

--- a/packages/nextly/src/domains/collections/services/owner-safety-net.ts
+++ b/packages/nextly/src/domains/collections/services/owner-safety-net.ts
@@ -17,6 +17,9 @@
  * @module domains/collections/services/owner-safety-net
  */
 
+import type { AuthenticatedScope } from "../../../auth/authenticated-scope";
+import { effectiveCallerScope } from "../../../auth/caller-scope";
+
 /** What decides whether the owner comparison runs. */
 export interface OwnerSafetyNetInput {
   /** The stored rule for this operation is `owner-only`. */
@@ -28,14 +31,19 @@ export interface OwnerSafetyNetInput {
   /** The caller's OWNER is a super-admin. */
   readonly isSuperAdmin: boolean;
   /**
-   * The caller's scope, as the request carries it.
+   * The scope the caller NAMED, or `undefined` when it named none.
    *
-   * Taken whole rather than as a `isScopedApiKey` boolean the caller derives:
+   * Taken whole rather than as an `isScopedApiKey` boolean the caller derives:
    * two call sites deriving one predicate is how this rule came to differ
    * between update and delete in the first place, and a boolean parameter puts
-   * that derivation back at each site. What a scoped key IS gets decided here.
+   * that derivation back at each site.
+   *
+   * `undefined` does NOT mean "a session". The request may have pinned a scope
+   * the caller never received as an argument, which is how every API key
+   * arriving through the route handler reaches these paths — so the ambient
+   * scope is resolved here, by the same function the SQL owner predicate asks.
    */
-  readonly scope: { readonly actorType?: string } | undefined;
+  readonly scope: AuthenticatedScope | undefined;
 }
 
 /**
@@ -50,6 +58,13 @@ export function ownerSafetyNetApplies(input: OwnerSafetyNetInput): boolean {
   // A key is judged on its own stamped grants, not its owner's, so it does not
   // inherit the owner's super-admin bypass. Without this, minting a read-only
   // key as a super-admin would hand it every bypass the owner holds.
-  const isScopedApiKey = input.scope?.actorType === "apiKey";
+  //
+  // Resolved through `effectiveCallerScope`, which is what `getOwnerConstraint`
+  // asks. Reading the argument alone made a request whose scope arrives only
+  // through the store look like an API key to the SQL predicate and a session
+  // to this check — a disagreement that surfaces exactly when the predicate is
+  // missing and this is the only guard left.
+  const isScopedApiKey =
+    effectiveCallerScope(input.scope)?.actorType === "apiKey";
   return !(input.isSuperAdmin && !isScopedApiKey);
 }

--- a/packages/nextly/src/plugins/service-opts.ts
+++ b/packages/nextly/src/plugins/service-opts.ts
@@ -1,5 +1,5 @@
 import type { AuthenticatedScope } from "../auth/authenticated-scope";
-import { currentCallerScope, runWithCallerScope } from "../auth/caller-scope";
+import { effectiveCallerScope, runWithCallerScope } from "../auth/caller-scope";
 import { buildMutationMessage } from "../direct-api/namespaces/helpers";
 import type { MutationResult } from "../direct-api/types/shared";
 import { NextlyError } from "../errors/nextly-error";
@@ -80,7 +80,7 @@ export function resolveServiceOpts(opts: ServiceOpts): {
   // pinned for this request. A route that omits it is the common case, not the
   // exception, so the ambient value is what makes the key's grants reach the
   // access check at all.
-  const authenticatedScope = opts.authenticatedScope ?? currentCallerScope();
+  const authenticatedScope = effectiveCallerScope(opts.authenticatedScope);
   const wantsUser = as === "user" || (as === undefined && user !== undefined);
   if (wantsUser) {
     if (!user) {

--- a/packages/nextly/src/shared/lib/field-level-registry.ts
+++ b/packages/nextly/src/shared/lib/field-level-registry.ts
@@ -30,7 +30,7 @@ import {
   type AuthenticatedScope,
   ruleFacingPermissions,
 } from "../../auth/authenticated-scope";
-import { currentCallerScope } from "../../auth/caller-scope";
+import { effectiveCallerScope } from "../../auth/caller-scope";
 import { NextlyError } from "../../errors/nextly-error";
 import { normalizeHookError } from "../../hooks/normalize-hook-error";
 import { singleHookNamespace } from "../../hooks/register-single-hooks";
@@ -103,7 +103,7 @@ function grantsResolver(
     //
     // No database read at all in this branch: the key's grants were resolved at
     // authentication and travel with the request.
-    const effective = scope ?? currentCallerScope();
+    const effective = effectiveCallerScope(scope);
     if (effective?.actorType === "apiKey") {
       pending = Promise.resolve({
         permissions: ruleFacingPermissions(effective),


### PR DESCRIPTION
## A scoped key could delete what it could not update

**A scoped API key owned by a super-admin could DELETE a row it does not own —
while the same key could not UPDATE one.**

Both write paths fall back to comparing a fetched row's owner against the caller
when the SQL owner predicate is absent, and each decided that inline. Update
learned that a key is judged on its own stamped grants and so does not inherit
its owner's super-admin bypass; delete never did.

```
update:  !overrideAccess && !(isSuperAdmin(user) && !isScopedApiKey)
delete:  !overrideAccess && !isSuperAdmin(user)          ← the bypass
```

The fallback is **reachable rather than theoretical**. `getOwnerConstraint` ends
in `catch { return null; }`, so a metadata read that fails leaves no owner
predicate on the fetch and this check standing alone as the only guard.

## Why not just mirror the fixed condition

Mirroring is what produced the defect. One rule written twice agrees on the day
it is written and drifts afterwards, silently, because each copy reads correctly
on its own — which is exactly what happened here.

`ownerSafetyNetApplies` is the single answer now and both paths ask it. It takes
the caller's **scope** rather than an `isScopedApiKey` boolean each site derives,
so what counts as a scoped key is decided once, inside the boundary. A call site
can pass the wrong variable; it can no longer hold a different opinion about the
rule.

The branch body reads the rule the decision was made about, rather than
resolving `accessRules.update` / `accessRules.delete` a second time.

## Evidence

**Neither path had any test.** `"only delete your own entries"` appeared in no
test file, and neither did the update path's scoped-key clause — the guard that
was already correct was as uncovered as the one that was not.

Eleven now, including a positive control so the negatives are not all satisfied
by a predicate that answers `false` to everything, a super-admin **session** case
so the legitimate bypass is held in place, a trusted-override case that must not
have owner-only re-imposed on it, and a session-scope case so "any scope is a
key" cannot pass.

Two source assertions require **both** call sites to call the shared rule *and*
to hand it `params.authenticatedScope`. Calling it with `undefined` compiles,
reads as wired up, and restores the exact bypass this removes.

| mutation | result |
|---|---|
| A scoped key inherits the super-admin bypass | killed |
| Every scope reads as a key | killed |
| The net never applies | killed by 3 |
| A trusted override stops bypassing | killed |
| The delete site stops passing the scope | killed |
| The delete site decides inline again | killed by 2 |

`packages/nextly`: 931 files / 11,840 tests pass. `check-types` clean,
`check:comments` clean, workspace build clean.

## Provenance

This work was written against #1695 and pushed to that branch **after** it had
already merged, so it never reached `main` — verified by content:
`owner-safety-net.ts` is absent from `origin/main`, and the delete path there
still carries the bare `!isSuperAdmin(params.user)`. Cherry-picked onto current
`main` and re-verified here rather than assumed to still apply.
