### PR TITLE
chore(root): describe the documentation to Context7

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,12 @@ for all published packages. Status: alpha, all packages version in lockstep.
 - `apps/playground` - contributor dev harness (not published).
 - `e2e/` - Playwright suite. `docs/` - user docs (MDX, deployed to
   nextlyhq.com/docs).
+- `context7.json` - what Context7 indexes for coding agents: `docs/` and the
+  root README, with every other root Markdown file excluded by name (Context7
+  reads root-level Markdown whatever `folders` says). Its description is held
+  to the core package's by `check-docs-claims`; `pnpm check:context7-index`
+  reads back what the live index cites, and exits 2 rather than 0 while the
+  library is unregistered.
 
 Before editing a package, read its README.md and check for a nested AGENTS.md.
 

--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://context7.com/schema/context7.json",
+  "projectTitle": "Nextly",
+  "description": "Nextly is an open-source CMS and visual page builder for Next.js. Model content, build pages, localize, version and release from your own stack.",
+  "folders": ["docs"],
+  "excludeFolders": [],
+  "excludeFiles": [
+    "AGENTS.md",
+    "AGENTS.measured.md",
+    "ARCHITECTURE.md",
+    "CLAUDE.md",
+    "CONTRIBUTING.md",
+    "SECURITY.md",
+    "followup-report.md"
+  ],
+  "rules": [
+    "Read content on the server through the Direct API (getNextly + find); do not build an API route to fetch your own content.",
+    "Users are not a normal collection: read them through nextly.users, not find({ collection: \"users\" }).",
+    "Run types:generate after a schema change, in the same change; until then find() returns loosely typed documents.",
+    "Migrations are append-only once shared: add a new one rather than editing an applied file.",
+    "Ask the project which Nextly it is with `nextly --version`; the documentation describes the current release and is not version-stamped."
+  ],
+  "previousVersions": []
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "check:doc-samples": "node scripts/check-doc-samples.mjs",
     "docs:fix": "node scripts/check-docs-claims.mjs --fix",
     "check:repo-metadata": "node scripts/check-repo-metadata.mjs",
+    "check:context7-index": "node scripts/check-context7-index.mjs",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "lint": "turbo run lint",
     "lint:design": "node scripts/lint-design.mjs",

--- a/scripts/check-context7-index.mjs
+++ b/scripts/check-context7-index.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+
+/**
+ * What Context7 actually indexed, read back from Context7.
+ *
+ * `context7.json` says what to index. Context7's own documentation says two things that
+ * make the file insufficient on its own: root-level Markdown is always included whatever
+ * `folders` says, and the index is rebuilt on its schedule rather than on a push. So the
+ * configuration is a request, and this reads the answer: which files the index cites, and
+ * whether a sentence from a file the configuration excludes can be retrieved from it.
+ *
+ * Every assertion here is POSITIVE first. "No AGENTS.md content came back" is satisfied by
+ * a library that is not indexed at all, so the library has to be found and finalized, and a
+ * docs sentence has to be retrievable, before an absence means anything.
+ *
+ * Exit status: 0 the index agrees with the configuration; 1 it does not; 2 the question
+ * could not be answered — not registered yet, still indexing, or Context7 unreachable —
+ * which a caller must never read as a pass.
+ *
+ * Usage:
+ *   node scripts/check-context7-index.mjs
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export const LIBRARY = "/nextlyhq/nextly";
+const API = "https://context7.com/api/v1";
+export const REPO_BLOB = "https://github.com/nextlyhq/nextly/blob/";
+
+/**
+ * The repository paths an index dump cites.
+ *
+ * Context7 prefixes each snippet with `Source: <blob url>`; the path is what follows the
+ * ref, whichever branch it read. A citation of another repository is not this index's
+ * business and is skipped.
+ */
+export function citedPaths(text) {
+  const cited = new Set();
+  for (const match of text.matchAll(/^Source:\s+(\S+)/gm)) {
+    const url = match[1];
+    if (!url.startsWith(REPO_BLOB)) continue;
+    const path = url.slice(REPO_BLOB.length).split("/").slice(1).join("/");
+    if (path) cited.add(path);
+  }
+  return cited;
+}
+
+/** A list field of the configuration, or none. */
+function listField(config, name) {
+  return Array.isArray(config[name]) ? config[name] : [];
+}
+
+/** Root-level Markdown, which Context7 reads whatever `folders` says. */
+function isRootMarkdown(path) {
+  return !path.includes("/") && path.endsWith(".md");
+}
+
+function isInside(path, folders) {
+  return folders.some(folder => path.startsWith(`${folder}/`));
+}
+
+/**
+ * Why one cited path disagrees with the configuration, or `null`.
+ *
+ * A root-level Markdown file is allowed unless `excludeFiles` names it, which is the rule
+ * Context7 documents; anything else must sit under a listed folder.
+ */
+export function citationFinding(path, config) {
+  const folders = listField(config, "folders");
+  if (listField(config, "excludeFiles").includes(path)) {
+    return `${path} is in excludeFiles and was indexed anyway`;
+  }
+  if (isInside(path, folders) || isRootMarkdown(path)) return null;
+  return `${path} is outside folders ${JSON.stringify(folders)} and was indexed`;
+}
+
+/**
+ * Where the cited files disagree with the configuration.
+ *
+ * An empty citation set is itself a finding: it means nothing else was checked.
+ */
+export function citationFindings(cited, config) {
+  if (cited.size === 0) {
+    return [
+      "the index cites no file from this repository, so nothing else could be checked",
+    ];
+  }
+  return [...cited].map(path => citationFinding(path, config)).filter(Boolean);
+}
+
+/**
+ * A sentence the index must be able to return, taken from the file rather than written
+ * here, so a rewrite of the page cannot leave this comparing against words that no longer
+ * exist. The first second-level heading is specific enough to belong to one page.
+ */
+export function firstHeading(text, name) {
+  const match = /^##\s+(.+)$/m.exec(text);
+  if (!match)
+    throw new Error(`${name}: no second-level heading to use as a marker`);
+  return match[1].trim();
+}
+
+async function fetchText(url) {
+  const response = await fetch(url, {
+    headers: { accept: "text/plain, application/json" },
+  });
+  return { status: response.status, body: await response.text() };
+}
+
+function unanswerable(message) {
+  console.error(`check-context7-index: cannot answer — ${message}`);
+  process.exit(2);
+}
+
+const invokedDirectly =
+  process.argv[1] && process.argv[1].endsWith("check-context7-index.mjs");
+
+if (invokedDirectly) {
+  const root = process.cwd();
+  const config = JSON.parse(readFileSync(join(root, "context7.json"), "utf-8"));
+
+  // 1. The library exists and has finished indexing.
+  const search = await fetchText(
+    `${API}/search?query=${encodeURIComponent("nextly")}`
+  );
+  if (search.status !== 200) unanswerable(`search answered ${search.status}`);
+  const entry = JSON.parse(search.body).results?.find(
+    result => result.id === LIBRARY
+  );
+  if (!entry)
+    unanswerable(
+      `${LIBRARY} is not in Context7's search results; register it first`
+    );
+  if (entry.state !== "finalized")
+    unanswerable(`${LIBRARY} is in state "${entry.state}"`);
+
+  // 2. Pull as much of the index as one request returns, and read what it cites.
+  const dump = await fetchText(`${API}${LIBRARY}?type=txt&tokens=50000`);
+  if (dump.status !== 200) unanswerable(`${LIBRARY} answered ${dump.status}`);
+  const cited = citedPaths(dump.body);
+  const findings = citationFindings(cited, config);
+
+  // 3. A docs sentence comes back for its own topic; an excluded file's does not. The
+  //    positive half comes first, because the negative half proves nothing without it.
+  const docsMarker = firstHeading(
+    readFileSync(join(root, "docs", "getting-started", "index.mdx"), "utf-8"),
+    "docs/getting-started/index.mdx"
+  );
+  const docsAnswer = await fetchText(
+    `${API}${LIBRARY}?type=txt&topic=${encodeURIComponent(docsMarker)}&tokens=5000`
+  );
+  if (docsAnswer.status !== 200 || !docsAnswer.body.includes(docsMarker)) {
+    findings.push(
+      `the index cannot return "${docsMarker}" from docs/getting-started/index.mdx, so an absence would prove nothing`
+    );
+  } else {
+    const agentsMarker = firstHeading(
+      readFileSync(join(root, "AGENTS.md"), "utf-8"),
+      "AGENTS.md"
+    );
+    const agentsAnswer = await fetchText(
+      `${API}${LIBRARY}?type=txt&topic=${encodeURIComponent(agentsMarker)}&tokens=5000`
+    );
+    if (
+      agentsAnswer.status === 200 &&
+      agentsAnswer.body.includes(agentsMarker)
+    ) {
+      findings.push(
+        `"${agentsMarker}" from AGENTS.md is retrievable; the exclusion did not take`
+      );
+    }
+  }
+
+  if (findings.length > 0) {
+    console.error(
+      `check-context7-index: ${findings.length} finding(s) against ${cited.size} cited file(s)`
+    );
+    for (const finding of findings) console.error(`  - ${finding}`);
+    process.exit(1);
+  }
+
+  console.log(
+    `check-context7-index: ${LIBRARY} finalized; ${cited.size} cited file(s) all inside the configuration; docs retrievable, AGENTS.md not.`
+  );
+}

