### PR TITLE
feat(nextly): a job handler is told which job it is running

### DIFF
--- a/.changeset/a-job-knows-which-job-it-is.md
+++ b/.changeset/a-job-knows-which-job-it-is.md
@@ -1,0 +1,49 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A job handler is told which job it is running.
+
+Delivery is at-least-once, so one queued job can reach a handler more than
+once, and the documentation says to write handlers that survive that. It did
+not say how. The context carried the identity, the clock, a content API and the
+tick deadline, and nothing that identified the queued row, so a handler had
+nothing stable to key an external side effect on.
+
+It now receives `jobId`, the same on every attempt, which is the key to hand a
+payment provider's idempotency header or the unique column an upsert targets.
+It also receives `attempt`, counting from 1, for behaviour that should change
+on a retry. `attempt` is deliberately not the deduplication signal: it counts
+attempts the runner managed to record, so a run whose process died before
+writing anything back leaves the count where it was.
+
+The same page told operators to size `leaseMs` to the work. Nobody could:
+the built-in route passes only a batch size and a duration, and the public
+configuration takes job definitions alone. It was also the wrong advice, since
+the lease is renewed while a handler is alive and so already covers work that
+merely takes a long time. The page now documents the fixed lease as a stall
+tolerance and points at the key a handler can actually use.

--- a/.changeset/a-job-knows-which-job-it-is.md
+++ b/.changeset/a-job-knows-which-job-it-is.md
@@ -36,10 +36,10 @@ nothing stable to key an external side effect on.
 
 It now receives `jobId`, the same on every attempt, which is the key to hand a
 payment provider's idempotency header or the unique column an upsert targets.
-It also receives `attempt`, counting from 1, for behaviour that should change
-on a retry. `attempt` is deliberately not the deduplication signal: it counts
-attempts the runner managed to record, so a run whose process died before
-writing anything back leaves the count where it was.
+It also receives `attempt`, counting from 1, which is written to the row before
+the handler starts, so a handler that dies part-way still leaves the count
+advanced. It is not the deduplication signal: `attempt > 1` says an earlier run
+began, not what it finished.
 
 The same page told operators to size `leaseMs` to the work. Nobody could:
 the built-in route passes only a batch size and a duration, and the public

