### PR TITLE
fix(builder): a refusal without a reason is not one the panel can report

### DIFF
--- a/.changeset/a-refusal-without-a-reason-is-not-an-outcome.md
+++ b/.changeset/a-refusal-without-a-reason-is-not-an-outcome.md
@@ -1,0 +1,40 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A class rename refused by a host is shown to the author only when the refusal
+carries the reason the panel is about to print. The guard that recognised an
+outcome read one field of it — whether `ok` was a boolean — and then narrowed
+to a type promising `reason: string`, so any unrelated failure-shaped result a
+host handed back was accepted as a refusal. `{ ok: false, error }`, which is
+what an ordinary mutation helper answers with, reported `undefined`.
+
+The notice renders on the reported reason not being `null`, and `undefined` is
+not `null`, so the author got an error box with nothing written in it and a
+screen reader announced an alert carrying no text — a rename declared failed
+with no way to learn why. A result this cannot vouch for is silence again, as
+it always was for a host that answers with nothing.

--- a/packages/builder/src/class-manager-panel.test.tsx
+++ b/packages/builder/src/class-manager-panel.test.tsx
@@ -516,6 +516,79 @@ describe("a rename the host refuses", () => {
     expect(screen.queryByRole("alert")).toBeNull();
   });
 
+  it("says nothing when a synchronous answer is failure-SHAPED but has no reason", async () => {
+    /*
+     * 🔴 The distinguishing control, and the one the two above cannot stand in
+     * for: they vary `ok`, and this varies whether the value is an outcome at
+     * all. A mutation helper answering `{ ok: false, error }` is not this
+     * panel's contract — its refusal carries `reason` — but a guard that reads
+     * only `ok` accepted it and reported `undefined`, which renders an alert
+     * with nothing written in it. An empty error box is worse than silence: it
+     * says a rename failed and refuses to say why.
+     *
+     * Asserting on the ROLE rather than on text is what makes it discriminate.
+     * The blank alert is present in the accessibility tree and announced; only
+     * its text is missing, so any assertion phrased on the words would pass
+     * against the very output this is here to reject.
+     */
+    const onRename = vi.fn(() => ({ ok: false as const, error: "locked" }));
+    render(
+      <ClassManagerPanel
+        library={LIBRARY}
+        usage={{}}
+        documentClassIds={[]}
+        onRename={onRename}
+        onDelete={vi.fn()}
+      />
+    );
+    const field = nameField("hero");
+    fireEvent.change(field, { target: { value: "renamed" } });
+    fireEvent.blur(field);
+
+    await Promise.resolve();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("says nothing when an AWAITED answer is failure-shaped but has no reason", async () => {
+    /*
+     * The same shape down the promise path, which had the defect first and
+     * keeps it if the guard is repaired only where the synchronous branch
+     * reads it. Two paths interpreting one answer must not disagree about
+     * whether it is an answer.
+     *
+     * The resolution is flushed inside `act` rather than by awaiting a
+     * microtask or two. Nothing VISIBLE marks a non-outcome being dismissed —
+     * the path clears state that is already clear — so an assertion racing the
+     * commit finds no alert whatever the guard decides, and passes just as
+     * happily against the version this rejects. Flushing first is what makes
+     * the silence a result instead of a head start.
+     */
+    const onRename = vi.fn(async () => ({
+      ok: false as const,
+      error: "locked",
+    }));
+    render(
+      <ClassManagerPanel
+        library={LIBRARY}
+        usage={{}}
+        documentClassIds={[]}
+        onRename={onRename}
+        onDelete={vi.fn()}
+      />
+    );
+    const field = nameField("hero");
+    fireEvent.change(field, { target: { value: "renamed" } });
+    fireEvent.blur(field);
+
+    // The host was actually asked: the silence below is about what came back,
+    // not about a rename that never left the panel.
+    expect(onRename).toHaveBeenCalled();
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
   it("shows the reason rather than clearing as though it landed", async () => {
     const onRename = vi.fn(async () => ({
       ok: false as const,

--- a/packages/builder/src/class-manager-panel.tsx
+++ b/packages/builder/src/class-manager-panel.tsx
@@ -132,14 +132,25 @@ function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
   );
 }
 
-/** Whether a resolution is an outcome this panel can report, or something else. */
+/**
+ * Whether a resolution is an outcome this panel can report, or something else.
+ *
+ * A refusal is checked all the way down to its `reason`, because the answer is
+ * `unknown` and plenty of unrelated results are shaped like a failure — a
+ * mutation helper resolving `{ ok: false, error: "locked" }` is the ordinary
+ * one. Narrowing on `ok` alone accepted those as {@link ClassRenameOutcome},
+ * which promises `reason: string`, so the reported reason was `undefined`; the
+ * alert below renders on `refused !== null`, and `undefined` is not `null`, so
+ * the author got an error box with nothing written in it and a screen reader
+ * announced an alert with no text. A shape this cannot vouch for is silence.
+ */
 function isRenameOutcome(value: unknown): value is ClassRenameOutcome {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "ok" in value &&
-    typeof value.ok === "boolean"
-  );
+  if (typeof value !== "object" || value === null || !("ok" in value)) {
+    return false;
+  }
+  if (value.ok === true) return true;
+  if (value.ok !== false) return false;
+  return "reason" in value && typeof value.reason === "string";
 }
 
 export interface ClassManagerPanelProps {


### PR DESCRIPTION
Follow-up to #1747, which made a synchronous refusal reach the author. The guard both paths use to recognise a refusal was narrower than the type it narrowed to.

## What was wrong

`isRenameOutcome` checked one thing — `typeof value.ok === "boolean"` — and then narrowed to `ClassRenameOutcome`, whose refusal arm declares `reason: string` as **required**. So the guard vouched for a field it never looked at, and TypeScript typed `answered.reason` as `string` when it could be `undefined`.

The answer is `unknown` by design (the contract this replaced was `=> void`), and plenty of ordinary results are failure-shaped without being this panel's contract. A mutation helper resolving `{ ok: false, error: "locked" }` is the common one. That was accepted as a refusal, and `report(undefined)` ran.

## What the author saw

The notice is gated on `refused !== null`. `undefined !== null` is `true`, so the panel rendered:

```html
<p class="nx-classman__issue" role="alert"></p>
```

An empty error box, and for a screen reader an alert announced with no text. A rename declared failed with no way to learn why — which is worse than the silence #1747 removed, because that silence at least looked like success.

## Why the fix is in the guard, not the branch

Both readers of a rename answer share `isRenameOutcome`: the synchronous branch #1747 added and the pre-existing promise branch. The defect existed on the promise path first. Repairing only the synchronous branch would leave two paths disagreeing about whether one answer is an answer, which is the class of split this whole area exists to prevent.

The guard now requires `reason` to be a string when `ok` is `false`. A shape it cannot vouch for is silence, exactly as it always was for a host that returns nothing.

## Evidence

Two tests, one per path, both asserting on the **role** rather than on text — the blank alert is present in the accessibility tree with only its text missing, so an assertion phrased on the words passes against the very output being rejected.

Break-verified by restoring the shipped loose guard:

| guard | sync test | async test |
|---|---|---|
| loose (shipped) | **fails** | **fails** |
| required `reason` | passes | passes |

The async test's first version **survived the break** — it awaited two microtasks and raced the commit, so it found no alert whatever the guard decided. Flushing inside `act` is what makes its silence a result rather than a head start; it kills on the break now, and that is recorded in the test.

## Gates

`pnpm build` 0 · `check-types` 0 · `lint` 0 · vitest 0 (107 files, 3078 tests — +2) · fallow `pass`, every `*_introduced` 0 over 3 changed files · `changeset status` 0. All re-run after the commit hook's `prettier --write`.
