### PR TITLE
docs(nextly): the plugin route URL people actually get, and a check that holds it

### DIFF
--- a/docs/plugins/author-guide.mdx
+++ b/docs/plugins/author-guide.mdx
@@ -116,7 +116,7 @@ something newer.
 - `extend` — add fields to existing entities by slug.
 - `permissions` — custom (non-CRUD) permissions; CRUD is auto-seeded per collection/single.
 - `events` — custom event names you may emit.
-- `routes` — HTTP endpoints, namespaced under `/api/plugins/<name>/…`, secure by default.
+- `routes` — HTTP endpoints, namespaced under `/plugins/<name>/…` beneath wherever your app mounts the Nextly handler (`/admin/api` in a scaffolded project), secure by default.
 - `admin` — menu, pages, settings, and per-collection view overrides (referenced by string component path).
 
 ### Lifecycle

--- a/docs/plugins/error-reference.mdx
+++ b/docs/plugins/error-reference.mdx
@@ -34,7 +34,7 @@ Nextly validates plugins **fail-fast at boot** (D7): a bad plugin config stops s
 
 | Code | Status | Cause | Fix |
 |---|---|---|---|
-| `NEXTLY_ROUTE_COLLISION` | 409 | Two routes share the same `(method, full path)` after namespacing under `/api/plugins/<name>`. | Give each route a distinct method/path. |
+| `NEXTLY_ROUTE_COLLISION` | 409 | Two routes share the same `(method, full path)` after namespacing under `/plugins/<name>`. | Give each route a distinct method/path. |
 | `NEXTLY_ROUTE_INVALID_PATH` | 400 | A route `path` does not start with `/`. | Start the path with `/` (e.g. `/export`). |
 
 ## Inspecting plugins

--- a/docs/plugins/form-builder.mdx
+++ b/docs/plugins/form-builder.mdx
@@ -15,12 +15,25 @@ The Form Builder plugin adds a complete form management system to Nextly. Build 
 npm install @nextlyhq/plugin-form-builder
 ```
 
-The plugin requires these peer dependencies (already present in most Nextly projects):
+The plugin declares these peer dependencies:
 
-- `nextly` >= 0.0.13
-- `@nextlyhq/admin` >= 0.0.13
-- `react` ^18 or ^19
-- `next` ^14, ^15, or ^16
+| Peer | Range |
+|---|---|
+| `nextly` | the matching lockstep version, pinned exactly |
+| `@nextlyhq/admin` | the matching lockstep version, pinned exactly |
+| `@nextlyhq/plugin-sdk` | the matching lockstep version |
+| `@nextlyhq/ui` | the matching lockstep version |
+| `@tanstack/react-query` | >= 5 |
+| `lucide-react` | >= 0.400.0 |
+| `react` | ^18 or ^19 |
+| `next` | ^14, ^15 or ^16 |
+
+While Nextly is in alpha every publishable package ships on one train, so the four Nextly
+peers are pinned to the exact version the plugin was built against: install the plugin and
+your core at the same version rather than a range. `@tanstack/react-query` and
+`lucide-react` are the two most likely to be missing from a project that has not needed
+them yet, and their absence shows up as a broken admin screen rather than an install
+error.
 
 ## Basic Setup
 
@@ -766,7 +779,8 @@ export default defineConfig({
 ```
 
 The route is mounted under the contributing plugin's namespace, so the form posts to
-`/api/plugins/@acme/contact-endpoint/contact`.
+`/admin/api/plugins/@acme/contact-endpoint/contact` in a scaffolded app, where `/admin/api`
+is wherever `createDynamicHandlers` is mounted.
 
 
 

--- a/docs/plugins/form-builder.mdx
+++ b/docs/plugins/form-builder.mdx
@@ -21,16 +21,17 @@ The plugin declares these peer dependencies:
 |---|---|
 | `nextly` | the matching lockstep version, pinned exactly |
 | `@nextlyhq/admin` | the matching lockstep version, pinned exactly |
