### PR TITLE
refactor(blocks-engine)!: one way to re-identify a copy

### DIFF
--- a/.changeset/one-way-to-re-identify-a-copy.md
+++ b/.changeset/one-way-to-re-identify-a-copy.md
@@ -1,0 +1,38 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+`reidSubtreeWithMap` is no longer exported. Use `reidForestWithMap([node])`.
+
+It re-identified a single subtree, and it was a thinner version of the function
+beside it: the forest form takes a policy saying what should happen to DOM ids,
+and the single-root form never accepted one. Anything needing that behaviour had
+to use the forest form anyway, and nothing in the product ever called this.
+
+The forest form does the same work for one root as for many, so a caller passes
+a list of one and gets the answer it already wanted, with the option this one
+could not offer.

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -137,7 +137,6 @@ export {
   removeNode,
   moveNode,
   reidSubtree,
-  reidSubtreeWithMap,
   // The forest form, which is the shape a saved selection actually has: a
   // pattern is a run of siblings, and re-identifying its roots one at a time
   // leaves a reference that crosses between them pointing at the original.
@@ -175,7 +174,6 @@ export {
 export type {
   NodeLocation,
   ReidentifiedForest,
-  ReidentifiedSubtree,
   SlotDefaultSource,
   TreePosition,
   // Beside `walkNodes`, because a caller BOUNDING a walk has to hold its

--- a/packages/blocks-engine/src/resolve-instances.ts
+++ b/packages/blocks-engine/src/resolve-instances.ts
@@ -1589,7 +1589,7 @@ interface InlineContext {
    * Asked once per distinct ORIGINAL, so a definition whose two nodes carry
    * one DOM id maps both to a single replacement — the pair pointed at one
    * target before and still reaches one target after. The same memo
-   * `reidSubtreeWithMap` keeps, for the same reason.
+   * `reidForestWithMap` keeps, for the same reason.
    */
   domIds: Map<string, string>;
   /** The scope INSIDE this component, for instances the definition itself holds. */

--- a/packages/blocks-engine/src/tree.reid-with-map.test.ts
+++ b/packages/blocks-engine/src/tree.reid-with-map.test.ts
@@ -12,12 +12,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { BlockNode } from "./document";
-import {
-  reidForestWithMap,
-  reidSubtree,
-  reidSubtreeWithMap,
-  walkNodes,
-} from "./tree";
+import { reidForestWithMap, reidSubtree, walkNodes } from "./tree";
 
 /** A node with an optional DOM id, and children. */
 function node(
@@ -42,10 +37,28 @@ function allNodes(root: BlockNode): BlockNode[] {
   return out;
 }
 
+/**
+ * The forest rewrite for a SINGLE root, shaped like the assertions below expect.
+ *
+ * Local to the tests because the product has no singular form: everything that
+ * re-identifies works on a run of siblings and reaches for `reidForestWithMap`.
+ * These cases are about what a copy IS — new ids, remapped DOM ids, references
+ * that round-trip — and one root is the smallest forest that shows it, so they
+ * are kept and pointed at the function the product actually calls.
+ */
+function reidOne(root: BlockNode): {
+  node: BlockNode;
+  nodeIds: ReadonlyMap<string, string>;
+  domIds: ReadonlyMap<string, string>;
+} {
+  const { nodes, nodeIds, domIds } = reidForestWithMap([root]);
+  return { node: nodes[0] ?? root, nodeIds, domIds };
+}
+
 describe("a re-identified subtree is a different subtree", () => {
   it("gives every node a fresh id and records the mapping", () => {
     const tree = node("root", {}, [node("a"), node("b")]);
-    const result = reidSubtreeWithMap(tree);
+    const result = reidOne(tree);
 
     const ids = allNodes(result.node).map(n => n.id);
     // The control: three nodes in, three out — so the assertions below are
@@ -62,7 +75,7 @@ describe("a re-identified subtree is a different subtree", () => {
 
 describe("a DOM id is remapped rather than dropped", () => {
   it("keeps an id, changes it, and reports the replacement", () => {
-    const result = reidSubtreeWithMap(node("root", { cssId: "pricing" }));
+    const result = reidOne(node("root", { cssId: "pricing" }));
 
     // Three separate claims, and the middle one is the point. Dropping would
     // satisfy "not the original"; keeping would satisfy "still has one".
@@ -75,7 +88,7 @@ describe("a DOM id is remapped rather than dropped", () => {
     // An author reads and writes this value: it appears in a URL fragment, in a
     // stylesheet and in the attribute panel. A UUID would be unique and
     // unusable.
-    const result = reidSubtreeWithMap(node("root", { cssId: "pricing" }));
+    const result = reidOne(node("root", { cssId: "pricing" }));
 
     expect(result.node.cssId).toMatch(/^pricing-/);
   });
@@ -83,7 +96,7 @@ describe("a DOM id is remapped rather than dropped", () => {
   it("remaps the attributes escape hatch too, case-insensitively", () => {
     // A DOM id reaches a page two ways, and a remap that covered one would
     // leave the other emitting a duplicate.
-    const result = reidSubtreeWithMap(
+    const result = reidOne(
       node("root", { attributes: { ID: "pricing", "data-keep": "yes" } })
     );
 
@@ -98,9 +111,7 @@ describe("a DOM id is remapped rather than dropped", () => {
     // one page must not emit the same HTML id.
     const tree = node("root", { cssId: "pricing" });
 
-    expect(reidSubtreeWithMap(tree).node.cssId).not.toBe(
-      reidSubtreeWithMap(tree).node.cssId
-    );
+    expect(reidOne(tree).node.cssId).not.toBe(reidOne(tree).node.cssId);
   });
 
   it("still drops the id through the plain reidSubtree", () => {
@@ -125,7 +136,7 @@ describe("every internal reference round-trips", () => {
       node("b", { attributes: { id: "sidebar" } }),
     ]);
 
-    const result = reidSubtreeWithMap(tree);
+    const result = reidOne(tree);
     const before = ["top", "middle", "deep", "sidebar"];
 
     expect([...result.domIds.keys()].sort()).toEqual([...before].sort());
@@ -147,7 +158,7 @@ describe("every internal reference round-trips", () => {
     // not make it worse. The pair pointed at one target before, so a reference
     // to it still reaches one target after.
     const tree = node("root", { cssId: "dup" }, [node("a", { cssId: "dup" })]);
-    const result = reidSubtreeWithMap(tree);
+    const result = reidOne(tree);
 
     const seen = allNodes(result.node).map(n => n.cssId);
     expect(new Set(seen).size).toBe(1);
@@ -157,14 +168,14 @@ describe("every internal reference round-trips", () => {
   it("leaves a subtree carrying no DOM ids with an empty map", () => {
     // The control for the map itself: it reports what was there, so a function
     // inventing entries would fail here while passing everything above.
-    const result = reidSubtreeWithMap(node("root", {}, [node("a")]));
+    const result = reidOne(node("root", {}, [node("a")]));
 
     expect(result.domIds.size).toBe(0);
     expect(result.nodeIds.size).toBe(2);
   });
 });
 
-describe("reidSubtreeWithMap id references", () => {
+describe("a single root's id references", () => {
   it("points a copied reference at the copy's own target", () => {
     const original: BlockNode = {
       id: "root",
@@ -185,7 +196,7 @@ describe("reidSubtreeWithMap id references", () => {
       },
     };
 
-    const { node } = reidSubtreeWithMap(original);
+    const { node } = reidOne(original);
     const children = node.slots!.children!;
 
     // Without the second pass the copy still says "help", which resolves to
@@ -198,7 +209,7 @@ describe("reidSubtreeWithMap id references", () => {
   });
 });
 
-describe("reidSubtreeWithMap malformed attributes", () => {
+describe("a single root's malformed attributes", () => {
   it("survives a stored attributes: null beside a node with a DOM id", () => {
     const original = {
       id: "root",
@@ -219,7 +230,7 @@ describe("reidSubtreeWithMap malformed attributes", () => {
       },
     } as unknown as BlockNode;
 
-    expect(() => reidSubtreeWithMap(original)).not.toThrow();
+    expect(() => reidOne(original)).not.toThrow();
   });
 });
 

--- a/packages/blocks-engine/src/tree.ts
+++ b/packages/blocks-engine/src/tree.ts
@@ -1052,35 +1052,6 @@ export function reidSubtree(node: BlockNode): BlockNode {
 }
 
 /**
- * What re-identifying a subtree produced, when the caller needs to follow it.
- *
- * {@link reidSubtree} drops a copy's DOM ids, which is right when the copy is
- * all anyone will look at. It is wrong when the subtree REFERS to itself: a
- * link inside a saved pattern pointing at `#pricing` resolves to a node in the
- * same pattern, and dropping the target's id leaves the copy carrying a link to
- * nowhere — worse, to whatever `#pricing` the destination page happens to own.
- *
- * So the ids are remapped rather than dropped, and both maps are handed back.
- * The engine cannot rewrite the references itself: a link's target lives in a
- * block's props, and which prop holds one is a property of the block's
- * definition rather than of the document format.
- */
-export interface ReidentifiedSubtree {
-  /** The rebuilt subtree. */
-  node: BlockNode;
-  /** Every node's old id → its new one. */
-  nodeIds: ReadonlyMap<string, string>;
-  /**
-   * Every DOM id the subtree carried → its replacement.
-   *
-   * Keyed by the id as written. A subtree that already used one id on two nodes
-   * is malformed — validation reports it as a duplicate — and appears here once,
-   * mapped to the first replacement minted.
-   */
-  domIds: ReadonlyMap<string, string>;
-}
-
-/**
  * What a re-identification does with the DOM ids it copies.
  *
  * Two words rather than a boolean, because the call site is where this is read
@@ -1351,26 +1322,6 @@ export function referencedDomIds(
     mapForest([root], copy => relinkOne(copy, probe));
   });
   return perRoot;
-}
-
-/**
- * One subtree, re-identified — {@link reidForestWithMap} for a single root.
- *
- * Delegates rather than repeating the two passes, so the singular and the
- * plural cannot drift into disagreeing about what a copy is.
- *
- * It takes no {@link DomIdPolicy}, and the honest reason is that nothing in the
- * product calls this. Measured: every occurrence outside this file is a test,
- * the package entry, or a comment in `resolve-instances.ts` citing it as an
- * analogy — composition keeps a `domIds` memo of its own and re-identifies to
- * deterministic scoped ids rather than random ones, and a save works on a RUN
- * of siblings and reaches for the forest form. Adding the parameter would be
- * offering an option to nobody. Whether a published helper with no caller
- * should stay is a separate question from this one.
- */
-export function reidSubtreeWithMap(node: BlockNode): ReidentifiedSubtree {
-  const { nodes, nodeIds, domIds } = reidForestWithMap([node]);
-  return { node: nodes[0] ?? node, nodeIds, domIds };
 }
 
 /** One node, re-identified, with its DOM id remapped rather than removed. */


### PR DESCRIPTION
`reidSubtreeWithMap` re-identified a single subtree by delegating to `reidForestWithMap([node])`, and nothing in the product called it.

Measured before removing it, with a control:

```
reidSubtreeWithMap   every occurrence outside its own definition is a test,
                     the entry re-export, or a comment citing it as an analogy
reidForestWithMap    11 non-test occurrences
```

## Why remove rather than keep and document

Its docblock already said nothing calls it, so "keep it and say so" was largely already done.

**It was the lesser of the two.** `reidForestWithMap` takes a `DomIdPolicy` saying what happens to DOM ids; the single-root form accepted none, and its own docblock said adding one "would be offering an option to nobody". A caller needing a policy had to reach for the forest form anyway — which is most of what a convenience exists for.

**No gate could ever have noticed.** It is an entry export, and the dead-code analysis counts a published name as used, so it would have sat here indefinitely.

`ReidentifiedSubtree` goes with it, having no other use.

## Its tests are kept, not deleted

This is the part I want reviewed most closely.

Fourteen references exercised the singular form, but what they assert belongs to the forest form: fresh node ids, a DOM id remapped rather than dropped, internal references that round-trip, malformed attributes tolerated. One root is simply the smallest forest that shows it.

They now call `reidForestWithMap([root])` through a local helper shaped like the old return value, so **every assertion is unchanged** and the file still runs 47 tests. `blocks-engine` holds at 2432 — the coverage moved rather than went.

## The entry guard still discriminates

Removing a function AND its export could make the guard pass because the name left both sides. Break-verified that it does not, by adding an exported function the entry does not re-export:

```
× re-exports every function tree.ts exports
  AssertionError: expected [ 'probeAfterRemoval' ] to deeply equal []
```

## Also

A comment in `resolve-instances.ts` cited the deleted function as an analogy for its own memo. Repointed at `reidForestWithMap`, which keeps that memo for the same reason.

## Gates

Every dependent, because this withdraws a published export rather than changing code behind one.

| package | types | lint | tests |
| --- | --- | --- | --- |
| blocks-engine | 0 | 0 | **2432** |
| blocks-react | 0 | 0 | **1168** |
| builder | 0 | 0 | **3073** |
| plugin-page-builder | 0 | 0 | **833** |

`pnpm build` 0 · `lint:design` 35/35 · `fallow audit --base origin/main` **pass**, `changed_files_count: 5`, every `*_introduced: 0` · changeset covers all 25 lockstep packages.
