### PR TITLE
fix(admin): one complete manifest projection, so an edit cannot drop what a create wrote

### DIFF
--- a/.changeset/one-complete-manifest-projection.md
+++ b/.changeset/one-complete-manifest-projection.md
@@ -37,7 +37,13 @@ different setting. They now share one projection, and which settings the file
 carries is declared in a single list that the compiler checks: adding a Builder
 setting no longer compiles until somebody has said whether the file carries it.
 
-A blank description is also normalised in one place now, so the record written
-to the database and the entry written to the file can no longer disagree about
-whether a field group has one. And saving a field group's fields before its
-settings have loaded no longer replaces its entry with a nameless one.
+Which settings a _component_ may carry is part of that list, because the manifest
+refuses version history, retention, cache revalidation and webhook recording on
+one — a component has no entries of its own, so those belong to whatever embeds
+it. It refuses the key rather than the value, so a shared projection had to leave
+them out rather than send `false`.
+
+A description is also normalised in one place now — the settings form both writes
+read from — so the record in the database and the entry in the file can no longer
+disagree about one. And saving a field group's fields before its settings have
+loaded no longer replaces its entry with a nameless one.

--- a/.changeset/one-complete-manifest-projection.md
+++ b/.changeset/one-complete-manifest-projection.md
@@ -1,0 +1,43 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Choosing how many versions a collection keeps, and then editing that collection
+in the Builder, silently discarded the retention setting from `ui-schema.json`.
+The create path wrote it and the edit path did not, and the file is updated by
+replacing the whole entity — so the next edit replaced an entity that had the
+setting with one that did not.
+
+Six places each built that file's entry by hand, and each had forgotten a
+different setting. They now share one projection, and which settings the file
+carries is declared in a single list that the compiler checks: adding a Builder
+setting no longer compiles until somebody has said whether the file carries it.
+
+A blank description is also normalised in one place now, so the record written
+to the database and the entry written to the file can no longer disagree about
+whether a field group has one. And saving a field group's fields before its
+settings have loaded no longer replaces its entry with a nameless one.

--- a/.changeset/one-complete-manifest-projection.md
+++ b/.changeset/one-complete-manifest-projection.md
@@ -43,7 +43,8 @@ one — a component has no entries of its own, so those belong to whatever embed
 it. It refuses the key rather than the value, so a shared projection had to leave
 them out rather than send `false`.
 
-A description is also normalised in one place now — the settings form both writes
+A description is also trimmed in one place now — the settings form both writes
 read from — so the record in the database and the entry in the file can no longer
-disagree about one. And saving a field group's fields before its settings have
+disagree about one with spaces around it. Clearing a description still sends the
+value that clears it, which is not the same as saying nothing about the field. And saving a field group's fields before its settings have
 loaded no longer replaces its entry with a nameless one.

--- a/packages/admin/src/components/features/schema-builder/BuilderSettingsModal.tsx
+++ b/packages/admin/src/components/features/schema-builder/BuilderSettingsModal.tsx
@@ -110,6 +110,24 @@ const KIND_TITLE: Record<BuilderConfig["kind"], string> = {
   "field-group": "field group",
 };
 