--- a/docs/jobs/index.mdx
+++ b/docs/jobs/index.mdx
@@ -21,8 +21,9 @@ import { defineJob } from "nextly";
 
 export const sendDigest = defineJob({
   slug: "send-digest",
-  handler: async ctx => {
-    // ctx carries the payload the job was enqueued with.
+  handler: async (input, context) => {
+    // `input` is the payload the job was enqueued with. `context` is what the
+    // runner tells the handler about the run it is in.
   },
 });
 ```
@@ -131,9 +132,52 @@ lease: a process that stalls, is paused, or loses its connection stops renewing 
 side effects are still in flight, and a later pass can reclaim and run the same job.
 
 The fence can refuse the first runner's database write. It cannot undo an email it already
-sent. Size `leaseMs` to the work, and write handlers that can run twice without harm. This
-is the same contract SQS, BullMQ and pg-boss give, for the same reason.
+sent. This is the same contract SQS, BullMQ and pg-boss give, for the same reason.
 </Callout>
+
+### Writing a handler that can run twice
+
+Every handler is told the id of the job it is running, and that id is the same on every
+attempt at it. It is the key to hand anything the database cannot take back:
+
+```ts
+import { defineJob } from "nextly";
+
+export const chargeInvoice = defineJob<{ invoiceId: string; cents: number }>({
+  slug: "charge-invoice",
+  async handler({ invoiceId, cents }, { jobId }) {
+    // The provider de-duplicates on this header, so a second run of the same
+    // job returns the first charge instead of making a second one.
+    await fetch("https://api.payments.example/charges", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Idempotency-Key": jobId,
+      },
+      body: JSON.stringify({ invoiceId, amountCents: cents }),
+    });
+  },
+});
+```
+
+`Idempotency-Key` is the header Stripe, Square and Adyen all read, so most providers
+already have somewhere to put this. Where the side effect is a row rather than a call, the
+same idea is an upsert against a unique column holding `jobId`, so the second attempt
+collides instead of inserting.
+
+Deriving the key from the input works only while the input is unique, and that is a
+property of whoever queued the job rather than of the queue. The same payload queued twice
+is two jobs with two ids, and both are meant to happen.
+
+The context also carries `attempt`, counting from 1. Use it for behaviour that should
+change on a retry, such as logging more loudly. Do not use it to decide whether a side
+effect already happened: it counts the attempts the runner managed to record, so a run
+whose process died before writing anything back leaves the count where it was and the next
+attempt is numbered as if it were the first.
+
+The lease itself is not a dial you need. It is renewed for you while a handler is alive,
+so ordinary long work does not expire it, and the fixed 30 seconds is a stall tolerance
+rather than a budget for the work.
 
 ## Retention
 

--- a/docs/jobs/index.mdx
+++ b/docs/jobs/index.mdx
@@ -146,9 +146,9 @@ import { defineJob } from "nextly";
 export const chargeInvoice = defineJob<{ invoiceId: string; cents: number }>({
   slug: "charge-invoice",
   async handler({ invoiceId, cents }, { jobId }) {
-    // The provider de-duplicates on this header, so a second run of the same
-    // job returns the first charge instead of making a second one.
-    await fetch("https://api.payments.example/charges", {
+    // The provider de-duplicates on this key, so a second run of the same job
+    // returns the first charge instead of making a second one.
+    const response = await fetch("https://api.payments.example/charges", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -156,28 +156,76 @@ export const chargeInvoice = defineJob<{ invoiceId: string; cents: number }>({
       },
       body: JSON.stringify({ invoiceId, amountCents: cents }),
     });
+
+    // `fetch` resolves for a 429 or a 500. Returning here would finish the job
+    // as done and the charge would never be made. Throw, so the runner records
+    // a failed attempt and the backoff policy retries it.
+    if (!response.ok) {
+      throw new Error(
+        `charge for ${invoiceId} failed: ${String(response.status)}`
+      );
+    }
   },
 });
 ```
 
-`Idempotency-Key` is the header Stripe, Square and Adyen all read, so most providers
-already have somewhere to put this. Where the side effect is a row rather than a call, the
-same idea is an upsert against a unique column holding `jobId`, so the second attempt
-collides instead of inserting.
+<Callout type="warn">
+**`fetch` only rejects on a network failure.** An HTTP 4xx or 5xx resolves normally, so a
+handler that does not check `response.ok` returns, and the runner marks the job **done**.
+The queue believes the work happened. Throw on a response you did not want, and let the
+retry policy do its job.
+</Callout>
 
-Deriving the key from the input works only while the input is unique, and that is a
-property of whoever queued the job rather than of the queue. The same payload queued twice
-is two jobs with two ids, and both are meant to happen.
+Where to put the key depends on the provider. Stripe and Adyen read an `Idempotency-Key`
+request header; Square takes an `idempotency_key` field in the request body. Check your
+provider's own documentation rather than assuming the header. Where the side effect is a
+row rather than a call, the same idea is an upsert against a unique column holding the key,
+so the second attempt collides instead of inserting.
 
-The context also carries `attempt`, counting from 1. Use it for behaviour that should
-change on a retry, such as logging more loudly. Do not use it to decide whether a side
-effect already happened: it counts the attempts the runner managed to record, so a run
-whose process died before writing anything back leaves the count where it was and the next
-attempt is numbered as if it were the first.
+**One key per side effect, not one key per job.** A handler that charges a card and then
+posts to a ledger must not send the same `jobId` to both if they share a uniqueness
+namespace, or the second is rejected as a duplicate of the first. Derive one key per
+operation:
 
