### PR TITLE
fix(nextly): the CLI reports the version that shipped

### DIFF
--- a/.changeset/a-version-the-tool-can-tell-you.md
+++ b/.changeset/a-version-the-tool-can-tell-you.md
@@ -1,0 +1,44 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+`nextly --version` reports the version that shipped.
+
+The constant behind it was typed by hand under a comment saying it "should
+match package.json version". It did not: the CLI answered `0.1.0` while the
+package shipped `0.0.2-alpha.65`, so anyone asking the tool which Nextly they
+were working against got a confident wrong answer — and telemetry attributed
+every CLI event to a version that has never been published.
+
+It is asked of the same resolver the plugin system already uses to validate a
+plugin's `nextly` compatibility range, so a reported version and a
+compatibility answer can no longer disagree. A test holds the two together.
+
+The scaffolded agent guide now says how to find that version and where the
+authoritative documentation is, including the two machine-readable indexes at
+`/llms.txt` and `/llms-full.txt`. An agent working in a Nextly project would
+otherwise answer from whatever it remembers of some other version.

--- a/packages/nextly/src/cli/__tests__/cli-version.test.ts
+++ b/packages/nextly/src/cli/__tests__/cli-version.test.ts
@@ -1,0 +1,48 @@
+/**
+ * `nextly --version` reports the version that shipped.
+ *
+ * The constant used to be typed by hand under a comment saying it "should match
+ * package.json version". It did not: the CLI answered `0.1.0` while the package
+ * shipped `0.0.2-alpha.65`, so anyone — or any agent — asking the tool which
+ * Nextly they were working against got a confident wrong answer, and telemetry
+ * attributed every CLI event to a version that has never been published.
+ *
+ * A comment is not a control, which is what this is.
+ *
+ * @module cli/__tests__/cli-version.test
+ */
+import { createRequire } from "node:module";
+
+import { describe, expect, it } from "vitest";
+
+import { getCoreVersion } from "../../plugins/core-version";
+import { CLI_VERSION } from "../program";
+
+const pkg = createRequire(import.meta.url)("../../../package.json") as {
+  version?: string;
+};
+
+describe("the version the CLI reports", () => {
+  it("is the version this package publishes", () => {
+    // The population: a package.json with no version would satisfy an equality
+    // between two empty values.
+    expect(pkg.version).toBeTruthy();
+    expect(CLI_VERSION).toBe(pkg.version);
+  });
+
+  it("is the same answer the plugin resolver validates ranges against", () => {
+    // Two version constants is how this drifted. A plugin declaring a `nextly`
+    // range is checked against `getCoreVersion`, so a CLI reporting something
+    // else would tell a user their range is satisfied by a version the resolver
+    // never saw.
+    expect(CLI_VERSION).toBe(getCoreVersion());
+  });
+
+  it("is not the sentinel the resolver falls back to", () => {
+    // `getCoreVersion` never throws: with no injected constant and no readable
+    // package.json it answers "0.0.0". Without this, the two assertions above
+    // are satisfied by both sides being equally uninformative.
+    expect(CLI_VERSION).not.toBe("0.0.0");
+    expect(CLI_VERSION).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});

--- a/packages/nextly/src/cli/program.ts
+++ b/packages/nextly/src/cli/program.ts
@@ -13,6 +13,8 @@ import * as telemetry from "@nextlyhq/telemetry";
 import { Command, Option } from "commander";
 import pc from "picocolors";
 
+import { getCoreVersion } from "../plugins/core-version";
+
 import { registerAddCommand } from "./commands/add";
 import { registerBuildCommand } from "./commands/build";
 // What: import the renamed one-shot sync command.
@@ -46,9 +48,20 @@ import { createLogger, type Logger, type LoggerOptions } from "./utils/logger";
 // ============================================================================
 
 /**
- * CLI version - should match package.json version
+ * The running `nextly` version, as `--version` and telemetry report it.
+ *
+ * Asked of {@link getCoreVersion} rather than typed here. "Should match
+ * package.json" was a comment with nothing enforcing it, and it did not: the
+ * constant read `0.1.0` while the package shipped `0.0.2-alpha.65`, so
+ * `nextly --version` answered confidently and wrongly, and telemetry attributed
+ * every CLI event to a version that has never been published.
+ *
+ * `getCoreVersion` is the same question the plugin resolver asks to validate a
+ * plugin's `nextly` range, and it already reads the build-time constant the
+ * tsup and vitest `define` blocks inject from `package.json`, with a runtime
+ * read as a fallback.
  */
-export const CLI_VERSION = "0.1.0";
+export const CLI_VERSION = getCoreVersion();
 
 // ============================================================================
 // Types

--- a/templates/base/AGENTS.md.template
+++ b/templates/base/AGENTS.md.template
@@ -147,6 +147,33 @@ const slug = typeof doc.slug === "string" ? doc.slug : undefined;
   If you are unsure whether a collection has read rules, do not cache it. A
   missing cache is slow; a shared one leaks.
 
+## Which Nextly this is, and where its docs are
+
+An agent working here will otherwise answer from whatever it remembers of some
+other version. Ask the project instead:
+
+```bash
+{{execCommand}} nextly --version      # the running core version
+```
+
+That is the same version the plugin resolver validates a plugin's `nextly`
+range against, so a compatibility answer and a reported version cannot
+disagree. The dependency range this project pins is in `package.json` under
+`nextly`; the resolved version is what the command above prints.
+
+**The authoritative documentation is <https://nextlyhq.com/docs>.** Two files
+are published for machine readers and are the ones to fetch:
+
+| file | what it is |
+| ---- | ---------- |
+| <https://nextlyhq.com/llms.txt> | the index — every documentation page, with a one-line summary |
+| <https://nextlyhq.com/llms-full.txt> | the same documentation as one file |
+
+Both are generated from the pages the site publishes, so they cannot describe a
+page that does not exist. Neither is version-stamped: they describe the CURRENT
+release, so check the version above before trusting a detail against an older
+pin.
+
 ## Conventions worth keeping
 
 - Server components read content directly; do not build an API route to fetch

--- a/templates/plugin/AGENTS.md.template
+++ b/templates/plugin/AGENTS.md.template
@@ -84,6 +84,33 @@ those slugs a second time as code-owned entities and boot fails with
 Assert on behaviour through `t.nextly` rather than on the plugin object: what a
 host observes is the contract, and the object shape is not.
 
+## Which Nextly this is, and where its docs are
+
+An agent working here will otherwise answer from whatever it remembers of some
+other version. Ask the project instead:
+
+```bash
+{{execCommand}} nextly --version      # the running core version
+```
+
+That is the same version the plugin resolver validates a plugin's `nextly`
+range against, so a compatibility answer and a reported version cannot
+disagree. The dependency range this project pins is in `package.json` under
+`nextly`; the resolved version is what the command above prints.
+
+**The authoritative documentation is <https://nextlyhq.com/docs>.** Two files
+are published for machine readers and are the ones to fetch:
+
+| file | what it is |
+| ---- | ---------- |
+| <https://nextlyhq.com/llms.txt> | the index — every documentation page, with a one-line summary |
+| <https://nextlyhq.com/llms-full.txt> | the same documentation as one file |
+
+Both are generated from the pages the site publishes, so they cannot describe a
+page that does not exist. Neither is version-stamped: they describe the CURRENT
+release, so check the version above before trusting a detail against an older
+pin.
+
 ## Conventions worth keeping
 
 - Version `nextly` compatibility in the factory's `nextly` range, and widen it


### PR DESCRIPTION
## `nextly --version` was answering wrongly

Phase 1.5 was "the `AGENTS.md.template` version-discovery paragraph, which points
at no authoritative docs". Writing that paragraph meant checking what an agent
could actually be told to run — and the answer was broken:

```
package.json   0.0.2-alpha.65
nextly --version   0.1.0
```

The constant sat under a comment reading **"CLI version - should match
package.json version"**. A documented rule with nothing enforcing it is not a
control, and this one had drifted to a version that has never been published.

It also reached telemetry: `telemetry.ts` reports `CLI_VERSION`, so every CLI
event was attributed to `0.1.0`.

## Not a new mechanism — the existing one

`getCoreVersion()` already answers exactly this question for the plugin
resolver, which uses it to validate a plugin's `nextly` compatibility range. It
reads the build-time constant the tsup **and** vitest `define` blocks inject
from `package.json`, with a runtime read as a fallback, and never throws.

So `CLI_VERSION` asks it. Two constants for one fact is how this drifted; now a
reported version and a compatibility verdict cannot disagree.

## The paragraph it was blocking

Both scaffolded guides (`base` and `plugin`; the `CLAUDE.md` templates are a
one-line `@AGENTS.md` include) now carry **"Which Nextly this is, and where its
docs are"**:

- how to ask the project rather than recall it — and the guide says *why*: an
  agent otherwise answers from whatever it remembers of some other version
- that this is the same version plugin ranges are validated against
- the authoritative docs, and the two machine-readable indexes at `/llms.txt`
  and `/llms-full.txt`, which are generated from the pages the site publishes
  and so cannot describe a page that does not exist
- that those indexes are **not** version-stamped — they describe the current
  release, not whatever this project pins

`{{execCommand}}` resolves per package manager, and a scaffolded plugin project
has `nextly` installed (its `/dev` playground imports `nextly/config`), so the
command works in both templates.

## Evidence

`packages/nextly` 935 files / 11,873 tests · `create-nextly-app` 254 tests ·
lint clean at `--max-warnings 0` · `check:comments` clean · changeset validates.

Three assertions, including one that refuses `getCoreVersion`'s own `0.0.0`
sentinel — without it, both sides agreeing while equally uninformative reads as
a pass.

| mutation | killed by |
|---|---|
| the original defect, a hand-typed `0.1.0` | 2 tests |
| a plausible-looking but wrong alpha | 2 |
| the resolver's own `0.0.0` sentinel | 3 |
