### PR TITLE
ci: make an integration leg that overruns its budget fail, not cancel

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,6 +22,22 @@ on:
 permissions:
   contents: read
 
+# The wall-clock budget for ONE dialect's suite, enforced per step rather than
+# per job — see scripts/run-with-budget.sh for why the distinction decides
+# whether a slow leg reports at all.
+#
+# 55 against a MySQL leg that spends about 34 minutes in this step and an sqlite
+# leg that spends about 22. Set with real headroom rather than just past the
+# last measurement: a bound at the current duration is a bound that fires on
+# variance, and this one is meant to catch a suite that has genuinely run away,
+# not to police a slow morning on shared runners.
+#
+# ONE knob for all three legs on purpose. Per-leg budgets would have to be
+# re-tuned as each suite grows, and a budget nobody re-tunes is a budget that
+# drifts back into firing on variance.
+env:
+  INTEGRATION_SUITE_BUDGET: 55m
+
 # Keyed per commit on `main` for the same reason as the CI workflow: a shared
 # `github.ref` group cancelled the previous commit's run on every merge, and
 # switching cancellation off is not enough — a group holds one running and one
@@ -34,6 +50,8 @@ jobs:
   integration:
     name: Integration (${{ matrix.dialect }})
     runs-on: ubuntu-latest
+    # A BACKSTOP now, not the bound that should ever fire.
+    #
     # 25 minutes until the suite outgrew it. The MySQL leg's last GREEN run
     # finished in 24m52s — eight seconds inside the limit — and every run after
     # that hit the ceiling. A timeout-minutes kill is reported as
@@ -41,12 +59,19 @@ jobs:
     # a verdict while looking like somebody had cancelled the run: six
     # consecutive PRs merged with MySQL coverage that never reported.
     #
-    # `packages/nextly` runs its integration files sequentially on purpose
-    # (fileParallelism: false, single fork — the system-table suites share
-    # fixed table names), so this number only ever needs to grow. Raised with
-    # real headroom rather than to just past the last measurement, because a
-    # ceiling set at the current duration is a ceiling that fails on variance.
-    timeout-minutes: 45
+    # Raising it to 45 bought time and left that trap fully armed, which is how
+    # it recurred: on 2026-09-10 three separate branches were killed at exactly
+    # 45 minutes and all three read as cancellations. Raising the number is not
+    # the fix, because `packages/nextly` runs its integration files sequentially
+    # on purpose (fileParallelism: false, single fork — the system-table suites
+    # share fixed table names), so this number only ever grows.
+    #
+    # So the real bound moved into the STEP, where overrunning exits non-zero
+    # and the job FAILS (INTEGRATION_SUITE_BUDGET, above). This value only has
+    # to stay far enough above it that the step's bound always fires first —
+    # 55 for the suite plus checkout, install and build — leaving this to catch
+    # a hang somewhere else in the job, which nothing else would end.
+    timeout-minutes: 75
 
     strategy:
       # One dialect failing must not cancel the others: seeing that a change
@@ -159,7 +184,9 @@ jobs:
         if: matrix.dialect == 'postgres'
         run: |
           pnpm turbo build --filter=nextly --filter=@nextlyhq/adapter-postgres --filter=@nextlyhq/adapter-mysql --filter=@nextlyhq/adapter-sqlite --filter=@nextlyhq/plugin-page-builder
-          pnpm lane:test:integration:postgres
+          scripts/run-with-budget.sh "$INTEGRATION_SUITE_BUDGET" \
+            "the PostgreSQL integration suite" \
+            pnpm lane:test:integration:postgres
         env:
           TEST_POSTGRES_URL: postgres://nextly:nextly@localhost:5432/nextly_test
           TURBO_CACHE_DIR: .turbo
@@ -168,7 +195,9 @@ jobs:
         if: matrix.dialect == 'mysql'
         run: |
           pnpm turbo build --filter=nextly --filter=@nextlyhq/adapter-postgres --filter=@nextlyhq/adapter-mysql --filter=@nextlyhq/adapter-sqlite --filter=@nextlyhq/plugin-page-builder
