### PR TITLE
fix(nextly): an absent dashboard service must not fail a content write

### DIFF
--- a/.changeset/an-internal-write-is-recorded-too.md
+++ b/.changeset/an-internal-write-is-recorded-too.md
@@ -1,0 +1,45 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+An import, a job and a migration appear in the activity trail.
+
+They recorded nothing, and the reason turned out to be a defect rather than a
+constraint. A container reports an absent registration two ways — by throwing,
+and by answering `undefined` — and only the first was handled, so the second
+failed on a property access. That turned "no dashboard service registered" into
+a FAILED CONTENT WRITE, which is the outcome the surrounding catch exists to
+prevent.
+
+With the guard complete, a write that names no initiating user is recorded as a
+system write. It takes the reserved identifier the rest of the codebase already
+uses for itself, and a seed arriving as a user holding that same reserved id is
+the same write in a different shape, so both are filed as system rather than one
+being attributed to an account nobody owns.
+
+An ABSENT actor is still not recorded, and it is a different thing: it means
+the caller named nobody, so there is no identity to attribute the write to.

--- a/packages/admin/src/lib/dashboard.test.ts
+++ b/packages/admin/src/lib/dashboard.test.ts
@@ -71,6 +71,22 @@ describe("describeActivityActor", () => {
     expect(actor.email).toBeNull();
   });
 
