### PR TITLE
fix(builder): a refusal with no words is said in the generic ones, not in none

### DIFF
--- a/.changeset/a-refusal-with-no-words-is-said-in-the-generic-ones.md
+++ b/.changeset/a-refusal-with-no-words-is-said-in-the-generic-ones.md
@@ -1,0 +1,33 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A class rename the host refuses with an empty or whitespace-only reason is now
+reported in the same words a rename that threw already used, rather than as
+an alert with nothing written in it. The refusal's shape is the documented one
+and the host did refuse, so silence would report a failed rename as a success;
+what was missing was only the words, and those are supplied.

--- a/packages/builder/src/class-manager-panel.test.tsx
+++ b/packages/builder/src/class-manager-panel.test.tsx
@@ -589,6 +589,63 @@ describe("a rename the host refuses", () => {
     expect(screen.queryByRole("alert")).toBeNull();
   });
 
+  it("says a refusal with an EMPTY reason in the generic words, not in none", async () => {
+    /*
+     * 🔴 The separating input for the guard above, from the other side. This
+     * IS a conforming outcome — `reason: string` admits `""` — so the guard is
+     * right to accept it, and the two silence tests cannot speak for it. But
+     * printing it rendered the same textless alert a non-outcome did, and
+     * silence would be worse: the host DID refuse, and a row that clears with
+     * no notice reports a failed rename as a success.
+     *
+     * The assertion is the generic copy, which separates this from BOTH wrong
+     * answers at once — a blank alert has no text to find, and silence has no
+     * alert.
+     */
+    const onRename = vi.fn(() => ({ ok: false as const, reason: "" }));
+    render(
+      <ClassManagerPanel
+        library={LIBRARY}
+        usage={{}}
+        documentClassIds={[]}
+        onRename={onRename}
+        onDelete={vi.fn()}
+      />
+    );
+    const field = nameField("hero");
+    fireEvent.change(field, { target: { value: "renamed" } });
+    fireEvent.blur(field);
+
+    expect(
+      await screen.findByText("This class could not be renamed.")
+    ).toBeTruthy();
+  });
+
+  it("treats a whitespace-only reason the same, down the promise path", async () => {
+    // Whitespace is what a template literal with nothing interpolated into it
+    // produces, and it renders exactly as empty does.
+    const onRename = vi.fn(async () => ({
+      ok: false as const,
+      reason: "  \n",
+    }));
+    render(
+      <ClassManagerPanel
+        library={LIBRARY}
+        usage={{}}
+        documentClassIds={[]}
+        onRename={onRename}
+        onDelete={vi.fn()}
+      />
+    );
+    const field = nameField("hero");
+    fireEvent.change(field, { target: { value: "renamed" } });
+    fireEvent.blur(field);
+
+    expect(
+      await screen.findByText("This class could not be renamed.")
+    ).toBeTruthy();
+  });
+
   it("shows the reason rather than clearing as though it landed", async () => {
     const onRename = vi.fn(async () => ({
       ok: false as const,

--- a/packages/builder/src/class-manager-panel.tsx
+++ b/packages/builder/src/class-manager-panel.tsx
@@ -902,6 +902,19 @@ function ClassRowView({
 }
 
 /**
+ * What a refusal says when the host gave it no words.
+ *
+ * Three answers put the author in the same position — refused, and not told
+ * why: a host that threw, a write that rejected, and a conforming refusal whose
+ * `reason` is empty or only whitespace. The type admits that last one, and
+ * rendering it produced an alert with nothing in it; but a host that answered
+ * `{ ok: false }` DID refuse, so unlike a result that is not an outcome at all
+ * this cannot be silence — the rename failed, and the row would otherwise
+ * clear as though it had landed.
+ */
+const UNEXPLAINED_REFUSAL = "This class could not be renamed.";
+
+/**
  * The name, edited in place, committed only when the engine would accept it.
  *
  * The draft is local so a half-typed name is not reported as a rename on every
@@ -948,8 +961,11 @@ function NameField({
    */
   const survive = useSurvivingReport();
   const report = (reason: string): void => {
-    survive(reason, () => {
-      setRefused(reason);
+    // Substituted here, ahead of both sinks, so the shell notice a departed
+    // row falls back to never carries the blank either.
+    const shown = reason.trim() === "" ? UNEXPLAINED_REFUSAL : reason;
+    survive(shown, () => {
+      setRefused(shown);
       return true;
     });
   };
@@ -997,7 +1013,7 @@ function NameField({
       answered = onRename(row.id, outcome.slug);
     } catch {
       setDraft(null);
-      report("This class could not be renamed.");
+      report(UNEXPLAINED_REFUSAL);
       return;
     }
     /*
@@ -1052,7 +1068,7 @@ function NameField({
        */
       .catch(() => {
         if (attempt.current !== mine) return;
-        report("This class could not be renamed.");
+        report(UNEXPLAINED_REFUSAL);
       });
   };
 


### PR DESCRIPTION
Follow-up to #1752, which merged while this was being written. #1752 stopped a **non-outcome** from rendering a blank alert; this handles the other way of reaching the same blank box — a **conforming** refusal whose `reason` is empty or whitespace.

## The case #1752 could not cover

`ClassRenameOutcome` declares `reason: string`, and `""` is a string. So `{ ok: false, reason: "" }` passes the tightened guard — correctly, it is the documented shape — and `report("")` runs. The alert renders on `refused !== null`, and `"" !== null`, so the author again got an error box with nothing in it.

## Why this is not silence

The two answers look alike and must be treated oppositely:

| the host answered | is it a refusal? | what the author sees |
|---|---|---|
| `{ ok: false, error: "locked" }` | no — not this panel's contract | nothing (#1752) |
| `{ ok: false, reason: "" }` | **yes** — it said `ok: false` | **"This class could not be renamed."** (this PR) |

Rejecting a blank reason in the guard would have been the smaller diff, and it would report a rename the host *refused* as a rename that landed — the row clears and nothing is said. That is the exact silence #1747 removed.

## One implementation of "refused, and not told why"

A host that threw, a write that rejected, and a refusal with no words put the author in the same position, and the first two already said `"This class could not be renamed."` in two places. All three now share `UNEXPLAINED_REFUSAL`, substituted inside `report()` ahead of **both** sinks — the inline alert and the shell notice a departed row falls back to — so the blank cannot reach either.

## Evidence

Two tests, one per path (`reason: ""` synchronous, `reason: "  \n"` awaited), each asserting `findByText("This class could not be renamed.")`. That single assertion separates the fix from **both** wrong implementations at once — a blank alert has no text to find, and silence has no alert. Verified rather than argued: each wrong implementation was written and run.

| implementation | the two new tests |
|---|---|
| print the reason as given (blank alert) | **both fail** |
| guard rejects a blank reason (silence) | **both fail** |
| substitute the generic copy | pass |

Only those two tests move in either break; the other 72 in the file stay green.

## Gates

`pnpm --filter @nextlyhq/builder... build` 0 · `check-types` 0 · `lint` 0 · vitest 0 (107 files, **3080** tests, +2) · fallow `pass`, every `*_introduced` 0 over 3 changed files · `changeset status` 0. Its own changeset; the cherry-pick's edit to #1752's already-merged changeset was reverted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Class rename refusals now display a clear fallback message when no explanation is provided.
  * Whitespace-only refusal messages no longer result in blank alerts or notifications.
  * Consistent messaging is shown for synchronous and asynchronous rename failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->