--- a/scripts/check-context7-index.mjs
+++ b/scripts/check-context7-index.mjs
@@ -61,9 +61,16 @@ function listField(config, name) {
   return Array.isArray(config[name]) ? config[name] : [];
 }
 
-/** Root-level Markdown, which Context7 reads whatever `folders` says. */
-function isRootMarkdown(path) {
-  return !path.includes("/") && path.endsWith(".md");
+/**
+ * The one root file the configuration means to keep.
+ *
+ * Context7 reads every root Markdown file whatever `folders` says, and the configuration
+ * names the rest to exclude them. A cited root file that is neither the README nor named
+ * there, such as a CHANGELOG Context7's defaults are trusted to drop, is a file the index
+ * holds that the configuration never agreed to.
+ */
+function isKeptRoot(path) {
+  return path === README;
 }
 
 function isInside(path, folders) {
@@ -73,16 +80,16 @@ function isInside(path, folders) {
 /**
  * Why one cited path disagrees with the configuration, or `null`.
  *
- * A root-level Markdown file is allowed unless `excludeFiles` names it, which is the rule
- * Context7 documents; anything else must sit under a listed folder.
+ * A file must sit under a listed folder, or be the README; anything else the index cites is
+ * a file it holds that the configuration never agreed to.
  */
 export function citationFinding(path, config) {
   const folders = listField(config, "folders");
   if (listField(config, "excludeFiles").includes(path)) {
     return `${path} is in excludeFiles and was indexed anyway`;
   }
-  if (isInside(path, folders) || isRootMarkdown(path)) return null;
-  return `${path} is outside folders ${JSON.stringify(folders)} and was indexed`;
+  if (isInside(path, folders) || isKeptRoot(path)) return null;
+  return `${path} is outside folders ${JSON.stringify(folders)} and is not the README, and was indexed`;
 }
 
 /**
@@ -188,6 +195,15 @@ async function retrievable(get, api, marker, name) {
   return answer.body.includes(marker);
 }
 
+/** A JSON body, or `Unanswerable`: a truncated or non-JSON answer is no verdict either. */
+function parseAnswer(body, what) {
+  try {
+    return JSON.parse(body);
+  } catch {
+    throw new Unanswerable(`${what} answered with a body that is not JSON`);
+  }
+}
+
 /** The library's search entry, once it exists and has finished indexing. */
 async function finalizedEntry(get, api) {
   const search = await get(
@@ -195,7 +211,7 @@ async function finalizedEntry(get, api) {
   );
   if (search.status !== 200)
     throw new Unanswerable(`search answered ${search.status}`);
-  const entry = JSON.parse(search.body).results?.find(
+  const entry = parseAnswer(search.body, "search").results?.find(
     result => result.id === LIBRARY
   );
   if (!entry) {

--- a/scripts/check-context7-index.mjs
+++ b/scripts/check-context7-index.mjs
@@ -10,12 +10,13 @@
  * whether a sentence from a file the configuration excludes can be retrieved from it.
  *
  * Every assertion here is POSITIVE first. "No AGENTS.md content came back" is satisfied by
- * a library that is not indexed at all, so the library has to be found and finalized, and a
- * docs sentence has to be retrievable, before an absence means anything.
+ * a library that is not indexed at all, so the library has to be found and finalized, and
+ * a docs sentence and the README's have to be retrievable, before an absence means anything.
  *
  * Exit status: 0 the index agrees with the configuration; 1 it does not; 2 the question
- * could not be answered — not registered yet, still indexing, or Context7 unreachable —
- * which a caller must never read as a pass.
+ * could not be answered — not registered yet, still indexing, Context7 unreachable, or a
+ * probe that got no answer — which a caller must never read as a pass. Nothing here passes
+ * on a question it could not ask.
  *
  * Usage:
  *   node scripts/check-context7-index.mjs
@@ -28,6 +29,14 @@ export const LIBRARY = "/nextlyhq/nextly";
 /** Overridable so a test can point the script at a port nothing listens on. */
 const API = process.env.CONTEXT7_API ?? "https://context7.com/api/v1";
 export const REPO_BLOB = "https://github.com/nextlyhq/nextly/blob/";
+
+/** The page whose retrievability proves the index answers for the docs at all. */
+const DOCS_WITNESS = "docs/getting-started/index.mdx";
+/** Root Markdown the configuration keeps, whose retrievability proves that inclusion. */
+const README = "README.md";
+
+/** "I could not answer", as distinct from "the answer is no". */
+export class Unanswerable extends Error {}
 
 /**
  * The repository paths an index dump cites.
@@ -107,17 +116,25 @@ export function headings(text) {
   return [...text.matchAll(/^#{1,2}\s+(.+)$/gm)].map(match => match[1].trim());
 }
 
+/** Lines of a file that could stand as a marker: prose, not markup, long enough to be one. */
+function markerLines(text) {
+  return text
+    .split("\n")
+    .map(line => line.trim())
+    .filter(line => line.length >= 8 && !/^[<|\-*#`]/.test(line));
+}
+
 /**
- * A heading of an EXCLUDED file that no documentation page contains.
+ * A sentence of a file that no documentation page contains.
  *
- * The probe asks the index for a heading and requires it absent, so a heading
- * the docs also use would report an exclusion as broken when the index had
- * merely answered from the docs: "Overview" and "packages" both do. The first
- * heading the corpus does not contain is the marker; a file with none, such as
- * a one-line `CLAUDE.md`, has nothing to probe and says so.
+ * The probe asks the index for the sentence and reads the answer, so a heading the docs
+ * also use would find the docs: "Overview" and "packages" both do. Headings are tried
+ * first, then any line of prose, which is what a one-line `CLAUDE.md` has. `null` means
+ * the file offers nothing to ask for, and the caller must not read that as a pass.
  */
 export function probeMarker(text, corpus) {
-  return headings(text).find(heading => !corpus.includes(heading)) ?? null;
+  const candidates = [...headings(text), ...markerLines(text)];
+  return candidates.find(candidate => !corpus.includes(candidate)) ?? null;
 }
 
 /** The documentation, concatenated, for deciding what a marker must not share. */
@@ -135,28 +152,189 @@ function docsCorpus(root) {
   return out.join("\n");
 }
 
-function unanswerable(message) {
-  console.error(`check-context7-index: cannot answer — ${message}`);
-  process.exit(2);
-}
-
 /**
- * Context7's answer, or an exit with the unanswerable status.
+ * Context7's answer, or `Unanswerable`.
  *
- * A rejected fetch (DNS, TLS, a proxy, a dropped connection) is not a verdict
- * about the index. Left to propagate it would exit 1, and a caller would read
- * a Context7 outage as the configuration being wrong.
+ * A rejected fetch (DNS, TLS, a proxy, a dropped connection) is not a verdict about the
+ * index. Left to propagate it would exit 1, and a caller would read a Context7 outage as
+ * the configuration being wrong.
  */
-async function fetchText(url) {
+export async function fetchText(url) {
   try {
     const response = await fetch(url, {
       headers: { accept: "text/plain, application/json" },
     });
     return { status: response.status, body: await response.text() };
   } catch (error) {
-    return unanswerable(
+    throw new Unanswerable(
       `${url} could not be fetched: ${error instanceof Error ? error.message : String(error)}`
     );
+  }
+}
+
+/**
+ * Whether the index returns a sentence for its own topic.
+ *
+ * A non-200 is not "no": it is the question going unanswered, and it stops the run rather
+ * than being counted as an absence that would then clear an exclusion.
+ */
+async function retrievable(get, api, marker, name) {
+  const answer = await get(
+    `${api}${LIBRARY}?type=txt&topic=${encodeURIComponent(marker)}&tokens=5000`
+  );
+  if (answer.status !== 200) {
+    throw new Unanswerable(`probing for ${name} answered ${answer.status}`);
+  }
+  return answer.body.includes(marker);
+}
+
+/** The library's search entry, once it exists and has finished indexing. */
+async function finalizedEntry(get, api) {
+  const search = await get(
+    `${api}/search?query=${encodeURIComponent("nextly")}`
+  );
+  if (search.status !== 200)
+    throw new Unanswerable(`search answered ${search.status}`);
+  const entry = JSON.parse(search.body).results?.find(
+    result => result.id === LIBRARY
+  );
+  if (!entry) {
+    throw new Unanswerable(
+      `${LIBRARY} is not in Context7's search results; register it first`
+    );
+  }
+  if (entry.state !== "finalized") {
+    throw new Unanswerable(`${LIBRARY} is in state "${entry.state}"`);
+  }
+  return entry;
+}
+
+/** A marker for a file, or `Unanswerable` when the file offers nothing to ask for. */
+function markerFor(root, name, corpus) {
+  const marker = probeMarker(readFileSync(join(root, name), "utf-8"), corpus);
+  if (marker === null)
+    throw new Unanswerable(`${name} offers no sentence to ask for`);
+  return marker;
+}
+
+/**
+ * Whether what the configuration keeps comes back for its own topic.
+ *
+ * A docs page and the README. Each is a positive control for every absence the exclusion
+ * probes report, and the README's is also the only way to see root Markdown was kept,
+ * since the citation sample cannot. A control that fails is a finding, and the exclusions
+ * are then not probed at all: their absences would prove nothing.
+ */
+async function keptControls({ root, api, get, corpus }) {
+  const kept = [
+    [
+      DOCS_WITNESS,
+      firstHeading(
+        readFileSync(join(root, DOCS_WITNESS), "utf-8"),
+        DOCS_WITNESS
+      ),
+    ],
+    [README, markerFor(root, README, corpus)],
+  ];
+  const findings = [];
+  for (const [name, marker] of kept) {
+    if (await retrievable(get, api, marker, name)) continue;
+    findings.push(
+      `the index cannot return "${marker}" from ${name}; an absence would prove nothing`
+    );
+  }
+  return findings;
+}
+
+/**
+ * Every excluded file, probed for a sentence of its own. Not a sample of them, and one
+ * that offers nothing to ask for stops the run: a "not probed" would read as a pass to
+ * whoever only sees the status.
+ */
+async function exclusionFindings({ root, api, get, config, corpus }) {
+  const findings = [];
+  for (const name of listField(config, "excludeFiles")) {
+    if (!existsSync(join(root, name))) continue;
+    const marker = markerFor(root, name, corpus);
+    if (await retrievable(get, api, marker, name)) {
+      findings.push(
+        `"${marker}" from ${name} is retrievable; its exclusion did not take`
+      );
+    }
+  }
+  return findings;
+}
+
+/** The findings the index earns against the configuration, given a working library. */
+async function indexFindings({ root, api, get, config, cited }) {
+  const corpus = docsCorpus(root);
+  const findings = [
+    ...citationFindings(cited, config),
+    ...(await keptControls({ root, api, get, corpus })),
+  ];
+  if (
+    findings.some(finding => finding.includes("an absence would prove nothing"))
+  ) {
+    return findings;
+  }
+  return [
+    ...findings,
+    ...(await exclusionFindings({ root, api, get, config, corpus })),
+  ];
+}
+
+/** The status and the lines to print, from what the index earned. */
+function report(cited, findings) {
+  if (findings.length > 0) {
+    return {
+      status: 1,
+      lines: [
+        `check-context7-index: ${findings.length} finding(s) against ${cited.size} sampled citation(s)`,
+        ...findings.map(finding => `  - ${finding}`),
+      ],
+    };
+  }
+  return {
+    status: 0,
+    lines: [
+      `check-context7-index: ${LIBRARY} finalized; ${cited.size} sampled citation(s) all inside the configuration; docs and README retrievable, no excluded file's sentence is.`,
+    ],
+  };
+}
+
+/**
+ * The verdict, as a status and the lines to print.
+ *
+ * `get` is injectable so a test can stand in for Context7 with scripted answers and hold
+ * every branch of the judgement, including the ones only an outage or a misindexing
+ * would reach.
+ */
+export async function verify({ root, api = API, get = fetchText }) {
+  try {
+    const config = JSON.parse(
+      readFileSync(join(root, "context7.json"), "utf-8")
+    );
+    await finalizedEntry(get, api);
+
+    // The citation dump is one capped response and the documentation is larger than it,
+    // so it is a sample; the exclusions are probed one by one rather than read off it.
+    const dump = await get(`${api}${LIBRARY}?type=txt&tokens=50000`);
+    if (dump.status !== 200)
+      throw new Unanswerable(`${LIBRARY} answered ${dump.status}`);
+    const cited = citedPaths(dump.body);
+
+    return report(
+      cited,
+      await indexFindings({ root, api, get, config, cited })
+    );
+  } catch (error) {
+    if (error instanceof Unanswerable) {
+      return {
+        status: 2,
+        lines: [`check-context7-index: cannot answer — ${error.message}`],
+      };
+    }
+    throw error;
   }
 }
 
@@ -164,82 +342,8 @@ const invokedDirectly =
   process.argv[1] && process.argv[1].endsWith("check-context7-index.mjs");
 
 if (invokedDirectly) {
-  const root = process.cwd();
-  const config = JSON.parse(readFileSync(join(root, "context7.json"), "utf-8"));
-
-  // 1. The library exists and has finished indexing.
-  const search = await fetchText(
-    `${API}/search?query=${encodeURIComponent("nextly")}`
-  );
-  if (search.status !== 200) unanswerable(`search answered ${search.status}`);
-  const entry = JSON.parse(search.body).results?.find(
-    result => result.id === LIBRARY
-  );
-  if (!entry)
-    unanswerable(
-      `${LIBRARY} is not in Context7's search results; register it first`
-    );
-  if (entry.state !== "finalized")
-    unanswerable(`${LIBRARY} is in state "${entry.state}"`);
-
-  // 2. Read what the index cites, within one response. The documentation is larger
-  //    than one response, so this is a sample of the citations, and it is why the
-  //    exclusions are probed one by one below rather than read off this list.
-  const dump = await fetchText(`${API}${LIBRARY}?type=txt&tokens=50000`);
-  if (dump.status !== 200) unanswerable(`${LIBRARY} answered ${dump.status}`);
-  const cited = citedPaths(dump.body);
-  const findings = citationFindings(cited, config);
-
-  // 3. A docs sentence comes back for its own topic. The positive half comes first,
-  //    because every absence below proves nothing without it.
-  const docsMarker = firstHeading(
-    readFileSync(join(root, "docs", "getting-started", "index.mdx"), "utf-8"),
-    "docs/getting-started/index.mdx"
-  );
-  const docsAnswer = await fetchText(
-    `${API}${LIBRARY}?type=txt&topic=${encodeURIComponent(docsMarker)}&tokens=5000`
-  );
-  const docsRetrievable =
-    docsAnswer.status === 200 && docsAnswer.body.includes(docsMarker);
-  if (!docsRetrievable) {
-    findings.push(
-      `the index cannot return "${docsMarker}" from docs/getting-started/index.mdx, so an absence would prove nothing`
-    );
-  }
-
-  // 4. No excluded file's heading comes back. Every excluded file is probed, not a
-  //    sample of them: the dump above is capped at one response, and a file the cap
-  //    left out would otherwise pass by never having been looked at.
-  const corpus = docsCorpus(root);
-  for (const name of listField(config, "excludeFiles")) {
-    if (!docsRetrievable) break;
-    if (!existsSync(join(root, name))) continue;
-    const marker = probeMarker(readFileSync(join(root, name), "utf-8"), corpus);
-    if (marker === null) {
-      console.warn(
-        `check-context7-index: ${name} has no heading the docs lack; not probed`
-      );
-      continue;
-    }
-    const answer = await fetchText(
-      `${API}${LIBRARY}?type=txt&topic=${encodeURIComponent(marker)}&tokens=5000`
-    );
-    if (answer.status === 200 && answer.body.includes(marker)) {
-      findings.push(
-        `"${marker}" from ${name} is retrievable; its exclusion did not take`
-      );
-    }
-  }
-
-  if (findings.length > 0) {
-    console.error(
-      `check-context7-index: ${findings.length} finding(s) against ${cited.size} cited file(s)`
-    );
-    for (const finding of findings) console.error(`  - ${finding}`);
-    process.exit(1);
-  }
-
-  console.log(
-    `check-context7-index: ${LIBRARY} finalized; ${cited.size} sampled citation(s) all inside the configuration; docs retrievable, no excluded file's heading is.`
-  );
+  const { status, lines } = await verify({ root: process.cwd() });
+  const out = status === 0 ? console.log : console.error;
+  for (const line of lines) out(line);
+  process.exit(status);
 }

--- a/scripts/check-context7-index.mjs
+++ b/scripts/check-context7-index.mjs
@@ -21,11 +21,12 @@
  *   node scripts/check-context7-index.mjs
  */
 
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
 export const LIBRARY = "/nextlyhq/nextly";
-const API = "https://context7.com/api/v1";
+/** Overridable so a test can point the script at a port nothing listens on. */
+const API = process.env.CONTEXT7_API ?? "https://context7.com/api/v1";
 export const REPO_BLOB = "https://github.com/nextlyhq/nextly/blob/";
 
 /**
@@ -101,16 +102,62 @@ export function firstHeading(text, name) {
   return match[1].trim();
 }
 
-async function fetchText(url) {
-  const response = await fetch(url, {
-    headers: { accept: "text/plain, application/json" },
-  });
-  return { status: response.status, body: await response.text() };
+/** Every heading in a file, top-level and second-level, in order. */
+export function headings(text) {
+  return [...text.matchAll(/^#{1,2}\s+(.+)$/gm)].map(match => match[1].trim());
+}
+
+/**
+ * A heading of an EXCLUDED file that no documentation page contains.
+ *
+ * The probe asks the index for a heading and requires it absent, so a heading
+ * the docs also use would report an exclusion as broken when the index had
+ * merely answered from the docs: "Overview" and "packages" both do. The first
+ * heading the corpus does not contain is the marker; a file with none, such as
+ * a one-line `CLAUDE.md`, has nothing to probe and says so.
+ */
+export function probeMarker(text, corpus) {
+  return headings(text).find(heading => !corpus.includes(heading)) ?? null;
+}
+
+/** The documentation, concatenated, for deciding what a marker must not share. */
+function docsCorpus(root) {
+  const out = [];
+  const walk = dir => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name.endsWith(".mdx"))
+        out.push(readFileSync(full, "utf-8"));
+    }
+  };
+  walk(join(root, "docs"));
+  return out.join("\n");
 }
 
 function unanswerable(message) {
   console.error(`check-context7-index: cannot answer — ${message}`);
   process.exit(2);
+}
+
+/**
+ * Context7's answer, or an exit with the unanswerable status.
+ *
+ * A rejected fetch (DNS, TLS, a proxy, a dropped connection) is not a verdict
+ * about the index. Left to propagate it would exit 1, and a caller would read
+ * a Context7 outage as the configuration being wrong.
+ */
+async function fetchText(url) {
+  try {
+    const response = await fetch(url, {
+      headers: { accept: "text/plain, application/json" },
+    });
+    return { status: response.status, body: await response.text() };
+  } catch (error) {
+    return unanswerable(
+      `${url} could not be fetched: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
 }
 
 const invokedDirectly =
@@ -135,14 +182,16 @@ if (invokedDirectly) {
   if (entry.state !== "finalized")
     unanswerable(`${LIBRARY} is in state "${entry.state}"`);
 
-  // 2. Pull as much of the index as one request returns, and read what it cites.
+  // 2. Read what the index cites, within one response. The documentation is larger
+  //    than one response, so this is a sample of the citations, and it is why the
+  //    exclusions are probed one by one below rather than read off this list.
   const dump = await fetchText(`${API}${LIBRARY}?type=txt&tokens=50000`);
   if (dump.status !== 200) unanswerable(`${LIBRARY} answered ${dump.status}`);
   const cited = citedPaths(dump.body);
   const findings = citationFindings(cited, config);
 
-  // 3. A docs sentence comes back for its own topic; an excluded file's does not. The
-  //    positive half comes first, because the negative half proves nothing without it.
+  // 3. A docs sentence comes back for its own topic. The positive half comes first,
+  //    because every absence below proves nothing without it.
   const docsMarker = firstHeading(
     readFileSync(join(root, "docs", "getting-started", "index.mdx"), "utf-8"),
     "docs/getting-started/index.mdx"
@@ -150,24 +199,34 @@ if (invokedDirectly) {
   const docsAnswer = await fetchText(
     `${API}${LIBRARY}?type=txt&topic=${encodeURIComponent(docsMarker)}&tokens=5000`
   );
-  if (docsAnswer.status !== 200 || !docsAnswer.body.includes(docsMarker)) {
+  const docsRetrievable =
+    docsAnswer.status === 200 && docsAnswer.body.includes(docsMarker);
+  if (!docsRetrievable) {
     findings.push(
       `the index cannot return "${docsMarker}" from docs/getting-started/index.mdx, so an absence would prove nothing`
     );
-  } else {
-    const agentsMarker = firstHeading(
-      readFileSync(join(root, "AGENTS.md"), "utf-8"),
-      "AGENTS.md"
+  }
+
+  // 4. No excluded file's heading comes back. Every excluded file is probed, not a
+  //    sample of them: the dump above is capped at one response, and a file the cap
+  //    left out would otherwise pass by never having been looked at.
+  const corpus = docsCorpus(root);
+  for (const name of listField(config, "excludeFiles")) {
+    if (!docsRetrievable) break;
+    if (!existsSync(join(root, name))) continue;
+    const marker = probeMarker(readFileSync(join(root, name), "utf-8"), corpus);
+    if (marker === null) {
+      console.warn(
+        `check-context7-index: ${name} has no heading the docs lack; not probed`
+      );
+      continue;
+    }
+    const answer = await fetchText(
+      `${API}${LIBRARY}?type=txt&topic=${encodeURIComponent(marker)}&tokens=5000`
     );
-    const agentsAnswer = await fetchText(
-      `${API}${LIBRARY}?type=txt&topic=${encodeURIComponent(agentsMarker)}&tokens=5000`
-    );
-    if (
-      agentsAnswer.status === 200 &&
-      agentsAnswer.body.includes(agentsMarker)
-    ) {
+    if (answer.status === 200 && answer.body.includes(marker)) {
       findings.push(
-        `"${agentsMarker}" from AGENTS.md is retrievable; the exclusion did not take`
+        `"${marker}" from ${name} is retrievable; its exclusion did not take`
       );
     }
   }
@@ -181,6 +240,6 @@ if (invokedDirectly) {
   }
 
   console.log(
-    `check-context7-index: ${LIBRARY} finalized; ${cited.size} cited file(s) all inside the configuration; docs retrievable, AGENTS.md not.`
+    `check-context7-index: ${LIBRARY} finalized; ${cited.size} sampled citation(s) all inside the configuration; docs retrievable, no excluded file's heading is.`
   );
 }

--- a/scripts/check-context7-index.test.mjs
+++ b/scripts/check-context7-index.test.mjs
@@ -1,0 +1,110 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+import {
+  citationFindings,
+  citedPaths,
+  firstHeading,
+  REPO_BLOB,
+} from "./check-context7-index.mjs";
+
+/** A dump in the shape Context7 returns, measured on /upstash/context7. */
+const dump = (...paths) =>
+  paths
+    .map(
+      path => `### A snippet\n\nSource: ${REPO_BLOB}main/${path}\n\nsome text\n`
+    )
+    .join("\n--------------------------------\n\n");
+
+describe("citedPaths", () => {
+  it("reads the path after the ref from every Source line", () => {
+    expect([...citedPaths(dump("docs/index.mdx", "README.md"))]).toEqual([
+      "docs/index.mdx",
+      "README.md",
+    ]);
+  });
+
+  it("ignores a citation of another repository", () => {
+    const text = `Source: https://github.com/upstash/context7/blob/master/docs/x.mdx\n`;
+    expect(citedPaths(text).size).toBe(0);
+  });
+
+  it("reads nothing from a dump with no citations, which the caller reports", () => {
+    expect(citedPaths("no sources here").size).toBe(0);
+  });
+});
+
+describe("citationFindings", () => {
+  const config = { folders: ["docs"], excludeFiles: ["AGENTS.md"] };
+
+  it("is silent when every citation is inside the configuration", () => {
+    expect(
+      citationFindings(
+        new Set(["docs/index.mdx", "docs/a/b.mdx", "README.md"]),
+        config
+      )
+    ).toEqual([]);
+  });
+
+  it("reports an excluded root file that was indexed anyway", () => {
+    expect(
+      citationFindings(new Set(["docs/index.mdx", "AGENTS.md"]), config)
+    ).toEqual(["AGENTS.md is in excludeFiles and was indexed anyway"]);
+  });
+
+  it("reports a file outside the listed folders", () => {
+    expect(
+      citationFindings(new Set(["packages/nextly/README.md"]), config)
+    ).toEqual([
+      'packages/nextly/README.md is outside folders ["docs"] and was indexed',
+    ]);
+  });
+
+  it("reports an empty citation set rather than passing on it", () => {
+    expect(citationFindings(new Set(), config)).toHaveLength(1);
+  });
+});
+
+describe("the committed configuration", () => {
+  it("excludes every root Markdown file that is not documentation", () => {
+    // The list in context7.json is checked against the files that exist, so a
+    // new root file that is not for readers of the product is a failing test
+    // rather than a surprise in the index.
+    const config = JSON.parse(readFileSync("context7.json", "utf-8"));
+    const rootMarkdown = readdirSync(".").filter(name => name.endsWith(".md"));
+    // Excluded by Context7's defaults, per its documentation.
+    const defaults = new Set([
+      "CHANGELOG.md",
+      "LICENSE.md",
+      "CODE_OF_CONDUCT.md",
+    ]);
+    const forReaders = new Set(["README.md"]);
+    const unaccounted = rootMarkdown.filter(
+      name =>
+        !config.excludeFiles.includes(name) &&
+        !defaults.has(name) &&
+        !forReaders.has(name)
+    );
+    expect(unaccounted).toEqual([]);
+  });
+
+  it("names only files that exist, so a rename cannot leave one indexed", () => {
+    const config = JSON.parse(readFileSync("context7.json", "utf-8"));
+    expect(config.excludeFiles.filter(name => !existsSync(name))).toEqual([]);
+    expect(config.folders.filter(name => !existsSync(name))).toEqual([]);
+  });
+});
+
+describe("firstHeading", () => {
+  it("takes the first second-level heading", () => {
+    expect(firstHeading("# T\n\ntext\n\n## First\n\n## Second\n", "x")).toBe(
+      "First"
+    );
+  });
+
+  it("refuses a page with none, rather than probing for an empty string", () => {
+    expect(() => firstHeading("# T\n\ntext\n", "x")).toThrow(
+      /no second-level heading/
+    );
+  });
+});

--- a/scripts/check-context7-index.test.mjs
+++ b/scripts/check-context7-index.test.mjs
@@ -1,4 +1,4 @@
-import { spawnSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
@@ -58,11 +58,18 @@ describe("citationFindings", () => {
     ).toEqual(["AGENTS.md is in excludeFiles and was indexed anyway"]);
   });
 
+  it("reports a root file that is neither the README nor excluded", () => {
+    // A CHANGELOG Context7's defaults are trusted to drop, cited anyway.
+    expect(citationFindings(new Set(["CHANGELOG.md"]), config)).toEqual([
+      'CHANGELOG.md is outside folders ["docs"] and is not the README, and was indexed',
+    ]);
+  });
+
   it("reports a file outside the listed folders", () => {
     expect(
       citationFindings(new Set(["packages/nextly/README.md"]), config)
     ).toEqual([
-      'packages/nextly/README.md is outside folders ["docs"] and was indexed',
+      'packages/nextly/README.md is outside folders ["docs"] and is not the README, and was indexed',
     ]);
   });
 
@@ -77,7 +84,13 @@ describe("the committed configuration", () => {
     // new root file that is not for readers of the product is a failing test
     // rather than a surprise in the index.
     const config = JSON.parse(readFileSync("context7.json", "utf-8"));
-    const rootMarkdown = readdirSync(".").filter(name => name.endsWith(".md"));
+    // Tracked files, not the directory: Context7 indexes what is committed,
+    // and a contributor's untracked NOTES.md is not the repository's problem.
+    const rootMarkdown = execFileSync("git", ["ls-files", "--", "*.md"], {
+      encoding: "utf-8",
+    })
+      .split("\n")
+      .filter(name => name.endsWith(".md") && !name.includes("/"));
     // Excluded by Context7's defaults, per its documentation.
     const defaults = new Set([
       "CHANGELOG.md",
@@ -92,6 +105,11 @@ describe("the committed configuration", () => {
         !forReaders.has(name)
     );
     expect(unaccounted).toEqual([]);
+  });
+
+  it("keeps the README, which is the one root file meant to be indexed", () => {
+    const config = JSON.parse(readFileSync("context7.json", "utf-8"));
+    expect(config.excludeFiles).not.toContain("README.md");
   });
 
   it("names only files that exist, so a rename cannot leave one indexed", () => {
@@ -282,6 +300,15 @@ describe("verify", () => {
     });
     expect(status).toBe(2);
     expect(lines.join("\n")).toContain("answered 500");
+  });
+
+  it("cannot answer when the search body is not JSON", async () => {
+    const { status, lines } = await verify({
+      root: ".",
+      get: async () => ({ status: 200, body: "<html>rate limited</html>" }),
+    });
+    expect(status).toBe(2);
+    expect(lines.join("\n")).toContain("not JSON");
   });
 
   it("cannot answer when the transport fails", async () => {

--- a/scripts/check-context7-index.test.mjs
+++ b/scripts/check-context7-index.test.mjs
@@ -7,8 +7,11 @@ import {
   citedPaths,
   firstHeading,
   headings,
+  LIBRARY,
   probeMarker,
   REPO_BLOB,
+  Unanswerable,
+  verify,
 } from "./check-context7-index.mjs";
 
 /** A dump in the shape Context7 returns, measured on /upstash/context7. */
@@ -123,9 +126,10 @@ describe("probeMarker", () => {
     );
   });
 
-  it("reports nothing to probe for a file with no unshared heading", () => {
-    expect(probeMarker("@AGENTS.md\n", "")).toBeNull();
+  it("falls back to a line of prose, and reports nothing when every line is shared", () => {
+    expect(probeMarker("@AGENTS.md\n", "")).toBe("@AGENTS.md");
     expect(probeMarker("## Setup\n", "## Setup")).toBeNull();
+    expect(probeMarker("<p>markup</p>\n- a list\n", "")).toBeNull();
   });
 
   it("finds a marker in every committed excluded file that has headings", () => {
@@ -137,10 +141,158 @@ describe("probeMarker", () => {
       .map(name => readFileSync(`docs/${name}`, "utf-8"))
       .join("\n");
     expect(corpus.length).toBeGreaterThan(10000);
+    // Every excluded file, CLAUDE.md included: its one line, `@AGENTS.md`, is a
+    // sentence the docs do not contain, so even that file can be asked for.
     const unprobeable = config.excludeFiles.filter(
       name => probeMarker(readFileSync(name, "utf-8"), corpus) === null
     );
-    expect(unprobeable).toEqual(["CLAUDE.md"]);
+    expect(unprobeable).toEqual([]);
+  });
+});
+
+/** What the search endpoint says about the library. */
+function searchAnswer({ registered, state }) {
+  const results = registered ? [{ id: LIBRARY, state }] : [];
+  return { status: 200, body: JSON.stringify({ results }) };
+}
+
+/** What a topic query returns: the sentence, when the script says the index has it. */
+function topicAnswer(topic, topics) {
+  return {
+    status: 200,
+    body: topics[topic] ? `### x\n\n${topic}\n` : "nothing\n",
+  };
+}
+
+/**
+ * A Context7 that answers from a script.
+ *
+ * `topics` maps a probed sentence to whether the index "returns" it; anything
+ * not listed comes back empty. The real files under the repository root are
+ * read for their markers, so the stand-in answers the questions the script
+ * really asks.
+ */
+function context7({
+  state = "finalized",
+  registered = true,
+  cites = ["docs/index.mdx", "README.md"],
+  topics = {},
+  statusFor = () => 200,
+} = {}) {
+  const dump = cites
+    .map(path => `Source: ${REPO_BLOB}main/${path}\n`)
+    .join("\n");
+  return async url => {
+    const status = statusFor(url);
+    if (status !== 200) return { status, body: "" };
+    if (url.includes("/search?")) return searchAnswer({ registered, state });
+    const topic = new URL(url).searchParams.get("topic");
+    return topic === null
+      ? { status: 200, body: dump }
+      : topicAnswer(topic, topics);
+  };
+}
+
+/** The markers the script will ask for, read from the real files. */
+function realMarkers() {
+  const corpus = readdirSync("docs", { recursive: true })
+    .filter(name => String(name).endsWith(".mdx"))
+    .map(name => readFileSync(`docs/${name}`, "utf-8"))
+    .join("\n");
+  const config = JSON.parse(readFileSync("context7.json", "utf-8"));
+  return {
+    docs: firstHeading(
+      readFileSync("docs/getting-started/index.mdx", "utf-8"),
+      "docs"
+    ),
+    readme: probeMarker(readFileSync("README.md", "utf-8"), corpus),
+    excluded: Object.fromEntries(
+      config.excludeFiles
+        .filter(name => existsSync(name))
+        .map(name => [name, probeMarker(readFileSync(name, "utf-8"), corpus)])
+    ),
+  };
+}
+
+describe("verify", () => {
+  const markers = realMarkers();
+  const kept = { [markers.docs]: true, [markers.readme]: true };
+
+  it("passes when the kept files come back and no excluded file does", async () => {
+    const { status, lines } = await verify({
+      root: ".",
+      get: context7({ topics: kept }),
+    });
+    expect(lines.join("\n")).toContain("finalized");
+    expect(status).toBe(0);
+  });
+
+  it("fails when an excluded file's sentence is retrievable", async () => {
+    const [name, marker] = Object.entries(markers.excluded)[0];
+    const { status, lines } = await verify({
+      root: ".",
+      get: context7({ topics: { ...kept, [marker]: true } }),
+    });
+    expect(status).toBe(1);
+    expect(lines.join("\n")).toContain(`from ${name} is retrievable`);
+  });
+
+  it("fails when the README, which the configuration keeps, cannot be retrieved", async () => {
+    const { status, lines } = await verify({
+      root: ".",
+      get: context7({ topics: { [markers.docs]: true } }),
+    });
+    expect(status).toBe(1);
+    expect(lines.join("\n")).toContain(
+      "from README.md; an absence would prove nothing"
+    );
+  });
+
+  it("fails when a cited file is one the configuration excludes", async () => {
+    const { status, lines } = await verify({
+      root: ".",
+      get: context7({ topics: kept, cites: ["docs/index.mdx", "AGENTS.md"] }),
+    });
+    expect(status).toBe(1);
+    expect(lines.join("\n")).toContain(
+      "AGENTS.md is in excludeFiles and was indexed anyway"
+    );
+  });
+
+  it("cannot answer while the library is unregistered or still indexing", async () => {
+    expect(
+      (await verify({ root: ".", get: context7({ registered: false }) })).status
+    ).toBe(2);
+    expect(
+      (await verify({ root: ".", get: context7({ state: "initial" }) })).status
+    ).toBe(2);
+  });
+
+  it("cannot answer when a probe gets no answer, rather than counting it as absent", async () => {
+    // The excluded-file probe answers 500. Read as "not retrievable" it would
+    // clear the exclusion; it is the question going unanswered.
+    const excludedMarker = Object.values(markers.excluded)[0];
+    const { status, lines } = await verify({
+      root: ".",
+      get: context7({
+        topics: kept,
+        statusFor: url =>
+          decodeURIComponent(url).includes(excludedMarker) ? 500 : 200,
+      }),
+    });
+    expect(status).toBe(2);
+    expect(lines.join("\n")).toContain("answered 500");
+  });
+
+  it("cannot answer when the transport fails", async () => {
+    const { status, lines } = await verify({
+      root: ".",
+      get: async () => {
+        throw new Unanswerable("boom");
+      },
+    });
+    expect(status).toBe(2);
+    expect(lines.join("\n")).toContain("cannot answer");
   });
 });
 

--- a/scripts/check-context7-index.test.mjs
+++ b/scripts/check-context7-index.test.mjs
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
@@ -5,6 +6,8 @@ import {
   citationFindings,
   citedPaths,
   firstHeading,
+  headings,
+  probeMarker,
   REPO_BLOB,
 } from "./check-context7-index.mjs";
 
@@ -106,5 +109,53 @@ describe("firstHeading", () => {
     expect(() => firstHeading("# T\n\ntext\n", "x")).toThrow(
       /no second-level heading/
     );
+  });
+});
+
+describe("probeMarker", () => {
+  it("takes the first heading the documentation does not contain", () => {
+    const file = "# Title\n\n## Overview\n\n## Repository map\n";
+    expect(headings(file)).toEqual(["Title", "Overview", "Repository map"]);
+    // "Overview" is a heading a docs page also uses, so probing for it would
+    // find the docs and report the exclusion as broken.
+    expect(probeMarker(file, "## Overview\n\n## Title of a page")).toBe(
+      "Repository map"
+    );
+  });
+
+  it("reports nothing to probe for a file with no unshared heading", () => {
+    expect(probeMarker("@AGENTS.md\n", "")).toBeNull();
+    expect(probeMarker("## Setup\n", "## Setup")).toBeNull();
+  });
+
+  it("finds a marker in every committed excluded file that has headings", () => {
+    // The real files against the real docs, so the probe has something to ask
+    // for; CLAUDE.md is one line and is the known exception.
+    const config = JSON.parse(readFileSync("context7.json", "utf-8"));
+    const corpus = readdirSync("docs", { recursive: true })
+      .filter(name => String(name).endsWith(".mdx"))
+      .map(name => readFileSync(`docs/${name}`, "utf-8"))
+      .join("\n");
+    expect(corpus.length).toBeGreaterThan(10000);
+    const unprobeable = config.excludeFiles.filter(
+      name => probeMarker(readFileSync(name, "utf-8"), corpus) === null
+    );
+    expect(unprobeable).toEqual(["CLAUDE.md"]);
+  });
+});
+
+describe("when Context7 cannot be reached", () => {
+  it("exits 2, never 1, so an outage is not read as a wrong configuration", () => {
+    // A port nothing listens on: the fetch rejects before any verdict exists.
+    const run = spawnSync(
+      process.execPath,
+      ["scripts/check-context7-index.mjs"],
+      {
+        env: { ...process.env, CONTEXT7_API: "http://127.0.0.1:9" },
+        encoding: "utf-8",
+      }
+    );
+    expect(run.status).toBe(2);
+    expect(run.stderr).toContain("cannot answer");
   });
 });

--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -121,11 +121,21 @@ const context7Finding = (check, message) => ({
  * What is wrong with a Context7 configuration, or nothing.
  *
  * The rules are in priority order, and the first that applies is the finding: a file that
- * does not parse says nothing an indexer can use; a description naming the retired category
- * is the claim this whole check exists to stop; and a description that merely differs from
- * the core package's is the drift that lets the first two happen unnoticed.
+ * is not tracked or does not parse says nothing an indexer can use; a description naming
+ * the retired category is the claim this whole check exists to stop; a core package with
+ * no description leaves nothing to follow; and a description that merely differs from the
+ * core package's is the drift that lets the others happen unnoticed. `undefined` is the
+ * untracked file, `null` the unreadable one.
  */
 const CONTEXT7_RULES = [
+  [
+    config => config === undefined,
+    () =>
+      context7Finding(
+        "context7-missing",
+        "is not tracked; without it an indexer reads the whole repository and guesses what the project is"
+      ),
+  ],
   [
     config => config === null || typeof config !== "object",
     () => context7Finding("context7-unreadable", "is not a JSON object"),
@@ -147,7 +157,15 @@ const CONTEXT7_RULES = [
       ),
   ],
   [
-    (config, core) => typeof core === "string" && config.description !== core,
+    (_config, core) => typeof core !== "string" || core.trim() === "",
+    () =>
+      context7Finding(
+        "context7-description",
+        `packages/${CORE_PACKAGE}/package.json has no description for this to follow; the sentence lives there`
+      ),
+  ],
+  [
+    (config, core) => config.description !== core,
     () =>
       context7Finding(
         "context7-description",
@@ -1802,10 +1820,16 @@ export async function runChecks({
   // rather than checked on its own: two sentences saying what Nextly is, in
   // two files nobody reads together, is how the second one was still calling
   // this an app framework months after the first stopped.
-  if (trackedSet.has(CONTEXT7_CONFIG)) {
+  //
+  // Held whether or not the file is there: a configuration that is deleted or
+  // never tracked is an indexer left to guess, and a check that skipped it
+  // would report that as clean.
+  {
     const core = packages.find(pkg => pkg.json.name === CORE_PACKAGE);
     const finding = context7Findings(
-      readContext7Config(join(repoRoot, CONTEXT7_CONFIG)),
+      trackedSet.has(CONTEXT7_CONFIG)
+        ? readContext7Config(join(repoRoot, CONTEXT7_CONFIG))
+        : undefined,
       core?.json.description
     );
     if (finding) findings.push(finding);

--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -95,6 +95,72 @@ export const CATEGORY_SURFACES = [
   "docs/getting-started/index.mdx",
 ];
 
+/** The file Context7 reads to decide what to index, at the repository root. */
+export const CONTEXT7_CONFIG = "context7.json";
+
+/** The package whose description every other statement of the category follows. */
+export const CORE_PACKAGE = "nextly";
+
+/** The parsed configuration, or `null` for a file that is absent or not JSON. */
+export function readContext7Config(path) {
+  try {
+    return JSON.parse(readFileSync(path, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+const context7Finding = (check, message) => ({
+  check,
+  file: CONTEXT7_CONFIG,
+  line: null,
+  message,
+});
+
+/**
+ * What is wrong with a Context7 configuration, or nothing.
+ *
+ * The rules are in priority order, and the first that applies is the finding: a file that
+ * does not parse says nothing an indexer can use; a description naming the retired category
+ * is the claim this whole check exists to stop; and a description that merely differs from
+ * the core package's is the drift that lets the first two happen unnoticed.
+ */
+const CONTEXT7_RULES = [
+  [
+    config => config === null || typeof config !== "object",
+    () => context7Finding("context7-unreadable", "is not a JSON object"),
+  ],
+  [
+    config => typeof config.description !== "string" || config.description.trim() === "",
+    () =>
+      context7Finding(
+        "context7-description",
+        "has no description; an indexer falls back to guessing what the project is"
+      ),
+  ],
+  [
+    config => RETIRED_CATEGORY.test(config.description),
+    () =>
+      context7Finding(
+        "retired-category",
+        `"app framework" — the category is "content platform"; say what this is for`
+      ),
+  ],
+  [
+    (config, core) => typeof core === "string" && config.description !== core,
+    () =>
+      context7Finding(
+        "context7-description",
+        `description differs from packages/${CORE_PACKAGE}/package.json; one sentence says what this is`
+      ),
+  ],
+];
+
+export function context7Findings(config, coreDescription) {
+  const rule = CONTEXT7_RULES.find(([applies]) => applies(config, coreDescription));
+  return rule ? rule[1]() : null;
+}
+
 /**
  * The category the project moved away from.
  *
@@ -1728,6 +1794,21 @@ export async function runChecks({
       line: null,
       message: `"app framework" — the category is "content platform"; say what this is for`,
     });
+  }
+
+  // `context7.json` tells an indexer what the project is, in one sentence an
+  // agent reads before any page. It is a category surface like the npm
+  // description, and it is held to the SAME sentence as the core package's
+  // rather than checked on its own: two sentences saying what Nextly is, in
+  // two files nobody reads together, is how the second one was still calling
+  // this an app framework months after the first stopped.
+  if (trackedSet.has(CONTEXT7_CONFIG)) {
+    const core = packages.find(pkg => pkg.json.name === CORE_PACKAGE);
+    const finding = context7Findings(
+      readContext7Config(join(repoRoot, CONTEXT7_CONFIG)),
+      core?.json.description
+    );
+    if (finding) findings.push(finding);
   }
 
   // --- per-line prose checks ---

--- a/scripts/check-docs-claims.test.mjs
+++ b/scripts/check-docs-claims.test.mjs
@@ -269,6 +269,21 @@ describe("context7", () => {
     ).toContain("context7-description");
   });
 
+  it("fires when the file is not tracked at all", async () => {
+    expect(
+      await checksFor({ "packages/nextly/package.json": core(SENTENCE) })
+    ).toContain("context7-missing");
+  });
+
+  it("fires when the core package has no description to follow", async () => {
+    expect(
+      await checksFor({
+        "packages/nextly/package.json": JSON.stringify({ name: "nextly", version: "1.0.0" }),
+        "context7.json": config(SENTENCE),
+      })
+    ).toContain("context7-description");
+  });
+
   it("fires when the file does not parse", async () => {
     expect(
       await checksFor({

--- a/scripts/check-docs-claims.test.mjs
+++ b/scripts/check-docs-claims.test.mjs
@@ -226,6 +226,69 @@ describe("naming-rule", () => {
   });
 });
 
+describe("context7", () => {
+  const core = (description) =>
+    JSON.stringify({ name: "nextly", version: "1.0.0", description });
+  const config = (description) =>
+    JSON.stringify({ projectTitle: "Nextly", description, folders: ["docs"] });
+  const SENTENCE = "Nextly is an open-source CMS and visual page builder for Next.js.";
+
+  it("holds the committed file to the committed core description", async () => {
+    // The real files, not a fixture: this is the parity the check exists for.
+    const { context7Findings, readContext7Config } = await import("./check-docs-claims.mjs");
+    const config = readContext7Config("context7.json");
+    const { description } = JSON.parse(await readFile("packages/nextly/package.json", "utf-8"));
+    expect(config).not.toBeNull();
+    expect(context7Findings(config, description)).toBeNull();
+  });
+
+  it("fires when the description names the retired category", async () => {
+    expect(
+      await checksFor({
+        "packages/nextly/package.json": core(SENTENCE),
+        "context7.json": config("Nextly is an app framework for Next.js."),
+      })
+    ).toContain("retired-category");
+  });
+
+  it("fires when the description drifts from the core package's", async () => {
+    expect(
+      await checksFor({
+        "packages/nextly/package.json": core(SENTENCE),
+        "context7.json": config("Nextly is a CMS for Next.js."),
+      })
+    ).toContain("context7-description");
+  });
+
+  it("fires when there is no description at all", async () => {
+    expect(
+      await checksFor({
+        "packages/nextly/package.json": core(SENTENCE),
+        "context7.json": JSON.stringify({ folders: ["docs"] }),
+      })
+    ).toContain("context7-description");
+  });
+
+  it("fires when the file does not parse", async () => {
+    expect(
+      await checksFor({
+        "packages/nextly/package.json": core(SENTENCE),
+        "context7.json": "{ not json",
+      })
+    ).toContain("context7-unreadable");
+  });
+
+  it("is silent when the two sentences agree", async () => {
+    const checks = await checksFor({
+      "packages/nextly/package.json": core(SENTENCE),
+      "context7.json": config(SENTENCE),
+    });
+    expect(checks).not.toContain("context7-description");
+    expect(checks).not.toContain("context7-unreadable");
+    expect(checks).not.toContain("retired-category");
+  });
+});
+
 describe("retired-category", () => {
   it("declares only surfaces that exist, so a rename cannot drop one silently", async () => {
     const { CATEGORY_SURFACES } = await import("./check-docs-claims.mjs");


### PR DESCRIPTION
`context7.json` at the repository root, so Context7 indexes the documentation for coding agents and nothing else.

## What it says

- `folders: ["docs"]`: the 66 documentation pages, the same tree nextlyhq.com/docs is built from.
- `excludeFiles`: `AGENTS.md`, `AGENTS.measured.md`, `ARCHITECTURE.md`, `CLAUDE.md`, `CONTRIBUTING.md`, `SECURITY.md`, `followup-report.md`. Context7's documentation says root-level Markdown is always included whatever `folders` says, and these are for people working on the repository, not with the product. `README.md` stays in: it is the front door. `CHANGELOG`/`LICENSE`/`CODE_OF_CONDUCT` are excluded by Context7's defaults.
- `rules`: five, taken from what the scaffolded `AGENTS.md.template` already teaches (Direct API on the server, `nextly.users`, `types:generate`, append-only migrations, `nextly --version`). Nothing new is asserted.
- `description`: the core package's sentence, verbatim.

## Two checks, because the file is a request rather than an answer

**`check-docs-claims` now holds `context7.json` to the core package.** It is a category surface like the npm description: one sentence an agent reads before any page. It is checked for the retired category and, separately, for drifting from `packages/nextly/package.json`'s description at all. Six tests; the live parity is asserted against the committed files, not a fixture. Mutation: with the description changed to name the retired category, `node scripts/check-docs-claims.mjs` exits 1 and names `context7.json`; restored, no findings. It reads the git index, so the file had to be staged for the real run to see it, which it now is.

**`pnpm check:context7-index` reads back what Context7 actually indexed.** It requires the library to be found and `finalized`, dumps the index, and checks every cited path against the configuration: excluded files must not appear, everything else must be under `docs/` or root Markdown. Then it asks for the first heading of `docs/getting-started/index.mdx` and requires it back, and only THEN asks for the first heading of `AGENTS.md` and requires it absent: an absence with no positive control would be satisfied by a library that is not indexed at all. Exit 2, never 0, while the library is unregistered. Right now: `cannot answer — /nextlyhq/nextly is not in Context7's search results; register it first`. 11 tests on the parsing and the judgement, plus two over the committed file: every root Markdown file is accounted for, and every name in it exists.

## Gates

`fallow audit`: pass. The first cut tripped the CRAP threshold on two new functions (cyclomatic 8 and 9 against an assumed 0% coverage); both are now rule tables and small predicates. `lint:scripts`, comment convention, `test:scripts` (1249), `check:docs-claims`: all clean. `check-docs-claims.test.mjs` is not Prettier-clean on `main`, so the additions match its local style rather than reformatting 793 lines beside them.

## What this does not do

It does not register the library. Adding a public repository on context7.com is a submission under the project's name, and **claiming** it (which is what lets `context7.json` be authoritative and the index be refreshed on demand) needs the founder's Context7 account and a public key placed in this file. Both are yours; the verification script is ready for the moment either happens. Once the index is `finalized` and the script exits 0, a scheduled workflow running it is the control that catches Context7 starting to index what the configuration excludes; not wired here because it would be red every week until then.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added Context7 configuration to define indexed documentation, exclusions, and usage guidance.

- **New Features**
  - Added a command to verify that the live Context7 index matches the configured documentation scope.
  - Added checks confirming documentation availability and excluded-file handling.

- **Bug Fixes**
  - Added validation to detect missing, outdated, unreadable, or inconsistent Context7 descriptions.

- **Tests**
  - Added coverage for index verification, configuration validation, citation handling, and unavailable service responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->