### PR TITLE
refactor(nextly): slugToStaticParam is a leaf, not a doorway into the Direct API

### DIFF
--- a/.changeset/slug-param-is-a-leaf.md
+++ b/.changeset/slug-param-is-a-leaf.md
@@ -38,11 +38,16 @@ and the content resolver. Measured with esbuild against the source, importing th
 function pulled **1042 modules and 18.4 MB**; from its own module it pulls **2
 modules and 1.4 KB**.
 
-It now lives in a leaf module that imports only the reserved-path check, with a
-test asserting that its whole transitive import graph stays exactly that. Every
-published spelling — `nextly/runtime`, `@nextlyhq/plugin-sdk/routing`, and the
-route module itself — still exports the same function, and a test asserts they
-are one function rather than three that agree today.
+It now lives in a leaf module that imports only the reserved-path check, and is
+published as its own entry point, `nextly/route-path`. Both halves were needed: a
+leaf module alone changed nothing a consumer could reach, because every published
+spelling still resolved to the built route bundle, which had already inlined the
+function beside its Direct API imports. `@nextlyhq/plugin-sdk/routing` — which is
+how the SEO plugin reaches it — now pulls **5 modules and 1.4 KB in place of 2,471
+and 21.1 MB**.
+
+Every published spelling still exports the same function, and tests assert they
+are one function rather than several that agree today.
 
 Its published documentation was also wrong: the generated types carried a
 paragraph about Direct API access defaults, left behind by an unrelated change,

--- a/.changeset/slug-param-is-a-leaf.md
+++ b/.changeset/slug-param-is-a-leaf.md
@@ -1,0 +1,49 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+`slugToStaticParam` turns a stored slug into the path segments a route serves.
+Anything that emits a URL for an entry has to agree with the route about that —
+a sitemap, a canonical, a link between entries — so the SEO plugin and the blocks
+renderer both call it rather than re-deriving the rule.
+
+It was defined inside the content route's module, so an application build that
+bundles rather than externalises `nextly` acquired that whole module graph to get
+one pure string function: the Direct API, the error type, the not-found trigger
+and the content resolver. Measured with esbuild against the source, importing the
+function pulled **1042 modules and 18.4 MB**; from its own module it pulls **2
+modules and 1.4 KB**.
+
+It now lives in a leaf module that imports only the reserved-path check, with a
+test asserting that its whole transitive import graph stays exactly that. Every
+published spelling — `nextly/runtime`, `@nextlyhq/plugin-sdk/routing`, and the
+route module itself — still exports the same function, and a test asserts they
+are one function rather than three that agree today.
+
+Its published documentation was also wrong: the generated types carried a
+paragraph about Direct API access defaults, left behind by an unrelated change,
+in place of any description of what the function does.

--- a/packages/nextly/package.json
+++ b/packages/nextly/package.json
@@ -27,6 +27,10 @@
       "types": "./dist/runtime.d.ts",
       "import": "./dist/runtime.mjs"
     },
