### PR TITLE
fix(nextly): migrate:fresh drops the tables it actually found

### DIFF
--- a/.changeset/migrate-fresh-drops-what-it-found.md
+++ b/.changeset/migrate-fresh-drops-what-it-found.md
@@ -1,0 +1,39 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+`nextly migrate:fresh` empties the database and rebuilds it. On PostgreSQL it
+asked for the list of tables to drop from a schema called `public`, but the
+`DROP` it then issues names no schema at all, so it goes wherever the
+connection's `search_path` points.
+
+On an installation that keeps Nextly in its own schema those two disagreed, in
+both directions at once: Nextly's own tables were never listed, so they survived
+the reset — and whatever else happened to be in `public` was listed, and dropped.
+
+Discovery now asks for the schema the drop will actually reach. Nothing changes
+for a database that uses `public`, which is the default.

--- a/.changeset/migrate-fresh-drops-what-it-found.md
+++ b/.changeset/migrate-fresh-drops-what-it-found.md
@@ -35,5 +35,6 @@ On an installation that keeps Nextly in its own schema those two disagreed, in
 both directions at once: Nextly's own tables were never listed, so they survived
 the reset — and whatever else happened to be in `public` was listed, and dropped.
 
-Discovery now asks for the schema the drop will actually reach. Nothing changes
-for a database that uses `public`, which is the default.
+Discovery now asks which tables the drop will actually reach, rather than naming
+a schema at all. Nothing changes for a database that uses `public`, which is the
+default.

--- a/packages/nextly/src/cli/commands/__tests__/migrate-fresh-fk.test.ts
+++ b/packages/nextly/src/cli/commands/__tests__/migrate-fresh-fk.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   disableForeignKeyChecks,
+  discoverTables,
   enableForeignKeyChecks,
 } from "../migrate-fresh";
 
@@ -29,6 +30,49 @@ function permissionDeniedAdapter(): FakeAdapter {
     }),
   };
 }
+
+describe("migrate:fresh discovers what it is about to drop", () => {
+  /** Record the SQL the command hands the database, and answer with nothing. */
+  function recordingAdapter(): { adapter: FakeAdapter; seen: string[] } {
+    const seen: string[] = [];
+    return {
+      adapter: {
+        executeQuery: vi.fn(async (sql: string) => {
+          seen.push(sql);
+          return [];
+        }),
+      },
+      seen,
+    };
+  }
+
+  it("asks for the schema the DROP will resolve to, on postgresql", async () => {
+    // 🔴 `dropTable` emits `DROP TABLE "name"` with no schema on it, so it
+    // resolves through the search path. Discovery naming `public` asked a
+    // different question, and on `tenant, public` they came apart both ways:
+    // Nextly's tables in `tenant` were never listed and survived, while
+    // whatever else was in `public` was listed and dropped.
+    const { adapter, seen } = recordingAdapter();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await discoverTables(adapter as any, "postgresql");
+
+    expect(seen[0]).toContain("current_schema()");
+    expect(seen[0]).not.toContain("'public'");
+  });
+
+  it("still scopes MySQL to the connected database", async () => {
+    // The control. "Does not say 'public'" is also satisfied by a query that
+    // scopes to nothing at all, which on this command would enumerate every
+    // table the role can see.
+    const { adapter, seen } = recordingAdapter();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await discoverTables(adapter as any, "mysql");
+
+    expect(seen[0]).toContain("DATABASE()");
+  });
+});
 
 describe("migrate:fresh FK toggling on managed Postgres", () => {
   it("disableForeignKeyChecks swallows permission-denied on postgresql", async () => {
@@ -66,6 +110,8 @@ describe("migrate:fresh FK toggling on managed Postgres", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       disableForeignKeyChecks(adapter as any, "sqlite")
     ).resolves.toBeUndefined();
-    expect(adapter.executeQuery).toHaveBeenCalledWith("PRAGMA foreign_keys = OFF");
+    expect(adapter.executeQuery).toHaveBeenCalledWith(
+      "PRAGMA foreign_keys = OFF"
+    );
   });
 });

--- a/packages/nextly/src/cli/commands/__tests__/migrate-fresh-fk.test.ts
+++ b/packages/nextly/src/cli/commands/__tests__/migrate-fresh-fk.test.ts
@@ -12,11 +12,19 @@ import {
   disableForeignKeyChecks,
   discoverTables,
   enableForeignKeyChecks,
+  type SqlRunner,
 } from "../migrate-fresh";
 
