### PR TITLE
fix(nextly): give the activity fixtures the actor kind their type now requires

### DIFF
--- a/packages/nextly/src/domains/users/__tests__/activity-write-locks-actor.integration.test.ts
+++ b/packages/nextly/src/domains/users/__tests__/activity-write-locks-actor.integration.test.ts
@@ -140,6 +140,7 @@ describeMaybe(
       expect(account).toHaveLength(0);
 
       await activity.logActivity({
+        actorType: "user",
         userId: goneId,
         userName: "Already Gone",
         userEmail: "gone@test.local",
@@ -174,6 +175,7 @@ describeMaybe(
     it("keeps the author's identity while the account still exists", async () => {
       // The other half, so the test above cannot pass by erasing everything.
       await activity.logActivity({
+        actorType: "user",
         userId: actorId,
         userName: "Locked Actor",
         userEmail: "locked@test.local",
@@ -234,6 +236,7 @@ describeMaybe(
 
       const write = activity
         .logActivity({
+          actorType: "user",
           userId: actorId,
           userName: "Locked Actor",
           userEmail: "locked@test.local",

--- a/packages/nextly/src/domains/users/__tests__/activity-write-mysql.integration.test.ts
+++ b/packages/nextly/src/domains/users/__tests__/activity-write-mysql.integration.test.ts
@@ -113,6 +113,7 @@ describeMaybe("the locked activity write on MySQL", () => {
 
   it("keeps the author's identity while the account still exists", async () => {
     await activity.logActivity({
+      actorType: "user",
       userId: LIVE_ACTOR,
       userName: "Live Actor",
       userEmail: "mysql-live@test.local",
@@ -144,6 +145,7 @@ describeMaybe("the locked activity write on MySQL", () => {
     expect(account).toHaveLength(0);
 
     await activity.logActivity({
+      actorType: "user",
       userId: GONE_ACTOR,
       userName: "Already Gone",
       userEmail: "mysql-gone@test.local",

--- a/packages/nextly/src/domains/users/__tests__/user-delete-audit-erasure.integration.test.ts
+++ b/packages/nextly/src/domains/users/__tests__/user-delete-audit-erasure.integration.test.ts
@@ -183,6 +183,7 @@ describe("deleting a user erases them from the activity log without erasing the 
       isActive: true,
     });
     await activity.logActivity({
+      actorType: "user",
       userId: String(actor.id),
       userName: "No Audit",
       userEmail: "no-audit-table@test.local",
@@ -304,6 +305,7 @@ describe("deleting a user erases them from the activity log without erasing the 
     // Written through the production writer rather than a hand-built INSERT,
     // so the columns under test are the ones the product actually fills.
     await activity.logActivity({
+      actorType: "user",
       userId: String(author.id),
       userName: "Ada Author",
       userEmail: "erasure-author@test.local",
@@ -369,6 +371,7 @@ describe("deleting a user erases them from the activity log without erasing the 
     expect(account).toHaveLength(0);
 
     await activity.logActivity({
+      actorType: "user",
       userId: String(gone.id),
       userName: "Late Writer",
       userEmail: "erasure-late@test.local",
@@ -402,6 +405,7 @@ describe("deleting a user erases them from the activity log without erasing the 
       isActive: true,
     });
     await activity.logActivity({
+      actorType: "user",
       userId: String(author.id),
       userName: "Read Path",
       userEmail: "erasure-readpath@test.local",
@@ -460,6 +464,7 @@ describe("deleting a user erases them from the activity log without erasing the 
     });
     for (const title of ["older", "newer"]) {
       await activity.logActivity({
+        actorType: "user",
         userId: String(author.id),
         userName: "Orderly",
         userEmail: "erasure-order@test.local",
@@ -503,6 +508,7 @@ describe("deleting a user erases them from the activity log without erasing the 
       isActive: true,
     });
     await activity.logActivity({
+      actorType: "user",
       userId: String(author.id),
       userName: "Stamped",
       userEmail: "erasure-stamp@test.local",
@@ -556,6 +562,7 @@ describe("deleting a user erases them from the activity log without erasing the 
       [staying, "staying_posts"],
     ] as const) {
       await activity.logActivity({
+        actorType: "user",
         userId: String(user.id),
         userName: user.name ?? "",
         userEmail: user.email,

--- a/packages/nextly/src/services/dashboard/__tests__/activity-scope.integration.test.ts
+++ b/packages/nextly/src/services/dashboard/__tests__/activity-scope.integration.test.ts
@@ -41,12 +41,14 @@ describe("activity feed scope (sqlite integration)", () => {
 
     const activityLog = current.getService("activityLogService");
     await activityLog.logActivity({
+      actorType: "user",
       userId: actorId,
       action: "create",
       collection: "posts",
       entryTitle: "Visible Post",
     });
     await activityLog.logActivity({
+      actorType: "user",
       userId: actorId,
       action: "create",
       collection: "pages",


### PR DESCRIPTION
`main` is red on `check-types`, from its own current tip.

```
error TS2345: Argument of type '{ userId: string; ... }' is not assignable
  to parameter of type 'LogActivityInput'.
```

14 occurrences across 4 suites.

## Why it was green in both changes and red once merged

`LogActivityInput.actorType` became **required** in #1735 (`8653c1920`, the current tip). These fixtures were written against the older shape. Each side typechecked against a base without the other, so they met for the first time on `main` — where nothing runs them together until the next PR inherits the failure.

Same shape as #1718 earlier today. It is worth noting how ordinary this is becoming: a required field added to a shared input, and the fixtures that build that input by hand are the population nothing rebuilds.

## Why `"user"` and not something that merely compiles

The field's own docblock:

> only a `user` has an account, so only a user's write is routed through the erasure-aware insert. A key or system identifier has no row in `users`, and looking it up there would write the entry already-erased.

Three of these four suites exist to exercise exactly that path — the account lock held across a commit, its MySQL variant, and the erasure sweep after a delete. Any other actor kind routes the write **away** from the behaviour under test and leaves those suites asserting nothing. So `"user"` is what keeps them testing what their names claim, not the value that quiets the compiler.

## Verification

Every `logActivity` call in those files was counted before editing and after: 3 + 2 + 7 + 2 = 14 calls, 14 compiler errors, none already carrying the field — so the population edited is exactly the population reported, with nothing else touched.

`pnpm check-types` 0 errors from a full build (was 14). `pnpm lint` clean. fallow `pass`, 4 files, nothing introduced.

Test-only, so no changeset per AGENTS.md.