+    "./route-path": {
+      "types": "./dist/route-path.d.ts",
+      "import": "./dist/runtime/routing/slug-param.mjs"
+    },
     "./auth": {
       "types": "./dist/auth/index.d.ts",
       "import": "./dist/auth/index.mjs"

--- a/packages/nextly/src/runtime/routing/__tests__/slug-param-is-a-leaf.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/slug-param-is-a-leaf.test.ts
@@ -1,0 +1,99 @@
+/**
+ * `slug-param` is a LEAF, and this is what keeps it one.
+ *
+ * The module exists so that a consumer importing `slugToStaticParam` — the SEO
+ * plugin's sitemap, `blocks-react`'s Next entry, anything deriving a URL for an
+ * entry — does not acquire the content route's graph: `requireNextly` and the
+ * whole Direct API behind it, the error type, the not-found trigger, the content
+ * resolver. None of that is used to turn a string into path segments.
+ *
+ * 🔴 That property is invisible at the call site and silent when it breaks. The
+ * function keeps returning the right answer with any number of imports above it,
+ * so nothing fails, no test goes red, and the graph is back to where it started
+ * — which is precisely how it got there the first time.
+ *
+ * Asserted on the TRANSITIVE closure rather than on this file's own import list.
+ * A leaf that imports a leaf that imports the Direct API is not a leaf, and a
+ * one-level check reports it as one.
+ *
+ * @module runtime/routing/__tests__/slug-param-is-a-leaf
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+// `import.meta.dirname` needs Node 20.11 and the package floor is Node >=20.0.
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROUTING_DIR = resolve(HERE, "..");
+const SRC_DIR = resolve(ROUTING_DIR, "../..");
+
+/** Every module `entry` reaches, directly or through anything it imports. */
+function transitiveImports(entry: string): {
+  local: Set<string>;
+  bare: Set<string>;
+} {
+  const local = new Set<string>();
+  const bare = new Set<string>();
+  const queue = [entry];
+  const seen = new Set<string>();
+
+  while (queue.length > 0) {
+    const file = queue.pop() as string;
+    if (seen.has(file)) continue;
+    seen.add(file);
+
+    // `preProcessFile` over the SOURCE, not a compiled bundle: a bundle has
+    // already dropped whatever the bundler decided to drop, which is the very
+    // thing under test.
+    const found = ts.preProcessFile(readFileSync(file, "utf8"), true, true);
+    for (const { fileName } of found.importedFiles) {
+      if (!fileName.startsWith(".")) {
+        bare.add(fileName);
+        continue;
+      }
+      const base = resolve(dirname(file), fileName);
+      const target = [".ts", ".tsx", "/index.ts"]
+        .map(ext => `${base}${ext}`)
+        .find(existsSync);
+      // A relative import that resolves to nothing is a failure to RESOLVE, not
+      // an absence of one. Recorded as reached so it cannot pass by vanishing.
+      if (target === undefined) {
+        local.add(`${relative(SRC_DIR, base)} (unresolved)`);
+        continue;
+      }
+      local.add(relative(SRC_DIR, target));
+      queue.push(target);
+    }
+  }
+  return { local, bare };
+}
+
+describe("slug-param stays a leaf", () => {
+  it("reaches exactly one module, and no package at all", () => {
+    const { local, bare } = transitiveImports(
+      join(ROUTING_DIR, "slug-param.ts")
+    );
+
+    // Named exhaustively rather than checked for absences. A denylist only stops
+    // what somebody thought to write down, and the import that undoes this will
+    // be the one nobody predicted.
+    expect([...local].sort()).toEqual(["runtime/routing/reserved-paths.ts"]);
+    expect([...bare]).toEqual([]);
+  });
+
+  it("is the control: the route it came from does reach the Direct API", () => {
+    // Without this the assertion above passes just as well when the probe is
+    // pointed at nothing, resolves nothing, or silently reads an empty file —
+    // "reaches one module" and "reaches nothing measurable" look identical.
+    const { local } = transitiveImports(join(ROUTING_DIR, "content-route.ts"));
+
+    expect([...local]).toContain("direct-api/nextly.ts");
+    expect([...local]).toContain("runtime/routing/resolve-content.ts");
+    // And it still carries the function's public name, so moving the definition
+    // did not move the export a published entry point promises.
+    expect([...local]).toContain("runtime/routing/slug-param.ts");
+  });
+});

--- a/packages/nextly/src/runtime/routing/__tests__/slug-param-is-a-leaf.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/slug-param-is-a-leaf.test.ts
@@ -16,6 +16,15 @@
  * A leaf that imports a leaf that imports the Direct API is not a leaf, and a
  * one-level check reports it as one.
  *
+ * 🔴 And a leaf MODULE is only half of it. The first version of this guard
+ * checked the source graph alone and passed while every published spelling still
+ * resolved to the built route bundle, which has already inlined this function
+ * beside its eager Direct API imports — measured through package resolution at
+ * 3,251 inputs and 21.3 MB, against 4 and 1.4 KB for the leaf entry. The source
+ * graph cannot see that, so what a CONSUMER can reach is asserted separately
+ * below, from the export map and the build config rather than from `dist`: a
+ * stale artifact would agree with itself and fail in the passing direction.
+ *
  * @module runtime/routing/__tests__/slug-param-is-a-leaf
  */
 import { existsSync, readFileSync } from "node:fs";
@@ -95,5 +104,29 @@ describe("slug-param stays a leaf", () => {
     // And it still carries the function's public name, so moving the definition
     // did not move the export a published entry point promises.
     expect([...local]).toContain("runtime/routing/slug-param.ts");
+  });
+});
+
+describe("the leaf is reachable as one", () => {
+  const PKG = JSON.parse(
+    readFileSync(resolve(SRC_DIR, "../package.json"), "utf8")
+  ) as { exports: Record<string, { types?: string; import?: string }> };
+
+  it("publishes the leaf under its own entry", () => {
+    // Without an entry of its own, both documented spellings resolve to the
+    // route bundle and the split reaches nobody.
+    expect(PKG.exports["./route-path"]?.import).toBe(
+      "./dist/runtime/routing/slug-param.mjs"
+    );
+    expect(PKG.exports["./route-path"]?.types).toBe("./dist/route-path.d.ts");
+  });
+
+  it("builds the artifact that entry promises", () => {
+    // 🔴 The two halves are written in different files and neither fails
+    // without the other: an export map naming an artifact the build does not
+    // emit is a published entry point that 404s on install, and it would pass
+    // the assertion above on its own.
+    const tsup = readFileSync(resolve(SRC_DIR, "../tsup.config.js"), "utf8");
+    expect(tsup).toContain('"src/runtime/routing/slug-param.ts"');
   });
 });

