### PR TITLE
fix(nextly): the prohibition check matches shape, not phrasing

### DIFF
--- a/.changeset/getcachednextly-reaches-plugins-through-the-sdk.md
+++ b/.changeset/getcachednextly-reaches-plugins-through-the-sdk.md
@@ -1,0 +1,43 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+`getCachedNextly` is exported from `@nextlyhq/plugin-sdk`. Plugin server work
+that runs outside a route has no `ctx.services` to reach through and no config
+in scope, so it needs the already-booted instance; until now the only import
+path was core's root, which is not the surface a plugin's compatibility is
+governed on. It is `@experimental` there, per the stability ladder.
+
+`@nextlyhq/plugin-page-builder` reads its site-style single through that import
+now instead of core's root.
+
+Its docblock also described the wrong boundary. It said publishing the accessor
+from `nextly/runtime` would force a `next` peer dependency on plugin consumers.
+It would not: `next` is the one peer this package does not mark optional, so a
+consumer resolves it whichever subpath they import. What the root actually
+avoids is `next/*` entering a module graph that has no request lifecycle to run
+inside, which matters to a plugin bundled for the browser and to the CLI.

--- a/packages/nextly/src/__tests__/accessors-stay-where-their-callers-are.test.ts
+++ b/packages/nextly/src/__tests__/accessors-stay-where-their-callers-are.test.ts
@@ -83,25 +83,36 @@ describe("instance accessors are published where their callers can reach them", 
   });
 
   it("does not forbid the callers it names, however the prohibition is worded", () => {
-    // Not a search for one historical sentence. Any phrasing that tells this
-    // function's audience to stay away contradicts the paragraph above it, and
-    // a docblock that does both is worse than either alone.
+    // A list of forbidden phrasings is the wrong shape for this. "must not
+    // call" was covered and "should not call" was not, and the next wording
+    // nobody anticipates passes just as easily. So it is structural instead.
+    //
+    // Every sentence mentioning this function's audience is examined, and none
+    // of them may be a prohibition. A docblock cannot then name plugins as
+    // callers in one breath and warn them off in the next, whatever verb it
+    // reaches for.
     const doc = docblockFor(
       initSource,
       "export async function getCachedNextly"
     );
 
-    const prohibitions = [
-      /do not use this/i,
-      /don't use this/i,
-      /must not (be )?call/i,
-      /not for (user|plugin)/i,
-      /internal use only/i,
-    ];
+    const sentences = doc
+      .replace(/^\s*\*+ ?/gm, "")
+      .split(/(?<=[.:])\s+/)
+      .map(line => line.trim())
+      .filter(line => /plugin|user code|caller/i.test(line));
 
-    expect(
-      prohibitions.filter(pattern => pattern.test(doc)).map(String)
-    ).toEqual([]);
+    // The control. With nothing matched the assertion below is vacuous, and
+    // would stay green through a docblock that never names the audience at all.
+    expect(sentences.length).toBeGreaterThan(0);
+
+    const forbidding = sentences.filter(line =>
+      /\b(do not|don't|does not|must not|should not|never|cannot|not for|internal use only)\b/i.test(
+        line
+      )
+    );
+
+    expect(forbidding).toEqual([]);
   });
 
   it("does not claim the root avoids the Next peer dependency", () => {


### PR DESCRIPTION
Two findings from #1738's last review round. That PR merged before I could push them, so they land here.

## The changeset it stopped being able to skip

#1738 correctly had no changeset while it was a docblock and two tests. It stopped being that when the accessor was re-exported from `@nextlyhq/plugin-sdk` and `plugin-page-builder` moved its import onto it: a **new published export** and a **changed import in shipped plugin code** are both runtime changes to released packages.

Reclassifying was the step I skipped, having decided the answer once at the start.

## A list of phrasings is the wrong shape for the question

The check that guards the accessor's docblock rejected a fixed set of prohibitions. `must not call` was covered; `should not call` was not, and the next wording nobody anticipates passes just as easily.

It is structural now. Every sentence in the docblock that mentions this function's audience is examined, and none of them may be a prohibition. A docblock cannot name plugins as callers in one breath and warn them off in the next, whatever verb it reaches for.

Verified against three wordings, including the one the list missed:

| Inserted sentence | Old check | New check |
|---|---|---|
| `Plugins should not call this.` | passed | **caught** |
| `Plugin authors are advised never to call this.` | passed | **caught** |
| `This is not for plugin code.` | passed | **caught** |

It also carries a control that fails when no sentence mentions the audience at all, since an empty match would make the assertion vacuous while looking green.

## Note on the third finding

The review also flagged the docblock as still promising compatibility for an `@experimental` export. That was already fixed in #1738's final commit — the review ran against `bb2bce560`, one commit earlier. Both blocks now state the `@experimental` position rather than contradicting it. Nothing to do here.

**Gates:** nextly 11,907 · lint 0 · comments 0 · changeset covers the group.