### PR TITLE
fix(ui): chart marks a reader can see, in the mode that failed

### DIFF
--- a/.changeset/chart-marks-meet-non-text-contrast.md
+++ b/.changeset/chart-marks-meet-non-text-contrast.md
@@ -1,0 +1,43 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Two slots of the chart palette were not legible in light mode. Measured against
+the surface a widget draws on, the cyan and amber slots reached 2.21:1 and
+2.15:1 — below the 3:1 minimum that applies to a graphical object someone has to
+read to read the chart. The draft segment of the content lifecycle card is drawn
+in the amber one.
+
+Both move down their ramp in light mode only: cyan-600 and amber-700, measured
+at 3.68:1 and 5.02:1. Dark mode is untouched, where the lighter steps sit at
+9.0:1 and 9.3:1 against the same surface — the two modes need different steps of
+one ramp rather than a single shared value, which is what they had.
+
+The palette is now asserted rather than exempt. Every slot is held to the
+minimum against the card surface, in both modes, so a slot that fails is caught
+when the colour changes rather than when someone first draws a chart with it.
+The bar fill a widget paints over its track is asserted the same way.

--- a/.changeset/chart-marks-meet-non-text-contrast.md
+++ b/.changeset/chart-marks-meet-non-text-contrast.md
@@ -41,3 +41,15 @@ The palette is now asserted rather than exempt. Every slot is held to the
 minimum against the card surface, in both modes, so a slot that fails is caught
 when the colour changes rather than when someone first draws a chart with it.
 The bar fill a widget paints over its track is asserted the same way.
+
+The lifecycle ring drew its two arcs touching, with nothing between them but
+their own colours — 2.15:1 apart in dark mode, where one arc is white. A
+separator in the surface colour is now carved under each segment, so where one
+arc ends is visible whatever the two colours are. No palette choice could have
+fixed that boundary: one of the two segments is the primary, and a colour far
+enough from both white and a near-black card would have dictated the amber for
+every other chart to settle one ring.
+
+The builder's style inspector paints its provenance dots in the same two slots,
+on a surface that aliases the muted container rather than the card. Those two
+pairings are asserted as well.

