### PR TITLE
test(ui): prove the derived failure path at the threshold

### DIFF
--- a/packages/ui/src/styles/contrast/__tests__/alpha-utilities.test.ts
+++ b/packages/ui/src/styles/contrast/__tests__/alpha-utilities.test.ts
@@ -1106,7 +1106,10 @@ describe("alpha-opacity color utilities", { timeout: 30_000 }, () => {
     const body = source.slice(from, source.indexOf("\n}\n", from));
     expect(body).toContain("function unacceptedFailures");
     expect(body).toContain("failingModes(r)");
-    expect(body).not.toMatch(/ratio\s*<\s*r\.need/);
+    // Any comparison against the threshold, not the one spelling that was
+    // there when this was written. Rejecting `<` alone let `<=` through, which
+    // is a different predicate reported by the same body.
+    expect(body).not.toMatch(/r\.need/);
   });
 
   it("reports a mode exactly at its threshold as passing", () => {
@@ -1115,6 +1118,21 @@ describe("alpha-opacity color utilities", { timeout: 30_000 }, () => {
     const r = worstRatio("border-border/50");
     const exact = { ...r, modes: [{ ...r.modes[0], ratio: r.need }] };
     expect(failingModes(exact)).toEqual([]);
+  });
+
+  it("reports nothing at the threshold through the SCAN's own path too", () => {
+    // The control above calls `failingModes` directly, so it says nothing
+    // about the function the scan actually asks. `unacceptedFailures` reading
+    // `<=` against its own copy of the threshold passes every source check and
+    // every message control, and reports an exact-threshold mode as a
+    // violation — a red on a utility that meets its target.
+    const combo = "border-border/50";
+    const r = worstRatio(combo);
+    const exact = { ...r, modes: [{ ...r.modes[0], ratio: r.need }] };
+    expect(unacceptedFailures(combo, exact)).toEqual([]);
+    // The other arm, so this cannot be satisfied by a function that reports
+    // nothing whatever it is handed.
+    expect(unacceptedFailures(combo, r)).toEqual(failingModes(r));
   });
 
   it("puts no alpha on the control boundary, in any utility", () => {


### PR DESCRIPTION
## A guard that read stronger than it was

Follow-up to #1696, which merged before this landed.

That PR carried a source check asserting `unacceptedFailures` **derives** its
failures from `failingModes` rather than re-testing the threshold. The property
is real — a duplicate agrees with the original until the threshold rule changes,
which is exactly why no behavioural test can observe it — but the check written
for it rejected only the current `<` spelling.

So replacing the body with `m.ratio <= r.need` satisfied it: a **different
predicate**, reported by the same function, which reports an exact-threshold
mode as a violation. All 31 tests stayed green.

## Two halves, two instruments

Neither instrument reaches both halves, so both are needed:

| the duplicate is… | caught by |
|---|---|
| semantically **different** (`<=`) | a behavioural control at the threshold |
| semantically **identical** (`<`) | the source check |

The source check now rejects **any** comparison against `r.need`, not one
spelling of one operator. And a control calls `unacceptedFailures` itself at the
threshold — the existing one called `failingModes` directly, so it said nothing
about the function the scan actually asks.

Both arms are asserted, so the new control cannot be satisfied by a function
that reports nothing whatever it is handed.

## Why my own mutation testing missed it

Worth stating, because it is the more useful finding. My harness *did* mutate
`failingModes` to `<=` and watched the direct control kill it — so the property
read as covered. It never mutated **the function the scan calls**, which is
where the duplication would actually live.

A mutation that kills a test proves the test reaches *some* code. It does not
prove it reaches the code whose behaviour is being claimed.

## Evidence

1,207 tests pass, `tsc --noEmit` clean, `check:comments` clean, `fallow:audit`
clean.

| mutation | result |
|---|---|
| `unacceptedFailures` re-tests with `<=` (the reported one) | killed by 2 |
| the same with the correct `<` — pure duplication | killed by 1 |
| `unacceptedFailures` reports nothing at all | killed by 4 |