-| `@nextlyhq/plugin-sdk` | the matching lockstep version |
-| `@nextlyhq/ui` | the matching lockstep version |
+| `@nextlyhq/plugin-sdk` | the matching lockstep version, pinned exactly |
+| `@nextlyhq/ui` | a caret range on the matching lockstep version |
 | `@tanstack/react-query` | >= 5 |
 | `lucide-react` | >= 0.400.0 |
 | `react` | ^18 or ^19 |
 | `next` | ^14, ^15 or ^16 |
 
-While Nextly is in alpha every publishable package ships on one train, so the four Nextly
-peers are pinned to the exact version the plugin was built against: install the plugin and
-your core at the same version rather than a range. `@tanstack/react-query` and
+While Nextly is in alpha every publishable package ships on one train, so three of the four
+Nextly peers are pinned to the exact version the plugin was built against, and `@nextlyhq/ui`
+publishes as a caret range on it. Either way, install the plugin and your core at the same
+version rather than reaching for a range of your own. `@tanstack/react-query` and
 `lucide-react` are the two most likely to be missing from a project that has not needed
 them yet, and their absence shows up as a broken admin screen rather than an install
 error.

--- a/docs/plugins/routes.mdx
+++ b/docs/plugins/routes.mdx
@@ -30,11 +30,28 @@ definePlugin({
 The route above is served at:
 
 ```
-/api/plugins/@acme/nextly-plugin-reports/summary
+/admin/api/plugins/@acme/nextly-plugin-reports/summary
 ```
 
-i.e. `/api/plugins/<plugin-name><path>`. Paths support `:param` segments
-(`/items/:id`), captured into `ctx.params`.
+That address has two halves, and only the second one is Nextly's.
+
+**The namespace** is `/plugins/<plugin-name><path>`, and the plugin name is the raw
+package name rather than the admin slug: `@acme/p` answers at `/plugins/@acme/p/export`,
+even though the admin addresses that plugin as `/admin/plugins/acme-p`.
+
+**The mount** is wherever your app puts `createDynamicHandlers`, and Nextly cannot know
+it: the handler is a route file in your app directory. A scaffolded project mounts it at
+`src/app/admin/api/[[...params]]/route.ts`, which is where the `/admin/api` above comes
+from. Move that file and every plugin route moves with it.
+
+<Callout type="warn">
+A bare `/api` prefix is **not** the mount in a scaffolded app. The base template puts only
+`health` and `media` under `/api`, with no catch-all, so a plugin route addressed there is
+a 404 with nothing to explain it. If your routes are not answering, check where your own
+`createDynamicHandlers` route file actually sits.
+</Callout>
+
+Paths support `:param` segments (`/items/:id`), captured into `ctx.params`.
 
 ## The handler context
 

--- a/packages/admin/src/lib/plugins/plugin-route-registry.ts
+++ b/packages/admin/src/lib/plugins/plugin-route-registry.ts
@@ -2,8 +2,9 @@
  * Client-side registry of plugin-contributed admin pages.
  *
  * Plugin pages are namespaced under `/admin/plugins/<slug>/<path>` to avoid
- * collisions with core routes (mirrors the P4 API namespacing `/api/plugins/
- * <name>`). The registry is consulted by `resolveRoute` (after exact matches,
+ * collisions with core routes (mirrors the P4 API namespacing, `/plugins/
+ * <name>` beneath the handler's mount). The registry is consulted by
+ * `resolveRoute` (after exact matches,
  * before dynamic matches). Components are resolved client-side via the string-
  * path component registry (`PluginSlot`).
  *

--- a/packages/nextly/src/plugins/contributions.ts
+++ b/packages/nextly/src/plugins/contributions.ts
@@ -555,7 +555,10 @@ export interface PluginContributions {
   fieldTypes?: PluginFieldType[];
   /** @experimental Custom event names this plugin may emit. No first-party plugin declares custom events yet. */
   events?: Array<{ name: string }>;
-  /** @public HTTP routes, namespaced under /api/plugins/<name>. */
+  /**
+   * @public HTTP routes, namespaced under `/plugins/<name>` beneath wherever the
+   * app mounts the Nextly handler (`/admin/api` in a scaffolded project).
+   */
   routes?: PluginRoute[];
   /**
    * @public Admin UI contributions: menu, pages +

--- a/packages/nextly/src/plugins/routes/plugin-routes.integration.test.ts
+++ b/packages/nextly/src/plugins/routes/plugin-routes.integration.test.ts
@@ -68,7 +68,12 @@ async function cookie(roleIds: string[] = []): Promise<string> {
   return `nextly_session=${token}`;
 }
 
-/** Call the real catch-all for GET /api/plugins/<PLUGIN>/<sub>. */
+/**
+ * Call the real catch-all for a GET in the plugin namespace.
+ *
+ * The prefix below is this test's own: the dispatcher is addressed directly
+ * here, so it says nothing about where a mounted handler serves from.
+ */
 function get(
   sub: string,
   headers: Record<string, string> = {}

--- a/packages/nextly/src/plugins/routes/route-error.ts
+++ b/packages/nextly/src/plugins/routes/route-error.ts
@@ -25,8 +25,8 @@ export function routeCollisionError(
 
 /**
  * Fail-fast boot error when a contributed route's `path` does not start with
- * "/". Paths are mounted under `/api/plugins/<name>` and must be absolute
- * within the plugin namespace.
+ * "/". Paths are namespaced under `/plugins/<name>` beneath wherever the app
+ * mounts the handler, and must be absolute within the plugin namespace.
  */
 export function routeInvalidPathError(
   pluginName: string,

--- a/packages/nextly/src/plugins/routes/route-path.ts
+++ b/packages/nextly/src/plugins/routes/route-path.ts
@@ -12,8 +12,12 @@
  * `/admin/plugins/acme-p`; the slug is how the ADMIN names a plugin and has
  * never been how the dispatcher does.
  *
- * No mount prefix: the host app decides where the Nextly handler is mounted
- * (`/api/...` by convention), so that half is the caller's to add.
+ * No mount prefix: the host app decides where the Nextly handler is mounted, so
+ * that half is the caller's to add. The scaffold mounts it at
+ * `src/app/admin/api/[[...params]]/route.ts`, which makes the full address
+ * `/admin/api/plugins/<name><path>` in a generated project. This comment said
+ * `/api/...` "by convention" and four documentation pages were written from it,
+ * every one of them naming a URL that 404s in a scaffolded app.
  *
  * @module plugins/routes/route-path
  */

--- a/packages/nextly/src/plugins/routes/route-types.ts
+++ b/packages/nextly/src/plugins/routes/route-types.ts
@@ -126,15 +126,18 @@ export type Middleware = (
 export type PluginRouteMount = "plugin" | "root";
 
 /**
- * @public A single HTTP route contributed by a plugin. Mounted at
- * `/api/plugins/<plugin-name><path>` under the existing catch-all and secure by
- * default (auth + RBAC) unless `public: true`.
+ * @public A single HTTP route contributed by a plugin. Answers at
+ * `/plugins/<plugin-name><path>` under the existing catch-all, so its full URL
+ * depends on where the app mounts that handler: a scaffolded project serves it
+ * from `/admin/api`. Secure by default (auth + RBAC) unless `public: true`.
  */
 export interface PluginRoute {
   method: RouteMethod;
   /**
    * Path within the plugin namespace; MUST start with `"/"`. Supports `:param`
-   * segments (e.g. `"/items/:id"`). Final URL: `/api/plugins/<plugin-name><path>`.
+   * segments (e.g. `"/items/:id"`). Answers at
+   * `<handler mount>/plugins/<plugin-name><path>`, which is
+   * `/admin/api/plugins/...` in a scaffolded project.
    */
   path: string;
   handler: PluginRouteHandler;

--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -615,52 +615,105 @@ function metaReachability(repoRoot, tracked, findings) {
  *
  * 🔴 Four documentation pages named `/api/plugins/<name>` because a comment in
  * `route-path.ts` called that the convention. The base template mounts the
- * dynamic handler at `src/app/admin/api/[[...params]]/route.ts`, and `/api`
- * carries only `health` and `media` with no catch-all, so every one of those
- * URLs 404s in a generated project with nothing to explain why. It is the
- * first thing a plugin author hits.
+ * dynamic handler under `/admin/api`, and `/api` carries only `health` and
+ * `media` with no catch-all, so every one of those URLs answers 404 in a
+ * generated project. It is the first thing a plugin author hits.
  *
- * The mount is DERIVED from the template on every run, so moving that route
- * file reports the pages that now disagree instead of leaving them wrong, and
- * the namespace segment is read from its one declaration for the same reason.
+ * Everything this compares against is DERIVED on each run: the namespace
+ * segment from its one declaration, and the mount from BOTH places that decide
+ * it, since `create-nextly-app` scaffolds into an empty project from the
+ * template and into an existing one from its own generator. Two sources that
+ * disagree mean the docs cannot state one answer, so this refuses instead of
+ * picking a side.
+ *
+ * Comments in published source are read too. The wrong claim started in a
+ * `@public` JSDoc, so a guard that watched only Markdown would leave the
+ * original mistake free to come back and take the pages with it. Code is
+ * blanked first: integration tests address the dispatcher directly at an
+ * arbitrary prefix, which is theirs to choose and not a claim about anything.
  */
-const DYNAMIC_HANDLER_IMPORT = /createDynamicHandlers/;
 const NAMESPACE_DECLARATION =
   /export const PLUGIN_NAMESPACE_SEGMENT\s*=\s*"([^"]+)"/;
 const NAMESPACE_SOURCE = "packages/nextly/src/plugins/routes/route-path.ts";
 const TEMPLATE_APP_DIR = "templates/base/src/app/";
 const TEMPLATE_CATCH_ALL = "/[[...params]]/route.ts";
-/** A path ending in `api` that then namespaces plugins, i.e. a mounted route. */
-const MOUNTED_PLUGIN_PATH = /((?:\/[A-Za-z0-9_-]+)*\/api)\/plugins\//g;
+const GENERATOR_SOURCE = "packages/create-nextly-app/src/generators/routes.ts";
+const GENERATOR_MOUNT =
+  /path\.join\(\s*cwd,\s*projectInfo\.appDir,\s*((?:"[^"]*",\s*)+)"\[\[\.\.\.params\]\]"/;
+const QUOTED_SEGMENT = /"([^"]*)"/g;
 
-function pluginRouteMount(repoRoot, tracked, findings) {
-  const refuse = message => {
-    findings.push({
-      check: "plugin-route-mount-unreadable",
-      file: NAMESPACE_SOURCE,
-      line: null,
-      message,
-    });
-  };
-
-  // Fails closed on both halves. Checking the docs against a mount this could
-  // not establish would report "no findings" for a question it never asked.
-  const mounts = tracked
+/** The mount the base template hard-codes by where its route file sits. */
+function templateMount(repoRoot, tracked, refuse) {
+  const candidates = tracked
     .filter(
       rel => rel.startsWith(TEMPLATE_APP_DIR) && rel.endsWith(TEMPLATE_CATCH_ALL)
     )
     .filter(rel => {
       try {
-        return DYNAMIC_HANDLER_IMPORT.test(
+        return /createDynamicHandlers/.test(
           readFileSync(join(repoRoot, rel), "utf-8")
         );
       } catch {
         return false;
       }
     });
-  if (mounts.length !== 1) {
+  if (candidates.length !== 1) {
     refuse(
-      `expected exactly one scaffolded createDynamicHandlers route to read the mount from, found ${String(mounts.length)}`
+      TEMPLATE_APP_DIR,
+      `expected exactly one scaffolded createDynamicHandlers route to read the mount from, found ${String(candidates.length)}`
+    );
+    return null;
+  }
+  return `/${candidates[0].slice(
+    TEMPLATE_APP_DIR.length,
+    candidates[0].length - TEMPLATE_CATCH_ALL.length
+  )}`;
+}
+
+/** The mount the generator builds when scaffolding into an existing project. */
+function generatorMount(repoRoot, refuse) {
+  let source;
+  try {
+    source = readFileSync(join(repoRoot, GENERATOR_SOURCE), "utf-8");
+  } catch {
+    refuse(GENERATOR_SOURCE, "could not be read, so the mount it generates is unknown");
+    return null;
+  }
+  const declared = GENERATOR_MOUNT.exec(source);
+  if (declared === null) {
+    refuse(
+      GENERATOR_SOURCE,
+      "no longer builds the catch-all route path in the shape this reads, so the mount it generates is unknown"
+    );
+    return null;
+  }
+  const segments = [...declared[1].matchAll(QUOTED_SEGMENT)].map(m => m[1]);
+  if (segments.length === 0) {
+    refuse(GENERATOR_SOURCE, "builds a catch-all route path with no leading segments");
+    return null;
+  }
+  return `/${segments.join("/")}`;
+}
+
+function pluginRouteMount(repoRoot, tracked, findings, isExempt) {
+  const refuse = (file, message) => {
+    findings.push({
+      check: "plugin-route-mount-unreadable",
+      file,
+      line: null,
+      message,
+    });
+  };
+
+  // Fails closed on every input. Checking the docs against a mount this could
+  // not establish would report "no findings" for a question it never asked.
+  const fromTemplate = templateMount(repoRoot, tracked, refuse);
+  const fromGenerator = generatorMount(repoRoot, refuse);
+  if (fromTemplate === null || fromGenerator === null) return;
+  if (fromTemplate !== fromGenerator) {
+    refuse(
+      GENERATOR_SOURCE,
+      `generates ${fromGenerator} while the template mounts at ${fromTemplate}; a scaffolded project's plugin routes would answer at two different addresses, so the docs cannot name one`
     );
     return;
   }
@@ -672,6 +725,7 @@ function pluginRouteMount(repoRoot, tracked, findings) {
     );
     if (declared === null) {
       refuse(
+        NAMESPACE_SOURCE,
         "PLUGIN_NAMESPACE_SEGMENT is not declared where this check reads it"
       );
       return;
@@ -679,40 +733,61 @@ function pluginRouteMount(repoRoot, tracked, findings) {
     namespace = declared[1];
   } catch {
     refuse(
+      NAMESPACE_SOURCE,
       "could not be read, so the documented plugin route path has nothing to be checked against"
     );
     return;
   }
 
-  // `templates/base/src/app/admin/api/[[...params]]/route.ts` -> `/admin/api`
-  const mount = `/${mounts[0].slice(
-    TEMPLATE_APP_DIR.length,
-    mounts[0].length - TEMPLATE_CATCH_ALL.length
-  )}`;
+  const mount = fromTemplate;
   const expected = `${mount}/${namespace}/`;
+  // Built from the two derived values, so renaming either reports the pages
+  // that now disagree rather than quietly matching nothing.
+  const tail = mount.slice(mount.lastIndexOf("/") + 1);
+  const escape = value => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const mountedPath = new RegExp(
+    `((?:\\/[A-Za-z0-9_-]+)*\\/${escape(tail)})\\/${escape(namespace)}\\/`,
+    "g"
+  );
+
+  const isDoc = rel =>
+    (rel.startsWith("docs/") || rel.endsWith("/README.md")) &&
+    (rel.endsWith(".mdx") || rel.endsWith(".md")) &&
+    basename(rel) !== "CHANGELOG.md";
+  const isSource = rel =>
+    rel.startsWith("packages/") &&
+    /\.(ts|tsx|mjs)$/.test(rel) &&
+    !rel.includes("/dist/");
 
   for (const rel of tracked) {
-    if (!rel.startsWith("docs/") && !rel.endsWith("/README.md")) continue;
-    if (!rel.endsWith(".mdx") && !rel.endsWith(".md")) continue;
-    if (basename(rel) === "CHANGELOG.md") continue;
+    const doc = isDoc(rel);
+    if (!doc && !isSource(rel)) continue;
     let text;
     try {
       text = readFileSync(join(repoRoot, rel), "utf-8");
     } catch {
       continue;
     }
-    const lines = text.split("\n");
+    // Source is read as its comments alone. A test that calls the dispatcher at
+    // some prefix of its own is not claiming anything about where a route
+    // answers, and `sourceComments` keeps the line numbers a reader needs.
+    const lines = (doc ? text : sourceComments(text)).split("\n");
     for (let i = 0; i < lines.length; i++) {
-      MOUNTED_PLUGIN_PATH.lastIndex = 0;
+      mountedPath.lastIndex = 0;
       let match;
-      while ((match = MOUNTED_PLUGIN_PATH.exec(lines[i])) !== null) {
+      while ((match = mountedPath.exec(lines[i])) !== null) {
         const found = `${match[1]}/${namespace}/`;
         if (found === expected) continue;
+        // A page teaching that the OLD address 404s has to be able to write it
+        // down. That is one line of prose rather than a pattern this can
+        // recognise, so it goes through the same per-line allowlist every other
+        // deliberate exception here uses.
+        if (isExempt(rel, lines[i])) continue;
         findings.push({
           check: "plugin-route-mount",
           file: rel,
           line: i + 1,
-          message: `documents a plugin route at ${found}, but the scaffold mounts the handler at ${mount}, so it answers at ${expected}`,
+          message: `names a plugin route at ${found}, but the handler is mounted at ${mount}, so it answers at ${expected}`,
         });
       }
     }
@@ -1741,7 +1816,7 @@ export async function runChecks({
     repairs
   );
   internalLinks(repoRoot, tracked, findings);
-  pluginRouteMount(repoRoot, tracked, findings);
+  pluginRouteMount(repoRoot, tracked, findings, exemption("plugin-route-mount"));
   metaReachability(repoRoot, tracked, findings);
 
   return { findings, unverifiable };

--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -609,6 +609,116 @@ function metaReachability(repoRoot, tracked, findings) {
  * reports it until a reader hits a 404. The set of pages is derived from the same tracked
  * list everything else here reads, so a link to a page that exists only locally fails too.
  */
+/**
+ * Where a plugin route actually answers, checked against the scaffold rather
+ * than against a convention someone remembered.
+ *
+ * 🔴 Four documentation pages named `/api/plugins/<name>` because a comment in
+ * `route-path.ts` called that the convention. The base template mounts the
+ * dynamic handler at `src/app/admin/api/[[...params]]/route.ts`, and `/api`
+ * carries only `health` and `media` with no catch-all, so every one of those
+ * URLs 404s in a generated project with nothing to explain why. It is the
+ * first thing a plugin author hits.
+ *
+ * The mount is DERIVED from the template on every run, so moving that route
+ * file reports the pages that now disagree instead of leaving them wrong, and
+ * the namespace segment is read from its one declaration for the same reason.
+ */
+const DYNAMIC_HANDLER_IMPORT = /createDynamicHandlers/;
+const NAMESPACE_DECLARATION =
+  /export const PLUGIN_NAMESPACE_SEGMENT\s*=\s*"([^"]+)"/;
+const NAMESPACE_SOURCE = "packages/nextly/src/plugins/routes/route-path.ts";
+const TEMPLATE_APP_DIR = "templates/base/src/app/";
+const TEMPLATE_CATCH_ALL = "/[[...params]]/route.ts";
+/** A path ending in `api` that then namespaces plugins, i.e. a mounted route. */
+const MOUNTED_PLUGIN_PATH = /((?:\/[A-Za-z0-9_-]+)*\/api)\/plugins\//g;
+
+function pluginRouteMount(repoRoot, tracked, findings) {
+  const refuse = message => {
+    findings.push({
+      check: "plugin-route-mount-unreadable",
+      file: NAMESPACE_SOURCE,
+      line: null,
+      message,
+    });
+  };
+
+  // Fails closed on both halves. Checking the docs against a mount this could
+  // not establish would report "no findings" for a question it never asked.
+  const mounts = tracked
+    .filter(
+      rel => rel.startsWith(TEMPLATE_APP_DIR) && rel.endsWith(TEMPLATE_CATCH_ALL)
+    )
+    .filter(rel => {
+      try {
+        return DYNAMIC_HANDLER_IMPORT.test(
+          readFileSync(join(repoRoot, rel), "utf-8")
+        );
+      } catch {
+        return false;
+      }
+    });
+  if (mounts.length !== 1) {
+    refuse(
+      `expected exactly one scaffolded createDynamicHandlers route to read the mount from, found ${String(mounts.length)}`
+    );
+    return;
+  }
+
+  let namespace;
+  try {
+    const declared = NAMESPACE_DECLARATION.exec(
+      readFileSync(join(repoRoot, NAMESPACE_SOURCE), "utf-8")
+    );
+    if (declared === null) {
+      refuse(
+        "PLUGIN_NAMESPACE_SEGMENT is not declared where this check reads it"
+      );
+      return;
+    }
+    namespace = declared[1];
+  } catch {
+    refuse(
+      "could not be read, so the documented plugin route path has nothing to be checked against"
+    );
+    return;
+  }
+
+  // `templates/base/src/app/admin/api/[[...params]]/route.ts` -> `/admin/api`
+  const mount = `/${mounts[0].slice(
+    TEMPLATE_APP_DIR.length,
+    mounts[0].length - TEMPLATE_CATCH_ALL.length
+  )}`;
+  const expected = `${mount}/${namespace}/`;
+
+  for (const rel of tracked) {
+    if (!rel.startsWith("docs/") && !rel.endsWith("/README.md")) continue;
+    if (!rel.endsWith(".mdx") && !rel.endsWith(".md")) continue;
+    if (basename(rel) === "CHANGELOG.md") continue;
+    let text;
+    try {
+      text = readFileSync(join(repoRoot, rel), "utf-8");
+    } catch {
+      continue;
+    }
+    const lines = text.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      MOUNTED_PLUGIN_PATH.lastIndex = 0;
+      let match;
+      while ((match = MOUNTED_PLUGIN_PATH.exec(lines[i])) !== null) {
+        const found = `${match[1]}/${namespace}/`;
+        if (found === expected) continue;
+        findings.push({
+          check: "plugin-route-mount",
+          file: rel,
+          line: i + 1,
+          message: `documents a plugin route at ${found}, but the scaffold mounts the handler at ${mount}, so it answers at ${expected}`,
+        });
+      }
+    }
+  }
+}
+
 function internalLinks(repoRoot, tracked, findings) {
   const pages = new Set(tracked.filter(rel => rel.endsWith(".mdx")));
   const resolves = target => {
@@ -1631,6 +1741,7 @@ export async function runChecks({
     repairs
   );
   internalLinks(repoRoot, tracked, findings);
+  pluginRouteMount(repoRoot, tracked, findings);
   metaReachability(repoRoot, tracked, findings);
 
   return { findings, unverifiable };

--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -750,6 +750,13 @@ function pluginRouteMount(repoRoot, tracked, findings, isExempt) {
     "g"
   );
 
+  // Counted, because everything above is a search for a WRONG shape and a
+  // search finds nothing in two different situations. Renaming the namespace
+  // makes every correct reference stop matching and every stale one invisible,
+  // so the run goes green by having asked about nothing at all. At least one
+  // reference has to be found saying the right thing.
+  let correct = 0;
+
   const isDoc = rel =>
     (rel.startsWith("docs/") || rel.endsWith("/README.md")) &&
     (rel.endsWith(".mdx") || rel.endsWith(".md")) &&
@@ -777,7 +784,10 @@ function pluginRouteMount(repoRoot, tracked, findings, isExempt) {
       let match;
       while ((match = mountedPath.exec(lines[i])) !== null) {
         const found = `${match[1]}/${namespace}/`;
-        if (found === expected) continue;
+        if (found === expected) {
+          correct += 1;
+          continue;
+        }
         // A page teaching that the OLD address 404s has to be able to write it
         // down. That is one line of prose rather than a pattern this can
         // recognise, so it goes through the same per-line allowlist every other
@@ -791,6 +801,13 @@ function pluginRouteMount(repoRoot, tracked, findings, isExempt) {
         });
       }
     }
+  }
+
+  if (correct === 0) {
+    refuse(
+      NAMESPACE_SOURCE,
+      `nothing documents a plugin route at ${expected}, so this check compared the docs against a shape none of them use. Either the namespace or the mount moved and every reference is now stale, or the pages that named one are gone`
+    );
   }
 }
 

--- a/scripts/docs-claims-allowlist.json
+++ b/scripts/docs-claims-allowlist.json
@@ -5,5 +5,12 @@
       "digests": ["eceb86bd05632f29"],
       "reason": "Accurate. packages/nextly/src/routeHandler.ts returns { message: \"Batch regeneration coming soon\" } for the image-size regenerationStatus and regenerate sub-routes. Remove this entry when those routes do the work."
     }
+  },
+  "plugin-route-mount": {
+    "docs/plugins/seo.mdx": {
+      "count": 1,
+      "digests": ["a46ee0722e3fd074"],
+      "reason": "Accurate, and deliberately names the obsolete address. The sentence exists so a reader who tried /api/plugins/... and got a 404 can search for it and find the explanation; rewording it to avoid the literal would remove the only string that reader has. Remove this entry if the troubleshooting note goes."
+    }
   }
 }


### PR DESCRIPTION
Four documentation pages told plugin authors their routes answer at
`/api/plugins/<name>`. They do not. The base template mounts the dynamic
handler at `src/app/admin/api/[[...params]]/route.ts`, and `/api` carries only
`health` and `media` with no catch-all, so every one of those URLs is a **404
in a generated project** with nothing to explain why.

It is the first thing a third-party plugin author hits after writing a route.

The project already knew the right answer in two places: `plugin-seo`'s README
uses `/admin/api/plugins/...`, and so does the changelog entry for #351. Only
the docs were wrong.

## The address has two halves, and the pages conflated them

**The namespace is Nextly's**: `/plugins/<package-name><path>`, using the raw
package name rather than the admin slug, so `@acme/p` answers at
`/plugins/@acme/p/export` while the admin addresses it as `/admin/plugins/acme-p`.

**The mount is the app's**, because the handler is a route file in the app
directory and Nextly cannot know where it sits.

Saying only the concatenation left a reader unable to reason about moving that
file. The pages say both halves now.

## The comment that caused it

`route-path.ts` said the mount is `/api/...` "by convention", which is where all
four pages came from, and `contributions.ts` repeated it on a `@public` field.
Both are corrected, with the reason recorded so the next reader does not restore
the shorter, wronger version.

## A check, so it cannot drift back

`check-docs-claims` gained `plugin-route-mount`. It **derives** the mount from
the template's own catch-all route on every run and reads the namespace segment
from its single declaration, rather than hardcoding a path that becomes another
thing to remember.

| Mutation | Result |
|---|---|
| Restore the original `/api/plugins/...` in `routes.mdx` | 1 finding |
| Move the scaffold's handler to `/api` | **5 findings**, every documented reference |
| Two candidate handlers, so the mount is ambiguous | `plugin-route-mount-unreadable`, fails closed |
| Unmutated | no findings |

The second row is the one that matters: the check tracks where the handler
actually is, so moving it reports the pages that now disagree instead of
silently passing. The third confirms it refuses rather than checking docs
against a mount it could not establish.

## Also, in form-builder

Its documented peers said `nextly >= 0.0.13` and `@nextlyhq/admin >= 0.0.13`
against a published `0.0.2-alpha.65`. Under semver `0.0.13` is *newer* than
`0.0.2-alpha.65`, so that constraint resolves to nothing installable.

It also omitted four real peers. `@tanstack/react-query` and `lucide-react` are
the two most likely to be missing from a project that has not needed them yet,
and their absence breaks an admin screen rather than the install, which is the
hardest kind to diagnose.

## No changeset

Docs, a dev-tooling script, and two **comment-only** edits in `packages/nextly`
(`git diff` on the source is comments and nothing else). No behaviour and no
published type changes.