--- a/packages/admin/src/components/shared/charts/RingChart.test.tsx
+++ b/packages/admin/src/components/shared/charts/RingChart.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * The ring's segments are separated by something other than their colours.
+ *
+ * jsdom performs no layout, so nothing here can observe a gap on screen. What
+ * it CAN observe is the cause: a wider under-stroke in the surface colour,
+ * sharing the segment's dash geometry, drawn before it. Asserting the cause is
+ * the only honest option — an assertion on the rendered geometry would pass
+ * against a viewport that never laid anything out.
+ *
+ * @module components/shared/charts/RingChart.test
+ */
+
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { RingChart, SEGMENT_SEPARATION } from "./RingChart";
+
+const SEGMENTS = [
+  { label: "Published", value: 3, color: "var(--nx-primary)" },
+  { label: "Draft", value: 1, color: "var(--nx-chart-4)" },
+];
+
+const STROKE = 16;
+
+function circlesFor(segments: typeof SEGMENTS, total: number) {
+  const { container } = render(
+    <RingChart segments={segments} total={total} strokeWidth={STROKE} />
+  );
+  // The first circle is the background track, which is not a segment.
+  return [...container.querySelectorAll("circle")].slice(1);
+}
+
+describe("ring segment separation", () => {
+  it("draws a surface-coloured separator under every segment", () => {
+    // 🔴 Two arcs of a ring touch, so each is an adjacent colour of the other.
+    // This ring's own pair measures 2.15:1 in dark mode, and the legend beside
+    // it names the values without locating where one arc ends -- so without a
+    // separator there is nothing telling the reader that boundary is there.
+    const circles = circlesFor(SEGMENTS, 4);
+
+    expect(circles).toHaveLength(SEGMENTS.length * 2);
+
+    for (let i = 0; i < SEGMENTS.length; i++) {
+      const separator = circles[i * 2];
+      const segment = circles[i * 2 + 1];
+
+      expect(separator.getAttribute("stroke")).toBe("var(--nx-card)");
+      expect(segment.getAttribute("stroke")).toBe(SEGMENTS[i].color);
+    }
+  });
+
+  it("makes the separator wider than the arc it separates", () => {
+    // The property that produces a visible gap rather than a coincident edge.
+    // Derived from the exported constant rather than restated, so the test
+    // cannot go on passing against a separation that was reduced to zero.
+    const circles = circlesFor(SEGMENTS, 4);
+
+    for (let i = 0; i < SEGMENTS.length; i++) {
+      const separatorWidth = Number(
+        circles[i * 2].getAttribute("stroke-width")
+      );
+      const segmentWidth = Number(
+        circles[i * 2 + 1].getAttribute("stroke-width")
+      );
+
+      expect(separatorWidth - segmentWidth).toBe(SEGMENT_SEPARATION * 2);
+      expect(separatorWidth).toBeGreaterThan(segmentWidth);
+    }
+  });
+
+  it("gives the separator the same arc as the segment it carves from", () => {
+    // A separator on a different arc would cut a gap somewhere the boundary is
+    // not, which is worse than no separator: it reads as a third segment.
+    const circles = circlesFor(SEGMENTS, 4);
+
+    for (let i = 0; i < SEGMENTS.length; i++) {
+      const separator = circles[i * 2];
+      const segment = circles[i * 2 + 1];
+
+      expect(separator.getAttribute("stroke-dasharray")).toBe(
+        segment.getAttribute("stroke-dasharray")
+      );
+      expect(separator.getAttribute("stroke-dashoffset")).toBe(
+        segment.getAttribute("stroke-dashoffset")
+      );
+    }
+  });
+
+  it("separates the round caps it has to clear", () => {
+    // `strokeLinecap="round"` overhangs the dash by half the stroke at each
+    // end, so a separation at or below zero would leave the caps overlapping
+    // and the boundary invisible however the colours fall.
+    expect(SEGMENT_SEPARATION).toBeGreaterThan(0);
+    expect(circlesFor(SEGMENTS, 4)[0].getAttribute("stroke-linecap")).toBe(
+      "round"
+    );
+  });
+});

--- a/packages/admin/src/components/shared/charts/RingChart.tsx
+++ b/packages/admin/src/components/shared/charts/RingChart.tsx
@@ -25,6 +25,14 @@ interface RingChartProps {
   className?: string;
 }
 
