### PR TITLE
ci: make the integration budget guard catch what it claims to

### DIFF
--- a/scripts/integration-legs-fail-on-overrun.test.mjs
+++ b/scripts/integration-legs-fail-on-overrun.test.mjs
@@ -15,7 +15,7 @@
  * armed. So the real bound lives on the STEP, in `run-with-budget.sh`, where an
  * overrun exits non-zero and the job fails like any other red.
  *
- * ## Every assertion here derives its population from the workflow
+ * ## Every assertion here derives its population from the artifacts
  *
  * The first version of this file did not, and that is the defect it exists to
  * prevent, committed inside the guard against it. It iterated a three-item list
@@ -24,17 +24,19 @@
  * every assertion passed without ever looking at it.
  *
  * So a leg is anything the workflow runs a `lane:test:integration:` script for,
- * and a job is anything `jobs:` declares. A floor check keeps that from failing
- * open: if the reader finds no legs at all, an assertion over "every leg" is
- * satisfied by having nothing to check.
+ * a job is anything `jobs:` declares, and the escalation delay is read from the
+ * script that enforces it rather than repeated here. A floor check keeps the
+ * derivation from failing open: if the reader finds no legs at all, an
+ * assertion over "every leg" is satisfied by having nothing to check.
  *
  * ## And each assertion tests a RELATIONSHIP, not a coincidence
  *
- * Asserting that a block contains the wrapper and contains the lane script is
- * satisfied by a block that runs the lane bare and calls the wrapper on
- * something else entirely. What has to hold is that the wrapper INVOKES the
- * lane, so the commands are joined across their line continuations and read as
- * one.
+ * A block containing the wrapper and containing the lane script is satisfied by
+ * one that runs the lane bare beside a wrapper call on something else. String
+ * ORDER does not settle it either: `wrapper ... true && pnpm lane:...` puts the
+ * wrapper first and still runs the lane unbounded. So each script is split into
+ * its simple commands — across line continuations, and at `&&`, `||`, `;` and
+ * `|` — and the wrapper must be the command that invokes the lane.
  *
  * @module integration-legs-fail-on-overrun.test
  */
@@ -54,106 +56,112 @@ const WORKFLOW = path.join(
   "workflows",
   "integration.yml"
 );
+const SCRIPT = path.join(HERE, "run-with-budget.sh");
 
-const LANE = "lane:test:integration:";
+const LANE = /\blane:test:integration:([a-z0-9]+)/;
 const WRAPPER = "scripts/run-with-budget.sh";
 
 /**
  * The dialects that must be present for the reader to be believed.
  *
  * A FLOOR, not the population. Every assertion below iterates what the workflow
- * actually declares; this one exists so a reader that silently found nothing
- * cannot satisfy them all by leaving them nothing to iterate.
+ * actually invokes; this one exists so a reader that silently found nothing
+ * cannot satisfy them all by leaving them nothing to iterate. Checked against
+ * the LANE SCRIPTS the steps run, not their display names — a step still named
+ * `(postgres)` that had been changed to run the MySQL lane would otherwise
+ * count as postgres coverage.
  */
 const AT_LEAST = ["postgres", "mysql", "sqlite"];
 
 /**
- * What a job's ceiling must clear beyond the suite's own budget.
- *
- * The suite may use its whole budget, then ignore TERM and take the escalation
- * delay on top, and the job has already spent time on checkout, install and
- * build before any of that. A ceiling only just above the budget cancels the
- * job mid-escalation — which is the cancellation this whole mechanism exists to
- * replace, restored by a number that looks like it has headroom.
+ * Time the job needs beyond the budget and the escalation for checkout,
+ * install and build, which all run before the suite's clock starts.
  */
-const ESCALATION_MINUTES = 2;
 const SETUP_MINUTES = 5;
 
 let workflow = "";
+let script = "";
 
 beforeAll(async () => {
-  workflow = await readFile(WORKFLOW, "utf8");
+  [workflow, script] = await Promise.all([
+    readFile(WORKFLOW, "utf8"),
+    readFile(SCRIPT, "utf8"),
+  ]);
 });
 
 /**
- * Shell lines with their `\` continuations joined, so one command is one line.
+ * Every simple command in a script, one per element.
  *
- * The wrapper invocation spans three physical lines. Read line by line, the
- * line naming the lane script does not name the wrapper, and no assertion about
- * the two together can hold.
+ * Line continuations are joined first, so the wrapper's three physical lines
+ * read as one invocation. Then each line is split at the shell operators, so
+ * `a && b` is two commands — and a lane in `b` cannot borrow a wrapper in `a`.
+ * Quoted operators are not special-cased: nothing in this workflow quotes one,
+ * and a reader that mis-split a quoted `|` would err toward reporting a bare
+ * lane, which is the loud direction.
  */
