### PR TITLE
fix(nextly): give the owner safety net's session scope the field it requires

### DIFF
--- a/packages/nextly/src/domains/collections/services/__tests__/owner-safety-net.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/owner-safety-net.test.ts
@@ -69,7 +69,12 @@ describe("ownerSafetyNetApplies", () => {
       ownerSafetyNetApplies({
         ...BASE,
         isSuperAdmin: true,
-        scope: { actorType: "user" },
+        // `permissions` is required on the scope, and empty is what a SESSION
+        // caller carries: it resolves its grants the normal way rather than
+        // from the scope. Spelled out because the field is what every coarse
+        // check compares against, so omitting it is not the same as passing
+        // none.
+        scope: { actorType: "user", permissions: [] },
       })
     ).toBe(false);
   });


### PR DESCRIPTION
`main` is red on `check-types`.

```
src/domains/collections/services/__tests__/owner-safety-net.test.ts(72,9):
error TS2741: Property 'permissions' is missing in type '{ actorType: "user"; }'
  but required in type 'AuthenticatedScope'
```

## Why it was green in both PRs and red once merged

Neither change is wrong on its own.

`AuthenticatedScope.permissions` became **required** with the key-scope work (#1695). The owner-safety-net test arrived afterwards, in #1708, carrying a scope literal written against the older shape. Each PR typechecked against a base that did not contain the other, so the two met for the first time on `main` — where nothing runs them together until something else merges and inherits the failure.

Verified as genuinely on `main` rather than an artefact of a local merge: branched clean from `aaa8c8ce2` and the line is there.

## The fix

Empty is the correct value, not a placeholder to satisfy the compiler. The field's own docblock says a session caller carries no permissions on the scope and resolves its grants the normal way, and every other user-typed scope in this package already spells it:

```
{ actorType: "user", permissions: [] }
```

Four existing call sites use exactly that, so this is the established idiom rather than a new one.

## Verification

`pnpm check-types` — 0 errors, from a full build. The owner-safety-net suite passes 14 of 14, so the case still asserts what it was written for: a super-admin whose scope is a session rather than a key does not get the safety net.

fallow `pass`, 1 changed file, nothing introduced.

Test-only, so no changeset — per AGENTS.md.