-          pnpm lane:test:integration:mysql
+          scripts/run-with-budget.sh "$INTEGRATION_SUITE_BUDGET" \
+            "the MySQL integration suite" \
+            pnpm lane:test:integration:mysql
         env:
           TEST_MYSQL_URL: mysql://root:nextly@127.0.0.1:3306/nextly_test
           TURBO_CACHE_DIR: .turbo
@@ -193,9 +222,12 @@ jobs:
   integration-sqlite:
     name: Integration (sqlite)
     runs-on: ubuntu-latest
-    # Raised with the matrix legs above: this one passed at 22m18s, which is
-    # inside 25 but not by enough to leave alone while its siblings move.
-    timeout-minutes: 45
+    # A BACKSTOP, for the same reason as the matrix legs above: the bound that
+    # should ever fire is INTEGRATION_SUITE_BUDGET on the step, which reports as
+    # a failure. This one passed at 22m18s, so it has the most room of the
+    # three, and it moves with its siblings so there is one rule to reason about
+    # rather than a per-leg ceiling nobody re-derives.
+    timeout-minutes: 75
 
     steps:
       - name: Checkout
@@ -261,7 +293,9 @@ jobs:
       - name: Run integration tests (sqlite)
         run: |
           pnpm turbo build --filter=nextly --filter=@nextlyhq/adapter-postgres --filter=@nextlyhq/adapter-mysql --filter=@nextlyhq/adapter-sqlite --filter=@nextlyhq/plugin-page-builder --filter=@nextlyhq/plugin-seo --filter=@nextlyhq/plugin-form-builder
-          pnpm lane:test:integration:sqlite
+          scripts/run-with-budget.sh "$INTEGRATION_SUITE_BUDGET" \
+            "the SQLite integration suite" \
+            pnpm lane:test:integration:sqlite
         env:
           TURBO_CACHE_DIR: .turbo
 

--- a/scripts/integration-legs-fail-on-overrun.test.mjs
+++ b/scripts/integration-legs-fail-on-overrun.test.mjs
@@ -3,8 +3,9 @@
  *
  * GitHub enforces a job's `timeout-minutes` by cancelling it, so a leg killed
  * for running too long is recorded as `conclusion: cancelled`. Nothing reads a
- * cancellation as a verdict — branch protection ignores it and the PR rollup
- * shows no red — so the leg silently stops contributing an answer while looking
+ * cancellation as a verdict — branch protection ignores it and the checks
+ * rollup shows no red — so the leg silently stops contributing an answer while
+ * looking
  * like somebody pressed the button.
  *
  * It has happened twice. At the 25-minute ceiling the MySQL leg stopped

