### PR TITLE
fix(builder): the insert panel names a container the way the palette does

### DIFF
--- a/.changeset/the-insert-panel-names-the-container-as-the-palette-does.md
+++ b/.changeset/the-insert-panel-names-the-container-as-the-palette-does.md
@@ -1,0 +1,36 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The insert panel's placement sentence — "Adds inside …", announced to a
+screen-reader author as the answer to where the next block will land — now
+names the container the way every other surface does. It read the container's
+declared label directly and said "the selected block" when there was none, so
+a container the palette, the layers and the inspector all call "Box" was the
+one place it went unnamed, and a label declared as an empty string produced a
+sentence with nothing after "inside". The name is derived from the same rule
+the palette reads, so the container is called what the author just clicked.

--- a/packages/builder/src/insert-panel.test.tsx
+++ b/packages/builder/src/insert-panel.test.tsx
@@ -36,6 +36,7 @@ import {
 
 import { InsertPanel } from "./insert-panel";
 import type { EditorState } from "./editor-state";
+import { EMPTY_SELECTION } from "./selection";
 
 // The command primitives observe their list box to size it, and jsdom
 // implements no ResizeObserver. Without this every case dies at render with a
@@ -86,6 +87,7 @@ function editorSpy(document: BlockDocument): EditorState & {
   return {
     document,
     selectedId: null,
+    selection: EMPTY_SELECTION,
     select: vi.fn(),
     apply: vi.fn(() => document),
     applyAll: vi.fn(() => document),
@@ -458,13 +460,32 @@ describe("the sentence that says where the next block lands", () => {
    * paragraph is the polite live region that tells them — for a screen-reader
    * author it is the whole answer to "where will this go".
    *
-   * The container's name comes from a lookup the sentence does not need to
-   * render — it has a fallback for a type the registry cannot name — so the
-   * lookup can be dropped and every inside-selection placement still announces
-   * something. Measured: with the lookup replaced by a constant, this file
-   * passed whole. These are the tests that were missing.
+   * The container is named by `blockLabel`, the same rule the palette, the
+   * layers and the inspector read, so the sentence agrees with every other
+   * place the author has already met the block.
    */
-  function selectedEmptyContainer(): EditorState {
+
+  /**
+   * An editor with one block selected, stated the way the real editor states
+   * it: `selectedId` is `selection.primary`, so a fixture that set one and not
+   * the other would be a state the editor never produces.
+   */
+  function selecting(editor: EditorState, id: string): EditorState {
+    return {
+      ...editor,
+      selectedId: id,
+      selection: { ids: [id], primary: id },
+    };
+  }
+
+  function emptyContainer(id: string, type: string): EditorState {
+    return selecting(
+      editorSpy(documentOf([{ id, type, version: 1, props: {} }] as never)),
+      id
+    );
+  }
+
+  it("names the container the block will go inside", () => {
     registerBlocks(
       [
         {
@@ -473,53 +494,32 @@ describe("the sentence that says where the next block lands", () => {
           editor: { label: "Section" },
           slots: { children: {} },
         },
-        { ...base, name: "acme/text", editor: { label: "Text" } },
       ] as never,
       { source: "acme" }
     );
-    const editor = editorSpy(
-      documentOf([
-        { id: "s", type: "acme/section", version: 1, props: {} },
-      ] as never)
-    );
-    return { ...editor, selectedId: "s" } as EditorState;
-  }
-
-  it("names the container the block will go inside", () => {
-    render(<InsertPanel editor={selectedEmptyContainer()} />);
+    render(<InsertPanel editor={emptyContainer("s", "acme/section")} />);
 
     const sentence = screen.getByText("Adds inside Section");
-    // Asserted against the fallback by name, so the failure reads as the
-    // wording the author would actually have heard rather than as a missing
-    // element: the fallback is a real sentence and a real live region.
-    expect(screen.queryByText("Adds inside the selected block")).toBeNull();
     // The announcement is the point. A paragraph with the right words that is
     // not a live region tells a sighted author and nobody else.
     expect(sentence.getAttribute("aria-live")).toBe("polite");
   });
 
-  it("falls back to 'the selected block' only when the registry cannot name it", () => {
+  it("calls an unlabelled container what the palette calls it", () => {
     /*
-     * The control that keeps the fallback honest: it must exist for a container
-     * whose definition carries no label, and it must not be what a labelled
-     * container gets. Without this, making the sentence always say "the
-     * selected block" fails the test above for the right reason, while making
-     * it always say "Section" — or throw on a nameless type — would go unseen.
+     * The control on the name: a container with no `editor.label` still reads
+     * as the humanised type every other surface shows, not as "the selected
+     * block" and not as its raw identity. A sentence that always said
+     * "Section" would fail here; one that kept a naming rule of its own would
+     * disagree with the tile the author just clicked.
      */
     registerBlocks(
       [{ ...base, name: "acme/box", slots: { children: {} } }] as never,
       { source: "acme" }
     );
-    const editor = editorSpy(
-      documentOf([
-        { id: "b", type: "acme/box", version: 1, props: {} },
-      ] as never)
-    );
-    render(
-      <InsertPanel editor={{ ...editor, selectedId: "b" } as EditorState} />
-    );
+    render(<InsertPanel editor={emptyContainer("b", "acme/box")} />);
 
-    expect(screen.getByText("Adds inside the selected block")).toBeTruthy();
+    expect(screen.getByText("Adds inside Box")).toBeTruthy();
   });
 });
 

--- a/packages/builder/src/insert-panel.test.tsx
+++ b/packages/builder/src/insert-panel.test.tsx
@@ -450,6 +450,79 @@ describe("InsertPanel", () => {
   });
 });
 
+describe("the sentence that says where the next block lands", () => {
+  /*
+   * The one placement that differs from what selecting a block usually implies
+   * is "inside": an empty container takes the block rather than standing beside
+   * it. "Inside" is only meaningful if the author knows inside WHAT, and this
+   * paragraph is the polite live region that tells them — for a screen-reader
+   * author it is the whole answer to "where will this go".
+   *
+   * The container's name comes from a lookup the sentence does not need to
+   * render — it has a fallback for a type the registry cannot name — so the
+   * lookup can be dropped and every inside-selection placement still announces
+   * something. Measured: with the lookup replaced by a constant, this file
+   * passed whole. These are the tests that were missing.
+   */
+  function selectedEmptyContainer(): EditorState {
+    registerBlocks(
+      [
+        {
+          ...base,
+          name: "acme/section",
+          editor: { label: "Section" },
+          slots: { children: {} },
+        },
+        { ...base, name: "acme/text", editor: { label: "Text" } },
+      ] as never,
+      { source: "acme" }
+    );
+    const editor = editorSpy(
+      documentOf([
+        { id: "s", type: "acme/section", version: 1, props: {} },
+      ] as never)
+    );
+    return { ...editor, selectedId: "s" } as EditorState;
+  }
+
+  it("names the container the block will go inside", () => {
+    render(<InsertPanel editor={selectedEmptyContainer()} />);
+
+    const sentence = screen.getByText("Adds inside Section");
+    // Asserted against the fallback by name, so the failure reads as the
+    // wording the author would actually have heard rather than as a missing
+    // element: the fallback is a real sentence and a real live region.
+    expect(screen.queryByText("Adds inside the selected block")).toBeNull();
+    // The announcement is the point. A paragraph with the right words that is
+    // not a live region tells a sighted author and nobody else.
+    expect(sentence.getAttribute("aria-live")).toBe("polite");
+  });
+
+  it("falls back to 'the selected block' only when the registry cannot name it", () => {
+    /*
+     * The control that keeps the fallback honest: it must exist for a container
+     * whose definition carries no label, and it must not be what a labelled
+     * container gets. Without this, making the sentence always say "the
+     * selected block" fails the test above for the right reason, while making
+     * it always say "Section" — or throw on a nameless type — would go unseen.
+     */
+    registerBlocks(
+      [{ ...base, name: "acme/box", slots: { children: {} } }] as never,
+      { source: "acme" }
+    );
+    const editor = editorSpy(
+      documentOf([
+        { id: "b", type: "acme/box", version: 1, props: {} },
+      ] as never)
+    );
+    render(
+      <InsertPanel editor={{ ...editor, selectedId: "b" } as EditorState} />
+    );
+
+    expect(screen.getByText("Adds inside the selected block")).toBeTruthy();
+  });
+});
+
 describe("the grid, and the strip that describes it", () => {
   /**
    * Seven blocks in one category, named so their position is readable.

--- a/packages/builder/src/insert-panel.tsx
+++ b/packages/builder/src/insert-panel.tsx
@@ -50,7 +50,6 @@
 
 import {
   allBlocks,
-  getBlock,
   planInsertPattern,
   registryNestingSource,
   type AnyBlockDefinition,
@@ -73,6 +72,7 @@ import type { InsertDragEntry } from "./canvas-drag";
 import type { EditorState } from "./editor-state";
 import {
   allowedEntries,
+  blockLabel,
   blockSourceFor,
   catalogFrom,
   filterEntries,
@@ -373,12 +373,20 @@ function describedEntry(
 }
 
 /** Sentence describing where the next insert will land. */
-function placementLabel(point: InsertionPoint, label?: string): string {
+function placementLabel(point: InsertionPoint): string {
   if (point.kind === "inside-selection") {
     // Names the container, because "inside" is only meaningful if the author
     // knows what it is inside OF — and this is the one placement that differs
-    // from what selecting a block usually implies.
-    return `Adds inside ${label ?? "the selected block"}`;
+    // from what selecting a block usually implies. The name is the one every
+    // other surface reads, so a container the palette calls "Box" is not
+    // "the selected block" here; and a container is only ever entered through
+    // a slot, so the other arm is a guard over a target the point cannot carry
+    // rather than a case an author reaches.
+    const container =
+      point.target.kind === "slot"
+        ? blockLabel(point.target.parentType)
+        : "the selected block";
+    return `Adds inside ${container}`;
   }
   return point.kind === "after-selection"
     ? "Adds after the selected block"
@@ -635,14 +643,7 @@ export function InsertPanel({
           placeholder="Search blocks"
         />
         <p className="nx-insert-panel__placement" aria-live="polite">
-          {placementLabel(
-            point,
-            point.kind === "inside-selection"
-              ? getBlock(
-                  point.target.kind === "slot" ? point.target.parentType : ""
-                )?.editor?.label
-              : undefined
-          )}
+          {placementLabel(point)}
         </p>
         <CommandList>
           <CommandEmpty>


### PR DESCRIPTION
Started as test-only coverage for the insert panel's placement announcement; review found the sentence was using a naming rule of its own, so it is a fix now, with a changeset.

## The gap that started it

When an empty container is selected the next block goes **inside** it, and the panel says so in a polite live region: *"Adds inside Section"*. For a screen-reader author that sentence is the whole answer to "where will this go". Measured on `origin/main` `cde0bd0b8` before writing anything: with the container lookup replaced by a constant, `insert-panel.test.tsx` passed **41/41**. Nothing named the container and nothing said so.

## What the coverage exposed

The sentence read `getBlock(type)?.editor?.label` and fell back to *"the selected block"*. Every other surface — the palette tile the author just clicked, the layers, the inspector, a drag refusal — names a block through `blockLabel()`, which humanises an unlabelled type. So a container those all call **"Box"** was unnamed in the one sentence that matters most to a non-sighted author, and a label declared as `""` produced *"Adds inside "* with nothing after it. Two rules for one question; `blockLabel()` is the one that survives.

## The tests

1. **names the container the block will go inside** — a labelled container reads `Adds inside Section`, and the sentence carries `aria-live="polite"`; a paragraph with the right words that is not a live region tells a sighted author and nobody else.
2. **calls an unlabelled container what the palette calls it** — `acme/box` with no label reads `Adds inside Box`. This is the control that separates the shared rule from the lookup it replaced.

Fixtures state a selection the way the editor does: `selectedId` **is** `selection.primary`, so `editorSpy` now carries `EMPTY_SELECTION` and the selecting helper sets both.

## Break-verification

| implementation | fails |
|---|---|
| the original lookup put back (`editor.label ?? "the selected block"`) | test 2 only |
| never names the container | both |
| `aria-live` removed | test 1 |

## Gates

`check-types` 0 · `lint` 0 · vitest 0 (107 files, 3080 tests, +2) · fallow `pass`, `changed_files_count` 3, every `*_introduced` 0 · `changeset status` 0. Re-run after the commit hook.
