### PR TITLE
fix(admin): four repairs to the onboarding card, and one read it made twice

### DIFF
--- a/.changeset/onboarding-card-follow-ups.md
+++ b/.changeset/onboarding-card-follow-ups.md
@@ -1,0 +1,52 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Four repairs to the dashboard's onboarding card, and one performance fix behind
+it.
+
+Declining the offer of demo content now drops the card from the open dashboard.
+Skipping used to change nothing the server could see, so only a successful seed
+refreshed the arrangement; the card's condition reads the decline now, which
+left the one gesture that could strand a placement the server had stopped
+offering — visible in edit mode, and refused on save.
+
+A step this build cannot name no longer reads as a finished checklist. Dropping
+an unreadable row keeps the card from breaking, and on its own it introduced
+something worse: a newer server reporting an outstanding step under a name this
+build does not know would leave every remaining row complete, so the card
+announced itself finished and asked to be taken down while the server went on
+offering it.
+
+The checklist follows a schema change. Two of its steps are answered from the
+collection registry, so creating a collection in another tab moved the answer
+without moving the card, which went on asking for a collection that existed.
+
+One layout read now resolves the reader's collections once. Two conditions ask
+overlapping questions of the same rows, and each was resolving them
+independently — three authorization traversals and two counted reads per
+collection for a single dashboard load.

--- a/packages/admin/src/components/features/dashboard/OnboardingChecklist.test.tsx
+++ b/packages/admin/src/components/features/dashboard/OnboardingChecklist.test.tsx
@@ -128,25 +128,52 @@ describe("the onboarding checklist", () => {
     ).toBeInTheDocument();
   });
 