--- a/scripts/integration-legs-fail-on-overrun.test.mjs
+++ b/scripts/integration-legs-fail-on-overrun.test.mjs
@@ -1,0 +1,105 @@
+/**
+ * An integration leg that outgrows its budget must FAIL, not vanish.
+ *
+ * GitHub enforces a job's `timeout-minutes` by cancelling it, so a leg killed
+ * for running too long is recorded as `conclusion: cancelled`. Nothing reads a
+ * cancellation as a verdict — branch protection ignores it and the PR rollup
+ * shows no red — so the leg silently stops contributing an answer while looking
+ * like somebody pressed the button.
+ *
+ * It has happened twice. At the 25-minute ceiling the MySQL leg stopped
+ * reporting for six consecutive pull requests. At 45 it killed three separate
+ * branches in one day, and all three read as cancellations.
+ *
+ * Raising the ceiling is what was done the first time, and it left the trap
+ * armed. So the real bound now lives on the STEP, in `run-with-budget.sh`,
+ * where an overrun exits non-zero and the job fails like any other red.
+ *
+ * 🔴 Nothing else in the repository reads this. A dialect added later that
+ * calls its lane script directly gets the old behaviour back — silently, and
+ * only for the new leg, which is the hardest version to notice. That is what
+ * this file is for.
+ *
+ * ## Why these three assertions and not a simpler one
+ *
+ * Counting is what a first version of this did, and a count cannot see the
+ * defect it exists to catch: a fourth leg added without the wrapper moves the
+ * total, and a total compared against a hardcoded number either fails for
+ * every legitimate addition or gets bumped without anyone checking WHICH legs
+ * are covered. So membership is asserted per dialect, by name.
+ *
+ * The budget comparison is the non-obvious one. The step bound only does
+ * anything if it fires FIRST — a job whose `timeout-minutes` is below the step
+ * budget cancels on its way to the failure, and the whole mechanism reverts to
+ * the behaviour being removed while every step still visibly calls the wrapper.
+ *
+ * The workflow is read through `workflow-run-blocks.mjs`, which pins the
+ * reader's own traps — chiefly that a step's block must not absorb the comment
+ * introducing the NEXT step, since these comments quote commands verbatim.
+ *
+ * @module integration-legs-fail-on-overrun.test
+ */
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { runBlocks } from "./workflow-run-blocks.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const WORKFLOW = path.join(HERE, "..", ".github", "workflows", "integration.yml");
+
+/** Every dialect the suite runs. A new one added here must be wired too. */
+const DIALECTS = ["postgres", "mysql", "sqlite"];
+
+let workflow = "";
+
+beforeAll(async () => {
+  workflow = await readFile(WORKFLOW, "utf8");
+});
+
+describe("integration.yml", () => {
+  it("has a run block for every dialect's suite", () => {
+    // The population, asserted before anything is judged about it. Every
+    // assertion below is satisfied vacuously by a file this parser could not
+    // read — an empty map passes "none of them skips the wrapper" perfectly.
+    const named = [...runBlocks(workflow).keys()];
+
+    for (const dialect of DIALECTS) {
+      expect(named).toContain(`Run integration tests (${dialect})`);
+    }
+  });
+
+  it.each(DIALECTS)(
+    "runs the %s suite through the budget wrapper, not bare",
+    (dialect) => {
+      const block = runBlocks(workflow).get(
+        `Run integration tests (${dialect})`
+      );
+
+      expect(block).toBeDefined();
+      // Both halves matter. The lane script must be invoked (or this leg tests
+      // nothing), and the invocation must go through the wrapper (or an
+      // overrun is a cancellation again).
+      expect(block).toContain(`lane:test:integration:${dialect}`);
+      expect(block).toContain("scripts/run-with-budget.sh");
+    }
+  );
+
+  it("gives every job a ceiling ABOVE the step budget, so the step fires first", () => {
+    const budget = /INTEGRATION_SUITE_BUDGET:\s*(\d+)m/.exec(workflow);
+    expect(budget, "the workflow declares a step budget").not.toBeNull();
+
+    const ceilings = [...workflow.matchAll(/^\s*timeout-minutes:\s*(\d+)\s*$/gm)]
+      .map((m) => Number(m[1]));
+
+    // Nonzero, because "every ceiling exceeds the budget" is true of no
+    // ceilings at all — and a regex that stopped matching would read as a pass.
+    expect(ceilings.length).toBeGreaterThan(0);
+
+    for (const ceiling of ceilings) {
+      expect(ceiling).toBeGreaterThan(Number(budget[1]));
+    }
+  });
+});

