### PR TITLE
feat(blocks-engine): publish isPartName, and leave the entry guard no exceptions

### DIFF
--- a/.changeset/one-answer-to-what-names-a-part.md
+++ b/.changeset/one-answer-to-what-names-a-part.md
@@ -1,0 +1,38 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The check for a part name is now available to code outside the engine.
+
+A block states styles against named parts, and whether a given name is one the
+engine will accept was a question only the engine could answer — the check sat
+inside the package with no way out. Anything else that had to know, a store
+validating a class library on save for instance, had to keep its own copy of the
+rule, and a second copy drifts from the first without anyone noticing: the copy
+accepts a name the compiler then refuses, and the styles simply do not appear.
+
+There is one answer to that question again, and it is the engine's.

--- a/packages/blocks-engine/src/entry-surface.test.ts
+++ b/packages/blocks-engine/src/entry-surface.test.ts
@@ -43,14 +43,19 @@ function exportedFunctions(module: string): string[] {
  */
 const reachable = new Set(Object.keys(entry));
 
-/**
- * Names the entry does not re-export.
+/*
+ * There is no allowlist, and that is the point.
  *
- * A record of what the entry holds today, not a judgement that it should: the
- * assertion below fails on a name listed here that IS reachable, so the list
- * cannot quietly outlive the state it describes.
+ * One existed while `isPartName` was declared shared and not reachable, and it
+ * carried a second assertion to stop an entry outliving the state it described.
+ * An empty list cannot do that job: the loop over it would run no assertion at
+ * all and report a pass, which is the one result this file must never give.
+ *
+ * So an exception is not a list entry any more, it is a diff. A function added
+ * to `document.ts` or `tree.ts` and not re-exported fails the assertion below,
+ * and anyone who believes it genuinely should not be published has to say so
+ * where a reader will see it rather than by adding a name to a set.
  */
-const KNOWN_UNPUBLISHED = new Set(["isPartName"]);
 
 describe("the package entry reaches every primitive that claims to be shared", () => {
   for (const module of ["document", "tree"]) {
@@ -61,17 +66,8 @@ describe("the package entry reaches every primitive that claims to be shared", (
       // testing no symbol at all.
       expect(declared.length).toBeGreaterThan(5);
 
-      const missing = declared.filter(
-        name => !reachable.has(name) && !KNOWN_UNPUBLISHED.has(name)
-      );
+      const missing = declared.filter(name => !reachable.has(name));
       expect(missing).toEqual([]);
     });
   }
-
-  it("still names something the entry genuinely does not export", () => {
-    // The allowlist has to describe reality, or it is a place defects hide.
-    for (const name of KNOWN_UNPUBLISHED) {
-      expect(reachable.has(name)).toBe(false);
-    }
-  });
 });

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -42,6 +42,11 @@ export {
   isBindingSource,
   isBlockType,
   MAX_BLOCK_TYPE_LENGTH,
+  // Published on the argument its own docblock makes: it is the ONE answer to
+  // whether a value names a part, for the same reason `isBlockType` above is.
+  // A caller outside this package that bounds a part name where the compiler
+  // does not emits a class the compiler refuses to read.
+  isPartName,
   isComponentDocument,
   isComponentInstance,
   isUnsetOverride,


### PR DESCRIPTION
`isPartName` decides whether a value names a part a block may state styles for. Its own docblock calls it the ONE answer, *"for the same reason `isBlockType` is: a caller that bounds this where another does not emits a class its neighbour refuses."*

`isBlockType` is reachable from the package entry. This was not — so the argument its docblock makes held for nobody outside the package, and anything that needed the rule (a store validating a class library on save, say) had to keep a copy. A second copy drifts from the first without anyone noticing: it accepts a name the compiler then refuses, and the styles simply do not appear.

## What changed

**Published from the entry**, beside `isBlockType`, which its docblock already names as the precedent.

**Its bound stays private.** `MAX_BLOCK_TYPE_LENGTH` is published because a store validating on write needs the number itself. Nothing needs `MAX_BLOCK_PART_LENGTH`, and a constant published without a consumer is a second thing to keep true.

**The guard's allowlist is gone rather than emptied**, and this is the part worth reading.

`entry-surface.test.ts` carried one allowlisted name and a second assertion to stop an entry outliving the state it described — it fails if an allowlisted name becomes reachable. Emptying the set does not leave that working: the loop runs no assertion at all and reports a pass, which is the one answer a guard must never give.

So an exception is now a **diff** rather than a list entry. A function added to `document.ts` or `tree.ts` and not re-exported fails the assertion, and anyone who believes a shared primitive should stay unpublished has to say so where a reader will see it.

## Verification

The guard caught the export **before** I touched it, which is a free demonstration that the assertion I removed was doing its job:

```
× still names something the entry genuinely does not export
  AssertionError: expected true to be false
```

Then the simplified guard, break-verified by writing the wrong implementation — an exported function the entry does not re-export:

```
× re-exports every function document.ts exports
  AssertionError: expected [ 'probeUnpublishedName' ] to deeply equal []
```

It still discriminates, and it names the offender.

## Gates

Every dependent was gated, because this widens a published surface rather than changing code behind it.

| package | types | lint | tests |
| --- | --- | --- | --- |
| blocks-engine | 0 | 0 | **2425** |
| blocks-react | 0 | 0 | **1168** |
| builder | 0 | 0 | **3073** |
| plugin-page-builder | 0 | 0 | **819** |

`pnpm build` 0 · `lint:design` 35/35 · `fallow audit --base origin/main` **pass**, `changed_files_count: 3`, every `*_introduced: 0` · changeset covers all 25 lockstep packages.
