### PR TITLE
test(nextly): give the session-scope fixture the permissions its type requires

### DIFF
--- a/packages/nextly/src/domains/collections/services/__tests__/owner-safety-net.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/owner-safety-net.test.ts
@@ -69,7 +69,11 @@ describe("ownerSafetyNetApplies", () => {
       ownerSafetyNetApplies({
         ...BASE,
         isSuperAdmin: true,
-        scope: { actorType: "user" },
+        // `permissions` is required on the scope and empty is what a session
+        // carries: grants are an API key's, and this case exists to assert a
+        // session is not read as one. Spelled as the other session fixtures in
+        // this package spell it.
+        scope: { actorType: "user", permissions: [] },
       })
     ).toBe(false);
   });


### PR DESCRIPTION
`main` is red on `check-types`, and it blocks more than this package.

```
src/domains/collections/services/__tests__/owner-safety-net.test.ts(72,9):
error TS2741: Property 'permissions' is missing in type '{ actorType: "user"; }'
but required in type 'AuthenticatedScope'.
```

`AuthenticatedScope` requires `permissions: readonly string[]`, and this fixture
builds a session scope as a bare `{ actorType: "user" }`.

## Why it is worth fixing straight away

The pre-push hook runs a repo-wide `pnpm check-types`, so this refuses a push
from **any** branch that has merged `main` — not only work in `packages/nextly`.
I hit it pushing a `blocks-react` change whose diff touches zero files here.

Confirmed inherited rather than mine before touching anything: the failing file
is byte-identical to `origin/main`'s, and my branch's diff contains no
`packages/nextly` path at all.

## The fix

`permissions: []` — empty because that is what a session carries, not because it
satisfies the compiler. Grants belong to an API key, and this case exists
precisely to assert that a session is NOT read as one, so an empty list is the
accurate value.

Spelled the way four other session fixtures in this package already spell it
(`single-access-stored-rules.test.ts`, `collection-access-route-authorized.test.ts`,
`authenticated-scope.test.ts`), so there is one shape for the thing rather than
a second.

## Verified

- `packages/nextly` tests for that file: 14 passed
- repo-wide `pnpm check-types`: **42/42 successful** (was 41/42 with this failing)

No changeset: the change is to a test file and nothing published moves.