### PR TITLE
fix(release): two ways release health graded a question it had quietly changed

### DIFF
--- a/scripts/release/check-finalized.mjs
+++ b/scripts/release/check-finalized.mjs
@@ -50,6 +50,7 @@ import {
   fetchRegistryState,
   getExpectedDistTag,
   isBootstrapPlaceholderOnly,
+  firstPrereleaseId,
   readPreMode,
   readPreState,
   waitForCompleteRelease,
@@ -58,6 +59,20 @@ import {
 /** The package whose version names the release; every other one is in lockstep. */
 export const ANCHOR_PACKAGE = "nextly";
 const ANCHOR_MANIFEST = "packages/nextly/package.json";
+
+/**
+ * A manifest field that can be used to ask a question, rather than merely a
+ * field of the right type.
+ *
+ * 🔴 `typeof value === "string"` is not that test. `""` and `"   "` satisfy it
+ * and then fail downstream in silence, where a name is a registry request for
+ * a package that cannot exist and a version can match nothing the registry
+ * serves. Validation exists to stop the question being quietly shrunk, so the
+ * shapes that shrink it have to be rejected here.
+ */
+function isUsableString(value) {
+  return typeof value === "string" && value.trim() !== "";
+}
 
 /**
  * The version `main` declares, read out of git rather than off the disk.
@@ -72,7 +87,7 @@ export function versionAtRef(ref, run = execFileSync) {
     maxBuffer: 8 * 1024 * 1024,
   });
   const version = JSON.parse(source).version;
-  if (typeof version !== "string" || version === "") {
+  if (!isUsableString(version)) {
     throw new Error(`${ANCHOR_MANIFEST} at ${ref} declares no version`);
   }
   return version;
@@ -138,8 +153,13 @@ export function manifestAtRef(ref, run = execFileSync) {
      * registry about it, and a release could be reported finished while that
      * package was never published. An unreadable manifest is a question that
      * cannot be asked, not a package that is not there.
+     *
+     * An EMPTY name is the same defect wearing the right type. For the anchor
+     * it also defeats the lockstep check below, which finds no `nextly` and so
+     * compares nothing; for any other package the registry is asked about a
+     * name that cannot exist, and that answer reads as never-published.
      */
-    if (typeof pkg.name !== "string" || typeof pkg.version !== "string") {
+    if (!isUsableString(pkg.name) || !isUsableString(pkg.version)) {
       throw new Error(
         `${path} at ${ref} is publishable but declares no usable name and ` +
           "version, so the release it belongs to cannot be graded."
@@ -653,24 +673,37 @@ const STEP_TEXT = {
 /**
  * Whether the channel tag should be asserted for this subject.
  *
- * 🔴 Two situations answer "no", and they are easy to collapse into one.
+ * 🔴 Two separate questions, and only one of them is about prerelease mode.
  *
  * A HISTORICAL subject is not the release `main` declares now, so today's
  * channel tag has moved past it and was never meant to point at it.
  *
- * A repository EXITING prerelease mode is mid-transition: `pre.json` says
- * `mode: "exit"` from the exit commit until the Version PR lands, and the
- * manifests still declare the last alpha for that whole window. `readPreState`
- * answers null there, exactly as it does when the repository was never in pre
- * mode, so the expected tag comes out as `latest`. Asserting it yields a remedy
- * that says to move `latest` onto a prerelease, serving an alpha to every
- * stable install.
+ * Everything else turns on whether `pre.json` and the manifests AGREE about
+ * which kind of release this is. Changesets moves those two in separate
+ * commits, so each prerelease transition opens a window where the repository
+ * says both things at once, and in that window the expected tag is derived from
+ * one claim and compared against the other:
+ *
+ *     mode "pre",  manifests STABLE      entering    -> skip
+ *     mode "pre",  manifests prerelease  in pre mode -> assert
+ *     mode "exit", manifests PRERELEASE  leaving     -> skip
+ *     mode null,   manifests stable      outside     -> assert
+ *
+ * Both windows were reported one at a time, and a mode test answers only the
+ * one it was written for. Leaving: `readPreState` gives null for `"exit"` and
+ * for no file alike, so `latest` is expected and the remedy says to move it
+ * onto a prerelease, serving an alpha to every stable install. Entering: the
+ * new prerelease tag is expected and the remedy says to move it onto the last
+ * stable build. Comparing the two claims answers the window itself rather than
+ * naming its ends, which is why this is not a second special case beside the
+ * exit one.
  *
  * Exported because the command-line block below has no test, and a rule that
  * lives only inside it is a rule nothing can exercise.
  */
-export function shouldAssertChannel(currentTrain, preMode) {
-  return currentTrain && preMode !== "exit";
+export function shouldAssertChannel(currentTrain, preMode, version) {
+  if (!currentTrain) return false;
+  return (preMode === "pre") === (firstPrereleaseId(version) !== undefined);
 }
 
 /**
@@ -755,6 +788,10 @@ if (invokedDirectly) {
     currentTrain = false;
   }
 
+  // Decided here rather than beside the `publishState` call, so that a failure
+  // to decide it is not reported as the registry being unreachable.
+  const assertChannel = shouldAssertChannel(currentTrain, readPreMode(), version);
+
   let publish;
   try {
     /*
@@ -796,7 +833,7 @@ if (invokedDirectly) {
       manifest,
       (name) => registry.get(name) ?? null,
       readPreState(),
-      { assertChannel: shouldAssertChannel(currentTrain, readPreMode()) }
+      { assertChannel }
     );
   } catch (error) {
     console.error(

--- a/scripts/release/check-finalized.mjs
+++ b/scripts/release/check-finalized.mjs
@@ -51,6 +51,7 @@ import {
   getExpectedDistTag,
   isBootstrapPlaceholderOnly,
   firstPrereleaseId,
+  isPrereleaseOfTag,
   readPreConfig,
   readPreState,
   waitForCompleteRelease,
@@ -710,11 +711,24 @@ const STEP_TEXT = {
  */
 export function shouldAssertChannel(currentTrain, pre, version) {
   if (!currentTrain) return false;
-  const declared = firstPrereleaseId(version);
   // Outside prerelease mode, and mid-exit, the only agreeable version is a
   // stable one: `getExpectedDistTag` answers `latest` for both.
-  if (pre?.mode !== "pre") return declared === undefined;
-  return declared === pre.tag;
+  if (pre?.mode !== "pre") return firstPrereleaseId(version) === undefined;
+  /*
+   * 🔴 Prerelease mode with no usable tag is UNANSWERABLE, not "no". A merge or
+   * a hand edit is enough to leave `{ "mode": "pre" }` behind, and a null tag
+   * compares unequal to every version, so returning false there would switch
+   * the channel check off and look exactly like a check that ran and found
+   * nothing wrong. `channelDecision` turns this into exit 2, which is what
+   * every other unestablished answer here does.
+   */
+  if (typeof pre.tag !== "string" || pre.tag.trim() === "") {
+    throw new Error(
+      ".changeset/pre.json declares prerelease mode with no usable tag, so " +
+        "the channel this release belongs to cannot be established."
+    );
+  }
+  return isPrereleaseOfTag(version, pre.tag);
 }
 
 /**

--- a/scripts/release/check-finalized.mjs
+++ b/scripts/release/check-finalized.mjs
@@ -685,11 +685,21 @@ const STEP_TEXT = {
  * says both things at once, and in that window the expected tag is derived from
  * one claim and compared against the other:
  *
+ *     no file,     manifests stable       outside         -> assert
+ *     mode "exit", manifests -alpha.N     leaving         -> skip
  *     tag "alpha", manifests STABLE       entering        -> skip
  *     tag "alpha", manifests -alpha.N     in pre mode     -> assert
  *     tag "beta",  manifests -alpha.N     re-entered      -> skip
- *     mode "exit", manifests -alpha.N     leaving         -> skip
- *     no file,     manifests stable       outside         -> assert
+ *     tag "next",  manifests -next.1.N    nested cycle    -> skip
+ *     tag missing, any manifests          malformed       -> UNANSWERABLE
+ *     mode unknown, any manifests         malformed       -> UNANSWERABLE
+ *
+ * Three outcomes, not two. Six findings arrived on this rule one corner at a
+ * time, and every one of them was a state that fell through to "do not assert",
+ * which switches the check off and reads exactly like a check that ran and
+ * found nothing wrong. So the modes are named and anything else is refused:
+ * `channelDecision` carries the refusal out as exit 2, which is what every
+ * other unestablished answer here does.
  *
  * Agreement is about the prerelease IDENTIFIER, not merely about whether there
  * is one. Changesets allows pre mode to be exited and re-entered under a
@@ -711,23 +721,45 @@ const STEP_TEXT = {
  */
 export function shouldAssertChannel(currentTrain, pre, version) {
   if (!currentTrain) return false;
-  // Outside prerelease mode, and mid-exit, the only agreeable version is a
-  // stable one: `getExpectedDistTag` answers `latest` for both.
-  if (pre?.mode !== "pre") return firstPrereleaseId(version) === undefined;
+
+  // No file at all: the repository is not in prerelease mode and never said
+  // otherwise, so the only agreeable version is a stable one.
+  if (pre === null) return firstPrereleaseId(version) === undefined;
+
   /*
-   * 🔴 Prerelease mode with no usable tag is UNANSWERABLE, not "no". A merge or
-   * a hand edit is enough to leave `{ "mode": "pre" }` behind, and a null tag
-   * compares unequal to every version, so returning false there would switch
-   * the channel check off and look exactly like a check that ran and found
-   * nothing wrong. `channelDecision` turns this into exit 2, which is what
-   * every other unestablished answer here does.
+   * 🔴 Everything below is a TOTAL reading of a file that exists. Six review
+   * findings arrived on this rule one shape at a time, and every one of them
+   * was a corner of the state space answered by falling through to "do not
+   * assert" — which switches the check off and reads exactly like a check that
+   * ran and found nothing wrong. So the three modes are named, and anything
+   * else is refused rather than assumed.
    */
+  if (pre.mode === "exit") {
+    // Mid-exit: the manifests still carry the last prerelease until the Version
+    // PR lands, and `readPreState` answers null here, so `latest` is expected.
+    return firstPrereleaseId(version) === undefined;
+  }
+
+  if (pre.mode !== "pre") {
+    // A missing mode, or one this checker does not know, is a file whose
+    // meaning cannot be established. `channelDecision` turns it into exit 2.
+    throw new Error(
+      `.changeset/pre.json declares mode ${JSON.stringify(pre.mode)}, which ` +
+        "this check does not know how to read, so the channel this release " +
+        "belongs to cannot be established."
+    );
+  }
+
   if (typeof pre.tag !== "string" || pre.tag.trim() === "") {
+    // Prerelease mode with no tag. A null tag compares unequal to every
+    // version, so answering "do not assert" would be the silent switch-off
+    // again. A merge or a hand edit is enough to produce it.
     throw new Error(
       ".changeset/pre.json declares prerelease mode with no usable tag, so " +
         "the channel this release belongs to cannot be established."
     );
   }
+
   return isPrereleaseOfTag(version, pre.tag);
 }
 

--- a/scripts/release/check-finalized.mjs
+++ b/scripts/release/check-finalized.mjs
@@ -51,7 +51,7 @@ import {
   getExpectedDistTag,
   isBootstrapPlaceholderOnly,
   firstPrereleaseId,
-  readPreMode,
+  readPreConfig,
   readPreState,
   waitForCompleteRelease,
 } from "./lib.mjs";
@@ -684,26 +684,64 @@ const STEP_TEXT = {
  * says both things at once, and in that window the expected tag is derived from
  * one claim and compared against the other:
  *
- *     mode "pre",  manifests STABLE      entering    -> skip
- *     mode "pre",  manifests prerelease  in pre mode -> assert
- *     mode "exit", manifests PRERELEASE  leaving     -> skip
- *     mode null,   manifests stable      outside     -> assert
+ *     tag "alpha", manifests STABLE       entering        -> skip
+ *     tag "alpha", manifests -alpha.N     in pre mode     -> assert
+ *     tag "beta",  manifests -alpha.N     re-entered      -> skip
+ *     mode "exit", manifests -alpha.N     leaving         -> skip
+ *     no file,     manifests stable       outside         -> assert
  *
- * Both windows were reported one at a time, and a mode test answers only the
- * one it was written for. Leaving: `readPreState` gives null for `"exit"` and
- * for no file alike, so `latest` is expected and the remedy says to move it
- * onto a prerelease, serving an alpha to every stable install. Entering: the
- * new prerelease tag is expected and the remedy says to move it onto the last
- * stable build. Comparing the two claims answers the window itself rather than
- * naming its ends, which is why this is not a second special case beside the
- * exit one.
+ * Agreement is about the prerelease IDENTIFIER, not merely about whether there
+ * is one. Changesets allows pre mode to be exited and re-entered under a
+ * different tag before the Version PR lands, and in that window the manifests
+ * carry `-alpha.N` while the active tag is `beta`: both claims say "this is a
+ * prerelease" and they still disagree about which one, so `beta` would be
+ * expected to resolve to the old alpha build.
+ *
+ * Each window was reported on its own, and a rule shaped to one of them answers
+ * only that one. Leaving: `readPreState` gives null for `"exit"` and for no
+ * file alike, so `latest` is expected and the remedy says to move it onto a
+ * prerelease, serving an alpha to every stable install. Entering: the new
+ * prerelease tag is expected of the last stable build. Comparing what the two
+ * files actually CLAIM answers the whole space rather than the corners of it
+ * that have been noticed so far.
  *
  * Exported because the command-line block below has no test, and a rule that
  * lives only inside it is a rule nothing can exercise.
  */
-export function shouldAssertChannel(currentTrain, preMode, version) {
+export function shouldAssertChannel(currentTrain, pre, version) {
   if (!currentTrain) return false;
-  return (preMode === "pre") === (firstPrereleaseId(version) !== undefined);
+  const declared = firstPrereleaseId(version);
+  // Outside prerelease mode, and mid-exit, the only agreeable version is a
+  // stable one: `getExpectedDistTag` answers `latest` for both.
+  if (pre?.mode !== "pre") return declared === undefined;
+  return declared === pre.tag;
+}
+
+/**
+ * The channel decision the command-line block acts on, INCLUDING what to do
+ * when it cannot be made.
+ *
+ * 🔴 An unreadable or malformed `.changeset/pre.json` is not a release that is
+ * unfinished, it is a question that could not be asked, and the two leave by
+ * different doors: `.github/workflows/release-health.yml` treats exit 1 as a
+ * confirmed defect and files an issue for it, so a JSON parse error escaping
+ * from here would become an issue whose headline is a stack trace.
+ *
+ * Exported, and taking its reader as an argument, for the same reason
+ * `shouldAssertChannel` is: the block below is entered by no test, so a rule
+ * that lives only inside it can be broken without anything noticing.
+ */
+export function channelDecision(currentTrain, version, readPre = readPreConfig) {
+  try {
+    return { ok: true, assertChannel: shouldAssertChannel(currentTrain, readPre(), version) };
+  } catch (error) {
+    return {
+      ok: false,
+      message:
+        "check-finalized: .changeset/pre.json could not be read, so which " +
+        `channel this release belongs to is unknown rather than wrong: ${error.message}`,
+    };
+  }
 }
 
 /**
@@ -788,9 +826,15 @@ if (invokedDirectly) {
     currentTrain = false;
   }
 
-  // Decided here rather than beside the `publishState` call, so that a failure
-  // to decide it is not reported as the registry being unreachable.
-  const assertChannel = shouldAssertChannel(currentTrain, readPreMode(), version);
+  // Decided before the registry is reached, so that a failure to decide it is
+  // not reported as npm being unreachable. `channelDecision` carries the
+  // unanswerable case with it rather than leaving it to this block.
+  const channel = channelDecision(currentTrain, version);
+  if (!channel.ok) {
+    console.error(channel.message);
+    process.exit(2);
+  }
+  const assertChannel = channel.assertChannel;
 
   let publish;
   try {

--- a/scripts/release/check-finalized.test.mjs
+++ b/scripts/release/check-finalized.test.mjs
@@ -972,6 +972,41 @@ describe("when the channel tag is worth asserting", () => {
     expect(new Set(answers).size).toBe(2);
   });
 
+  it("refuses a mode it does not recognise, rather than reading it as exit", () => {
+    /*
+     * 🔴 The last corner. A `pre.json` with no `mode`, or one this checker has
+     * never heard of, used to fall through to the not-pre branch and be read as
+     * a repository outside prerelease mode. With prerelease manifests that
+     * answers "do not assert", and the check switches itself off in the state
+     * where it is most likely to be needed.
+     */
+    for (const mode of [null, undefined, "exiting", "", 3]) {
+      expect(() =>
+        shouldAssertChannel(true, { mode, tag: "alpha" }, VERSION)
+      ).toThrow(/does not know how to read/);
+    }
+
+    // The control: the two modes it DOES know are still read, not refused.
+    expect(shouldAssertChannel(true, IN_ALPHA, VERSION)).toBe(true);
+    expect(shouldAssertChannel(true, LEAVING, VERSION)).toBe(false);
+  });
+
+  it("does not accept a NESTED cycle's build for the shorter tag", () => {
+    /*
+     * 🔴 `changeset version` writes `<version>-<tag>.<n>`, so `next` produces
+     * `-next.0` and `next.1` produces `-next.1.0`. A prefix test alone reads
+     * the second as an artifact of `next` as well, and a cycle exited under
+     * `next.1` and re-entered under `next` would have its old builds accepted
+     * as the new channel's.
+     */
+    const NEXT = { mode: "pre", tag: "next" };
+
+    expect(shouldAssertChannel(true, NEXT, "1.2.3-next.0")).toBe(true);
+    expect(shouldAssertChannel(true, NEXT, "1.2.3-next.1.0")).toBe(false);
+    // And a counter has to BE a counter.
+    expect(shouldAssertChannel(true, NEXT, "1.2.3-next.rc")).toBe(false);
+  });
+
   it("refuses prerelease mode with no usable tag, rather than answering no", () => {
     /*
      * 🔴 `{ "mode": "pre" }` survives a merge or a hand edit, and a null tag

--- a/scripts/release/check-finalized.test.mjs
+++ b/scripts/release/check-finalized.test.mjs
@@ -6,10 +6,14 @@
  * include that exact combination, because a check written after an incident
  * should be able to fail on the incident.
  */
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
 import { describe, expect, it } from "vitest";
 
 import {
   ANCHOR_PACKAGE,
+  channelDecision,
   manifestAtRef,
   publishState,
   releaseState,
@@ -902,38 +906,54 @@ describe("when the channel tag is worth asserting", () => {
    * chooses correctly.
    */
   const STABLE = "0.0.2";
+  const IN_ALPHA = { mode: "pre", tag: "alpha" };
+  const IN_BETA = { mode: "pre", tag: "beta" };
+  const LEAVING = { mode: "exit", tag: "alpha" };
+  const OUTSIDE = null;
 
-  it("asserts it when the mode and the declared version agree", () => {
-    // The two settled states. Both claims say the same thing about this
-    // release, so the tag derived from one can be held against the other.
-    expect(shouldAssertChannel(true, "pre", VERSION)).toBe(true);
-    expect(shouldAssertChannel(true, null, STABLE)).toBe(true);
+  it("asserts it when pre.json and the manifests agree", () => {
+    // The two settled states. Both files say the same thing about this release,
+    // so the tag derived from one can be held against the other.
+    expect(shouldAssertChannel(true, IN_ALPHA, VERSION)).toBe(true);
+    expect(shouldAssertChannel(true, OUTSIDE, STABLE)).toBe(true);
   });
 
   it("does not assert it for a historical subject", () => {
     // Today's channel tag moved past an older release and was never meant to
     // point at it. Independent of the mode, so both settled states are shown.
-    expect(shouldAssertChannel(false, "pre", VERSION)).toBe(false);
-    expect(shouldAssertChannel(false, null, STABLE)).toBe(false);
+    expect(shouldAssertChannel(false, IN_ALPHA, VERSION)).toBe(false);
+    expect(shouldAssertChannel(false, OUTSIDE, STABLE)).toBe(false);
   });
 
   it("does not assert it while prerelease mode is being EXITED", () => {
     // `readPreState` answers null for `mode: "exit"` just as it does for "never
     // in pre mode", so the expected tag becomes `latest` and the remedy says to
     // move `latest` onto the alpha still in the manifests.
-    expect(shouldAssertChannel(true, "exit", VERSION)).toBe(false);
+    expect(shouldAssertChannel(true, LEAVING, VERSION)).toBe(false);
   });
 
   it("does not assert it while prerelease mode is being ENTERED", () => {
     /*
-     * 🔴 The mirror, and the reason this asks about agreement rather than about
-     * the mode. `pnpm changeset pre enter alpha` writes `mode: "pre"` in its own
-     * commit, and `release.yml` runs on it while every manifest still declares
-     * the preceding STABLE release. A mode test alone answers "assert" here,
-     * the new prerelease dist-tag is expected of a stable version, and the
-     * remedy prescribes moving `alpha` onto the last stable build.
+     * 🔴 The mirror of the exit. `pnpm changeset pre enter alpha` writes
+     * `mode: "pre"` in its own commit, and `release.yml` runs on it while every
+     * manifest still declares the preceding STABLE release. A mode test alone
+     * answers "assert" here, the new prerelease dist-tag is expected of a
+     * stable version, and the remedy prescribes moving `alpha` onto the last
+     * stable build.
      */
-    expect(shouldAssertChannel(true, "pre", STABLE)).toBe(false);
+    expect(shouldAssertChannel(true, IN_ALPHA, STABLE)).toBe(false);
+  });
+
+  it("does not assert it when pre mode was RE-ENTERED under a different tag", () => {
+    /*
+     * 🔴 Why this compares identifiers rather than asking "is it a prerelease".
+     * Changesets allows an exit and a re-entry under a new tag before the
+     * Version PR lands, so `pre.json` can say `beta` while the manifests still
+     * carry `-alpha.N`. Both claims agree that this is a prerelease and still
+     * disagree about which one, and asserting there expects `beta` to resolve
+     * to the old alpha build.
+     */
+    expect(shouldAssertChannel(true, IN_BETA, VERSION)).toBe(false);
   });
 
   it("does not answer the same way for every input", () => {
@@ -943,19 +963,47 @@ describe("when the channel tag is worth asserting", () => {
      * true, so neither group proves anything on its own.
      */
     const answers = [
-      shouldAssertChannel(true, "pre", VERSION),
-      shouldAssertChannel(true, "pre", STABLE),
-      shouldAssertChannel(true, "exit", VERSION),
-      shouldAssertChannel(true, null, STABLE),
+      shouldAssertChannel(true, IN_ALPHA, VERSION),
+      shouldAssertChannel(true, IN_ALPHA, STABLE),
+      shouldAssertChannel(true, IN_BETA, VERSION),
+      shouldAssertChannel(true, LEAVING, VERSION),
+      shouldAssertChannel(true, OUTSIDE, STABLE),
     ];
     expect(new Set(answers).size).toBe(2);
+  });
+
+  it("reports an unreadable pre.json as unanswerable, not as a defect", () => {
+    /*
+     * 🔴 The exit code carries this distinction and nothing else does.
+     * `release-health.yml` treats exit 1 as a CONFIRMED unfinished release and
+     * opens an issue from the report, so a parse error escaping here becomes an
+     * issue whose headline is a stack trace and whose remedy is nonsense. The
+     * question could not be asked; that is exit 2.
+     */
+    const unreadable = () => {
+      throw new SyntaxError("Unexpected token } in JSON at position 4");
+    };
+
+    const decision = channelDecision(true, VERSION, unreadable);
+
+    expect(decision.ok).toBe(false);
+    expect(decision.message).toContain("pre.json");
+    expect(decision.message).toContain("unknown rather than wrong");
+  });
+
+  it("passes the decision through when pre.json can be read", () => {
+    // The control. A decision that reported every read as unanswerable would
+    // satisfy the case above and switch the channel check off permanently.
+    const decision = channelDecision(true, VERSION, () => IN_ALPHA);
+
+    expect(decision).toEqual({ ok: true, assertChannel: true });
   });
 
   it("reads build metadata as part of the version, not as a prerelease", () => {
     // Shares `firstPrereleaseId` with the tag rule rather than re-deciding what
     // a prerelease looks like, so `+build` cannot be mistaken for `-alpha`.
-    expect(shouldAssertChannel(true, null, "0.0.2+build.7")).toBe(true);
-    expect(shouldAssertChannel(true, "pre", "0.0.2+build.7")).toBe(false);
+    expect(shouldAssertChannel(true, OUTSIDE, "0.0.2+build.7")).toBe(true);
+    expect(shouldAssertChannel(true, IN_ALPHA, "0.0.2+build.7")).toBe(false);
   });
 });
 
@@ -1137,5 +1185,41 @@ describe("what the settle actually waits for", () => {
     ]);
 
     expect(unsettledPackages(manifest, registry)).toEqual([]);
+  });
+});
+
+describe("the command-line path, run as a program", () => {
+  /*
+   * 🔴 The first test that enters `if (invokedDirectly)` at all. Importing the
+   * module never does, which is how a rewrite deleted a constant the block
+   * still referenced while 1200 unit tests passed, and how two mutations of the
+   * channel rule passed the entire suite.
+   *
+   * This covers the exit-code contract rather than the whole block, because the
+   * rest of it reaches the registry. It is the half that matters most to a
+   * reader: `.github/workflows/release-health.yml` treats exit 1 as a CONFIRMED
+   * unfinished release and files an issue for it, so any question that could
+   * not be asked has to leave by a different door.
+   */
+  const SCRIPT = fileURLToPath(new URL("./check-finalized.mjs", import.meta.url));
+
+  const runProgram = ref =>
+    spawnSync(process.execPath, [SCRIPT, ref], { encoding: "utf8" });
+
+  it("exits 2, not 1, when the ref it was given cannot be read", () => {
+    // A ref this shape resolves to nothing, so the run ends before any network
+    // call: `versionAtRef` throws and the block has to classify that.
+    const result = runProgram("0000000000000000000000000000000000000000");
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("nothing");
+  });
+
+  it("says which ref it could not read", () => {
+    // The workflow prints this report into an issue body. A diagnosis that does
+    // not name its subject is one a reader cannot act on.
+    const result = runProgram("refs/heads/no-such-branch-here");
+
+    expect(result.stderr).toContain("refs/heads/no-such-branch-here");
   });
 });

--- a/scripts/release/check-finalized.test.mjs
+++ b/scripts/release/check-finalized.test.mjs
@@ -972,6 +972,26 @@ describe("when the channel tag is worth asserting", () => {
     expect(new Set(answers).size).toBe(2);
   });
 
+  it("refuses prerelease mode with no usable tag, rather than answering no", () => {
+    /*
+     * 🔴 `{ "mode": "pre" }` survives a merge or a hand edit, and a null tag
+     * compares unequal to every version there is. Answering "do not assert"
+     * there switches the channel check off and reports nothing, which reads
+     * exactly like a check that ran and found nothing wrong. The question
+     * cannot be asked, so it leaves by the unanswerable door.
+     */
+    for (const tag of [null, undefined, "", "   "]) {
+      expect(() => shouldAssertChannel(true, { mode: "pre", tag }, VERSION)).toThrow(
+        /no usable tag/
+      );
+    }
+
+    // And it reaches the caller as exit-2 material rather than as a crash.
+    const decision = channelDecision(true, VERSION, () => ({ mode: "pre", tag: null }));
+    expect(decision.ok).toBe(false);
+    expect(decision.message).toContain("no usable tag");
+  });
+
   it("reports an unreadable pre.json as unanswerable, not as a defect", () => {
     /*
      * 🔴 The exit code carries this distinction and nothing else does.
@@ -997,6 +1017,29 @@ describe("when the channel tag is worth asserting", () => {
     const decision = channelDecision(true, VERSION, () => IN_ALPHA);
 
     expect(decision).toEqual({ ok: true, assertChannel: true });
+  });
+
+  it("recognises a DOTTED tag, whose versions carry more than one identifier", () => {
+    /*
+     * 🔴 `pnpm changeset pre enter next.1` produces `1.2.3-next.1.0`, whose
+     * first prerelease identifier is `next`. Comparing that against the tag
+     * `next.1` is false for every version the cycle will ever produce, so the
+     * channel check would report nothing for the whole cycle while looking
+     * exactly like a check that ran and found nothing wrong.
+     *
+     * `getExpectedDistTag` keeps the first-identifier comparison, because it
+     * exists to mirror what Changesets does and Changesets classifies that way.
+     * These are two questions, not one rule spelled twice.
+     */
+    const DOTTED = { mode: "pre", tag: "next.1" };
+
+    expect(shouldAssertChannel(true, DOTTED, "1.2.3-next.1.0")).toBe(true);
+    // Still discriminating: a different cycle's build does not pass.
+    expect(shouldAssertChannel(true, DOTTED, "1.2.3-next.2.0")).toBe(false);
+    // And a tag is not a prefix of an unrelated identifier that starts the same.
+    expect(shouldAssertChannel(true, { mode: "pre", tag: "next" }, "1.2.3-nextly.1")).toBe(
+      false
+    );
   });
 
   it("reads build metadata as part of the version, not as a prerelease", () => {

--- a/scripts/release/check-finalized.test.mjs
+++ b/scripts/release/check-finalized.test.mjs
@@ -21,6 +21,10 @@ import {
   verdict,
   versionAtRef,
 } from "./check-finalized.mjs";
+// The bootstrap placeholder is what makes a package NOT `only-pre`, which is
+// what makes the prerelease tag the expected one below. Imported rather than
+// spelled, so the fixture cannot drift from the rule it depends on.
+import { PLACEHOLDER_VERSION } from "./lib.mjs";
 
 const ALL = { kind: "all", published: 20, total: 20 };
 const NONE = { kind: "none", published: 0, total: 20 };
@@ -695,6 +699,68 @@ describe("deriving the train from git", () => {
     expect(() => manifestAtRef("abc123", run)).toThrow(/packages\/broken/);
   });
 
+  it("refuses a public package whose name is EMPTY, not just missing", () => {
+    /*
+     * 🔴 `""` is a string, so a type check passes it through. The registry is
+     * then asked about a package that cannot exist, that answer reads as never
+     * published, and the package leaves the train without a word: the same
+     * silent shrink the malformed-manifest refusal above exists to stop,
+     * reached through a value of the correct type.
+     */
+    const files = {
+      "packages/nextly/package.json": { name: "nextly", version: VERSION },
+      "packages/blank/package.json": { name: "", version: VERSION },
+    };
+    const run = (_cmd, args) => {
+      if (args[0] === "ls-tree") return Object.keys(files).join("\n");
+      return JSON.stringify(files[args[1].split(":")[1]]);
+    };
+
+    expect(() => manifestAtRef("abc123", run)).toThrow(/packages\/blank/);
+  });
+
+  it("refuses a whitespace-only name, and an empty version too", () => {
+    // Whitespace reaches the registry exactly as emptiness does, and a version
+    // is asked of the registry in the same breath as the name, so both fields
+    // have to clear the same bar.
+    const spaced = {
+      "packages/nextly/package.json": { name: "nextly", version: VERSION },
+      "packages/spaced/package.json": { name: "   ", version: VERSION },
+    };
+    const versionless = {
+      "packages/nextly/package.json": { name: "nextly", version: VERSION },
+      "packages/unversioned/package.json": { name: "@nextlyhq/unversioned", version: "" },
+    };
+    const runner = files => (_cmd, args) => {
+      if (args[0] === "ls-tree") return Object.keys(files).join("\n");
+      return JSON.stringify(files[args[1].split(":")[1]]);
+    };
+
+    expect(() => manifestAtRef("abc123", runner(spaced))).toThrow(/packages\/spaced/);
+    expect(() => manifestAtRef("abc123", runner(versionless))).toThrow(
+      /packages\/unversioned/
+    );
+  });
+
+  it("refuses an ANCHOR with an empty name, which defeats the lockstep check", () => {
+    /*
+     * 🔴 The worst shape. With no readable `nextly` in the manifest the
+     * lockstep comparison finds no anchor and compares nothing, so a ref where
+     * every other package has drifted to a different version is graded as a
+     * single coherent release.
+     */
+    const files = {
+      "packages/nextly/package.json": { name: "", version: VERSION },
+      "packages/admin/package.json": { name: "@nextlyhq/admin", version: "9.9.9" },
+    };
+    const run = (_cmd, args) => {
+      if (args[0] === "ls-tree") return Object.keys(files).join("\n");
+      return JSON.stringify(files[args[1].split(":")[1]]);
+    };
+
+    expect(() => manifestAtRef("abc123", run)).toThrow(/packages\/nextly/);
+  });
+
   it("still skips a PRIVATE manifest that declares no version", () => {
     // The control: refusing every unreadable manifest would refuse the private
     // ones this deliberately ignores, and no release would ever be gradable.
@@ -835,22 +901,61 @@ describe("when the channel tag is worth asserting", () => {
    * which shows the MECHANISM works and says nothing about whether the caller
    * chooses correctly.
    */
-  it("asserts it for the train main declares now", () => {
-    expect(shouldAssertChannel(true, "pre")).toBe(true);
-    expect(shouldAssertChannel(true, null)).toBe(true);
+  const STABLE = "0.0.2";
+
+  it("asserts it when the mode and the declared version agree", () => {
+    // The two settled states. Both claims say the same thing about this
+    // release, so the tag derived from one can be held against the other.
+    expect(shouldAssertChannel(true, "pre", VERSION)).toBe(true);
+    expect(shouldAssertChannel(true, null, STABLE)).toBe(true);
   });
 
   it("does not assert it for a historical subject", () => {
     // Today's channel tag moved past an older release and was never meant to
-    // point at it.
-    expect(shouldAssertChannel(false, "pre")).toBe(false);
+    // point at it. Independent of the mode, so both settled states are shown.
+    expect(shouldAssertChannel(false, "pre", VERSION)).toBe(false);
+    expect(shouldAssertChannel(false, null, STABLE)).toBe(false);
   });
 
-  it("does not assert it while prerelease mode is being exited", () => {
-    // The dangerous one: `readPreState` answers null for `mode: "exit"` just as
-    // it does for "never in pre mode", so the expected tag becomes `latest` and
-    // the remedy says to move `latest` onto the alpha still in the manifests.
-    expect(shouldAssertChannel(true, "exit")).toBe(false);
+  it("does not assert it while prerelease mode is being EXITED", () => {
+    // `readPreState` answers null for `mode: "exit"` just as it does for "never
+    // in pre mode", so the expected tag becomes `latest` and the remedy says to
+    // move `latest` onto the alpha still in the manifests.
+    expect(shouldAssertChannel(true, "exit", VERSION)).toBe(false);
+  });
+
+  it("does not assert it while prerelease mode is being ENTERED", () => {
+    /*
+     * 🔴 The mirror, and the reason this asks about agreement rather than about
+     * the mode. `pnpm changeset pre enter alpha` writes `mode: "pre"` in its own
+     * commit, and `release.yml` runs on it while every manifest still declares
+     * the preceding STABLE release. A mode test alone answers "assert" here,
+     * the new prerelease dist-tag is expected of a stable version, and the
+     * remedy prescribes moving `alpha` onto the last stable build.
+     */
+    expect(shouldAssertChannel(true, "pre", STABLE)).toBe(false);
+  });
+
+  it("does not answer the same way for every input", () => {
+    /*
+     * The control. A rule that never fires satisfies every case above that
+     * expects false, and a rule that always fires satisfies the two that expect
+     * true, so neither group proves anything on its own.
+     */
+    const answers = [
+      shouldAssertChannel(true, "pre", VERSION),
+      shouldAssertChannel(true, "pre", STABLE),
+      shouldAssertChannel(true, "exit", VERSION),
+      shouldAssertChannel(true, null, STABLE),
+    ];
+    expect(new Set(answers).size).toBe(2);
+  });
+
+  it("reads build metadata as part of the version, not as a prerelease", () => {
+    // Shares `firstPrereleaseId` with the tag rule rather than re-deciding what
+    // a prerelease looks like, so `+build` cannot be mistaken for `-alpha`.
+    expect(shouldAssertChannel(true, null, "0.0.2+build.7")).toBe(true);
+    expect(shouldAssertChannel(true, "pre", "0.0.2+build.7")).toBe(false);
   });
 });
 
@@ -880,6 +985,45 @@ describe("a repository part-way out of prerelease mode", () => {
     expect(asserted.channelStale[0]).toContain("latest");
 
     const skipped = await publishState(manifest, async () => state, null, {
+      assertChannel: false,
+    });
+    expect(skipped.kind).toBe("all");
+    expect(skipped.channelStale ?? []).toEqual([]);
+  });
+});
+
+describe("a repository part-way INTO prerelease mode", () => {
+  it("does not expect a channel tag while pre mode is being entered", async () => {
+    /*
+     * 🔴 The mirror of the exit above, and it goes wrong in the opposite
+     * direction. `pnpm changeset pre enter alpha` writes `mode: "pre"` in its
+     * own commit, so `readPreState` answers with the new tag while every
+     * manifest still declares the preceding STABLE release, and `release.yml`
+     * runs on exactly that commit.
+     *
+     * `getExpectedDistTag` reads the REGISTRY to decide `only-pre`, and a
+     * package with real stable versions is not only-pre, so `alpha` is expected
+     * to point at the stable version the manifests name. It points at the last
+     * prerelease instead, and the remedy that follows says to move `alpha` onto
+     * a stable build.
+     */
+    const STABLE = "0.0.2";
+    const manifest = [{ name: "nextly", version: STABLE }];
+    const state = {
+      versions: [PLACEHOLDER_VERSION, "0.0.2-alpha.65", STABLE],
+      distTags: { latest: STABLE, alpha: "0.0.2-alpha.65" },
+    };
+    const entering = { mode: "pre", tag: "alpha" };
+
+    const asserted = await publishState(manifest, async () => state, entering, {
+      assertChannel: true,
+    });
+    // What a mode-only rule produced here: `alpha` expected of a stable
+    // version, and a remedy that would move the prerelease channel onto it.
+    expect(asserted.channelStale).toHaveLength(1);
+    expect(asserted.channelStale[0]).toContain("alpha");
+
+    const skipped = await publishState(manifest, async () => state, entering, {
       assertChannel: false,
     });
     expect(skipped.kind).toBe("all");

--- a/scripts/release/lib.mjs
+++ b/scripts/release/lib.mjs
@@ -98,7 +98,7 @@ export function readPreState() {
 }
 
 /**
- * The mode `.changeset/pre.json` records, or `null` when there is no such file.
+ * `.changeset/pre.json` as it stands, or `null` when there is no such file.
  *
  * 🔴 Deliberately NOT `readPreState`, which answers `null` for `mode: "exit"`
  * and for no file at all. Those are different situations. Exiting prerelease
@@ -107,10 +107,16 @@ export function readPreState() {
  * apart treats that alpha as a stable release and expects `latest` to resolve
  * to it. The remedy that follows from believing this says to move `latest` onto
  * a prerelease, which is a worse outcome than the check not running at all.
+ *
+ * The whole record rather than the mode alone, because the ACTIVE TAG is half
+ * of what makes a mode and a version agree: prerelease mode re-entered under a
+ * new tag leaves manifests declaring the old one, and a reader holding only
+ * `mode` cannot see the difference.
  */
-export function readPreMode() {
+export function readPreConfig() {
   if (!existsSync(PRE_STATE_PATH)) return null;
-  return readJson(PRE_STATE_PATH).mode ?? null;
+  const state = readJson(PRE_STATE_PATH);
+  return { mode: state.mode ?? null, tag: state.tag ?? null };
 }
 
 /**

--- a/scripts/release/lib.mjs
+++ b/scripts/release/lib.mjs
@@ -87,6 +87,32 @@ export function firstPrereleaseId(version) {
 }
 
 /**
+ * Whether a version is a prerelease OF a given active tag.
+ *
+ * 🔴 Deliberately not `firstPrereleaseId(version) === tag`, and deliberately
+ * different from the comparison inside `getExpectedDistTag`. That one mirrors
+ * Changesets, which classifies with `semver.parse(v).prerelease[0] === tag`
+ * and so reads `1.2.3-next.1.0` as belonging to `next` rather than to
+ * `next.1`. It has to keep that quirk: its job is to predict what
+ * `changeset publish` will do, and predicting something better than the tool
+ * does is still predicting wrong.
+ *
+ * This answers a different question, which is whether `pre.json` and the
+ * manifests describe the same release. A dotted tag is where the two answers
+ * part company, and borrowing the mirror here would switch the channel check
+ * off for the whole of a `next.1` cycle rather than answer it incorrectly.
+ * Both spellings are correct, for their own question, which is why they are
+ * two functions with this note between them.
+ */
+export function isPrereleaseOfTag(version, tag) {
+  const withoutBuildMetadata = version.split("+")[0];
+  const separator = withoutBuildMetadata.indexOf("-");
+  if (separator === -1) return false;
+  const identifiers = withoutBuildMetadata.slice(separator + 1);
+  return identifiers === tag || identifiers.startsWith(`${tag}.`);
+}
+
+/**
  * The Changesets prerelease state, or `null` outside prerelease mode. The active
  * tag decides which dist-tag consumers install from, so verification has to read
  * it rather than assume `latest`.
@@ -116,6 +142,9 @@ export function readPreState() {
 export function readPreConfig() {
   if (!existsSync(PRE_STATE_PATH)) return null;
   const state = readJson(PRE_STATE_PATH);
+  // A plain reader. Whether a mode and a tag make SENSE together is a question
+  // for whoever is asking, and it is asked in `shouldAssertChannel`, where a
+  // test can reach it.
   return { mode: state.mode ?? null, tag: state.tag ?? null };
 }
 

--- a/scripts/release/lib.mjs
+++ b/scripts/release/lib.mjs
@@ -109,7 +109,16 @@ export function isPrereleaseOfTag(version, tag) {
   const separator = withoutBuildMetadata.indexOf("-");
   if (separator === -1) return false;
   const identifiers = withoutBuildMetadata.slice(separator + 1);
-  return identifiers === tag || identifiers.startsWith(`${tag}.`);
+  if (!identifiers.startsWith(`${tag}.`)) return false;
+  /*
+   * 🔴 Exactly ONE counter after the tag, not merely the tag as a prefix.
+   * `changeset version` in pre mode writes `<version>-<tag>.<n>`, so a `next`
+   * cycle produces `-next.0` and a `next.1` cycle produces `-next.1.0`. A
+   * prefix test alone reads that second one as an artifact of `next` too, and
+   * a cycle exited under `next.1` and re-entered under `next` would then have
+   * its old builds accepted as the new channel's.
+   */
+  return /^\d+$/.test(identifiers.slice(tag.length + 1));
 }
 
 /**

--- a/scripts/release/lib.mjs
+++ b/scripts/release/lib.mjs
@@ -74,8 +74,12 @@ function getPath(object, path) {
  * stable version: `1.0.0-alpha.4` -> `"alpha"`, `1.0.0` -> `undefined`. Mirrors
  * `semver.parse(v).prerelease[0]` for the shapes npm accepts, without pulling in
  * a dependency for one field.
+ *
+ * Exported so that "is this a prerelease" is asked in ONE place. A second
+ * spelling of it, however obvious, is a second answer waiting to disagree with
+ * this one about a build-metadata suffix.
  */
-function firstPrereleaseId(version) {
+export function firstPrereleaseId(version) {
   const withoutBuildMetadata = version.split("+")[0];
   const separator = withoutBuildMetadata.indexOf("-");
   if (separator === -1) return undefined;


### PR DESCRIPTION
Two findings that arrived on #1691 after it merged. Both end with the check
reporting on something other than the release it was asked about.

## P1: an empty public package name passed validation

`manifestAtRef` required `name` and `version` to be strings. `""` is a string,
and so is `"   "`.

On the anchor that also defeats the lockstep comparison below it: with no
readable `nextly` there is no anchor to compare against, so a ref where every
other package has drifted is graded as one coherent release. On any other
package the registry is asked about a name that cannot exist, and that answer
reads as never published, so the package leaves the train without a word.

`isUsableString` is the bar both fields now clear, in `versionAtRef` too so the
rule is spelled once.

## P2: the channel tag was held through the wrong half of prerelease mode

The rule was `preMode !== "exit"`. That answers the exit window and nothing
else. `pnpm changeset pre enter <tag>` writes `mode: "pre"` in its own commit,
`release.yml` runs on that commit, and every manifest still declares the
preceding **stable** release. `getExpectedDistTag` decides `only-pre` from the
registry, and a package with real stable versions is not only-pre, so `alpha`
is expected to point at a stable version, `channel-stale` is filed, and the
remedy prescribes moving the prerelease channel onto a stable build.

Two windows of the same shape, so this is now one rule rather than a second
special case: hold the channel only when `pre.json` and the manifests agree
about which kind of release this is.

```
mode "pre",  manifests STABLE      entering    -> skip
mode "pre",  manifests prerelease  in pre mode -> assert
mode "exit", manifests PRERELEASE  leaving     -> skip
mode null,   manifests stable      outside     -> assert
```

`firstPrereleaseId` is exported from `lib.mjs` so "is this a prerelease" has
one answer rather than a second spelling that can disagree about `+build`.

The decision also moves out of the registry `try`, where a failure to make it
would have been reported as npm being unreachable.

## Verification

Every fix was broken and the suite re-run, with controls for the answers that
are constant:

| Mutation | Result |
|---|---|
| `isUsableString` back to a bare `typeof` check | 3 failed |
| `isUsableString` always true | 5 failed |
| `shouldAssertChannel` back to `preMode !== "exit"` | 2 failed, including the entry window |
| `shouldAssertChannel` always false | 3 failed |
| `shouldAssertChannel` always true | 5 failed |
| unmutated | 66 passed |

A rule that never fires satisfies every case that expects `false`, so there is
an explicit control asserting the function does not answer the same way for
every input.

The entry window is also proven at the level of its consequence, mirroring the
existing exit test: `publishState` with the entry fixture files exactly one
`channel-stale` when the channel is asserted, and none when it is skipped.

`node scripts/release/check-finalized.mjs HEAD` was run against the real
registry, because no test enters the command-line block and that block is where
the last three defects in this file lived. It reports
`state=finalized` for `nextly@0.0.2-alpha.65` and exits 0, which also proves
the new third argument reaches the call site: without it `firstPrereleaseId`
would throw on `undefined`.

Full lane: 1294 scripts tests pass, `pnpm lint:scripts` clean.

## No changeset

Root tooling only. The root package is private and nothing publishable changes.