-function commands(block) {
+function simpleCommands(block) {
   return block
     .replace(/\\\n\s*/g, " ")
     .split("\n")
-    .map((line) => line.trim())
-    .filter((line) => line !== "" && !line.startsWith("#"));
+    .flatMap(line => line.split(/\s*(?:&&|\|\||;|\|)\s*/))
+    .map(command => command.trim())
+    .filter(command => command !== "" && !command.startsWith("#"));
 }
 
-/** Every step whose script runs one of the integration lane scripts. */
-function integrationLegs(text) {
-  return [...workflowSteps(text).blocks.entries()].filter(([, block]) =>
-    block.includes(LANE)
-  );
+/** The dialects a script invokes, by lane name. */
+function dialectsInvoked(block) {
+  // `matchAll` requires the global flag, and that flag is what makes `.test()`
+  // stateful — so the global copy lives here, and nowhere else.
+  return [...block.matchAll(new RegExp(LANE.source, "g"))].map(m => m[1]);
 }
 
 /**
- * True when the wrapper is what invokes the lane on this command.
+ * True when the wrapper is the command invoking the lane.
  *
- * The ORDER is the check. A command merely containing both strings is satisfied
- * by a block that calls the wrapper on something else and the lane bare beside
- * it, which is precisely the unbounded state being guarded against.
+ * Within one SIMPLE command, order is enough: there is no operator left for a
+ * wrapper to hide behind, so the wrapper appearing before the lane means the
+ * lane is one of its arguments.
  */
 function wrapsLane(command) {
-  if (!command.includes(WRAPPER)) return false;
-  return command.indexOf(WRAPPER) < command.indexOf(LANE);
+  const wrapper = command.indexOf(WRAPPER);
+  return wrapper !== -1 && wrapper < command.search(LANE);
 }
 
-/** The lane invocations in one block that do NOT go through the wrapper. */
+/** The lane invocations in one script that do NOT go through the wrapper. */
 function bareInvocations(name, block) {
-  return commands(block)
-    .filter((command) => command.includes(LANE) && !wrapsLane(command))
-    .map((command) => `${name}: ${command}`);
+  return simpleCommands(block)
+    .filter(command => LANE.test(command) && !wrapsLane(command))
+    .map(command => `${name ?? "(unnamed step)"}: ${command}`);
+}
+
+/** The escalation delay the SCRIPT enforces, in minutes. */
+function escalationMinutes(text) {
+  const found = /^KILL_AFTER=(\d+)m$/m.exec(text);
+  expect(found, "run-with-budget.sh declares KILL_AFTER in minutes").not.toBeNull();
+  return Number(found[1]);
 }
 
 describe("integration.yml", () => {
-  it("declares a leg for at least every dialect the suite is known to run", () => {
+  it("invokes a lane for at least every dialect the suite is known to run", () => {
     // The floor. Without it, a reader that returned nothing would make every
     // "for each leg" assertion below vacuously true.
-    const found = integrationLegs(workflow)
-      .map(([name]) => name)
-      .join(" ");
+    const invoked = workflowSteps(workflow).flatMap(step =>
+      dialectsInvoked(step.block)
+    );
 
     for (const dialect of AT_LEAST) {
-      expect(found).toContain(dialect);
+      expect(invoked).toContain(dialect);
     }
   });
 
   it("runs EVERY lane it invokes through the budget wrapper", () => {
-    // Derived from the workflow, so a dialect added later is covered without
-    // anybody remembering to edit this file.
-    const bare = integrationLegs(workflow).flatMap(([name, block]) =>
-      bareInvocations(name, block)
+    // Derived from the workflow — named steps and anonymous ones alike — so a
+    // dialect added later is covered without anybody editing this file.
+    const bare = workflowSteps(workflow).flatMap(step =>
+      bareInvocations(step.name, step.block)
     );
 
     expect(bare).toEqual([]);
-  });
-
-  it("names each leg's step only once, so none can hide another", () => {
-    // Two steps may share a name legitimately. The reader keeps the last, so a
-    // wrapped later step would hide an unwrapped earlier one — and this gate
-    // would pass on the strength of the step it did not read.
-    expect(workflowSteps(workflow).duplicated).toEqual([]);
   });
 
   it("gives EVERY job a ceiling, with room for the escalation and the setup", () => {
@@ -165,7 +173,12 @@ describe("integration.yml", () => {
     // means the workflow cannot be merged in that state at all.
     expect(Number(budget[1])).toBeGreaterThan(0);
 
-    const floor = Number(budget[1]) + ESCALATION_MINUTES + SETUP_MINUTES;
+    // The escalation comes from the script that performs it. A copy of the
+    // number here would agree today and drift the first time the script's
+    // changed alone — and the drift would only show as a job cancelled during
+    // an escalation this guard had certified there was room for.
+    const floor =
+      Number(budget[1]) + escalationMinutes(script) + SETUP_MINUTES;
     const ceilings = jobTimeouts(workflow);
     const ids = jobIds(workflow);
 

--- a/scripts/integration-legs-fail-on-overrun.test.mjs
+++ b/scripts/integration-legs-fail-on-overrun.test.mjs
@@ -2,41 +2,39 @@
  * An integration leg that outgrows its budget must FAIL, not vanish.
  *
  * GitHub enforces a job's `timeout-minutes` by cancelling it, so a leg killed
- * for running too long is recorded as `conclusion: cancelled`. Nothing reads a
- * cancellation as a verdict — branch protection ignores it and the checks
- * rollup shows no red — so the leg silently stops contributing an answer while
- * looking
- * like somebody pressed the button.
+ * for running too long is recorded as `conclusion: cancelled` rather than
+ * `failure`. Nothing reads a cancellation as a verdict — branch protection
+ * ignores it and the checks rollup shows no red — so the leg silently stops
+ * contributing an answer while looking like somebody pressed the button.
  *
  * It has happened twice. At the 25-minute ceiling the MySQL leg stopped
- * reporting for six consecutive pull requests. At 45 it killed three separate
- * branches in one day, and all three read as cancellations.
+ * reporting for six consecutive rounds of merges. At 45 it killed three
+ * separate branches in one day, and all three read as cancellations.
  *
  * Raising the ceiling is what was done the first time, and it left the trap
- * armed. So the real bound now lives on the STEP, in `run-with-budget.sh`,
- * where an overrun exits non-zero and the job fails like any other red.
+ * armed. So the real bound lives on the STEP, in `run-with-budget.sh`, where an
+ * overrun exits non-zero and the job fails like any other red.
  *
- * 🔴 Nothing else in the repository reads this. A dialect added later that
- * calls its lane script directly gets the old behaviour back — silently, and
- * only for the new leg, which is the hardest version to notice. That is what
- * this file is for.
+ * ## Every assertion here derives its population from the workflow
  *
- * ## Why these three assertions and not a simpler one
+ * The first version of this file did not, and that is the defect it exists to
+ * prevent, committed inside the guard against it. It iterated a three-item list
+ * of dialects written HERE, so a fourth leg added to the workflow alone — the
+ * exact regression the file claims to catch — was outside the population and
+ * every assertion passed without ever looking at it.
  *
- * Counting is what a first version of this did, and a count cannot see the
- * defect it exists to catch: a fourth leg added without the wrapper moves the
- * total, and a total compared against a hardcoded number either fails for
- * every legitimate addition or gets bumped without anyone checking WHICH legs
- * are covered. So membership is asserted per dialect, by name.
+ * So a leg is anything the workflow runs a `lane:test:integration:` script for,
+ * and a job is anything `jobs:` declares. A floor check keeps that from failing
+ * open: if the reader finds no legs at all, an assertion over "every leg" is
+ * satisfied by having nothing to check.
  *
- * The budget comparison is the non-obvious one. The step bound only does
- * anything if it fires FIRST — a job whose `timeout-minutes` is below the step
- * budget cancels on its way to the failure, and the whole mechanism reverts to
- * the behaviour being removed while every step still visibly calls the wrapper.
+ * ## And each assertion tests a RELATIONSHIP, not a coincidence
  *
- * The workflow is read through `workflow-run-blocks.mjs`, which pins the
- * reader's own traps — chiefly that a step's block must not absorb the comment
- * introducing the NEXT step, since these comments quote commands verbatim.
+ * Asserting that a block contains the wrapper and contains the lane script is
+ * satisfied by a block that runs the lane bare and calls the wrapper on
+ * something else entirely. What has to hold is that the wrapper INVOKES the
+ * lane, so the commands are joined across their line continuations and read as
+ * one.
  *
  * @module integration-legs-fail-on-overrun.test
  */
@@ -46,13 +44,40 @@ import { fileURLToPath } from "node:url";
 
 import { beforeAll, describe, expect, it } from "vitest";
 
-import { runBlocks } from "./workflow-run-blocks.mjs";
+import { jobIds, jobTimeouts, workflowSteps } from "./workflow-run-blocks.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
-const WORKFLOW = path.join(HERE, "..", ".github", "workflows", "integration.yml");
+const WORKFLOW = path.join(
+  HERE,
+  "..",
+  ".github",
+  "workflows",
+  "integration.yml"
+);
 
-/** Every dialect the suite runs. A new one added here must be wired too. */
-const DIALECTS = ["postgres", "mysql", "sqlite"];
+const LANE = "lane:test:integration:";
+const WRAPPER = "scripts/run-with-budget.sh";
+
+/**
+ * The dialects that must be present for the reader to be believed.
+ *
+ * A FLOOR, not the population. Every assertion below iterates what the workflow
+ * actually declares; this one exists so a reader that silently found nothing
+ * cannot satisfy them all by leaving them nothing to iterate.
+ */
+const AT_LEAST = ["postgres", "mysql", "sqlite"];
+
+/**
+ * What a job's ceiling must clear beyond the suite's own budget.
+ *
+ * The suite may use its whole budget, then ignore TERM and take the escalation
+ * delay on top, and the job has already spent time on checkout, install and
+ * build before any of that. A ceiling only just above the budget cancels the
+ * job mid-escalation — which is the cancellation this whole mechanism exists to
+ * replace, restored by a number that looks like it has headroom.
+ */
+const ESCALATION_MINUTES = 2;
+const SETUP_MINUTES = 5;
 
 let workflow = "";
 
@@ -60,47 +85,104 @@ beforeAll(async () => {
   workflow = await readFile(WORKFLOW, "utf8");
 });
 
-describe("integration.yml", () => {
-  it("has a run block for every dialect's suite", () => {
-    // The population, asserted before anything is judged about it. Every
-    // assertion below is satisfied vacuously by a file this parser could not
-    // read — an empty map passes "none of them skips the wrapper" perfectly.
-    const named = [...runBlocks(workflow).keys()];
+/**
+ * Shell lines with their `\` continuations joined, so one command is one line.
+ *
+ * The wrapper invocation spans three physical lines. Read line by line, the
+ * line naming the lane script does not name the wrapper, and no assertion about
+ * the two together can hold.
+ */
+function commands(block) {
+  return block
+    .replace(/\\\n\s*/g, " ")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line !== "" && !line.startsWith("#"));
+}
 
-    for (const dialect of DIALECTS) {
-      expect(named).toContain(`Run integration tests (${dialect})`);
+/** Every step whose script runs one of the integration lane scripts. */
+function integrationLegs(text) {
+  return [...workflowSteps(text).blocks.entries()].filter(([, block]) =>
+    block.includes(LANE)
+  );
+}
+
+/**
+ * True when the wrapper is what invokes the lane on this command.
+ *
+ * The ORDER is the check. A command merely containing both strings is satisfied
+ * by a block that calls the wrapper on something else and the lane bare beside
+ * it, which is precisely the unbounded state being guarded against.
+ */
+function wrapsLane(command) {
+  if (!command.includes(WRAPPER)) return false;
+  return command.indexOf(WRAPPER) < command.indexOf(LANE);
+}
+
+/** The lane invocations in one block that do NOT go through the wrapper. */
+function bareInvocations(name, block) {
+  return commands(block)
+    .filter((command) => command.includes(LANE) && !wrapsLane(command))
+    .map((command) => `${name}: ${command}`);
+}
+
+describe("integration.yml", () => {
+  it("declares a leg for at least every dialect the suite is known to run", () => {
+    // The floor. Without it, a reader that returned nothing would make every
+    // "for each leg" assertion below vacuously true.
+    const found = integrationLegs(workflow)
+      .map(([name]) => name)
+      .join(" ");
+
+    for (const dialect of AT_LEAST) {
+      expect(found).toContain(dialect);
     }
   });
 
-  it.each(DIALECTS)(
-    "runs the %s suite through the budget wrapper, not bare",
-    (dialect) => {
-      const block = runBlocks(workflow).get(
-        `Run integration tests (${dialect})`
-      );
+  it("runs EVERY lane it invokes through the budget wrapper", () => {
+    // Derived from the workflow, so a dialect added later is covered without
+    // anybody remembering to edit this file.
+    const bare = integrationLegs(workflow).flatMap(([name, block]) =>
+      bareInvocations(name, block)
+    );
 
-      expect(block).toBeDefined();
-      // Both halves matter. The lane script must be invoked (or this leg tests
-      // nothing), and the invocation must go through the wrapper (or an
-      // overrun is a cancellation again).
-      expect(block).toContain(`lane:test:integration:${dialect}`);
-      expect(block).toContain("scripts/run-with-budget.sh");
-    }
-  );
+    expect(bare).toEqual([]);
+  });
 
-  it("gives every job a ceiling ABOVE the step budget, so the step fires first", () => {
+  it("names each leg's step only once, so none can hide another", () => {
+    // Two steps may share a name legitimately. The reader keeps the last, so a
+    // wrapped later step would hide an unwrapped earlier one — and this gate
+    // would pass on the strength of the step it did not read.
+    expect(workflowSteps(workflow).duplicated).toEqual([]);
+  });
+
+  it("gives EVERY job a ceiling, with room for the escalation and the setup", () => {
     const budget = /INTEGRATION_SUITE_BUDGET:\s*(\d+)m/.exec(workflow);
     expect(budget, "the workflow declares a step budget").not.toBeNull();
 
-    const ceilings = [...workflow.matchAll(/^\s*timeout-minutes:\s*(\d+)\s*$/gm)]
-      .map((m) => Number(m[1]));
+    // Non-zero, because GNU `timeout` documents a duration of 0 as DISABLING
+    // the bound. `run-with-budget.sh` refuses one at run time; catching it here
+    // means the workflow cannot be merged in that state at all.
+    expect(Number(budget[1])).toBeGreaterThan(0);
 
-    // Nonzero, because "every ceiling exceeds the budget" is true of no
-    // ceilings at all — and a regex that stopped matching would read as a pass.
-    expect(ceilings.length).toBeGreaterThan(0);
+    const floor = Number(budget[1]) + ESCALATION_MINUTES + SETUP_MINUTES;
+    const ceilings = jobTimeouts(workflow);
+    const ids = jobIds(workflow);
 
-    for (const ceiling of ceilings) {
-      expect(ceiling).toBeGreaterThan(Number(budget[1]));
+    // Non-empty, or "every job clears the floor" is true of no jobs at all.
+    expect(ids.length).toBeGreaterThan(0);
+
+    // Per job, by id. One list of every number in the file is satisfied by the
+    // siblings of a job whose own ceiling was deleted.
+    for (const id of ids) {
+      expect(
+        ceilings.get(id),
+        `${id} declares no timeout-minutes`
+      ).toBeDefined();
+      expect(
+        ceilings.get(id),
+        `${id} leaves no room above the budget`
+      ).toBeGreaterThanOrEqual(floor);
     }
   });
 });

--- a/scripts/run-with-budget.sh
+++ b/scripts/run-with-budget.sh
@@ -36,6 +36,12 @@ budget="$1"
 what="$2"
 shift 2
 
+# How long TERM is given before KILL. Named rather than inline because the job's
+# own ceiling has to sit above the budget PLUS this, or the job is cancelled
+# while the escalation is still running and the failure reverts to the
+# cancellation this script exists to replace.
+KILL_AFTER=2m
+
 # Refuse rather than run unbounded.
 #
 # Degrading to an unbounded run when `timeout` is missing would restore exactly
@@ -49,19 +55,62 @@ if ! command -v timeout > /dev/null 2>&1; then
   exit 2
 fi
 
+# Seconds, so the elapsed time below can be compared against it.
+#
+# Refused rather than defaulted when it cannot be read. A budget this script
+# cannot parse is one it cannot check the outcome against, and carrying on would
+# run the command under a bound nobody can verify — which looks exactly like a
+# bounded run.
+budget_seconds=$(printf '%s' "$budget" | awk '
+  /^[0-9]+$/            { print $0;        exit }
+  /^[0-9]+s$/           { print $0 + 0;    exit }
+  /^[0-9]+m$/           { print $0 * 60;   exit }
+  /^[0-9]+h$/           { print $0 * 3600; exit }
+                        { print "";        exit }')
+
+if [ -z "$budget_seconds" ]; then
+  echo "run-with-budget.sh: cannot read '${budget}' as a duration, refusing." >&2
+  exit 2
+fi
+
+# GNU `timeout` documents a duration of 0 as DISABLING the timeout, so a budget
+# of `0m` would run the command unbounded while every visible sign — the wrapper
+# in the workflow, the budget in the env — says it is bounded. That is the
+# failure this script exists to remove, wearing the costume of the fix.
+if [ "$budget_seconds" -le 0 ]; then
+  echo "run-with-budget.sh: a budget of '${budget}' disables the timeout, refusing." >&2
+  exit 2
+fi
+
 # `--kill-after` because TERM is a request. A vitest worker wedged on a database
 # socket can ignore it, and a budget that a hung process can decline to honour
 # is not a budget.
+started=$(date +%s)
 set +e
-timeout --kill-after=2m "$budget" "$@"
+timeout --kill-after="$KILL_AFTER" "$budget" "$@"
 status=$?
 set -e
+elapsed=$(( $(date +%s) - started ))
 
-# 124 is `timeout`'s own "the command timed out"; 137 is 128+SIGKILL, which is
-# what the `--kill-after` escalation produces when TERM was ignored. Both mean
-# the budget fired, and neither is a result the command produced itself.
-if [ "$status" -eq 124 ] || [ "$status" -eq 137 ]; then
-  echo "::error title=Integration budget exceeded::${what} ran past its ${budget} budget and was stopped. This is reported as a FAILURE on purpose: a job-level timeout would have been recorded as a cancellation, which no gate reads. Either the suite has genuinely outgrown the budget (raise it in integration.yml, and see whether it is time to shard instead) or something is hanging."
+# 124 is `timeout`'s own "the command timed out", and nothing else produces it.
+if [ "$status" -eq 124 ]; then
+  budget_exceeded=yes
+# 137 is 128+SIGKILL, which the `--kill-after` escalation produces when TERM was
+# ignored — and which the runner's OOM killer produces too, on a command that
+# died in its first minute. The exit code cannot tell those apart, so the
+# ELAPSED time does: a budget that never came close to expiring did not expire.
+# Reporting an out-of-memory kill as an overrun would send the next person to
+# raise a budget that was never the problem.
+elif [ "$status" -eq 137 ] && [ "$elapsed" -ge "$budget_seconds" ]; then
+  budget_exceeded=yes
+else
+  budget_exceeded=no
+fi
+
+if [ "$budget_exceeded" = yes ]; then
+  echo "::error title=Integration budget exceeded::${what} ran past its ${budget} budget and was stopped after ${elapsed}s. This is reported as a FAILURE on purpose: a job-level timeout would have been recorded as a cancellation, which no gate reads. Either the suite has genuinely outgrown the budget (raise it in integration.yml, and see whether it is time to shard instead) or something is hanging."
+elif [ "$status" -eq 137 ]; then
+  echo "::error title=Integration suite was killed::${what} was killed by SIGKILL after ${elapsed}s, inside its ${budget} budget. That is something outside this script — the runner's out-of-memory killer is the usual one. Raising the budget will not help."
 fi
 
 exit "$status"

--- a/scripts/run-with-budget.sh
+++ b/scripts/run-with-budget.sh
@@ -22,8 +22,16 @@
 # bound always fires first.
 #
 # Usage: run-with-budget.sh <budget> <what> <command> [args...]
-#   budget   any GNU `timeout` DURATION, e.g. 55m
+#   budget   a whole number of seconds, minutes or hours: 3300, 55m, 1h
 #   what     what to name in the error, e.g. "the MySQL integration suite"
+#
+# The budget grammar is DELIBERATELY narrower than GNU `timeout`'s, which also
+# takes fractions and a `d` suffix. This script has to convert the budget to
+# seconds to judge the outcome, and every form it accepts is one it has to
+# parse — so the contract is the set it parses, stated here, rather than a
+# broader one the parser silently fails on. A CI budget written as `0.5h` or
+# `1d` is refused with a message naming the value, not run under a bound
+# nobody checked.
 
 set -e
 

--- a/scripts/run-with-budget.test.mjs
+++ b/scripts/run-with-budget.test.mjs
@@ -18,6 +18,13 @@
  *   printed "budget exceeded" for every non-zero exit, which would send the
  *   next person to raise a budget over a genuine red suite.
  *
+ * A third case was REMOVED rather than repaired: it read a bare 137 as the
+ * budget firing. That is no longer what the script does, because the runner's
+ * out-of-memory killer produces 137 as well — so exit code alone cannot
+ * separate them and elapsed time does. The two cases named "does NOT call an
+ * early SIGKILL a budget overrun" and "DOES call a SIGKILL after the budget
+ * elapsed an overrun" cover both directions of that split.
+ *
  * And one property is the reason the script is a script at all: with no
  * `timeout` on PATH it must REFUSE rather than run the command unbounded.
  * Degrading quietly would reinstate exactly the state being removed while
@@ -41,7 +48,7 @@ import { describe, expect, it } from "vitest";
 const SCRIPT = fileURLToPath(new URL("./run-with-budget.sh", import.meta.url));
 
 /** A `timeout` that exits with whatever the case asks for, and records its argv. */
-function stubDir(exitCode) {
+function stubDir(exitCode, sleepSeconds = 0) {
   const dir = mkdtempSync(join(tmpdir(), "budget-"));
   const argvLog = join(dir, "argv");
   const stub = join(dir, "timeout");
@@ -49,7 +56,11 @@ function stubDir(exitCode) {
     stub,
     // `#!/bin/sh`, not `#!/usr/bin/env sh`: PATH holds only this directory, so
     // `env` would have no `sh` to find and every case would exit 127.
-    `#!/bin/sh\nprintf '%s\\n' "$@" > ${argvLog}\nexit ${exitCode}\n`
+    //
+    // The sleep is how a case controls ELAPSED time, which is the only thing
+    // that separates a budget that expired from a command killed by something
+    // else — both exit 137.
+    `#!/bin/sh\nprintf '%s\\n' "$@" > ${argvLog}\nsleep ${sleepSeconds}\nexit ${exitCode}\n`
   );
   chmodSync(stub, 0o755);
   return { dir, argvLog };
@@ -70,7 +81,10 @@ function run(args, { path }) {
     // and fail identically in every case, which reads as seven passing
     // refusals rather than a broken harness.
     const stdout = execFileSync("/bin/sh", [SCRIPT, ...args], {
-      env: { PATH: path },
+      // `/bin` after the stub so the script finds the STUB `timeout` while
+      // `sleep`, `date` and `awk` still resolve. Order is what makes the stub
+      // win; dropping /bin entirely would fail every case for the wrong reason.
+      env: { PATH: `${path}:/bin:/usr/bin` },
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -123,17 +137,6 @@ describe("run-with-budget.sh", () => {
     expect(result.output).toContain("55m");
   });
 
-  it("treats a SIGKILL escalation as the budget firing too", () => {
-    // 137 is 128+9: what `--kill-after` produces when the command ignored
-    // TERM. Reading only 124 would let a wedged worker — the case the
-    // escalation exists for — exit quietly.
-    const { dir } = stubDir(137);
-    const result = run(["55m", "the suite", "anything"], { path: dir });
-
-    expect(result.status).toBe(137);
-    expect(result.output).toContain(BUDGET_ERROR);
-  });
-
   it("does NOT call an ordinary test failure a budget overrun", () => {
     const { dir } = stubDir(3);
     const result = run(["55m", "the suite", "anything"], { path: dir });
@@ -143,11 +146,57 @@ describe("run-with-budget.sh", () => {
   });
 
   it("refuses rather than running unbounded when there is no `timeout`", () => {
+    // PATH with no system directories at all, so this cannot accidentally find
+    // a real `timeout` on a machine that has one — the case would then pass for
+    // having run the command rather than for refusing it.
     const empty = mkdtempSync(join(tmpdir(), "no-timeout-"));
     const result = run(["55m", "the suite", "anything"], { path: empty });
 
     expect(result.status).toBe(2);
     expect(result.output).toContain("refusing to run unbounded");
+  });
+
+  it("refuses a budget of zero, which DISABLES the timeout", () => {
+    // GNU `timeout` documents 0 as disabling the bound, so `0m` would run the
+    // command unbounded while the workflow, the env var and this wrapper all
+    // still read as bounded.
+    const { dir } = stubDir(0);
+    const result = run(["0m", "the suite", "anything"], { path: dir });
+
+    expect(result.status).toBe(2);
+    expect(result.output).toContain("disables the timeout");
+  });
+
+  it("refuses a duration it cannot read, rather than guessing one", () => {
+    const { dir } = stubDir(0);
+    const result = run(["soon", "the suite", "anything"], { path: dir });
+
+    expect(result.status).toBe(2);
+    expect(result.output).toContain("cannot read");
+  });
+
+  it("does NOT call an early SIGKILL a budget overrun", () => {
+    // The runner's out-of-memory killer also produces 137, on a command that
+    // died in its first seconds. Reporting that as an overrun sends the next
+    // person to raise a budget that was never the problem.
+    const { dir } = stubDir(137);
+    const result = run(["1h", "the MySQL integration suite", "anything"], {
+      path: dir,
+    });
+
+    expect(result.status).toBe(137);
+    expect(result.output).not.toContain(BUDGET_ERROR);
+    expect(result.output).toContain("killed by SIGKILL");
+  });
+
+  it("DOES call a SIGKILL after the budget elapsed an overrun", () => {
+    // The other side of the same discrimination: a TERM-ignoring worker killed
+    // by the escalation, which is a real overrun and must stay loud.
+    const { dir } = stubDir(137, 2);
+    const result = run(["1s", "the suite", "anything"], { path: dir });
+
+    expect(result.status).toBe(137);
+    expect(result.output).toContain(BUDGET_ERROR);
   });
 
   it("refuses a call that names no command to run", () => {

--- a/scripts/run-with-budget.test.mjs
+++ b/scripts/run-with-budget.test.mjs
@@ -38,7 +38,13 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -46,6 +52,28 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 const SCRIPT = fileURLToPath(new URL("./run-with-budget.sh", import.meta.url));
+
+/**
+ * A directory holding ONLY the tools the script needs besides `timeout`.
+ *
+ * PATH is set to this and nothing else, so the script's own `awk`, `date` and
+ * `sleep` resolve while `timeout` resolves only when a case supplies one. The
+ * obvious alternative — appending `/bin:/usr/bin` — makes the "no `timeout`"
+ * case find the REAL `/usr/bin/timeout` on every Ubuntu runner, run the command
+ * through it, and pass or fail for reasons that have nothing to do with the
+ * refusal being tested. That was live: it read as green on a Mac, which has no
+ * `timeout`, and would have gone red on CI for the wrong reason.
+ */
+function toolsDir() {
+  const dir = mkdtempSync(join(tmpdir(), "tools-"));
+  for (const tool of ["awk", "date", "sleep"]) {
+    const real = execFileSync("/bin/sh", ["-c", `command -v ${tool}`], {
+      encoding: "utf8",
+    }).trim();
+    symlinkSync(real, join(dir, tool));
+  }
+  return dir;
+}
 
 /** A `timeout` that exits with whatever the case asks for, and records its argv. */
 function stubDir(exitCode, sleepSeconds = 0) {
@@ -81,10 +109,11 @@ function run(args, { path }) {
     // and fail identically in every case, which reads as seven passing
     // refusals rather than a broken harness.
     const stdout = execFileSync("/bin/sh", [SCRIPT, ...args], {
-      // `/bin` after the stub so the script finds the STUB `timeout` while
-      // `sleep`, `date` and `awk` still resolve. Order is what makes the stub
-      // win; dropping /bin entirely would fail every case for the wrong reason.
-      env: { PATH: `${path}:/bin:/usr/bin` },
+      // The case's directory first, then the tools the script needs — and no
+      // system directory at all, so a real `timeout` can never be found by
+      // accident. `/bin/sh` itself is invoked by absolute path for the same
+      // reason.
+      env: { PATH: `${path}:${toolsDir()}` },
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -146,9 +175,10 @@ describe("run-with-budget.sh", () => {
   });
 
   it("refuses rather than running unbounded when there is no `timeout`", () => {
-    // PATH with no system directories at all, so this cannot accidentally find
-    // a real `timeout` on a machine that has one — the case would then pass for
-    // having run the command rather than for refusing it.
+    // An empty directory as the case's own, so PATH holds the tools and nothing
+    // that could resolve `timeout`. On a runner with `/usr/bin/timeout` the old
+    // PATH found it, ran `anything` through it, and exited 127 — a red that
+    // said nothing about the refusal.
     const empty = mkdtempSync(join(tmpdir(), "no-timeout-"));
     const result = run(["55m", "the suite", "anything"], { path: empty });
 

--- a/scripts/workflow-run-blocks.mjs
+++ b/scripts/workflow-run-blocks.mjs
@@ -1,5 +1,6 @@
 /**
- * The `run:` script of each named step in a workflow file, keyed by step name.
+ * The `run:` script of each named step in a workflow file, and each job's
+ * ceiling.
  *
  * Its own module rather than a helper inside the test that needs it, for the
  * reason `ci-gate.mjs` and `ci-verdict.mjs` are: a derivation a gate depends on
@@ -11,8 +12,30 @@
  * rather than by declaration, and a resolution that depends on hoisting is not
  * one to build a gate on.
  *
+ * ## Two ways a reader like this credits a step with somebody else's script
+ *
+ * Both are silent, and both make a gate built on it pass over the thing it
+ * exists to catch.
+ *
+ * A step boundary is a LIST ITEM, not a `name:` key. `- name: X` and a bare `-`
+ * followed by an indented `run:` are both steps, so tracking ownership by name
+ * alone leaves an anonymous step's script recorded against whichever named step
+ * came before it — and a gate then reads a wrapped command on a step that does
+ * not run one.
+ *
+ * And two steps may legitimately carry the SAME name — conditional variants of
+ * one job usually do. A map keeps the last, so a wrapped later step hides an
+ * unwrapped earlier one. Reported rather than merged, because which of the two
+ * a caller wants is the caller's question and silently answering it is how the
+ * hiding happens.
+ *
  * @module workflow-run-blocks
  */
+
+/** How far a line is indented, in spaces. */
+function indentOf(line) {
+  return line.length - line.trimStart().length;
+}
 
 /**
  * The lines of one block scalar: everything indented FURTHER than its key.
@@ -26,54 +49,151 @@ function blockBody(lines, from, indent) {
 
   for (let i = from; i < lines.length; i += 1) {
     if (lines[i].trim() === "") continue;
-    const here = lines[i].length - lines[i].trimStart().length;
-    if (here <= indent) break;
+    if (indentOf(lines[i]) <= indent) break;
     body.push(lines[i]);
   }
 
   return body.join("\n");
 }
 
-/** The step name a line declares, or null if it declares none. */
-function stepNameAt(line) {
-  const named = /^\s*- name:\s*(.+?)\s*$/.exec(line);
+/** The step name a list-item line declares, or null when it names none. */
+function stepNameOn(line) {
+  const named = /^\s*-\s*name:\s*(.+?)\s*$/.exec(line);
   return named === null ? null : named[1];
 }
 
-/**
- * The indentation of a `run: |` key on this line, or null.
- *
- * Null for an ANONYMOUS step as well as for a line that opens no block, so a
- * run block no named step owns is skipped rather than credited to whichever
- * name came last — which would report a step as running a script it does not.
- */
-function runIndentAt(line, owner) {
-  const run = owner === null ? null : /^(\s*)run:\s*\|/.exec(line);
+/** The indentation of a `run: |` key on this line, or null. */
+function runIndentOn(line) {
+  const run = /^(\s*)run:\s*\|/.exec(line);
   return run === null ? null : run[1].length;
 }
 
 /**
- * Each step's OWN run block — never the text running to the next step.
+ * True when a line opens a new step.
  *
- * A chunk bounded by the following `- name:` would include the comment block
- * that introduces the NEXT step, and workflow comments here quote commands
- * verbatim, so a comment about step N+1 would certify step N. The bound is the
- * block scalar's indentation instead, which ends where `env:` or the next
- * step's comments begin.
+ * A list item at the step list's own indentation. Items nested DEEPER belong to
+ * the step's own values — a `with:` taking a list, say — and treating one as a
+ * boundary would end the step early and orphan its script.
+ */
+function startsStep(line, stepIndent) {
+  if (!/^\s*-(\s|$)/.test(line)) return false;
+  return stepIndent === null || indentOf(line) <= stepIndent;
+}
+
+/** Move ownership to the step this line opens, named or not. */
+function applyBoundary(state, line) {
+  if (!startsStep(line, state.stepIndent)) return;
+  state.stepIndent = indentOf(line);
+  state.owner = stepNameOn(line);
+}
+
+/** Record a run block against the step that owns it, if any step does. */
+function recordRun(state, lines, index, indent) {
+  const owner = state.owner;
+  if (owner === null) return;
+  if (state.blocks.has(owner)) state.duplicated.push(owner);
+  state.blocks.set(owner, blockBody(lines, index + 1, indent));
+}
+
+/** One line's effect: it may open a step, and it may open that step's script. */
+function readStepLine(state, lines, index) {
+  applyBoundary(state, lines[index]);
+  const indent = runIndentOn(lines[index]);
+  if (indent !== null) recordRun(state, lines, index, indent);
+}
+
+/**
+ * Every step's own run block, keyed by step name, plus the names that appeared
+ * more than once.
+ *
+ * A step's OWN block — never the text running to the next step. A chunk bounded
+ * by the following `- name:` would include the comment block that introduces
+ * the NEXT step, and workflow comments here quote commands verbatim, so a
+ * comment about step N+1 would certify step N. The bound is the block scalar's
+ * indentation instead, which ends where `env:` or the next step's comments
+ * begin.
  *
  * @param {string} text the workflow file's contents
- * @returns {Map<string, string>} step name to the body of its `run:` block
+ * @returns {{ blocks: Map<string, string>, duplicated: string[] }}
  */
-export function runBlocks(text) {
+export function workflowSteps(text) {
   const lines = text.split("\n");
-  const blocks = new Map();
-  let name = null;
+  const state = {
+    blocks: new Map(),
+    duplicated: [],
+    owner: null,
+    stepIndent: null,
+  };
 
-  for (let i = 0; i < lines.length; i += 1) {
-    name = stepNameAt(lines[i]) ?? name;
-    const indent = runIndentAt(lines[i], name);
-    if (indent !== null) blocks.set(name, blockBody(lines, i + 1, indent));
+  for (let i = 0; i < lines.length; i += 1) readStepLine(state, lines, i);
+
+  return { blocks: state.blocks, duplicated: state.duplicated };
+}
+
+/** Collect a job id, once inside `jobs:`. */
+function collectJobId(state, line) {
+  if (!state.inJobs) {
+    state.inJobs = line.trimEnd() === "jobs:";
+    return;
   }
+  const job = /^ {2}([A-Za-z0-9_-]+):\s*$/.exec(line);
+  if (job !== null) state.ids.push(job[1]);
+}
 
-  return blocks;
+/**
+ * Every job the workflow declares, in file order.
+ *
+ * The population a caller needs before judging ceilings. Asking only
+ * {@link jobTimeouts} answers about the jobs that HAVE one, so a job whose
+ * ceiling was deleted is absent from the answer rather than reported — which
+ * reads as nothing to check.
+ *
+ * @param {string} text the workflow file's contents
+ * @returns {string[]} job ids
+ */
+export function jobIds(text) {
+  const state = { ids: [], inJobs: false };
+  for (const line of text.split("\n")) collectJobId(state, line);
+  return state.ids;
+}
+
+/** Note the job a two-space key opens. */
+function noteJob(state, line) {
+  const job = /^ {2}([A-Za-z0-9_-]+):\s*$/.exec(line);
+  if (job !== null) state.job = job[1];
+}
+
+/** Note a ceiling against the job currently open. */
+function noteTimeout(state, line) {
+  const found = /^\s*timeout-minutes:\s*(\d+)\s*$/.exec(line);
+  if (found === null || state.job === null) return;
+  state.timeouts.set(state.job, Number(found[1]));
+}
+
+/** One line's effect while inside `jobs:`. */
+function readJobLine(state, line) {
+  if (!state.inJobs) {
+    state.inJobs = line.trimEnd() === "jobs:";
+    return;
+  }
+  noteJob(state, line);
+  noteTimeout(state, line);
+}
+
+/**
+ * Each job's `timeout-minutes`, keyed by job id.
+ *
+ * Per JOB rather than as one list of the numbers in the file. A caller checking
+ * that every ceiling clears some floor is satisfied by a list that is merely
+ * non-empty, so a job whose ceiling was DELETED passes on its siblings' values
+ * while having none of its own — the job then keeps whatever GitHub's six-hour
+ * default gives it, which is the unbounded state a ceiling exists to remove.
+ *
+ * @param {string} text the workflow file's contents
+ * @returns {Map<string, number>} job id to its ceiling in minutes
+ */
+export function jobTimeouts(text) {
+  const state = { timeouts: new Map(), job: null, inJobs: false };
+  for (const line of text.split("\n")) readJobLine(state, line);
+  return state.timeouts;
 }

--- a/scripts/workflow-run-blocks.mjs
+++ b/scripts/workflow-run-blocks.mjs
@@ -1,6 +1,5 @@
 /**
- * The `run:` script of each named step in a workflow file, and each job's
- * ceiling.
+ * The `run:` script of each step in a workflow file, and each job's ceiling.
  *
  * Its own module rather than a helper inside the test that needs it, for the
  * reason `ci-gate.mjs` and `ci-verdict.mjs` are: a derivation a gate depends on
@@ -12,22 +11,31 @@
  * rather than by declaration, and a resolution that depends on hoisting is not
  * one to build a gate on.
  *
- * ## Two ways a reader like this credits a step with somebody else's script
+ * ## What a reader like this gets wrong, and why each is silent
  *
- * Both are silent, and both make a gate built on it pass over the thing it
- * exists to catch.
+ * A gate built on it then passes over exactly the thing it exists to catch.
  *
  * A step boundary is a LIST ITEM, not a `name:` key. `- name: X` and a bare `-`
  * followed by an indented `run:` are both steps, so tracking ownership by name
- * alone leaves an anonymous step's script recorded against whichever named step
- * came before it — and a gate then reads a wrapped command on a step that does
- * not run one.
+ * alone records an anonymous step's script against whichever named step came
+ * before it. Steps are therefore returned as a LIST, each with the name it has
+ * or `null` — dropping the unnamed ones instead would trade crediting the wrong
+ * step for not seeing it at all, which a gate scanning for unwrapped commands
+ * cannot afford.
  *
- * And two steps may legitimately carry the SAME name — conditional variants of
- * one job usually do. A map keeps the last, so a wrapped later step hides an
- * unwrapped earlier one. Reported rather than merged, because which of the two
- * a caller wants is the caller's question and silently answering it is how the
- * hiding happens.
+ * Two steps may legitimately carry the SAME name — conditional variants of one
+ * job usually do, and every job repeats `Install dependencies`. Returning a map
+ * keyed by name kept only the last, so a wrapped step could hide an unwrapped
+ * one; a LIST cannot, which is why this returns one. A boundary the parser
+ * cannot cross beats a check that looks for crossings.
+ *
+ * A script may be written INLINE (`run: pnpm test`) as well as as a block
+ * scalar, and both are ordinary YAML. Reading only `run: |` makes a step with
+ * an inline command invisible.
+ *
+ * And `timeout-minutes` is legal on a STEP as well as on a job, so a matcher
+ * that ignores indentation records a step's value as its job's ceiling — which
+ * reads as a bounded job whose own bound was deleted.
  *
  * @module workflow-run-blocks
  */
@@ -62,12 +70,6 @@ function stepNameOn(line) {
   return named === null ? null : named[1];
 }
 
-/** The indentation of a `run: |` key on this line, or null. */
-function runIndentOn(line) {
-  const run = /^(\s*)run:\s*\|/.exec(line);
-  return run === null ? null : run[1].length;
-}
-
 /**
  * True when a line opens a new step.
  *
@@ -85,59 +87,99 @@ function applyBoundary(state, line) {
   if (!startsStep(line, state.stepIndent)) return;
   state.stepIndent = indentOf(line);
   state.owner = stepNameOn(line);
+  state.opened = true;
 }
 
-/** Record a run block against the step that owns it, if any step does. */
-function recordRun(state, lines, index, indent) {
-  const owner = state.owner;
-  if (owner === null) return;
-  if (state.blocks.has(owner)) state.duplicated.push(owner);
-  state.blocks.set(owner, blockBody(lines, index + 1, indent));
+/**
+ * The script a `run:` line carries: the inline command, or the block below it.
+ *
+ * Returns null when the line opens no script at all. Both YAML forms are read,
+ * because a step written `run: pnpm test` is as ordinary as one written
+ * `run: |`, and a reader that saw only the second would report a step with an
+ * inline command as running nothing.
+ */
+function runScript(lines, index) {
+  const run = /^(\s*)run:(\s*\|)?(.*)$/.exec(lines[index]);
+  if (run === null) return null;
+  if (run[2] !== undefined) return blockBody(lines, index + 1, run[1].length);
+  return run[3].trim() === "" ? null : run[3].trim();
+}
+
+/** Record a script against the step that owns it. */
+function recordRun(state, script) {
+  if (!state.opened) return;
+  state.steps.push({ name: state.owner, block: script });
 }
 
 /** One line's effect: it may open a step, and it may open that step's script. */
 function readStepLine(state, lines, index) {
   applyBoundary(state, lines[index]);
-  const indent = runIndentOn(lines[index]);
-  if (indent !== null) recordRun(state, lines, index, indent);
+  const script = runScript(lines, index);
+  if (script !== null) recordRun(state, script);
 }
 
 /**
- * Every step's own run block, keyed by step name, plus the names that appeared
- * more than once.
+ * Every step's own script, in file order, plus the names seen more than once.
  *
- * A step's OWN block — never the text running to the next step. A chunk bounded
- * by the following `- name:` would include the comment block that introduces
- * the NEXT step, and workflow comments here quote commands verbatim, so a
- * comment about step N+1 would certify step N. The bound is the block scalar's
- * indentation instead, which ends where `env:` or the next step's comments
- * begin.
+ * A step's OWN script — never the text running to the next step. A chunk
+ * bounded by the following `- name:` would include the comment block that
+ * introduces the NEXT step, and workflow comments here quote commands verbatim,
+ * so a comment about step N+1 would certify step N. The bound is the block
+ * scalar's indentation instead, which ends where `env:` or the next step's
+ * comments begin.
  *
  * @param {string} text the workflow file's contents
- * @returns {{ blocks: Map<string, string>, duplicated: string[] }}
+ * @returns {{name: string|null, block: string}[]} every step's script, in order
  */
 export function workflowSteps(text) {
   const lines = text.split("\n");
-  const state = {
-    blocks: new Map(),
-    duplicated: [],
-    owner: null,
-    stepIndent: null,
-  };
+  const state = { steps: [], owner: null, stepIndent: null, opened: false };
 
   for (let i = 0; i < lines.length; i += 1) readStepLine(state, lines, i);
 
-  return { blocks: state.blocks, duplicated: state.duplicated };
+  return state.steps;
 }
 
-/** Collect a job id, once inside `jobs:`. */
-function collectJobId(state, line) {
-  if (!state.inJobs) {
-    state.inJobs = line.trimEnd() === "jobs:";
-    return;
-  }
+/**
+ * The job a line opens, or null.
+ *
+ * ONE recogniser, used by both readers below. Two of them agreed on the day
+ * they were written and would drift the first time either learned about another
+ * key shape — and the drift is invisible, because one supplies the population
+ * of jobs to check and the other supplies the ceilings, so a job could fall out
+ * of exactly one of them.
+ */
+function jobKeyOn(line) {
   const job = /^ {2}([A-Za-z0-9_-]+):\s*$/.exec(line);
-  if (job !== null) state.ids.push(job[1]);
+  return job === null ? null : job[1];
+}
+
+/**
+ * A JOB's own ceiling on this line, or null.
+ *
+ * Four spaces exactly. `timeout-minutes` is legal on a step too, at a deeper
+ * indentation, and an indentation-agnostic matcher records that step's value
+ * against the job — so a job whose own ceiling was deleted reads as bounded by
+ * one of its steps.
+ */
+function jobTimeoutOn(line) {
+  const found = /^ {4}timeout-minutes:\s*(\d+)\s*$/.exec(line);
+  return found === null ? null : Number(found[1]);
+}
+
+/** Walk `jobs:`, handing each line to a visitor once inside it. */
+function walkJobs(text, visit) {
+  let job = null;
+  let inJobs = false;
+
+  for (const line of text.split("\n")) {
+    if (!inJobs) {
+      inJobs = line.trimEnd() === "jobs:";
+      continue;
+    }
+    job = jobKeyOn(line) ?? job;
+    visit(job, line);
+  }
 }
 
 /**
@@ -152,36 +194,15 @@ function collectJobId(state, line) {
  * @returns {string[]} job ids
  */
 export function jobIds(text) {
-  const state = { ids: [], inJobs: false };
-  for (const line of text.split("\n")) collectJobId(state, line);
-  return state.ids;
-}
-
-/** Note the job a two-space key opens. */
-function noteJob(state, line) {
-  const job = /^ {2}([A-Za-z0-9_-]+):\s*$/.exec(line);
-  if (job !== null) state.job = job[1];
-}
-
-/** Note a ceiling against the job currently open. */
-function noteTimeout(state, line) {
-  const found = /^\s*timeout-minutes:\s*(\d+)\s*$/.exec(line);
-  if (found === null || state.job === null) return;
-  state.timeouts.set(state.job, Number(found[1]));
-}
-
-/** One line's effect while inside `jobs:`. */
-function readJobLine(state, line) {
-  if (!state.inJobs) {
-    state.inJobs = line.trimEnd() === "jobs:";
-    return;
-  }
-  noteJob(state, line);
-  noteTimeout(state, line);
+  const ids = [];
+  walkJobs(text, (job, line) => {
+    if (jobKeyOn(line) !== null) ids.push(job);
+  });
+  return ids;
 }
 
 /**
- * Each job's `timeout-minutes`, keyed by job id.
+ * Each job's own `timeout-minutes`, keyed by job id.
  *
  * Per JOB rather than as one list of the numbers in the file. A caller checking
  * that every ceiling clears some floor is satisfied by a list that is merely
@@ -193,7 +214,10 @@ function readJobLine(state, line) {
  * @returns {Map<string, number>} job id to its ceiling in minutes
  */
 export function jobTimeouts(text) {
-  const state = { timeouts: new Map(), job: null, inJobs: false };
-  for (const line of text.split("\n")) readJobLine(state, line);
-  return state.timeouts;
+  const timeouts = new Map();
+  walkJobs(text, (job, line) => {
+    const minutes = jobTimeoutOn(line);
+    if (minutes !== null && job !== null) timeouts.set(job, minutes);
+  });
+  return timeouts;
 }

--- a/scripts/workflow-run-blocks.test.mjs
+++ b/scripts/workflow-run-blocks.test.mjs
@@ -2,27 +2,37 @@
  * `workflowSteps` is the reader every workflow gate built on it inherits, so
  * the cases here are the ones where a reader can be wrong while looking right.
  *
- * Three of them credit a step with a script it does not run, and each makes a
- * gate pass over exactly what it exists to catch:
+ * Each of these credits a step with a script it does not run, or fails to see
+ * a script at all — and each makes a gate pass over exactly what it exists to
+ * catch:
  *
  * - a chunk bounded by the next `- name:` sweeps in the comment block
  *   introducing the FOLLOWING step, and workflow comments here quote commands
  *   verbatim, so a comment about step N+1 satisfies an assertion about step N;
  * - an ANONYMOUS step — a bare `-` with an indented `run:` — has no name, so a
  *   reader tracking ownership by name records its script against whichever
- *   named step came before it;
- * - two steps may legitimately share a name, and a map keeps the last, so a
- *   wrapped later step hides an unwrapped earlier one.
+ *   named step came before it, and a reader that DROPS it instead cannot see
+ *   the unwrapped command it runs;
+ * - two steps may legitimately share a name, and a map keeps only the last;
+ * - a script may be INLINE (`run: pnpm test`), which a reader matching only
+ *   `run: |` never sees;
+ * - `timeout-minutes` is legal on a step, and an indentation-blind matcher
+ *   records a step's value as its job's ceiling.
  *
  * @module workflow-run-blocks.test
  */
 import { describe, expect, it } from "vitest";
 
-import { jobTimeouts, workflowSteps } from "./workflow-run-blocks.mjs";
+import { jobIds, jobTimeouts, workflowSteps } from "./workflow-run-blocks.mjs";
+
+/** The script of the FIRST step with this name, or undefined. */
+function blockOf(steps, name) {
+  return steps.find(step => step.name === name)?.block;
+}
 
 describe("workflowSteps", () => {
   it("reads a step's run block", () => {
-    const { blocks } = workflowSteps(
+    const steps = workflowSteps(
       [
         "    steps:",
         "      - name: Build",
@@ -32,11 +42,22 @@ describe("workflowSteps", () => {
       ].join("\n")
     );
 
-    expect(blocks.get("Build")).toBe("          pnpm build");
+    expect(blockOf(steps, "Build")).toBe("          pnpm build");
+  });
+
+  it("reads an INLINE run command as well as a block scalar", () => {
+    // `run: pnpm test` is as ordinary as `run: |`. A reader that saw only the
+    // block form would report this step as running nothing — and a lane
+    // invoked this way would be invisible to a gate scanning for bare ones.
+    const steps = workflowSteps(
+      ["      - name: Quick", "        run: pnpm test"].join("\n")
+    );
+
+    expect(blockOf(steps, "Quick")).toBe("pnpm test");
   });
 
   it("stops at `env:` rather than swallowing the keys after the script", () => {
-    const { blocks } = workflowSteps(
+    const steps = workflowSteps(
       [
         "      - name: Test",
         "        run: |",
@@ -46,12 +67,12 @@ describe("workflowSteps", () => {
       ].join("\n")
     );
 
-    expect(blocks.get("Test")).toBe("          pnpm test");
-    expect(blocks.get("Test")).not.toContain("TOKEN");
+    expect(blockOf(steps, "Test")).toBe("          pnpm test");
+    expect(blockOf(steps, "Test")).not.toContain("TOKEN");
   });
 
   it("does NOT let a comment introducing the next step land in this one", () => {
-    const { blocks } = workflowSteps(
+    const steps = workflowSteps(
       [
         "      - name: First",
         "        run: |",
@@ -64,16 +85,16 @@ describe("workflowSteps", () => {
       ].join("\n")
     );
 
-    expect(blocks.get("First")).toBe("          safe-thing");
-    expect(blocks.get("First")).not.toContain("dangerous-thing");
-    expect(blocks.get("Second")).toBe("          dangerous-thing");
+    expect(blockOf(steps, "First")).toBe("          safe-thing");
+    expect(blockOf(steps, "First")).not.toContain("dangerous-thing");
+    expect(blockOf(steps, "Second")).toBe("          dangerous-thing");
   });
 
-  it("does NOT credit a named step with a following ANONYMOUS step's script", () => {
-    // A bare `-` is a legal step. A reader that changed owner only on `name:`
-    // records `unbounded-thing` against `Guarded` — so a gate asserting that
-    // `Guarded` runs a wrapped command reads one that another step runs.
-    const { blocks } = workflowSteps(
+  it("keeps an ANONYMOUS step's script, under no name, rather than mis-crediting or dropping it", () => {
+    // Both wrong answers are live. Crediting `unbounded-thing` to `Guarded`
+    // makes a gate read a wrapped command on a step that runs none; dropping
+    // it makes the gate unable to see the unwrapped command at all.
+    const steps = workflowSteps(
       [
         "      - name: Guarded",
         "        run: |",
@@ -84,15 +105,15 @@ describe("workflowSteps", () => {
       ].join("\n")
     );
 
-    expect(blocks.get("Guarded")).toBe("          wrapped-thing");
-    expect(blocks.get("Guarded")).not.toContain("unbounded-thing");
+    expect(blockOf(steps, "Guarded")).toBe("          wrapped-thing");
+    expect(steps).toContainEqual({ name: null, block: "          unbounded-thing" });
   });
 
   it("keeps a blank line inside a script from truncating it", () => {
     // A reader that ended the block at the first blank line would return a
     // PREFIX of the script — and a prefix still contains the first command, so
     // an assertion about that command passes while the rest is invisible.
-    const { blocks } = workflowSteps(
+    const steps = workflowSteps(
       [
         "      - name: Two parts",
         "        run: |",
@@ -102,14 +123,14 @@ describe("workflowSteps", () => {
       ].join("\n")
     );
 
-    expect(blocks.get("Two parts")).toContain("first");
-    expect(blocks.get("Two parts")).toContain("second");
+    expect(blockOf(steps, "Two parts")).toContain("first");
+    expect(blockOf(steps, "Two parts")).toContain("second");
   });
 
   it("does not treat a list nested INSIDE a step as a new step", () => {
     // The `- chromium` belongs to `with:`. Ending the step there would leave
-    // the script that follows owned by nobody and silently unchecked.
-    const { blocks } = workflowSteps(
+    // the script that follows owned by nobody.
+    const steps = workflowSteps(
       [
         "      - name: Install",
         "        with:",
@@ -120,14 +141,14 @@ describe("workflowSteps", () => {
       ].join("\n")
     );
 
-    expect(blocks.get("Install")).toBe("          install-thing");
+    expect(blockOf(steps, "Install")).toBe("          install-thing");
   });
 
-  it("reports a repeated step name instead of keeping only the last", () => {
-    // Conditional variants of one step legitimately share a name. Keeping the
-    // last lets a wrapped variant hide an unwrapped one, which is a gate
-    // passing on the strength of the step it did not read.
-    const { blocks, duplicated } = workflowSteps(
+  it("keeps BOTH steps when two share a name, so neither can hide the other", () => {
+    // Conditional variants of one step legitimately share a name, and every job
+    // repeats `Install dependencies`. A map keyed by name kept the last, which
+    // let a wrapped variant hide an unwrapped one. A list cannot.
+    const steps = workflowSteps(
       [
         "      - name: Run tests",
         "        if: matrix.dialect == 'mysql'",
@@ -140,35 +161,24 @@ describe("workflowSteps", () => {
       ].join("\n")
     );
 
-    expect(duplicated).toEqual(["Run tests"]);
-    // Still readable, so a caller can refuse rather than having nothing.
-    expect(blocks.has("Run tests")).toBe(true);
+    const blocks = steps.filter(s => s.name === "Run tests").map(s => s.block);
+    expect(blocks).toEqual(["          bare-thing", "          wrapped-thing"]);
   });
 
-  it("reports nothing duplicated when every step name is distinct", () => {
-    const { duplicated } = workflowSteps(
-      ["      - name: A", "        run: |", "          a"].join("\n")
-    );
+  it("ignores a run key that no step has opened", () => {
+    // A `run:` before any list item is not a step's script. Recording it would
+    // invent a step the workflow does not have.
+    const steps = workflowSteps(["    run: |", "      stray"].join("\n"));
 
-    expect(duplicated).toEqual([]);
-  });
-
-  it("ignores a run block that no step owns", () => {
-    const { blocks } = workflowSteps(["      - run: |", "          orphan"].join("\n"));
-
-    // The step is anonymous, so there is no name to record it under — and
-    // attributing it to whichever name came last is the defect above.
-    expect([...blocks.keys()]).toEqual([]);
+    expect(steps).toEqual([]);
   });
 
   it("returns nothing for a file with no steps, rather than throwing", () => {
-    expect([...workflowSteps("name: Nothing\non: push\n").blocks.keys()]).toEqual(
-      []
-    );
+    expect(workflowSteps("name: Nothing\non: push\n")).toEqual([]);
   });
 });
 
-describe("jobTimeouts", () => {
+describe("jobIds and jobTimeouts", () => {
   const workflow = [
     "on:",
     "  push:",
@@ -176,9 +186,30 @@ describe("jobTimeouts", () => {
     "  integration:",
     "    name: Integration",
     "    timeout-minutes: 75",
+    "    steps:",
+    "      - name: Install",
+    "        timeout-minutes: 8",
+    "        run: pnpm install",
     "  integration-sqlite:",
     "    timeout-minutes: 60",
+    "  unbounded:",
+    "    name: No ceiling",
+    "    steps:",
+    "      - name: Slow",
+    "        timeout-minutes: 30",
+    "        run: pnpm slow",
   ].join("\n");
+
+  it("lists every job the workflow declares, ceiling or not", () => {
+    // The population. `jobTimeouts` alone answers only about jobs that HAVE a
+    // ceiling, so a job whose ceiling was deleted vanishes from that answer
+    // instead of being reported.
+    expect(jobIds(workflow)).toEqual([
+      "integration",
+      "integration-sqlite",
+      "unbounded",
+    ]);
+  });
 
   it("keys each ceiling to the job that declares it", () => {
     expect([...jobTimeouts(workflow).entries()]).toEqual([
@@ -187,18 +218,17 @@ describe("jobTimeouts", () => {
     ]);
   });
 
-  it("omits a job that declares no ceiling, rather than inventing one", () => {
-    // The absence is the finding. A reader that supplied a default would report
-    // an unbounded job as bounded, which is the state a ceiling removes.
-    const missing = ["jobs:", "  a:", "    timeout-minutes: 30", "  b:", "    name: B"].join(
-      "\n"
-    );
-
-    expect(jobTimeouts(missing).has("b")).toBe(false);
+  it("does NOT read a STEP's timeout-minutes as its job's ceiling", () => {
+    // `unbounded` has no ceiling of its own; its `Slow` step has one. An
+    // indentation-blind matcher would record 30 against the job, and a gate
+    // would then call an unbounded job bounded.
+    expect(jobTimeouts(workflow).has("unbounded")).toBe(false);
+    // And the step-level 8 must not overwrite integration's own 75.
+    expect(jobTimeouts(workflow).get("integration")).toBe(75);
   });
 
   it("does not read a two-space key from OUTSIDE jobs as a job", () => {
-    // `on:` has `push:` and `pull_request:` at the same indentation as a job id.
-    expect([...jobTimeouts(workflow).keys()]).not.toContain("push");
+    // `on:` has `push:` at the same indentation as a job id.
+    expect(jobIds(workflow)).not.toContain("push");
   });
 });

--- a/scripts/workflow-run-blocks.test.mjs
+++ b/scripts/workflow-run-blocks.test.mjs
@@ -1,32 +1,42 @@
 /**
- * `runBlocks` is the reader every workflow gate built on it inherits, so the
- * cases here are the ones where a reader can be wrong while looking right.
+ * `workflowSteps` is the reader every workflow gate built on it inherits, so
+ * the cases here are the ones where a reader can be wrong while looking right.
  *
- * The load-bearing one is the boundary. A reader that took each step's text as
- * "everything up to the next `- name:`" would sweep in the comment block that
- * introduces the FOLLOWING step — and workflow comments in this repository
- * quote commands verbatim, so a comment about step N+1 would satisfy an
- * assertion about step N. `ci-steps-report-independently.test.mjs` records
- * making exactly that mistake, which is why it is pinned here rather than
- * trusted.
+ * Three of them credit a step with a script it does not run, and each makes a
+ * gate pass over exactly what it exists to catch:
+ *
+ * - a chunk bounded by the next `- name:` sweeps in the comment block
+ *   introducing the FOLLOWING step, and workflow comments here quote commands
+ *   verbatim, so a comment about step N+1 satisfies an assertion about step N;
+ * - an ANONYMOUS step — a bare `-` with an indented `run:` — has no name, so a
+ *   reader tracking ownership by name records its script against whichever
+ *   named step came before it;
+ * - two steps may legitimately share a name, and a map keeps the last, so a
+ *   wrapped later step hides an unwrapped earlier one.
  *
  * @module workflow-run-blocks.test
  */
 import { describe, expect, it } from "vitest";
 
-import { runBlocks } from "./workflow-run-blocks.mjs";
+import { jobTimeouts, workflowSteps } from "./workflow-run-blocks.mjs";
 
-describe("runBlocks", () => {
+describe("workflowSteps", () => {
   it("reads a step's run block", () => {
-    const blocks = runBlocks(
-      ["    steps:", "      - name: Build", "        run: |", "          pnpm build", ""].join("\n")
+    const { blocks } = workflowSteps(
+      [
+        "    steps:",
+        "      - name: Build",
+        "        run: |",
+        "          pnpm build",
+        "",
+      ].join("\n")
     );
 
     expect(blocks.get("Build")).toBe("          pnpm build");
   });
 
   it("stops at `env:` rather than swallowing the keys after the script", () => {
-    const blocks = runBlocks(
+    const { blocks } = workflowSteps(
       [
         "      - name: Test",
         "        run: |",
@@ -41,11 +51,7 @@ describe("runBlocks", () => {
   });
 
   it("does NOT let a comment introducing the next step land in this one", () => {
-    // The defect this reader exists to avoid: the comment below belongs to
-    // `Second`, and it names a command. A chunk bounded by the next `- name:`
-    // would put it inside `First`, and an assertion that `First` runs
-    // `dangerous-thing` would pass on a step that does no such thing.
-    const blocks = runBlocks(
+    const { blocks } = workflowSteps(
       [
         "      - name: First",
         "        run: |",
@@ -63,11 +69,30 @@ describe("runBlocks", () => {
     expect(blocks.get("Second")).toBe("          dangerous-thing");
   });
 
+  it("does NOT credit a named step with a following ANONYMOUS step's script", () => {
+    // A bare `-` is a legal step. A reader that changed owner only on `name:`
+    // records `unbounded-thing` against `Guarded` — so a gate asserting that
+    // `Guarded` runs a wrapped command reads one that another step runs.
+    const { blocks } = workflowSteps(
+      [
+        "      - name: Guarded",
+        "        run: |",
+        "          wrapped-thing",
+        "      -",
+        "        run: |",
+        "          unbounded-thing",
+      ].join("\n")
+    );
+
+    expect(blocks.get("Guarded")).toBe("          wrapped-thing");
+    expect(blocks.get("Guarded")).not.toContain("unbounded-thing");
+  });
+
   it("keeps a blank line inside a script from truncating it", () => {
     // A reader that ended the block at the first blank line would return a
     // PREFIX of the script — and a prefix still contains the first command, so
     // an assertion about that command passes while the rest is invisible.
-    const blocks = runBlocks(
+    const { blocks } = workflowSteps(
       [
         "      - name: Two parts",
         "        run: |",
@@ -81,15 +106,99 @@ describe("runBlocks", () => {
     expect(blocks.get("Two parts")).toContain("second");
   });
 
-  it("ignores a run block that no named step owns", () => {
-    // Anonymous steps are legal. Attributing one to whatever name came last
-    // would credit a step with a script it does not run.
-    const blocks = runBlocks(["      - run: |", "          orphan"].join("\n"));
+  it("does not treat a list nested INSIDE a step as a new step", () => {
+    // The `- chromium` belongs to `with:`. Ending the step there would leave
+    // the script that follows owned by nobody and silently unchecked.
+    const { blocks } = workflowSteps(
+      [
+        "      - name: Install",
+        "        with:",
+        "          browsers:",
+        "            - chromium",
+        "        run: |",
+        "          install-thing",
+      ].join("\n")
+    );
 
+    expect(blocks.get("Install")).toBe("          install-thing");
+  });
+
+  it("reports a repeated step name instead of keeping only the last", () => {
+    // Conditional variants of one step legitimately share a name. Keeping the
+    // last lets a wrapped variant hide an unwrapped one, which is a gate
+    // passing on the strength of the step it did not read.
+    const { blocks, duplicated } = workflowSteps(
+      [
+        "      - name: Run tests",
+        "        if: matrix.dialect == 'mysql'",
+        "        run: |",
+        "          bare-thing",
+        "      - name: Run tests",
+        "        if: matrix.dialect == 'postgres'",
+        "        run: |",
+        "          wrapped-thing",
+      ].join("\n")
+    );
+
+    expect(duplicated).toEqual(["Run tests"]);
+    // Still readable, so a caller can refuse rather than having nothing.
+    expect(blocks.has("Run tests")).toBe(true);
+  });
+
+  it("reports nothing duplicated when every step name is distinct", () => {
+    const { duplicated } = workflowSteps(
+      ["      - name: A", "        run: |", "          a"].join("\n")
+    );
+
+    expect(duplicated).toEqual([]);
+  });
+
+  it("ignores a run block that no step owns", () => {
+    const { blocks } = workflowSteps(["      - run: |", "          orphan"].join("\n"));
+
+    // The step is anonymous, so there is no name to record it under — and
+    // attributing it to whichever name came last is the defect above.
     expect([...blocks.keys()]).toEqual([]);
   });
 
   it("returns nothing for a file with no steps, rather than throwing", () => {
-    expect([...runBlocks("name: Nothing\non: push\n").keys()]).toEqual([]);
+    expect([...workflowSteps("name: Nothing\non: push\n").blocks.keys()]).toEqual(
+      []
+    );
+  });
+});
+
+describe("jobTimeouts", () => {
+  const workflow = [
+    "on:",
+    "  push:",
+    "jobs:",
+    "  integration:",
+    "    name: Integration",
+    "    timeout-minutes: 75",
+    "  integration-sqlite:",
+    "    timeout-minutes: 60",
+  ].join("\n");
+
+  it("keys each ceiling to the job that declares it", () => {
+    expect([...jobTimeouts(workflow).entries()]).toEqual([
+      ["integration", 75],
+      ["integration-sqlite", 60],
+    ]);
+  });
+
+  it("omits a job that declares no ceiling, rather than inventing one", () => {
+    // The absence is the finding. A reader that supplied a default would report
+    // an unbounded job as bounded, which is the state a ceiling removes.
+    const missing = ["jobs:", "  a:", "    timeout-minutes: 30", "  b:", "    name: B"].join(
+      "\n"
+    );
+
+    expect(jobTimeouts(missing).has("b")).toBe(false);
+  });
+
+  it("does not read a two-space key from OUTSIDE jobs as a job", () => {
+    // `on:` has `push:` and `pull_request:` at the same indentation as a job id.
+    expect([...jobTimeouts(workflow).keys()]).not.toContain("push");
   });
 });


### PR DESCRIPTION
Eight P2 findings from the Codex review of #1744, which merged before they were worked. All eight reproduce; all eight are fixed here.

Three of them are **one shape**: the guard asserted properties of a list written inside itself rather than of the workflow it guards.

## The guard did not cover a leg added later — which is its entire purpose

It iterated a three-item dialect constant. A fourth leg added to the workflow alone, invoking its lane directly and unbounded, was **outside the population**, so every assertion passed without ever looking at it. The file's own docblock claimed that case was caught.

A leg is now **anything the workflow runs a `lane:test:integration:` script for**, and a job is **anything `jobs:` declares** — with a floor check, so a reader that finds nothing cannot satisfy "every leg" by having none to check.

## Two assertions were satisfied by coincidence, not relationship

A block invoking the lane **bare** while calling the wrapper on something else contains both strings, and passed. Commands are now joined across their line continuations, and the wrapper must be what *invokes* the lane.

Ceilings were read as one list of every number in the file, so deleting the sqlite job's ceiling left the list non-empty and passing **on its sibling's value**. They are now read per job id, against the jobs the file declares.

## A ceiling above the budget is not yet room

The suite may use its whole budget, then ignore TERM and take the two-minute escalation on top — after the job has already spent time on checkout, install and build. A 56-minute ceiling over a 55-minute budget cancels the job mid-escalation: the cancellation this mechanism exists to replace, restored by a number that looks like headroom. The floor is now budget + escalation + setup.

## 137 does not mean the budget fired

The runner's OOM killer produces 137 too, on a command that died in its first seconds, so the exit code cannot separate an escalation from an external kill. **Elapsed time can.** An overrun stays loud; a kill inside the budget says so instead — reporting that as an overrun would send the next person to raise a budget that was never the problem.

## A budget of zero disables the bound

GNU `timeout` documents a duration of `0` as *disabling* the timeout, so `0m` would run the suite unbounded while the wrapper, the env var and the workflow all still read as bounded — the failure this script removes, wearing the costume of the fix. The script now parses the duration, refuses one it cannot read, and refuses zero. The guard refuses it statically as well.

## The reader credited steps with other steps' scripts

A step boundary is a **list item**, not a `name:` key, so an anonymous step's script was recorded against whichever named step preceded it. Two steps may also legitimately share a name — conditional variants usually do — and keeping the last let a wrapped step hide an unwrapped one. Ownership now moves on any list item at the step list's own indentation, and repeated names are reported rather than merged.

## What was measured

Each fix break-verified against the workflow that would defeat it:

| break | what it kills |
|---|---|
| a fourth dialect added, lane invoked bare | runs EVERY lane through the wrapper |
| wrapper called on something else, lane bare | runs EVERY lane through the wrapper |
| ceiling one minute above the budget | every job has a ceiling with room |
| sqlite job loses its ceiling, sibling keeps one | every job has a ceiling with room |
| budget set to `0m` | every job has a ceiling with room |
| two steps sharing a name, later one wrapped | names each leg's step only once |
| bare 137 read as the budget firing | does NOT call an early SIGKILL an overrun |
| ownership changes only on a named step | does not credit a named step with an anonymous one's script |

One test was **removed rather than repaired**: it read a bare 137 as the budget firing, which is no longer what the script does. Obsolete rather than redundant, and the docblock names the two cases that replace it.

27 tests across the three files. `fallow` pass, 0 introduced findings. Comment-convention clean, `lint:scripts` clean, `sh -n` clean.

No changeset: CI-only, nothing published changes.