-  it("drops a step id this build cannot draw, rather than crashing on it", async () => {
-    // 🔴 The presentation map is exhaustive over the ids core owns, and that is
-    // a COMPILE-time guarantee about two packages built together. It says
-    // nothing about the wire: a newer server sending an id this build has no
-    // entry for would have had its row destructured out of `undefined`, taking
-    // the whole dashboard down rather than one row.
-    //
-    // The union is imported from core now, so the two definitions cannot drift.
-    // This covers the case that survives that: the definitions agreeing and the
-    // RUNTIME disagreeing anyway.
+  it("reports UNAVAILABLE for a step id this build cannot draw", async () => {
+    // 🔴 Dropping the row keeps the card from crashing, and on its own it
+    // introduces something worse. A newer server sending an INCOMPLETE step
+    // this build cannot name leaves every remaining row complete, so a card
+    // that merely filtered would report 100%, announce itself finished, and ask
+    // the host to drop it -- while the host went on offering it for the step
+    // that was dropped. A checklist claiming completion it cannot see is worse
+    // than one that says it cannot describe your progress.
     protectedGet.mockResolvedValue({
-      steps: [...ALL_BUT_ONE, { id: "billing:configured", complete: false }],
+      steps: [
+        { id: "account", complete: true },
+        { id: "collection", complete: true },
+        { id: "entry", complete: true },
+        { id: "billing:configured", complete: false },
+      ],
     });
     draw(client());
 
     await waitFor(() =>
-      expect(screen.getAllByRole("listitem")).toHaveLength(ALL_BUT_ONE.length)
+      expect(
+        screen.getByText(/Setup progress is unavailable/)
+      ).toBeInTheDocument()
     );
-    expect(screen.getByText(/of 3 done/)).toBeInTheDocument();
+    expect(screen.queryByText(/of 3 done/)).not.toBeInTheDocument();
+  });
+
+  it("does NOT ask for a fresh layout when a row was unreadable", async () => {
+    // The consequence that made the filtered reading dangerous: the card would
+    // have told the host to stop offering it, on the strength of rows it could
+    // not see.
+    protectedGet.mockResolvedValue({
+      steps: [
+        { id: "account", complete: true },
+        { id: "collection", complete: true },
+        { id: "entry", complete: true },
+        { id: "billing:configured", complete: false },
+      ],
+    });
+    const { readLayout } = await drawBesideLayout(client());
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Setup progress is unavailable/)
+      ).toBeInTheDocument()
+    );
+    expect(readLayout).toHaveBeenCalledTimes(1);
   });
 
   it("says progress is unavailable rather than showing it finished", async () => {

--- a/packages/admin/src/hooks/queries/useOnboardingSteps.ts
+++ b/packages/admin/src/hooks/queries/useOnboardingSteps.ts
@@ -20,6 +20,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { isOnboardingStepId, type OnboardingStepId } from "nextly/config";
 import { useEffect, useRef } from "react";
 
+import { useSchemaUpdateInvalidation } from "@admin/hooks/useSchemaUpdateInvalidation";
 import { protectedApi } from "@admin/lib/api/protectedApi";
 
 import { DASHBOARD_LAYOUT_KEY } from "./useDashboardLayout";
@@ -63,19 +64,50 @@ export interface UseOnboardingStepsResult {
   isUnavailable: boolean;
 }
 
-/** The steps this build can draw, in the order the host sent them. */
-function readSteps(value: unknown): OnboardingStepState[] {
-  if (!Array.isArray(value)) return [];
-  return value.flatMap((raw): OnboardingStepState[] => {
-    if (typeof raw !== "object" || raw === null) return [];
-    const { id, complete } = raw as { id?: unknown; complete?: unknown };
-    if (!isOnboardingStepId(id) || typeof complete !== "boolean") return [];
-    return [{ id, complete }];
-  });
+/**
+ * The steps this build can draw, and whether anything was left out.
+ *
+ * 🔴 The count matters as much as the rows. Dropping an unreadable row keeps
+ * the card from crashing, and on its own it introduces a worse failure: a newer
+ * server sending an INCOMPLETE step this build cannot name would leave every
+ * remaining row complete, so the card would report 100%, announce itself
+ * finished, and ask the host to drop it -- while the host went on offering it
+ * for the step that was dropped. A checklist claiming completion it cannot see
+ * is the one thing worse than one that cannot draw.
+ */
+function readSteps(value: unknown): {
+  steps: OnboardingStepState[];
+  rejected: boolean;
+} {
+  if (!Array.isArray(value)) return { steps: [], rejected: false };
+  const steps: OnboardingStepState[] = [];
+  let rejected = false;
+  for (const raw of value) {
+    const row = readStep(raw);
+    if (row) steps.push(row);
+    else rejected = true;
+  }
+  return { steps, rejected };
+}
+
+/** One row, or nothing when this build cannot describe it. */
+function readStep(raw: unknown): OnboardingStepState | undefined {
+  if (typeof raw !== "object" || raw === null) return undefined;
+  const { id, complete } = raw as { id?: unknown; complete?: unknown };
+  if (!isOnboardingStepId(id) || typeof complete !== "boolean")
+    return undefined;
+  return { id, complete };
 }
 
 export function useOnboardingSteps(): UseOnboardingStepsResult {
   const queryClient = useQueryClient();
+  // Two of the three steps are answered from the collection registry, so a
+  // schema change moves them. The layout query already subscribes to this; this
+  // one did not, so creating a collection in another tab -- or through a
+  // code-first reload -- left the card still saying "Create a collection" until
+  // the window regained focus.
+  useSchemaUpdateInvalidation(ONBOARDING_STEPS_KEY);
+
   const query = useQuery<OnboardingResponse>({
     queryKey: ONBOARDING_STEPS_KEY,
     queryFn: () =>
@@ -88,10 +120,12 @@ export function useOnboardingSteps(): UseOnboardingStepsResult {
   // lockstep only until someone runs a newer server against an older admin. An
   // id this build cannot draw is DROPPED rather than rendered, because the
   // alternative is a row built from an absent presentation entry.
-  const steps = readSteps(query.data?.steps);
+  const { steps, rejected } = readSteps(query.data?.steps);
   const completedCount = steps.filter(step => step.complete).length;
   const totalCount = steps.length;
-  const finished = totalCount > 0 && completedCount === totalCount;
+  // A rejected row means the checklist this build can see is not the checklist
+  // the host has, so completeness cannot be concluded from what is left.
+  const finished = !rejected && totalCount > 0 && completedCount === totalCount;
 
   // Finishing the last step is the moment the card stops being offered, and
   // the layout query neither polls nor refetches except on focus -- so without
@@ -111,6 +145,9 @@ export function useOnboardingSteps(): UseOnboardingStepsResult {
     completedCount,
     totalCount,
     isPending: query.isPending,
-    isUnavailable: query.isError,
+    // A row this build could not read leaves the card unable to describe the
+    // reader's progress, which is the same position a failed request leaves it
+    // in -- and both are better said than guessed at.
+    isUnavailable: query.isError || rejected,
   };
 }

--- a/packages/admin/src/hooks/queries/useSeedStatus.test.tsx
+++ b/packages/admin/src/hooks/queries/useSeedStatus.test.tsx
@@ -228,6 +228,56 @@ describe("useSeedStatus", () => {
     await waitFor(() => expect(readLayout).toHaveBeenCalledTimes(2));
   });
 
+  it("refetches the dashboard layout once the offer is DECLINED", async () => {
+    // 🔴 Declining now closes `seed:unanswered`, so the server stops offering
+    // this card exactly as it does after a successful seed. Skip used to change
+    // nothing the host could see, which is why only the seed path invalidated
+    // -- and that made this the one gesture that left the open dashboard
+    // holding a placement the server had dropped. Entering edit mode then
+    // surfaces it, and saving is refused on the scope token.
+    vi.mocked(seedApi.probe).mockResolvedValue({
+      available: true,
+      template: { slug: "blog", label: "Blog" },
+    });
+    vi.mocked(seedApi.getStatus).mockResolvedValue({
+      completedAt: null,
+      skippedAt: null,
+    });
+    vi.mocked(seedApi.setSkipped).mockResolvedValue(undefined);
+
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 0 },
+        mutations: { retry: false },
+      },
+    });
+    const readLayout = vi.fn().mockResolvedValue({ placements: [] });
+
+    const { result } = renderHook(
+      () => ({
+        seed: useSeedStatus(),
+        layout: useQuery({
+          queryKey: DASHBOARD_LAYOUT_KEY,
+          queryFn: readLayout,
+        }),
+      }),
+      {
+        wrapper: ({ children }: { children: ReactNode }) => (
+          <QueryClientProvider client={client}>{children}</QueryClientProvider>
+        ),
+      }
+    );
+
+    await waitFor(() => expect(result.current.seed.status.kind).toBe("idle"));
+    await waitFor(() => expect(readLayout).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      result.current.seed.skip();
+    });
+
+    await waitFor(() => expect(readLayout).toHaveBeenCalledTimes(2));
+  });
+
   it("skip writes skippedAt and transitions to hidden", async () => {
     vi.mocked(seedApi.probe).mockResolvedValue({
       available: true,

--- a/packages/admin/src/hooks/queries/useSeedStatus.ts
+++ b/packages/admin/src/hooks/queries/useSeedStatus.ts
@@ -100,6 +100,13 @@ export function useSeedStatus(): UseSeedStatusReturn {
     },
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: QK_STATUS });
+      // Declining now closes the `seed:unanswered` condition, so the server
+      // stops offering this card exactly as it does after a successful seed.
+      // Without this the open dashboard keeps the pre-skip arrangement: edit
+      // mode can surface a placement the server has dropped, and saving it is
+      // refused on the scope token. Skip used to change nothing the host could
+      // see, which is why only the seed path invalidated.
+      void qc.invalidateQueries({ queryKey: DASHBOARD_LAYOUT_KEY });
     },
   });
 

