### PR TITLE
fix(admin): recover the onboarding staleness guard stranded by #1737

### DIFF
--- a/.changeset/onboarding-card-reads-what-is-true-now.md
+++ b/.changeset/onboarding-card-reads-what-is-true-now.md
@@ -1,0 +1,40 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The setup checklist no longer shows a finished list to a reader who still has
+work to do.
+
+Its answer was held as fresh for five minutes and the card is unmounted whenever
+it is not offered, so the two combined: a reader who completed onboarding and
+then deleted their last collection was offered the card again, and it drew every
+row ticked from the answer the previous visit had left behind. It reads what is
+true now, and will not report completion from anything it did not just fetch.
+
+Applying schema changes refreshes it too. Two of its steps are answered from the
+collections a schema change moves, and the card's own listener is not mounted at
+the moment that matters — the answer changes precisely while the card is absent.

--- a/packages/admin/src/components/features/dashboard/OnboardingChecklist.test.tsx
+++ b/packages/admin/src/components/features/dashboard/OnboardingChecklist.test.tsx
@@ -39,10 +39,25 @@ const ALL_BUT_ONE = [
 
 const EVERY_STEP = ALL_BUT_ONE.map(step => ({ ...step, complete: true }));
 
+/**
+ * A client carrying the defaults PRODUCTION uses.
+ *
+ * 🔴 `gcTime: 0` and an absent `staleTime` are what a test client reaches for,
+ * and both hide real defects here. The admin's `QueryProvider` holds data fresh
+ * for five minutes, keeps it for ten, and does not refetch on focus — so a
+ * cached answer genuinely survives an unmount and genuinely is not refreshed by
+ * returning to the tab. A client that collects the entry immediately, or treats
+ * it as stale on arrival, can never meet either case.
+ */
 function client() {
   return new QueryClient({
     defaultOptions: {
-      queries: { retry: false, gcTime: 0 },
+      queries: {
+        retry: false,
+        staleTime: 5 * 60 * 1000,
+        gcTime: 10 * 60 * 1000,
+        refetchOnWindowFocus: false,
+      },
       mutations: { retry: false },
     },
   });
@@ -190,12 +205,7 @@ describe("the onboarding checklist", () => {
     // layout consumer has to stay mounted for the SECOND mount too, or the
     // invalidation has no observer and its refetch count cannot move either way.
     protectedGet.mockResolvedValue({ steps: EVERY_STEP });
-    const qc = new QueryClient({
-      defaultOptions: {
-        queries: { retry: false, gcTime: 60_000 },
-        mutations: { retry: false },
-      },
-    });
+    const qc = client();
     const readLayout = vi.fn().mockResolvedValue({ placements: [] });
     const LayoutConsumer = () => {
       useQuery({ queryKey: DASHBOARD_LAYOUT_KEY, queryFn: readLayout });
@@ -221,9 +231,15 @@ describe("the onboarding checklist", () => {
     protectedGet.mockResolvedValue({ steps: ALL_BUT_ONE });
     view.rerender(withCard(true));
 
+    // 🔴 Asserted on the PROGRESS, not the row count. Both answers hold three
+    // rows -- the cached one has them all ticked -- so counting rows cannot
+    // separate the obsolete answer from the fresh one, and a test that counts
+    // them passes with the refetch removed entirely. "2 of 3" is true only of
+    // the answer this mount fetched.
     await waitFor(() =>
-      expect(screen.getAllByRole("listitem")).toHaveLength(ALL_BUT_ONE.length)
+      expect(screen.getByText(/2 of 3 done/)).toBeInTheDocument()
     );
+    expect(screen.getAllByRole("listitem")).toHaveLength(ALL_BUT_ONE.length);
     expect(readLayout).toHaveBeenCalledTimes(afterDrop);
   });
 

--- a/packages/admin/src/components/features/dashboard/OnboardingChecklist.test.tsx
+++ b/packages/admin/src/components/features/dashboard/OnboardingChecklist.test.tsx
@@ -16,7 +16,7 @@ import {
   QueryClientProvider,
   useQuery,
 } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -174,6 +174,57 @@ describe("the onboarding checklist", () => {
       ).toBeInTheDocument()
     );
     expect(readLayout).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT act on a completed answer cached by an EARLIER mount", async () => {
+    // 🔴 The card is unmounted whenever it is not offered, and a cached response
+    // outlives that. A reader who finishes onboarding and then deletes their
+    // last collection gets the card offered again -- and it would remount
+    // holding the previous mount's all-complete answer, announce itself
+    // finished before its own refetch landed, and ask the host for a layout the
+    // server has just decided should include it.
+    //
+    // Two things this fixture must get right, both found by the break killing
+    // nothing: the client has to KEEP its cache across the unmount, which the
+    // shared `client()` does not (`gcTime: 0` collects it immediately); and the
+    // layout consumer has to stay mounted for the SECOND mount too, or the
+    // invalidation has no observer and its refetch count cannot move either way.
+    protectedGet.mockResolvedValue({ steps: EVERY_STEP });
+    const qc = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 60_000 },
+        mutations: { retry: false },
+      },
+    });
+    const readLayout = vi.fn().mockResolvedValue({ placements: [] });
+    const LayoutConsumer = () => {
+      useQuery({ queryKey: DASHBOARD_LAYOUT_KEY, queryFn: readLayout });
+      return null;
+    };
+    const withCard = (card: boolean) => (
+      <QueryClientProvider client={qc}>
+        <LayoutConsumer />
+        {card ? <OnboardingChecklist /> : null}
+      </QueryClientProvider>
+    );
+
+    const view = render(withCard(true));
+    // The first mount completes and correctly asks the host to drop the card.
+    await waitFor(() => expect(readLayout).toHaveBeenCalledTimes(2));
+
+    // The host drops it, so the card unmounts while its answer stays cached.
+    view.rerender(withCard(false));
+    const afterDrop = readLayout.mock.calls.length;
+
+    // The reader deletes their last collection: the host offers the card again,
+    // and the fresh answer has work outstanding.
+    protectedGet.mockResolvedValue({ steps: ALL_BUT_ONE });
+    view.rerender(withCard(true));
+
+    await waitFor(() =>
+      expect(screen.getAllByRole("listitem")).toHaveLength(ALL_BUT_ONE.length)
+    );
+    expect(readLayout).toHaveBeenCalledTimes(afterDrop);
   });
 
   it("says progress is unavailable rather than showing it finished", async () => {

--- a/packages/admin/src/context/RestartContext.tsx
+++ b/packages/admin/src/context/RestartContext.tsx
@@ -20,6 +20,7 @@ import {
 } from "react";
 
 import { DASHBOARD_LAYOUT_KEY } from "@admin/hooks/queries/useDashboardLayout";
+import { ONBOARDING_STEPS_KEY } from "@admin/hooks/queries/useOnboardingSteps";
 import { ADMIN_META_KEY } from "@admin/hooks/useSchemaUpdateInvalidation";
 
 import { fieldGroupKeys } from "../hooks/queries";
@@ -106,6 +107,12 @@ export function RestartProvider({ children }: { children: ReactNode }) {
         // which are offered. Both go stale for the same reason and neither is
         // reachable from the other's key.
         void queryClient.invalidateQueries({ queryKey: DASHBOARD_LAYOUT_KEY });
+        // And the onboarding steps, two of which are answered from the
+        // collection registry a schema apply has just moved. Invalidated here
+        // rather than only through the card's own listener, because that
+        // listener is unmounted whenever the card is not offered -- and the
+        // moment the answer changes is exactly when it is not.
+        void queryClient.invalidateQueries({ queryKey: ONBOARDING_STEPS_KEY });
       } else {
         toast.error(message ?? "Failed to apply schema changes");
       }

--- a/packages/admin/src/hooks/queries/useOnboardingSteps.ts
+++ b/packages/admin/src/hooks/queries/useOnboardingSteps.ts
@@ -134,11 +134,26 @@ export function useOnboardingSteps(): UseOnboardingStepsResult {
   // unmounts this hook, and a guardless effect would re-invalidate on every
   // render for as long as anything kept it alive.
   const dropped = useRef(false);
+  // 🔴 Only data fetched during THIS mount may ask the host to drop the card.
+  //
+  // The card is unmounted whenever it is not offered, and a cached response
+  // outlives that. So a reader who finishes onboarding, then deletes their last
+  // collection, gets the card offered again -- and it would remount holding the
+  // previous mount's all-complete answer, announce itself finished before its
+  // own refetch landed, and ask for a layout the server has just decided should
+  // include it. One spurious round trip, and a card that flickers away from a
+  // reader who needs it.
+  //
+  // Compared against the mount rather than trusting `isStale`: the query sets no
+  // `staleTime`, so its data is stale the instant it arrives and that flag
+  // cannot separate "not yet refetched" from "just fetched".
+  const mountedAt = useRef(Date.now());
   useEffect(() => {
     if (!finished || dropped.current) return;
+    if (query.dataUpdatedAt < mountedAt.current) return;
     dropped.current = true;
     void queryClient.invalidateQueries({ queryKey: DASHBOARD_LAYOUT_KEY });
-  }, [finished, queryClient]);
+  }, [finished, query.dataUpdatedAt, queryClient]);
 
   return {
     steps,

--- a/packages/admin/src/hooks/queries/useOnboardingSteps.ts
+++ b/packages/admin/src/hooks/queries/useOnboardingSteps.ts
@@ -113,6 +113,24 @@ export function useOnboardingSteps(): UseOnboardingStepsResult {
     queryFn: () =>
       protectedApi.get<OnboardingResponse>("/dashboard/onboarding"),
     retry: false,
+    /*
+     * 🔴 Overrides the provider's five-minute default, and the card does not
+     * work without it. This answer changes when the reader creates a collection
+     * or writes their first entry -- things they do elsewhere in the admin,
+     * often seconds before returning here -- and the provider also disables
+     * focus refetching, so an answer held fresh is not refreshed by coming back
+     * to the tab either.
+     *
+     * The case that makes it sharp: the card is unmounted whenever it is not
+     * offered, and the cached answer outlives that by ten minutes. A reader who
+     * finishes onboarding and then deletes their last collection is offered the
+     * card again -- and a cached answer still counted fresh means it draws
+     * every row ticked, while the host is offering it precisely because a row
+     * is not.
+     *
+     * Cheap: this query only mounts while onboarding is outstanding.
+     */
+    staleTime: 0,
   });
 
   // Guarded at the boundary rather than trusted. The response is JSON, so the
@@ -144,9 +162,10 @@ export function useOnboardingSteps(): UseOnboardingStepsResult {
   // include it. One spurious round trip, and a card that flickers away from a
   // reader who needs it.
   //
-  // Compared against the mount rather than trusting `isStale`: the query sets no
-  // `staleTime`, so its data is stale the instant it arrives and that flag
-  // cannot separate "not yet refetched" from "just fetched".
+  // Compared against the MOUNT rather than trusting `isStale`. With
+  // `staleTime: 0` above, data is stale the instant it arrives, so that flag
+  // cannot separate "not yet refetched" from "just fetched" -- and it is the
+  // refetch this has to wait for, not the staleness.
   const mountedAt = useRef(Date.now());
   useEffect(() => {
     if (!finished || dropped.current) return;


### PR DESCRIPTION
Recovers work that was **stranded by the merge of #1737**.

## What happened

#1737 merged from `0f2688f1d`. My last commit on that branch, `161cebe74`, was pushed after GitHub had computed the merge — so it is absent from the merge commit and never reached `main`. The PR reads merged and complete; nothing about it looks wrong.

Confirmed rather than assumed:

```
node scripts/verify-merge.mjs 1737
  PR #1737 @ 81bf0d163 (merge commit; branch 161cebe74)
  landed-whole: candidates (absent-from-merge)
    candidate, confirm by content: 161cebe74
```

Then by content against the merge commit, with controls in both directions:

| check | result |
| --- | --- |
| `mountedAt` in `useOnboardingSteps.ts` | **missing** |
| `ONBOARDING_STEPS_KEY` in `RestartContext.tsx` | **missing** |
| control — those paths resolve in the merge | found |
| control — the earlier commit's work landed | found |

The controls matter: `git grep` exits 1 both for "no match" and for "the pathspec matched nothing", so an absent marker proves nothing until the same search is shown capable of finding something in that file. And the earlier commit landing is what makes this a lost **tail** rather than a lost PR.

## What it restores

**The card no longer acts on an answer an earlier mount fetched.** It is unmounted whenever it is not offered, and a cached response outlives that — so a reader who finishes onboarding, then deletes their last collection, gets it offered again, and it would remount holding the previous mount's all-complete answer, announce itself finished before its own refetch landed, and ask the host for a layout the server had just decided should include it.

Compared against the **mount** rather than `isStale`: the query sets no `staleTime`, so its data is stale the instant it arrives and that flag cannot separate "not yet refetched" from "just fetched".

**The restart path invalidates the onboarding steps.** It already invalidates the layout, and two of the three steps are answered from the collection registry a schema apply has just moved — while the card's own listener is unmounted in exactly the case that matters.

## The test needed two repairs before it could fail

Both found by breaking the guard and watching nothing happen — twice.

The shared test client sets `gcTime: 0`, which collects the cached answer the moment the card unmounts, so the remount met nothing stale and the fixture never reached the mechanism. And the layout consumer has to stay mounted across **both** mounts, or the invalidation has no observer and its refetch count cannot move in either direction.

With both corrected, deleting the guard fails the case by name.

## Verification on this base

`check-types` 0 · lint clean · admin suite 4,213 passing · fallow `pass`.

Note this branch is cut from a `main` that is currently red on `check-types` for an unrelated reason — #1740 fixes that, and the 0 above is measured with that fix applied locally to isolate this change.