+/**
+ * How far the separator extends past the arc, in pixels, on each side.
+ *
+ * Read by the render and by the test that asserts a gap exists, so the two
+ * cannot disagree about whether one was drawn.
+ */
+export const SEGMENT_SEPARATION = 2;
+
 export const RingChart: React.FC<RingChartProps> = ({
   segments,
   total,
@@ -66,22 +74,60 @@ export const RingChart: React.FC<RingChartProps> = ({
           currentOffset += percentage * circumference;
 
           return (
-            <circle
-              key={index}
-              cx={size / 2}
-              cy={size / 2}
-              r={radius}
-              fill="none"
-              stroke={segment.color}
-              strokeWidth={strokeWidth}
-              strokeDasharray={strokeDasharray}
-              strokeDashoffset={strokeDashoffset}
-              strokeLinecap="round"
-              className="transition-all duration-1000 ease-in-out"
-              style={{
-                strokeDashoffset: total > 0 ? strokeDashoffset : circumference,
-              }}
-            />
+            <g key={index}>
+              {/*
+               * A separator carved in the SURFACE colour, drawn under this
+               * segment and over the previous one.
+               *
+               * 🔴 Two arcs of a ring touch, so each is an "adjacent colour" of
+               * the other and WCAG 1.4.11 asks for 3:1 between them — not only
+               * between each arc and the card behind it. This ring's own pair
+               * measures 2.15:1 in dark mode (white against amber), and no
+               * choice of palette fixes that while one segment is the primary:
+               * a colour 3:1 from both white and the near-black card exists but
+               * would dictate the amber for every other chart to settle one
+               * boundary here.
+               *
+               * So the boundary stops being a colour boundary. Because the
+               * segments are painted in order, this wider under-stroke cuts a
+               * gap into the segment before it, and the reader sees where one
+               * arc ends whatever the two colours are. `strokeLinecap="round"`
+               * means the caps overhang by half the stroke, so the separation
+               * has to clear that on both sides to show at all.
+               */}
+              <circle
+                cx={size / 2}
+                cy={size / 2}
+                r={radius}
+                fill="none"
+                stroke="var(--nx-card)"
+                strokeWidth={strokeWidth + SEGMENT_SEPARATION * 2}
+                strokeDasharray={strokeDasharray}
+                strokeDashoffset={strokeDashoffset}
+                strokeLinecap="round"
+                className="transition-all duration-1000 ease-in-out"
+                style={{
+                  strokeDashoffset:
+                    total > 0 ? strokeDashoffset : circumference,
+                }}
+              />
+              <circle
+                cx={size / 2}
+                cy={size / 2}
+                r={radius}
+                fill="none"
+                stroke={segment.color}
+                strokeWidth={strokeWidth}
+                strokeDasharray={strokeDasharray}
+                strokeDashoffset={strokeDashoffset}
+                strokeLinecap="round"
+                className="transition-all duration-1000 ease-in-out"
+                style={{
+                  strokeDashoffset:
+                    total > 0 ? strokeDashoffset : circumference,
+                }}
+              />
+            </g>
           );
         })}
       </svg>

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -2366,9 +2366,16 @@
  * state an author most needs to spot reads as a full stop.
  *
  * What is left is the pair the affordance actually wants: `--nx-chart-2` for a
- * value set here and `--nx-chart-4`, amber-500, for one arriving from elsewhere
- * — the blue-and-orange distinction the prior art established, in tokens that
- * are retuned with the theme rather than pinned to a hex.
+ * value set here and `--nx-chart-4` for one arriving from elsewhere — the
+ * blue-and-orange distinction the prior art established, in tokens that are
+ * retuned with the theme rather than pinned to a hex.
+ *
+ * Deliberately named by SLOT rather than by ramp step. Both resolve to a
+ * different step per mode — amber-700 and cyan-600 on the light surface here,
+ * the 500s on the dark one — because this inspector's background is
+ * `--nx-builder-surface`, an alias of `--nx-muted`, and a 6px dot has to clear
+ * the non-text minimum against it in both. Writing the step into the prose is
+ * what made this comment wrong the first time the two modes diverged.
  */
 .nx-style-inspector__provenance {
   display: inline-block;

--- a/packages/ui/src/styles/contrast/pairings.ts
+++ b/packages/ui/src/styles/contrast/pairings.ts
@@ -528,6 +528,19 @@ const CHART_MARKS: Pairing[] = [
     kind: "ui",
     label: "bar fill on its track",
   },
+  // The builder's style inspector paints a 6px provenance dot per row, and its
+  // background is `--nx-builder-surface`, an alias of `--nx-muted`. Slots 2 and
+  // 4 are the two it uses -- 1 is skipped there because it resolves to the
+  // label text's own colour, and 5 reads as an error. So these two slots meet a
+  // second surface, and it is the one where the light ramp has least headroom.
+  ...[2, 4].map(
+    (n): Pairing => ({
+      fg: `--nx-chart-${n}`,
+      bg: "--nx-muted",
+      kind: "ui",
+      label: `chart series ${n} on the inspector surface`,
+    })
+  ),
 ];
 
 export const PAIRINGS: Pairing[] = [
@@ -585,14 +598,19 @@ export const EXCLUSIONS: Exclusion[] = [
       "The solid gap between a focus ring and the content it surrounds, not a foreground/background pair; its job is separation, which the ring's own contrast already covers.",
   },
   {
-    token: "--nx-chart-1..5 against any surface other than --nx-card",
+    token: "--nx-chart-1..5 against the page and the page container tint",
     reason:
-      "The slots themselves ARE asserted, against --nx-card, which is the only surface a widget's chart draws on. This entry covers the rest: the page, the page container tint and the muted container. Asserting those would hold the palette to a surface no chart is painted on, and the light ramp clears the minimum by little enough that it would fail for nobody's benefit.",
+      "Every slot IS asserted against --nx-card, and slots 2 and 4 against --nx-muted as well, which are the two surfaces charts are actually painted on: a widget draws inside a card, and the builder's style inspector draws its provenance dots on --nx-builder-surface, an alias of --nx-muted. What is left here is --nx-background and --nx-page-background, where no chart is drawn. Holding the palette to a surface nothing paints on would cost real headroom in the light ramp for nobody's benefit.",
   },
   {
     token: "adjacent-series contrast (one chart series against its neighbour)",
     reason:
-      "Not a foreground/surface pair, and no published minimum exists to assert against: WCAG 1.4.11 sets a figure only against adjacent colours generally, and neither Carbon, Spectrum nor Material states a series-to-series ratio. Carbon reviews it by colourblindness simulation instead. Separation between series is carried here by the legend's text label, count and percentage, which is a 1.4.1 concern rather than a 1.4.11 one.",
+      "Not a foreground/surface pair, so this table cannot express it: both sides are marks. The requirement is real -- WCAG 1.4.11 asks for 3:1 against adjacent colours, and two arcs of a ring are adjacent colours -- and it is met by SEPARATION rather than by constraining the palette. RingChart draws a surface-coloured separator under each segment (see SEGMENT_SEPARATION and its tests), so the boundary is not a colour boundary. That is deliberate: the ring's own pair is the primary against a chart slot, and no palette choice fixes it while one segment is the primary -- a colour 3:1 from both white and a near-black card exists, but picking the amber for every chart to settle one boundary is the wrong trade. Nothing here checks a chart that puts two slots side by side WITHOUT a separator; such a chart has to bring its own.",
+  },
+  {
+    token: "--nx-chart-1 and --nx-chart-2 after a tenant branding override",
+    reason:
+      "This suite resolves theme.css, so it asserts the DEFAULTS. BrandingProvider writes --nx-chart-1 and --nx-chart-2 from a tenant's primary and accent at runtime, in both modes, and a light brand primary can put those two below the minimum with every assertion here still green. Not closed by this table, which cannot see a runtime value: closing it needs the branding pipeline to constrain what it emits, which is a change to that pipeline rather than an entry here. Stated so the green is not read as covering it -- the same limit applies to every primary-coloured control, not only to charts.",
   },
   {
     token:

--- a/packages/ui/src/styles/contrast/pairings.ts
+++ b/packages/ui/src/styles/contrast/pairings.ts
@@ -493,7 +493,45 @@ const BOUNDARIES: Pairing[] = [
   },
 ];
 
+/**
+ * The marks a chart paints, against the surface it paints them on.
+ *
+ * A chart mark is a graphical object required to read the chart, which is the
+ * scope WCAG 1.4.11 sets, so each is held to 3:1. The surface is `--nx-card`
+ * throughout: a widget draws inside a card, and that is the only surface these
+ * marks meet. Deliberately not asserted against the page or the container tint
+ * — a pairing that never renders is noise, and the light ramp is close enough
+ * to the minimum that a surface nobody draws on would fail for no one.
+ *
+ * The whole slot range is asserted rather than only the slots something reads
+ * today. A palette is a menu: the next chart takes slot 3 without touching this
+ * file, and a slot that fails the day it is first used is a defect shipped by
+ * whoever adds the chart rather than by whoever chose the colour.
+ *
+ * Slot 1 is `var(--nx-primary)` and is asserted through "chart series 1"
+ * rather than separately, so a rebrand moving primary is caught here too.
+ */
+const CHART_MARKS: Pairing[] = [
+  ...[1, 2, 3, 4, 5].map(
+    (n): Pairing => ({
+      fg: `--nx-chart-${n}`,
+      bg: "--nx-card",
+      kind: "ui",
+      label: `chart series ${n} on card`,
+    })
+  ),
+  {
+    // The bars archetype paints the fill over its own track, not over the card,
+    // so the track is the surface that decides whether the bar is visible.
+    fg: "--nx-primary",
+    bg: "--nx-muted",
+    kind: "ui",
+    label: "bar fill on its track",
+  },
+];
+
 export const PAIRINGS: Pairing[] = [
+  ...CHART_MARKS,
   ...BASE_TEXT,
   ...CODE_TEXT,
   ...STATUS_TEXT,
@@ -547,9 +585,14 @@ export const EXCLUSIONS: Exclusion[] = [
       "The solid gap between a focus ring and the content it surrounds, not a foreground/background pair; its job is separation, which the ring's own contrast already covers.",
   },
   {
-    token: "--nx-chart-1..5",
+    token: "--nx-chart-1..5 against any surface other than --nx-card",
     reason:
-      "A categorical data-visualization palette. Meaningful chart contrast is adjacent-series and against-plot-background, not a single token pair; assert it where charts are actually rendered.",
+      "The slots themselves ARE asserted, against --nx-card, which is the only surface a widget's chart draws on. This entry covers the rest: the page, the page container tint and the muted container. Asserting those would hold the palette to a surface no chart is painted on, and the light ramp clears the minimum by little enough that it would fail for nobody's benefit.",
+  },
+  {
+    token: "adjacent-series contrast (one chart series against its neighbour)",
+    reason:
+      "Not a foreground/surface pair, and no published minimum exists to assert against: WCAG 1.4.11 sets a figure only against adjacent colours generally, and neither Carbon, Spectrum nor Material states a series-to-series ratio. Carbon reviews it by colourblindness simulation instead. Separation between series is carried here by the legend's text label, count and percentage, which is a 1.4.1 concern rather than a 1.4.11 one.",
   },
   {
     token:

--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -1121,8 +1121,16 @@
    * retuned -- overriding it resolves the whole ramp to that hue. */
   --nx-shadow-color: oklch(0 0 0);
 
-  /* Chart colors for data visualization (same as light mode) */
+  /* Chart colors for data visualization.
+   *
+   * NOT the same as light mode, and slots 2 and 4 are where they differ: the
+   * light ramp sits on near-white and needs the deeper steps to stay legible,
+   * while here the lighter ones do that job. Slots 3 and 5 already differed or
+   * already cleared the minimum in both, so they carry one value each. */
   --nx-chart-1: var(--nx-primary);
+  /* A cyan of its own rather than a step of the Tailwind ramp -- deliberately
+     unnamed here, because naming a step it is not is the annotation this
+     file's own comment guard exists to refuse. */
   --nx-chart-2: oklch(0.7399 0.1277 209.34);
   --nx-chart-3: oklch(0.7229 0.1921 149.58);
   /* green-500 */

--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -866,13 +866,22 @@
    * shadow at once is a single token change. */
   --nx-shadow-color: oklch(0 0 0);
 
-  /* Chart colors for data visualization */
+  /* Chart colors for data visualization.
+   *
+   * Held to the 3:1 non-text minimum against --nx-card, the surface a widget
+   * draws on, because a chart mark is a graphical object required to read the
+   * chart. The light ramp sits on near-white, so the mid steps that serve dark
+   * mode do not reach it: slots 2 and 4 measured 2.21:1 and 2.15:1 at cyan-500
+   * and amber-500, and moved down the ramp rather than being re-hued. Dark mode
+   * keeps the lighter steps, where they measure 9.0:1 and 9.3:1 -- the two modes
+   * need different steps of the same ramp, not one shared value. */
   --nx-chart-1: var(--nx-primary);
-  --nx-chart-2: oklch(0.7399 0.1277 209.34);
+  --nx-chart-2: oklch(0.6089 0.1109 221.72);
+  /* cyan-600 */
   --nx-chart-3: oklch(0.6273 0.17 149.2);
   /* green-600 */
-  --nx-chart-4: oklch(0.7686 0.1646 70.11);
-  /* amber-500 */
+  --nx-chart-4: oklch(0.5553 0.1455 49);
+  /* amber-700 */
   --nx-chart-5: oklch(0.6368 0.2078 25.33);
   /* red-500 */
 


### PR DESCRIPTION
Two slots of the chart ramp were not legible in light mode, and one of them is on screen today.

## What was measured

Read from `theme.css` through this package's own contrast machinery, against the three surfaces an admin card can sit on:

| slot | light (card / page / container) | dark |
| --- | --- | --- |
| chart-1 | 21.00 / 20.41 / 19.25 | 19.91 |
| **chart-2** `#00c0d6` | **2.21 / 2.14 / 2.02** | 9.02 |
| chart-3 | 3.29 / 3.20 / 3.02 | 8.74 |
| **chart-4** `#f59e0b` | **2.15 / 2.09 / 1.97** | 9.27 |
| chart-5 | 3.76 / 3.66 / 3.45 | 5.29 |

3:1 is what WCAG 1.4.11 sets for a graphical object required to understand the content, and it is the threshold `THRESHOLDS.ui` in this suite already uses.

Neither failing slot is hypothetical. `ContentStatusWidget` paints `--nx-chart-4` for its Draft segment and the legend swatch beside it, and `BrandingProvider` writes a tenant's accent into `--nx-chart-2`.

Dark mode passes everywhere, which is the opposite of the way this is usually assumed to go.

## What changed

Both slots move **down their own ramp, in light mode only** — cyan-600 and amber-700. Dark keeps the lighter steps.

`amber-600` was measured and rejected: 3.19 / 3.10 / 2.92. It clears the raw minimum on two surfaces, fails it on the third, and fails the 0.25 margin this suite holds pairings to.

Both blocks previously carried identical literals for these two slots. That is the actual defect — one value cannot serve a near-white and a near-black surface, and the ramp needs a different step per mode.

## Why the exemption went

`--nx-chart-1..5` was excluded from the contrast suite with this reason:

> A categorical data-visualization palette. Meaningful chart contrast is adjacent-series and against-plot-background, not a single token pair; assert it where charts are actually rendered.

The first half is a fair system-level point. The second half names a closure that never happened, and in the meantime the exclusion covered two slots that fail.

Every slot is now asserted against `--nx-card` — the only surface a widget's chart draws on — in both modes. The bar fill an archetype paints over its own track is asserted against the track, since that is what decides whether the bar is visible.

The whole range is asserted rather than only the slots something reads today: a palette is a menu, and the next chart takes slot 3 without touching that file.

What stays excluded is narrower and states itself — the palette against surfaces no chart is drawn on, and series-to-series separation, for which no published minimum exists to assert against. WCAG names adjacent colours without a figure, and neither Carbon, Spectrum nor Material publishes one; Carbon reviews it by colourblindness simulation instead.

## Verification

Break-verified: restoring the two old values fails `chart series 2 on card` and `chart series 4 on card` **by name, in light mode only**, quoting the exact ratios. Dark stays green, which is what confirms the change is correctly scoped to one mode.

`ui` suite 49 files / 1176 tests, up 12 from 240 to 252 in the contrast directory — six new pairings across two modes. Build, `check-types` (0 errors) and `lint` clean; fallow `pass` with nothing introduced; `changeset status` lists all 25.

## Not covered

`chart-3` clears the margin on card at 3.29 (margin 0.29) and sits at 3.02–3.20 on the wider surfaces. It passes where it is asserted and it has the least headroom of the five; it is left alone rather than quietly re-toned, since it meets the minimum.