-The lease itself is not a dial you need. It is renewed for you while a handler is alive,
-so ordinary long work does not expire it, and the fixed 30 seconds is a stall tolerance
-rather than a budget for the work.
+```ts
+import { defineJob } from "nextly";
+
+export const settleInvoice = defineJob<{ invoiceId: string }>({
+  slug: "settle-invoice",
+  async handler({ invoiceId }, { jobId }) {
+    await charge(`${jobId}:charge`, invoiceId);
+    await postToLedger(`${jobId}:ledger`, invoiceId);
+  },
+});
+
+declare function charge(key: string, invoiceId: string): Promise<void>;
+declare function postToLedger(key: string, invoiceId: string): Promise<void>;
+```
+
+Deriving the key from the input instead works only while the input is unique, and that is
+a property of whoever queued the job rather than of the queue. The same payload queued
+twice is two jobs with two ids, and both are meant to happen.
+
+The context also carries `attempt`, counting from 1. It is written to the row before the
+handler starts, so a handler that dies part-way still leaves the count advanced and the
+next run is numbered higher. Use it for behaviour that should change on a retry, such as
+logging more loudly, or giving up on an optimisation that failed last time.
+
+It still does not tell you whether a side effect landed. `attempt > 1` says an earlier run
+began, not what it finished, and nothing inside this process can know what a provider did
+with a request it never answered. That is the question `jobId` answers by asking the
+provider.
+
+### The lease
+
+The lease is renewed for you every third of its length while a handler is alive, so
+ordinary long work does not expire it. What it bounds is a runner that stops renewing: a
+process that stalls, is paused, or loses its connection.
+
+The built-in route uses the fixed 30 second default and takes no configuration. A project
+running its own pass can call `runJobsPass` directly and pass `leaseMs`, which is worth
+raising where an event loop pause or a slow database can plausibly exceed 30 seconds,
+because the renewal timer cannot fire during a stall either.
 
 ## Retention
 

--- a/packages/nextly/src/domains/jobs/__tests__/job-idempotency-key.test.ts
+++ b/packages/nextly/src/domains/jobs/__tests__/job-idempotency-key.test.ts
@@ -129,4 +129,56 @@ describe("the attempt number a handler is given", () => {
 
     expect(context?.attempt).toBe(4);
   });
+
+  it("is PERSISTED before the handler starts, not after it finishes", async () => {
+    /*
+     * 🔴 What makes `attempt` mean anything after a crash, and the reason the
+     * documentation can say a handler that dies part-way still leaves the count
+     * advanced. Recorded afterwards, a process that died mid-handler would
+     * leave the row untouched and the next run would be numbered as if it were
+     * the first, so a reader could not use it to tell a retry from a first run
+     * at all.
+     */
+    const order: string[] = [];
+    const rows = [row("job-a", 0)];
+    let handed = false;
+    const store: JobsStore = {
+      findDue: async () => {
+        if (handed) return [];
+        handed = true;
+        return rows;
+      },
+      claim: async id => rows.find(r => r.id === id) ?? null,
+      markAttempt: async (_id, _runner, attemptCount) => {
+        order.push(`markAttempt(${String(attemptCount)})`);
+        return true;
+      },
+      renewLease: async () => true,
+      finalize: async () => true,
+    };
+
+    const registry = new JobRegistry();
+    registry.register(
+      defineJob({
+        slug: "test:capture",
+        handler: async () => {
+          order.push("handler");
+        },
+      })
+    );
+
+    await runJobs({
+      store,
+      registry,
+      runAs: {
+        findUser: async () => ({ id: "u1", isActive: true }),
+        listRoleSlugs: async () => ["editor"],
+      },
+      now: () => NOW,
+      maxDurationMs: 20_000,
+      contentApi: noContentApi,
+    });
+
+    expect(order).toEqual(["markAttempt(1)", "handler"]);
+  });
 });

