### PR TITLE
fix(nextly): the last two reads outside the pipeline resolve like a write

### DIFF
--- a/.changeset/the-last-two-pinned-schemas.md
+++ b/.changeset/the-last-two-pinned-schemas.md
@@ -1,0 +1,37 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Two more PostgreSQL reads looked for tables in a schema called `public` while
+every statement Nextly writes goes wherever the connection's `search_path`
+points. On a deployment that uses its own schema they answered about the wrong
+place: the column check reported every column as missing, so Nextly tried to add
+columns the table already had, and the table check reported an existing table as
+absent.
+
+Both now resolve a table the same way a write does, using the same rule as the
+reads fixed alongside them. Nothing changes for a database that uses `public`.

--- a/packages/nextly/src/domains/schema/pipeline/pg-visible-relation.ts
+++ b/packages/nextly/src/domains/schema/pipeline/pg-visible-relation.ts
@@ -37,8 +37,9 @@
 import { sql, type SQL } from "drizzle-orm";
 
 /**
- * True for the one `information_schema.columns` row set whose relation an
- * unqualified statement would reach.
+ * True for the one `information_schema` row whose relation an unqualified
+ * statement would reach — of `columns` or of `tables` alike, since both name
+ * the relation with `table_schema` and `table_name`.
  *
  * 🔴 Written against the alias `c`, because a predicate over
  * `information_schema` has to name that view's own columns and they cannot be
@@ -52,7 +53,22 @@ import { sql, type SQL } from "drizzle-orm";
  * and the equality asks whether they are the same relation. The same device the
  * sequence-ownership check in `introspect-live.ts` already uses.
  */
