### PR TITLE
fix(admin): only the newest renewal may change the waiting notice

### DIFF
--- a/.changeset/newest-renewal-owns-the-waiting-notice.md
+++ b/.changeset/newest-renewal-owns-the-waiting-notice.md
@@ -1,0 +1,38 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+An editor holding a document confirms its claim every fifteen seconds, and those
+confirmations can overlap: a slow one and the next one are both in flight, and
+their answers can come back in the wrong order. The lease already knew this and
+only ever moves forward. What the same reply says about a colleague waiting for
+the document did not, so a confirmation that left BEFORE anybody asked could land
+after one that already reported the request, and quietly take the notice away
+again until some later beat happened to restore it.
+
+Only the newest confirmation may now change that notice, on the same rule and for
+the same reason the lease uses.

--- a/packages/admin/src/hooks/queries/__tests__/useDocumentLock.test.tsx
+++ b/packages/admin/src/hooks/queries/__tests__/useDocumentLock.test.tsx
@@ -415,6 +415,54 @@ describe("useDocumentLock", () => {
     );
   });
 
+  it("does not let an older renewal reverse a newer one's answer", async () => {
+    // 🔴 Renewals overlap, and their replies can arrive out of order — the
+    // lease is already advanced with `Math.max` for exactly this reason. The
+    // waiting answer needs the same fence: a slow beat that left BEFORE anybody
+    // asked still says "nobody is waiting", and landing after a later beat that
+    // said otherwise would take the notice away from the holder until some
+    // subsequent renewal happened to put it back.
+    const { result } = renderHook(() => useDocumentLock(ref));
+    await waitFor(() => expect(result.current.state.status).toBe("held-by-me"));
+
+    // The older beat leaves first and is still in flight, carrying the answer
+    // from before the ask.
+    let settleOlder: (value: unknown) => void = () => {};
+    patch.mockReturnValueOnce(
+      new Promise(resolve => {
+        settleOlder = resolve;
+      })
+    );
+    await act(async () => {
+      vi.advanceTimersByTime(DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS);
+    });
+
+    // The newer beat leaves afterwards and answers first.
+    patch.mockResolvedValue({
+      message: "",
+      item: { status: "renewed", waiting: true },
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS);
+    });
+    await waitFor(() =>
+      expect(result.current.state).toEqual({
+        status: "held-by-me",
+        someoneWaiting: true,
+      })
+    );
+
+    await act(async () => {
+      settleOlder({ message: "", item: { status: "renewed", waiting: false } });
+    });
+
+    // Still told. The stale reply describes a moment that has passed.
+    expect(result.current.state).toEqual({
+      status: "held-by-me",
+      someoneWaiting: true,
+    });
+  });
+
   it("says it once, not once per beat", async () => {
     // 🔴 The notice lives in a live region, so re-rendering it on an unchanged
     // answer would read the same sentence to somebody every fifteen seconds.

--- a/packages/admin/src/hooks/queries/useDocumentLock.ts
+++ b/packages/admin/src/hooks/queries/useDocumentLock.ts
@@ -248,6 +248,15 @@ export function useDocumentLock({
     // unchanged answer on every beat does not re-render the editor, and does not
     // re-announce a sentence the reader has already heard.
     let awaited = false;
+    // 🔴 The dispatch time of the renewal that last spoke for `awaited`.
+    //
+    // Renewals overlap and their replies can arrive out of order, which is why
+    // the lease below is advanced with `Math.max` rather than assigned. What
+    // they say about somebody waiting needs the same fence for the same reason:
+    // an older reply landing after a newer one answers a question that has
+    // already moved on, and the holder is left with the PREVIOUS beat's answer
+    // until another renewal happens to correct it. Only the newest may speak.
+    let awaitedAt = 0;
     // Set when this editor stops being a contender: displaced by the server, or
     // past its own deadline. The beat then waits for the person rather than
     // re-taking a claim they were just told they had lost.
@@ -306,6 +315,10 @@ export function useDocumentLock({
       requesting = false;
       requestSent = false;
       awaited = false;
+      // A new claim is a new conversation: renewals of the claim just replaced
+      // carry a different token and are already refused, so this only has to
+      // stop an EARLIER dispatch time from outranking this claim's own beats.
+      awaitedAt = 0;
       setState({ status: "held-by-me", someoneWaiting: false });
     };
 
@@ -544,9 +557,15 @@ export function useDocumentLock({
             // the heartbeat's granularity instead of ticking at a reader.
             // Rendered only on a CHANGE, so an unchanged answer every 15 seconds
             // is not a live region repeating itself.
-            if (item.waiting !== awaited) {
-              awaited = item.waiting;
-              setState({ status: "held-by-me", someoneWaiting: item.waiting });
+            if (renewSentAt > awaitedAt) {
+              awaitedAt = renewSentAt;
+              if (item.waiting !== awaited) {
+                awaited = item.waiting;
+                setState({
+                  status: "held-by-me",
+                  someoneWaiting: item.waiting,
+                });
+              }
             }
             return;
           }


### PR DESCRIPTION
Follows #1707, from a Codex finding on it (P2). The review landed while #1707 was
merging, so this is the same fix on a fresh branch rather than a push to a closed PR.

## The defect

A holder confirms its claim every 15s, and the heartbeat does not wait for the
previous confirmation before sending the next — so two can be in flight, and
their replies can arrive in either order. The lease already knew this:

```ts
confirmedAt = Math.max(confirmedAt, renewSentAt);
```

What the same reply says about a colleague waiting did **not**. A confirmation
dispatched *before* anyone asked still carries `waiting: false`; landing after a
later one that reported the request, it took the notice back off the holder's
screen and left it off until some subsequent beat happened to restore it.

So the holder is told "someone is waiting", and then quietly un-told, for reasons
nothing on their screen can explain.

## The fix

The waiting answer gets the same fence the lease has, for the same reason: only
the newest confirmation may change it. One `awaitedAt` timestamp, reset with the
claim it belongs to — a renewal of a *replaced* claim carries a different token
and is already refused upstream, so this only has to settle ordering among one
claim's own beats.

## Evidence

New test, break-verified: replacing the fence with `if (true)` fails
`does not let an older renewal reverse a newer one's answer` and nothing else.
The test drives the real race — an older renewal held open on a deferred promise,
a newer one resolved first, then the older one settled.

## Gates

`pnpm build` 0 · admin `check-types` 0 `lint` 0 `vitest` 0 (417 files, 4183 tests)
· `fallow audit` pass, every `*_introduced` 0 over 3 changed files ·
`changeset status` 0.