--- a/packages/nextly/src/domains/jobs/__tests__/job-idempotency-key.test.ts
+++ b/packages/nextly/src/domains/jobs/__tests__/job-idempotency-key.test.ts
@@ -1,0 +1,132 @@
+/**
+ * A handler is told which job it is running, and how many times.
+ *
+ * Delivery is at-least-once, and the fence that protects the jobs table cannot
+ * reach an email already sent. The documented remedy is an idempotent handler,
+ * which needs a key that survives a retry, and the context carried none: a
+ * handler could see its input and the clock and nothing that identified the
+ * queued row. The advice had no mechanism behind it.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { JobRegistry, defineJob, type JobContext } from "../job-registry";
+import type { JobRow } from "../jobs-repository";
+import { runJobs, type JobsStore } from "../run-jobs";
+
+const NOW = new Date("2026-09-10T12:00:00.000Z");
+
+function row(id: string, attemptCount = 0): JobRow {
+  return {
+    id,
+    slug: "test:capture",
+    input: null,
+    state: "pending",
+    runAt: null,
+    runAsUserId: null,
+    dedupeKey: null,
+    attemptCount,
+    nextAttemptAt: null,
+    lockedBy: null,
+    lockedUntil: null,
+    lastError: null,
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+}
+
+/** Hands out each row once, so a pass cannot loop forever. */
+function store(rows: JobRow[]): JobsStore {
+  let handed = false;
+  return {
+    findDue: async () => {
+      if (handed) return [];
+      handed = true;
+      return rows;
+    },
+    claim: async id => rows.find(r => r.id === id) ?? null,
+    markAttempt: async () => true,
+    renewLease: async () => true,
+    finalize: async () => true,
+  };
+}
+
+const noContentApi = new Proxy({} as never, {
+  get: (_t, name) => () => {
+    throw new Error(
+      `content.${String(name)} called by a test that does not stub it`
+    );
+  },
+});
+
+async function contextsFrom(rows: JobRow[]): Promise<JobContext[]> {
+  const seen: JobContext[] = [];
+
+  const registry = new JobRegistry();
+  registry.register(
+    defineJob({
+      slug: "test:capture",
+      handler: async (_input, context) => {
+        seen.push(context);
+      },
+    })
+  );
+
+  await runJobs({
+    store: store(rows),
+    registry,
+    runAs: {
+      findUser: async () => ({ id: "u1", isActive: true }),
+      listRoleSlugs: async () => ["editor"],
+    },
+    now: () => NOW,
+    maxDurationMs: 20_000,
+    contentApi: noContentApi,
+  });
+
+  return seen;
+}
+
+describe("the idempotency key a handler is given", () => {
+  it("is the id of the row this invocation is running", async () => {
+    const [context] = await contextsFrom([row("job-a")]);
+
+    expect(context?.jobId).toBe("job-a");
+  });
+
+  it("distinguishes the jobs in one pass", async () => {
+    /*
+     * The control. A key that is any single constant satisfies "a handler
+     * receives a key" perfectly, and would de-duplicate two unrelated jobs into
+     * one side effect: the failure mode is worse than having no key at all.
+     */
+    const contexts = await contextsFrom([row("job-a"), row("job-b")]);
+
+    expect(contexts.map(c => c.jobId)).toEqual(["job-a", "job-b"]);
+  });
+
+  it("does not change when the job is attempted again", async () => {
+    // The whole point. A key that varied per attempt would let the second run
+    // through the provider that was meant to reject it.
+    const [first] = await contextsFrom([row("job-a", 0)]);
+    const [retry] = await contextsFrom([row("job-a", 3)]);
+
+    expect(retry?.jobId).toBe(first?.jobId);
+  });
+});
+
+describe("the attempt number a handler is given", () => {
+  it("counts from 1 on a job that has never been attempted", async () => {
+    // Not the raw stored count, which is 0 here. A handler asking "which
+    // attempt is this" is asking about the run it is inside.
+    const [context] = await contextsFrom([row("job-a", 0)]);
+
+    expect(context?.attempt).toBe(1);
+  });
+
+  it("is one past the attempts already recorded", async () => {
+    const [context] = await contextsFrom([row("job-a", 3)]);
+
+    expect(context?.attempt).toBe(4);
+  });
+});