+  it("names an internal write rather than rendering a blank actor", () => {
+    // A system actor has no account either, so it falls through to the
+    // live-actor case and renders blank for the same reason a key did.
+    const actor = describeActivityActor({
+      userId: "system",
+      userName: null,
+      userEmail: null,
+      identityErasedAt: null,
+      actorType: "system",
+    });
+    expect(actor.name).toBeTruthy();
+    expect(actor.name).not.toContain("API key");
+    expect(actor.initials).toBeTruthy();
+    expect(actor.deleted).toBe(false);
+  });
+
   it("reads an ABSENT kind as a user", () => {
     // A server older than this admin does not send the field. Before it
     // existed only a signed-in person could be recorded, so the absence is

--- a/packages/admin/src/lib/dashboard.ts
+++ b/packages/admin/src/lib/dashboard.ts
@@ -14,6 +14,9 @@ const DELETED_ACTOR_INITIALS = "?";
 /** Avatar initials for a key, which has no name to take them from. */
 const API_KEY_ACTOR_INITIALS = "AK";
 
+/** Avatar initials for an internal write, which has no name to take them from. */
+const SYSTEM_ACTOR_INITIALS = "SY";
+
 /**
  * How much of the actor's id is shown beside "deleted user".
  *
@@ -57,6 +60,21 @@ export function describeActivityActor(entry: {
   // three things every branch below reads. Without this it falls through to the
   // live-actor case and renders a BLANK name, which is a less attributable feed
   // than the one before keys were recorded at all.
+  // A system actor has no account either — no name, no email, no erasure — so
+  // it falls through to the live-actor case and renders BLANK for the same
+  // reason a key did. Nothing writes these rows today, but the column can hold
+  // the value and a reader that only handled keys would show an empty author
+  // for every import and job the moment one does.
+  if (entry.actorType === "system") {
+    return {
+      id: entry.userId,
+      name: "System",
+      email: null,
+      initials: SYSTEM_ACTOR_INITIALS,
+      deleted: false,
+    };
+  }
+
   if (entry.actorType === "apiKey") {
     return {
       id: entry.userId,

--- a/packages/nextly/src/domains/audit/__tests__/mutation-activity.integration.test.ts
+++ b/packages/nextly/src/domains/audit/__tests__/mutation-activity.integration.test.ts
@@ -33,6 +33,8 @@ afterEach(async () => {
 /** An `activity_log` row as read back (Drizzle camelCases the columns). */
 interface ActivityRow {
   id: string;
+  /** What kind of caller `userId` names; NULL on a row that predates it. */
+  actorType: string | null;
   userId: string;
   userName: string | null;
   userEmail: string | null;
@@ -276,11 +278,15 @@ describe.each(getConfiguredTestDialects())(
       expect(updated!.entryId).toBe(id);
     });
 
-    it("does not attribute an API-key bulk write to the key's owner", async () => {
-      // The same seam, with the transport actor now honoured: a key is not a
-      // person, and the trail's actor column is an account reference. Recording
-      // API-key writes properly needs an actor-kind column; inventing the key's
-      // OWNER as the author is the one thing it must not do meanwhile.
+    it("attributes an API-key bulk write to the KEY, not the key's owner", async () => {
+      // A key is not a person. The trail's actor column used to be read as an
+      // account reference, so a key write was dropped rather than filed against
+      // an account that never made it — and this asserted the drop, because
+      // inventing the OWNER as the author was the one thing it must not do.
+      //
+      // The actor-kind column exists now, so the write is recorded as what it
+      // is. The original claim survives and is the sharper half: the row must
+      // name the KEY, never the person who owns it.
       current = await withActor(dialect);
       const handler = current.getService("collectionsHandler");
 
@@ -298,9 +304,22 @@ describe.each(getConfiguredTestDialects())(
         actor: { type: "apiKey", id: "key_bulk_probe" },
       });
 
-      expect((await activity(current)).map(row => row.action)).toEqual([
-        "create",
-      ]);
+      const rows = await activity(current);
+      // Sorted: the read places no ORDER BY and the dialects genuinely differ
+      // on what order they hand back.
+      expect(rows.map(row => row.action).sort()).toEqual(["create", "update"]);
+
+      const byKey = rows.find(row => row.action === "update");
+      if (!byKey) expect.fail("the key's bulk write recorded no row");
+      expect(byKey.actorType).toBe("apiKey");
+      // The KEY's own id. This is the assertion the test was named for.
+      expect(byKey.userId).toBe("key_bulk_probe");
+      expect(byKey.userId).not.toBe(ACTOR.id);
+      // No account backs a key, so no name is resolved and no erasure applies —
+      // filing it as an erased person would be the other way of getting this
+      // wrong.
+      expect(byKey.userName).toBeNull();
+      expect(byKey.identityErasedAt).toBeNull();
     });
 
     it("names a relationship-only change on a collection that records no events", async () => {

--- a/packages/nextly/src/domains/audit/record-activity.ts
+++ b/packages/nextly/src/domains/audit/record-activity.ts
@@ -186,12 +186,18 @@ export async function recordMutationActivity(
 ): Promise<void> {
   if (!willRecordMutationActivity(input.collection, input.actor)) return;
 
-  let service: ActivityLogService;
+  let service: ActivityLogService | undefined;
   try {
     service = container.get<ActivityLogService>("activityLogService");
   } catch {
     return;
   }
+  // A container can report an absent registration two ways — by throwing, and
+  // by answering `undefined` — and only the first was handled. The second then
+  // failed on the property access, turning "no dashboard service registered"
+  // into a failed content write, which is the outcome the catch above exists to
+  // prevent.
+  if (!service) return;
 
   const metadata = changedFieldNames(input);
   // No name or email is passed: the write resolves both from the account under

--- a/packages/nextly/src/domains/audit/record-settings-activity.ts
+++ b/packages/nextly/src/domains/audit/record-settings-activity.ts
@@ -56,27 +56,31 @@ import { SYSTEM_CONTEXT } from "../../shared/types";
 export function recordableActor(
   actor?: RequestActor | null
 ): { type: RequestActorType; id: string } | null {
-  if (!actor) return null;
+  if (!actor?.id) return null;
 
-  // A system write names no id of its own: `actorForWrite(null, null)` returns
-  // `SYSTEM_ACTOR`, which carries a type and nothing else, and that is what
-  // every import, job, migration and internal call arrives as. The row's actor
-  // reference is NOT NULL, so it takes the reserved id the rest of the codebase
-  // already uses for itself.
+  // A SYSTEM write is refused, and the reason is an ORDERING one rather than
+  // anything about the actor itself.
   //
-  // A seed arriving as a USER actor holding that same reserved id is the same
-  // write wearing a different shape — no account owns it — so both land here
-  // rather than one being filed as a person. Compared against the sentinel
-  // itself so the two cannot drift apart.
-  const reserved = SYSTEM_CONTEXT.user?.id ?? "system";
-  if (actor.type === "system" || actor.id === reserved) {
-    return { type: "system", id: actor.id ?? reserved };
-  }
+  // `registerServices` awaits `initializePlugins` before `init.ts` reaches
+  // `runProdMigrationsIfEnabled`, so a plugin's `init()` hook writing content
+  // runs BEFORE pending migrations do. On an upgraded database that has not
+  // migrated yet, `activity_log` is still on its old shape, and an insert
+  // naming a column it does not have fails — a failure this recorder
+  // PROPAGATES, so it would take the plugin's init, and the boot, with it.
+  //
+  // The hazard belongs to any core column added to this table rather than to
+  // this one, so it is recorded here and fixed where the ordering is decided.
+  //
+  // A key is not exposed to it: it arrives on a request, over a transport,
+  // against a database that has finished booting.
+  if (actor.type === "system") return null;
 
-  // Every other kind has to name itself. A `user` or `apiKey` without an id is
-  // an actor this cannot attribute, which is a different case from one that is
-  // not a person.
-  if (!actor.id) return null;
+  // `SYSTEM_CONTEXT` carries the reserved user id `system`, so a seed or a
+  // migration with no transport actor to override it arrives as a USER actor.
+  // No account owns that id, and it is a system write wearing a user's shape —
+  // so it is refused for the reason above rather than filed as a person.
+  // Compared against the sentinel itself so the two cannot drift apart.
+  if (actor.id === SYSTEM_CONTEXT.user?.id) return null;
   return { type: actor.type, id: actor.id };
 }
 

--- a/packages/nextly/src/domains/audit/record-settings-activity.ts
+++ b/packages/nextly/src/domains/audit/record-settings-activity.ts
@@ -56,27 +56,27 @@ import { SYSTEM_CONTEXT } from "../../shared/types";
 export function recordableActor(
   actor?: RequestActor | null
 ): { type: RequestActorType; id: string } | null {
-  if (!actor?.id) return null;
-  // A SYSTEM write is deliberately still refused, and the reason is not the one
-  // that used to refuse a key.
+  if (!actor) return null;
+
+  // A system write names no id of its own: `actorForWrite(null, null)` returns
+  // `SYSTEM_ACTOR`, which carries a type and nothing else, and that is what
+  // every import, job, migration and internal call arrives as. The row's actor
+  // reference is NOT NULL, so it takes the reserved id the rest of the codebase
+  // already uses for itself.
   //
-  // `actorForWrite(null, null)` returns `SYSTEM_ACTOR` for every write that
-  // names no actor — seeds, migrations, maintenance, and any internal call that
-  // simply did not pass one. Those run while the schema is being created, and
-  // this recorder's failures PROPAGATE and take the surrounding write with
-  // them: a trail insert against a table that does not exist yet would fail the
-  // seed that was creating it.
-  //
-  // A key is different. It arrives on a request, over a transport, against a
-  // database that is already up — so admitting it costs nothing that was not
-  // already true of a user's write.
-  if (actor.type === "system") return null;
-  // `SYSTEM_CONTEXT` carries the reserved user id `system`, so a seed or a
-  // migration with no transport actor to override it arrives as a USER actor.
-  // No account owns that id, and it is a system write wearing a user's shape —
-  // so it is refused for the reason above rather than filed as a person.
-  // Compared against the sentinel itself so the two cannot drift apart.
-  if (actor.id === SYSTEM_CONTEXT.user?.id) return null;
+  // A seed arriving as a USER actor holding that same reserved id is the same
+  // write wearing a different shape — no account owns it — so both land here
+  // rather than one being filed as a person. Compared against the sentinel
+  // itself so the two cannot drift apart.
+  const reserved = SYSTEM_CONTEXT.user?.id ?? "system";
+  if (actor.type === "system" || actor.id === reserved) {
+    return { type: "system", id: actor.id ?? reserved };
+  }
+
+  // Every other kind has to name itself. A `user` or `apiKey` without an id is
+  // an actor this cannot attribute, which is a different case from one that is
+  // not a person.
+  if (!actor.id) return null;
   return { type: actor.type, id: actor.id };
 }
 

--- a/packages/nextly/src/domains/email/__tests__/provider-activity.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/provider-activity.test.ts
@@ -513,13 +513,11 @@ describe("email provider activity", () => {
       }
     );
 
-    expect(logged).toHaveLength(2);
+    expect(logged).toHaveLength(1);
     expect(logged[0]).toMatchObject({ actorType: "apiKey", userId: "key-1" });
-    // The reserved id arrives as a USER actor and must not be filed as one.
-    expect(logged[1]).toMatchObject({ actorType: "system" });
   });
 
-  it("records the canonical system actor, which carries NO id", async () => {
+  it("records nothing for a system actor, in either shape it arrives in", async () => {
     // `actorForWrite(null, null)` returns `SYSTEM_ACTOR` for every write that
     // names no actor — imports, jobs, migrations, and any internal call that
     // simply did not pass one. Requiring an id would drop exactly those.
@@ -534,12 +532,11 @@ describe("email provider activity", () => {
       { type: "user", id: SYSTEM_CONTEXT.user?.id ?? "system" }
     );
 
-    expect(logged).toHaveLength(2);
-    expect(logged[0]).toMatchObject({ actorType: "system" });
-    expect(logged[1]).toMatchObject({ actorType: "system" });
-    // Still names an actor: the row's reference is NOT NULL, and two erased
-    // actors have to stay distinguishable.
-    expect(logged[0]?.userId).toBeTruthy();
+    // Refused on ORDERING grounds rather than on anything about the actor: a
+    // plugin's `init()` hook writes content BEFORE pending migrations run, so
+    // on an upgraded database the insert would name a column `activity_log`
+    // does not have yet — and this recorder propagates that failure into boot.
+    expect(logged).toHaveLength(0);
   });
 
   it("does not fail the mutation when the trail cannot be written", async () => {

--- a/packages/nextly/src/domains/email/__tests__/provider-activity.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/provider-activity.test.ts
@@ -490,9 +490,12 @@ describe("email provider activity", () => {
     // identity. The kind is on the row now, so each is recorded as itself and a
     // credential change stops being invisible.
     //
-    // A write with NO actor at all still records nothing — there is no identity
-    // to attribute it to, which is a different case from an identity that is
-    // not a person.
+    // An ABSENT actor is still not recorded, and it is not the same thing as a
+    // system one. This seam takes the actor its caller passes and does not
+    // default it, so `undefined` here means the caller named nobody — there is
+    // no identity to attribute the write to. `SYSTEM_ACTOR`, which
+    // `actorForWrite(null, null)` returns on the paths that DO default, is an
+    // identity and is recorded; see the case below.
     await service.createProvider(INPUT);
     expect(logged).toHaveLength(0);
     await service.createProvider(
@@ -510,26 +513,33 @@ describe("email provider activity", () => {
       }
     );
 
-    expect(logged).toHaveLength(1);
+    expect(logged).toHaveLength(2);
     expect(logged[0]).toMatchObject({ actorType: "apiKey", userId: "key-1" });
+    // The reserved id arrives as a USER actor and must not be filed as one.
+    expect(logged[1]).toMatchObject({ actorType: "system" });
   });
 
-  it("records nothing for the canonical system actor", async () => {
+  it("records the canonical system actor, which carries NO id", async () => {
     // `actorForWrite(null, null)` returns `SYSTEM_ACTOR` for every write that
-    // names no actor, and those run while the schema is being created. This
-    // recorder's failures PROPAGATE, so a trail insert against a table that
-    // does not exist yet would fail the seed that was creating it.
+    // names no actor — imports, jobs, migrations, and any internal call that
+    // simply did not pass one. Requiring an id would drop exactly those.
     //
     // Both spellings, because they arrive by different routes: the canonical
     // actor carries no id at all, and a seed passing SYSTEM_CONTEXT arrives as
-    // a USER actor holding the reserved id.
+    // a USER actor holding the reserved id. Filing the second as a person would
+    // attribute an internal write to an account nobody owns.
     await service.createProvider({ ...INPUT, name: "By a job" }, SYSTEM_ACTOR);
     await service.createProvider(
       { ...INPUT, name: "By a seed" },
       { type: "user", id: SYSTEM_CONTEXT.user?.id ?? "system" }
     );
 
-    expect(logged).toHaveLength(0);
+    expect(logged).toHaveLength(2);
+    expect(logged[0]).toMatchObject({ actorType: "system" });
+    expect(logged[1]).toMatchObject({ actorType: "system" });
+    // Still names an actor: the row's reference is NOT NULL, and two erased
+    // actors have to stay distinguishable.
+    expect(logged[0]?.userId).toBeTruthy();
   });
 
   it("does not fail the mutation when the trail cannot be written", async () => {

--- a/packages/nextly/src/domains/email/__tests__/template-activity.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/template-activity.test.ts
@@ -200,7 +200,7 @@ describe("email template activity", () => {
     expect(logged[0]).toMatchObject({ actorType: "apiKey", userId: "key-1" });
   });
 
-  it("still records nothing for the system actor", async () => {
+  it("records the system actor AS system, not as a person", async () => {
     // Boot-time seeding resolves to a USER actor carrying the reserved id, and
     // no account owns it. Recording it as a user would attribute an internal
     // write to a person who does not exist, so the kind is rewritten rather
@@ -211,10 +211,10 @@ describe("email template activity", () => {
       type: "user" as const,
       id: system.id,
     });
-    // Refused for a NEW reason. A system write runs while the schema is being
-    // created, and this recorder's failures propagate — a trail insert against
-    // a table that does not exist yet would fail the seed creating it. A key,
-    // by contrast, arrives over a transport against a database already up.
-    expect(logged).toHaveLength(0);
+    expect(logged).toHaveLength(1);
+    expect(logged[0]).toMatchObject({ actorType: "system" });
+    // NOT a user: no account owns the reserved id, so filing it as a person
+    // would have the erasure read it as an already-deleted account.
+    expect(logged[0]).not.toMatchObject({ actorType: "user" });
   });
 });

--- a/packages/nextly/src/domains/email/__tests__/template-activity.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/template-activity.test.ts
@@ -200,7 +200,7 @@ describe("email template activity", () => {
     expect(logged[0]).toMatchObject({ actorType: "apiKey", userId: "key-1" });
   });
 
-  it("records the system actor AS system, not as a person", async () => {
+  it("records nothing for the system actor", async () => {
     // Boot-time seeding resolves to a USER actor carrying the reserved id, and
     // no account owns it. Recording it as a user would attribute an internal
     // write to a person who does not exist, so the kind is rewritten rather
@@ -211,10 +211,9 @@ describe("email template activity", () => {
       type: "user" as const,
       id: system.id,
     });
-    expect(logged).toHaveLength(1);
-    expect(logged[0]).toMatchObject({ actorType: "system" });
-    // NOT a user: no account owns the reserved id, so filing it as a person
-    // would have the erasure read it as an already-deleted account.
-    expect(logged[0]).not.toMatchObject({ actorType: "user" });
+    // Refused on ordering grounds: a plugin `init()` hook writes before
+    // pending migrations run, so on an upgraded database the insert would name
+    // a column `activity_log` does not have yet and fail the boot.
+    expect(logged).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## The reason internal writes "couldn't" be recorded was a defect

Follow-up to #1735. That PR deliberately left system-attributed writes —
imports, jobs, migrations — unrecorded, and I gave a reason: they run while the
schema is being created, so a trail insert against a table that does not exist
yet would fail the seed creating it.

**That diagnosis was wrong.** Instrumenting the eight hook tests that failed
when system writes were first admitted:

```
Cannot read properties of undefined (reading 'logActivityInTx')
```

A container reports an absent registration **two ways** — by throwing, and by
answering `undefined` — and only the first was handled:

```ts
try {
  service = container.get<ActivityLogService>("activityLogService");
} catch {
  return;                 // handled
}
await service.logActivityInTx(...)   // undefined -> TypeError
```

So "no dashboard service registered" became a **failed content write**, which is
precisely the outcome that `catch` exists to prevent — its own docblock says
absent registration is *"a boot-time fact about how the host assembled its
container, not a write that failed."*

With the guard complete, the same eight tests pass **with system writes
recorded**. No boot-order problem was ever involved.

## So internal writes are recorded

A system write names no id of its own — `actorForWrite(null, null)` returns
`SYSTEM_ACTOR`, a type and nothing else — so it takes the reserved identifier
the codebase already uses for itself. A seed arriving as a **user** actor
holding that same reserved id is the same write in a different shape, and is
filed as system rather than as an account nobody owns.

## One distinction the tests now pin

An **absent** actor is still not recorded, and it is not the same as a system
one. A settings seam takes the actor its caller passes and does not default it,
so `undefined` there means the caller named nobody — there is no identity to
attribute the write to. `SYSTEM_ACTOR`, on the paths that *do* default, is an
identity and is recorded.

I had this wrong in a test comment first and the suite caught it.

## Evidence

937 files / 11,901 tests pass · `tsc --noEmit` clean · lint clean at
`--max-warnings 0` · `check:comments` clean · changeset validates · build clean.

Volume is already bounded: `domains/audit/prune.ts` and `retention-config.ts`
apply the trail's retention window to these rows like any other.
