### PR TITLE
test(nextly): prove migrate:fresh discovery against a real postgres

### DIFF
--- a/packages/nextly/src/cli/commands/__tests__/migrate-fresh-discovery.integration.test.ts
+++ b/packages/nextly/src/cli/commands/__tests__/migrate-fresh-discovery.integration.test.ts
@@ -1,0 +1,148 @@
+/**
+ * What `migrate:fresh` will DROP, decided by a real PostgreSQL.
+ *
+ * This command empties a database. Its discovery step chooses the list, and its
+ * drop step emits `DROP TABLE "name"` with no schema on it — so discovery is
+ * only correct if it returns exactly the relations an unqualified name resolves
+ * to. Too few and the reset silently leaves tables behind; too many and it
+ * destroys data it was never pointed at.
+ *
+ * 🔴 A unit test cannot establish this, and the one that tried is why this file
+ * exists. Asserting that the rendered SQL contains `to_regclass` stays green
+ * when the predicate is inverted to `<>` or joined with `OR` — both of which
+ * enumerate the wrong relations. The property that separates a correct
+ * implementation from those is WHICH ROWS COME BACK, and only a database can
+ * answer it.
+ *
+ * The fixture is built to make each wrong answer visible:
+ *
+ * - `shadowed` exists in BOTH schemas. Correct: returned once, and it is the
+ *   tenant one the drop would reach.
+ * - `tenant_only` is reachable and must be there.
+ * - `public_only` is ALSO reachable — `public` is on the path — so it must be
+ *   there too. This is the row that fails a `current_schema()` implementation,
+ *   which sees only the first entry.
+ * - `hidden_only` sits in a schema NOT on the path. Unreachable by the drop, so
+ *   returning it would mean destroying a table this command cannot even name.
+ *
+ * @module cli/commands/__tests__/migrate-fresh-discovery.integration
+ */
+import { sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { discoverTables } from "../migrate-fresh";
+
+const URL = process.env.TEST_POSTGRES_URL ?? "";
+
+// Dialect gate, matching the other PostgreSQL integration tests in this package.
+const describePg = describe.skipIf(!URL);
+
+const TENANT = "nx_discovery_tenant";
+const HIDDEN = "nx_discovery_hidden";
+const SHADOWED = "nx_discovery_shadowed";
+const TENANT_ONLY = "nx_discovery_tenant_only";
+const PUBLIC_ONLY = "nx_discovery_public_only";
+const HIDDEN_ONLY = "nx_discovery_hidden_only";
+
+describePg(
+  "migrate:fresh discovers what the DROP will reach (postgres)",
+  () => {
+    let client: Client | undefined;
+    // Typed from the call rather than from `typeof drizzle`, whose default
+    // overload infers a Pool-backed client and does not accept this one.
+    let db: ReturnType<typeof drizzle<Record<string, never>, Client>>;
+
+    beforeAll(async () => {
+      if (!URL) return;
+      // 🔴 One Client, held for the file. `getDrizzle()` wraps a Pool, so
+      // `SET search_path` would bind to whichever connection served it and the
+      // reads could run on another — the fixture would then be asserting against
+      // a session it never configured.
+      client = new Client({ connectionString: URL });
+      await client.connect();
+      db = drizzle({ client });
+      const run = (text: string) => db.execute(sql.raw(text));
+
+      await run(`DROP TABLE IF EXISTS public.${SHADOWED}`);
+      await run(`DROP TABLE IF EXISTS public.${PUBLIC_ONLY}`);
+      await run(`DROP SCHEMA IF EXISTS ${TENANT} CASCADE`);
+      await run(`DROP SCHEMA IF EXISTS ${HIDDEN} CASCADE`);
+      await run(`CREATE SCHEMA ${TENANT}`);
+      await run(`CREATE SCHEMA ${HIDDEN}`);
+
+      await run(`CREATE TABLE ${TENANT}.${SHADOWED} (id integer)`);
+      await run(`CREATE TABLE public.${SHADOWED} (id integer)`);
+      await run(`CREATE TABLE ${TENANT}.${TENANT_ONLY} (id integer)`);
+      await run(`CREATE TABLE public.${PUBLIC_ONLY} (id integer)`);
+      await run(`CREATE TABLE ${HIDDEN}.${HIDDEN_ONLY} (id integer)`);
+
+      await run(`SET search_path TO ${TENANT}, public`);
+    });
+
+    afterAll(async () => {
+      if (client === undefined) return;
+      await db.execute(sql.raw(`SET search_path TO public`));
+      await db.execute(sql.raw(`DROP TABLE IF EXISTS public.${SHADOWED}`));
+      await db.execute(sql.raw(`DROP TABLE IF EXISTS public.${PUBLIC_ONLY}`));
+      await db.execute(sql.raw(`DROP SCHEMA IF EXISTS ${TENANT} CASCADE`));
+      await db.execute(sql.raw(`DROP SCHEMA IF EXISTS ${HIDDEN} CASCADE`));
+      await client.end();
+    });
+
+    /** The adapter surface `discoverTables` asks for, backed by this session. */
+    function runner() {
+      return {
+        queryStatement: async <T>(statement: unknown): Promise<T[]> => {
+          const result = (await db.execute(
+            statement as Parameters<typeof db.execute>[0]
+          )) as unknown as { rows: T[] };
+          return result.rows;
+        },
+      } as Parameters<typeof discoverTables>[0];
+    }
+
+    it("proves the session is the one that was configured", async () => {
+      // The control for everything below. A session that had silently reset would
+      // fail the assertions in a way that looks like a defect in the predicate.
+      const shown = (await db.execute(sql`SHOW search_path`)) as unknown as {
+        rows: { search_path: string }[];
+      };
+      expect(shown.rows[0]?.search_path).toContain(TENANT);
+    });
+
+    it("returns every relation the drop can reach, and only those", async () => {
+      const found = await discoverTables(runner(), "postgresql");
+
+      expect(found).toContain(TENANT_ONLY);
+      // 🔴 On the path through its second entry, so the unqualified DROP reaches
+      // it. A `current_schema()` implementation misses this one and leaves the
+      // table behind.
+      expect(found).toContain(PUBLIC_ONLY);
+      // 🔴 Off the path entirely. Returning it would hand a DROP a table this
+      // command cannot even name — which is what an inverted or OR-ed predicate
+      // does.
+      expect(found).not.toContain(HIDDEN_ONLY);
+    });
+
+    it("returns a shadowed name once, not once per copy", async () => {
+      // 🔴 Two relations share this name; exactly one is what `DROP TABLE
+      // "shadowed"` resolves to. Returning both would make the command issue the
+      // same statement twice and believe it had dropped two different tables —
+      // and the second `IF EXISTS` would quietly succeed having done nothing.
+      const found = await discoverTables(runner(), "postgresql");
+
+      expect(found.filter(name => name === SHADOWED)).toHaveLength(1);
+    });
+
+    it("never offers a system catalog table to the drop", async () => {
+      // `pg_catalog` is on every search path implicitly, so relation visibility
+      // alone admits it.
+      const found = await discoverTables(runner(), "postgresql");
+
+      expect(found).not.toContain("pg_class");
+      expect(found).not.toContain("pg_namespace");
+    });
+  }
+);


### PR DESCRIPTION
Follows #1736, from a Codex P1 on its merged head. Test-only, so no changeset.

## What the existing test could not see

The unit test asserts the rendered SQL contains `to_regclass` and `quote_ident`.
That is necessary and **not sufficient**: it stays green if the predicate is
inverted with `<>`, or joined with `OR` instead of `AND`. Both enumerate the
wrong relations, and this is a command that **drops** what it enumerates.

It is the failure `AGENTS.md` names — a property that returns green from the
broken implementation too, carrying the authority of having been checked. I
quoted that rule at someone else this morning and then shipped an instance of it.

The property that actually separates correct from broken is **which rows come
back**, and only a database can answer that.

## The fixture, built so each wrong answer shows

`search_path` is `tenant, public`, and four tables sit in three schemas:

| table | where | must be returned | because |
|---|---|---|---|
| `shadowed` | tenant **and** public | **once** | two relations, one name; the drop reaches exactly one |
| `tenant_only` | tenant | yes | reachable |
| `public_only` | public | **yes** | reachable through the path's *second* entry |
| `hidden_only` | a schema off the path | **no** | the drop cannot name it |

`public_only` is the row that fails a `current_schema()` implementation — the
version I wrote first, and the one this PR's predecessor corrected. `hidden_only`
is the row that fails an inverted or `OR`-ed predicate. `shadowed` is the row
that fails a query returning every copy rather than the resolved one.

A fourth case asserts `pg_class` and `pg_namespace` never appear: `pg_catalog` is
on every search path implicitly, so relation visibility on its own admits it.

## Session pinning

One `pg.Client` held for the file, because `getDrizzle()` wraps a Pool — a
`SET search_path` on a pooled connection binds to whichever client served it and
the reads may run on another. A first case asserts `SHOW search_path` really
contains the tenant schema, so a reset session fails as a fixture problem rather
than looking like a defect in the predicate.

## Verification

Locally: typechecks, lints, 11,901 unit tests pass, and the file is **collected**
by `vitest.integration.config.ts` (4 tests, skipped for the documented missing-URL
reason) rather than silently excluded.

⚠️ The assertions have not executed here — no Docker or PostgreSQL is reachable
from this machine. The Postgres CI leg is the oracle. The sibling probe added in
#1721/#1727 uses this same shape and has since passed on all three dialects, so
the harness itself is proven even though these cases are new.