--- a/scripts/run-with-budget.sh
+++ b/scripts/run-with-budget.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env sh
+
+# Run a command under a wall-clock budget that reports as a FAILURE.
+#
+# GitHub enforces `timeout-minutes` by CANCELLING the job, so a job killed for
+# running too long carries `conclusion: cancelled` — not `failure`. Nothing
+# reads a cancellation as a verdict: branch protection ignores it, the PR rollup
+# shows no red, and a reviewer sees a leg that looks like somebody pressed the
+# button. The coverage is gone and the signal that it is gone is gone with it.
+#
+# That is not hypothetical here. The MySQL integration leg hit its 25-minute
+# ceiling and stopped reporting for six consecutive pull requests before anyone
+# noticed (integration.yml documents that round). It then hit the 45-minute
+# ceiling the same way on three separate branches in one day.
+#
+# So the budget lives HERE instead, one level below the job's. `timeout` exits
+# 124 when it fires, the step exits non-zero, and the job fails — which is
+# ordinary, bedrock CI behaviour rather than a property of how GitHub reports
+# any particular kind of kill. The job's own `timeout-minutes` stays on as a
+# backstop for a hang OUTSIDE this command, and is set high enough that this
+# bound always fires first.
+#
+# Usage: run-with-budget.sh <budget> <what> <command> [args...]
+#   budget   any GNU `timeout` DURATION, e.g. 55m
+#   what     what to name in the error, e.g. "the MySQL integration suite"
+
+set -e
+
+if [ "$#" -lt 3 ]; then
+  echo "run-with-budget.sh: usage: <budget> <what> <command> [args...]" >&2
+  exit 2
+fi
+
+budget="$1"
+what="$2"
+shift 2
+
+# Refuse rather than run unbounded.
+#
+# Degrading to an unbounded run when `timeout` is missing would restore exactly
+# the state this script exists to remove, and would do it silently — the run
+# would look bounded and be a no-op guard. CI is `ubuntu-latest`, where GNU
+# coreutils is always present, so this only fires for someone invoking the
+# script by hand on a machine without it.
+if ! command -v timeout > /dev/null 2>&1; then
+  echo "run-with-budget.sh: no \`timeout\` on PATH, refusing to run unbounded." >&2
+  echo "  On macOS: brew install coreutils, then expose it as \`timeout\`." >&2
+  exit 2
+fi
+
+# `--kill-after` because TERM is a request. A vitest worker wedged on a database
+# socket can ignore it, and a budget that a hung process can decline to honour
+# is not a budget.
+set +e
+timeout --kill-after=2m "$budget" "$@"
+status=$?
+set -e
+
+# 124 is `timeout`'s own "the command timed out"; 137 is 128+SIGKILL, which is
+# what the `--kill-after` escalation produces when TERM was ignored. Both mean
+# the budget fired, and neither is a result the command produced itself.
+if [ "$status" -eq 124 ] || [ "$status" -eq 137 ]; then
+  echo "::error title=Integration budget exceeded::${what} ran past its ${budget} budget and was stopped. This is reported as a FAILURE on purpose: a job-level timeout would have been recorded as a cancellation, which no gate reads. Either the suite has genuinely outgrown the budget (raise it in integration.yml, and see whether it is time to shard instead) or something is hanging."
+fi
+
+exit "$status"

--- a/scripts/run-with-budget.sh
+++ b/scripts/run-with-budget.sh
@@ -4,8 +4,9 @@
 #
 # GitHub enforces `timeout-minutes` by CANCELLING the job, so a job killed for
 # running too long carries `conclusion: cancelled` — not `failure`. Nothing
-# reads a cancellation as a verdict: branch protection ignores it, the PR rollup
-# shows no red, and a reviewer sees a leg that looks like somebody pressed the
+# reads a cancellation as a verdict: branch protection ignores it, the checks
+# rollup shows no red, and a reviewer sees a leg that looks like somebody pressed
+# the
 # button. The coverage is gone and the signal that it is gone is gone with it.
 #
 # That is not hypothetical here. The MySQL integration leg hit its 25-minute

