### PR TITLE
fix(admin): order the two mounts by the observer, not by the clock

### DIFF
--- a/.changeset/onboarding-guard-off-the-wall-clock.md
+++ b/.changeset/onboarding-guard-off-the-wall-clock.md
@@ -1,0 +1,44 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The setup checklist no longer vanishes from a reader who still has a step to do.
+
+Whether the card was allowed to drop itself was settled by comparing when its
+answer arrived against when it mounted, and a wall clock cannot make that
+comparison. `Date.now()` is deliberately coarsened by browser
+anti-fingerprinting -- to 100ms buckets under Firefox's resistFingerprinting --
+so both readings can land on the same value; and it steps backwards under a
+clock correction, which can place the mount before an answer that genuinely
+predates it. Either one let the card act on the previous visit's completed
+answer and drop itself while a step was still outstanding.
+
+It now asks the query observer how many answers have arrived since it
+subscribed, a count that can neither collide nor run backwards, and requires
+that answer to have succeeded: a refetch that fails leaves the earlier
+completed answer in place, and a failure to refresh is no longer read as
+progress.

--- a/packages/admin/src/components/features/dashboard/OnboardingChecklist.test.tsx
+++ b/packages/admin/src/components/features/dashboard/OnboardingChecklist.test.tsx
@@ -73,10 +73,10 @@ function draw(qc: QueryClient) {
 /**
  * The card rendered beside a LIVE consumer of the dashboard layout key.
  *
- * The consumer is a mounted `useQuery` rather than a prefetch: only an active
- * query refetches on invalidation, and an entry nothing observes is collected
- * immediately under `gcTime: 0` — so a prefetched one reports no state at all
- * and the assertion would pass or fail for the wrong reason.
+ * The consumer is a mounted `useQuery` rather than a prefetch, because an
+ * invalidation refetches ACTIVE queries only: a prefetched entry is marked
+ * stale and nothing reads it again, so `readLayout` would sit at one call
+ * whether the card asked for a fresh layout or not.
  */
 async function drawBesideLayout(qc: QueryClient) {
   const readLayout = vi.fn().mockResolvedValue({ placements: [] });
@@ -96,8 +96,58 @@ async function drawBesideLayout(qc: QueryClient) {
   return { readLayout };
 }
 
+/**
+ * Finish onboarding, let the host drop the card, then have it offered again.
+ *
+ * The sequence every staleness case shares. The first mount completes and
+ * correctly asks for a fresh layout; the host drops the card, so it unmounts
+ * while its all-complete answer stays cached; then the reader deletes their
+ * last collection and the host offers it again. `secondAnswer` arranges what
+ * that second mount's OWN read returns.
+ *
+ * The cache has to SURVIVE the unmount, which is what the ten-minute `gcTime`
+ * in `client()` is for -- the reflexive `gcTime: 0` collects the entry the
+ * moment the card goes, so the second mount starts from nothing and the case
+ * under test cannot arise. The layout consumer has to stay mounted across BOTH
+ * mounts too, or the invalidation has no observer and its refetch count cannot
+ * move either way. Both were found by the break killing nothing.
+ *
+ * `afterDrop` is the layout read count at the moment the card came back. Any
+ * later call means the remount acted on an answer it did not fetch itself.
+ */
+async function finishThenReoffer(secondAnswer: () => void) {
+  const qc = client();
+  const readLayout = vi.fn().mockResolvedValue({ placements: [] });
+  const LayoutConsumer = () => {
+    useQuery({ queryKey: DASHBOARD_LAYOUT_KEY, queryFn: readLayout });
+    return null;
+  };
+  const withCard = (card: boolean) => (
+    <QueryClientProvider client={qc}>
+      <LayoutConsumer />
+      {card ? <OnboardingChecklist /> : null}
+    </QueryClientProvider>
+  );
+
+  protectedGet.mockResolvedValue({ steps: EVERY_STEP });
+  const view = render(withCard(true));
+  // The first mount completes and correctly asks the host to drop the card.
+  await waitFor(() => expect(readLayout).toHaveBeenCalledTimes(2));
+
+  // The host drops it, so the card unmounts while its answer stays cached.
+  view.rerender(withCard(false));
+  const afterDrop = readLayout.mock.calls.length;
+
+  secondAnswer();
+  view.rerender(withCard(true));
+  return { readLayout, afterDrop };
+}
+
 afterEach(() => {
   vi.clearAllMocks();
+  // Restores `Date.now`, which one case replaces. `clearAllMocks` empties a
+  // spy's calls and leaves the replacement installed.
+  vi.restoreAllMocks();
 });
 
 describe("the onboarding checklist", () => {
@@ -199,37 +249,11 @@ describe("the onboarding checklist", () => {
     // finished before its own refetch landed, and ask the host for a layout the
     // server has just decided should include it.
     //
-    // Two things this fixture must get right, both found by the break killing
-    // nothing: the client has to KEEP its cache across the unmount, which the
-    // shared `client()` does not (`gcTime: 0` collects it immediately); and the
-    // layout consumer has to stay mounted for the SECOND mount too, or the
-    // invalidation has no observer and its refetch count cannot move either way.
-    protectedGet.mockResolvedValue({ steps: EVERY_STEP });
-    const qc = client();
-    const readLayout = vi.fn().mockResolvedValue({ placements: [] });
-    const LayoutConsumer = () => {
-      useQuery({ queryKey: DASHBOARD_LAYOUT_KEY, queryFn: readLayout });
-      return null;
-    };
-    const withCard = (card: boolean) => (
-      <QueryClientProvider client={qc}>
-        <LayoutConsumer />
-        {card ? <OnboardingChecklist /> : null}
-      </QueryClientProvider>
-    );
-
-    const view = render(withCard(true));
-    // The first mount completes and correctly asks the host to drop the card.
-    await waitFor(() => expect(readLayout).toHaveBeenCalledTimes(2));
-
-    // The host drops it, so the card unmounts while its answer stays cached.
-    view.rerender(withCard(false));
-    const afterDrop = readLayout.mock.calls.length;
-
-    // The reader deletes their last collection: the host offers the card again,
-    // and the fresh answer has work outstanding.
-    protectedGet.mockResolvedValue({ steps: ALL_BUT_ONE });
-    view.rerender(withCard(true));
+    // The reader deletes their last collection, so the answer this mount
+    // fetches for itself has work outstanding.
+    const { readLayout, afterDrop } = await finishThenReoffer(() => {
+      protectedGet.mockResolvedValue({ steps: ALL_BUT_ONE });
+    });
 
     // 🔴 Asserted on the PROGRESS, not the row count. Both answers hold three
     // rows -- the cached one has them all ticked -- so counting rows cannot
@@ -240,6 +264,48 @@ describe("the onboarding checklist", () => {
       expect(screen.getByText(/2 of 3 done/)).toBeInTheDocument()
     );
     expect(screen.getAllByRole("listitem")).toHaveLength(ALL_BUT_ONE.length);
+    expect(readLayout).toHaveBeenCalledTimes(afterDrop);
+  });
+
+  it("separates the two mounts when the CLOCK cannot", async () => {
+    // 🔴 Which mount fetched an answer is not a question a wall clock can
+    // settle. `Date.now()` is coarsened for anti-fingerprinting -- to 100ms
+    // under Firefox's resistFingerprinting -- and steps backwards under an NTP
+    // correction, so a cached response can carry a stamp at or after the mount
+    // that is reading it. Frozen here, which is the extreme of the same thing:
+    // every reading collides, so ordering the response against the mount
+    // accepts the earlier mount's all-complete answer and drops the card on it.
+    vi.spyOn(Date, "now").mockReturnValue(1_760_000_000_000);
+
+    const { readLayout, afterDrop } = await finishThenReoffer(() => {
+      protectedGet.mockResolvedValue({ steps: ALL_BUT_ONE });
+    });
+
+    // Waited on the fresh answer rather than asserting the count immediately,
+    // which is true before this mount has read anything at all.
+    await waitFor(() =>
+      expect(screen.getByText(/2 of 3 done/)).toBeInTheDocument()
+    );
+    expect(readLayout).toHaveBeenCalledTimes(afterDrop);
+  });
+
+  it("does NOT act on a cached answer whose refresh FAILED", async () => {
+    // 🔴 An update landing is not an answer arriving. The observer counts a
+    // failed update alongside a successful one, and a rejected refetch leaves
+    // the earlier mount's all-complete data in place -- so a guard reading the
+    // count alone drops the card on an answer nobody managed to refresh, at the
+    // exact moment the refresh reported it could not.
+    const { readLayout, afterDrop } = await finishThenReoffer(() => {
+      protectedGet.mockRejectedValue(new Error("network"));
+    });
+
+    // Waited on the FAILURE, for the same reason: the count is unmoved before
+    // the refetch has been attempted, so asserting it first passes vacuously.
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Setup progress is unavailable/)
+      ).toBeInTheDocument()
+    );
     expect(readLayout).toHaveBeenCalledTimes(afterDrop);
   });
 
@@ -266,8 +332,8 @@ describe("the onboarding checklist", () => {
     // Asserted as a REFETCH by a LIVE consumer of the key rather than as a call
     // on `invalidateQueries`, which any key at all satisfies -- including one
     // nothing is mounted under. The consumer also has to be mounted rather than
-    // prefetched: an invalidation refetches ACTIVE queries, and an entry with
-    // no observer is collected outright under this client's `gcTime: 0`.
+    // prefetched: an invalidation refetches ACTIVE queries only, so a
+    // prefetched entry is marked stale and never read again.
     protectedGet.mockResolvedValue({ steps: EVERY_STEP });
     const { readLayout } = await drawBesideLayout(client());
 

--- a/packages/admin/src/hooks/queries/useOnboardingSteps.ts
+++ b/packages/admin/src/hooks/queries/useOnboardingSteps.ts
@@ -162,17 +162,29 @@ export function useOnboardingSteps(): UseOnboardingStepsResult {
   // include it. One spurious round trip, and a card that flickers away from a
   // reader who needs it.
   //
-  // Compared against the MOUNT rather than trusting `isStale`. With
-  // `staleTime: 0` above, data is stale the instant it arrives, so that flag
-  // cannot separate "not yet refetched" from "just fetched" -- and it is the
-  // refetch this has to wait for, not the staleness.
-  const mountedAt = useRef(Date.now());
+  // Taken from the OBSERVER, which counts the updates it has seen since this
+  // hook subscribed, rather than from a wall-clock comparison against the
+  // mount. A clock cannot order the two mounts reliably: `Date.now()` is
+  // coarsened by browser anti-fingerprinting -- to 100ms under Firefox's
+  // resistFingerprinting -- and steps backwards under an NTP correction, and
+  // either one lets a cached `dataUpdatedAt` read as this mount's own. An
+  // update count cannot run backwards or collide.
+  //
+  // `isStale` cannot stand in for it: with `staleTime: 0` above the data is
+  // stale the instant it arrives, so that flag cannot separate "not yet
+  // refetched" from "just fetched" -- and it is the refetch this waits for.
+  //
+  // ANDed with success because the observer counts a FAILED update too. A
+  // refetch that rejects leaves the previous mount's all-complete data in
+  // place, and on the count alone the card would drop itself on an answer
+  // nobody managed to refresh.
+  const fetchedHere = query.isSuccess && query.isFetchedAfterMount;
   useEffect(() => {
     if (!finished || dropped.current) return;
-    if (query.dataUpdatedAt < mountedAt.current) return;
+    if (!fetchedHere) return;
     dropped.current = true;
     void queryClient.invalidateQueries({ queryKey: DASHBOARD_LAYOUT_KEY });
-  }, [finished, query.dataUpdatedAt, queryClient]);
+  }, [finished, fetchedHere, queryClient]);
 
   return {
     steps,


### PR DESCRIPTION
Two review findings arrived on #1742 at 23:06 and were fixed at 23:20 — five minutes after #1742 merged at 23:15. The commit was pushed to a branch that had already been squashed, so it never landed. This carries it, unchanged, on top of `main`.

Verified by content rather than by state, with controls in both directions:

| probe | on `main` before this |
|---|---|
| `isFetchedAfterMount` (the fix) | **absent** |
| `mountedAt` (the guard it replaces) | present, 2 occurrences |
| the file itself | present, so the search was aimed at something |

`scripts/verify-merge.mjs 1742` independently named the same single commit as `absent-from-merge`. Everything else in #1742 landed.

## What it fixes

The onboarding card may only drop itself on an answer **this** mount fetched — otherwise a reader who finishes onboarding, then deletes their last collection, is offered the card again and it vanishes on the previous visit's all-complete answer before its own refetch lands.

That was decided by comparing `query.dataUpdatedAt` against a `Date.now()` read at mount. A wall clock cannot make the comparison:

- **Collision.** `<` is strict, so equal readings accept the cached answer. Firefox's `privacy.resistFingerprinting` coarsens `Date.now()` to 100ms buckets, which is the realistic scale for this rather than a single millisecond.
- **Backwards motion.** Both stamps come from the same clock and `Date.now()` is not monotonic. An NTP correction between the cached fetch and the mount puts the mount *earlier* than genuinely stale data — a window of seconds.

It now comes from the observer. `QueryObserver.createResult` (query-core 5.90.7, `queryObserver.js:328`) computes `isFetchedAfterMount` as `dataUpdateCount > queryInitialState.dataUpdateCount || errorUpdateCount > queryInitialState.errorUpdateCount`, with `queryInitialState` captured at subscribe. A count against this mount's own baseline can neither collide nor run backwards.

ANDed with `isSuccess`, because that expression counts a **failed** update too. v5 retains `data` and sets `status: "error"` on a failed refetch, so on the count alone the card would drop itself at the exact moment its refresh reported it could not.

## Evidence

Break-verified by writing the **previous implementation** back, not by mutating the new one — each break named by the tests it killed:

| break | tests killed |
|---|---|
| old wall-clock guard restored | `separates the two mounts when the CLOCK cannot` |
| `isSuccess` conjunct dropped | `does NOT act on a cached answer whose refresh FAILED` |
| guard removed entirely | all three staleness cases |

Both conjuncts are independently load-bearing, and the first break is the reviewer's own reproduction — `Date.now()` frozen across the remount, the coarse-clock case at its limit.

Also corrects three comments in the test that explained the fixture by a `gcTime: 0` the same file no longer sets, two of which cited the wrong mechanism: a layout consumer must be **mounted** rather than prefetched because invalidation refetches *active* queries only, not because an unobserved entry is collected. The remount sequence the three staleness cases share is now one helper rather than three copies.

`4218` admin tests, `check-types`, `lint` and `check:comments` green locally, each confirmed to have actually run.