### PR TITLE
fix(builder): a refusal answered straight away reaches the author

### DIFF
--- a/.changeset/a-synchronous-refusal-reaches-the-author.md
+++ b/.changeset/a-synchronous-refusal-reaches-the-author.md
@@ -1,0 +1,34 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Renaming a class in the page builder could be refused without the author being
+told. A host that answers immediately — because the site style is locked, or the
+name is one it already knows is taken — had its refusal discarded, so the row
+cleared and the rename looked like it had worked until the next read. A host that
+answered a moment later was always shown correctly; only the immediate answer was
+lost.

--- a/packages/builder/src/class-manager-panel.test.tsx
+++ b/packages/builder/src/class-manager-panel.test.tsx
@@ -436,6 +436,86 @@ describe("a host with no way to carry out a delete", () => {
 });
 
 describe("a rename the host refuses", () => {
+  it("shows a refusal the host answers with STRAIGHT AWAY", async () => {
+    /*
+     * 🔴 The contract is "returning a ClassRenameOutcome is how a refusal
+     * reaches the author", and it says nothing about WHEN. A host that checks
+     * something it already knows — a locked site style, a slug it holds in
+     * memory — answers inside the call, and that answer was being dropped: the
+     * row cleared and the author was told nothing, which is the exact silence
+     * the outcome exists to remove.
+     *
+     * Deliberately NOT async. The asynchronous case is covered below, and it
+     * passed throughout; only the synchronous one was lost.
+     */
+    const onRename = vi.fn(() => ({
+      ok: false as const,
+      reason: "The site style is locked.",
+    }));
+    render(
+      <ClassManagerPanel
+        library={LIBRARY}
+        usage={{}}
+        documentClassIds={[]}
+        onRename={onRename}
+        onDelete={vi.fn()}
+      />
+    );
+    const field = nameField("hero");
+    fireEvent.change(field, { target: { value: "renamed" } });
+    fireEvent.blur(field);
+
+    expect(await screen.findByText("The site style is locked.")).toBeTruthy();
+  });
+
+  it("says nothing when a synchronous host answers that it worked", async () => {
+    /*
+     * The control for the case above. Reporting whatever a host returns would
+     * also satisfy it — and would put a refusal notice beside every successful
+     * rename by a host that answers `{ ok: true }`.
+     */
+    const onRename = vi.fn(() => ({ ok: true as const }));
+    render(
+      <ClassManagerPanel
+        library={LIBRARY}
+        usage={{}}
+        documentClassIds={[]}
+        onRename={onRename}
+        onDelete={vi.fn()}
+      />
+    );
+    const field = nameField("hero");
+    fireEvent.change(field, { target: { value: "renamed" } });
+    fireEvent.blur(field);
+
+    await Promise.resolve();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("still says nothing when a host answers with void, as most do", async () => {
+    /*
+     * The second control. The contract this replaced was `=> void`, so the
+     * common host returns nothing at all — and treating an un-outcome as a
+     * refusal would report a failure for every rename those hosts perform.
+     */
+    const onRename = vi.fn(() => undefined);
+    render(
+      <ClassManagerPanel
+        library={LIBRARY}
+        usage={{}}
+        documentClassIds={[]}
+        onRename={onRename}
+        onDelete={vi.fn()}
+      />
+    );
+    const field = nameField("hero");
+    fireEvent.change(field, { target: { value: "renamed" } });
+    fireEvent.blur(field);
+
+    await Promise.resolve();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
   it("shows the reason rather than clearing as though it landed", async () => {
     const onRename = vi.fn(async () => ({
       ok: false as const,

--- a/packages/builder/src/class-manager-panel.tsx
+++ b/packages/builder/src/class-manager-panel.tsx
@@ -998,9 +998,27 @@ function NameField({
      */
     setDraft(null);
     setRefused(null);
-    // A host that answered with something un-awaitable is one that does not
-    // report. Reaching for `.then` on it threw out of this event handler.
-    if (!isPromiseLike(answered)) return;
+    if (!isPromiseLike(answered)) {
+      /*
+       * 🔴 A refusal does not have to arrive later. The contract says an
+       * outcome "is how a refusal reaches the author" and says nothing about
+       * WHEN — a host that checks a permission it already holds, or a slug it
+       * already knows is taken, answers straight away. Dropping that answer
+       * left the row cleared and the author told nothing, which is the exact
+       * silence the outcome was added to remove.
+       *
+       * Everything else un-awaitable is a host that does not report: the
+       * contract this replaced was `=> void`, so most callers answer with
+       * nothing at all, and reaching for `.then` on that threw out of this
+       * event handler.
+       *
+       * No supersession check, unlike the promise path below. A synchronous
+       * answer is delivered inside the same commit that asked for it, so no
+       * newer attempt can have started in between.
+       */
+      if (isRenameOutcome(answered) && !answered.ok) report(answered.reason);
+      return;
+    }
     void Promise.resolve(answered)
       .then(result => {
         // Superseded: a newer rename on this row is the one being awaited, and


### PR DESCRIPTION
One of three Codex findings on merged #1367. The other two live in
`plugin-page-builder`, which lane `builder` holds whole — so this takes the one
in `packages/builder` and leaves those, with the split recorded on the task.

## The defect

`onRename`'s contract is explicit:

> May answer with the outcome. A host that persists asynchronously and stays
> silent leaves the row looking renamed whatever happened, so returning a
> **`ClassRenameOutcome` is how a refusal reaches the author**.

It says nothing about *when*. But the panel did:

```ts
if (!isPromiseLike(answered)) return;
```

So a host answering **straight away** — a locked site style, a name it already
knows is taken — had its refusal thrown away. The row cleared and the rename
looked like it had worked until the next read, which is precisely the silence
the outcome was added to remove. `ClassRenameAnswer` is `unknown`, so a
synchronous outcome is a conforming answer.

An asynchronous refusal was always shown correctly. Only the immediate one was lost.

## The fix

A synchronous answer is inspected before the promise path bails out. No
supersession check on that branch, and the comment says why: a synchronous
answer arrives inside the same commit that asked for it, so no newer attempt can
have started in between.

## Evidence

Three cases, break-verified — and the two controls matter more than the fix here,
because "report what the host returned" is the easy wrong version:

| mutation | fails |
|---|---|
| drop every non-promise again (the shipped defect) | the new refusal test |
| report **any** synchronous outcome, `ok` or not | the `{ ok: true }` control |
| treat a **void** answer as a refusal | the void control, plus two pre-existing tests |

That third row is the one that keeps this honest: the contract this replaced was
`=> void`, so most hosts answer with nothing, and a fix that reported an
un-outcome would put a failure notice beside every rename those hosts perform.

## Gates

`pnpm build` 0 · builder `check-types` 0 `lint` 0 `vitest` 0 (107 files, 3,076
tests) · `fallow audit` pass, every `*_introduced` 0 · `changeset status` 0.
