### PR TITLE
docs: link a page by its URL, and source by its GitHub URL

### DIFF
--- a/docs/admin/index.mdx
+++ b/docs/admin/index.mdx
@@ -69,7 +69,7 @@ Image-size presets and the (programmatic) Permissions page also live under setti
 
 ## Permissions
 
-Nextly's RBAC model uses permission slugs in the form `<action>-<resource>` (e.g. `read-users`, `create-roles`, `update-api-keys`, `manage-settings`). Permissions and the `Super Admin` role are seeded the first time the database is set up — for the core resources (`users`, `roles`, `permissions`) the seeder creates one row per `(action, resource)` pair across `create`, `read`, `update`, `delete`. See [`packages/nextly/src/database/seeders/permissions.ts`](../packages/nextly/src/database/seeders/permissions.ts) for the seeder source.
+Nextly's RBAC model uses permission slugs in the form `<action>-<resource>` (e.g. `read-users`, `create-roles`, `update-api-keys`, `manage-settings`). Permissions and the `Super Admin` role are seeded the first time the database is set up — for the core resources (`users`, `roles`, `permissions`) the seeder creates one row per `(action, resource)` pair across `create`, `read`, `update`, `delete`. See [`packages/nextly/src/database/seeders/permissions.ts`](https://github.com/nextlyhq/nextly/blob/main/packages/nextly/src/database/seeders/permissions.ts) for the seeder source.
 
 The admin sidebar is permission-gated. The built-in mapping is:
 

--- a/docs/guides/draft-published-status.mdx
+++ b/docs/guides/draft-published-status.mdx
@@ -169,6 +169,6 @@ The blog template (`create-nextly-app` blog) ships this migration applied; new p
 
 ## See also
 
-- [Collection configuration reference](../configuration/index.mdx)
-- [Schema Builder admin UI](../schema-builder/index.mdx)
-- [Production migrations](./production-migrations.mdx)
+- [Collection configuration reference](/docs/configuration)
+- [Schema Builder admin UI](/docs/schema-builder)
+- [Production migrations](/docs/guides/production-migrations)

--- a/docs/schema-builder/index.mdx
+++ b/docs/schema-builder/index.mdx
@@ -88,7 +88,7 @@ After save, the new collection appears in the admin sidebar under Collections. T
 | Single | `dynamic_singles` table | Runtime-only: the schema is regenerated from the database row on each request. No files are written. |
 | Component | Database row | Runtime-only: stored alongside dynamic singles. No files are written. |
 
-When you edit and re-save a collection, Nextly emits an additive migration (or, when destructive, prompts for confirmation in the toolbar). The generator avoids re-running migrations that have already been applied — see [`packages/nextly/src/services/collection-file-manager.ts`](../packages/nextly/src/services/collection-file-manager.ts) for the implementation.
+When you edit and re-save a collection, Nextly emits an additive migration (or, when destructive, prompts for confirmation in the toolbar). The generator avoids re-running migrations that have already been applied — see [`packages/nextly/src/services/collection-file-manager.ts`](https://github.com/nextlyhq/nextly/blob/main/packages/nextly/src/services/collection-file-manager.ts) for the implementation.
 
 ## Permissions and visibility
 

--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -419,6 +419,18 @@ const HEX_REF = /^[0-9a-f]{7,40}$/i;
 const INTERNAL_DOCS_LINK = /\]\((\/docs\/[^)\s]*)\)/g;
 
 /**
+ * A link written as a path from the FILE: `../configuration/index.mdx`, `./x.mdx`,
+ * `../packages/...`.
+ *
+ * Five of these existed beside three hundred and eighty `/docs/...` links, and every one was
+ * outside the check above, which reads only the root-relative form. Two pointed at repository
+ * source files and were broken everywhere; three pointed at sibling pages and rendered as
+ * written on the site, which had nothing resolving them. One spelling, the guarded one, is
+ * the boundary: a docs page links to another page by its URL, and to source by its GitHub URL.
+ */
+const FILE_PATH_LINK = /\]\((\.\.?\/[^)\s]*)\)/g;
+
+/**
  * Split a link's tail into the ref and the path under it.
  *
  * The ref boundary is not derivable from the string, so it is resolved against the refs the
@@ -842,6 +854,17 @@ function internalLinks(repoRoot, tracked, findings) {
             message: `links to ${match[1]}, which is not a docs page`,
           });
         }
+      }
+      // Only a published page: a README linking `./CONTRIBUTING.md` is a link GitHub renders.
+      if (!pages.has(rel)) continue;
+      FILE_PATH_LINK.lastIndex = 0;
+      while ((match = FILE_PATH_LINK.exec(lines[i])) !== null) {
+        findings.push({
+          check: "internal-docs-link",
+          file: rel,
+          line: i + 1,
+          message: `links to ${match[1]} as a file path; a page is linked by its URL, /docs/..., and source by its GitHub URL`,
+        });
       }
     }
   }

--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -428,7 +428,24 @@ const INTERNAL_DOCS_LINK = /\]\((\/docs\/[^)\s]*)\)/g;
  * written on the site, which had nothing resolving them. One spelling, the guarded one, is
  * the boundary: a docs page links to another page by its URL, and to source by its GitHub URL.
  */
