### PR TITLE
refactor(nextly): one name per question

### DIFF
--- a/.changeset/one-name-per-question.md
+++ b/.changeset/one-name-per-question.md
@@ -1,0 +1,53 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Two names each meant two different things depending on which entry point you
+imported from, and nothing at the call site said which had arrived.
+
+`isFieldGroupType` was a one-argument boolean test on `nextly` and a
+two-argument type guard on `nextly/field-group-type`. The guard keeps the name,
+because it is the one application code writes when rendering a dynamic zone:
+`isFieldGroupType(block, "hero")`. The token test is `isFieldGroupFieldType`,
+which is not a new coinage: `nextly/field-group-type` was already re-exporting
+it under exactly that alias, with a comment explaining that the two predicates
+had to be kept apart. The alias is the real name now, so no entry publishes the
+spelling it was working around.
+
+`createAdapter` was the database factory on `nextly` and `nextly/database`, and
+the CLI's own on `nextly/cli/utils`. They return different types. The factory
+keeps the name, since it builds the `DrizzleAdapter` an application runs on; the
+CLI's is `createCliAdapter`, returning the small `CLIDatabaseAdapter` that is
+connect, disconnect and a dialect.
+
+Neither name appears in the docs or any template, so nothing published changes
+for a reader.
+
+The list of known clashes in the export-contract test is now EMPTY, which is the
+part that lasts. It held these two, recorded rather than fixed because each
+needed the decision `getNextly` needed. With both made, nothing is exempt and
+the next such name fails on the day it appears instead of joining a list.

--- a/packages/nextly/src/__tests__/export-contract.test.ts
+++ b/packages/nextly/src/__tests__/export-contract.test.ts
@@ -79,23 +79,19 @@ function namesPublishedTwice(
 }
 
 /**
- * Names already published from two entry points meaning different things.
+ * Names published from two entry points meaning different things.
  *
- * 🔴 Recorded, not accepted. Each is the same defect `getNextly` was: one name,
- * two functions, and nothing at an import site to say which one arrived.
- * `isFieldGroupType` is a boolean test in one place and a generic narrowing in
- * the other; `createAdapter` is the CLI's and the database factory's, which
- * take different arguments and do different work.
+ * 🔴 EMPTY, and that is the point. It held the two this check found when it was
+ * written, `isFieldGroupType` and `createAdapter`, each recorded rather than
+ * fixed because each needed the decision `getNextly` needed about which keeps
+ * the name. Both have now been made, so nothing is exempt and the next one
+ * fails on the day it appears rather than joining a list.
  *
- * They are listed rather than fixed here because each needs the same decision
- * `getNextly` needed about which keeps the name, and answering several of those
- * inside one rename is how a considered API becomes an incidental one. Listing
- * them is what makes a NEW one fail this test on the day it appears.
+ * Add to this only to record a clash somebody has decided to keep, with the
+ * reason. A name added here to make a red test green is the defect being
+ * written down instead of fixed.
  */
-const KNOWN_SHAPE_CLASHES = [
-  "isFieldGroupType: nextly sync/1, nextly/field-group-type sync/2",
-  "createAdapter: nextly async/1, nextly/database async/1, nextly/cli/utils async/0",
-];
+const KNOWN_SHAPE_CLASHES: string[] = [];
 
 const manifestUrl = new URL("../../package.json", import.meta.url);
 const packageRoot = path.dirname(fileURLToPath(manifestUrl));

--- a/packages/nextly/src/__tests__/export-contract.test.ts
+++ b/packages/nextly/src/__tests__/export-contract.test.ts
@@ -254,4 +254,41 @@ describe("published export surface", () => {
     expect(typeof mod.isFieldGroupType).toBe("function");
     expect(typeof mod.writeFieldGroupType).toBe("function");
   });
+
+  /**
+   * The names a resolved clash left behind, asserted where they were promised.
+   *
+   * An empty {@link KNOWN_SHAPE_CLASHES} says only that no name is published
+   * twice with different shapes. Deleting `isFieldGroupFieldType` outright
+   * satisfies that too, and so does dropping `createCliAdapter`: the collision
+   * is gone either way, and a rename that quietly became a deletion reads as a
+   * pass.
+   *
+   * So each is asserted at the entry it was moved TO. A rename is a promise
+   * about where a caller finds the function afterwards, and that is the half an
+   * absence check cannot make.
+   */
+  it("keeps the names the resolved clashes were renamed to", async () => {
+    const root = (await import("../index")) as Record<string, unknown>;
+    expect(typeof root.isFieldGroupFieldType).toBe("function");
+
+    const fieldGroupType = (await import("../field-group-type")) as Record<
+      string,
+      unknown
+    >;
+    expect(typeof fieldGroupType.isFieldGroupFieldType).toBe("function");
+
+    const cli = (await import("../cli/utils")) as Record<string, unknown>;
+    expect(typeof cli.createCliAdapter).toBe("function");
+
+    const database = (await import("../database")) as Record<string, unknown>;
+    expect(typeof database.createAdapter).toBe("function");
+
+    // The root re-exports the database factory, so `createAdapter` is expected
+    // HERE and is the same function `nextly/database` publishes. That pair was
+    // never the clash: they agreed. The CLI's was the odd one, and the other
+    // half of the promise is that its old spelling has not come back.
+    expect(root.createAdapter).toBe(database.createAdapter);
+    expect(cli.createAdapter).toBeUndefined();
+  });
 });