-export const PG_RELATION_THE_WRITES_HIT: SQL = sql`format('%I.%I', c.table_schema, c.table_name)::regclass = to_regclass(quote_ident(c.table_name))`;
+export const PG_RELATION_THE_WRITES_HIT_SQL = `format('%I.%I', c.table_schema, c.table_name)::regclass = to_regclass(quote_ident(c.table_name))`;
+
+/**
+ * The same predicate as a Drizzle fragment, BUILT from the text above rather
+ * than written a second time.
+ *
+ * 🔴 Two spellings of this rule is the defect it exists to prevent, one level
+ * up: some readers here compose Drizzle `sql` templates and others hand raw
+ * text to the driver, and a rule copied between those forms drifts the first
+ * time either is corrected. `sql.raw` over a module constant interpolates
+ * nothing — the text is fixed at build time and names only catalog columns —
+ * so it carries no injection surface.
+ */
+export const PG_RELATION_THE_WRITES_HIT: SQL = sql.raw(
+  PG_RELATION_THE_WRITES_HIT_SQL
+);
 
 /**
  * The same question asked of a `pg_class` row, which carries the OID directly.

--- a/packages/nextly/src/domains/schema/utils/__tests__/missing-columns.test.ts
+++ b/packages/nextly/src/domains/schema/utils/__tests__/missing-columns.test.ts
@@ -89,6 +89,38 @@ describe("addMissingColumnsForFields", () => {
     expect(alter?.sql).toBe(`ALTER TABLE "dc_posts" ADD COLUMN "excerpt" TEXT`);
   });
 
+  it("scopes the column read to the relation an unqualified write reaches", async () => {
+    // 🔴 Not `table_schema = 'public'`. Every statement this package emits is
+    // unqualified, so PostgreSQL resolves it across the whole `search_path`; a
+    // read naming one schema answers about a different table. Here that reports
+    // EVERY column as missing, and the caller then tries to add columns the
+    // table already has.
+    //
+    // Asserted on the SQL the adapter is HANDED, which is what the server sees,
+    // rather than on the source text of the module that built it.
+    const { adapter, calls } = makeAdapter({
+      dialect: "postgresql",
+      existingColumns: ["id"],
+    });
+
+    await addMissingColumnsForFields(
+      adapter as unknown as Parameters<typeof addMissingColumnsForFields>[0],
+      fakeLogger,
+      "dc_posts",
+      [{ name: "id", type: "text" } as FieldConfig],
+      { timestamps: false, builtBy: "codeFirst" }
+    );
+
+    const introspect = calls.find(c =>
+      c.sql.includes("information_schema.columns")
+    );
+    expect(introspect?.sql).toContain("to_regclass");
+    // The name is quoted before it is resolved, or a table whose spelling
+    // carries capitals folds to lower case and resolves to nothing.
+    expect(introspect?.sql).toContain("quote_ident");
+    expect(introspect?.sql).not.toContain("'public'");
+  });
+
   it("never adds a parent column for a component field", async () => {
     const { adapter, calls } = makeAdapter({
       dialect: "postgresql",

--- a/packages/nextly/src/domains/schema/utils/missing-columns.ts
+++ b/packages/nextly/src/domains/schema/utils/missing-columns.ts
@@ -29,6 +29,7 @@ import { isBuiltInFieldType } from "../../../schemas/_zod/ui-schema";
 import type { FieldDefinition } from "../../../schemas/dynamic-collections/legacy-types";
 import type { Logger } from "../../../shared/types/index";
 import type { SupportedDialect } from "../../../types/database";
+import { PG_RELATION_THE_WRITES_HIT_SQL } from "../pipeline/pg-visible-relation";
 import {
   fieldProducesColumn,
   getColumnDescriptor,
@@ -290,7 +291,10 @@ async function getExistingColumns(
 
   switch (dialect) {
     case "postgresql":
-      sql = `SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = $1`;
+      // Scoped by `PG_RELATION_THE_WRITES_HIT_SQL`, which carries the reason.
+      // Getting this wrong reports EVERY column as missing, and the caller then
+      // tries to add columns that are already there.
+      sql = `SELECT c.column_name FROM information_schema.columns c WHERE ${PG_RELATION_THE_WRITES_HIT_SQL} AND c.table_name = $1`;
       params.push(tableName);
       break;
     case "mysql":

--- a/packages/nextly/src/services/system/system-table-service.ts
+++ b/packages/nextly/src/services/system/system-table-service.ts
@@ -42,6 +42,7 @@ import {
   resolveFieldGroupRegistryName,
   resolveFieldGroupRegistryTable,
 } from "../../domains/field-groups/storage/resolve-storage-names";
+import { PG_RELATION_THE_WRITES_HIT_SQL } from "../../domains/schema/pipeline/pg-visible-relation";
 import { STORAGE_FORMAT } from "../../schemas/storage-format";
 import { BaseService } from "../base-service";
 import type { Logger } from "../shared";
@@ -87,11 +88,14 @@ export interface SystemMigrationSQL {
 }
 
 const POSTGRES_SQL = {
+  // Scoped by `PG_RELATION_THE_WRITES_HIT_SQL`, which carries the reason.
+  // Getting this wrong reports an existing table as absent, and the caller
+  // then sets about creating one it already has.
   checkTable: `
     SELECT EXISTS (
-      SELECT FROM information_schema.tables
-      WHERE table_schema = 'public'
-      AND table_name = $1
+      SELECT FROM information_schema.tables c
+      WHERE ${PG_RELATION_THE_WRITES_HIT_SQL}
+      AND c.table_name = $1
     ) AS exists
   `,
 


### PR DESCRIPTION
Finishes `finding:pg-schema-pinned-in-seven-places`. #1721 took the three reads in
the schema pipeline; these are the last two that are free to touch.

| site | what a wrong answer does |
|---|---|
| `schema/utils/missing-columns.ts` | reports **every** column as missing, so the caller tries to add columns the table already has |
| `services/system/system-table-service.ts` | reports an **existing** table as absent, so the caller sets about creating one it already has |

Both now use the rule #1721 established: resolve the relation an unqualified
statement reaches, rather than naming a schema. Nothing changes for a database on
`public`, which is the default.

## One rule, two forms — not two rules

These two build **raw SQL text** for the driver; the pipeline reads compose
Drizzle `sql` templates. Rather than write the predicate twice, the module now
holds it once as text and derives the Drizzle fragment from that:

```ts
export const PG_RELATION_THE_WRITES_HIT_SQL = `format('%I.%I', …)::regclass = to_regclass(quote_ident(c.table_name))`;
export const PG_RELATION_THE_WRITES_HIT: SQL = sql.raw(PG_RELATION_THE_WRITES_HIT_SQL);
```

`sql.raw` over a module constant interpolates nothing — the text is fixed at
build time and names only catalog columns — so it carries no injection surface.
A rule copied between the two forms would drift the first time either was
corrected, which is the defect this whole finding is about.

## Evidence

A test asserts the **SQL the adapter is handed**, not the source text of the
module that built it — `missing-columns.test.ts` already has a fake adapter that
records queries, so the assertion sits on the value the server would see.

Break-verified twice, each failing only that test:

| mutation | result |
|---|---|
| re-pin the read to `'public'` | fails |
| drop `quote_ident`, so a capitalised name folds away | fails |

## Not here

Two of the seven sites stay on the finding:

- `cli/commands/migrate-fresh.ts` — **the destructive one**: it lists `public`'s
  tables in order to DROP them, so on a tenant search path it drops unrelated
  tables and leaves the real ones. PR #1729 is currently editing that file for an
  unrelated refactor, so this would conflict. It deserves its own review anyway.
- `domains/collections/services/collection-relationship-service.ts` — inside
  PR #1659's territory.

## Gates

`pnpm build` 0 · nextly `check-types` 0 `lint` 0 `vitest` 0 (935 files, 11,874
tests) · `fallow audit` **pass**, every `*_introduced` 0 over 5 files ·
`changeset status` 0.

Worth noting: the integration probe added in #1721/#1727 has now executed for the
first time and passed on **all three dialects**, so the search-path rule these
reads adopt is verified against a real PostgreSQL rather than only reasoned about.