+/**
+ * The answers as everything downstream should see them.
+ *
+ * 🔴 Normalised HERE, at the one boundary the values cross, rather than by each
+ * consumer. A settings save fans out to two writes — the create/update request
+ * and the `ui-schema.json` projection — and they describe the same entity. When
+ * only one of them trimmed, a description typed with trailing spaces was stored
+ * one way in the row and another in the file, and replaying the manifest
+ * visibly changed the value a person had saved.
+ *
+ * Empty becomes `undefined` rather than `""`, because that is the difference
+ * between "no description" and "a description that is blank", and only the
+ * first is a thing a reader can mean.
+ */
+function normalized(values: BuilderSettingsValues): BuilderSettingsValues {
+  return { ...values, description: values.description?.trim() || undefined };
+}
+
 const EMPTY_VALUES: BuilderSettingsValues = {
   singularName: "",
   pluralName: "",
@@ -216,7 +234,9 @@ export function BuilderSettingsModal({
               <Button variant="outline" onClick={onCancel}>
                 Cancel
               </Button>
-              <Button onClick={() => onSubmit(values)}>{primaryLabel}</Button>
+              <Button onClick={() => onSubmit(normalized(values))}>
+                {primaryLabel}
+              </Button>
             </>
           )}
         </DialogFooter>

--- a/packages/admin/src/components/features/schema-builder/BuilderSettingsModal.tsx
+++ b/packages/admin/src/components/features/schema-builder/BuilderSettingsModal.tsx
@@ -120,12 +120,20 @@ const KIND_TITLE: Record<BuilderConfig["kind"], string> = {
  * one way in the row and another in the file, and replaying the manifest
  * visibly changed the value a person had saved.
  *
- * Empty becomes `undefined` rather than `""`, because that is the difference
- * between "no description" and "a description that is blank", and only the
- * first is a thing a reader can mean.
+ * 🔴 TRIMMED, and nothing else. An emptied box stays `""` and must not become
+ * `undefined`: the update handlers all read `description !== undefined` as "the
+ * caller is not talking about this field", and `JSON.stringify` drops an
+ * undefined property entirely — so clearing a description would leave the old
+ * one in the database while the manifest's full replace dropped it, with the
+ * interface reporting success either way. `""` is a person saying "remove it",
+ * which is a different message from not mentioning it, and only the request can
+ * carry that difference.
+ *
+ * What the MANIFEST does with an empty description is the manifest's own
+ * question, answered where its entity is built.
  */
 function normalized(values: BuilderSettingsValues): BuilderSettingsValues {
-  return { ...values, description: values.description?.trim() || undefined };
+  return { ...values, description: values.description?.trim() };
 }
 
 const EMPTY_VALUES: BuilderSettingsValues = {

--- a/packages/admin/src/components/features/schema-builder/__tests__/BuilderSettingsModal.test.tsx
+++ b/packages/admin/src/components/features/schema-builder/__tests__/BuilderSettingsModal.test.tsx
@@ -65,12 +65,22 @@ describe("BuilderSettingsModal — what it hands the page", () => {
     ).toBe("Long-form writing");
   });
 
-  it("hands back nothing for a description that is only whitespace", () => {
-    // "No description" and "a description that is blank" are different things
-    // and only the first is one a reader can mean. `undefined` is also what
-    // makes the manifest projection omit the key rather than write "".
-    expect(submitted({ description: "   " }).description).toBeUndefined();
-    expect(submitted({ description: "" }).description).toBeUndefined();
+  it("keeps a CLEARED description as an explicit empty string", () => {
+    // 🔴 Not `undefined`. Every update handler reads `description !== undefined`
+    // as "the caller is not talking about this field", and `JSON.stringify`
+    // drops an undefined property — so an emptied box would leave the old
+    // description in the database while the manifest's full replace dropped it,
+    // and the interface would report success. `""` is the only value that says
+    // "remove it".
+    expect(submitted({ description: "   " }).description).toBe("");
+    expect(submitted({ description: "" }).description).toBe("");
+  });
+
+  it("still hands back undefined when there was never a description", () => {
+    // The control for the case above: "" must mean CLEARED, so an absent one
+    // must not also arrive as "" — that would turn every save of an entity
+    // without a description into an instruction to clear one.
+    expect(submitted({}).description).toBeUndefined();
   });
 
   it("leaves every other answer exactly as it was", () => {

--- a/packages/admin/src/components/features/schema-builder/__tests__/BuilderSettingsModal.test.tsx
+++ b/packages/admin/src/components/features/schema-builder/__tests__/BuilderSettingsModal.test.tsx
@@ -6,9 +6,12 @@
 // AdvancedTab tests in their own files; this file only verifies the wiring.
 import { describe, expect, it, vi } from "vitest";
 
-import { render, screen } from "@admin/__tests__/utils";
+import { fireEvent, render, screen } from "@admin/__tests__/utils";
 
-import { BuilderSettingsModal } from "../BuilderSettingsModal";
+import {
+  BuilderSettingsModal,
+  type BuilderSettingsValues,
+} from "../BuilderSettingsModal";
 import type { BuilderConfig } from "../builder-config";
 
 const collectionConfig: BuilderConfig = {
@@ -26,6 +29,64 @@ const componentConfig: BuilderConfig = {
   toolbar: { previewSchemaChange: false },
   picker: {},
 };
+
+describe("BuilderSettingsModal — what it hands the page", () => {
+  /** Submit with `initialValues` and hand back the single argument onSubmit got. */
+  function submitted(values: Partial<BuilderSettingsValues>) {
+    const onSubmit = vi.fn();
+    render(
+      <BuilderSettingsModal
+        open
+        mode="edit"
+        config={collectionConfig}
+        initialValues={{
+          singularName: "Post",
+          slug: "posts",
+          icon: "Database",
+          ...values,
+        }}
+        onCancel={vi.fn()}
+        onSubmit={onSubmit}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    return onSubmit.mock.calls[0][0] as BuilderSettingsValues;
+  }
+
+  it("trims the description before anyone writes it", () => {
+    // 🔴 A settings save fans out to TWO writes — the create/update request and
+    // the `ui-schema.json` projection — describing the same entity. Normalising
+    // in one of them is what let a row and the file record different
+    // descriptions, so replaying the manifest visibly changed a saved value.
+    // Trimmed here, at the one boundary both of them read from.
+    expect(
+      submitted({ description: "  Long-form writing  " }).description
+    ).toBe("Long-form writing");
+  });
+
+  it("hands back nothing for a description that is only whitespace", () => {
+    // "No description" and "a description that is blank" are different things
+    // and only the first is one a reader can mean. `undefined` is also what
+    // makes the manifest projection omit the key rather than write "".
+    expect(submitted({ description: "   " }).description).toBeUndefined();
+    expect(submitted({ description: "" }).description).toBeUndefined();
+  });
+
+  it("leaves every other answer exactly as it was", () => {
+    // The control. Normalising at this boundary must not become a second place
+    // that quietly reshapes the values — only the description is touched.
+    const values = submitted({
+      status: true,
+      i18n: true,
+      category: "  Content  ",
+    });
+    expect(values.status).toBe(true);
+    expect(values.i18n).toBe(true);
+    expect(values.category).toBe("  Content  ");
+    expect(values.singularName).toBe("Post");
+  });
+});
 
 describe("BuilderSettingsModal — shell", () => {
   it("renders the kind-aware title in create mode", () => {

--- a/packages/admin/src/lib/builder/settings-to-manifest.test.ts
+++ b/packages/admin/src/lib/builder/settings-to-manifest.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  MANIFEST_SETTING_KEYS,
   collectionEntityFromSettings,
   fieldGroupEntityFromSettings,
+  manifestSettingKeys,
   manifestSettingsFrom,
   singleEntityFromSettings,
 } from "./settings-to-manifest";
@@ -36,17 +36,45 @@ const EVERY_SETTING = {
 };
 
 describe("the projection carries every setting the manifest declares", () => {
-  it("emits each key the classification says it carries", () => {
-    // 🔴 Against the CLASSIFICATION, not against a second hand-written list.
-    // The point of the map is that a new setting fails to compile until it is
-    // classified; this is the other half — that a key classified as carried is
-    // actually projected, rather than declared and forgotten.
-    const projected = manifestSettingsFrom(EVERY_SETTING);
-    const emitted = Object.entries(projected)
-      .filter(([, v]) => v !== undefined)
-      .map(([k]) => (k === "localized" ? "i18n" : k))
-      .sort();
-    expect(emitted).toEqual(MANIFEST_SETTING_KEYS);
+  it.each(["collection", "single", "component"] as const)(
+    "emits each key the classification says a %s carries",
+    kind => {
+      // 🔴 Against the CLASSIFICATION, not against a second hand-written list.
+      // The point of the map is that a new setting fails to compile until it is
+      // classified; this is the other half — that a key classified as carried is
+      // actually projected, rather than declared and forgotten.
+      const projected = manifestSettingsFrom(EVERY_SETTING, kind);
+      const emitted = Object.entries(projected)
+        .filter(([, v]) => v !== undefined)
+        .map(([k]) => (k === "localized" ? "i18n" : k))
+        .sort();
+      expect(emitted).toEqual(manifestSettingKeys(kind));
+    }
+  );
+
+  it("leaves a component the four keys the manifest schema refuses", () => {
+    // 🔴 `_zod/ui-schema.ts` rejects these KEYS on a component — `versions`,
+    // `versionsMaxPerDoc`, `revalidate`, `webhooks` — testing `!== undefined`,
+    // so an explicit `false` is refused exactly like a `true`. A shared
+    // projection that emitted them would leave every field-group manifest write
+    // rejected while its database write succeeded, and the file silently stale
+    // behind a warning toast.
+    const entity = fieldGroupEntityFromSettings("seo", EVERY_SETTING, FIELDS);
+    expect(entity.versions).toBeUndefined();
+    expect(entity.versionsMaxPerDoc).toBeUndefined();
+    expect(entity.revalidate).toBeUndefined();
+    expect(entity.webhooks).toBeUndefined();
+    // The control: a collection still gets all four, so the assertion above
+    // cannot pass by the projection having stopped emitting them everywhere.
+    const collection = collectionEntityFromSettings(
+      "posts",
+      EVERY_SETTING,
+      FIELDS
+    );
+    expect(collection.versions).toBe(true);
+    expect(collection.versionsMaxPerDoc).toBe(10);
+    expect(collection.revalidate).toBe(false);
+    expect(collection.webhooks).toBe(false);
   });
 
   it("keeps version retention through an EDIT, not only a create", () => {
@@ -82,33 +110,28 @@ describe("the projection carries every setting the manifest declares", () => {
     expect(entity.labels).toEqual({ singular: "Post", plural: "Post" });
   });
 
-  it("maps a blank description to an absent key, in every kind", () => {
-    // 🔴 One normalisation, so the create REQUEST and the manifest cannot
-    // disagree about whether a whitespace-only description exists. Stored as
-    // text in the file while the row holds NULL is two records of one entity
-    // saying different things.
-    for (const blank of ["", "   "]) {
-      const settings = { ...EVERY_SETTING, description: blank };
-      expect(
-        collectionEntityFromSettings("posts", settings, []).description
-      ).toBeUndefined();
-      expect(
-        singleEntityFromSettings("home", settings, []).description
-      ).toBeUndefined();
-      expect(
-        fieldGroupEntityFromSettings("seo", settings, []).description
-      ).toBeUndefined();
-    }
+  it("passes the description through, because it was normalised at the form", () => {
+    // 🔴 The projection deliberately does NOT trim. It once did, and that made
+    // it the only writer that normalised: the create and update REQUESTS send
+    // the raw value, so a description typed with trailing spaces was stored one
+    // way in the row and another in the file, and replaying the manifest
+    // visibly changed what a person had saved. The trim moved to the settings
+    // form, which is the one boundary both writes read from — see
+    // `BuilderSettingsModal`'s `normalized`.
+    const settings = { ...EVERY_SETTING, description: "  spaced  " };
+    expect(
+      collectionEntityFromSettings("posts", settings, []).description
+    ).toBe("  spaced  ");
   });
 
   it("does not project what the manifest has no place for", () => {
     // A control for the assertion above: "emits every carried key" also passes
     // if the projection emits EVERYTHING, which would put keys into the file
     // that its schema rejects.
-    const projected = manifestSettingsFrom(EVERY_SETTING) as Record<
-      string,
-      unknown
-    >;
+    const projected = manifestSettingsFrom(
+      EVERY_SETTING,
+      "collection"
+    ) as Record<string, unknown>;
     for (const key of ["icon", "category", "slug", "startingFieldType"]) {
       expect(projected[key]).toBeUndefined();
     }

--- a/packages/admin/src/lib/builder/settings-to-manifest.test.ts
+++ b/packages/admin/src/lib/builder/settings-to-manifest.test.ts
@@ -1,11 +1,119 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  MANIFEST_SETTING_KEYS,
   collectionEntityFromSettings,
+  fieldGroupEntityFromSettings,
+  manifestSettingsFrom,
   singleEntityFromSettings,
 } from "./settings-to-manifest";
 
 const FIELDS = [{ name: "headline", type: "text", required: false }];
+
+/**
+ * Every setting a person can answer, each with a value distinguishable from the
+ * default the projection would produce by forgetting it.
+ *
+ * 🔴 Built once and shared, so a test cannot pass by omitting the key it is
+ * about. `revalidate` and `webhooks` are FALSE here for that reason: they
+ * default on, so a projection that dropped them would still emit `true` and an
+ * assertion written against a truthy value could not tell the two apart.
+ */
+const EVERY_SETTING = {
+  singularName: "Post",
+  pluralName: "Posts",
+  slug: "posts",
+  icon: "Database",
+  category: "Content",
+  description: "Long-form writing",
+  status: true,
+  i18n: true,
+  versions: true,
+  versionsMaxPerDoc: 10 as number | false,
+  revalidate: false,
+  webhooks: false,
+  startingFieldType: "text",
+};
+
+describe("the projection carries every setting the manifest declares", () => {
+  it("emits each key the classification says it carries", () => {
+    // 🔴 Against the CLASSIFICATION, not against a second hand-written list.
+    // The point of the map is that a new setting fails to compile until it is
+    // classified; this is the other half — that a key classified as carried is
+    // actually projected, rather than declared and forgotten.
+    const projected = manifestSettingsFrom(EVERY_SETTING);
+    const emitted = Object.entries(projected)
+      .filter(([, v]) => v !== undefined)
+      .map(([k]) => (k === "localized" ? "i18n" : k))
+      .sort();
+    expect(emitted).toEqual(MANIFEST_SETTING_KEYS);
+  });
+
+  it("keeps version retention through an EDIT, not only a create", () => {
+    // 🔴 The defect this module was rewritten for. The dev-schema endpoint
+    // full-replaces the entity by slug, and the create path projected
+    // `versionsMaxPerDoc` while both edit paths did not — so choosing "keep 10"
+    // on a new collection wrote it to ui-schema.json and the next edit of that
+    // collection replaced the entity without it. Not a missing feature: a value
+    // the file HAD and lost.
+    const created = collectionEntityFromSettings("posts", EVERY_SETTING, []);
+    const edited = collectionEntityFromSettings("posts", EVERY_SETTING, FIELDS);
+    expect(created.versionsMaxPerDoc).toBe(10);
+    expect(edited.versionsMaxPerDoc).toBe(10);
+  });
+
+  it("carries unlimited retention, which is false and not absent", () => {
+    // `false` means keep everything and `undefined` means the default of 50, so
+    // a projection that treated the two alike would silently cap a history the
+    // author asked to keep whole.
+    const entity = singleEntityFromSettings(
+      "home",
+      { ...EVERY_SETTING, versionsMaxPerDoc: false },
+      []
+    );
+    expect(entity.versionsMaxPerDoc).toBe(false);
+  });
+
+  it("gives a field group the same description projection as the others", () => {
+    // Field groups were the sites that forgot the description most often,
+    // because each wrote its own projection inline.
+    const entity = fieldGroupEntityFromSettings("seo", EVERY_SETTING, FIELDS);
+    expect(entity.description).toBe("Long-form writing");
+    expect(entity.labels).toEqual({ singular: "Post", plural: "Post" });
+  });
+
+  it("maps a blank description to an absent key, in every kind", () => {
+    // 🔴 One normalisation, so the create REQUEST and the manifest cannot
+    // disagree about whether a whitespace-only description exists. Stored as
+    // text in the file while the row holds NULL is two records of one entity
+    // saying different things.
+    for (const blank of ["", "   "]) {
+      const settings = { ...EVERY_SETTING, description: blank };
+      expect(
+        collectionEntityFromSettings("posts", settings, []).description
+      ).toBeUndefined();
+      expect(
+        singleEntityFromSettings("home", settings, []).description
+      ).toBeUndefined();
+      expect(
+        fieldGroupEntityFromSettings("seo", settings, []).description
+      ).toBeUndefined();
+    }
+  });
+
+  it("does not project what the manifest has no place for", () => {
+    // A control for the assertion above: "emits every carried key" also passes
+    // if the projection emits EVERYTHING, which would put keys into the file
+    // that its schema rejects.
+    const projected = manifestSettingsFrom(EVERY_SETTING) as Record<
+      string,
+      unknown
+    >;
+    for (const key of ["icon", "category", "slug", "startingFieldType"]) {
+      expect(projected[key]).toBeUndefined();
+    }
+  });
+});
 
 describe("collectionEntityFromSettings", () => {
   it("forwards status: true into the manifest entity", () => {

--- a/packages/admin/src/lib/builder/settings-to-manifest.test.ts
+++ b/packages/admin/src/lib/builder/settings-to-manifest.test.ts
@@ -110,6 +110,25 @@ describe("the projection carries every setting the manifest declares", () => {
     expect(entity.labels).toEqual({ singular: "Post", plural: "Post" });
   });
 
+  it("omits a cleared description from the manifest, in every kind", () => {
+    // 🔴 The manifest can only carry a description or not carry one; there is
+    // no key that means "cleared". `ManifestEntity.description` records that
+    // limitation, and writing `""` would publish a description that IS the
+    // empty string, which is a different claim from having none. The database
+    // still receives the explicit `""` that clears the column — see
+    // `BuilderSettingsModal`.
+    const settings = { ...EVERY_SETTING, description: "" };
+    expect(
+      collectionEntityFromSettings("posts", settings, []).description
+    ).toBeUndefined();
+    expect(
+      singleEntityFromSettings("home", settings, []).description
+    ).toBeUndefined();
+    expect(
+      fieldGroupEntityFromSettings("seo", settings, []).description
+    ).toBeUndefined();
+  });
+
   it("passes the description through, because it was normalised at the form", () => {
     // 🔴 The projection deliberately does NOT trim. It once did, and that made
     // it the only writer that normalised: the create and update REQUESTS send

--- a/packages/admin/src/lib/builder/settings-to-manifest.ts
+++ b/packages/admin/src/lib/builder/settings-to-manifest.ts
@@ -58,38 +58,64 @@ import { singleToManifestEntity } from "./to-manifest-entity-single";
  * never means "not got round to yet"; a setting that ought to travel and cannot
  * belongs in a finding, not in a silent `false`.
  */
+export type ManifestEntityKind = "collection" | "single" | "component";
+
+const EVERY_KIND: readonly ManifestEntityKind[] = [
+  "collection",
+  "single",
+  "component",
+];
+
+/** The two kinds that own entries, and so have a lifecycle of their own. */
+const ENTRY_KINDS: readonly ManifestEntityKind[] = ["collection", "single"];
+
 const CARRIED_BY_THE_MANIFEST: {
-  readonly [K in keyof Required<BuilderSettingsValues>]: boolean;
+  readonly [K in keyof Required<BuilderSettingsValues>]: readonly ManifestEntityKind[];
 } = {
   // Create-only and never persisted: it decides what the create call seeds and
   // has no meaning afterwards.
-  startingFieldType: false,
+  startingFieldType: [],
   // The entity's identity, not one of its settings. Passed as its own argument
   // because the manifest is keyed on it.
-  slug: false,
+  slug: [],
   // `ManifestEntity.admin` carries useAsTitle, defaultColumns and group, and
   // neither of these. They reach the database through the create/update request
   // instead, so projecting them here would invent a key the schema rejects.
-  icon: false,
-  category: false,
+  icon: [],
+  category: [],
 
-  singularName: true,
-  pluralName: true,
-  description: true,
-  status: true,
+  singularName: EVERY_KIND,
+  // A single and a component are one thing each; only a collection has a plural.
+  pluralName: ["collection"],
+  description: EVERY_KIND,
+  status: EVERY_KIND,
   // Spelled `localized` on the manifest; see the projection below.
-  i18n: true,
-  versions: true,
-  versionsMaxPerDoc: true,
-  revalidate: true,
-  webhooks: true,
+  i18n: EVERY_KIND,
+
+  // 🔴 The four the manifest schema REFUSES on a component, each by name and
+  // with its own reason: a component has no entries of its own, so version
+  // history, its retention, cache revalidation and outbox recording all belong
+  // to the collection or single that embeds it.
+  //
+  // `_zod/ui-schema.ts` rejects the KEY, not a truthy value — the test is
+  // `versions !== undefined` — so an explicit `false` is refused exactly like
+  // `true`. That is why this is a per-kind list and not a boolean: one shared
+  // projection emitting them would leave every field-group manifest write
+  // rejected while its database write succeeded, and `ui-schema.json` silently
+  // stale behind a warning toast.
+  versions: ENTRY_KINDS,
+  versionsMaxPerDoc: ENTRY_KINDS,
+  revalidate: ENTRY_KINDS,
+  webhooks: ENTRY_KINDS,
 };
 
-/** The settings keys the manifest carries, derived rather than restated. */
-export const MANIFEST_SETTING_KEYS = Object.entries(CARRIED_BY_THE_MANIFEST)
-  .filter(([, carried]) => carried)
-  .map(([key]) => key)
-  .sort();
+/** The settings keys the manifest carries for one kind, derived not restated. */
+export function manifestSettingKeys(kind: ManifestEntityKind): string[] {
+  return Object.entries(CARRIED_BY_THE_MANIFEST)
+    .filter(([, kinds]) => kinds.includes(kind))
+    .map(([key]) => key)
+    .sort();
+}
 
 /**
  * The builder's settings as the manifest spells them.
@@ -110,18 +136,26 @@ export const MANIFEST_SETTING_KEYS = Object.entries(CARRIED_BY_THE_MANIFEST)
  * different one.
  */
 export function manifestSettingsFrom(
-  settings: BuilderSettingsValues
+  settings: BuilderSettingsValues,
+  kind: ManifestEntityKind
 ): BuilderSettingsInput {
+  // 🔴 `undefined`, never `false`, for a key this kind does not carry.
+  // `applyCommonSettings` writes a key only when the settings object defines
+  // one, and the manifest schema refuses the KEY rather than a value — so an
+  // explicit `false` is rejected exactly like a `true`.
+  const when = <T>(key: keyof BuilderSettingsValues, value: T) =>
+    CARRIED_BY_THE_MANIFEST[key].includes(kind) ? value : undefined;
+
   return {
     singularName: settings.singularName,
-    pluralName: settings.pluralName,
-    description: settings.description?.trim() || undefined,
+    pluralName: when("pluralName", settings.pluralName),
+    description: settings.description,
     status: settings.status === true,
     localized: settings.i18n === true,
-    versions: settings.versions === true,
-    versionsMaxPerDoc: settings.versionsMaxPerDoc,
-    revalidate: settings.revalidate !== false,
-    webhooks: settings.webhooks !== false,
+    versions: when("versions", settings.versions === true),
+    versionsMaxPerDoc: when("versionsMaxPerDoc", settings.versionsMaxPerDoc),
+    revalidate: when("revalidate", settings.revalidate !== false),
+    webhooks: when("webhooks", settings.webhooks !== false),
   };
 }
 
@@ -132,7 +166,7 @@ export function collectionEntityFromSettings(
 ): ManifestEntity {
   return collectionToManifestEntity({
     slug,
-    settings: manifestSettingsFrom(settings),
+    settings: manifestSettingsFrom(settings, "collection"),
     fields,
   });
 }
@@ -144,7 +178,7 @@ export function singleEntityFromSettings(
 ): ManifestEntity {
   return singleToManifestEntity({
     slug,
-    settings: manifestSettingsFrom(settings),
+    settings: manifestSettingsFrom(settings, "single"),
     fields,
   });
 }
@@ -167,7 +201,7 @@ export function fieldGroupEntityFromSettings(
 ): ManifestEntity {
   return fieldGroupToManifestEntity({
     slug,
-    settings: manifestSettingsFrom(settings),
+    settings: manifestSettingsFrom(settings, "component"),
     fields,
   });
 }

--- a/packages/admin/src/lib/builder/settings-to-manifest.ts
+++ b/packages/admin/src/lib/builder/settings-to-manifest.ts
@@ -1,10 +1,29 @@
 /**
  * Map the builder's settings snapshot (`BuilderSettingsValues`) → a complete
- * `ui-schema.json` `ManifestEntity`. The single chokepoint both edit pages use
- * from BOTH their save paths (field-change + settings-only), so the
- * Draft/Published `status` flag can never again be dropped on the way to
- * ui-schema.json. `status` is passed explicitly (true OR false, never
- * undefined) so the dev-write full-replace can turn the lifecycle back off.
+ * `ui-schema.json` `ManifestEntity`. The single chokepoint every builder page
+ * uses from BOTH its save paths (field-change + settings-only), so no setting
+ * can be dropped on the way to ui-schema.json.
+ *
+ * ## Why "complete" is the whole job
+ *
+ * 🔴 The dev-schema endpoint FULL-REPLACES the entity it is given, by slug, and
+ * says so: a shallow merge would make unsetting impossible, since an omitted key
+ * would silently retain the old value. That contract names this module as the
+ * caller it trusts to "send a COMPLETE entity". A projection that forgets a key
+ * therefore does not merely fail to write it — it ERASES whatever a previous
+ * write put there.
+ *
+ * It had already happened. `versionsMaxPerDoc` was projected by both create
+ * paths and by neither edit path, so choosing "keep 10 versions" on a new
+ * collection wrote the retention into ui-schema.json, and the next edit of that
+ * collection — a renamed label, one added field — replaced the entity without it
+ * and the retention was gone from the file.
+ *
+ * That is why the projection below is not a hand-written list per call site. It
+ * is derived from `BuilderSettingsValues` through a TOTAL map, so adding a
+ * setting does not compile until somebody has said whether the manifest carries
+ * it. The old shape needed six places to each remember every key; four of them
+ * were written inline at the call site, and each forgot a different one.
  *
  * @module lib/builder/settings-to-manifest
  */
@@ -13,9 +32,98 @@ import type { BuilderSettingsValues } from "../../components/features/schema-bui
 import {
   collectionToManifestEntity,
   type BuilderFieldInput,
+  type BuilderSettingsInput,
   type ManifestEntity,
 } from "./to-manifest-entity";
+import { fieldGroupToManifestEntity } from "./to-manifest-entity-field-group";
 import { singleToManifestEntity } from "./to-manifest-entity-single";
+
+/**
+ * Every builder setting, and whether the manifest carries it.
+ *
+ * 🔴 A TOTAL map over `BuilderSettingsValues`, and that is the mechanism rather
+ * than documentation of one: adding a setting makes this object literal miss a
+ * property, which does not compile. The alternative — a function that reads the
+ * keys it happens to remember — is what produced a create path and an edit path
+ * that disagreed about `versionsMaxPerDoc` in opposite directions.
+ *
+ * The technique is not invented here. `settings-dirty.ts`, one file away, has
+ * enforced exactly this over the same type since the Save button was enabled by
+ * a hand-written diff and a new setting left it greyed out — "a failure that
+ * looks like nothing happening at all", as its own note puts it. That guard is
+ * why a new setting already reaches the dirty check; this one is why it now also
+ * reaches the file the dirty check lets you save.
+ *
+ * `false` means the manifest does not carry it, with the reason beside it. It
+ * never means "not got round to yet"; a setting that ought to travel and cannot
+ * belongs in a finding, not in a silent `false`.
+ */
+const CARRIED_BY_THE_MANIFEST: {
+  readonly [K in keyof Required<BuilderSettingsValues>]: boolean;
+} = {
+  // Create-only and never persisted: it decides what the create call seeds and
+  // has no meaning afterwards.
+  startingFieldType: false,
+  // The entity's identity, not one of its settings. Passed as its own argument
+  // because the manifest is keyed on it.
+  slug: false,
+  // `ManifestEntity.admin` carries useAsTitle, defaultColumns and group, and
+  // neither of these. They reach the database through the create/update request
+  // instead, so projecting them here would invent a key the schema rejects.
+  icon: false,
+  category: false,
+
+  singularName: true,
+  pluralName: true,
+  description: true,
+  status: true,
+  // Spelled `localized` on the manifest; see the projection below.
+  i18n: true,
+  versions: true,
+  versionsMaxPerDoc: true,
+  revalidate: true,
+  webhooks: true,
+};
+
+/** The settings keys the manifest carries, derived rather than restated. */
+export const MANIFEST_SETTING_KEYS = Object.entries(CARRIED_BY_THE_MANIFEST)
+  .filter(([, carried]) => carried)
+  .map(([key]) => key)
+  .sort();
+
+/**
+ * The builder's settings as the manifest spells them.
+ *
+ * Two renames happen here and nowhere else. `i18n` is the toggle's name in the
+ * form and `localized` is the manifest's, and `revalidate`/`webhooks` default ON
+ * — so only an explicit `false` opts an entity out, and `undefined` must not be
+ * allowed to read as "off".
+ *
+ * 🔴 The description is normalised HERE rather than at a call site, because the
+ * create request and the manifest describe the same entity and one of them was
+ * normalising while the others passed the raw value. A whitespace-only
+ * description was then stored as text in ui-schema.json while the row it mirrors
+ * held NULL — two records of one field group disagreeing about whether it has a
+ * description. Empty maps to `undefined`, which the entity mapper writes as an
+ * absent key; that keeps the documented limitation that a CLEARED description
+ * cannot propagate through a migration, rather than quietly inventing a
+ * different one.
+ */
+export function manifestSettingsFrom(
+  settings: BuilderSettingsValues
+): BuilderSettingsInput {
+  return {
+    singularName: settings.singularName,
+    pluralName: settings.pluralName,
+    description: settings.description?.trim() || undefined,
+    status: settings.status === true,
+    localized: settings.i18n === true,
+    versions: settings.versions === true,
+    versionsMaxPerDoc: settings.versionsMaxPerDoc,
+    revalidate: settings.revalidate !== false,
+    webhooks: settings.webhooks !== false,
+  };
+}
 
 export function collectionEntityFromSettings(
   slug: string,
@@ -24,23 +132,7 @@ export function collectionEntityFromSettings(
 ): ManifestEntity {
   return collectionToManifestEntity({
     slug,
-    settings: {
-      singularName: settings.singularName,
-      description: settings.description,
-      pluralName: settings.pluralName,
-      status: settings.status === true,
-      // i18n: the collection-level Internationalization toggle.
-      localized: settings.i18n === true,
-      // Version history, mirrored into ui-schema.json so the committed
-      // manifest matches what the registry was just told.
-      versions: settings.versions === true,
-      // Cache revalidation, mirrored into ui-schema.json. Defaults on, so only
-      // an explicit `false` opts the collection out; anything else stays on.
-      revalidate: settings.revalidate !== false,
-      // Webhook recording, mirrored the same way: defaults on, only an explicit
-      // `false` keeps the collection's writes out of the outbox.
-      webhooks: settings.webhooks !== false,
-    },
+    settings: manifestSettingsFrom(settings),
     fields,
   });
 }
@@ -52,21 +144,30 @@ export function singleEntityFromSettings(
 ): ManifestEntity {
   return singleToManifestEntity({
     slug,
-    settings: {
-      singularName: settings.singularName,
-      description: settings.description,
-      status: settings.status === true,
-      // i18n: the single-level Internationalization toggle (mirrors collectionEntityFromSettings).
-      localized: settings.i18n === true,
-      // Version history (mirrors collectionEntityFromSettings).
-      versions: settings.versions === true,
-      // Cache revalidation (mirrors collectionEntityFromSettings): defaults on,
-      // only an explicit `false` opts the single out.
-      revalidate: settings.revalidate !== false,
-      // Webhook recording (mirrors collectionEntityFromSettings): defaults on,
-      // only an explicit `false` keeps the single's writes out of the outbox.
-      webhooks: settings.webhooks !== false,
-    },
+    settings: manifestSettingsFrom(settings),
+    fields,
+  });
+}
+
+/**
+ * A field group's manifest entity.
+ *
+ * A field group has no lifecycle, no versions and no cache or webhook posture of
+ * its own — it is a reusable set of fields — so the projection it shares with
+ * the other two carries values those keys do not apply to. It is still the SAME
+ * projection: `applyCommonSettings` writes a key only when the settings object
+ * defines it, and a field group's form leaves them undefined, so nothing is
+ * invented here. Sharing it is what stops a field group being the one entity
+ * that forgets `description` again.
+ */
+export function fieldGroupEntityFromSettings(
+  slug: string,
+  settings: BuilderSettingsValues,
+  fields: BuilderFieldInput[]
+): ManifestEntity {
+  return fieldGroupToManifestEntity({
+    slug,
+    settings: manifestSettingsFrom(settings),
     fields,
   });
 }

--- a/packages/admin/src/lib/builder/settings-to-manifest.ts
+++ b/packages/admin/src/lib/builder/settings-to-manifest.ts
@@ -149,7 +149,17 @@ export function manifestSettingsFrom(
   return {
     singularName: settings.singularName,
     pluralName: when("pluralName", settings.pluralName),
-    description: settings.description,
+    // 🔴 Empty becomes ABSENT, and only here. `applyCommonSettings` writes the
+    // key only when it is defined, and `ManifestEntity.description` records the
+    // standing limitation this expresses: the upsert omits the column when a
+    // manifest carries none, so a CLEARED description cannot travel through a
+    // migration. Writing `""` instead would not fix that — it would publish a
+    // description that is the empty string, which is a different claim.
+    //
+    // The trim is deliberately NOT repeated here: it happens once, at the
+    // settings form, so this projection and the create/update request cannot
+    // disagree about a value with spaces around it.
+    description: settings.description || undefined,
     status: settings.status === true,
     localized: settings.i18n === true,
     versions: when("versions", settings.versions === true),

--- a/packages/admin/src/pages/dashboard/collections/builder/index.tsx
+++ b/packages/admin/src/pages/dashboard/collections/builder/index.tsx
@@ -24,8 +24,8 @@ import { toast } from "@admin/components/ui";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
 import { useCreateCollection } from "@admin/hooks/queries";
 import { toSnakeName } from "@admin/lib/builder";
+import { collectionEntityFromSettings } from "@admin/lib/builder/settings-to-manifest";
 import { startingFields } from "@admin/lib/builder/starting-field";
-import { collectionToManifestEntity } from "@admin/lib/builder/to-manifest-entity";
 import { navigateTo } from "@admin/lib/navigation";
 import { schemaFileApi } from "@admin/services/schemaFileApi";
 
@@ -94,25 +94,13 @@ export default function CollectionBuilderPage(): React.ReactElement | null {
           void (async () => {
             try {
               await schemaFileApi.writeCollection(
-                collectionToManifestEntity({
+                collectionEntityFromSettings(
                   slug,
-                  settings: {
-                    singularName: singular,
-                    pluralName: plural,
-                    status: values.status === true,
-                    // keep ui-schema.json in sync with the localized flag.
-                    localized: values.i18n === true,
-                    // and with version history.
-                    versions: values.versions === true,
-                    // and with its retention setting.
-                    versionsMaxPerDoc: values.versionsMaxPerDoc,
-                    // and with cache revalidation (on unless explicitly off).
-                    revalidate: values.revalidate !== false,
-                    // and with webhook recording (on unless explicitly off).
-                    webhooks: values.webhooks !== false,
-                  },
-                  fields: [],
-                })
+                  // The names the form collected, which are not yet on `values`
+                  // at create time.
+                  { ...values, singularName: singular, pluralName: plural },
+                  []
+                )
               );
             } catch (err) {
               const m = (err as { message?: string })?.message;

--- a/packages/admin/src/pages/dashboard/collections/builder/index.tsx
+++ b/packages/admin/src/pages/dashboard/collections/builder/index.tsx
@@ -52,7 +52,7 @@ export default function CollectionBuilderPage(): React.ReactElement | null {
       {
         name: slug,
         labels: { singular, plural },
-        description: values.description?.trim() || undefined,
+        description: values.description,
         icon: values.icon,
         // tab. Code-first config can still set admin.group / admin.order;
         // we just don't surface them in the create modal.

--- a/packages/admin/src/pages/dashboard/field-group/builder/[slug].tsx
+++ b/packages/admin/src/pages/dashboard/field-group/builder/[slug].tsx
@@ -44,7 +44,7 @@ import {
   mirrorSchemaFile,
   useSchemaSave,
 } from "@admin/hooks/useSchemaSave";
-import { fieldGroupToManifestEntity } from "@admin/lib/builder/to-manifest-entity-field-group";
+import { fieldGroupEntityFromSettings } from "@admin/lib/builder/settings-to-manifest";
 import { fieldGroupApi } from "@admin/services/fieldGroupApi";
 import { schemaFileApi } from "@admin/services/schemaFileApi";
 import type { FieldDefinition } from "@admin/types/collection";
@@ -176,25 +176,23 @@ export default function FieldGroupBuilderEditPage({
     async (fieldDefinitions: FieldDefinition[]) => {
       if (!slug) return;
       pinFields();
-      if (settings) pinSettings(settings);
+
+      // 🔴 No settings, no manifest write — and this is not the same as writing
+      // an empty one. The dev-schema endpoint FULL-REPLACES the entity by slug,
+      // so a projection built from absent settings would replace this field
+      // group's labels and description in ui-schema.json with nothing. The
+      // database write has already succeeded either way; skipping the mirror
+      // leaves the file as it was, which is the recoverable outcome.
+      //
+      // The fields are pinned above regardless: they landed, and the baseline
+      // has to move with them or the page reports unsaved work that is saved.
+      if (!settings) return;
+      pinSettings(settings);
 
       await mirrorSchemaFile(
         () =>
           schemaFileApi.writeFieldGroup(
-            fieldGroupToManifestEntity({
-              slug,
-              settings: {
-                singularName: settings?.singularName,
-                // 🔴 The description travels too, so it reaches a database
-                // the manifest is replayed against. The upsert omits the column
-                // when a manifest carries none, so this supplies the value
-                // rather than protecting it from being nulled.
-                description: settings?.description,
-                // Mirror the Internationalization flag into ui-schema.json.
-                localized: settings?.i18n === true,
-              },
-              fields: fieldDefinitions,
-            })
+            fieldGroupEntityFromSettings(slug, settings, fieldDefinitions)
           ),
         "Field group applied to the database"
       );

--- a/packages/admin/src/pages/dashboard/field-group/builder/index.tsx
+++ b/packages/admin/src/pages/dashboard/field-group/builder/index.tsx
@@ -42,11 +42,10 @@ export default function FieldGroupBuilderPage(): React.ReactElement | null {
   const handleSubmit = (values: BuilderSettingsValues) => {
     const singular = values.singularName.trim();
     const slug = values.slug?.trim() || toSnakeName(singular);
-    // Normalised once. The request and the manifest projection describe the
-    // same field group, so deriving them from one value is what keeps a
-    // whitespace-only description from being stored as text in the manifest
-    // while the row it mirrors holds NULL.
-    const description = values.description?.trim() || undefined;
+    // Already normalised, at the settings form — the one boundary both this
+    // request and the manifest projection read from. Trimming again here would
+    // be a second spelling of that rule, which is how the two came to disagree.
+    const description = values.description;
 
     createFieldGroup(
       {

--- a/packages/admin/src/pages/dashboard/field-group/builder/index.tsx
+++ b/packages/admin/src/pages/dashboard/field-group/builder/index.tsx
@@ -23,7 +23,7 @@ import { toast } from "@admin/components/ui";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
 import { useCreateFieldGroup } from "@admin/hooks/queries/useFieldGroups";
 import { toSnakeName } from "@admin/lib/builder";
-import { fieldGroupToManifestEntity } from "@admin/lib/builder/to-manifest-entity-field-group";
+import { fieldGroupEntityFromSettings } from "@admin/lib/builder/settings-to-manifest";
 import { navigateTo } from "@admin/lib/navigation";
 import { schemaFileApi } from "@admin/services/schemaFileApi";
 
@@ -72,20 +72,15 @@ export default function FieldGroupBuilderPage(): React.ReactElement | null {
           void (async () => {
             try {
               await schemaFileApi.writeFieldGroup(
-                fieldGroupToManifestEntity({
+                fieldGroupEntityFromSettings(
                   slug,
-                  settings: {
-                    singularName: singular,
-                    // Carried so the description reaches a database the
-                    // manifest is replayed against; the builder omits the
-                    // column when it is absent, so this is what supplies it
-                    // rather than what protects it.
-                    description,
-                    // i18n: mirror the Internationalization flag into ui-schema.json.
-                    localized: values.i18n === true,
-                  },
-                  fields: [],
-                })
+                  // The name the form collected, which is not yet on `values` at
+                  // create time. The description needs no normalising here: the
+                  // projection does it, which is what keeps this write and the
+                  // create request above agreeing about a blank one.
+                  { ...values, singularName: singular },
+                  []
+                )
               );
             } catch (err) {
               const m = (err as { message?: string })?.message;

--- a/packages/admin/src/pages/dashboard/singles/builder/index.tsx
+++ b/packages/admin/src/pages/dashboard/singles/builder/index.tsx
@@ -20,7 +20,7 @@ import { toast } from "@admin/components/ui";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
 import { useCreateSingle } from "@admin/hooks/queries";
 import { toKebabName } from "@admin/lib/builder";
-import { singleToManifestEntity } from "@admin/lib/builder/to-manifest-entity-single";
+import { singleEntityFromSettings } from "@admin/lib/builder/settings-to-manifest";
 import { navigateTo } from "@admin/lib/navigation";
 import { schemaFileApi } from "@admin/services/schemaFileApi";
 
@@ -88,24 +88,13 @@ export default function SingleBuilderPage(): React.ReactElement | null {
           void (async () => {
             try {
               await schemaFileApi.writeSingle(
-                singleToManifestEntity({
+                singleEntityFromSettings(
                   slug,
-                  settings: {
-                    singularName: singular,
-                    status: values.status === true,
-                    // i18n: mirror the Internationalization flag into ui-schema.json.
-                    localized: values.i18n === true,
-                    // and version history.
-                    versions: values.versions === true,
-                    // and its retention setting.
-                    versionsMaxPerDoc: values.versionsMaxPerDoc,
-                    // and cache revalidation (on unless explicitly off).
-                    revalidate: values.revalidate !== false,
-                    // and webhook recording (on unless explicitly off).
-                    webhooks: values.webhooks !== false,
-                  },
-                  fields: [],
-                })
+                  // The name the form collected, which is not yet on `values` at
+                  // create time.
+                  { ...values, singularName: singular },
+                  []
+                )
               );
             } catch (err) {
               const m = (err as { message?: string })?.message;

--- a/packages/admin/src/pages/dashboard/singles/builder/index.tsx
+++ b/packages/admin/src/pages/dashboard/singles/builder/index.tsx
@@ -49,7 +49,7 @@ export default function SingleBuilderPage(): React.ReactElement | null {
       {
         slug,
         label: singular,
-        description: values.description?.trim() || undefined,
+        description: values.description,
         admin: {
           icon: values.icon,
           // Advanced tab. Code-first config can still set admin.group /


### PR DESCRIPTION
Filed from #1498 round 7, where four review findings turned out to be one class.
Measuring it first turned up a fifth that is worse than the four.

## A setting the file HAD and lost

The dev-schema endpoint replaces a manifest entity wholesale, by slug, and says
why:

> Full-replace by slug is intentional: callers (the admin builder via
> `settings-to-manifest.ts`) send a **COMPLETE entity** … a shallow merge would
> make unsetting impossible.

`settings-to-manifest.ts` is the module that comment names, and it did not project
`versionsMaxPerDoc`. The **create** paths did. So:

1. Create a collection, choose "keep 10 versions" → `ui-schema.json` gets `versionsMaxPerDoc: 10`.
2. Edit that collection at all — rename a label, add one field → the entity is replaced **without** it.
3. The retention setting is gone from the committed manifest.

The filing recorded this class as downgraded from data-loss to completeness after
#1498 made `description` and hooks conditional. That is true of those keys and not
of this one, which is why the table below was worth building rather than trusting
the note.

| key | collection edit | collection create | single edit | single create |
|---|---|---|---|---|
| `description` | ✅ | ❌ | ✅ | ❌ |
| `versionsMaxPerDoc` | ❌ | ✅ | ❌ | ✅ |

The two paths disagreed **in both directions**.

## The fix: complete by construction, not by remembering

Six sites each built the entity by hand; four did it inline at the call site. They
now share one projection, and which settings the manifest carries is a **total map
over `BuilderSettingsValues`** — so adding a Builder setting does not compile until
somebody classifies it.

**The technique is not new here.** `settings-dirty.ts`, one file away, has enforced
exactly this over the same type since a hand-written diff left Save greyed out for
new settings — "a failure that looks like nothing happening at all", in its own
words. That guard is why a new setting reaches the dirty check; this one is why it
now also reaches the file the dirty check lets you save. Verified: adding a
`searchable?: boolean` fails to compile in **both** modules.

## Two more the type check surfaced

- **A blank description** was normalised at one call site and passed raw at the
  others, so a whitespace-only description could sit as text in the file while the
  row it mirrors held `NULL`. Normalised once, in the projection.
- **A field group saved before its settings loaded** projected a nameless entity
  into a full replace — erasing its labels and description. It now skips the mirror
  rather than replacing an entry with a blank one; the fields are still pinned,
  because they did land. The type system forced this question by refusing
  `BuilderSettingsValues | null`.

## Evidence

Six tests, each break-verified against the implementation it names — including one
that reproduces the original defect exactly (drop `versionsMaxPerDoc` from the
projection and "keeps version retention through an EDIT" fails). The "emits every
carried key" test is written against the **classification**, not a second
hand-written list, and carries a control for the opposite failure — a projection
that emits everything, including keys the schema rejects.

## Gates

`pnpm build` 0 (after `rm -rf` of the touched dists) · admin `check-types` 0
`lint` 0 `vitest` 0 (417 files, 4191 tests) · `fallow audit` pass, every
`*_introduced` 0 over 7 files · `changeset status` 0.

Scope: the projection only. The `migration_status` reconciliation filed under
"ALSO HERE, separately" on the same node is a different subject in different files
and stays there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Builder settings now trim descriptions before saving and treat blank descriptions as unset.
  - Schema builder flows consistently preserve supported settings, including version retention limits and field-group labels and descriptions.
  - Field-group updates no longer overwrite schema metadata when settings are unavailable.
  - Collection, single, and field-group builders now apply consistent settings when creating or updating schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->