### PR TITLE
fix(admin): order renewals by a counter, not by a clock that can move backwards

### DIFF
--- a/.changeset/renewal-order-is-counted-not-clocked.md
+++ b/.changeset/renewal-order-is-counted-not-clocked.md
@@ -1,0 +1,40 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Deciding which of two overlapping heartbeats answered most recently was done by
+comparing the time each was sent. That reads the wall clock, and a wall clock can
+go backwards — an NTP correction, a virtual machine resuming, somebody setting the
+time by hand. After a correction, a later heartbeat carries a SMALLER number than
+an earlier one, so the editor holding the document would ignore every subsequent
+answer about a colleague waiting until the clock caught up, which for a large
+correction is minutes or never.
+
+Which reply is newer is a question about order, not about elapsed time, so it is
+now decided by counting the heartbeats rather than by timing them. How much lease
+is left is still measured with the clock, because that is a duration and only a
+clock can answer it.

--- a/packages/admin/src/hooks/queries/__tests__/useDocumentLock.test.tsx
+++ b/packages/admin/src/hooks/queries/__tests__/useDocumentLock.test.tsx
@@ -463,6 +463,56 @@ describe("useDocumentLock", () => {
     });
   });
 
+  it("keeps the newest answer when the system clock jumps backwards", async () => {
+    // 🔴 The test above cannot tell a correct fence from a plausible broken one.
+    // Its clock only ever moves forwards, so "newest dispatch" and "largest
+    // `Date.now()`" are the same number there, and a fence built on either
+    // passes. `Date.now()` is WALL time: an NTP correction, a VM resuming or
+    // somebody setting the clock moves it backwards, and a timestamp fence then
+    // ranks a later renewal BELOW an earlier one and ignores every answer until
+    // wall time catches up. Rolling the clock back is what separates the two.
+    const { result } = renderHook(() => useDocumentLock(ref));
+    await waitFor(() => expect(result.current.state.status).toBe("held-by-me"));
+
+    let settleOlder: (value: unknown) => void = () => {};
+    patch.mockReturnValueOnce(
+      new Promise(resolve => {
+        settleOlder = resolve;
+      })
+    );
+    await act(async () => {
+      vi.advanceTimersByTime(DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS);
+    });
+
+    // The clock is corrected backwards while that renewal is still in flight,
+    // so every beat after this one carries a SMALLER timestamp than it does.
+    vi.setSystemTime(Date.now() - 10 * 60 * 1000);
+
+    patch.mockResolvedValue({
+      message: "",
+      item: { status: "renewed", waiting: true },
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS);
+    });
+    await waitFor(() =>
+      expect(result.current.state).toEqual({
+        status: "held-by-me",
+        someoneWaiting: true,
+      })
+    );
+
+    await act(async () => {
+      settleOlder({ message: "", item: { status: "renewed", waiting: false } });
+    });
+
+    // The earlier beat is still the earlier beat, whatever the clock says.
+    expect(result.current.state).toEqual({
+      status: "held-by-me",
+      someoneWaiting: true,
+    });
+  });
+
   it("says it once, not once per beat", async () => {
     // 🔴 The notice lives in a live region, so re-rendering it on an unchanged
     // answer would read the same sentence to somebody every fifteen seconds.

--- a/packages/admin/src/hooks/queries/useDocumentLock.ts
+++ b/packages/admin/src/hooks/queries/useDocumentLock.ts
@@ -248,15 +248,27 @@ export function useDocumentLock({
     // unchanged answer on every beat does not re-render the editor, and does not
     // re-announce a sentence the reader has already heard.
     let awaited = false;
-    // 🔴 The dispatch time of the renewal that last spoke for `awaited`.
+    // Which renewal last spoke for `awaited`, counted rather than clocked.
     //
-    // Renewals overlap and their replies can arrive out of order, which is why
-    // the lease below is advanced with `Math.max` rather than assigned. What
-    // they say about somebody waiting needs the same fence for the same reason:
-    // an older reply landing after a newer one answers a question that has
-    // already moved on, and the holder is left with the PREVIOUS beat's answer
-    // until another renewal happens to correct it. Only the newest may speak.
-    let awaitedAt = 0;
+    // Renewals overlap and their replies can arrive out of order, so the newest
+    // answer has to win: an older reply landing after a newer one describes a
+    // moment that has passed, and would leave the holder on the PREVIOUS beat's
+    // answer until some later renewal happened to correct it.
+    //
+    // 🔴 A COUNTER, not a timestamp, and the difference is not pedantry.
+    // `Date.now()` is wall time and can move BACKWARDS — an NTP correction, a
+    // VM resuming, someone changing the clock. A later renewal would then carry
+    // a smaller number than an earlier one, and a fence built on that would
+    // ignore every subsequent answer until wall time caught up, which after a
+    // large correction is minutes or never. A counter cannot go backwards
+    // because nothing outside this closure can touch it.
+    //
+    // The lease below still uses wall time, and that is not an inconsistency:
+    // it measures HOW MUCH TIME HAS PASSED, which is a duration only a clock can
+    // answer, while this asks WHICH REPLY IS NEWER, which is an ordering only a
+    // counter can answer honestly.
+    let renewSeq = 0;
+    let awaitedBeat = 0;
     // Set when this editor stops being a contender: displaced by the server, or
     // past its own deadline. The beat then waits for the person rather than
     // re-taking a claim they were just told they had lost.
@@ -315,10 +327,11 @@ export function useDocumentLock({
       requesting = false;
       requestSent = false;
       awaited = false;
-      // A new claim is a new conversation: renewals of the claim just replaced
-      // carry a different token and are already refused, so this only has to
-      // stop an EARLIER dispatch time from outranking this claim's own beats.
-      awaitedAt = 0;
+      // A new claim is a new conversation. Renewals of the claim just replaced
+      // carry a different token and are already refused upstream, so this only
+      // has to let this claim's own first beat speak. `renewSeq` is deliberately
+      // NOT reset: it only ever has to increase.
+      awaitedBeat = 0;
       setState({ status: "held-by-me", someoneWaiting: false });
     };
 
@@ -539,6 +552,9 @@ export function useDocumentLock({
       // Timed from dispatch for the same reason a claim is: the lease the server
       // grants starts when it processes this, not when the answer gets back.
       const renewSentAt = Date.now();
+      // Ordered from dispatch too, but counted rather than clocked. See
+      // `renewSeq` above for why these are two different instruments.
+      const beat = (renewSeq += 1);
       void protectedApi
         .patch<MutationResponse<RenewDocumentLockOutcome>>("/document-lock", {
           ...ref,
@@ -557,8 +573,8 @@ export function useDocumentLock({
             // the heartbeat's granularity instead of ticking at a reader.
             // Rendered only on a CHANGE, so an unchanged answer every 15 seconds
             // is not a live region repeating itself.
-            if (renewSentAt > awaitedAt) {
-              awaitedAt = renewSentAt;
+            if (beat > awaitedBeat) {
+              awaitedBeat = beat;
               if (item.waiting !== awaited) {
                 awaited = item.waiting;
                 setState({


### PR DESCRIPTION
Follows #1709, from a Codex finding on it (P2). #1709 merged while the fix was
being written, so this is a fresh branch rather than a push to a closed PR.

## The defect

#1709 made the newest heartbeat the one that decides whether the holder is told
somebody is waiting. It picked the newest by comparing **when each was sent**:

```ts
if (renewSentAt > awaitedAt) { … }
```

`Date.now()` is wall time, and wall time goes backwards — an NTP correction, a VM
resuming from a snapshot, someone setting the clock by hand. After a correction a
*later* heartbeat carries a *smaller* number than an earlier one, so the fence
stops admitting anything and the holder's notice freezes until wall time catches
up. For a large correction that is minutes, or never.

## The fix

Which reply is newer is a question about **order**, not about elapsed time, so it
is now decided by counting the beats. A counter cannot go backwards because
nothing outside the effect can touch it.

The lease still uses the clock, and that is not an inconsistency worth removing:
it measures *how much time has passed*, which is a duration only a clock can
answer. Two questions, two instruments — the docblock says so, because the two
sitting three lines apart is exactly what invites someone to "unify" them.

## Why the previous test did not catch this

It couldn't. Its clock only ever moved forwards, so "newest dispatch" and
"largest timestamp" were the same number and **both implementations passed** —
the necessary-but-insufficient property AGENTS.md warns about, which returns
green from the broken version carrying the authority of having been checked.

The new test rolls the clock back mid-flight. Both are break-verified, and they
separate cleanly:

| mutation | which tests fail |
|---|---|
| restore the wall-clock fence | **only** the new rollback test |
| remove the fence entirely | both |

That first row is the point: the new test is precisely the discriminator the old
one was missing.

## Gates

`pnpm build` 0 · admin `check-types` 0 `lint` 0 `vitest` 0 (417 files, 4184 tests)
· `fallow audit` pass, every `*_introduced` 0 · `changeset status` 0.
