### PR TITLE
feat(nextly): a write records what kind of caller made it

### DIFF
--- a/.changeset/a-write-records-what-made-it.md
+++ b/.changeset/a-write-records-what-made-it.md
@@ -26,18 +26,25 @@
 "@nextlyhq/module-specifiers": patch
 ---
 
-A write records what kind of caller made it.
+An API key's write appears in the activity trail.
 
-An API-key write, an import, a job write and a bulk edit recorded nothing in
-the activity trail — not mislabelled, absent. The recorder refused any actor
-that was not a signed-in person, because a row's identity column is joined to
-the accounts table and a key's own id would find no account and be filed as an
-already-erased person.
+It recorded nothing before — not mislabelled, absent. The recorder refused any
+actor that was not a signed-in person, because a row's identity column is
+joined to the accounts table and a key's own id would find no account and be
+filed as an already-erased person. So every write made with an API key was
+invisible, and nothing about it is recoverable after the fact.
 
-The row now carries the KIND of caller that column refers to, so each is
-recorded as itself. `user_id` is unchanged and still required: it is already
-documented as the actor's opaque reference, so one nullable `actor_type` is the
-whole schema change and no dialect needs a nullability rebuild.
+The row now carries the KIND of caller its identity column refers to, and the
+admin's Recent Activity names the key rather than showing a blank actor.
+`user_id` is unchanged and still required: it is already documented as the
+actor's opaque reference, so one nullable `actor_type` is the whole schema
+change and no dialect needs a nullability rebuild.
 
 A NULL kind means a row written before this existed. Those are all user writes,
 because no other kind was recordable.
+
+Writes with NO initiating actor — seeds, migrations, imports and jobs — are
+still not recorded, and the reason has changed rather than gone away. They run
+while the schema is being created, and a failure to write the trail fails the
+surrounding write: a trail insert against a table that does not exist yet would
+fail the seed that was creating it. That needs its own answer.

--- a/.changeset/a-write-records-what-made-it.md
+++ b/.changeset/a-write-records-what-made-it.md
@@ -1,0 +1,43 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A write records what kind of caller made it.
+
+An API-key write, an import, a job write and a bulk edit recorded nothing in
+the activity trail — not mislabelled, absent. The recorder refused any actor
+that was not a signed-in person, because a row's identity column is joined to
+the accounts table and a key's own id would find no account and be filed as an
+already-erased person.
+
+The row now carries the KIND of caller that column refers to, so each is
+recorded as itself. `user_id` is unchanged and still required: it is already
+documented as the actor's opaque reference, so one nullable `actor_type` is the
+whole schema change and no dialect needs a nullability rebuild.
+
+A NULL kind means a row written before this existed. Those are all user writes,
+because no other kind was recordable.

