### PR TITLE
test(nextly): the search-path probe sets up through the connection it reads

### DIFF
--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/introspect-search-path.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/introspect-search-path.integration.test.ts
@@ -17,13 +17,11 @@
  * "read the right table" from "read any table" passes on a predicate that names
  * `public` outright.
  *
- * The fixture tables are SYNTHETIC — a decoy and a subject that exist only to be
- * resolved, with no production counterpart. So they are written here rather than
- * derived from a DDL helper: the hazard that rule guards, a fixture copying a
- * real table's definition and then drifting from it, has nothing to drift from,
- * and deriving them from a real table would couple this file to that table's
- * shape and change what it measures. Their DDL still travels through Drizzle,
- * like every other statement here.
+ * The fixture tables are SYNTHETIC: a decoy and a subject that exist only to be
+ * resolved, with no production counterpart. Written out here rather than derived
+ * from a table the product also defines, because deriving them would tie this
+ * file to that table's shape — and what it measures is which relation a name
+ * resolves to, which any two columns can demonstrate.
  *
  * 🔴 ONE SESSION, held open for the whole file. `PostgresAdapter.getDrizzle()`
  * wraps a `pg.Pool`, so `SET search_path` binds to whichever client served that
@@ -65,12 +63,10 @@ describePg("introspection follows the search path (postgres)", () => {
     await client.connect();
     db = drizzle({ client });
 
-    // 🔴 Through Drizzle, not `client.query`. Database access in this repository
-    // is Drizzle-only, and the exemption a test might claim — that a fixture is
-    // not product code — does not apply to the thing under test here: these
-    // statements ESTABLISH the session state the assertions depend on, so they
-    // have to travel the same path the reads do. Sent on the client-bound
-    // instance, so `SET search_path` below lands on the connection that reads.
+    // 🔴 Sent through Drizzle rather than through the driver, because these
+    // statements establish the session state the assertions depend on: the
+    // `SET search_path` below has to land on the connection the reads use, and
+    // the only way to be sure of that is to send it the way the reads are sent.
     const run = (text: string) => db.execute(sql.raw(text));
 
     await run(`DROP TABLE IF EXISTS public."${TABLE}"`);

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/introspect-search-path.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/introspect-search-path.integration.test.ts
@@ -17,6 +17,14 @@
  * "read the right table" from "read any table" passes on a predicate that names
  * `public` outright.
  *
+ * The fixture tables are SYNTHETIC — a decoy and a subject that exist only to be
+ * resolved, with no production counterpart. So they are written here rather than
+ * derived from a DDL helper: the hazard that rule guards, a fixture copying a
+ * real table's definition and then drifting from it, has nothing to drift from,
+ * and deriving them from a real table would couple this file to that table's
+ * shape and change what it measures. Their DDL still travels through Drizzle,
+ * like every other statement here.
+ *
  * 🔴 ONE SESSION, held open for the whole file. `PostgresAdapter.getDrizzle()`
  * wraps a `pg.Pool`, so `SET search_path` binds to whichever client served that
  * statement and the next `execute()` may run on another — which would make this
@@ -57,7 +65,13 @@ describePg("introspection follows the search path (postgres)", () => {
     await client.connect();
     db = drizzle({ client });
 
-    const run = (text: string) => client!.query(text);
+    // 🔴 Through Drizzle, not `client.query`. Database access in this repository
+    // is Drizzle-only, and the exemption a test might claim — that a fixture is
+    // not product code — does not apply to the thing under test here: these
+    // statements ESTABLISH the session state the assertions depend on, so they
+    // have to travel the same path the reads do. Sent on the client-bound
+    // instance, so `SET search_path` below lands on the connection that reads.
+    const run = (text: string) => db.execute(sql.raw(text));
 
     await run(`DROP TABLE IF EXISTS public."${TABLE}"`);
     await run(`DROP SCHEMA IF EXISTS ${TENANT} CASCADE`);
@@ -78,9 +92,11 @@ describePg("introspection follows the search path (postgres)", () => {
 
   afterAll(async () => {
     if (client === undefined) return;
-    await client.query(`SET search_path TO public`);
-    await client.query(`DROP TABLE IF EXISTS public."${TABLE}"`);
-    await client.query(`DROP SCHEMA IF EXISTS ${TENANT} CASCADE`);
+    await db.execute(sql.raw(`SET search_path TO public`));
+    await db.execute(sql.raw(`DROP TABLE IF EXISTS public."${TABLE}"`));
+    await db.execute(sql.raw(`DROP SCHEMA IF EXISTS ${TENANT} CASCADE`));
+    // The connection itself is still the client's to close: it is what pins the
+    // session, so nothing above can release it.
     await client.end();
   });
 


### PR DESCRIPTION
Follows #1721, from a Codex P1 that landed as it merged. Test-only, so no changeset.

## What was wrong

The search-path probe set its fixture up with `pg.Client.query` directly. This
repository's rule is that database access is Drizzle-only, and the exemption a
test might claim — that a fixture is not product code — does not hold here: those
statements **establish the session state the assertions depend on**, so they have
to travel the same path the reads do.

Setup and teardown now go through `db.execute(sql.raw(...))` on the same
client-bound instance, so the `SET search_path` still lands on the connection
that reads. The `Client` is kept and still closed in `afterAll` — it is what pins
the session, so nothing else can release it.

## Where I did not follow the advice, and why

The review also asked me to "derive table DDL through the production helpers
rather than introducing a second DDL implementation". I have not, and I want to
be explicit rather than quietly partial.

These fixture tables are **synthetic**: a decoy and a subject that exist only to
be resolved by the search path, with no production counterpart. The hazard that
rule guards — a fixture copying a real table's definition and then drifting from
it — has nothing to drift from here. Deriving them from a real table would couple
this file to that table's shape and change what it measures.

Measured rather than asserted: this repository's own PostgreSQL integration tests
create synthetic probe tables inline for the same reason.

```
packages/nextly/src/database/__tests__/integration/schema-push.integration.test.ts:74   CREATE TABLE "dc_int_products"
packages/nextly/src/di/load-dynamic-slugs.integration.test.ts:33                        CREATE TABLE dynamic_collections (slug TEXT)
```

`getSchemaEventsDdl`, the helper the rule names, builds one specific production
table. There is no helper for a two-column decoy, and writing one would be the
second DDL implementation the advice warns against.

The reasoning is now in the file's docblock, so the next reader sees why these
are hand-written and does not have to re-litigate it.

## Gates

nextly `check-types` 0 · `lint` 0 · the probe is still collected by
`vitest.integration.config.ts` (5 tests, skipped locally for the documented
missing-URL reason).

⚠️ Still not executed anywhere I can see: no Docker or PostgreSQL is reachable
from this machine, and #1721 merged while its Postgres leg was queued. That leg
is running on `main` now and is the first real verdict on these assertions.
