### PR TITLE
docs(nextly): an anonymous read applies inline access rules now

### DIFF
--- a/.changeset/anonymous-reads-apply-inline-access.md
+++ b/.changeset/anonymous-reads-apply-inline-access.md
@@ -1,0 +1,46 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The guidance for anonymous content reads described a limitation that no longer
+holds, in the direction that matters: it said inline `defineCollection({ access })`
+code rules are not applied without a user, and told readers to gate such content
+behind an authenticated read.
+
+Those rules ARE applied now. A code rule reads what it is handed, and an
+anonymous caller is something it can be handed, so it receives `user: null` and
+no roles and decides on that. A rule written `read: ({ user }) => !!user` hides
+the content exactly as its author intended.
+
+What an anonymous read still cannot apply is a row-level CONSTRAINT rule,
+owner-only or a custom rule returning a query predicate. Those compare a row
+against somebody and there is nobody to compare it to, so the guidance to use an
+authenticated read stands for them and now says so specifically.
+
+Both copies are corrected, in `resolveContent`'s own contract and in the routing
+guide. Two tests hold the claim at the point that decides it, including a
+control that no inline rule still means the stored rules decide.

--- a/docs/guides/routing-and-seo.mdx
+++ b/docs/guides/routing-and-seo.mdx
@@ -99,11 +99,16 @@ await resolveContent("posts", slug, { overrideAccess: true, status: "all" });
 ```
 
 > An anonymous read enforces stored rules that **deny outright**
-> (public/authenticated/role-based). A **row-level constraint** rule (owner-only,
-> or a custom rule returning a query) and inline `defineCollection({ access })`
-> code rules need a `user` context to evaluate, so they are not applied for an
-> anonymous read. Gate that content behind an authenticated read (pass a `user`)
-> rather than the anonymous default.
+> (public/authenticated/role-based), and it enforces inline
+> `defineCollection({ access })` code rules: those are handed a real anonymous
+> context (`user: null`, no roles) and decide on it, so a rule like
+> `read: ({ user }) => !!user` hides the content as written.
+>
+> What an anonymous read still cannot apply is a **row-level constraint** rule
+> (owner-only, or a custom rule returning a query). Those compare a row against
+> somebody, and there is nobody to compare it to. Gate content that depends on
+> one behind an authenticated read (pass a `user`) rather than the anonymous
+> default.
 
 **Caching.** Only a **trusted** (`overrideAccess: true`) read with no `user` is
 F1-cached — an enforced read is never cached, because its result depends on an

--- a/packages/nextly/src/domains/collections/services/collection-access-anonymous.test.ts
+++ b/packages/nextly/src/domains/collections/services/collection-access-anonymous.test.ts
@@ -87,6 +87,46 @@ describe("checkCollectionAccess with no user", () => {
     expect(rbac.checkAccess).not.toHaveBeenCalled();
   });
 
+  it("applies the collection's inline code rule, which needs no user", async () => {
+    // The layer the doc on `resolveContent` said could not run. A code rule
+    // reads what it is given, and an anonymous caller is a thing it can be
+    // given: `user: null`, no roles. So it is consulted, and its refusal is the
+    // answer, even though the permission check beside it never runs.
+    const { service, rbac } = buildService({});
+    rbac.checkAnonymousCodeAccess.mockResolvedValue(false);
+
+    const result = await service.checkCollectionAccess(
+      "posts",
+      "read",
+      undefined
+    );
+
+    expect(rbac.checkAnonymousCodeAccess).toHaveBeenCalledWith({
+      operation: "read",
+      resource: "posts",
+    });
+    expect(result?.success).toBe(false);
+    expect(result?.statusCode).toBe(403);
+    expect(rbac.checkAccess).not.toHaveBeenCalled();
+  });
+
+  it("lets the stored rules decide when no inline rule governs the operation", async () => {
+    // The control that keeps the case above from meaning "anonymous is denied".
+    // `undefined` is no opinion, not a refusal, so a collection with no inline
+    // rule for this operation still reads as it always did.
+    const { service, rbac } = buildService({});
+    rbac.checkAnonymousCodeAccess.mockResolvedValue(undefined);
+
+    const result = await service.checkCollectionAccess(
+      "posts",
+      "read",
+      undefined
+    );
+
+    expect(rbac.checkAnonymousCodeAccess).toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
   it("refuses publish with no user and no rule for it", async () => {
     // The exception to that default, decided in this service rather than the
     // leaf: publishing anonymously needs a rule that says so.

--- a/packages/nextly/src/runtime/routing/resolve-content.ts
+++ b/packages/nextly/src/runtime/routing/resolve-content.ts
@@ -135,12 +135,14 @@ interface ResolveContentOptionsBase {
    * rule is hidden from an unauthenticated request (resolves to `null` →
    * `notFound()`). Pass `true` for a fully trusted read. NOTE on anonymous
    * scope: an anonymous read enforces stored rules that DENY outright
-   * (public/authenticated/role-based). A row-level CONSTRAINT rule (owner-only,
-   * or a custom rule returning a query predicate) and inline
-   * `defineCollection({ access })` code rules require a `user` context to
-   * evaluate, so they are not applied for an anonymous read — gate such content
-   * behind an authenticated read (pass a `user`) rather than relying on the
-   * anonymous default. CACHING: only a trusted (`overrideAccess: true`) read
+   * (public/authenticated/role-based), and it enforces inline
+   * `defineCollection({ access })` code rules, which are handed a real
+   * anonymous context (`user: null`, no roles) and decide on it. What an
+   * anonymous read still cannot apply is a row-level CONSTRAINT rule
+   * (owner-only, or a custom rule returning a query predicate): those compare
+   * the row against somebody, and there is nobody to compare it to. Gate
+   * content that depends on a CONSTRAINT rule behind an authenticated read
+   * (pass a `user`) rather than relying on the anonymous default. CACHING: only a trusted (`overrideAccess: true`) read
    * with no `user` is F1-cached — an enforced read is never cached (its access
    * decision can't be invalidated on a policy change). A public site that wants
    * cached pages should read its public content with `overrideAccess: true`.


### PR DESCRIPTION
Follow-through on #1704. That PR made code-defined `access` rules run for a caller with no session; this corrects two pieces of guidance which said they do not, and pins the new behaviour where it is decided.

## Why this is worth its own PR

The stale text is wrong in the direction that matters. It told readers:

> inline `defineCollection({ access })` code rules need a `user` context to evaluate, so they are not applied for an anonymous read. Gate that content behind an authenticated read.

Someone following that either builds an authenticated path they no longer need, or believes their content is unprotected when the rule they wrote is in fact hiding it. Documentation about where a security boundary sits is worth more than most, and stale in this direction is worse than absent.

## What is actually true now

Inline code rules **are** applied. A code rule reads what it is handed, and an anonymous caller is something it can be handed: `user: null`, no roles. So `read: ({ user }) => !!user` hides the content exactly as its author intended.

What an anonymous read still cannot apply is a **row-level constraint** rule, owner-only or a custom rule returning a query predicate. Those compare a row against somebody and there is nobody to compare it to. The advice to use an authenticated read stands for those, and now says which rules it means.

## Verified, not assumed

Traced the path rather than reasoning about it: `collection-query-service.ts` computes `accessUser = params.overrideAccess ? undefined : params.user`, so an anonymous enforced read reaches `checkCollectionAccess` with no user and `overrideAccess: false`, which is exactly the branch #1704 added.

Two tests hold it at the point that decides, not the point it is written:

- an inline rule's refusal is the answer for an anonymous caller, and the permission check beside it still never runs
- a control: no inline rule for the operation still leaves the stored rules deciding, so the first cannot be read as "anonymous is denied"

## Partially closes a tracked task

`task:core-anonymous-constraint-rules` describes both halves of this limitation. The inline-code-rules half is closed by #1704 and documented here. The **constraint-rule half remains genuinely open** and still needs the founder decision it depends on, so the task is not closed.

**Gates:** nextly 11,875 + types · lint 0 · comments 0 · doc-samples 0 · changeset covers the group.

Note: `docs/guides/routing-and-seo.mdx` still contains pre-existing em dashes. Those belong to F37, which is in flight in another lane, so this PR adds none and sweeps none.