-const FILE_PATH_LINK = /\]\((\.\.?\/[^)\s]*)\)/g;
+const FILE_PATH_LINK = /(?<!\\)\]\((\.\.?\/[^)\s]*)\)|^ {0,3}\[[^\]\n]+\]:[ \t]*(\.\.?\/\S*)/g;
+
+/**
+ * The text with everything Markdown does not render as prose blanked, line for line.
+ *
+ * A fenced sample that demonstrates a link, an inline code span, or an MDX comment is not a
+ * link; a check that read them as one would refuse a page for teaching the syntax. Blanked
+ * rather than removed so a finding still names the line it was read from: every newline is
+ * kept and every other character inside becomes a space. A fence closes only on its own
+ * marker, so a tilde fence holding backticks is one block.
+ */
+export function codeBlanked(text) {
+  const blank = fragment => fragment.replace(/[^\n]/g, " ");
+  return text
+    .replace(/^ {0,3}(`{3,}|~{3,})[^\n]*\n[\s\S]*?^ {0,3}\1[ \t]*$/gm, blank)
+    .replace(/\{\/\*[\s\S]*?\*\/\}/g, blank)
+    .replace(/(`+)[^`\n][\s\S]*?\1/g, blank);
+}
 
 /**
  * Split a link's tail into the ref and the path under it.
@@ -824,7 +841,9 @@ function pluginRouteMount(repoRoot, tracked, findings, isExempt) {
 }
 
 function internalLinks(repoRoot, tracked, findings) {
-  const pages = new Set(tracked.filter(rel => rel.endsWith(".mdx")));
+  // The published pages are the docs tree, not every `.mdx` git tracks: a
+  // package's README.mdx has GitHub as its surface and its own link rules.
+  const pages = new Set(tracked.filter(rel => rel.startsWith("docs/") && rel.endsWith(".mdx")));
   const resolves = target => {
     const path = target.split("#")[0].replace(/\/+$/, "");
     if (path === "/docs") return true;
@@ -841,7 +860,7 @@ function internalLinks(repoRoot, tracked, findings) {
     } catch {
       continue;
     }
-    const lines = text.split("\n");
+    const lines = codeBlanked(text).split("\n");
     for (let i = 0; i < lines.length; i++) {
       INTERNAL_DOCS_LINK.lastIndex = 0;
       let match;
@@ -863,7 +882,7 @@ function internalLinks(repoRoot, tracked, findings) {
           check: "internal-docs-link",
           file: rel,
           line: i + 1,
-          message: `links to ${match[1]} as a file path; a page is linked by its URL, /docs/..., and source by its GitHub URL`,
+          message: `links to ${match[1] ?? match[2]} as a file path; a page is linked by its URL, /docs/..., and source by its GitHub URL`,
         });
       }
     }

--- a/scripts/check-docs-claims.test.mjs
+++ b/scripts/check-docs-claims.test.mjs
@@ -974,6 +974,32 @@ describe("internal-docs-link", () => {
     }
   });
 
+  it("fires on a reference definition that points at a file", async () => {
+    expect(
+      await checksFor({
+        "docs/guides/a.mdx": "See [config][c].\n\n[c]: ../configuration/index.mdx\n",
+        "docs/configuration/index.mdx": "# c\n",
+      })
+    ).toContain("internal-docs-link");
+  });
+
+  it("does not fire on a link the page only shows, in a fence, a code span or a comment", async () => {
+    // A page teaching the syntax is not linking with it. The prose beside the
+    // samples still is, which is the control that the scan ran on the page.
+    const shown = [
+      "```md",
+      "[local](../README.md)",
+      "```",
+      "",
+      "Inline: `[local](../README.md)` and {/* [gone](../old.mdx) */} here.",
+      "",
+    ].join("\n");
+    expect(await checksFor({ "docs/a.mdx": shown })).not.toContain("internal-docs-link");
+    expect(
+      await checksFor({ "docs/a.mdx": `${shown}\nBut [this](../b.mdx) is a link.\n` })
+    ).toContain("internal-docs-link");
+  });
+
   it("does not fire on a file-path link outside the published pages", async () => {
     // A README's `./CONTRIBUTING.md` is a link GitHub renders; the boundary is
     // the docs, whose links are URLs on the site.
@@ -981,6 +1007,8 @@ describe("internal-docs-link", () => {
       await checksFor({
         "README.md": "See [contributing](./CONTRIBUTING.md).\n",
         "CONTRIBUTING.md": "# c\n",
+        // An `.mdx` outside the docs tree is not a published page either.
+        "packages/example/README.mdx": "See [contributing](./CONTRIBUTING.md).\n",
       })
     ).not.toContain("internal-docs-link");
   });

--- a/scripts/check-docs-claims.test.mjs
+++ b/scripts/check-docs-claims.test.mjs
@@ -958,6 +958,33 @@ describe("internal-docs-link", () => {
     ).not.toContain("internal-docs-link");
   });
 