--- a/packages/nextly/src/api/dashboard.ts
+++ b/packages/nextly/src/api/dashboard.ts
@@ -24,6 +24,7 @@ import { toNextlyAuthError } from "../auth/middleware/to-nextly-error";
 import { container } from "../di";
 import { SETTINGS_ACTIVITY_NAMESPACES } from "../domains/audit/settings-activity-namespaces";
 import { refreshCollectionSources } from "../domains/widgets/collection-sources";
+import { conditionProbe } from "../domains/widgets/condition-probe";
 import { onboardingSteps } from "../domains/widgets/onboarding";
 import { getCachedNextly } from "../init";
 import type { ActivityLogService } from "../services/dashboard/activity-log-service";
@@ -175,7 +176,10 @@ export const getDashboardOnboarding = withErrorHandler(async (req: Request) => {
 
   await refreshCollectionSources();
   const caller = await readCaller(auth);
-  const steps = await onboardingSteps(caller);
+  // The same probe the layout read builds, so this endpoint and the condition
+  // that decides whether the card is offered resolve the reader's collections
+  // by one path rather than two.
+  const steps = await onboardingSteps(conditionProbe(caller));
 
   return respondData({ steps }, { headers: PRIVATE_NO_STORE_HEADERS });
 });

--- a/packages/nextly/src/domains/widgets/__tests__/onboarding.integration.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/onboarding.integration.test.ts
@@ -19,6 +19,7 @@ import {
 } from "../../../plugins/test-nextly";
 import type { ReadCaller } from "../../../services/dashboard/readable-resources";
 import { refreshCollectionSources } from "../collection-sources";