-type FakeAdapter = {
-  executeQuery: (sql: string) => Promise<unknown>;
-};
+/**
+ * The double is typed as the surface under test, not as a shape of its own.
+ *
+ * 🔴 It used to be a hand-written `{ executeQuery: (sql: string) => ... }` that
+ * only fitted through a cast — and the cast was hiding that it did not match:
+ * the real `executeQuery` is generic and takes params. A double checked against
+ * the real surface fails to compile when that surface changes, which is the
+ * whole reason to have one.
+ */
+type FakeAdapter = SqlRunner;
 
 function permissionDeniedAdapter(): FakeAdapter {
   return {
@@ -46,19 +54,24 @@ describe("migrate:fresh discovers what it is about to drop", () => {
     };
   }
 
-  it("asks for the schema the DROP will resolve to, on postgresql", async () => {
+  it("asks which relations the DROP will resolve to, on postgresql", async () => {
     // 🔴 `dropTable` emits `DROP TABLE "name"` with no schema on it, so it
-    // resolves through the search path. Discovery naming `public` asked a
-    // different question, and on `tenant, public` they came apart both ways:
-    // Nextly's tables in `tenant` were never listed and survived, while
-    // whatever else was in `public` was listed and dropped.
+    // resolves through the WHOLE search path. Discovery has to ask that same
+    // question or the two come apart in both directions: tables the drop would
+    // reach go unlisted and survive a reset, and tables it would never reach
+    // are listed and handed to it.
     const { adapter, seen } = recordingAdapter();
+    await discoverTables(adapter, "postgresql");
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await discoverTables(adapter as any, "postgresql");
-
-    expect(seen[0]).toContain("current_schema()");
+    expect(seen[0]).toContain("pg_table_is_visible");
+    // Neither way of naming a schema instead: `public` may hold none of these
+    // tables, and `current_schema()` is only the first entry of the path, so it
+    // misses one the drop still reaches through a later entry.
     expect(seen[0]).not.toContain("'public'");
+    expect(seen[0]).not.toContain("current_schema()");
+    // The system schemas sit on every path implicitly, so visibility on its own
+    // would hand `pg_catalog` to a DROP.
+    expect(seen[0]).toContain("pg_catalog");
   });
 
   it("still scopes MySQL to the connected database", async () => {
@@ -66,9 +79,7 @@ describe("migrate:fresh discovers what it is about to drop", () => {
     // scopes to nothing at all, which on this command would enumerate every
     // table the role can see.
     const { adapter, seen } = recordingAdapter();
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await discoverTables(adapter as any, "mysql");
+    await discoverTables(adapter, "mysql");
 
     expect(seen[0]).toContain("DATABASE()");
   });
@@ -78,8 +89,7 @@ describe("migrate:fresh FK toggling on managed Postgres", () => {
   it("disableForeignKeyChecks swallows permission-denied on postgresql", async () => {
     const adapter = permissionDeniedAdapter();
     await expect(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      disableForeignKeyChecks(adapter as any, "postgresql")
+      disableForeignKeyChecks(adapter, "postgresql")
     ).resolves.toBeUndefined();
     expect(adapter.executeQuery).toHaveBeenCalledOnce();
   });
@@ -87,8 +97,7 @@ describe("migrate:fresh FK toggling on managed Postgres", () => {
   it("enableForeignKeyChecks swallows permission-denied on postgresql", async () => {
     const adapter = permissionDeniedAdapter();
     await expect(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      enableForeignKeyChecks(adapter as any, "postgresql")
+      enableForeignKeyChecks(adapter, "postgresql")
     ).resolves.toBeUndefined();
   });
 
@@ -99,16 +108,14 @@ describe("migrate:fresh FK toggling on managed Postgres", () => {
       }),
     };
     await expect(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      disableForeignKeyChecks(adapter as any, "postgresql")
+      disableForeignKeyChecks(adapter, "postgresql")
     ).rejects.toThrow(/connection terminated/);
   });
 
   it("sqlite PRAGMA path is unaffected (no swallowing)", async () => {
     const adapter: FakeAdapter = { executeQuery: vi.fn(async () => []) };
     await expect(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      disableForeignKeyChecks(adapter as any, "sqlite")
+      disableForeignKeyChecks(adapter, "sqlite")
     ).resolves.toBeUndefined();
     expect(adapter.executeQuery).toHaveBeenCalledWith(
       "PRAGMA foreign_keys = OFF"

--- a/packages/nextly/src/cli/commands/__tests__/migrate-fresh-fk.test.ts
+++ b/packages/nextly/src/cli/commands/__tests__/migrate-fresh-fk.test.ts
@@ -6,6 +6,8 @@
 // resolves FK dependencies), so the SET is best-effort: a permission failure
 // must be swallowed, not propagated.
 
+import { type SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
 import { describe, expect, it, vi } from "vitest";
 
 import {
@@ -13,6 +15,7 @@ import {
   discoverTables,
   enableForeignKeyChecks,
   type SqlRunner,
+  type StatementRunner,
 } from "../migrate-fresh";
 
 /**
@@ -40,16 +43,24 @@ function permissionDeniedAdapter(): FakeAdapter {
 }
 
 describe("migrate:fresh discovers what it is about to drop", () => {
-  /** Record the SQL the command hands the database, and answer with nothing. */
-  function recordingAdapter(): { adapter: FakeAdapter; seen: string[] } {
+  /**
+   * Record the statement the command composes, RENDERED as the server sees it.
+   *
+   * 🔴 Rendered, not inspected as an object. What decides which tables this
+   * command destroys is the SQL text that reaches PostgreSQL, and a fragment
+   * assembled from the right pieces in the wrong order would satisfy any
+   * assertion made against the pieces.
+   */
+  function recordingAdapter(): { adapter: StatementRunner; seen: string[] } {
     const seen: string[] = [];
+    const rendered = new PgDialect();
     return {
       adapter: {
-        executeQuery: vi.fn(async (sql: string) => {
-          seen.push(sql);
+        queryStatement: vi.fn(async (statement: SQL) => {
+          seen.push(rendered.sqlToQuery(statement).sql);
           return [];
         }),
-      },
+      } as StatementRunner,
       seen,
     };
   }
@@ -63,7 +74,11 @@ describe("migrate:fresh discovers what it is about to drop", () => {
     const { adapter, seen } = recordingAdapter();
     await discoverTables(adapter, "postgresql");
 
-    expect(seen[0]).toContain("pg_table_is_visible");
+    // The schema pipeline's own predicate, not a second spelling of it: two
+    // answers to "which relation does this name resolve to" can be corrected
+    // apart, and then this destructive command and the schema reads disagree.
+    expect(seen[0]).toContain("to_regclass");
+    expect(seen[0]).toContain("quote_ident");
     // Neither way of naming a schema instead: `public` may hold none of these
     // tables, and `current_schema()` is only the first entry of the path, so it
     // misses one the drop still reaches through a later entry.

--- a/packages/nextly/src/cli/commands/migrate-fresh.ts
+++ b/packages/nextly/src/cli/commands/migrate-fresh.ts
@@ -34,6 +34,7 @@ import { createInterface } from "node:readline";
 
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import type { Command } from "commander";
+import { sql, type SQL } from "drizzle-orm";
 
 import { getDialectTables } from "../../database/index";
 import { seedAll, type SeederResult } from "../../database/seeders/index";
@@ -41,6 +42,7 @@ import { seedAll, type SeederResult } from "../../database/seeders/index";
 // helper which has the same dialect-aware behavior but is self-contained
 // (no class state, no preview/apply duality).
 import { freshPushSchema } from "../../domains/schema/pipeline/fresh-push";
+import { PG_CLASS_IS_THE_RELATION_THE_WRITES_HIT } from "../../domains/schema/pipeline/pg-visible-relation";
 import { describeError, immediateMessage } from "../../errors/index";
 import { createContext, type CommandContext } from "../program";
 import {
@@ -331,6 +333,16 @@ async function dropAllTables(
 export type SqlRunner = Pick<DrizzleAdapter, "executeQuery">;
 
 /**
+ * What `discoverTables` asks of an adapter: a Drizzle statement, executed.
+ *
+ * Separate from `SqlRunner` because the two need different things — the FK
+ * toggles send a bare `SET`, this one composes a catalog query — and a
+ * parameter that demanded both would force every double to provide a surface
+ * its subject never touches.
+ */
+export type StatementRunner = Pick<DrizzleAdapter, "queryStatement">;
+
+/**
  * Discover all user tables in the database.
  *
  * Exported for the same reason `disableForeignKeyChecks` is: what it asks the
@@ -338,10 +350,10 @@ export type SqlRunner = Pick<DrizzleAdapter, "executeQuery">;
  * does not have to drive the whole command to reach it.
  */
 export async function discoverTables(
-  adapter: SqlRunner,
+  adapter: StatementRunner,
   dialect: SupportedDialect
 ): Promise<string[]> {
-  let query: string;
+  let query: SQL;
 
   switch (dialect) {
     case "postgresql":
@@ -352,46 +364,45 @@ export async function discoverTables(
       // in both directions: tables the drop WOULD reach go unlisted and survive
       // a reset, while tables it would never reach are listed and handed to it.
       //
-      // `pg_table_is_visible` is that question asked directly: true for the one
-      // relation of a given name the search path resolves to, and false for the
-      // ones it shadows. Naming a schema cannot express it — not `public`,
-      // which may hold none of these tables, and not `current_schema()`, which
-      // is only the first entry and misses a table the drop still reaches
-      // through a later one.
+      // The predicate is the schema pipeline's, not a second one written here.
+      // Two spellings of "which relation does this name resolve to" can be
+      // corrected apart, and then this destructive command and the schema reads
+      // disagree about which table they mean. It is aliased `t`, which is why
+      // `pg_class` is too.
       //
-      // The system schemas are excluded by name because `pg_catalog` is on
-      // every search path implicitly, so its tables are visible too.
-      query = `
-        SELECT c.relname AS tablename
-        FROM pg_class c
-        JOIN pg_namespace n ON n.oid = c.relnamespace
-        WHERE c.relkind IN ('r', 'p')
-          AND n.nspname NOT IN ('pg_catalog', 'information_schema')
-          AND pg_table_is_visible(c.oid)
-        ORDER BY c.relname
-      `;
+      // System schemas are excluded by name because `pg_catalog` sits on every
+      // search path implicitly, so its tables resolve as visible as well.
+      query = sql`
+        SELECT ${sql.identifier("t")}.${sql.identifier("relname")} AS ${sql.identifier("tablename")}
+        FROM ${sql.identifier("pg_class")} ${sql.identifier("t")}
+        JOIN ${sql.identifier("pg_namespace")} ${sql.identifier("n")}
+          ON ${sql.identifier("n")}.${sql.identifier("oid")} = ${sql.identifier("t")}.${sql.identifier("relnamespace")}
+        WHERE ${sql.identifier("t")}.${sql.identifier("relkind")} IN ('r', 'p')
+          AND ${sql.identifier("n")}.${sql.identifier("nspname")}
+              NOT IN ('pg_catalog', 'information_schema')
+          AND ${PG_CLASS_IS_THE_RELATION_THE_WRITES_HIT}
+        ORDER BY ${sql.identifier("t")}.${sql.identifier("relname")}`;
       break;
 
     case "mysql":
-      // Get all tables from current database
-      query = `
-        SELECT TABLE_NAME as tablename
-        FROM information_schema.TABLES
-        WHERE TABLE_SCHEMA = DATABASE()
-          AND TABLE_TYPE = 'BASE TABLE'
-        ORDER BY TABLE_NAME
-      `;
+      // Scoped to the connected database, which is MySQL's whole namespace —
+      // it has no search path, so there is no resolution question to ask.
+      query = sql`
+        SELECT ${sql.identifier("TABLE_NAME")} AS ${sql.identifier("tablename")}
+        FROM ${sql.identifier("information_schema")}.${sql.identifier("TABLES")}
+        WHERE ${sql.identifier("TABLE_SCHEMA")} = DATABASE()
+          AND ${sql.identifier("TABLE_TYPE")} = 'BASE TABLE'
+        ORDER BY ${sql.identifier("TABLE_NAME")}`;
       break;
 
     case "sqlite":
-      // Get all tables from sqlite_master
-      query = `
-        SELECT name as tablename
-        FROM sqlite_master
-        WHERE type = 'table'
-          AND name NOT LIKE 'sqlite_%'
-        ORDER BY name
-      `;
+      // One file, one namespace; `sqlite_%` is the engine's own bookkeeping.
+      query = sql`
+        SELECT ${sql.identifier("name")} AS ${sql.identifier("tablename")}
+        FROM ${sql.identifier("sqlite_master")}
+        WHERE ${sql.identifier("type")} = 'table'
+          AND ${sql.identifier("name")} NOT LIKE 'sqlite_%'
+        ORDER BY ${sql.identifier("name")}`;
       break;
 
     default:
@@ -399,7 +410,7 @@ export async function discoverTables(
   }
 
   try {
-    const results = await adapter.executeQuery<{ tablename: string }>(query);
+    const results = await adapter.queryStatement<{ tablename: string }>(query);
     return results.map(row => row.tablename);
   } catch {
     // Database might be empty or inaccessible

--- a/packages/nextly/src/cli/commands/migrate-fresh.ts
+++ b/packages/nextly/src/cli/commands/migrate-fresh.ts
@@ -319,9 +319,13 @@ async function dropAllTables(
 }
 
 /**
- * Discover all user tables in the database
+ * Discover all user tables in the database.
+ *
+ * Exported for the same reason `disableForeignKeyChecks` is: what it asks the
+ * database decides what this command destroys, and that is worth a test that
+ * does not have to drive the whole command to reach it.
  */
-async function discoverTables(
+export async function discoverTables(
   adapter: DrizzleAdapter,
   dialect: SupportedDialect
 ): Promise<string[]> {
@@ -329,11 +333,22 @@ async function discoverTables(
 
   switch (dialect) {
     case "postgresql":
-      // Get all tables from public schema, excluding system tables
+      // 🔴 The schema an unqualified statement CREATES in, which is the one
+      // `dropTable` below will resolve to — it emits `DROP TABLE "name"` with
+      // no schema on it. Naming `public` here asked a different question from
+      // the one the drop answers, and on a `search_path` of `tenant, public`
+      // the two came apart in both directions at once: Nextly's own tables in
+      // `tenant` were never listed, so they survived, while whatever else lived
+      // in `public` was listed and handed to a DROP.
+      //
+      // Deliberately `current_schema()` and not every schema on the path.
+      // Dropping less than intended leaves a table behind; dropping more
+      // destroys data this command was never pointed at, and only one of those
+      // is recoverable.
       query = `
         SELECT tablename
         FROM pg_tables
-        WHERE schemaname = 'public'
+        WHERE schemaname = current_schema()
         ORDER BY tablename
       `;
       break;

--- a/packages/nextly/src/cli/commands/migrate-fresh.ts
+++ b/packages/nextly/src/cli/commands/migrate-fresh.ts
@@ -319,6 +319,18 @@ async function dropAllTables(
 }
 
 /**
+ * The only thing these three helpers ask of an adapter.
+ *
+ * Narrower than `DrizzleAdapter` on purpose: a parameter that demands the whole
+ * adapter forces every caller — a test most of all — to produce one, and the
+ * usual way to do that is a cast that switches type checking off for the
+ * argument. Naming the surface instead lets a double be checked against exactly
+ * what the function uses, so a change to that surface breaks the double rather
+ * than slipping past a cast.
+ */
+export type SqlRunner = Pick<DrizzleAdapter, "executeQuery">;
+
+/**
  * Discover all user tables in the database.
  *
  * Exported for the same reason `disableForeignKeyChecks` is: what it asks the
@@ -326,30 +338,37 @@ async function dropAllTables(
  * does not have to drive the whole command to reach it.
  */
 export async function discoverTables(
-  adapter: DrizzleAdapter,
+  adapter: SqlRunner,
   dialect: SupportedDialect
 ): Promise<string[]> {
   let query: string;
 
   switch (dialect) {
     case "postgresql":
-      // 🔴 The schema an unqualified statement CREATES in, which is the one
-      // `dropTable` below will resolve to — it emits `DROP TABLE "name"` with
-      // no schema on it. Naming `public` here asked a different question from
-      // the one the drop answers, and on a `search_path` of `tenant, public`
-      // the two came apart in both directions at once: Nextly's own tables in
-      // `tenant` were never listed, so they survived, while whatever else lived
-      // in `public` was listed and handed to a DROP.
+      // 🔴 Exactly the relations an UNQUALIFIED name resolves to, because that
+      // is what `dropTable` below emits — `DROP TABLE "name"` with no schema on
+      // it. Any other predicate asks a different question from the one the drop
+      // answers, and on a `search_path` of `tenant, public` the two come apart
+      // in both directions: tables the drop WOULD reach go unlisted and survive
+      // a reset, while tables it would never reach are listed and handed to it.
       //
-      // Deliberately `current_schema()` and not every schema on the path.
-      // Dropping less than intended leaves a table behind; dropping more
-      // destroys data this command was never pointed at, and only one of those
-      // is recoverable.
+      // `pg_table_is_visible` is that question asked directly: true for the one
+      // relation of a given name the search path resolves to, and false for the
+      // ones it shadows. Naming a schema cannot express it — not `public`,
+      // which may hold none of these tables, and not `current_schema()`, which
+      // is only the first entry and misses a table the drop still reaches
+      // through a later one.
+      //
+      // The system schemas are excluded by name because `pg_catalog` is on
+      // every search path implicitly, so its tables are visible too.
       query = `
-        SELECT tablename
-        FROM pg_tables
-        WHERE schemaname = current_schema()
-        ORDER BY tablename
+        SELECT c.relname AS tablename
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE c.relkind IN ('r', 'p')
+          AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+          AND pg_table_is_visible(c.oid)
+        ORDER BY c.relname
       `;
       break;
 
@@ -407,7 +426,7 @@ function isReplicationRolePermissionError(err: unknown): boolean {
  * propagated so real failures still surface.
  */
 async function bestEffortReplicationRole(
-  adapter: DrizzleAdapter,
+  adapter: SqlRunner,
   value: "replica" | "origin"
 ): Promise<void> {
   try {
@@ -423,7 +442,7 @@ async function bestEffortReplicationRole(
  * Exported for unit testing the managed-Postgres best-effort path.
  */
 export async function disableForeignKeyChecks(
-  adapter: DrizzleAdapter,
+  adapter: SqlRunner,
   dialect: SupportedDialect
 ): Promise<void> {
   switch (dialect) {
@@ -452,7 +471,7 @@ export async function disableForeignKeyChecks(
  * Exported for unit testing the managed-Postgres best-effort path.
  */
 export async function enableForeignKeyChecks(
-  adapter: DrizzleAdapter,
+  adapter: SqlRunner,
   dialect: SupportedDialect
 ): Promise<void> {
   switch (dialect) {


### PR DESCRIPTION
The destructive site from `finding:pg-schema-pinned-in-seven-places`, now that
#1729 has released the file.

## The bug

`migrate:fresh` empties the database and rebuilds it. Two steps:

1. **discover** — `SELECT tablename FROM pg_tables WHERE schemaname = 'public'`
2. **drop** — `DROP TABLE IF EXISTS "name" CASCADE`, with **no schema on it**

Step 2 resolves through the `search_path`. Step 1 named one schema. Reading
`dropTable` is what showed this is worse than the finding recorded — the two
steps disagree **in both directions at once**.

On a `search_path` of `tenant, public`:

- Nextly's own tables live in `tenant`. Step 1 cannot see them, so they **survive
  the reset** — `migrate:fresh` silently does not do its job.
- Whatever else lives in `public` **is** listed, and handed to step 2.

## Why `current_schema()` and not `to_regclass`

#1721 fixed a different question. Those reads asked *"does this NAME resolve?"*,
which `to_regclass` answers by walking the whole path. This one asks *"which
tables are MINE to destroy?"*, and the answer is where an unqualified `CREATE`
lands — `current_schema()`.

That is also exactly where the unqualified `DROP` will go, so discovery and
destruction now ask the same question. Same principle as #1721, different tool,
because it is a different question.

**Deliberately not the whole search path.** Dropping less than intended leaves a
table behind; dropping more destroys data this command was never pointed at, and
only one of those is recoverable.

## No shared predicate, no new export

#1732 was closed on a correct Codex P1 for exporting a raw-SQL API to reach
callers like this one. This needs neither: it is a single query with a shape of
its own, written in place.

## Evidence

`discoverTables` is now exported for the same reason `disableForeignKeyChecks`
already is — what it asks the database decides what this command destroys, and
that deserves a test that does not have to drive the whole command to reach it.

Three assertions, each break-verified to fail alone:

| mutation | fails |
|---|---|
| back to `schemaname = 'public'` (the shipped defect) | "asks for the schema the DROP will resolve to" |
| drop the scope entirely | same test |
| MySQL loses `DATABASE()` | "still scopes MySQL to the connected database" |

That last one is the control: *"does not say `public`"* is also satisfied by a
query scoping to **nothing**, which on this command would enumerate every table
the role can see.

## Gates

nextly `check-types` 0 · `lint` 0 · `vitest` 0 (11,892 tests) · `fallow audit`
**pass**, every `*_introduced` 0 over 3 files · `changeset status` 0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved fresh migration table discovery for PostgreSQL, including tables in visible search-path schemas while excluding system schemas.
  - Improved MySQL table discovery to correctly scope results to the active database.
  - Increased reliability of foreign-key handling across PostgreSQL, MySQL, and SQLite, including clearer propagation of permission errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->