+  it("fires on a link written as a path from the file, to a page or to source", async () => {
+    for (const body of [
+      "See [config](../configuration/index.mdx).\n",
+      "See [next](./production-migrations.mdx).\n",
+      "See [code](../packages/nextly/src/x.ts).\n",
+    ]) {
+      expect(
+        await checksFor({
+          "docs/guides/a.mdx": body,
+          "docs/configuration/index.mdx": "# c\n",
+          "docs/guides/production-migrations.mdx": "# p\n",
+        })
+      ).toContain("internal-docs-link");
+    }
+  });
+
+  it("does not fire on a file-path link outside the published pages", async () => {
+    // A README's `./CONTRIBUTING.md` is a link GitHub renders; the boundary is
+    // the docs, whose links are URLs on the site.
+    expect(
+      await checksFor({
+        "README.md": "See [contributing](./CONTRIBUTING.md).\n",
+        "CONTRIBUTING.md": "# c\n",
+      })
+    ).not.toContain("internal-docs-link");
+  });
+
   it("ignores the anchor when resolving", async () => {
     expect(
       await checksFor({


### PR DESCRIPTION
Five links in the docs were written as paths from the file, and every one was outside the check that guards docs links.

Measured on nextlyhq.com/docs/guides/draft-published-status: `href="../configuration/index.mdx"`, `href="../schema-builder/index.mdx"`, `href="./production-migrations.mdx"`, rendered exactly as written, all 404. Two more, in `docs/admin` and `docs/schema-builder`, point at repository source files (`../packages/nextly/src/...`) and are broken everywhere they render. The other 380 docs links use `/docs/...`, which `internal-docs-link` resolves; these five used a form it never read, which is the population trap: the check was right about every link it looked at.

## What changes

- The three page links become `/docs/configuration`, `/docs/schema-builder`, `/docs/guides/production-migrations`. The two source links become the file's GitHub URL at `main`, which `dead-branch-link` already resolves against real refs.
- `internal-docs-link` now refuses a `./` or `../` link in a published page, naming the two forms to use. Scoped to `docs/**/*.mdx`: a README's `./CONTRIBUTING.md` is a link GitHub renders, and is left alone (tested).

## Evidence

- With one of the original links put back, `node scripts/check-docs-claims.mjs` exits 1 and names `docs/guides/draft-published-status.mdx:172`; restored, no findings.
- `test:scripts` 1234 passed, including two new cases (fires on all three file-path shapes; silent outside the docs). fallow pass, `lint:scripts`, comment convention, `check:doc-samples` all clean.

Docs and a check only: no changeset.

Found while building the Markdown twins on the site (nextly-site #228), where the same five links surfaced in every twin that carried them. The site now resolves the page form through Fumadocs' own resolver as well, so it is correct either way; this removes the form at the source so nothing has to.