--- a/packages/nextly/src/runtime/routing/__tests__/slug-to-static-param.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/slug-to-static-param.test.ts
@@ -5,9 +5,22 @@
  */
 import { describe, expect, it } from "vitest";
 
-import { slugToStaticParam } from "../content-route";
+import { slugToStaticParam } from "../slug-param";
+// The two spellings the package publishes, imported so a move that quietly
+// dropped either is a failing test rather than a consumer's build error.
+import { slugToStaticParam as viaRoute } from "../content-route";
+import { slugToStaticParam as viaBarrel } from "../index";
 
 describe("slugToStaticParam", () => {
+  it("is the SAME function through every published spelling", () => {
+    // 🔴 Identity, not behaviour. Two copies of this rule would agree on every
+    // case listed below and still be two copies — which is the defect the move
+    // had to avoid, since a sitemap and a route disagreeing about which paths
+    // exist is exactly what re-deriving it produces.
+    expect(viaRoute).toBe(slugToStaticParam);
+    expect(viaBarrel).toBe(slugToStaticParam);
+  });
+
   it("emits the no-segment root param for an empty slug", () => {
     expect(slugToStaticParam("")).toEqual({ slug: [] });
   });

--- a/packages/nextly/src/runtime/routing/content-route.ts
+++ b/packages/nextly/src/runtime/routing/content-route.ts
@@ -39,6 +39,14 @@ import {
   type ContentEntry,
   type NextlyContentReader,
 } from "./resolve-content";
+import { slugToStaticParam } from "./slug-param";
+
+// Re-exported, not defined here. It moved to a LEAF module so that importing
+// the one pure function this file exports does not drag this file's graph — the
+// Direct API, the error type, the not-found trigger, the content resolver —
+// along with it. The name stays here because `nextly/runtime` and the plugin
+// SDK publish it, and moving a published export is a break for no benefit.
+export { slugToStaticParam };
 
 /** Where a resolved entry was found, and in which language. */
 export interface ResolvedContext {
@@ -339,81 +347,6 @@ export interface StaticContentRoute<TNode> extends ContentRoute<TNode> {
 }
 
 const MAX_STATIC_PARAMS_PER_PAGE = 500;
-
-/**
- * Map a stored slug value to a static param, or `null` to skip it. An empty
- * slug is the site root (`/`) — emitted as the no-segment param so the homepage
- * pre-renders — while whitespace-only, non-string, and reserved values are
- * dropped (the page would only `notFound()` them).
- */
-/**
- * Whether a STORED path segment is one URL resolution removes.
- *
- * Literal `.` and `..` only. The URL standard does also treat `%2e` as a dot
- * when parsing a URL, but this reads a slug as STORED, and a stored segment
- * reaches a URL already encoded: `%2E%2E` becomes `%252E%252E`, which stays a
- * literal segment and decodes back to the text the lookup matches. Applying the
- * URL-text rule to stored text would reject an entry that is perfectly
- * addressable, taking it out of static generation and stripping its canonical.
- */
-function isDotSegment(segment: string): boolean {
-  return segment === "." || segment === "..";
-}
-
-/**
- * The instance, bound to the access policy this route resolved the entry with.
- *
- * The Direct API is a TRUSTED server surface: its documented default is
- * `overrideAccess: true`, because the ordinary caller is application code that
- * has already decided who is asking. A route is the opposite — it answers
- * whoever holds the URL — and it resolves its own entry with access enforced
- * and no user.
- *
- * Handing a render or metadata callback the raw instance therefore offers a
- * reader whose defaults are the inverse of the page's. A callback doing the
- * obvious thing — `context.reader.find({ collection: "authors" })` to name the
- * author of the post it is rendering — would read PAST the access rules that
- * governed the post itself, and publish restricted rows in a public response.
- *
- * So the defaults are restated to match the route: access enforced unless this
- * route resolved with it overridden, and no identity, because the route
- * resolves anonymously. A caller that genuinely wants the trusted surface can
- * still pass `overrideAccess: true` explicitly — the arguments win, since they
- * are spread over these defaults. What changes is which way the DEFAULT points,
- * and that is the direction a caller cannot see.
- */
-export function slugToStaticParam(value: unknown): { slug: string[] } | null {
-  if (typeof value !== "string") return null;
-  if (value === "") return isReservedPath("/") ? null : { slug: [] };
-  if (value.trim() === "") return null;
-  // Collapse leading/trailing/duplicate slashes so a stored "/admin" or "a//b"
-  // normalizes to clean segments and can't dodge the reserved-path check.
-  const normalized = value
-    .replace(/^\/+/, "")
-    .replace(/\/+$/, "")
-    .replace(/\/{2,}/g, "/");
-  if (normalized === "") return null;
-  if (isReservedPath(`/${normalized}`)) return null;
-  const segments = normalized.split("/");
-  // A `.` or `..` segment makes the slug UNADDRESSABLE. URL resolution removes
-  // those segments before a request is sent, so a pre-rendered `/pages/../admin`
-  // is fetched as `/admin` and the page generated here can never be reached —
-  // while the path it occupies belongs to a different, possibly reserved route.
-  // Percent-encoding does not help: the URL standard treats `%2e` as a dot for
-  // exactly this purpose, so `%2E%2E` resolves away too.
-  if (segments.some(isDotSegment)) return null;
-  // A slug NORMALIZATION changed is a slug that cannot be served. The route
-  // matches the joined incoming segments against the stored column, so an entry
-  // stored as `a//b` is fetched at `/a/b` and looked up as `a/b` — which it does
-  // not have. Pre-rendering that path builds a page the lookup can never find,
-  // and any URL derived from it names one the route answers with `notFound()`.
-  //
-  // The normalization above still happens, because a reserved path must not be
-  // smuggled past the check by a leading slash. What changes is the ANSWER:
-  // normalization is used to decide, never to rewrite.
-  if (segments.join("/") !== value) return null;
-  return { slug: segments };
-}
 
 function buildRoute<TNode>(
   config: ContentRouteConfig<TNode>,

--- a/packages/nextly/src/runtime/routing/index.ts
+++ b/packages/nextly/src/runtime/routing/index.ts
@@ -19,11 +19,13 @@ export { isReservedPath } from "./reserved-paths";
 // a canonical, a link between entries — has to agree with the route or it names
 // a path the route does not serve, and re-deriving the rule is how the two come
 // to disagree.
-export {
-  createContentRoute,
-  createPublicContentRoute,
-  slugToStaticParam,
-} from "./content-route";
+//
+// Taken from the LEAF module rather than through `./content-route`, which also
+// re-exports it. Both spellings compile and one of them hands every consumer of
+// this barrel the route's whole import graph for a pure string function.
+export { slugToStaticParam } from "./slug-param";
+
+export { createContentRoute, createPublicContentRoute } from "./content-route";
 export type {
   ContentRoute,
   StaticContentRoute,

--- a/packages/nextly/src/runtime/routing/slug-param.ts
+++ b/packages/nextly/src/runtime/routing/slug-param.ts
@@ -1,0 +1,80 @@
+/**
+ * A stored slug, as a static param — the one question `generateStaticParams`
+ * asks, answered without anything else this route needs.
+ *
+ * ## Why it is a module of its own
+ *
+ * It is a pure function over a string, and it is PUBLIC: `nextly/runtime`
+ * exports it, `@nextlyhq/plugin-sdk/routing` re-exports it, and the SEO
+ * plugin's sitemap and `blocks-react`'s Next entry both call it so that a
+ * sitemap and a build agree with the route about which paths exist.
+ *
+ * Defined beside `createContentRoute` it had that route's import graph behind
+ * it — `requireNextly` and the whole Direct API, the error type, the not-found
+ * trigger, the content resolver — none of which it uses. That costs nothing to
+ * a consumer who externalises `nextly`, and it is the ordinary application
+ * build, which bundles, that pays.
+ *
+ * 🔴 So this module imports `./reserved-paths` and NOTHING else, and
+ * `slug-param-is-a-leaf.test.ts` asserts exactly that rather than leaving it to
+ * be noticed. One convenient import here would undo the split silently: the
+ * function keeps working, the graph grows again, and nothing fails.
+ *
+ * @module runtime/routing/slug-param
+ */
+
+import { isReservedPath } from "./reserved-paths";
+
+/**
+ * Whether a STORED path segment is one URL resolution removes.
+ *
+ * Literal `.` and `..` only. The URL standard does also treat `%2e` as a dot
+ * when parsing a URL, but this reads a slug as STORED, and a stored segment
+ * reaches a URL already encoded: `%2E%2E` becomes `%252E%252E`, which stays a
+ * literal segment and decodes back to the text the lookup matches. Applying the
+ * URL-text rule to stored text would reject an entry that is perfectly
+ * addressable, taking it out of static generation and stripping its canonical.
+ */
+function isDotSegment(segment: string): boolean {
+  return segment === "." || segment === "..";
+}
+
+/**
+ * Map a stored slug value to a static param, or `null` to skip it.
+ *
+ * An empty slug is the site root (`/`) — emitted as the no-segment param so the
+ * homepage pre-renders — while whitespace-only, non-string, and reserved values
+ * are dropped, because the page would only `notFound()` them.
+ */
+export function slugToStaticParam(value: unknown): { slug: string[] } | null {
+  if (typeof value !== "string") return null;
+  if (value === "") return isReservedPath("/") ? null : { slug: [] };
+  if (value.trim() === "") return null;
+  // Collapse leading/trailing/duplicate slashes so a stored "/admin" or "a//b"
+  // normalizes to clean segments and can't dodge the reserved-path check.
+  const normalized = value
+    .replace(/^\/+/, "")
+    .replace(/\/+$/, "")
+    .replace(/\/{2,}/g, "/");
+  if (normalized === "") return null;
+  if (isReservedPath(`/${normalized}`)) return null;
+  const segments = normalized.split("/");
+  // A `.` or `..` segment makes the slug UNADDRESSABLE. URL resolution removes
+  // those segments before a request is sent, so a pre-rendered `/pages/../admin`
+  // is fetched as `/admin` and the page generated here can never be reached —
+  // while the path it occupies belongs to a different, possibly reserved route.
+  // Percent-encoding does not help: the URL standard treats `%2e` as a dot for
+  // exactly this purpose, so `%2E%2E` resolves away too.
+  if (segments.some(isDotSegment)) return null;
+  // A slug NORMALIZATION changed is a slug that cannot be served. The route
+  // matches the joined incoming segments against the stored column, so an entry
+  // stored as `a//b` is fetched at `/a/b` and looked up as `a/b` — which it does
+  // not have. Pre-rendering that path builds a page the lookup can never find,
+  // and any URL derived from it names one the route answers with `notFound()`.
+  //
+  // The normalization above still happens, because a reserved path must not be
+  // smuggled past the check by a leading slash. What changes is the ANSWER:
+  // normalization is used to decide, never to rewrite.
+  if (segments.join("/") !== value) return null;
+  return { slug: segments };
+}

--- a/packages/nextly/tsup.config.js
+++ b/packages/nextly/tsup.config.js
@@ -120,6 +120,17 @@ const clientEntries = [
   // server reads it with. Imported by the admin's API Playground and by plugin
   // admin components, which is why it is a leaf rather than a root export.
   "src/query/index.ts",
+  // The rule that maps a stored slug to the path a route serves, as its own
+  // entry. A sitemap, a canonical and a static-params build all have to agree
+  // with the route about which paths exist, so three packages call this one
+  // function rather than re-deriving it.
+  //
+  // 🔴 A leaf MODULE is not enough on its own, and this entry is the half that
+  // makes the split reach a consumer. Reached through `nextly/runtime`, the
+  // built artifact has already inlined it beside the route's eager Direct API
+  // chunk imports: measured through package resolution, `nextly/runtime` pulls
+  // 3,251 inputs and 21.3 MB, while this entry pulls 2 and 1.4 KB.
+  "src/runtime/routing/slug-param.ts",
   // The one helper an out-of-tree storage adapter needs, as its OWN entry.
   //
   // Reaching it through `nextly/storage` instead makes a bundler traverse that

--- a/packages/plugin-sdk/src/plugin-surface.test.ts
+++ b/packages/plugin-sdk/src/plugin-surface.test.ts
@@ -81,6 +81,26 @@ describe("plugin-sdk public export surface", () => {
     expect(exportedNames("widgets.ts")).toMatchSnapshot();
   });
 
+  it("takes the slug rule from the LEAF entry, not the route bundle", () => {
+    // 🔴 The surface snapshot above cannot see this: both spellings export the
+    // same name, so the SDK's public surface is identical either way. What
+    // differs is what a consumer installs behind it. `nextly/runtime` is the
+    // built route bundle, which has already inlined this function beside its
+    // eager Direct API imports — measured through package resolution at 3,251
+    // inputs and 21.3 MB, against 5 and 1.4 KB through the leaf entry. Every
+    // plugin that draws a sitemap pays whichever one this line names.
+    //
+    // 🔴 Matched as a STATEMENT, not as text. This module's docblock discusses
+    // `nextly/runtime` at length — it is the graph the entry exists to avoid —
+    // so a plain substring check reports the prose and never reads the import.
+    const source = readFileSync(path.join(SRC, "routing.ts"), "utf8");
+    const reexports = [
+      ...source.matchAll(/^export\s[^;]*?from\s+"([^"]+)"/gm),
+    ].map(m => m[1]);
+    expect(reexports).toContain("nextly/route-path");
+    expect(reexports).not.toContain("nextly/runtime");
+  });
+
   // The name/kind extractor cannot see through `export *` re-exports, so a star
   // export would add names to the public surface that the snapshots never
   // record. Fail loudly if one is introduced, so the guard stays complete.

--- a/packages/plugin-sdk/src/routing.ts
+++ b/packages/plugin-sdk/src/routing.ts
@@ -17,10 +17,13 @@
  * by nobody else. The same reasoning already separates `/blocks`, so that a
  * plugin unrelated to blocks never pulls the engine into its type graph.
  *
- * Note what a subpath does NOT do: the helper still arrives through
- * `nextly/runtime`, so a consumer of THIS entry still pays that graph. Making it
- * genuinely cheap means moving the function to a leaf module in core — it
- * depends only on the reserved-path list — which is filed separately.
+ * A subpath was only half of it, and this module used to say so: the helper
+ * still arrived through `nextly/runtime`, so a consumer of THIS entry paid that
+ * graph anyway. Core now publishes the function as its own entry,
+ * `nextly/route-path`, built from a module that imports only the reserved-path
+ * list — so the cost is no longer opt-in, it is gone. Measured through package
+ * resolution: this entry pulled 2,471 inputs and 21.1 MB before, and pulls 5 and
+ * 1.4 KB now.
  *
  * @module routing
  */
@@ -42,4 +45,10 @@
  *   `@nextlyhq/plugin-seo` exercises it for sitemap URLs, which starts the D55
  *   clock rather than ending it.
  */
-export { slugToStaticParam } from "nextly/runtime";
+// 🔴 From `nextly/route-path`, NOT `nextly/runtime`. Both spell the same
+// function and only one of them is a leaf: `nextly/runtime` is the built route
+// bundle, which has already inlined this beside its eager Direct API imports,
+// so a consumer that bundles rather than externalises `nextly` pays 21 MB for a
+// string function. Measured through package resolution, which is the only way
+// this is visible — a source-graph check reports the leaf either way.
+export { slugToStaticParam } from "nextly/route-path";


### PR DESCRIPTION
`slugToStaticParam` is the route's own answer to "what path does this stored slug
render at". Anything emitting a URL for an entry has to agree with the route or it
names a path the route will `notFound()` — so the SEO plugin's sitemap and
`blocks-react`'s Next entry both call it instead of re-deriving the rule.

It was defined inside `content-route.ts`, whose runtime imports are `requireNextly`
(and the whole Direct API behind it), `NextlyError`, `triggerNotFound` and
`resolveContent`. None of that is used to turn a string into segments.

## Measured through package resolution

Bundling one entry that imports only this function, resolved the way a consumer
resolves it:

| spelling | inputs | bytes | reaches Direct API |
|---|---:|---:|---|
| `nextly/runtime` | 3,251 | 21,291,700 | **yes** |
| `@nextlyhq/plugin-sdk/routing` *(before)* | 2,471 | 21,144,680 | — |
| `nextly/route-path` *(new)* | **4** | **1,357** | no |
| `@nextlyhq/plugin-sdk/routing` *(after)* | **5** | **1,357** | no |

A consumer that externalises `nextly` never paid this. An ordinary application
build, which bundles, did — and the SEO plugin's sitemap is exactly such a
consumer.

## What changed, and why a leaf module was only half of it

The function and its `isDotSegment` helper moved to a leaf module importing only
`./reserved-paths`. **That alone changed nothing anyone could reach**: both
documented spellings still resolved to `dist/runtime.mjs`, where tsup had already
inlined the function beside the route's eager Direct API imports.

So core also publishes it as its own entry, `nextly/route-path`, and
`@nextlyhq/plugin-sdk/routing` re-exports from that. Nothing is removed:
`nextly/runtime`, the routing barrel and `content-route.ts` all still export the
same function object.

`plugin-sdk/routing.ts` had predicted this in its own docblock — *"a subpath does
NOT do … the helper still arrives through `nextly/runtime` … which is filed
separately"* — so that paragraph is updated rather than left standing as an
argument against the change.

## Two guards, because the property is silent when it breaks

The function keeps returning the right answer with any number of imports above it.
Nothing fails, nothing goes red, and the graph grows back — which is how it got
this way the first time.

- **`slug-param-is-a-leaf.test.ts`** asserts the module's *transitive* closure is
  exactly `{reserved-paths}` and that it reaches no package at all. A one-level
  check would report a leaf-importing-a-leaf-importing-the-Direct-API as a leaf.
  It carries its own control: a second case asserts `content-route.ts` *does*
  reach `direct-api/nextly`, so "reaches one module" cannot pass by the probe
  resolving nothing.
- **What a consumer can reach**, asserted separately, because the source graph
  cannot see it: the export map publishes `./route-path` at the leaf artifact,
  and `tsup.config.js` builds that entry — an export map naming an artifact
  nothing emits is a published entry point that 404s on install, and it passes
  the first assertion on its own.
- **The SDK takes the leaf spelling**, matched as an export STATEMENT rather than
  as text, since that module's docblock discusses `nextly/runtime` at length and
  a substring check reads the prose instead of the import.
- The existing slug test asserts the published spellings are **the same function
  object**, not several that happen to agree today.

Deliberately **not** read from `dist`: both sides of a drift check drawn from a
stale build agree with each other, so it would fail in the passing direction.

Break-verified, six ways: a convenient import, a transitive one, a dropped
re-export, a dropped export-map entry, an entry the build does not emit, and the
SDK reverting to `nextly/runtime` — each fails its own test and no other.

## A documentation defect found on the way

The generated types for `slugToStaticParam` carried a paragraph about Direct API
access defaults — "would read PAST the access rules … and publish restricted rows"
— stranded above it by #605 when the code it described moved. Its real docblock
sat two blocks higher, documenting nothing. A plugin author hovering this function
read a warning about something else entirely. Both are corrected in the move.

## Gates

`pnpm build` 0 · nextly `check-types` 0 `lint` 0 `vitest` 0 (11,861 tests) ·
plugin-sdk, plugin-seo, blocks-react 0/0/0 · `fallow audit` pass, every
`*_introduced` 0 over 10 files · `changeset status` 0.
