### PR TITLE
docs(release): describe what ships, not the rows this refuses to write

### DIFF
--- a/.changeset/an-internal-write-is-recorded-too.md
+++ b/.changeset/an-internal-write-is-recorded-too.md
@@ -26,20 +26,18 @@
 "@nextlyhq/module-specifiers": patch
 ---
 
-An import, a job and a migration appear in the activity trail.
+A missing dashboard service no longer fails a content write.
 
-They recorded nothing, and the reason turned out to be a defect rather than a
-constraint. A container reports an absent registration two ways — by throwing,
-and by answering `undefined` — and only the first was handled, so the second
-failed on a property access. That turned "no dashboard service registered" into
-a FAILED CONTENT WRITE, which is the outcome the surrounding catch exists to
-prevent.
+The audit recorder asks the container for that service, and a container reports
+an absent registration two ways: by throwing, and by answering `undefined`. Only
+the throw was handled, so the second walked past the catch that exists to keep an
+audit failure from failing the write, and died on a property access instead. "No
+dashboard service registered" became a FAILED CONTENT WRITE.
 
-With the guard complete, a write that names no initiating user is recorded as a
-system write. It takes the reserved identifier the rest of the codebase already
-uses for itself, and a seed arriving as a user holding that same reserved id is
-the same write in a different shape, so both are filed as system rather than one
-being attributed to an account nobody owns.
-
-An ABSENT actor is still not recorded, and it is a different thing: it means
-the caller named nobody, so there is no identity to attribute the write to.
+The activity feed also names a system actor as "System" instead of rendering a
+blank author. Nothing writes those rows yet, and this release does not start:
+a write that names no initiating user is still not recorded, because a plugin's
+`init()` hook runs before pending migrations do, and an insert against a table
+that has not been migrated yet would take the boot down with it. The column can
+already hold the value, so the reader handles it rather than showing an empty
+author for every import and job the moment something does.

--- a/packages/admin/src/lib/dashboard.ts
+++ b/packages/admin/src/lib/dashboard.ts
@@ -56,15 +56,15 @@ export function describeActivityActor(entry: {
    */
   actorType?: string | null;
 }): ActivityUser {
-  // An API key has no account, so it has no name, no email and no erasure — the
-  // three things every branch below reads. Without this it falls through to the
-  // live-actor case and renders a BLANK name, which is a less attributable feed
-  // than the one before keys were recorded at all.
-  // A system actor has no account either — no name, no email, no erasure — so
-  // it falls through to the live-actor case and renders BLANK for the same
-  // reason a key did. Nothing writes these rows today, but the column can hold
-  // the value and a reader that only handled keys would show an empty author
-  // for every import and job the moment one does.
+  // Neither a key nor an internal write has an account, so neither has a name,
+  // an email or an erasure stamp: the three things every branch below reads.
+  // Without a branch of its own each falls through to the live-actor case and
+  // renders a BLANK name, which is a less attributable feed than the one before
+  // keys were recorded at all.
+  //
+  // Nothing writes a system row today. The column can hold the value, and a
+  // reader that handled only keys would show an empty author for every import
+  // and job the moment something does.
   if (entry.actorType === "system") {
     return {
       id: entry.userId,


### PR DESCRIPTION
The changeset that merged with #1743 announces behaviour that change does not ship.

Its headline reads "An import, a job and a migration appear in the activity trail."
They do not. `recordableActor` returns `null` for `actor.type === "system"` and for
the reserved system user id, on the ordering grounds worked out in that PR: a plugin's
`init()` hook runs before pending migrations do, so an insert naming a column an
un-migrated `activity_log` does not have would take the boot down with it.

Version PR #1671 is open and will consume this file, so the release notes would have
promised users a trail they cannot observe.

The summary now describes what actually ships:

- the absent-service guard, which is the fix. A container reports an absent
  registration two ways, by throwing and by answering `undefined`, and only the
  throw was handled, so "no dashboard service registered" became a failed content
  write.
- the feed naming a system actor as "System" rather than a blank author, said
  plainly as a reader that handles a value nothing writes yet.

Also merges the two stacked comments above the accountless branches in
`describeActivityActor`. The key's rationale had ended up sitting above the system
branch, so the two read as one blob. They share a reason, so they are one comment.

## Evidence

Docs-only, so no changeset.

- `packages/admin` unit: 13 passed (`src/lib/dashboard.test.ts`), 4217 passed for the
  package on the pre-push hook.
- `nextly` unit: 615 passed across `src/domains/audit` and `src/domains/email/__tests__`.
- `nextly` integration, sqlite: 12 passed
  (`src/domains/audit/__tests__/mutation-activity.integration.test.ts`).
- `fallow audit`: pass. `check-comment-convention`: exit 0, no new offence.

The removal is verified with a control rather than read off an empty result: the old
sentence matches once on `origin/main` and zero times here, so the search can find it.
