### PR TITLE
fix(builder): a drop region names its target the way a drop target does

### DIFF
--- a/.changeset/a-region-names-its-target.md
+++ b/.changeset/a-region-names-its-target.md
@@ -1,0 +1,36 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+`DropRegion.at` is now `DropRegion.target`. The module spelled two ideas with
+one word: on a region, `at` was the placement a block would be nested into,
+while on a `DropTarget`, `at` was a position and `target` was that placement.
+A host reading both had to remember which `at` it held. The region now names
+the placement as the target does, and `at` means a position everywhere in the
+module. A value still spelling `at` on a region is a type error rather than a
+silent fall-through; the package is `@experimental` throughout, so no alias
+is kept.

--- a/packages/builder/src/drop-targets.test.ts
+++ b/packages/builder/src/drop-targets.test.ts
@@ -77,7 +77,7 @@ function documentOf(nodes: BlockNode[]): BlockDocument {
 function rootRegion(childIds: string[], axis: "x" | "y" = "y"): DropRegion {
   return {
     id: ROOT_REGION,
-    at: { kind: "root" },
+    target: { kind: "root" },
     depth: 0,
     rect: { x: 0, y: 0, width: 400, height: 1000 },
     axis,
@@ -178,7 +178,7 @@ describe("targetsInRegion", () => {
     // would read as "beside this container" rather than "inside it".
     const region: DropRegion = {
       id: "box::children",
-      at: { kind: "slot", parentType: "core/box", slot: "children" },
+      target: { kind: "slot", parentType: "core/box", slot: "children" },
       parentId: "box",
       slot: "children",
       depth: 1,
@@ -219,7 +219,7 @@ describe("targetsInRegion", () => {
   it("addresses a slot region by parent and slot, never by position", () => {
     const region: DropRegion = {
       id: "box::children",
-      at: { kind: "slot", parentType: "core/box", slot: "children" },
+      target: { kind: "slot", parentType: "core/box", slot: "children" },
       parentId: "box",
       slot: "children",
       depth: 1,
@@ -322,7 +322,7 @@ describe("collectRegions", () => {
       })
     );
 
-    expect(regions.map(r => [r.id, r.at])).toEqual([
+    expect(regions.map(r => [r.id, r.target])).toEqual([
       [ROOT_REGION, { kind: "root" }],
       [
         "outer::children",
@@ -336,7 +336,7 @@ describe("collectRegions", () => {
 describe("regionAt", () => {
   const outer: DropRegion = {
     id: "outer::children",
-    at: { kind: "slot", parentType: "core/box", slot: "children" },
+    target: { kind: "slot", parentType: "core/box", slot: "children" },
     parentId: "outer",
     slot: "children",
     depth: 1,
@@ -346,7 +346,7 @@ describe("regionAt", () => {
   };
   const inner: DropRegion = {
     id: "inner::items",
-    at: { kind: "slot", parentType: "core/row", slot: "items" },
+    target: { kind: "slot", parentType: "core/row", slot: "items" },
     parentId: "inner",
     slot: "items",
     depth: 2,
@@ -459,7 +459,7 @@ describe("resolveDrop", () => {
     const regions = [
       {
         id: "acc::panels",
-        at: { kind: "slot", parentType: "core/accordion", slot: "panels" },
+        target: { kind: "slot", parentType: "core/accordion", slot: "panels" },
         parentId: "acc",
         slot: "panels",
         depth: 1,
@@ -515,7 +515,7 @@ describe("resolveDrop", () => {
         regions: [
           {
             id: ROOT_REGION,
-            at: { kind: "root" },
+            target: { kind: "root" },
             depth: 0,
             rect: { x: 0, y: 0, width: 400, height: 200 },
             axis: "y",

--- a/packages/builder/src/drop-targets.ts
+++ b/packages/builder/src/drop-targets.ts
@@ -116,8 +116,15 @@ export interface RectSource {
 export interface DropRegion {
   /** Stable identity: {@link ROOT_REGION}, or `"<parentId>::<slot>"`. */
   readonly id: string;
-  /** What this region is, as the nesting rule needs to see it. */
-  readonly at: PlacementTarget;
+  /**
+   * What this region is, as the nesting rule needs to see it.
+   *
+   * Named as {@link DropTarget.target} is, because it is the same thing: the
+   * placement a block would be nested into. `at` is reserved for a POSITION
+   * throughout this module, and a reader holding a region and a target should
+   * not have to remember which of two meanings the one word carries.
+   */
+  readonly target: PlacementTarget;
   /** The container node, absent for the root region. */
   readonly parentId?: string;
   /** The slot within that container, absent for the root region. */
@@ -302,7 +309,7 @@ export function collectRegions(
           .filter((child): child is Rect => child !== undefined);
         regions.push({
           id: `${node.id}::${slot}`,
-          at: { kind: "slot", parentType: node.type, slot },
+          target: { kind: "slot", parentType: node.type, slot },
           parentId: node.id,
           slot,
           depth,
@@ -321,7 +328,7 @@ export function collectRegions(
 
   regions.push({
     id: ROOT_REGION,
-    at: { kind: "root" },
+    target: { kind: "root" },
     depth: 0,
     rect: rects.rootRect(),
     axis: axisOfRects(rootChildRects),
@@ -374,7 +381,7 @@ export function targetsInRegion(
     id: `${region.id}#${String(index)}`,
     regionId: region.id,
     at: positionAt(index),
-    target: region.at,
+    target: region.target,
     axis,
     line,
     ...across,
@@ -525,7 +532,7 @@ export function resolveDrop(query: DropQuery, pointer: Point): DropResolution {
   const region = regionAt(query.regions, pointer, query.forbiddenParents);
   if (region === undefined) return { kind: "none" };
 
-  const verdict = blockAllowedAt(query.blockName, region.at, query.nesting);
+  const verdict = blockAllowedAt(query.blockName, region.target, query.nesting);
   if (!verdict.allowed) {
     return {
       kind: "refused",


### PR DESCRIPTION
`drop-targets` spelled two ideas with one word:

| interface | `at` | `target` |
|---|---|---|
| `DropRegion` | **the placement** (`PlacementTarget`) | — |
| `DropTarget` | a **position** (`OpPosition`) | the placement (`PlacementTarget`) |

A reader holding a region and a target had to remember which `at` they had. `DropRegion.at` is now `DropRegion.target`, matching `DropTarget.target`, so `at` means a position everywhere in the module.

## Why this is a plain rename and not an alias

The finding that filed this (`finding:pb-drop-targets-at-means-two-things`) held it back on the premise that a property rename is a hard break with no migration window. That premise does not apply here: the package README states **every export of `@nextlyhq/builder` is `@experimental` and carries no compatibility guarantee even within alpha.** Keeping both spellings would also reintroduce the exact two-names-for-one-value shape this removes.

## Blast radius, measured rather than guessed

Renamed the field, ran `pnpm check-types` in `packages/builder`: exit 2, **13 sites — 4 in `drop-targets.ts`, 9 in `drop-targets.test.ts`, none anywhere else.** `grep -rn DropRegion packages/` outside the builder finds nothing (admin's `DropTarget` in `widgets/layout-editor.ts` is an unrelated type of the same name). After the rename: check-types 0.

A value still spelling `at` on a region is a type error rather than a silent fall-through, which is the property the type checker verifies here — the 13 red sites before are the evidence that it does.

## Gates

`check-types` 0 · `lint` 0 · vitest 0 (107 files, 3078 tests) · fallow `pass`, `changed_files_count` 3, every `*_introduced` 0 · `changeset status` 0. Re-run after the commit hook.