+import { conditionProbe } from "../condition-probe";
 import { onboardingIsIncomplete, onboardingSteps } from "../onboarding";
 
 const NOTES = "notes";
@@ -92,7 +93,7 @@ async function boot(): Promise<TestNextly> {
 
 /** The steps as a map, so a case names the step it is about. */
 async function stepsFor(caller: ReadCaller): Promise<Record<string, boolean>> {
-  const steps = await onboardingSteps(caller);
+  const steps = await onboardingSteps(conditionProbe(caller));
   return Object.fromEntries(steps.map(step => [step.id, step.complete]));
 }
 
@@ -111,7 +112,7 @@ describe("onboarding steps against a real instance", () => {
 
     expect(steps.collection).toBe(true);
     expect(steps.entry).toBe(false);
-    expect(await onboardingIsIncomplete(admin)).toBe(true);
+    expect(await onboardingIsIncomplete(conditionProbe(admin))).toBe(true);
   });
 
   it("finishes once a row exists", async () => {
@@ -122,7 +123,7 @@ describe("onboarding steps against a real instance", () => {
     await write(t, NOTES, { title: "the first note" });
 
     expect((await stepsFor(admin)).entry).toBe(true);
-    expect(await onboardingIsIncomplete(admin)).toBe(false);
+    expect(await onboardingIsIncomplete(conditionProbe(admin))).toBe(false);
   });
 
   it("counts a DRAFT as content", async () => {
@@ -152,7 +153,7 @@ describe("onboarding steps against a real instance", () => {
     await write(t, SECRETS, { title: "not for you" });
 
     expect((await stepsFor(admin)).entry).toBe(false);
-    expect(await onboardingIsIncomplete(admin)).toBe(true);
+    expect(await onboardingIsIncomplete(conditionProbe(admin))).toBe(true);
   });
 
   // No case asserts that the condition agrees with the steps it reports.

--- a/packages/nextly/src/domains/widgets/condition-probe.ts
+++ b/packages/nextly/src/domains/widgets/condition-probe.ts
@@ -1,0 +1,66 @@
+/**
+ * The reads a condition makes, resolved ONCE per layout request.
+ *
+ * 🔴 Two conditions ask overlapping questions of the same rows, and both are on
+ * the default dashboard: `content:empty` wants to know whether this reader can
+ * see anything, and `onboarding:incomplete` wants that plus the collections it
+ * was derived from. Asked independently that is three authorization traversals
+ * and two counted reads per collection for ONE layout read — and the traversal
+ * is the expensive half, since it resolves the caller's permissions against
+ * every collection.
+ *
+ * Sharing them by calling one helper from the other is what produced the
+ * duplication: `onboardingSteps` resolved the slugs, then handed the caller to
+ * a function that resolved them again. A probe passed down instead makes the
+ * sharing structural — an evaluator cannot accidentally re-resolve, because it
+ * has no caller to re-resolve from.
+ *
+ * Lazy and MEMOISED ON THE PROMISE rather than on its value, so two evaluators
+ * running concurrently under `Promise.allSettled` join the same in-flight read
+ * instead of starting a second one. Memoising after the await would leave a
+ * window in which both see nothing cached and both go to the database, which is
+ * the exact case this exists for.
+ *
+ * Its lifetime is one request. Nothing here is cached across requests: a
+ * collection created between two dashboard loads must change the answer, and a
+ * probe that outlived the request would report the older one.
+ *
+ * @module domains/widgets/condition-probe
+ */
+
+import type { ReadCaller } from "../../services/dashboard/readable-resources";
+
+import { readableCollectionSlugs, readerHasContent } from "./reader-content";
+
+/** What every condition evaluator is handed. */
+export interface ConditionProbe {
+  /** Who is asking. Carried so an evaluator needing neither read still has it. */
+  readonly caller: ReadCaller;
+  /** The collections this reader may read, resolved at most once. */
+  readableSlugs(): Promise<string[]>;
+  /** Whether this reader can see any row at all, resolved at most once. */
+  hasContent(): Promise<boolean>;
+}
+
+export function conditionProbe(caller: ReadCaller): ConditionProbe {
+  let slugs: Promise<string[]> | undefined;
+  let content: Promise<boolean> | undefined;
+
+  const readableSlugs = (): Promise<string[]> => {
+    slugs ??= readableCollectionSlugs(caller);
+    return slugs;
+  };
+
+  return {
+    caller,
+    readableSlugs,
+    hasContent: () => {
+      // Takes the slugs from the same memo rather than resolving its own, which
+      // is the duplication this module was added to remove.
+      content ??= readableSlugs().then(resolved =>
+        readerHasContent(caller, resolved)
+      );
+      return content;
+    },
+  };
+}

--- a/packages/nextly/src/domains/widgets/conditions.ts
+++ b/packages/nextly/src/domains/widgets/conditions.ts
@@ -17,13 +17,13 @@
 import { getService } from "../../di";
 import type { ReadCaller } from "../../services/dashboard/readable-resources";
 
+import { conditionProbe, type ConditionProbe } from "./condition-probe";
 import {
   declaredConditions,
   isWidgetCondition,
   type WidgetCondition,
 } from "./lifecycle";
 import { onboardingIsIncomplete } from "./onboarding";
-import { readerHasContent } from "./reader-content";
 
 /**
  * Whether this reader can see any content at all.
@@ -38,8 +38,8 @@ import { readerHasContent } from "./reader-content";
  * The scoping, the short-circuit and the `status: "all"` reasoning now live
  * with the counting, in `reader-content.ts`.
  */
-async function contentIsEmpty(caller: ReadCaller): Promise<boolean> {
-  return !(await readerHasContent(caller));
+async function contentIsEmpty(probe: ConditionProbe): Promise<boolean> {
+  return !(await probe.hasContent());
 }
 
 /**
@@ -79,7 +79,7 @@ async function seedIsUnanswered(): Promise<boolean> {
  */
 const EVALUATORS: Record<
   WidgetCondition,
-  (caller: ReadCaller) => Promise<boolean>
+  (probe: ConditionProbe) => Promise<boolean>
 > = {
   "content:empty": contentIsEmpty,
   "onboarding:incomplete": onboardingIsIncomplete,
@@ -105,8 +105,14 @@ export async function evaluateConditions(
   // on one collection, would answer the whole request as an error and take
   // every PERMANENT card down with the optional one it was asked about. The
   // blast radius of a condition has to be the widget that named it.
+  // ONE probe for the whole request, so two conditions asking overlapping
+  // questions of the same rows resolve them once between them rather than once
+  // each. Built here rather than per evaluator, which is what made the sharing
+  // accidental before: a helper calling another helper re-resolved what its
+  // caller had just resolved.
+  const probe = conditionProbe(caller);
   const settled = await Promise.allSettled(
-    wanted.map(condition => EVALUATORS[condition](caller))
+    wanted.map(condition => EVALUATORS[condition](probe))
   );
   const verdicts = new Map<WidgetCondition, boolean>();
   wanted.forEach((condition, index) => {

--- a/packages/nextly/src/domains/widgets/onboarding.ts
+++ b/packages/nextly/src/domains/widgets/onboarding.ts
@@ -44,10 +44,8 @@
  * @module domains/widgets/onboarding
  */
 
-import type { ReadCaller } from "../../services/dashboard/readable-resources";
-
+import type { ConditionProbe } from "./condition-probe";
 import type { OnboardingStep } from "./onboarding-steps";
-import { readableCollectionSlugs, readerHasContent } from "./reader-content";
 
 /**
  * Every step, with the reader's progress through it.
@@ -62,13 +60,13 @@ import { readableCollectionSlugs, readerHasContent } from "./reader-content";
  * the first-entry step is outstanding.
  */
 export async function onboardingSteps(
-  caller: ReadCaller
+  probe: ConditionProbe
 ): Promise<OnboardingStep[]> {
-  const slugs = await readableCollectionSlugs(caller);
+  const slugs = await probe.readableSlugs();
   // Short-circuits inside, and skipped entirely where no collection exists:
   // with nothing to read there is no row to find, and the walk would be a
   // guaranteed-empty pass over an empty list.
-  const hasContent = slugs.length > 0 && (await readerHasContent(caller));
+  const hasContent = slugs.length > 0 && (await probe.hasContent());
 
   return [
     // True by construction: an unauthenticated caller never reaches this.
@@ -93,8 +91,8 @@ export async function onboardingSteps(
  * request that is about to make the same one.
  */
 export async function onboardingIsIncomplete(
-  caller: ReadCaller
+  probe: ConditionProbe
 ): Promise<boolean> {
-  const steps = await onboardingSteps(caller);
+  const steps = await onboardingSteps(probe);
   return steps.some(step => !step.complete);
 }

--- a/packages/nextly/src/domains/widgets/reader-content.ts
+++ b/packages/nextly/src/domains/widgets/reader-content.ts
@@ -97,8 +97,18 @@ export async function readableCollectionSlugs(
  * and not published it is not looking at an empty install, and telling them
  * they are is the onboarding equivalent of losing their work.
  */
-export async function readerHasContent(caller: ReadCaller): Promise<boolean> {
-  const slugs = await readableCollectionSlugs(caller);
+export async function readerHasContent(
+  caller: ReadCaller,
+  /**
+   * The reader's collections, when the caller already has them.
+   *
+   * Optional rather than required so this stays usable on its own, and passed
+   * by the condition probe so one layout read resolves the reader's
+   * permissions against every collection ONCE rather than per condition.
+   */
+  resolved?: readonly string[]
+): Promise<boolean> {
+  const slugs = resolved ?? (await readableCollectionSlugs(caller));
 
   for (const slug of slugs) {
     const { total } = await requireNextly().count({


### PR DESCRIPTION
Review findings on #1723 that arrived after it merged. Five worked, one filed with its measurement.

## Two are bugs I introduced in that PR

**The wire guard created a worse bug than it fixed.** Dropping a step id this build cannot name stops the card crashing. On its own it introduced this: a newer server reporting an **outstanding** step under an unknown name leaves every remaining row complete — so the card reported 100%, declared itself finished, and asked the host to drop it, while the host went on offering it for the step that was filtered away. A checklist claiming completion it cannot see is worse than one saying it cannot describe your progress. A rejected row now reports unavailable.

**Skip did not drop the card.** Before `seed:unanswered` existed, declining changed nothing the host could see, so only the seed-success path invalidated the layout. Adding the condition made a decline a state change — and left the one gesture that strands a placement the server has stopped offering: visible in edit mode, refused on save.

## The performance one, and why the first attempt was wrong

`content:empty` and `onboarding:incomplete` ask overlapping questions of the same rows, and both sit on the default dashboard. Each resolved them independently: **three authorization traversals and two counted reads per collection for one layout load.**

My first attempt at sharing — having one helper call another — is what produced the duplication: `onboardingSteps` resolved the slugs, then handed the caller to a function that resolved them again.

So the sharing is **structural** now. A probe is built once per request and handed to each evaluator, and an evaluator *cannot* re-resolve because it no longer holds a caller to re-resolve from. It memoises the **promise**, not its value, so two evaluators running concurrently under `Promise.allSettled` join one in-flight read rather than starting a second — memoising after the await leaves a window where both see nothing cached, which is the exact case it exists for. Its lifetime is one request: a collection created between loads has to move the answer.

## Also

The checklist now follows a schema change — two of its steps are answered from the collection registry, and the layout query already subscribed while this one did not, so a collection created in another tab left the card asking for one that existed.

## One finding was already fixed

The legacy `OnboardingStepId` export the review flagged was deleted in #1723's last commit; the finding was generated against an intermediate head. Verified against `main` rather than argued.

## One is NOT fixed, deliberately

A reader who may **read** a collection but not **create** in it has the entry step outstanding permanently — the card pins itself to their dashboard with an action that always fails. That is the opposite of what the lifecycle is for, and it is the most serious of the six despite its P2 label.

Closing it needs a reader-scoped may-create decision, and none exists: `readableEntities` answers reads only, so the equivalent means going through the access service per collection. Inventing that on an authorization path, inside a five-fix pass written in one sitting, is how such a path gets a wrong answer — and a wrong answer there is worse than the defect.

Filed as `finding:onboarding-steps-a-reader-cannot-perform` with the affected population (custom read-only roles, not the seeded editor, which can create) and the shape of the fix: a per-step `canView` predicate that HIDES rather than greys out, matching the pattern the earlier research found in WooCommerce's task list.

## Verification

Break-verified by name: removing the skip invalidation fails "refetches the dashboard layout once the offer is DECLINED".

The unknown-id test **changed meaning** rather than being extended — it previously asserted the row was silently dropped, which is the behaviour this PR shows was wrong. It now asserts the card reports unavailable, with a second case proving it does not ask the host to drop it.

nextly 973 · admin 4,212 · integration (sqlite) 264 files / 1,616 tests · `check-types` 0 · lint · fallow `pass` with nothing introduced · comment-convention · `changeset status` all 25.