--- a/scripts/run-with-budget.test.mjs
+++ b/scripts/run-with-budget.test.mjs
@@ -1,0 +1,160 @@
+/**
+ * `run-with-budget.sh` exists to turn one specific silent state into a loud
+ * one, so the cases that matter are the ones where it could go quiet again.
+ *
+ * The bug it removes: GitHub reports a `timeout-minutes` kill as
+ * `conclusion: cancelled`, which no gate reads as a verdict, so an integration
+ * leg that outgrows its ceiling stops reporting while looking like somebody
+ * pressed cancel. Twice now that has cost real coverage on real merges.
+ *
+ * Two properties therefore carry the whole value, and each has a way of
+ * passing for the wrong reason:
+ *
+ * - a budget overrun must EXIT NON-ZERO, and say so in words a reviewer can
+ *   act on. A test that only checks the exit code would pass against a script
+ *   that stayed silent, which is half the defect.
+ * - an ordinary test failure must NOT be dressed up as a budget overrun. A
+ *   test that only exercised the timeout path would pass against a script that
+ *   printed "budget exceeded" for every non-zero exit, which would send the
+ *   next person to raise a budget over a genuine red suite.
+ *
+ * And one property is the reason the script is a script at all: with no
+ * `timeout` on PATH it must REFUSE rather than run the command unbounded.
+ * Degrading quietly would reinstate exactly the state being removed while
+ * looking like a guard — the failing-in-the-passing-direction shape.
+ *
+ * `timeout` is stubbed rather than used. Driving the real one means burning
+ * wall-clock to observe a timeout, and the stub buys something the real binary
+ * cannot: it records its own argv, so the tests can assert that the budget and
+ * the command actually REACH it. Without that, a script that ignored its
+ * arguments and ran the command bare would pass every exit-code assertion here.
+ */
+
+import { execFileSync } from "node:child_process";
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const SCRIPT = fileURLToPath(new URL("./run-with-budget.sh", import.meta.url));
+
+/** A `timeout` that exits with whatever the case asks for, and records its argv. */
+function stubDir(exitCode) {
+  const dir = mkdtempSync(join(tmpdir(), "budget-"));
+  const argvLog = join(dir, "argv");
+  const stub = join(dir, "timeout");
+  writeFileSync(
+    stub,
+    // `#!/bin/sh`, not `#!/usr/bin/env sh`: PATH holds only this directory, so
+    // `env` would have no `sh` to find and every case would exit 127.
+    `#!/bin/sh\nprintf '%s\\n' "$@" > ${argvLog}\nexit ${exitCode}\n`
+  );
+  chmodSync(stub, 0o755);
+  return { dir, argvLog };
+}
+
+/**
+ * PATH is REPLACED, not prepended to.
+ *
+ * Prepending would leave the real `timeout` reachable on a machine that has
+ * one, so the "no timeout on PATH" case would silently become "some other
+ * timeout ran" — and it would pass, because that binary also exits non-zero
+ * for a command it cannot find.
+ */
+function run(args, { path }) {
+  try {
+    // `/bin/sh` by absolute path: PATH below holds only the stub directory, so
+    // resolving the shell THROUGH it would fail before the script ever ran —
+    // and fail identically in every case, which reads as seven passing
+    // refusals rather than a broken harness.
+    const stdout = execFileSync("/bin/sh", [SCRIPT, ...args], {
+      env: { PATH: path },
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { status: 0, output: stdout };
+  } catch (error) {
+    return {
+      status: error.status,
+      output: `${error.stdout ?? ""}${error.stderr ?? ""}`,
+    };
+  }
+}
+
+const BUDGET_ERROR = "::error title=Integration budget exceeded::";
+
+describe("run-with-budget.sh", () => {
+  it("passes a successful command straight through, saying nothing", () => {
+    const { dir } = stubDir(0);
+    const result = run(["55m", "the suite", "anything"], { path: dir });
+
+    expect(result.status).toBe(0);
+    expect(result.output).not.toContain(BUDGET_ERROR);
+  });
+
+  it("hands `timeout` the budget and the command, rather than running it bare", () => {
+    const { dir, argvLog } = stubDir(0);
+    run(["55m", "the suite", "pnpm", "lane:test:integration:mysql"], {
+      path: dir,
+    });
+
+    // The order matters as much as the presence: `--kill-after` before the
+    // duration, then the command. A script that passed the budget as an
+    // argument to `pnpm` would still "contain" every one of these.
+    expect(readFileSync(argvLog, "utf8").split("\n").slice(0, 4)).toEqual([
+      "--kill-after=2m",
+      "55m",
+      "pnpm",
+      "lane:test:integration:mysql",
+    ]);
+  });
+
+  it("fails LOUDLY when the budget fires, naming what overran", () => {
+    const { dir } = stubDir(124);
+    const result = run(["55m", "the MySQL integration suite", "anything"], {
+      path: dir,
+    });
+
+    expect(result.status).toBe(124);
+    expect(result.output).toContain(BUDGET_ERROR);
+    expect(result.output).toContain("the MySQL integration suite");
+    expect(result.output).toContain("55m");
+  });
+
+  it("treats a SIGKILL escalation as the budget firing too", () => {
+    // 137 is 128+9: what `--kill-after` produces when the command ignored
+    // TERM. Reading only 124 would let a wedged worker — the case the
+    // escalation exists for — exit quietly.
+    const { dir } = stubDir(137);
+    const result = run(["55m", "the suite", "anything"], { path: dir });
+
+    expect(result.status).toBe(137);
+    expect(result.output).toContain(BUDGET_ERROR);
+  });
+
+  it("does NOT call an ordinary test failure a budget overrun", () => {
+    const { dir } = stubDir(3);
+    const result = run(["55m", "the suite", "anything"], { path: dir });
+
+    expect(result.status).toBe(3);
+    expect(result.output).not.toContain(BUDGET_ERROR);
+  });
+
+  it("refuses rather than running unbounded when there is no `timeout`", () => {
+    const empty = mkdtempSync(join(tmpdir(), "no-timeout-"));
+    const result = run(["55m", "the suite", "anything"], { path: empty });
+
+    expect(result.status).toBe(2);
+    expect(result.output).toContain("refusing to run unbounded");
+  });
+
+  it("refuses a call that names no command to run", () => {
+    const { dir } = stubDir(0);
+    const result = run(["55m", "the suite"], { path: dir });
+
+    expect(result.status).toBe(2);
+    expect(result.output).toContain("usage");
+  });
+});

--- a/scripts/workflow-run-blocks.mjs
+++ b/scripts/workflow-run-blocks.mjs
@@ -1,0 +1,79 @@
+/**
+ * The `run:` script of each named step in a workflow file, keyed by step name.
+ *
+ * Its own module rather than a helper inside the test that needs it, for the
+ * reason `ci-gate.mjs` and `ci-verdict.mjs` are: a derivation a gate depends on
+ * is worth testing directly, and a parser living inside the single test that
+ * consumes it can only ever be exercised through that test's subject.
+ *
+ * Parsed as TEXT rather than through a YAML library on purpose: `yaml` appears
+ * in this repository only as a pnpm override, so it is reachable by hoisting
+ * rather than by declaration, and a resolution that depends on hoisting is not
+ * one to build a gate on.
+ *
+ * @module workflow-run-blocks
+ */
+
+/**
+ * The lines of one block scalar: everything indented FURTHER than its key.
+ *
+ * Blank lines are skipped rather than ending the block, because YAML allows
+ * them inside a block scalar and a reader that stopped at the first one would
+ * silently return a prefix of the script.
+ */
+function blockBody(lines, from, indent) {
+  const body = [];
+
+  for (let i = from; i < lines.length; i += 1) {
+    if (lines[i].trim() === "") continue;
+    const here = lines[i].length - lines[i].trimStart().length;
+    if (here <= indent) break;
+    body.push(lines[i]);
+  }
+
+  return body.join("\n");
+}
+
+/** The step name a line declares, or null if it declares none. */
+function stepNameAt(line) {
+  const named = /^\s*- name:\s*(.+?)\s*$/.exec(line);
+  return named === null ? null : named[1];
+}
+
+/**
+ * The indentation of a `run: |` key on this line, or null.
+ *
+ * Null for an ANONYMOUS step as well as for a line that opens no block, so a
+ * run block no named step owns is skipped rather than credited to whichever
+ * name came last — which would report a step as running a script it does not.
+ */
+function runIndentAt(line, owner) {
+  const run = owner === null ? null : /^(\s*)run:\s*\|/.exec(line);
+  return run === null ? null : run[1].length;
+}
+
+/**
+ * Each step's OWN run block — never the text running to the next step.
+ *
+ * A chunk bounded by the following `- name:` would include the comment block
+ * that introduces the NEXT step, and workflow comments here quote commands
+ * verbatim, so a comment about step N+1 would certify step N. The bound is the
+ * block scalar's indentation instead, which ends where `env:` or the next
+ * step's comments begin.
+ *
+ * @param {string} text the workflow file's contents
+ * @returns {Map<string, string>} step name to the body of its `run:` block
+ */
+export function runBlocks(text) {
+  const lines = text.split("\n");
+  const blocks = new Map();
+  let name = null;
+
+  for (let i = 0; i < lines.length; i += 1) {
+    name = stepNameAt(lines[i]) ?? name;
+    const indent = runIndentAt(lines[i], name);
+    if (indent !== null) blocks.set(name, blockBody(lines, i + 1, indent));
+  }
+
+  return blocks;
+}

--- a/scripts/workflow-run-blocks.test.mjs
+++ b/scripts/workflow-run-blocks.test.mjs
@@ -1,0 +1,95 @@
+/**
+ * `runBlocks` is the reader every workflow gate built on it inherits, so the
+ * cases here are the ones where a reader can be wrong while looking right.
+ *
+ * The load-bearing one is the boundary. A reader that took each step's text as
+ * "everything up to the next `- name:`" would sweep in the comment block that
+ * introduces the FOLLOWING step — and workflow comments in this repository
+ * quote commands verbatim, so a comment about step N+1 would satisfy an
+ * assertion about step N. `ci-steps-report-independently.test.mjs` records
+ * making exactly that mistake, which is why it is pinned here rather than
+ * trusted.
+ *
+ * @module workflow-run-blocks.test
+ */
+import { describe, expect, it } from "vitest";
+
+import { runBlocks } from "./workflow-run-blocks.mjs";
+
+describe("runBlocks", () => {
+  it("reads a step's run block", () => {
+    const blocks = runBlocks(
+      ["    steps:", "      - name: Build", "        run: |", "          pnpm build", ""].join("\n")
+    );
+
+    expect(blocks.get("Build")).toBe("          pnpm build");
+  });
+
+  it("stops at `env:` rather than swallowing the keys after the script", () => {
+    const blocks = runBlocks(
+      [
+        "      - name: Test",
+        "        run: |",
+        "          pnpm test",
+        "        env:",
+        "          TOKEN: shhh",
+      ].join("\n")
+    );
+
+    expect(blocks.get("Test")).toBe("          pnpm test");
+    expect(blocks.get("Test")).not.toContain("TOKEN");
+  });
+
+  it("does NOT let a comment introducing the next step land in this one", () => {
+    // The defect this reader exists to avoid: the comment below belongs to
+    // `Second`, and it names a command. A chunk bounded by the next `- name:`
+    // would put it inside `First`, and an assertion that `First` runs
+    // `dangerous-thing` would pass on a step that does no such thing.
+    const blocks = runBlocks(
+      [
+        "      - name: First",
+        "        run: |",
+        "          safe-thing",
+        "",
+        "      # This step runs `dangerous-thing` because of a long reason.",
+        "      - name: Second",
+        "        run: |",
+        "          dangerous-thing",
+      ].join("\n")
+    );
+
+    expect(blocks.get("First")).toBe("          safe-thing");
+    expect(blocks.get("First")).not.toContain("dangerous-thing");
+    expect(blocks.get("Second")).toBe("          dangerous-thing");
+  });
+
+  it("keeps a blank line inside a script from truncating it", () => {
+    // A reader that ended the block at the first blank line would return a
+    // PREFIX of the script — and a prefix still contains the first command, so
+    // an assertion about that command passes while the rest is invisible.
+    const blocks = runBlocks(
+      [
+        "      - name: Two parts",
+        "        run: |",
+        "          first",
+        "",
+        "          second",
+      ].join("\n")
+    );
+
+    expect(blocks.get("Two parts")).toContain("first");
+    expect(blocks.get("Two parts")).toContain("second");
+  });
+
+  it("ignores a run block that no named step owns", () => {
+    // Anonymous steps are legal. Attributing one to whatever name came last
+    // would credit a step with a script it does not run.
+    const blocks = runBlocks(["      - run: |", "          orphan"].join("\n"));
+
+    expect([...blocks.keys()]).toEqual([]);
+  });
+
+  it("returns nothing for a file with no steps, rather than throwing", () => {
+    expect([...runBlocks("name: Nothing\non: push\n").keys()]).toEqual([]);
+  });
+});


### PR DESCRIPTION
## The defect

GitHub enforces a job's `timeout-minutes` by **cancelling the job**, so a leg killed for running too long is recorded as `conclusion: cancelled` rather than `failure`. Nothing reads a cancellation as a verdict — branch protection ignores it, the PR rollup shows no red, and a reviewer sees a leg that looks like somebody pressed the button.

The coverage is gone, and the signal that it is gone goes with it.

## This is the second occurrence

`integration.yml` already documents the first: at the 25-minute ceiling the MySQL leg stopped reporting for **six consecutive pull requests**. That round was fixed by raising the ceiling to 45, which bought time and left the trap fully armed.

On 2026-09-10 it fired again. Three separate branches were killed at **exactly 45 minutes** — two page-builder branches and `fix/migrate-fresh-drops-what-it-found` — and all three read as cancellations.

Measured across the last 30 Integration runs, the MySQL leg clusters at **35–37 minutes** against that 45-minute ceiling: about 25% headroom on a suite that only grows, because `packages/nextly` runs its integration files sequentially on purpose (`fileParallelism: false`, single fork — the system-table suites share fixed table names).

## The change

**The real bound moves one level down, onto the step.** `scripts/run-with-budget.sh` wraps each lane invocation: `timeout` exits 124 (or 137 when the `--kill-after` escalation fires on a worker that ignored TERM), the step exits non-zero, and the job fails — ordinary CI behaviour, rather than a property of how GitHub reports one particular kind of kill.

It emits a named `::error::` saying which suite overran and what to do about it, and **refuses** when `timeout` is absent rather than degrading to the unbounded run it exists to remove.

The job ceilings become **backstops at 75**, high enough that the step's bound always fires first, and still there to end a hang elsewhere in the job.

## Raising a number is not a fix, so the invariant is guarded

`integration-legs-fail-on-overrun.test.mjs` asserts that every dialect's suite goes through the wrapper, and that every job ceiling sits above the step budget. A leg added later that calls its lane script directly is caught, rather than silently reverting to a cancellation.

The workflow reader is its own module with its own tests, chiefly pinning that a step's block must not absorb the comment introducing the **next** step — these comments quote commands verbatim, so that boundary is load-bearing.

## What was measured

Every test was break-verified by writing the wrong implementation, not by mutating:

| break | what it kills |
|---|---|
| overrun exits non-zero but says nothing | the two loudness tests |
| every non-zero exit called a budget overrun | the discrimination test |
| no `timeout` on PATH → run unbounded anyway | the refusal test |
| a leg calls its lane script bare | that dialect's wrapper test |
| job ceiling drops below the step budget | the ordering test |
| a step is renamed so the parser finds nothing | the population test |

That last one is the vacuous-pass control: every other assertion is satisfied by a file the parser could not read, so the population is asserted before anything is judged about it.

Gates: `fallow` pass (6 files analysed, 0 introduced findings), `lint:scripts` / `lint:design` / `lint:workspace` clean, `check-types` 42/42.

## Not in scope

Sharding the integration suite so it stops approaching whatever ceiling it is given. That is the real answer to the growth, it needs the shared-fixed-table-name problem solved first, and it deserves research rather than being bolted onto a repair.

No changeset: CI-only, nothing published changes.