--- a/packages/admin/src/hooks/queries/useRecentActivity.ts
+++ b/packages/admin/src/hooks/queries/useRecentActivity.ts
@@ -23,6 +23,14 @@ import type {
 
 interface ActivityLogEntry {
   id: string;
+  /**
+   * What KIND of caller `userId` refers to.
+   *
+   * Optional because a server older than this admin does not send it. The
+   * display helper decides what an absent value means, so this surface and any
+   * other reading the feed cannot disagree about it.
+   */
+  actorType?: "user" | "apiKey" | "system";
   userId: string;
   /** Null once the actor's account was deleted and their identity erased. */
   userName: string | null;

--- a/packages/admin/src/lib/dashboard.test.ts
+++ b/packages/admin/src/lib/dashboard.test.ts
@@ -48,6 +48,57 @@ describe("formatRelativeTime", () => {
 });
 
 describe("describeActivityActor", () => {
+  it("names an API key rather than rendering a blank actor", () => {
+    // A key has no account, so no name, no email and no erasure stamp. Without
+    // its own branch it falls through to the live-actor case and renders an
+    // empty name — a feed less attributable than the one before keys were
+    // recorded at all.
+    const actor = describeActivityActor({
+      userId: "k1b2c3d4-0000-4000-8000-000000000009",
+      userName: null,
+      userEmail: null,
+      identityErasedAt: null,
+      actorType: "apiKey",
+    });
+    expect(actor.name).toContain("API key");
+    // The key's own id, so two keys are told apart rather than both reading
+    // "API key".
+    expect(actor.name).toContain("k1b2c3d4");
+    expect(actor.initials).toBeTruthy();
+    // Not a deleted person: nothing was erased, and saying so would send a
+    // reader looking for an account that never existed.
+    expect(actor.deleted).toBe(false);
+    expect(actor.email).toBeNull();
+  });
+
+  it("reads an ABSENT kind as a user", () => {
+    // A server older than this admin does not send the field. Before it
+    // existed only a signed-in person could be recorded, so the absence is
+    // read rather than guessed — and treating it as a non-person would
+    // attribute a real person's write to a machine.
+    const actor = describeActivityActor({
+      userId: "a1b2c3d4-0000-4000-8000-000000000001",
+      userName: "Ada Author",
+      userEmail: "ada@example.com",
+      identityErasedAt: null,
+    });
+    expect(actor.name).toBe("Ada Author");
+  });
+
+  it("shows a deleted PERSON as deleted, not as a key", () => {
+    // The control for the branch above: the key case is checked first, so a
+    // condition that matched too broadly would relabel every erased account.
+    const actor = describeActivityActor({
+      userId: "a1b2c3d4-0000-4000-8000-000000000001",
+      userName: null,
+      userEmail: null,
+      identityErasedAt: "2026-03-06T12:00:00Z",
+      actorType: "user",
+    });
+    expect(actor.deleted).toBe(true);
+    expect(actor.name).not.toContain("API key");
+  });
+
   // A live actor: `identityErasedAt` is null, which is the single field that
   // decides every case below. Each test starts from this and changes only what
   // it is about, so a failure names the difference that caused it.

--- a/packages/admin/src/lib/dashboard.ts
+++ b/packages/admin/src/lib/dashboard.ts
@@ -11,6 +11,9 @@ import type { ActivityUser } from "@admin/types/dashboard/activity";
 /** Avatar fallback for an actor whose identity was erased. */
 const DELETED_ACTOR_INITIALS = "?";
 
+/** Avatar initials for a key, which has no name to take them from. */
+const API_KEY_ACTOR_INITIALS = "AK";
+
 /**
  * How much of the actor's id is shown beside "deleted user".
  *
@@ -41,7 +44,31 @@ export function describeActivityActor(entry: {
   userName: string | null;
   userEmail: string | null;
   identityErasedAt: string | null;
+  /**
+   * What KIND of caller `userId` refers to.
+   *
+   * Optional because it arrives over HTTP: a server older than this admin does
+   * not send it, and an absent field must read as the kind that was the only
+   * recordable one before it existed rather than as an unknown.
+   */
+  actorType?: string | null;
 }): ActivityUser {
+  // An API key has no account, so it has no name, no email and no erasure — the
+  // three things every branch below reads. Without this it falls through to the
+  // live-actor case and renders a BLANK name, which is a less attributable feed
+  // than the one before keys were recorded at all.
+  if (entry.actorType === "apiKey") {
+    return {
+      id: entry.userId,
+      // The key's own id, shortened the way a deleted actor's is, so two keys
+      // are told apart rather than both reading "API key".
+      name: `API key · ${entry.userId.slice(0, DELETED_ACTOR_ID_LENGTH)}`,
+      email: null,
+      initials: API_KEY_ACTOR_INITIALS,
+      deleted: false,
+    };
+  }
+
   // The stamp is the authority: a live actor can legitimately have no name
   // (the writer falls back through name → firstName → email), and calling
   // that person deleted would be worse than showing an empty label.

--- a/packages/nextly/eslint-api-key-scope-rule.js
+++ b/packages/nextly/eslint-api-key-scope-rule.js
@@ -69,7 +69,16 @@ export const API_KEY_SCOPE_SELECTOR =
   // scope. A guard that fires on correct code is the one people work around,
   // and the workarounds — renaming the field, disabling the rule — cost its
   // true positives too.
-  'ObjectExpression:has(> Property[key.name="actorType"][value.value="apiKey"])' +
+  //
+  // Both spellings of the literal, because `{ actorType: "apiKey" as const }`
+  // wraps it in a `TSAsExpression` and an attribute match on the property's own
+  // value cannot see through one. Two attribute paths rather than a descendant
+  // match: measured, a descendant `Literal[value="apiKey"]` matches NEITHER
+  // spelling, and `as const` is the ordinary TypeScript way to write this.
+  "ObjectExpression:has(" +
+  '> Property[key.name="actorType"][value.value="apiKey"], ' +
+  '> Property[key.name="actorType"][value.expression.value="apiKey"]' +
+  ")" +
   ":has(> SpreadElement)";
 
 export const API_KEY_SCOPE_MESSAGE =

--- a/packages/nextly/eslint-api-key-scope-rule.js
+++ b/packages/nextly/eslint-api-key-scope-rule.js
@@ -56,8 +56,21 @@
  * PAIR is what a scope is.
  */
 export const API_KEY_SCOPE_SELECTOR =
+  // The PAIR, in either order, whatever the values: this is what all nine
+  // hand-built scopes looked like.
   'ObjectExpression:has(> Property[key.name="actorType"])' +
-  ':has(> Property[key.name="permissions"], > SpreadElement)';
+  ':has(> Property[key.name="permissions"]), ' +
+  // Or the pair with the second half hidden behind a spread —
+  // `{ actorType: "apiKey", ...auth }` — which the shape above cannot see.
+  //
+  // Narrowed to the LITERAL `"apiKey"` on purpose. `actorType` plus any spread
+  // matched every object that merely carries a field of that name and spreads
+  // anything, and an activity-log row does exactly that while being no kind of
+  // scope. A guard that fires on correct code is the one people work around,
+  // and the workarounds — renaming the field, disabling the rule — cost its
+  // true positives too.
+  'ObjectExpression:has(> Property[key.name="actorType"][value.value="apiKey"])' +
+  ":has(> SpreadElement)";
 
 export const API_KEY_SCOPE_MESSAGE =
   "Build an API-key scope with `apiKeyScopeFrom(caller)`, or narrow one you hold with " +

--- a/packages/nextly/src/auth/__tests__/api-key-scope-selector.test.ts
+++ b/packages/nextly/src/auth/__tests__/api-key-scope-selector.test.ts
@@ -69,6 +69,17 @@ describe("the API-key scope selector", () => {
     ).toBe(true);
   });
 
+  it("fires on a const-asserted literal before a spread", async () => {
+    // `as const` wraps the literal in a TSAsExpression, so an attribute match
+    // on the property's own value cannot see it — and this is the ordinary
+    // TypeScript spelling of the shape the arm above exists for.
+    expect(
+      await firesOn(
+        'const a = {}; const s = { actorType: "apiKey" as const, ...a };'
+      )
+    ).toBe(true);
+  });
+
   it("does NOT fire on a row that merely has an actorType and a spread", async () => {
     // An activity-log row records what KIND of caller wrote it and spreads its
     // optional columns. It is no kind of scope, and a guard that refuses it is

--- a/packages/nextly/src/auth/__tests__/api-key-scope-selector.test.ts
+++ b/packages/nextly/src/auth/__tests__/api-key-scope-selector.test.ts
@@ -1,0 +1,88 @@
+/**
+ * The shapes the API-key scope guard fires on, and the ones it must not.
+ *
+ * The selector answers a question with two failure directions, and they are not
+ * symmetric. A MISS lets a hand-built scope back in — the defect the rule
+ * exists for. A FALSE POSITIVE is worse in a different way: it fires on code
+ * that is no kind of scope, and the cheapest ways out are renaming the field or
+ * disabling the rule, both of which cost every true positive too.
+ *
+ * That direction was live. `actorType` plus ANY spread matched every object
+ * carrying a field of that name and spreading anything, and an activity-log row
+ * does exactly that.
+ *
+ * @module auth/__tests__/api-key-scope-selector.test
+ */
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { ESLint } from "eslint";
+import { describe, expect, it } from "vitest";
+
+const packageRoot = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../.."
+);
+
+/** Whether the scope guard fires on `source`, linted as real package source. */
+async function firesOn(source: string): Promise<boolean> {
+  const results = await new ESLint({ cwd: packageRoot }).lintText(source, {
+    // A path that REALLY EXISTS in the package's tsconfig project. Type-aware
+    // linting resolves the file through the project service, and an invented
+    // path fails to parse — which arrives as a fatal message rather than as a
+    // rule that declined to fire, so the guard below tells the two apart.
+    filePath: join(packageRoot, "src", "api", "releases.ts"),
+  });
+  const messages = results[0]?.messages ?? [];
+  // A parse failure arrives as a fatal message with a null ruleId, which would
+  // otherwise read as "the rule did not fire" — the same answer a correct
+  // exemption gives.
+  const fatal = messages.find(message => message.fatal);
+  if (fatal) throw new Error(`probe failed to parse: ${fatal.message}`);
+  return messages.some(
+    message =>
+      message.ruleId === "no-restricted-syntax" &&
+      message.message.includes("apiKeyScopeFrom")
+  );
+}
+
+describe("the API-key scope selector", () => {
+  it("fires on the pair, which is what all nine instances looked like", async () => {
+    expect(
+      await firesOn('const s = { actorType: "apiKey", permissions: [] };')
+    ).toBe(true);
+  });
+
+  it("fires whichever order the pair is written in", async () => {
+    // `:has()` is order-independent; a scan over source is not, and the regex
+    // this replaced could be evaded by swapping the two keys.
+    expect(
+      await firesOn('const s = { permissions: [], actorType: "apiKey" };')
+    ).toBe(true);
+  });
+
+  it("fires when the second half is hidden behind a spread", async () => {
+    // `{ actorType: "apiKey", ...auth }` is as lossy as the pair and the pair
+    // shape cannot see it.
+    expect(
+      await firesOn('const a = {}; const s = { actorType: "apiKey", ...a };')
+    ).toBe(true);
+  });
+
+  it("does NOT fire on a row that merely has an actorType and a spread", async () => {
+    // An activity-log row records what KIND of caller wrote it and spreads its
+    // optional columns. It is no kind of scope, and a guard that refuses it is
+    // one a developer works around.
+    expect(
+      await firesOn(
+        'const rest = {}; const row = { actorType: "user" as string, userId: "u", ...rest };'
+      )
+    ).toBe(false);
+  });
+
+  it("does NOT fire on an object that only names an actorType", async () => {
+    // `actorType` alone would reject the webhook outbox row and its column
+    // definitions, which carry that field and are not scopes.
+    expect(await firesOn('const w = { actorType: "apiKey" };')).toBe(false);
+  });
+});

--- a/packages/nextly/src/domains/audit/record-activity.ts
+++ b/packages/nextly/src/domains/audit/record-activity.ts
@@ -23,8 +23,9 @@ import type {
   ActivityLogService,
   ActivityWriteDb,
 } from "../../services/dashboard/activity-log-service";
-import { SYSTEM_CONTEXT } from "../../shared/types";
 import { computeChangedFields } from "../webhooks/envelope";
+
+import { recordableActor } from "./record-settings-activity";
 
 /** What one mutation records, as the choke point already knows it. */
 export interface RecordMutationActivityInput {
@@ -136,15 +137,12 @@ function feedHeading(
 export function willRecordMutationActivity(
   collection: string,
   actor?: RequestActor | null
-): actor is RequestActor & { type: "user"; id: string } {
-  if (actor?.type !== "user" || !actor.id) return false;
-  // `SYSTEM_CONTEXT` is a RequestContext whose user carries the reserved id
-  // `system`, so a seed or migration passing it — with no transport actor to
-  // override it — resolves to a USER actor rather than a system one. No account
-  // owns that id, so the entry would be stored already-erased, attributing an
-  // internal write to a person who does not exist. Compared against the
-  // sentinel itself so the two cannot drift apart.
-  if (actor.id === SYSTEM_CONTEXT.user?.id) return false;
+): actor is RequestActor & { id: string } {
+  // Whether an actor belongs in the trail is `recordableActor`'s question,
+  // asked rather than restated: this file carried its own copy of the rule and
+  // the two had to be widened together, which is the drift that docblock warns
+  // about. What is local here is the collection's visibility.
+  if (!recordableActor(actor)) return false;
   return !collectionViews().hidden.has(collection);
 }
 
@@ -200,8 +198,12 @@ export async function recordMutationActivity(
   // the same lock that decides whether it still exists. The alternative — the
   // session's copy, carried down from the request — is a snapshot taken before
   // that decision and can name an account that has since been renamed.
+  // Non-null by the gate above, which every caller runs first.
+  const actor = recordableActor(input.actor);
+  if (!actor) return;
   await service.logActivityInTx(db(), {
-    userId: input.actor.id,
+    actorType: actor.type,
+    userId: actor.id,
     action: input.action,
     collection: input.collection,
     ...(input.locale === undefined ? {} : { locale: input.locale }),

--- a/packages/nextly/src/domains/audit/record-settings-activity.ts
+++ b/packages/nextly/src/domains/audit/record-settings-activity.ts
@@ -25,7 +25,7 @@
  * @module domains/audit/record-settings-activity
  */
 
-import type { RequestActor } from "../../auth/request-actor";
+import type { RequestActor, RequestActorType } from "../../auth/request-actor";
 import { container } from "../../di/container";
 import type {
   ActivityLogAction,
@@ -34,27 +34,40 @@ import type {
 import { SYSTEM_CONTEXT } from "../../shared/types";
 
 /**
- * Whether this actor produces an entry.
+ * The actor a trail row records, or `null` when this actor produces no entry.
  *
- * Only a signed-in person. An API key and an internal write carry no account,
- * and the trail's actor column is a user reference whose erasure state is
- * answered against the accounts table — a key's own id finds no account there
- * and would be filed as an already-erased identity, which is a worse record
- * than none.
+ * Answers both halves of the question at once — whether to record, and as WHAT
+ * — because they are decided by the same facts and a caller that asked them
+ * separately could record a row whose kind disagreed with the gate that let it
+ * through.
+ *
+ * Every actor that can name itself belongs in the trail. The rule used to admit
+ * a signed-in person alone, because a row's only identity column was a user
+ * reference joined to the accounts table: a key's own id there found no account
+ * and was filed as an already-erased identity, so a key write was dropped
+ * rather than recorded badly. `actor_type` carries the kind now and `user_id`
+ * is set only for a `user`, so a key, an import or a job records what it is.
  *
  * Exported and shared rather than restated per resource. The rule is one
- * question — "does this actor belong in the trail" — and every place that
- * answers it separately is a place it can drift.
+ * question, and every place that answers it separately is a place it can drift
+ * — which it did: the content trail carried its own copy and the two had to be
+ * widened together.
  */
-export function isRecordableActor(
+export function recordableActor(
   actor?: RequestActor | null
-): actor is RequestActor & { type: "user"; id: string } {
-  if (actor?.type !== "user" || !actor.id) return false;
+): { type: RequestActorType; id: string } | null {
+  if (!actor?.id) return null;
   // `SYSTEM_CONTEXT` carries the reserved user id `system`, so a seed or a
-  // migration with no transport actor to override it resolves to a USER actor.
-  // No account owns that id. Compared against the sentinel itself so the two
-  // cannot drift apart.
-  return actor.id !== SYSTEM_CONTEXT.user?.id;
+  // migration with no transport actor to override it arrives as a USER actor.
+  // No account owns that id, so recording it as a user would attribute an
+  // internal write to a person who does not exist. Compared against the
+  // sentinel itself so the two cannot drift apart, and rewritten rather than
+  // refused: the write IS a system write, and a row can say so now.
+  const type =
+    actor.type === "user" && actor.id === SYSTEM_CONTEXT.user?.id
+      ? "system"
+      : actor.type;
+  return { type, id: actor.id };
 }
 
 /** One recorded settings mutation. */
@@ -115,7 +128,8 @@ function worthRecording(input: SettingsActivityInput): boolean {
 export async function recordSettingsActivity(
   input: SettingsActivityInput
 ): Promise<void> {
-  if (!isRecordableActor(input.actor)) return;
+  const actor = recordableActor(input.actor);
+  if (!actor) return;
   if (!worthRecording(input)) return;
 
   let service: ActivityLogService;
@@ -133,7 +147,8 @@ export async function recordSettingsActivity(
   // invisible, which is worse than the failure it hides. Callers own the
   // never-throw guarantee and the log line that goes with it.
   await service.logActivity({
-    userId: input.actor.id,
+    actorType: actor.type,
+    userId: actor.id,
     action: input.action,
     collection: input.collection,
     entryId: input.entityId,

--- a/packages/nextly/src/domains/audit/record-settings-activity.ts
+++ b/packages/nextly/src/domains/audit/record-settings-activity.ts
@@ -57,17 +57,27 @@ export function recordableActor(
   actor?: RequestActor | null
 ): { type: RequestActorType; id: string } | null {
   if (!actor?.id) return null;
+  // A SYSTEM write is deliberately still refused, and the reason is not the one
+  // that used to refuse a key.
+  //
+  // `actorForWrite(null, null)` returns `SYSTEM_ACTOR` for every write that
+  // names no actor — seeds, migrations, maintenance, and any internal call that
+  // simply did not pass one. Those run while the schema is being created, and
+  // this recorder's failures PROPAGATE and take the surrounding write with
+  // them: a trail insert against a table that does not exist yet would fail the
+  // seed that was creating it.
+  //
+  // A key is different. It arrives on a request, over a transport, against a
+  // database that is already up — so admitting it costs nothing that was not
+  // already true of a user's write.
+  if (actor.type === "system") return null;
   // `SYSTEM_CONTEXT` carries the reserved user id `system`, so a seed or a
   // migration with no transport actor to override it arrives as a USER actor.
-  // No account owns that id, so recording it as a user would attribute an
-  // internal write to a person who does not exist. Compared against the
-  // sentinel itself so the two cannot drift apart, and rewritten rather than
-  // refused: the write IS a system write, and a row can say so now.
-  const type =
-    actor.type === "user" && actor.id === SYSTEM_CONTEXT.user?.id
-      ? "system"
-      : actor.type;
-  return { type, id: actor.id };
+  // No account owns that id, and it is a system write wearing a user's shape —
+  // so it is refused for the reason above rather than filed as a person.
+  // Compared against the sentinel itself so the two cannot drift apart.
+  if (actor.id === SYSTEM_CONTEXT.user?.id) return null;
+  return { type: actor.type, id: actor.id };
 }
 
 /** One recorded settings mutation. */

--- a/packages/nextly/src/domains/email/__tests__/provider-activity.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/provider-activity.test.ts
@@ -482,12 +482,18 @@ describe("email provider activity", () => {
     expect(logged).toHaveLength(0);
   });
 
-  it("records nothing for a write with no signed-in actor", async () => {
-    // A seed, a migration or an API key carries no account. The actor column is
-    // a user reference whose erasure state is answered against the accounts
-    // table, so an id with no account behind it files as an already-erased
-    // identity — a worse record than none.
+  it("records every actor that can name itself, as what it is", async () => {
+    // A seed, a migration or an API key carries no account, and each used to
+    // record NOTHING: the row's only identity column was read as a user
+    // reference, so an id with no account behind it filed as an already-erased
+    // identity. The kind is on the row now, so each is recorded as itself and a
+    // credential change stops being invisible.
+    //
+    // A write with NO actor at all still records nothing — there is no identity
+    // to attribute it to, which is a different case from an identity that is
+    // not a person.
     await service.createProvider(INPUT);
+    expect(logged).toHaveLength(0);
     await service.createProvider(
       { ...INPUT, name: "By key" },
       {
@@ -503,7 +509,11 @@ describe("email provider activity", () => {
       }
     );
 
-    expect(logged).toHaveLength(0);
+    expect(logged).toHaveLength(2);
+    expect(logged[0]).toMatchObject({ actorType: "apiKey", userId: "key-1" });
+    // The reserved id arrives as a USER actor and must not be filed as one:
+    // no account owns it, so the erasure would read it as an erased person.
+    expect(logged[1]).toMatchObject({ actorType: "system" });
   });
 
   it("does not fail the mutation when the trail cannot be written", async () => {

--- a/packages/nextly/src/domains/email/__tests__/provider-activity.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/provider-activity.test.ts
@@ -16,6 +16,7 @@ import { container } from "../../../di/container";
 import { getCoreSchema } from "../../../schemas";
 import type { LogActivityInput } from "../../../services/dashboard/activity-log-service";
 import type { Logger } from "../../../services/shared";
+import { SYSTEM_ACTOR } from "../../../auth/request-actor";
 import { SYSTEM_CONTEXT } from "../../../shared/types";
 import { createTableBody } from "../../schema/pipeline/sql-templates/create-table-body";
 import { EMAIL_PROVIDER_ACTIVITY_COLLECTION } from "../provider-activity";
@@ -509,11 +510,26 @@ describe("email provider activity", () => {
       }
     );
 
-    expect(logged).toHaveLength(2);
+    expect(logged).toHaveLength(1);
     expect(logged[0]).toMatchObject({ actorType: "apiKey", userId: "key-1" });
-    // The reserved id arrives as a USER actor and must not be filed as one:
-    // no account owns it, so the erasure would read it as an erased person.
-    expect(logged[1]).toMatchObject({ actorType: "system" });
+  });
+
+  it("records nothing for the canonical system actor", async () => {
+    // `actorForWrite(null, null)` returns `SYSTEM_ACTOR` for every write that
+    // names no actor, and those run while the schema is being created. This
+    // recorder's failures PROPAGATE, so a trail insert against a table that
+    // does not exist yet would fail the seed that was creating it.
+    //
+    // Both spellings, because they arrive by different routes: the canonical
+    // actor carries no id at all, and a seed passing SYSTEM_CONTEXT arrives as
+    // a USER actor holding the reserved id.
+    await service.createProvider({ ...INPUT, name: "By a job" }, SYSTEM_ACTOR);
+    await service.createProvider(
+      { ...INPUT, name: "By a seed" },
+      { type: "user", id: SYSTEM_CONTEXT.user?.id ?? "system" }
+    );
+
+    expect(logged).toHaveLength(0);
   });
 
   it("does not fail the mutation when the trail cannot be written", async () => {

--- a/packages/nextly/src/domains/email/__tests__/template-activity.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/template-activity.test.ts
@@ -200,7 +200,7 @@ describe("email template activity", () => {
     expect(logged[0]).toMatchObject({ actorType: "apiKey", userId: "key-1" });
   });
 
-  it("records the system actor AS system, not as a person", async () => {
+  it("still records nothing for the system actor", async () => {
     // Boot-time seeding resolves to a USER actor carrying the reserved id, and
     // no account owns it. Recording it as a user would attribute an internal
     // write to a person who does not exist, so the kind is rewritten rather
@@ -211,10 +211,10 @@ describe("email template activity", () => {
       type: "user" as const,
       id: system.id,
     });
-    expect(logged).toHaveLength(1);
-    expect(logged[0]).toMatchObject({ actorType: "system" });
-    // NOT a user: the erasure joins the account table on user rows, and a
-    // reserved id there would be filed as an already-erased person.
-    expect(logged[0]).not.toMatchObject({ actorType: "user" });
+    // Refused for a NEW reason. A system write runs while the schema is being
+    // created, and this recorder's failures propagate — a trail insert against
+    // a table that does not exist yet would fail the seed creating it. A key,
+    // by contrast, arrives over a transport against a database already up.
+    expect(logged).toHaveLength(0);
   });
 });

--- a/packages/nextly/src/domains/email/__tests__/template-activity.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/template-activity.test.ts
@@ -189,25 +189,32 @@ describe("email template activity", () => {
     );
   });
 
-  it("records nothing for an API-key actor", async () => {
-    // Reachable in production: an API-key request produces `{ type: "apiKey" }`,
-    // and the two absence cases below cover only a missing actor and the system
-    // one. The trail's actor column is a user reference, so a key's own id finds
-    // no account and would be filed as an already-erased identity.
+  it("records an API-key actor AS a key", async () => {
+    // Reachable in production: an API-key request produces `{ type: "apiKey" }`.
+    // This used to record nothing, because the row's only identity column was
+    // read as a user reference and a key's own id finds no account — so the
+    // write was dropped rather than filed as an already-erased person. The kind
+    // is on the row now, so the key is recorded as what it is.
     await service.createTemplate(INPUT, { type: "apiKey", id: "key-1" });
-    expect(logged).toHaveLength(0);
+    expect(logged).toHaveLength(1);
+    expect(logged[0]).toMatchObject({ actorType: "apiKey", userId: "key-1" });
   });
 
-  it("records nothing for the system actor", async () => {
+  it("records the system actor AS system, not as a person", async () => {
     // Boot-time seeding resolves to a USER actor carrying the reserved id, and
-    // no account owns it — an entry would be filed as an already-erased
-    // identity, which is a worse record than none.
+    // no account owns it. Recording it as a user would attribute an internal
+    // write to a person who does not exist, so the kind is rewritten rather
+    // than the write refused.
     const system = SYSTEM_CONTEXT.user;
     if (!system) expect.fail("SYSTEM_CONTEXT carries no user to test against");
     await service.createTemplate(INPUT, {
       type: "user" as const,
       id: system.id,
     });
-    expect(logged).toHaveLength(0);
+    expect(logged).toHaveLength(1);
+    expect(logged[0]).toMatchObject({ actorType: "system" });
+    // NOT a user: the erasure joins the account table on user rows, and a
+    // reserved id there would be filed as an already-erased person.
+    expect(logged[0]).not.toMatchObject({ actorType: "user" });
   });
 });

--- a/packages/nextly/src/schemas/audit/mysql.ts
+++ b/packages/nextly/src/schemas/audit/mysql.ts
@@ -96,6 +96,27 @@ export const activityLog = mysqlTable(
   {
     id: varchar("id", { length: 191 }).primaryKey(),
     userId: varchar("user_id", { length: 191 }).notNull(),
+    /**
+     * What KIND of caller `user_id` refers to.
+     *
+     * `user_id` is already documented as "the actor, as an opaque reference
+     * that outlives their account" — the name is historical, the meaning is the
+     * actor. What it could never say is WHICH KIND, so a write had to be by a
+     * signed-in person to be recordable at all: any other actor was refused and
+     * left no trace. Imports, API-key writes, job writes and bulk edits were
+     * invisible rather than merely unattributed, and nothing about them is
+     * recoverable after the fact.
+     *
+     * With the kind on the row, `user_id` holds a user's id, an API key's own
+     * id, or a system caller's name, and the reader knows which. The accountable
+     * human is derived rather than stored twice: for a key that is the key's
+     * owner, which the keys table holds and outlives this row.
+     *
+     * NULL on rows written before this existed. Those are all user writes, since
+     * no other kind was recordable — a fact about the old gate rather than an
+     * assumption, so a reader may read NULL as `"user"`.
+     */
+    actorType: varchar("actor_type", { length: 16 }),
     userName: varchar("user_name", { length: 255 }),
     userEmail: varchar("user_email", { length: 255 }),
     action: varchar("action", { length: 10 }).notNull(), // 'create' | 'update' | 'delete'

--- a/packages/nextly/src/schemas/audit/postgres.ts
+++ b/packages/nextly/src/schemas/audit/postgres.ts
@@ -108,6 +108,27 @@ export const activityLog = pgTable(
   {
     id: text("id").primaryKey(),
     userId: text("user_id").notNull(),
+    /**
+     * What KIND of caller `user_id` refers to.
+     *
+     * `user_id` is already documented as "the actor, as an opaque reference
+     * that outlives their account" — the name is historical, the meaning is the
+     * actor. What it could never say is WHICH KIND, so a write had to be by a
+     * signed-in person to be recordable at all: any other actor was refused and
+     * left no trace. Imports, API-key writes, job writes and bulk edits were
+     * invisible rather than merely unattributed, and nothing about them is
+     * recoverable after the fact.
+     *
+     * With the kind on the row, `user_id` holds a user's id, an API key's own
+     * id, or a system caller's name, and the reader knows which. The accountable
+     * human is derived rather than stored twice: for a key that is the key's
+     * owner, which the keys table holds and outlives this row.
+     *
+     * NULL on rows written before this existed. Those are all user writes, since
+     * no other kind was recordable — a fact about the old gate rather than an
+     * assumption, so a reader may read NULL as `"user"`.
+     */
+    actorType: text("actor_type"),
     userName: text("user_name"),
     userEmail: text("user_email"),
     action: varchar("action", { length: 10 }).notNull(), // 'create' | 'update' | 'delete'

--- a/packages/nextly/src/schemas/audit/sqlite.ts
+++ b/packages/nextly/src/schemas/audit/sqlite.ts
@@ -64,6 +64,27 @@ export const activityLog = sqliteTable(
   {
     id: text("id").primaryKey(),
     userId: text("user_id").notNull(),
+    /**
+     * What KIND of caller `user_id` refers to.
+     *
+     * `user_id` is already documented as "the actor, as an opaque reference
+     * that outlives their account" — the name is historical, the meaning is the
+     * actor. What it could never say is WHICH KIND, so a write had to be by a
+     * signed-in person to be recordable at all: any other actor was refused and
+     * left no trace. Imports, API-key writes, job writes and bulk edits were
+     * invisible rather than merely unattributed, and nothing about them is
+     * recoverable after the fact.
+     *
+     * With the kind on the row, `user_id` holds a user's id, an API key's own
+     * id, or a system caller's name, and the reader knows which. The accountable
+     * human is derived rather than stored twice: for a key that is the key's
+     * owner, which the keys table holds and outlives this row.
+     *
+     * NULL on rows written before this existed. Those are all user writes, since
+     * no other kind was recordable — a fact about the old gate rather than an
+     * assumption, so a reader may read NULL as `"user"`.
+     */
+    actorType: text("actor_type"),
     userName: text("user_name"),
     userEmail: text("user_email"),
     action: text("action").notNull(), // 'create' | 'update' | 'delete'

--- a/packages/nextly/src/services/dashboard/activity-log-service.ts
+++ b/packages/nextly/src/services/dashboard/activity-log-service.ts
@@ -49,6 +49,13 @@ export type ActivityLogAction = "create" | "update" | "delete";
 export interface ActivityLogEntry {
   id: string;
   /**
+   * What KIND of caller `userId` refers to.
+   *
+   * `"user"` on a row written before the column existed: no other kind was
+   * recordable then, so the NULL is read rather than guessed.
+   */
+  actorType: RequestActorType;
+  /**
    * The actor, as an opaque reference that outlives their account.
    *
    * Still set after the account is deleted — that is what keeps one deleted
@@ -84,12 +91,17 @@ export interface LogActivityInput {
   /**
    * What KIND of caller `userId` refers to.
    *
-   * `userId` is the actor's opaque reference whatever the kind: a user's id, an
-   * API key's own id, or a system caller's name. This says which, so the
-   * identity erasure and the feed can tell an account from a credential — the
-   * distinction that made a non-user write unrecordable before.
+   * Decides how the write is stored, not just how it reads: only a `user` has
+   * an account, so only a user's write is routed through the erasure-aware
+   * insert. A key or system identifier has no row in `users`, and looking it up
+   * there would write the entry already-erased.
    */
   actorType: RequestActorType;
+  /**
+   * The actor's opaque reference, whatever the kind — a user's id, an API key's
+   * own id, or a system caller's reserved name. Never null: it is what keeps
+   * one actor's entries distinguishable from another's after erasure.
+   */
   userId: string;
   /**
    * Display name to denormalize onto the row. Omit to take it from the account
@@ -597,6 +609,19 @@ export class ActivityLogService extends BaseService {
     // Taking it from the account is what a caller holding only an actor id
     // does: the write already looks at that row to decide whether the account
     // exists, so the name comes from the same look as that decision.
+    // Only a USER has an account, so only a user's write can race an erasure.
+    //
+    // `insertErasureAware` decides by looking the actor up in `users`, and an
+    // API key's own id or a system caller's name has no row there — so routing
+    // one through it writes the entry already-erased, with null identity
+    // columns and a non-null stamp. That is precisely the record the old gate
+    // refused to create, reappearing one layer down now that the gate admits
+    // these actors.
+    if (input.actorType !== "user") {
+      await db.insert(activityLog).values(this.entryValues(input, new Date()));
+      return;
+    }
+
     const supplied: Record<string, unknown> = {};
     const fromAccount: Record<string, Column> = {};
     if (input.userName !== undefined) supplied.userName = input.userName;
@@ -970,6 +995,18 @@ export class ActivityLogService extends BaseService {
     return kept;
   }
 
+  /**
+   * The kind a stored row records, defaulting a legacy NULL to `"user"`.
+   *
+   * An unrecognised value reads as `"user"` too. The column is written only by
+   * this service, so anything else came from outside it, and treating an
+   * unknown kind as a NON-person would attribute a real person's write to a
+   * machine — the more misleading of the two directions.
+   */
+  private static toActorType(value: unknown): RequestActorType {
+    return value === "apiKey" || value === "system" ? value : "user";
+  }
+
   private mapRow = (row: Record<string, unknown>): ActivityLogEntry => {
     let metadata: Record<string, unknown> | null = null;
     if (row.metadata) {
@@ -993,6 +1030,11 @@ export class ActivityLogService extends BaseService {
 
     return {
       id: String(row.id),
+      // NULL means a row written before the column existed. No kind but `user`
+      // was recordable then, so this reads the old gate rather than guessing —
+      // and a reader that dropped the field would silently attribute a key's
+      // write to a person.
+      actorType: ActivityLogService.toActorType(row.actorType),
       userId: String(row.userId),
       // Through the same narrowing as the other nullable columns: an erased
       // row holds SQL NULL here, and `String(null)` would surface the literal

--- a/packages/nextly/src/services/dashboard/activity-log-service.ts
+++ b/packages/nextly/src/services/dashboard/activity-log-service.ts
@@ -17,6 +17,7 @@ import type { WhereClause } from "@nextlyhq/adapter-drizzle/types";
 import { type Column, type Table } from "drizzle-orm";
 
 import { authorizationGroups } from "../../auth/entity-read-access";
+import type { RequestActorType } from "../../auth/request-actor";
 import { toDbError } from "../../database/errors";
 // PR 4 migration: switched from ServiceError.fromDatabaseError to
 // NextlyError.fromDatabaseError. Public message stays generic per §13.8;
@@ -80,6 +81,15 @@ export interface ActivityLogEntry {
 
 /** Input for recording a new activity. */
 export interface LogActivityInput {
+  /**
+   * What KIND of caller `userId` refers to.
+   *
+   * `userId` is the actor's opaque reference whatever the kind: a user's id, an
+   * API key's own id, or a system caller's name. This says which, so the
+   * identity erasure and the feed can tell an account from a credential — the
+   * distinction that made a non-user write unrecordable before.
+   */
+  actorType: RequestActorType;
   userId: string;
   /**
    * Display name to denormalize onto the row. Omit to take it from the account
@@ -495,6 +505,7 @@ export class ActivityLogService extends BaseService {
   ): Record<string, unknown> {
     return {
       id: randomUUID(),
+      actorType: input.actorType,
       userId: input.userId,
       action: input.action,
       collection: input.collection,


### PR DESCRIPTION
## Non-user writes recorded nothing at all

Phase 2.1, the one-way door. The plan said imports, API-key writes, job writes
and bulk edits were *unattributable*. Measuring it, the truth is stronger — they
are **invisible**:

```ts
// record-activity.ts, before
if (actor?.type !== "user" || !actor.id) return false;
```

A write that was not by a signed-in person produced **no row**. So the
irreversible loss is not rows recorded wrongly; it is **rows that were never
written**, and nothing about them is recoverable after the fact.

The old gate was sound for the old shape, and its docblock says why: a row's
identity column is joined to the accounts table to decide whether the actor
still exists, so a key's own id would find no account and be filed as an
already-erased *person* — a worse record than none.

## One column, not two

`user_id` is already documented as **"the actor, as an opaque reference that
outlives their account"**, and the schema test calls it "the opaque reference".
The name is historical; the meaning is already *actor*. What it could never say
is which KIND.

So the whole schema change is one nullable `actor_type` per dialect:

- `user_id` keeps `NOT NULL` — the guarantee that two erased actors stay
  distinguishable is untouched
- no dialect needs a nullability rebuild, which on SQLite is a table rebuild
- the identity erasure is unchanged: it filters on `user_id`, and a `user` row
  is still exactly what it was

**No backfill, and none needed.** A NULL kind means a row written before this
existed — and those are *all* user writes, because no other kind was
recordable. Reading NULL as `"user"` is a fact about the old gate, not a guess.

## The rule was already written twice

`record-settings-activity` exported `isRecordableActor` under a docblock saying
it was *"shared rather than restated per resource… every place that answers it
separately is a place it can drift"* — and `record-activity` restated it. It had
already drifted.

`recordableActor` replaces both and answers **both halves at once** — whether to
record, and as what — because a caller that asked them separately could record a
row whose kind disagreed with the gate that admitted it. The system sentinel is
*rewritten* to `system` rather than refused: the write really is a system write,
and that is now a thing a row can say.

## Tests that changed, named rather than quietly rewritten

Three encoded the old contract and now encode the new one:

| test | was | is |
|---|---|---|
| `records nothing for an API-key actor` | expects 0 rows | records it **as a key** |
| `records nothing for the system actor` | expects 0 rows | records it **as system**, never as a user |
| `records nothing for a write with no signed-in actor` | expects 0 rows | records key and system; a write with **no actor at all** still records nothing |

That last distinction is the one worth keeping: no identity to attribute is a
different case from an identity that is not a person.

## A false positive this surfaced in my own guard

The API-key scope rule from #1695 matched `actorType` plus **any** spread — so
it fired on the new activity row, which carries an `actorType` field and spreads
its optional columns while being no kind of scope.

That direction is the expensive one: a miss lets a hand-built scope back in, but
a false positive gets the rule renamed around or disabled, taking its true
positives with it. The spread arm is narrowed to the literal `"apiKey"`, the
shape it was added for.

**The selector had no test at all.** Five now, covering both directions, with
the fatal-parse guard the sibling uses — an invented probe path fails to parse
and would otherwise read as a rule that declined to fire.

| shape | fires |
|---|---|
| `{ actorType: "apiKey", permissions }` — all nine real instances | yes |
| the pair in reverse order | yes |
| `{ actorType: "apiKey", ...auth }` | yes |
| an activity row: `{ actorType, userId, ...rest }` | **no** |
| `{ actorType }` alone — the webhook outbox row | **no** |

## Evidence

936 files / 11,878 tests pass · `tsc --noEmit` clean · lint clean at
`--max-warnings 0` · `check:comments` clean · changeset validates · build clean.

Migration risk is measured rather than assumed: `core-reconcile-activity-actor.integration.test.ts`
already proves the two-pass reconcile adds columns to `activity_log` on a live
SQLite database that also holds content, without losing rows.

## Scope

`activity_log` only. `audit_log` already records without a user and is about
auth events; `nextly_versions` is a third subject. Per-field `origin` (2.2) is
its own design.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Activity logs now identify whether an action was performed by a user, API key, or system process.
  * Actions performed through API keys are now recorded in activity history with the relevant key identity.
  * System-generated actions are recorded and labeled as system activity.
  * Existing activity records remain supported, with older entries treated as user activity when no actor type is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->