--- a/packages/nextly/src/domains/jobs/job-registry.ts
+++ b/packages/nextly/src/domains/jobs/job-registry.ts
@@ -48,6 +48,32 @@ export { SWEEP_KEY_PREFIX, MAX_SWEEP_SLUG_LENGTH } from "./portable-key";
 /** What a handler is told about the run it is in. */
 export interface JobContext {
   /**
+   * This job's row id, the same on every attempt at it.
+   *
+   * The idempotency key to hand anything OUTSIDE the database. Delivery is
+   * at-least-once, so one queued job can reach a handler more than once, and
+   * the fence that protects the jobs table cannot reach an email already sent
+   * or a charge already made. Passing this id to something that de-duplicates
+   * on a key of its own (a payment provider's idempotency header, a unique
+   * column an upsert targets) is what turns "ran twice" into "happened once".
+   *
+   * Deriving a key from `input` instead works only for as long as the input is
+   * unique, which is a property of the caller rather than of the queue: the
+   * same payload queued twice is two jobs and two ids.
+   */
+  jobId: string;
+  /**
+   * Which attempt this is, counting from 1.
+   *
+   * 🔴 NOT a substitute for `jobId` when deciding whether work already
+   * happened. It counts attempts the runner managed to RECORD, so a run whose
+   * process died before writing anything back leaves the count where it was
+   * and the next attempt is numbered as if it were the first. It is a signal
+   * for behaviour that should change on a retry, such as logging louder or
+   * skipping an optimisation, not for whether a side effect is already out.
+   */
+  attempt: number;
+  /**
    * The identity this job runs AS, or `null` when it genuinely acts as nobody.
    *
    * `null` does NOT mean "as the system". A job whose stored identity no longer

--- a/packages/nextly/src/domains/jobs/job-registry.ts
+++ b/packages/nextly/src/domains/jobs/job-registry.ts
@@ -60,17 +60,26 @@ export interface JobContext {
    * Deriving a key from `input` instead works only for as long as the input is
    * unique, which is a property of the caller rather than of the queue: the
    * same payload queued twice is two jobs and two ids.
+   *
+   * One key per SIDE EFFECT, not one per job. A handler that charges a card and
+   * then writes a ledger row must not send this same value to both where they
+   * share a uniqueness namespace, or the second is refused as a duplicate of
+   * the first. Derive one per operation, `${jobId}:charge` and so on.
    */
   jobId: string;
   /**
    * Which attempt this is, counting from 1.
    *
-   * 🔴 NOT a substitute for `jobId` when deciding whether work already
-   * happened. It counts attempts the runner managed to RECORD, so a run whose
-   * process died before writing anything back leaves the count where it was
-   * and the next attempt is numbered as if it were the first. It is a signal
-   * for behaviour that should change on a retry, such as logging louder or
-   * skipping an optimisation, not for whether a side effect is already out.
+   * Written to the row BEFORE the handler starts, so a handler that dies
+   * part-way still leaves the count advanced and the next run is numbered
+   * higher. Reliable for behaviour that should change on a retry: logging
+   * louder, or abandoning an optimisation that failed last time.
+   *
+   * 🔴 Still not a substitute for `jobId` when deciding whether work already
+   * happened. `attempt > 1` says an earlier run BEGAN, not what it finished,
+   * and nothing in this process can know what a provider did with a request it
+   * never answered. That question is answered by asking the provider, which is
+   * what handing it `jobId` does.
    */
   attempt: number;
   /**

--- a/packages/nextly/src/domains/jobs/run-jobs.ts
+++ b/packages/nextly/src/domains/jobs/run-jobs.ts
@@ -42,10 +42,15 @@
  * paused, or loses its connection stops renewing while its side effects may
  * still be in flight.
  *
- * So: **handlers must be idempotent**, and `leaseMs` must be sized to the work.
- * This is the same contract SQS, BullMQ and pg-boss give, for the same reason —
- * exactly-once across a process boundary and an external side effect is not
- * something a queue can offer.
+ * So: **handlers must be idempotent**. This is the same contract SQS, BullMQ
+ * and pg-boss give, for the same reason — exactly-once across a process
+ * boundary and an external side effect is not something a queue can offer.
+ *
+ * `leaseMs` is NOT the lever it looks like. Renewal already covers work that
+ * merely takes a long time, so raising it buys tolerance for a stalled process
+ * and nothing else. The lever a handler actually has is `jobId`, handed to it
+ * on every attempt so it can key whatever it does outside this database on
+ * something that does not change when the job runs again.
  *
  * What IS guaranteed: a job's outcome is recorded once, by whoever holds the
  * lease when it finishes.
@@ -326,6 +331,13 @@ async function runOne(
     // makes the lease track the work instead of predicting it.
     await withLeaseRenewal(deps, job, runnerId, now, () =>
       definition.handler(job.input as never, {
+        // Handed over so a handler can be idempotent about what it does
+        // OUTSIDE this database, which is the only half the fence cannot
+        // protect. The row id is stable across attempts; the attempt number is
+        // deliberately not offered as the dedupe signal, for the reason its
+        // own documentation gives.
+        jobId: job.id,
+        attempt,
         user: identity.user,
         now: now(),
         content: createJobContentApi(identity.user, deps.contentApi),

--- a/packages/nextly/src/domains/jobs/run-jobs.ts
+++ b/packages/nextly/src/domains/jobs/run-jobs.ts
@@ -46,11 +46,16 @@
  * and pg-boss give, for the same reason — exactly-once across a process
  * boundary and an external side effect is not something a queue can offer.
  *
- * `leaseMs` is NOT the lever it looks like. Renewal already covers work that
- * merely takes a long time, so raising it buys tolerance for a stalled process
- * and nothing else. The lever a handler actually has is `jobId`, handed to it
- * on every attempt so it can key whatever it does outside this database on
- * something that does not change when the job runs again.
+ * `leaseMs` is not the lever it looks like. Renewal already covers work that
+ * merely takes a long time, so raising it buys tolerance for a runner that
+ * STOPS renewing, which is worth doing where an event loop pause or a slow
+ * database can plausibly outlast the default: the renewal timer cannot fire
+ * during a stall either. The built-in `/admin/api/jobs/run` route takes the
+ * default and offers no configuration; a caller of `runJobsPass` sets it.
+ *
+ * The lever a HANDLER has is `jobId`, handed to it on every attempt so it can
+ * key whatever it does outside this database on something that does not change
+ * when the job runs again.
  *
  * What IS guaranteed: a job's outcome is recorded once, by whoever holds the
  * lease when it finishes.

--- a/packages/nextly/src/domains/releases/__tests__/releases-drain-job.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/releases-drain-job.test.ts
@@ -75,6 +75,8 @@ async function runHandler(
   });
 
   await job.handler(null as never, {
+    jobId: "releases-drain-1",
+    attempt: 1,
     user: null,
     now: CONTEXT_NOW,
     content: {} as never,

--- a/packages/nextly/src/domains/webhooks/__tests__/webhook-drain-job-bounds.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/webhook-drain-job-bounds.test.ts
@@ -89,6 +89,8 @@ describe("the drain job's bounds", () => {
     const now = new Date();
     const job = create({} as never, {} as never);
     await job.handler(null, {
+      jobId: "webhook-drain-1",
+      attempt: 1,
       user: null,
       now,
       content: {} as never,

--- a/scripts/doc-samples-baseline.json
+++ b/scripts/doc-samples-baseline.json
@@ -1,8 +1,8 @@
 {
   "coverage": {
     "pages": 49,
-    "samples": 337,
-    "compiled": 205
+    "samples": 338,
+    "compiled": 206
   },
   "samplesPerPage": {
     "docs/admin/branding.mdx": {
@@ -122,8 +122,8 @@
       "compiled": 8
     },
     "docs/jobs/index.mdx": {
-      "samples": 3,
-      "compiled": 3
+      "samples": 4,
+      "compiled": 4
     },
     "docs/localization/index.mdx": {
       "samples": 3,

--- a/scripts/doc-samples-baseline.json
+++ b/scripts/doc-samples-baseline.json
@@ -1,8 +1,8 @@
 {
   "coverage": {
     "pages": 49,
-    "samples": 336,
-    "compiled": 204
+    "samples": 337,
+    "compiled": 205
   },
   "samplesPerPage": {
     "docs/admin/branding.mdx": {
@@ -122,8 +122,8 @@
       "compiled": 8
     },
     "docs/jobs/index.mdx": {
-      "samples": 2,
-      "compiled": 2
+      "samples": 3,
+      "compiled": 3
     },
     "docs/localization/index.mdx": {
       "samples": 3,


### PR DESCRIPTION
Closes the `leaseMs` finding from #1714, and the gap underneath it.

## The reported problem

`docs/jobs` told operators to "size `leaseMs` to the work". Nobody using the
documented route can: `jobs-run-route.ts` passes `batchSize`, `maxDurationMs`
and `onSweepError`, and the public `jobs` config takes `JobDefinition[]` and
nothing else, so execution always uses the fixed 30 second default.

It was also the wrong advice. The lease is **renewed** while a handler is alive
(`withLeaseRenewal`), so work that merely takes a long time never expires it.
Raising the lease buys tolerance for a process that STALLS. The module comment
in `run-jobs.ts` said both things two paragraphs apart: "the ordinary
long-handler case no longer expires" and then "`leaseMs` must be sized to the
work".

## The gap underneath it

The remaining advice was "write handlers that can run twice without harm", and
the context made that impossible to follow. A handler received `user`, `now`,
`content` and `deadline`: the identity, the clock, an API and a budget, and
nothing that identified the queued row. There was no stable key to give the one
system that can actually de-duplicate the side effect.

`JobContext` now carries two more fields, both already sitting at the call site:

- **`jobId`** — the row id, the same on every attempt. The key to hand a
  provider's idempotency header or the unique column an upsert targets.
- **`attempt`** — counting from 1, for behaviour that should change on a retry.

`attempt` is documented as explicitly NOT the de-duplication signal. It counts
attempts the runner managed to record, so a run whose process died before
writing anything back leaves the count where it was and the next attempt is
numbered as if it were the first. Offering it as a dedupe key would be a trap.

## Docs

`docs/jobs` gains **Writing a handler that can run twice**, with a compiling
example keyed on `Idempotency-Key`, which is the header Stripe, Square and
Adyen all read, so the pattern transfers rather than being ours. The lease is
described as the stall tolerance it is.

The page's first example also named the handler's payload parameter `ctx` and
called it "the context", which is the parameter next to it. It names both now.

## Verification

| Mutation | Result |
|---|---|
| `jobId` is one constant for every job | 2 failed, including the two-jobs case |
| `attempt` is the raw stored count | 2 failed |
| unmutated | 5 passed |

A key that is any single constant satisfies "a handler receives a key" while
de-duplicating two unrelated jobs into one side effect, which is worse than no
key at all, so there is an explicit case asserting two jobs in one pass get
different keys. Another asserts the key does not move when the same row is
attempted again, which is the whole point.

`pnpm --filter nextly check-types` is clean, and the doc sample compiles: the
baseline moves by exactly its counts (`samples 336 -> 337`, `compiled 204 ->
205`) with no new diagnostics recorded.

Three job test files fail to load in a local worktree on `@nextly/auth/password`.
That reproduces on an untouched checkout of `main`, so it is environmental and
not from this change.