--- a/packages/nextly/src/cli/commands/build.ts
+++ b/packages/nextly/src/cli/commands/build.ts
@@ -55,7 +55,7 @@ import type { SingleConfig } from "../../singles/config/types";
 import { assertValidSingleConfig } from "../../singles/config/validate-single";
 import { createContext, type CommandContext } from "../program";
 import {
-  createAdapter,
+  createCliAdapter,
   validateDatabaseEnv,
   getDialectDisplayName,
   type CLIDatabaseAdapter,
@@ -873,7 +873,7 @@ async function checkMigrationStatus(
   // Try to connect to database
   let adapter: CLIDatabaseAdapter;
   try {
-    adapter = await createAdapter({
+    adapter = await createCliAdapter({
       dialect: dbValidation.dialect,
       databaseUrl: dbValidation.databaseUrl,
       logger: options.verbose ? logger : undefined,

--- a/packages/nextly/src/cli/commands/db-sync-demote.ts
+++ b/packages/nextly/src/cli/commands/db-sync-demote.ts
@@ -14,7 +14,7 @@ import { serializeCollection } from "../../domains/schema/services/code-generato
 import { describeError } from "../../errors/index";
 import { CollectionRegistryService } from "../../services/collections/collection-registry-service";
 import type { CommandContext } from "../program";
-import { createAdapter, validateDatabaseEnv } from "../utils/adapter";
+import { createCliAdapter, validateDatabaseEnv } from "../utils/adapter";
 // F1 PR 4: switched from the deleted wrapper/config-loader (jiti-based,
 // took a positional cwd arg) to the canonical cli/utils/config-loader
 // (bundle-require-based, takes an options object). The wrapper helper
@@ -64,7 +64,7 @@ export async function runDemote(
     logger.error(env.errors.join("; "));
     process.exit(1);
   }
-  const adapter = await createAdapter({ logger });
+  const adapter = await createCliAdapter({ logger });
   const registry = new CollectionRegistryService(
     adapter as unknown as DrizzleAdapter,
     {

--- a/packages/nextly/src/cli/commands/db-sync-promote.ts
+++ b/packages/nextly/src/cli/commands/db-sync-promote.ts
@@ -13,7 +13,7 @@ import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import { serializeCollection } from "../../domains/schema/services/code-generator";
 import { CollectionRegistryService } from "../../services/collections/collection-registry-service";
 import type { CommandContext } from "../program";
-import { createAdapter, validateDatabaseEnv } from "../utils/adapter";
+import { createCliAdapter, validateDatabaseEnv } from "../utils/adapter";
 
 export async function runPromote(
   slug: string,
@@ -21,7 +21,7 @@ export async function runPromote(
 ): Promise<void> {
   const { logger } = context;
 
-  // 1. Database wiring. Reuses the same validateDatabaseEnv + createAdapter
+  // 1. Database wiring. Reuses the same validateDatabaseEnv + createCliAdapter
   // pipeline as the normal db:sync flow so DATABASE_URL errors look the
   // same as always.
   const env = validateDatabaseEnv();
@@ -29,7 +29,7 @@ export async function runPromote(
     logger.error(env.errors.join("; "));
     process.exit(1);
   }
-  const adapter = await createAdapter({ logger });
+  const adapter = await createCliAdapter({ logger });
 
   // CollectionRegistryService expects a full DrizzleAdapter. The CLI
   // adapter is structurally compatible; same cast pattern as dev-build.ts.

--- a/packages/nextly/src/cli/commands/db-sync.ts
+++ b/packages/nextly/src/cli/commands/db-sync.ts
@@ -74,7 +74,7 @@ import {
   type GlobalOptions,
 } from "../program";
 import {
-  createAdapter,
+  createCliAdapter,
   validateDatabaseEnv,
   getDialectDisplayName,
   type CLIDatabaseAdapter,
@@ -248,7 +248,7 @@ export async function runDbSync(
   // are known to exist — `dynamic_components` has to be readable before it can be listed.
   let schemaRegistry: SchemaRegistry;
   try {
-    adapter = await createAdapter({
+    adapter = await createCliAdapter({
       dialect: dbValidation.dialect,
       databaseUrl: dbValidation.databaseUrl,
       logger: options.verbose ? logger : undefined,

--- a/packages/nextly/src/cli/commands/migrate-baseline.ts
+++ b/packages/nextly/src/cli/commands/migrate-baseline.ts
@@ -73,7 +73,7 @@ import { describeError, NextlyError } from "../../errors/index";
 import { STORAGE_FORMAT } from "../../schemas/storage-format";
 import { createContext, type CommandContext } from "../program";
 import {
-  createAdapter,
+  createCliAdapter,
   validateDatabaseEnv,
   type CLIDatabaseAdapter,
 } from "../utils/adapter";
@@ -640,7 +640,7 @@ export async function runMigrateBaseline(
   const cwd = options.cwd ?? process.cwd();
   const migrationsDir = resolve(cwd, configResult.config.db.migrationsDir);
 
-  const adapter: CLIDatabaseAdapter = await createAdapter({
+  const adapter: CLIDatabaseAdapter = await createCliAdapter({
     dialect,
     databaseUrl: dbValidation.databaseUrl,
     logger: options.verbose ? logger : undefined,

--- a/packages/nextly/src/cli/commands/migrate-down.ts
+++ b/packages/nextly/src/cli/commands/migrate-down.ts
@@ -27,7 +27,7 @@ import { withMigrateLock } from "../../domains/schema/pipeline/locks";
 import { describeError } from "../../errors/index";
 import { createContext, type CommandContext } from "../program";
 import {
-  createAdapter,
+  createCliAdapter,
   validateDatabaseEnv,
   type CLIDatabaseAdapter,
   type SupportedDialect,
@@ -252,7 +252,7 @@ export async function runMigrateDown(
   const cwd = options.cwd ?? process.cwd();
   const migrationsDir = resolve(cwd, configResult.config.db.migrationsDir);
 
-  const adapter: CLIDatabaseAdapter = await createAdapter({
+  const adapter: CLIDatabaseAdapter = await createCliAdapter({
     dialect: dbValidation.dialect,
     databaseUrl: dbValidation.databaseUrl,
     logger: options.verbose ? logger : undefined,

--- a/packages/nextly/src/cli/commands/migrate-fresh.ts
+++ b/packages/nextly/src/cli/commands/migrate-fresh.ts
@@ -44,7 +44,7 @@ import { freshPushSchema } from "../../domains/schema/pipeline/fresh-push";
 import { describeError, immediateMessage } from "../../errors/index";
 import { createContext, type CommandContext } from "../program";
 import {
-  createAdapter,
+  createCliAdapter,
   validateDatabaseEnv,
   getDialectDisplayName,
   type CLIDatabaseAdapter,
@@ -185,7 +185,7 @@ export async function runMigrateFresh(
 
   let adapter: CLIDatabaseAdapter;
   try {
-    adapter = await createAdapter({
+    adapter = await createCliAdapter({
       dialect: dbValidation.dialect,
       databaseUrl: dbValidation.databaseUrl,
       logger: options.verbose ? logger : undefined,

--- a/packages/nextly/src/cli/commands/migrate-resolve.ts
+++ b/packages/nextly/src/cli/commands/migrate-resolve.ts
@@ -30,7 +30,7 @@ import { snapshotComparableTables } from "../../domains/schema/pipeline/managed-
 import { describeError, NextlyError } from "../../errors/index";
 import { createContext, type CommandContext } from "../program";
 import {
-  createAdapter,
+  createCliAdapter,
   validateDatabaseEnv,
   type CLIDatabaseAdapter,
 } from "../utils/adapter";
@@ -136,7 +136,7 @@ export async function runMigrateResolve(
   const migrationsDir = resolve(cwd, configResult.config.db.migrationsDir);
   const metaDir = resolve(migrationsDir, "meta");
 
-  const adapter: CLIDatabaseAdapter = await createAdapter({
+  const adapter: CLIDatabaseAdapter = await createCliAdapter({
     dialect: dbValidation.dialect,
     databaseUrl: dbValidation.databaseUrl,
     logger: options.verbose ? logger : undefined,

--- a/packages/nextly/src/cli/commands/migrate-status.ts
+++ b/packages/nextly/src/cli/commands/migrate-status.ts
@@ -39,7 +39,7 @@ import type {
 } from "../../schemas/dynamic-collections/types";
 import { createContext, type CommandContext } from "../program";
 import {
-  createAdapter,
+  createCliAdapter,
   validateDatabaseEnv,
   getDialectDisplayName,
   type CLIDatabaseAdapter,
@@ -220,7 +220,7 @@ export async function runMigrateStatus(
 
   let adapter: CLIDatabaseAdapter;
   try {
-    adapter = await createAdapter({
+    adapter = await createCliAdapter({
       dialect: dbValidation.dialect,
       databaseUrl: dbValidation.databaseUrl,
       logger: options.verbose ? logger : undefined,

--- a/packages/nextly/src/cli/commands/migrate.ts
+++ b/packages/nextly/src/cli/commands/migrate.ts
@@ -74,7 +74,7 @@ import { snapshotComparableTables } from "../../domains/schema/pipeline/managed-
 import { NextlyError, describeError } from "../../errors";
 import { createContext, type CommandContext } from "../program";
 import {
-  createAdapter,
+  createCliAdapter,
   validateDatabaseEnv,
   getDialectDisplayName,
   type CLIDatabaseAdapter,
@@ -243,7 +243,7 @@ export async function runMigrate(
 
   let adapter: CLIDatabaseAdapter;
   try {
-    adapter = await createAdapter({
+    adapter = await createCliAdapter({
       dialect: dbValidation.dialect,
       databaseUrl: dbValidation.databaseUrl,
       logger: options.verbose ? logger : undefined,

--- a/packages/nextly/src/cli/commands/permissions-cleanup.ts
+++ b/packages/nextly/src/cli/commands/permissions-cleanup.ts
@@ -4,7 +4,7 @@ import { Command } from "commander";
 import { PermissionSeedService } from "../../domains/auth/services/permission-seed-service";
 import { createContext } from "../program";
 import {
-  createAdapter,
+  createCliAdapter,
   validateDatabaseEnv,
   type CLIDatabaseAdapter,
 } from "../utils/adapter";
@@ -36,7 +36,7 @@ export function createPermissionsCleanupCommand(): Command {
         const dbValidation = validateDatabaseEnv();
 
         context.logger.info("Creating database adapter...");
-        adapter = await createAdapter({
+        adapter = await createCliAdapter({
           dialect: dbValidation.dialect,
           databaseUrl: dbValidation.databaseUrl,
           logger: context.options.verbose ? context.logger : undefined,

--- a/packages/nextly/src/cli/commands/prune.ts
+++ b/packages/nextly/src/cli/commands/prune.ts
@@ -31,7 +31,7 @@ import { isCompanionTable } from "../../domains/schema/pipeline/managed-tables";
 import { describeError } from "../../errors/index";
 import { createContext, type CommandContext } from "../program";
 import {
-  createAdapter,
+  createCliAdapter,
   validateDatabaseEnv,
   type CLIDatabaseAdapter,
 } from "../utils/adapter";
@@ -171,7 +171,7 @@ export async function runPruneCommand(
 
   let adapter: CLIDatabaseAdapter;
   try {
-    adapter = await createAdapter({
+    adapter = await createCliAdapter({
       dialect: dbValidation.dialect,
       databaseUrl: dbValidation.databaseUrl,
     });

--- a/packages/nextly/src/cli/commands/upgrade.ts
+++ b/packages/nextly/src/cli/commands/upgrade.ts
@@ -32,7 +32,7 @@ import { reconcileCore } from "../../domains/schema/migrate/core-reconcile";
 import { withMigrateLock } from "../../domains/schema/pipeline/locks";
 import { NextlyError, describeError } from "../../errors";
 import { createContext } from "../program";
-import { createAdapter, validateDatabaseEnv } from "../utils/adapter";
+import { createCliAdapter, validateDatabaseEnv } from "../utils/adapter";
 
 import { maybeForceUnlock } from "./migrate";
 
@@ -400,7 +400,7 @@ export function registerUpgradeCommand(program: Command): void {
 
       let adapter: { disconnect?: () => Promise<void> } & UpgradeAdapter;
       try {
-        adapter = (await createAdapter({
+        adapter = (await createCliAdapter({
           dialect: dbValidation.dialect,
           databaseUrl: dbValidation.databaseUrl,
           logger: globalOpts.verbose ? context.logger : undefined,

--- a/packages/nextly/src/cli/commands/webhooks-prune.test.ts
+++ b/packages/nextly/src/cli/commands/webhooks-prune.test.ts
@@ -19,14 +19,14 @@ vi.mock("../utils/adapter", () => ({
     dialect: "sqlite",
     databaseUrl: "memory",
   })),
-  createAdapter: vi.fn(),
+  createCliAdapter: vi.fn(),
 }));
 
 vi.mock("../utils/config-loader", () => ({
   loadConfig: vi.fn(async () => ({ config: { webhookRetention: null } })),
 }));
 
-import { createAdapter } from "../utils/adapter";
+import { createCliAdapter } from "../utils/adapter";
 
 function fakeContext(): CommandContext {
   const logger = {
@@ -47,7 +47,7 @@ describe("runWebhooksPruneCommand", () => {
 
     await runWebhooksPruneCommand({}, context);
 
-    expect(createAdapter).not.toHaveBeenCalled();
+    expect(createCliAdapter).not.toHaveBeenCalled();
     expect(context.logger.info).toHaveBeenCalledWith(
       expect.stringContaining("disabled")
     );

--- a/packages/nextly/src/cli/commands/webhooks-prune.ts
+++ b/packages/nextly/src/cli/commands/webhooks-prune.ts
@@ -29,7 +29,7 @@ import { pruneWebhookData } from "../../domains/webhooks/prune";
 import { describeError } from "../../errors/index";
 import { createContext, type CommandContext } from "../program";
 import {
-  createAdapter,
+  createCliAdapter,
   validateDatabaseEnv,
   type CLIDatabaseAdapter,
 } from "../utils/adapter";
@@ -73,7 +73,7 @@ export async function runWebhooksPruneCommand(
 
   let adapter: CLIDatabaseAdapter;
   try {
-    adapter = await createAdapter({
+    adapter = await createCliAdapter({
       dialect: dbValidation.dialect,
       databaseUrl: dbValidation.databaseUrl,
     });

--- a/packages/nextly/src/cli/utils/adapter.ts
+++ b/packages/nextly/src/cli/utils/adapter.ts
@@ -20,7 +20,7 @@ export type SupportedDialect = "postgresql" | "mysql" | "sqlite";
 /**
  * Options for creating a database adapter
  */
-export interface CreateAdapterOptions {
+export interface CreateCliAdapterOptions {
   /**
    * Database dialect (postgresql, mysql, sqlite)
    * If not provided, will be detected from DATABASE_URL or DB_DIALECT env var
@@ -118,15 +118,22 @@ export interface CLIDatabaseAdapter {
 }
 
 /**
- * Create a database adapter from environment or options
+ * Create the CLI's own minimal database adapter, from environment or options.
+ *
+ * Named apart from `createCliAdapter` in `nextly/database`, which is a different
+ * function returning a different type: that one builds the full
+ * `DrizzleAdapter` an application runs on, this one builds the small
+ * `CLIDatabaseAdapter` above, which is connect, disconnect and a dialect. Both
+ * were published under one name from two entries, so an import site said
+ * nothing about which had arrived or what it could do.
  *
  * @param options - Adapter creation options
- * @returns Database adapter instance
+ * @returns The CLI adapter instance
  * @throws Error if environment is invalid or adapter creation fails
  *
  * @example
  * ```typescript
- * const adapter = await createAdapter({ logger });
+ * const adapter = await createCliAdapter({ logger });
  * try {
  *   // Use adapter...
  * } finally {
@@ -134,8 +141,8 @@ export interface CLIDatabaseAdapter {
  * }
  * ```
  */
-export async function createAdapter(
-  options: CreateAdapterOptions = {}
+export async function createCliAdapter(
+  options: CreateCliAdapterOptions = {}
 ): Promise<CLIDatabaseAdapter> {
   const { logger } = options;
 
@@ -197,9 +204,9 @@ export async function createAdapter(
  */
 export async function withAdapter<T>(
   fn: (adapter: CLIDatabaseAdapter) => Promise<T>,
-  options: CreateAdapterOptions = {}
+  options: CreateCliAdapterOptions = {}
 ): Promise<T> {
-  const adapter = await createAdapter(options);
+  const adapter = await createCliAdapter(options);
   try {
     return await fn(adapter);
   } finally {

--- a/packages/nextly/src/cli/utils/adapter.ts
+++ b/packages/nextly/src/cli/utils/adapter.ts
@@ -120,7 +120,7 @@ export interface CLIDatabaseAdapter {
 /**
  * Create the CLI's own minimal database adapter, from environment or options.
  *
- * Named apart from `createCliAdapter` in `nextly/database`, which is a different
+ * Named apart from `createAdapter` in `nextly/database`, which is a different
  * function returning a different type: that one builds the full
  * `DrizzleAdapter` an application runs on, this one builds the small
  * `CLIDatabaseAdapter` above, which is connect, disconnect and a dialect. Both

--- a/packages/nextly/src/cli/utils/index.ts
+++ b/packages/nextly/src/cli/utils/index.ts
@@ -32,13 +32,13 @@ export {
 } from "./logger";
 
 export {
-  createAdapter,
+  createCliAdapter,
   withAdapter,
   validateDatabaseEnv,
   detectDialectFromUrl,
   getDialectDisplayName,
   dialectSupports,
-  type CreateAdapterOptions,
+  type CreateCliAdapterOptions,
   type DatabaseEnvValidation,
   type CLIDatabaseAdapter,
   type SupportedDialect,

--- a/packages/nextly/src/collections/config/define-config.ts
+++ b/packages/nextly/src/collections/config/define-config.ts
@@ -34,7 +34,7 @@
 
 import {
   extractFieldGroupReferences,
-  isFieldGroupType,
+  isFieldGroupFieldType,
 } from "../../domains/field-groups/storage/field-group-field-type";
 import { validateLocalizationConfig } from "../../domains/i18n/config/validate";
 import { resolveComponentTableName } from "../../domains/schema/utils/resolve-table-name";
@@ -89,7 +89,7 @@ function collectComponentRefs(
   refs: string[]
 ): void {
   for (const field of fields) {
-    if (isFieldGroupType(field.type)) {
+    if (isFieldGroupFieldType(field.type)) {
       const { single, many } = extractFieldGroupReferences(field);
       if (single) refs.push(single);
       if (many) {

--- a/packages/nextly/src/collections/fields/guards.ts
+++ b/packages/nextly/src/collections/fields/guards.ts
@@ -8,7 +8,7 @@
  * @since 1.0.0
  */
 
-import { isFieldGroupType } from "../../domains/field-groups/storage/field-group-field-type";
+import { isFieldGroupFieldType } from "../../domains/field-groups/storage/field-group-field-type";
 
 import type {
   // Text field types
@@ -310,10 +310,10 @@ export const isJSONField = createTypeGuard<JSONFieldConfig>("json");
  * }
  * ```
  */
-export function isFieldGroupField(
-  field: { type: string }
-): field is FieldGroupFieldConfig {
-  return isFieldGroupType(field.type);
+export function isFieldGroupField(field: {
+  type: string;
+}): field is FieldGroupFieldConfig {
+  return isFieldGroupFieldType(field.type);
 }
 
 // ============================================================

--- a/packages/nextly/src/domains/collections/query/query-operators.ts
+++ b/packages/nextly/src/domains/collections/query/query-operators.ts
@@ -36,7 +36,7 @@ import type {
 
 import {
   extractFieldGroupReferences,
-  isFieldGroupType,
+  isFieldGroupFieldType,
 } from "../../field-groups/storage/field-group-field-type";
 import { isFieldGroupTypeKey } from "../../field-groups/storage/field-group-type-key";
 
@@ -563,7 +563,7 @@ function isComponentFieldDef(field: {
   name: string;
   type: string;
 }): field is ComponentFieldDefinition {
-  return isFieldGroupType(field.type);
+  return isFieldGroupFieldType(field.type);
 }
 
 /**

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -35,7 +35,7 @@ import {
 } from "../../../shared/lib/plugin-storage";
 import {
   fieldGroupSlugList,
-  isFieldGroupType,
+  isFieldGroupFieldType,
 } from "../../field-groups/storage/field-group-field-type";
 import { resolveLocalizedFieldNames } from "../../i18n/classify-fields";
 import { generateSQL } from "../../schema/pipeline/sql-templates/index";
@@ -1507,10 +1507,10 @@ ${allColumnDefs.join(",\n")}
     const newNames = new Set(newFields.map(f => f.name));
 
     const oldOnly = oldFields.filter(
-      f => !newNames.has(f.name) && isFieldGroupType(f.type)
+      f => !newNames.has(f.name) && isFieldGroupFieldType(f.type)
     );
     const newOnly = newFields.filter(
-      f => !oldNames.has(f.name) && isFieldGroupType(f.type)
+      f => !oldNames.has(f.name) && isFieldGroupFieldType(f.type)
     );
     if (oldOnly.length === 0 || newOnly.length === 0) return null;
 

--- a/packages/nextly/src/domains/field-groups/services/field-group-mutation-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-mutation-service.ts
@@ -38,7 +38,7 @@ import {
   resolveCompanionReadiness,
 } from "../../i18n/runtime/companion-readiness";
 import {
-  isFieldGroupType,
+  isFieldGroupFieldType,
   withResolvedFieldGroupReferences,
 } from "../storage/field-group-field-type";
 import {
@@ -102,7 +102,7 @@ export interface DeleteComponentDataParams {
 }
 
 function isFieldGroupField(field: FieldConfig): field is FieldGroupFieldConfig {
-  return isFieldGroupType(field.type);
+  return isFieldGroupFieldType(field.type);
 }
 
 /**

--- a/packages/nextly/src/domains/field-groups/services/field-group-query-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-query-service.ts
@@ -28,7 +28,7 @@ import {
   type CompanionReadiness,
 } from "../../i18n/runtime/companion-readiness";
 import {
-  isFieldGroupType,
+  isFieldGroupFieldType,
   withResolvedFieldGroupReferences,
 } from "../storage/field-group-field-type";
 import { currentFieldGroupTypeKey } from "../storage/field-group-type-key";
@@ -151,7 +151,7 @@ export interface PopulateComponentDataManyParams {
 // Duplicated here (and in the mutation service) to avoid a cross-domain
 // import into collections just for a type predicate.
 function isFieldGroupField(field: FieldConfig): field is FieldGroupFieldConfig {
-  return isFieldGroupType(field.type);
+  return isFieldGroupFieldType(field.type);
 }
 
 /**

--- a/packages/nextly/src/domains/field-groups/services/field-group-registry-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-registry-service.ts
@@ -29,7 +29,7 @@ import {
 import { resolveComponentTableName } from "../../schema/utils/resolve-table-name";
 import {
   extractFieldGroupReferences,
-  isFieldGroupType,
+  isFieldGroupFieldType,
 } from "../storage/field-group-field-type";
 import { resolveRegistryTableName } from "../storage/resolve-storage-names";
 
@@ -1023,7 +1023,7 @@ export class FieldGroupRegistryService extends BaseRegistryService<
 
       // The slugs come from the shared reader so a definition referencing its
       // field group through either key spelling is collected the same way.
-      if (isFieldGroupType(fieldType)) {
+      if (isFieldGroupFieldType(fieldType)) {
         const { single, many } = extractFieldGroupReferences(field);
         if (single) {
           slugs.add(single);
@@ -1098,7 +1098,7 @@ export class FieldGroupRegistryService extends BaseRegistryService<
       const fieldType = field.type as string;
       const enrichedField: EnrichedFieldConfig = { ...field };
 
-      if (isFieldGroupType(fieldType)) {
+      if (isFieldGroupFieldType(fieldType)) {
         const { single: componentSlug, many: componentsArray } =
           extractFieldGroupReferences(field);
         if (componentSlug) {
@@ -1235,7 +1235,7 @@ export class FieldGroupRegistryService extends BaseRegistryService<
       const fieldPath = parentPath ? `${parentPath}.${fieldName}` : fieldName;
       const fieldType = field.type as string;
 
-      if (isFieldGroupType(fieldType)) {
+      if (isFieldGroupFieldType(fieldType)) {
         const { single, many } = extractFieldGroupReferences(field);
         if (single === targetSlug) {
           references.push({ entityType, entitySlug, fieldName, fieldPath });

--- a/packages/nextly/src/domains/field-groups/storage/field-group-field-type.ts
+++ b/packages/nextly/src/domains/field-groups/storage/field-group-field-type.ts
@@ -47,8 +47,14 @@ export const fieldGroupFieldTypes: readonly string[] = [
  * Whether a field type token names a field group, in either the current or the
  * migrated spelling. Anything else — including the kebab-cased
  * `"field-group"`, which no release ever wrote — is not a field group here.
+ *
+ * Named for the token it reads, not for the question `nextly/field-group-type`
+ * answers. That entry publishes an `isFieldGroupType` that takes an INSTANCE
+ * and narrows it, and while both were spelled the same a reader could not tell
+ * which had arrived without checking the import line. This one belongs to
+ * `fieldGroupFieldTypes` above it and is named after it.
  */
-export function isFieldGroupType(type: unknown): boolean {
+export function isFieldGroupFieldType(type: unknown): boolean {
   return typeof type === "string" && fieldGroupFieldTypes.includes(type);
 }
 

--- a/packages/nextly/src/domains/schema/services/__tests__/field-group-dual-vocabulary.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/field-group-dual-vocabulary.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { isFieldGroupField } from "../../../../collections/fields/guards";
 import {
   extractFieldGroupReferences,
-  isFieldGroupType,
+  isFieldGroupFieldType,
 } from "../../../field-groups/storage/field-group-field-type";
 import { buildDesiredTableFromFields } from "../../pipeline/diff/build-from-fields";
 import { diffSnapshots } from "../../pipeline/diff/diff";
@@ -15,14 +15,14 @@ import {
 
 describe("Field Group Dual Vocabulary — type recognition & guards", () => {
   it("recognizes all standard field-group type tokens", () => {
-    expect(isFieldGroupType("component")).toBe(true);
-    expect(isFieldGroupType("fieldGroup")).toBe(true);
-    expect(isFieldGroupType("text")).toBe(false);
+    expect(isFieldGroupFieldType("component")).toBe(true);
+    expect(isFieldGroupFieldType("fieldGroup")).toBe(true);
+    expect(isFieldGroupFieldType("text")).toBe(false);
     // No release ever wrote the kebab spelling, so accepting it would widen
     // the vocabulary beyond what storage declares.
-    expect(isFieldGroupType("field-group")).toBe(false);
-    expect(isFieldGroupType(null)).toBe(false);
-    expect(isFieldGroupType(undefined)).toBe(false);
+    expect(isFieldGroupFieldType("field-group")).toBe(false);
+    expect(isFieldGroupFieldType(null)).toBe(false);
+    expect(isFieldGroupFieldType(undefined)).toBe(false);
   });
 
   it("isFieldGroupField guard narrows both component and fieldGroup definitions", () => {

--- a/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
+++ b/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
@@ -38,7 +38,7 @@ import {
 } from "../../../lib/system-columns";
 import { isBuiltInFieldType } from "../../../schemas/_zod/ui-schema";
 import type { FieldDefinition } from "../../../schemas/dynamic-collections";
-import { isFieldGroupType } from "../../field-groups/storage/field-group-field-type";
+import { isFieldGroupFieldType } from "../../field-groups/storage/field-group-field-type";
 import { getFieldType } from "../field-types/field-type-registry";
 
 export type SupportedDialect = "postgresql" | "mysql" | "sqlite";
@@ -167,7 +167,7 @@ export function fieldProducesColumn(field: {
   if (typeof field.type !== "string") return true;
   // Field-group and component values live in their own dedicated tables (fg_{slug} or
   // comp_{slug}) and are stripped from the parent row on write, so the parent needs no column.
-  if (isFieldGroupType(field.type)) return false;
+  if (isFieldGroupFieldType(field.type)) return false;
   // A many-to-many relationship stores its links in a dedicated junction table, not on the parent
   // row. Every other relationship shape does get a column.
   if (usesJunctionTable(field)) return false;

--- a/packages/nextly/src/domains/versions/diff/compute-diff.ts
+++ b/packages/nextly/src/domains/versions/diff/compute-diff.ts
@@ -25,7 +25,7 @@ import type { FieldConfig } from "../../../collections/fields/types";
 import { normalizeStoredValue } from "../../../shared/lib/normalize-stored-value";
 import {
   extractFieldGroupReferences,
-  isFieldGroupType,
+  isFieldGroupFieldType,
 } from "../../field-groups/storage/field-group-field-type";
 import { readFieldGroupType } from "../../field-groups/storage/field-group-type-key";
 
@@ -255,7 +255,7 @@ function targetKey(target: RelationTarget): string {
 // ---- classification ---------------------------------------------------------
 
 function isComponentField(field: FieldConfig): boolean {
-  return isFieldGroupType(field.type);
+  return isFieldGroupFieldType(field.type);
 }
 /** Cardinality is decided by `repeatable`; a non-repeatable field holds one value. */
 function isComponentList(field: FieldConfig): boolean {

--- a/packages/nextly/src/domains/versions/snapshot-references.ts
+++ b/packages/nextly/src/domains/versions/snapshot-references.ts
@@ -16,7 +16,7 @@
 
 import type { AuthenticatedScope } from "../../auth/authenticated-scope";
 import type { FieldConfig } from "../../collections/fields/types";
-import { isFieldGroupType } from "../field-groups/storage/field-group-field-type";
+import { isFieldGroupFieldType } from "../field-groups/storage/field-group-field-type";
 import { readFieldGroupType } from "../field-groups/storage/field-group-type-key";
 import type { UserContext } from "../singles/types";
 
@@ -161,7 +161,7 @@ function walk(
     // instance's type, not in `fields`, so resolve them per instance. Everything
     // below a component is walked with `inComponent`, so the read-rule skip
     // above applies to its whole subtree.
-    if (isFieldGroupType(field.type)) {
+    if (isFieldGroupFieldType(field.type)) {
       const instances = Array.isArray(raw) ? raw : [raw];
       for (const instance of instances) {
         walk(instance, componentChildFieldsFor(field, instance), visit, true);

--- a/packages/nextly/src/domains/webhooks/expand-component-fields.ts
+++ b/packages/nextly/src/domains/webhooks/expand-component-fields.ts
@@ -16,7 +16,7 @@
 
 import {
   extractFieldGroupReferences,
-  isFieldGroupType,
+  isFieldGroupFieldType,
 } from "../field-groups/storage/field-group-field-type";
 
 import type { SensitiveFieldSource } from "./sensitive-fields";
@@ -37,7 +37,7 @@ export type ComponentFieldResolver = (
  * reaches the deny list.
  */
 function referencedSlugs(field: SensitiveFieldSource): string[] {
-  if (!isFieldGroupType(field.type)) return [];
+  if (!isFieldGroupFieldType(field.type)) return [];
   const { single, many } = extractFieldGroupReferences(field);
   const slugs: string[] = [];
   if (single) slugs.push(single);

--- a/packages/nextly/src/field-group-type.ts
+++ b/packages/nextly/src/field-group-type.ts
@@ -58,9 +58,12 @@ export {
 // and which reference keys it may point at. Renderers that dispatch on a
 // field's type — the admin entry form among them — ask the predicate rather
 // than compare either literal, so a migrated definition renders as what it is.
-// Renamed on this surface to keep the two predicates apart: the `isFieldGroupType`
-// above judges a stored INSTANCE's value, this one judges a FIELD's type token.
+//
+// This entry aliased the name apart before the other one did, for the reason
+// the alias gave: `isFieldGroupType` above judges a stored INSTANCE, this
+// judges a FIELD's type token. The alias is the real name now, so the root
+// entry cannot publish the ambiguous spelling the alias was working around.
 export {
   extractFieldGroupReferences,
-  isFieldGroupType as isFieldGroupFieldType,
+  isFieldGroupFieldType,
 } from "./domains/field-groups/storage/field-group-field-type";

--- a/packages/nextly/src/index.ts
+++ b/packages/nextly/src/index.ts
@@ -974,7 +974,7 @@ export type { FieldGroupFieldConfig } from "./collections/fields/types/component
 // literal, so a migrated definition renders as what it is.
 export {
   extractFieldGroupReferences,
-  isFieldGroupType,
+  isFieldGroupFieldType,
 } from "./domains/field-groups/storage/field-group-field-type";
 
 // Declares an entry field whose type a plugin contributed. `FieldConfig` is a

--- a/packages/nextly/src/schemas/_zod/ui-schema.ts
+++ b/packages/nextly/src/schemas/_zod/ui-schema.ts
@@ -15,7 +15,7 @@
 
 import { z } from "zod";
 
-import { isFieldGroupType } from "../../domains/field-groups/storage/field-group-field-type";
+import { isFieldGroupFieldType } from "../../domains/field-groups/storage/field-group-field-type";
 import { reservedSystemFieldNames } from "../../lib/system-columns";
 import {
   isPluginOptionContainer,
@@ -360,7 +360,7 @@ export const uiSchemaFieldSchema: z.ZodType<FieldNode> = z.lazy(() =>
       // counted BEFORE any value is read: coalescing the two spellings of one shape
       // first would silently prefer the legacy value and accept an ambiguous field
       // the code-first validator rejects.
-      if (isFieldGroupType(f.type)) {
+      if (isFieldGroupFieldType(f.type)) {
         // Both spellings are declared on the object above, so they survive
         // parsing and are readable off the node without a cast.
         const singleKeys = ["component", "fieldGroup"] as const;

--- a/packages/nextly/src/services/security/sanitization-service.ts
+++ b/packages/nextly/src/services/security/sanitization-service.ts
@@ -12,7 +12,7 @@
 import { typeHasNestedFields } from "../../collections/fields/guards";
 import {
   extractFieldGroupReferences,
-  isFieldGroupType,
+  isFieldGroupFieldType,
 } from "../../domains/field-groups/storage/field-group-field-type";
 import { readFieldGroupType } from "../../domains/field-groups/storage/field-group-type-key";
 import type { FieldDefinition } from "../../schemas/dynamic-collections";
@@ -193,7 +193,7 @@ export function sanitizeEntryData(
     // A field group's values are nested documents carrying the group's own
     // fields, so the descent must follow either type spelling — skipping the
     // migrated one would leave its text values unsanitized.
-    if (isFieldGroupType(field.type)) {
+    if (isFieldGroupFieldType(field.type)) {
       sanitizeFieldGroupValue(value, field, config);
       continue;
     }
@@ -384,7 +384,7 @@ export async function attachFieldGroupChildren(
   if (depth > MAX_FIELD_GROUP_RESOLVE_DEPTH) return fields;
 
   for (const field of fields) {
-    if (isFieldGroupType(field.type)) {
+    if (isFieldGroupFieldType(field.type)) {
       await attachFieldGroupReferences(
         field,
         resolveChildren,

--- a/packages/nextly/src/shared/lib/normalize-stored-value.ts
+++ b/packages/nextly/src/shared/lib/normalize-stored-value.ts
@@ -17,7 +17,7 @@
  * @module shared/lib/normalize-stored-value
  */
 
-import { isFieldGroupType } from "../../domains/field-groups/storage/field-group-field-type";
+import { isFieldGroupFieldType } from "../../domains/field-groups/storage/field-group-field-type";
 
 /**
  * The minimal field shape normalization reads. Declared structurally (rather
@@ -154,7 +154,7 @@ function reshapeTypedValue(field: NormalizableField, value: unknown): unknown {
   // would leave a migrated definition's array in place, and the nested diff
   // would then read the array — not the instance — as the value object,
   // losing every child.
-  if (isFieldGroupType(field.type)) {
+  if (isFieldGroupFieldType(field.type)) {
     return fieldGroupValue(field, value);
   }
 


### PR DESCRIPTION
Closes the two names recorded by #1646's export-contract check.

## The problem

Each name meant two different things depending on the import line, and nothing at the call site said which had arrived.

```ts
import { isFieldGroupType } from "nextly";
isFieldGroupType("component")        // 1 arg  → is this string a field-group type name?

import { isFieldGroupType } from "nextly/field-group-type";
isFieldGroupType(block, "hero")      // 2 args → is this block a hero? (and narrows it)
```

Same for `createAdapter`: the database factory on `nextly` and `nextly/database`, the CLI's own on `nextly/cli/utils`, returning **different types**.

## Which keeps the name

**The one application code writes.**

`isFieldGroupType(block, "hero")` is what a page component writes to render a dynamic zone. The token test is internal plumbing: **89 of its 90 call sites are inside this package**. It becomes `isFieldGroupFieldType`.

That is not a new coinage. `nextly/field-group-type` was **already** re-exporting it under exactly that alias, with a comment explaining the two predicates had to be kept apart. Someone reached this conclusion and applied it to one entry point while the root kept publishing the spelling the alias was working around. The alias is the real name now, and it matches the `fieldGroupFieldTypes` list it reads.

`createAdapter` stays with the factory that builds the `DrizzleAdapter` an application runs on. The CLI's becomes `createCliAdapter`, returning the small `CLIDatabaseAdapter` that is connect, disconnect and a dialect.

## How it was renamed

By moving the **definition** and letting the compiler enumerate call sites, not by find-and-replace. `isFieldGroupTypeKey` and `createAdapterFromEnv` are different functions whose names begin with these, and a blanket rename takes both. Each pass asserts their occurrence count is unchanged.

## What lasts

`KNOWN_SHAPE_CLASHES` is now **empty**. It held these two, recorded rather than fixed because each needed the decision `getNextly` needed. With both made, nothing is exempt and the next such name fails on the day it appears instead of joining a list.

Verified the guard still bites: restoring either name to the root entry fails the export-contract test with the clash spelled out.

## Scope

Neither name appears in `docs/` or any template, so nothing published changes for a reader. Confirmed with the maintainer that there are no public consumers yet, which is why the thorough rename is the cheap one to do now.

**Gates:** nextly 11,870 + types · lint 0 · comments 0 · changeset covers the group.