### PR TITLE
docs(nextly): close the sitemap callout, and compile every page before it leaves

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,6 +249,13 @@ jobs:
         if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: pnpm check:docs-claims
 
+      # The pages under docs/ are compiled by nextlyhq.com, not here, so a page
+      # that does not parse merges green and breaks the site's next deploy.
+      # Compiled with the compiler the site's pipeline is built on.
+      - name: Docs pages compile
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
+        run: pnpm check:docs-compile
+
       # Both lanes select packages with a hand-written filter list, so a package
       # that gains a test task and is not added to one runs NOWHERE, and every
       # job stays green because what would have been reported is absent. That is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,9 @@ for all published packages. Status: alpha, all packages version in lockstep.
   `packages/telemetry` - shared tooling and support packages.
 - `apps/playground` - contributor dev harness (not published).
 - `e2e/` - Playwright suite. `docs/` - user docs (MDX, deployed to
-  nextlyhq.com/docs).
+  nextlyhq.com/docs). Nothing here renders them: the site fetches and
+  compiles them at its build, so `pnpm check:docs-compile` compiles every page
+  with the same MDX compiler and CI refuses one that does not parse.
 
 Before editing a package, read its README.md and check for a nested AGENTS.md.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,9 @@ for all published packages. Status: alpha, all packages version in lockstep.
 - `e2e/` - Playwright suite. `docs/` - user docs (MDX, deployed to
   nextlyhq.com/docs). Nothing here renders them: the site fetches and
   compiles them at its build, so `pnpm check:docs-compile` compiles every page
-  with the same MDX compiler and CI refuses one that does not parse.
+  with the same MDX compiler, parses its frontmatter as the site's loader does,
+  and holds the components it uses to `docs/components.json`, the contract the
+  site registers from the other side. CI refuses a page that would not render.
 - `context7.json` - what Context7 indexes for coding agents: `docs/` and the
   root README, with every other root Markdown file excluded by name (Context7
   reads root-level Markdown whatever `folders` says). Its description is held

--- a/docs/components.json
+++ b/docs/components.json
@@ -1,0 +1,24 @@
+{
+  "$comment": "The MDX components a documentation page may use. nextlyhq.com registers every name here in app/docs/[[...slug]]/page.tsx and holds itself to this list; check-docs-compile holds every page to it. A page using a name that is not here compiles and then fails to render on the site. Fumadocs' default MDX components come first, then the ones the site adds.",
+  "components": [
+    "Callout",
+    "CalloutContainer",
+    "CalloutTitle",
+    "CalloutDescription",
+    "Card",
+    "Cards",
+    "CodeBlockTab",
+    "CodeBlockTabs",
+    "CodeBlockTabsList",
+    "CodeBlockTabsTrigger",
+    "Tab",
+    "Tabs",
+    "Accordion",
+    "Accordions",
+    "Step",
+    "Steps",
+    "File",
+    "Files",
+    "Folder"
+  ]
+}

--- a/docs/plugins/form-builder.mdx
+++ b/docs/plugins/form-builder.mdx
@@ -460,12 +460,12 @@ The rate limit store is in-memory. For multi-instance deployments, consider usin
 
 Configuration is available for Google reCAPTCHA v3. Set the site key and secret key globally or per form.
 
-<Warning>
+<Callout type="warn">
   **Not enforced yet.** The settings below are accepted and stored, and nothing
   verifies a token against Google: submissions are accepted whether the token is
   valid, invalid or absent. Turning it on protects nothing today. The honeypot
   and the rate limit above are enforced.
-</Warning>
+</Callout>
 
 ```typescript
 spamProtection: {

--- a/docs/plugins/seo.mdx
+++ b/docs/plugins/seo.mdx
@@ -198,7 +198,8 @@ Three things that each help, in the order they are worth doing:
    to the plugin route, so it is that route's cache, not the one in front of
    `/sitemap.xml`, that decides whether the origin rebuilds.
 3. **Pass a `skip`** to the rate limiter that does not exempt this path.
-   </Callout>
+
+</Callout>
 
 <Callout type="warn">
 **These exports cannot shard, so do not reach for them from `generateSitemaps()`.**

--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
   },
   "dependencies": {
     "@mdx-js/mdx": "3.1.1",
+    "js-yaml": "4.3.1",
     "zod": "^4.1.12"
   },
   "pnpm": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "check:instance-boot-lane": "node scripts/check-instance-boot-lane.mjs",
     "check:comments": "node scripts/check-comment-convention.mjs",
     "check:docs-claims": "node scripts/check-docs-claims.mjs",
+    "check:docs-compile": "node scripts/check-docs-compile.mjs",
     "check:doc-samples": "node scripts/check-doc-samples.mjs",
     "docs:fix": "node scripts/check-docs-claims.mjs --fix",
     "check:repo-metadata": "node scripts/check-repo-metadata.mjs",
@@ -137,6 +138,7 @@
     "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
   },
   "dependencies": {
+    "@mdx-js/mdx": "3.1.1",
     "zod": "^4.1.12"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
 
   .:
     dependencies:
+      '@mdx-js/mdx':
+        specifier: 3.1.1
+        version: 3.1.1
       zod:
         specifier: ^4.1.12
         version: 4.1.12
@@ -3579,6 +3582,9 @@ packages:
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
+  '@mdx-js/mdx@3.1.1':
+    resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
+
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
     cpu: [arm64]
@@ -5177,8 +5183,14 @@ packages:
   '@types/culori@4.0.1':
     resolution: {integrity: sha512-43M51r/22CjhbOXyGT361GZ9vncSVQ39u62x5eJdBQFviI8zWp2X5jzqg7k4M6PVgDQAClpy2bUe2dtwEgEDVQ==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -5189,6 +5201,9 @@ packages:
   '@types/fs-extra@11.0.4':
     resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
 
+  '@types/hast@3.0.5':
+    resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -5197,6 +5212,15 @@ packages:
 
   '@types/jsonfile@6.1.4':
     resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/mdx@2.0.14':
+    resolution: {integrity: sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
@@ -5235,6 +5259,12 @@ packages:
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
@@ -5442,6 +5472,9 @@ packages:
       codemirror: '>=6.0.0'
       react: '>=17.0.0'
       react-dom: '>=17.0.0'
+
+  '@ungap/structured-clone@1.4.0':
+    resolution: {integrity: sha512-1mEZtMKPM09vDmQt5y7YvmN2+DFTP7Tg0EWXdic8/C6VRnpb33e4ghisCIE3WZjsE2N8mf+QV1Zqh7ZFYLWInQ==}
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -5727,6 +5760,10 @@ packages:
   ast-v8-to-istanbul@1.0.5:
     resolution: {integrity: sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==}
 
+  astring@1.9.0:
+    resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
+    hasBin: true
+
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
@@ -5767,6 +5804,9 @@ packages:
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
+
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -5866,6 +5906,9 @@ packages:
   caniuse-lite@1.0.30001810:
     resolution: {integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -5881,6 +5924,18 @@ packages:
   char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
     engines: {node: '>=10'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
@@ -5950,6 +6005,9 @@ packages:
   codemirror@6.0.2:
     resolution: {integrity: sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==}
 
+  collapse-white-space@2.1.0:
+    resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -5959,6 +6017,9 @@ packages:
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@10.0.1:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
@@ -6116,6 +6177,9 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
@@ -6158,6 +6222,9 @@ packages:
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -6440,6 +6507,12 @@ packages:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
 
+  esast-util-from-estree@2.0.0:
+    resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
+
+  esast-util-from-js@2.0.1:
+    resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
+
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
@@ -6620,6 +6693,24 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-util-attach-comments@3.0.0:
+    resolution: {integrity: sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==}
+
+  estree-util-build-jsx@3.0.1:
+    resolution: {integrity: sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==}
+
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
+  estree-util-scope@1.0.1:
+    resolution: {integrity: sha512-B0np3dcdxqILX5e9nEi5/Fr4K7gL4oYFVPV1zRa2e9wRCbQoZZNWOZFYyoInvXUPJXBXjss+QXlWLJChDEHDkA==}
+
+  estree-util-to-js@2.0.0:
+    resolution: {integrity: sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==}
+
+  estree-util-visit@2.0.0:
+    resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -6645,6 +6736,9 @@ packages:
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
@@ -6924,6 +7018,15 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-to-estree@3.1.3:
+    resolution: {integrity: sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==}
+
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
 
@@ -7009,9 +7112,18 @@ packages:
     resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -7055,6 +7167,9 @@ packages:
     resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
     engines: {node: '>= 0.4'}
 
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -7078,6 +7193,9 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
@@ -7454,6 +7572,9 @@ packages:
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -7495,6 +7616,10 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  markdown-extensions@2.0.0:
+    resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
+    engines: {node: '>=16'}
+
   marked-terminal@7.3.0:
     resolution: {integrity: sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==}
     engines: {node: '>=16.0.0'}
@@ -7510,6 +7635,33 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdx@3.0.0:
+    resolution: {integrity: sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
   mdn-data@2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
 
@@ -7523,6 +7675,90 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-mdx-expression@3.0.1:
+    resolution: {integrity: sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==}
+
+  micromark-extension-mdx-jsx@3.0.2:
+    resolution: {integrity: sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==}
+
+  micromark-extension-mdx-md@2.0.0:
+    resolution: {integrity: sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==}
+
+  micromark-extension-mdxjs-esm@3.0.0:
+    resolution: {integrity: sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==}
+
+  micromark-extension-mdxjs@3.0.0:
+    resolution: {integrity: sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-mdx-expression@2.0.3:
+    resolution: {integrity: sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-events-to-acorn@2.0.3:
+    resolution: {integrity: sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -7793,6 +8029,9 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
@@ -8019,6 +8258,9 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  property-information@7.2.0:
+    resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
   publint@0.3.18:
     resolution: {integrity: sha512-JRJFeBTrfx4qLwEuGFPk+haJOJN97KnPuK01yj+4k/Wj5BgoOK5uNsivporiqBjk2JDaslg7qJOhGRnpltGeog==}
     engines: {node: '>=18'}
@@ -8137,6 +8379,20 @@ packages:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
 
+  recma-build-jsx@1.0.0:
+    resolution: {integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==}
+
+  recma-jsx@1.0.1:
+    resolution: {integrity: sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  recma-parse@1.0.0:
+    resolution: {integrity: sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ==}
+
+  recma-stringify@1.0.0:
+    resolution: {integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==}
+
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
@@ -8148,6 +8404,18 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  rehype-recma@1.0.0:
+    resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
+
+  remark-mdx@3.1.1:
+    resolution: {integrity: sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -8409,10 +8677,17 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
     deprecated: The work that was done in this beta branch won't be included in future versions
+
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
@@ -8494,6 +8769,9 @@ packages:
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -8534,6 +8812,12 @@ packages:
 
   style-mod@4.1.3:
     resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
+
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -8696,6 +8980,12 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -8841,6 +9131,27 @@ packages:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position-from-estree@2.0.0:
+    resolution: {integrity: sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
@@ -8913,6 +9224,12 @@ packages:
   validate-npm-package-name@5.0.1:
     resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite-tsconfig-paths@5.1.4:
     resolution: {integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==}
@@ -9198,6 +9515,9 @@ packages:
 
   zod@4.1.12:
     resolution: {integrity: sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -11087,6 +11407,36 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
+  '@mdx-js/mdx@3.1.1':
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdx': 2.0.14
+      acorn: 8.15.0
+      collapse-white-space: 2.1.0
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      estree-util-scope: 1.0.1
+      estree-walker: 3.0.3
+      hast-util-to-jsx-runtime: 2.3.6
+      markdown-extensions: 2.0.0
+      recma-build-jsx: 1.0.0
+      recma-jsx: 1.0.1(acorn@8.15.0)
+      recma-stringify: 1.0.0
+      rehype-recma: 1.0.0
+      remark-mdx: 3.1.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      source-map: 0.7.6
+      unified: 11.0.5
+      unist-util-position-from-estree: 2.0.0
+      unist-util-stringify-position: 4.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     optional: true
 
@@ -12474,7 +12824,15 @@ snapshots:
 
   '@types/culori@4.0.1': {}
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/deep-eql@4.0.2': {}
+
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.9
 
   '@types/estree@1.0.8': {}
 
@@ -12485,6 +12843,10 @@ snapshots:
       '@types/jsonfile': 6.1.4
       '@types/node': 24.10.0
 
+  '@types/hast@3.0.5':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
@@ -12492,6 +12854,14 @@ snapshots:
   '@types/jsonfile@6.1.4':
     dependencies:
       '@types/node': 24.10.0
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/mdx@2.0.14': {}
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@12.20.55': {}
 
@@ -12533,6 +12903,10 @@ snapshots:
       minipass: 4.2.8
 
   '@types/trusted-types@2.0.7': {}
+
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
 
   '@types/whatwg-mimetype@3.0.2':
     optional: true
@@ -12718,6 +13092,8 @@ snapshots:
       - '@codemirror/language'
       - '@codemirror/lint'
       - '@codemirror/search'
+
+  '@ungap/structured-clone@1.4.0': {}
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     optional: true
@@ -13056,6 +13432,8 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
+  astring@1.9.0: {}
+
   async-function@1.0.0: {}
 
   async-retry@1.3.3:
@@ -13090,6 +13468,8 @@ snapshots:
   axe-core@4.13.0: {}
 
   axobject-query@4.1.0: {}
+
+  bail@2.0.2: {}
 
   balanced-match@4.0.4: {}
 
@@ -13186,6 +13566,8 @@ snapshots:
 
   caniuse-lite@1.0.30001810: {}
 
+  ccount@2.0.1: {}
+
   chai@6.2.2: {}
 
   chalk@4.1.2:
@@ -13196,6 +13578,14 @@ snapshots:
   chalk@5.6.2: {}
 
   char-regex@1.0.2: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
 
   chardet@2.1.1: {}
 
@@ -13281,6 +13671,8 @@ snapshots:
       '@codemirror/state': 6.6.0
       '@codemirror/view': 6.43.1
 
+  collapse-white-space@2.1.0: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -13288,6 +13680,8 @@ snapshots:
   color-name@1.1.4: {}
 
   colorette@2.0.20: {}
+
+  comma-separated-tokens@2.0.3: {}
 
   commander@10.0.1: {}
 
@@ -13442,6 +13836,10 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
@@ -13473,6 +13871,10 @@ snapshots:
   detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   dir-glob@3.0.1:
     dependencies:
@@ -13686,6 +14088,20 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  esast-util-from-estree@2.0.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      devlop: 1.1.0
+      estree-util-visit: 2.0.0
+      unist-util-position-from-estree: 2.0.0
+
+  esast-util-from-js@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      acorn: 8.15.0
+      esast-util-from-estree: 2.0.0
+      vfile-message: 4.0.3
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -14022,6 +14438,35 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-util-attach-comments@3.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  estree-util-build-jsx@3.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      estree-walker: 3.0.3
+
+  estree-util-is-identifier-name@3.0.0: {}
+
+  estree-util-scope@1.0.1:
+    dependencies:
+      '@types/estree': 1.0.9
+      devlop: 1.1.0
+
+  estree-util-to-js@2.0.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      astring: 1.9.0
+      source-map: 0.7.6
+
+  estree-util-visit@2.0.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/unist': 3.0.3
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -14050,6 +14495,8 @@ snapshots:
   expand-template@2.0.3: {}
 
   expect-type@1.4.0: {}
+
+  extend@3.0.2: {}
 
   extendable-error@0.1.7: {}
 
@@ -14367,6 +14814,51 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-to-estree@3.1.3:
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-attach-comments: 3.0.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      zwitch: 2.0.4
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/hast': 3.0.5
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.5
+
   hermes-estree@0.25.1: {}
 
   hermes-parser@0.25.1:
@@ -14438,11 +14930,20 @@ snapshots:
 
   ini@4.1.1: {}
 
+  inline-style-parser@0.2.7: {}
+
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -14492,6 +14993,8 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
+  is-decimal@2.0.1: {}
+
   is-extglob@2.1.1: {}
 
   is-finalizationregistry@1.1.1:
@@ -14514,6 +15017,8 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-hexadecimal@2.0.1: {}
 
   is-map@2.0.3: {}
 
@@ -14882,6 +15387,8 @@ snapshots:
 
   long@5.3.2: {}
 
+  longest-streak@3.1.0: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -14918,6 +15425,8 @@ snapshots:
     dependencies:
       semver: 7.8.5
 
+  markdown-extensions@2.0.0: {}
+
   marked-terminal@7.3.0(marked@9.1.6):
     dependencies:
       ansi-escapes: 7.1.0
@@ -14933,6 +15442,105 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx@3.0.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.4.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
   mdn-data@2.0.30: {}
 
   mdn-data@2.12.2: {}
@@ -14940,6 +15548,212 @@ snapshots:
   meow@12.1.1: {}
 
   merge2@1.4.1: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdx-expression@3.0.1:
+    dependencies:
+      '@types/estree': 1.0.9
+      devlop: 1.1.0
+      micromark-factory-mdx-expression: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdx-jsx@3.0.2:
+    dependencies:
+      '@types/estree': 1.0.9
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      micromark-factory-mdx-expression: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      vfile-message: 4.0.3
+
+  micromark-extension-mdx-md@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdxjs-esm@3.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-position-from-estree: 2.0.0
+      vfile-message: 4.0.3
+
+  micromark-extension-mdxjs@3.0.0:
+    dependencies:
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
+      micromark-extension-mdx-expression: 3.0.1
+      micromark-extension-mdx-jsx: 3.0.2
+      micromark-extension-mdx-md: 2.0.0
+      micromark-extension-mdxjs-esm: 3.0.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-mdx-expression@2.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-position-from-estree: 2.0.0
+      vfile-message: 4.0.3
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-events-to-acorn@2.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      estree-util-visit: 2.0.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      vfile-message: 4.0.3
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   micromatch@4.0.8:
     dependencies:
@@ -15222,6 +16036,16 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   parse-json@5.2.0:
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -15428,6 +16252,8 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  property-information@7.2.0: {}
+
   publint@0.3.18:
     dependencies:
       '@publint/pack': 0.1.4
@@ -15539,6 +16365,35 @@ snapshots:
 
   readdirp@5.0.0: {}
 
+  recma-build-jsx@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+      estree-util-build-jsx: 3.0.1
+      vfile: 6.0.3
+
+  recma-jsx@1.0.1(acorn@8.15.0):
+    dependencies:
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
+      estree-util-to-js: 2.0.0
+      recma-parse: 1.0.0
+      recma-stringify: 1.0.0
+      unified: 11.0.5
+
+  recma-parse@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+      esast-util-from-js: 2.0.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  recma-stringify@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+      estree-util-to-js: 2.0.0
+      unified: 11.0.5
+      vfile: 6.0.3
+
   redent@3.0.0:
     dependencies:
       indent-string: 4.0.0
@@ -15563,6 +16418,38 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  rehype-recma@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/hast': 3.0.5
+      hast-util-to-estree: 3.1.3
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-mdx@3.1.1:
+    dependencies:
+      mdast-util-mdx: 3.0.0
+      micromark-extension-mdxjs: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
 
   require-directory@2.1.1: {}
 
@@ -15896,9 +16783,13 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  source-map@0.7.6: {}
+
   source-map@0.8.0-beta.0:
     dependencies:
       whatwg-url: 7.1.0
+
+  space-separated-tokens@2.0.2: {}
 
   spawndamnit@3.0.1:
     dependencies:
@@ -16008,6 +16899,11 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -16039,6 +16935,14 @@ snapshots:
   stubborn-utils@1.0.2: {}
 
   style-mod@4.1.3: {}
+
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
 
   styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.0):
     dependencies:
@@ -16187,6 +17091,10 @@ snapshots:
       punycode: 2.3.1
 
   tree-kill@1.2.2: {}
+
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
@@ -16428,6 +17336,43 @@ snapshots:
 
   unicorn-magic@0.3.0: {}
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position-from-estree@2.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   universalify@0.1.2: {}
 
   universalify@2.0.1: {}
@@ -16498,6 +17443,16 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   validate-npm-package-name@5.0.1: {}
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)):
     dependencies:
@@ -16911,3 +17866,5 @@ snapshots:
       zod: 4.1.12
 
   zod@4.1.12: {}
+
+  zwitch@2.0.4: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@mdx-js/mdx':
         specifier: 3.1.1
         version: 3.1.1
+      js-yaml:
+        specifier: ^4.3.1
+        version: 4.3.1
       zod:
         specifier: ^4.1.12
         version: 4.1.12

--- a/scripts/check-docs-compile.mjs
+++ b/scripts/check-docs-compile.mjs
@@ -11,10 +11,13 @@
  *
  * So the pages are compiled here, with the compiler the site's MDX pipeline is built on,
  * and a page the compiler rejects is reported with the file, line and column the compiler
- * names. Components are not resolved: `<Callout>` is JSX to the compiler and needs no
- * import, which is the same as at the site. Frontmatter is taken off first, because the
- * site's loader reads it separately and the compiler would otherwise parse the YAML as
- * Markdown.
+ * names. Frontmatter is taken off first, because the site's loader reads it separately and
+ * the compiler would otherwise parse the YAML as Markdown.
+ *
+ * A page can also compile and still not render: `<Warning>` is JSX to the compiler and
+ * needs no import, and the site throws at render time for a component it never
+ * registered. So every component a page uses is held to the set the site provides, read
+ * off the syntax tree so a `<T>` inside a code sample is never mistaken for one.
  *
  * Usage:
  *   node scripts/check-docs-compile.mjs
@@ -25,6 +28,57 @@ import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 
 import { compile } from "@mdx-js/mdx";
+
+/**
+ * The components a documentation page may use.
+ *
+ * The site registers these in `app/docs/[[...slug]]/page.tsx` of nextly-site: Fumadocs'
+ * default MDX components, plus the ones the page adds. A lowercase tag is HTML and is not
+ * checked. This list is a copy of the site's, kept here because the docs cannot read it;
+ * when a component is added there, add it here in the same change.
+ */
+export const SITE_COMPONENTS = new Set([
+  "Callout",
+  "CalloutContainer",
+  "CalloutTitle",
+  "CalloutDescription",
+  "Card",
+  "Cards",
+  "CodeBlockTab",
+  "CodeBlockTabs",
+  "CodeBlockTabsList",
+  "CodeBlockTabsTrigger",
+  "Tab",
+  "Tabs",
+  "Accordion",
+  "Accordions",
+  "Step",
+  "Steps",
+  "File",
+  "Files",
+  "Folder",
+]);
+
+/** Whether a syntax-tree node is a JSX element with a name, block or inline. */
+function isNamedJsx(node) {
+  const jsx =
+    node.type === "mdxJsxFlowElement" || node.type === "mdxJsxTextElement";
+  return jsx && Boolean(node.name);
+}
+
+/** A remark plugin that records the name of every component a page uses. */
+function collectComponents(names) {
+  const visit = node => {
+    if (isNamedJsx(node)) names.add(node.name);
+    for (const child of node.children ?? []) visit(child);
+  };
+  return () => visit;
+}
+
+/** Whether a tag names a component rather than an HTML element. */
+function isComponent(name) {
+  return /^[A-Z]/.test(name);
+}
 
 /**
  * The page body without the frontmatter block it opens with, and how many lines that
@@ -47,12 +101,23 @@ export function withoutFrontmatter(source) {
  */
 export async function compileFinding(source) {
   const { body, skipped } = withoutFrontmatter(source);
+  const names = new Set();
   try {
-    await compile(body, { format: "mdx" });
-    return null;
+    await compile(body, {
+      format: "mdx",
+      remarkPlugins: [collectComponents(names)],
+    });
   } catch (error) {
     return describeFailure(error, skipped);
   }
+  const unknown = [...names].filter(
+    name => isComponent(name) && !SITE_COMPONENTS.has(name)
+  );
+  if (unknown.length === 0) return null;
+  return {
+    where: "",
+    message: `uses ${unknown.map(name => `<${name}>`).join(", ")}, which the site does not register; the page compiles and fails to render`,
+  };
 }
 
 /**

--- a/scripts/check-docs-compile.mjs
+++ b/scripts/check-docs-compile.mjs
@@ -14,10 +14,14 @@
  * names. Frontmatter is taken off first, because the site's loader reads it separately and
  * the compiler would otherwise parse the YAML as Markdown.
  *
- * A page can also compile and still not render: `<Warning>` is JSX to the compiler and
+ * A page can also compile and still not render. `<Warning>` is JSX to the compiler and
  * needs no import, and the site throws at render time for a component it never
- * registered. So every component a page uses is held to the set the site provides, read
- * off the syntax tree so a `<T>` inside a code sample is never mistaken for one.
+ * registered; frontmatter the site's page schema refuses, a missing title or YAML that
+ * does not parse, never reaches the renderer at all. So the frontmatter is split and
+ * parsed exactly as the site's loader does it, and every component a page uses is held to
+ * `docs/components.json`, the contract kept beside the pages that the site holds itself
+ * to from the other side. Read off the syntax tree, expressions included, so a `<T>` inside
+ * a code sample is never mistaken for a component and `{cond && <Warning />}` is not missed.
  *
  * Usage:
  *   node scripts/check-docs-compile.mjs
@@ -28,36 +32,68 @@ import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 
 import { compile } from "@mdx-js/mdx";
+import { load } from "js-yaml";
+
+/** The contract a page's components are held to, kept beside the pages themselves. */
+export const COMPONENTS_CONTRACT = "docs/components.json";
 
 /**
- * The components a documentation page may use.
+ * The frontmatter block, split exactly as the site's loader splits it.
  *
- * The site registers these in `app/docs/[[...slug]]/page.tsx` of nextly-site: Fumadocs'
- * default MDX components, plus the ones the page adds. A lowercase tag is HTML and is not
- * checked. This list is a copy of the site's, kept here because the docs cannot read it;
- * when a component is added there, add it here in the same change.
+ * The site takes the block with this expression and parses it with js-yaml, so the same
+ * expression and the same parser are used here: a block the site would refuse is refused
+ * here, and a block the site would read is read the same way. The line count is kept so a
+ * position the compiler reports on the body can be given in the file's own lines.
  */
-export const SITE_COMPONENTS = new Set([
-  "Callout",
-  "CalloutContainer",
-  "CalloutTitle",
-  "CalloutDescription",
-  "Card",
-  "Cards",
-  "CodeBlockTab",
-  "CodeBlockTabs",
-  "CodeBlockTabsList",
-  "CodeBlockTabsTrigger",
-  "Tab",
-  "Tabs",
-  "Accordion",
-  "Accordions",
-  "Step",
-  "Steps",
-  "File",
-  "Files",
-  "Folder",
-]);
+const FRONTMATTER = /^---\r?\n(.+?)\r?\n---\r?\n?/s;
+
+export function splitFrontmatter(source) {
+  const match = FRONTMATTER.exec(source);
+  if (!match) return { body: source, skipped: 0, data: {} };
+  return {
+    body: source.slice(match[0].length),
+    skipped: match[0].split("\n").length - 1,
+    data: load(match[1]),
+  };
+}
+
+/** The fields the site's page schema types, and the type each must have when present. */
+const PAGE_FIELDS = [
+  ["description", "string"],
+  ["icon", "string"],
+  ["full", "boolean"],
+];
+
+function isMapping(data) {
+  return data !== null && typeof data === "object" && !Array.isArray(data);
+}
+
+function hasTitle(data) {
+  return typeof data.title === "string" && data.title.trim() !== "";
+}
+
+/** The typed fields present with the wrong type. */
+function mistyped(data) {
+  return PAGE_FIELDS.filter(
+    ([key, type]) => key in data && typeof data[key] !== type
+  ).map(([key]) => key);
+}
+
+/**
+ * Why the frontmatter is not what the site's page schema accepts, or `null`.
+ *
+ * The site validates a page's frontmatter with a schema that requires a `title` string and
+ * accepts `description` and `icon` as strings and `full` as a boolean. A page failing that
+ * never renders, whatever its body does, so it is refused here first.
+ */
+export function frontmatterFinding(data) {
+  if (!isMapping(data)) return "frontmatter is not a mapping";
+  if (!hasTitle(data))
+    return "frontmatter has no title, which the site's page schema requires";
+  const wrong = mistyped(data);
+  if (wrong.length === 0) return null;
+  return `frontmatter ${wrong.join(", ")} is not the type the site's page schema accepts`;
+}
 
 /** Whether a syntax-tree node is a JSX element with a name, block or inline. */
 function isNamedJsx(node) {
@@ -66,13 +102,41 @@ function isNamedJsx(node) {
   return jsx && Boolean(node.name);
 }
 
-/** A remark plugin that records the name of every component a page uses. */
-function collectComponents(names) {
+/** The names of every component a page uses, read off the syntax tree. */
+function componentNames(tree) {
+  const names = new Set();
   const visit = node => {
-    if (isNamedJsx(node)) names.add(node.name);
-    for (const child of node.children ?? []) visit(child);
+    // `<Foo.Bar>` is a member of `Foo`, and `Foo` is what the site registers.
+    if (isNamedJsx(node)) names.add(node.name.split(".")[0]);
+    visitEstree(node.data?.estree, names);
+    (node.children ?? []).forEach(visit);
   };
-  return () => visit;
+  visit(tree);
+  return names;
+}
+
+/** The ESTree nodes directly under one, whichever properties hold them. */
+function estreeChildren(node) {
+  const isNode = value =>
+    value !== null && typeof value === "object" && "type" in value;
+  return Object.values(node)
+    .flatMap(value => (Array.isArray(value) ? value : [value]))
+    .filter(isNode);
+}
+
+/**
+ * JSX inside an MDX expression, `{cond && <Warning />}`, is not a child of the expression
+ * node: it lives in the expression's ESTree. Walked for opening elements, whose name is an
+ * identifier or, for `<Foo.Bar>`, a member expression rooted in one.
+ */
+function visitEstree(node, names) {
+  if (!node) return;
+  if (node.type === "JSXOpeningElement") names.add(jsxName(node.name));
+  estreeChildren(node).forEach(child => visitEstree(child, names));
+}
+
+function jsxName(node) {
+  return node.type === "JSXMemberExpression" ? jsxName(node.object) : node.name;
 }
 
 /** Whether a tag names a component rather than an HTML element. */
@@ -80,43 +144,62 @@ function isComponent(name) {
   return /^[A-Z]/.test(name);
 }
 
-/**
- * The page body without the frontmatter block it opens with, and how many lines that
- * block took, so a position the compiler reports can be given in the file's own lines.
- */
-export function withoutFrontmatter(source) {
-  const match = /^---\r?\n[\s\S]*?\r?\n---\r?\n/.exec(source);
-  if (!match) return { body: source, skipped: 0 };
-  return {
-    body: source.slice(match[0].length),
-    skipped: match[0].split("\n").length - 1,
+/** A remark plugin that hands the finished tree to `receive`. */
+function collectTree(receive) {
+  return () => tree => {
+    receive(tree);
   };
 }
 
-/**
- * Why a page does not compile, or `null`.
- *
- * The compiler's own message, with its position in the FILE, so the finding points at the
- * character the parser stopped on rather than at the page.
- */
-export async function compileFinding(source) {
-  const { body, skipped } = withoutFrontmatter(source);
-  const names = new Set();
+/** The page split and parsed, or the finding that stops it being read at all. */
+function parsePage(source) {
   try {
-    await compile(body, {
-      format: "mdx",
-      remarkPlugins: [collectComponents(names)],
-    });
+    const page = splitFrontmatter(source);
+    const finding = frontmatterFinding(page.data);
+    return finding ? { finding: { where: ":1", message: finding } } : { page };
   } catch (error) {
-    return describeFailure(error, skipped);
+    return {
+      finding: {
+        where: ":1",
+        message: `frontmatter is not YAML: ${error.reason ?? error.message}`,
+      },
+    };
   }
-  const unknown = [...names].filter(
-    name => isComponent(name) && !SITE_COMPONENTS.has(name)
+}
+
+/** The tree of a body the compiler accepts, or the finding that names where it stopped. */
+async function compileBody(page) {
+  let tree;
+  try {
+    await compile(page.body, {
+      format: "mdx",
+      remarkPlugins: [collectTree(t => (tree = t))],
+    });
+    return { tree };
+  } catch (error) {
+    return { finding: describeFailure(error, page.skipped) };
+  }
+}
+
+/**
+ * Why a page would not render on the site, or `null`.
+ *
+ * In order: frontmatter the site's schema refuses, a body the compiler refuses (reported
+ * with the file's own line and column), and a component the site does not register, which
+ * compiles and then throws at render.
+ */
+export async function compileFinding(source, allowed) {
+  const parsed = parsePage(source);
+  if (parsed.finding) return parsed.finding;
+  const compiled = await compileBody(parsed.page);
+  if (compiled.finding) return compiled.finding;
+  const unknown = [...componentNames(compiled.tree)].filter(
+    name => isComponent(name) && !allowed.has(name)
   );
   if (unknown.length === 0) return null;
   return {
     where: "",
-    message: `uses ${unknown.map(name => `<${name}>`).join(", ")}, which the site does not register; the page compiles and fails to render`,
+    message: `uses ${unknown.map(name => `<${name}>`).join(", ")}, which ${COMPONENTS_CONTRACT} does not list; the page compiles and fails to render`,
   };
 }
 
@@ -132,6 +215,22 @@ function describeFailure(error, skipped) {
   return { where, message: reason ?? String(error) };
 }
 
+/** The components the contract allows, or a refusal when the contract cannot be read. */
+export function allowedComponents(repoRoot) {
+  const parsed = JSON.parse(
+    readFileSync(join(repoRoot, COMPONENTS_CONTRACT), "utf-8")
+  );
+  if (
+    !Array.isArray(parsed.components) ||
+    parsed.components.some(name => typeof name !== "string")
+  ) {
+    throw new Error(
+      `${COMPONENTS_CONTRACT}: "components" must be a list of names`
+    );
+  }
+  return new Set(parsed.components);
+}
+
 /** The pages git tracks under `docs/`, which is the set the site fetches. */
 function trackedPages(repoRoot) {
   const out = execFileSync("git", ["ls-files", "-z", "--", "docs"], {
@@ -142,11 +241,13 @@ function trackedPages(repoRoot) {
 }
 
 export async function checkDocsCompile(repoRoot) {
+  const allowed = allowedComponents(repoRoot);
   const pages = trackedPages(repoRoot);
   const findings = [];
   for (const rel of pages) {
     const finding = await compileFinding(
-      readFileSync(join(repoRoot, rel), "utf-8")
+      readFileSync(join(repoRoot, rel), "utf-8"),
+      allowed
     );
     if (finding) findings.push({ file: rel, ...finding });
   }

--- a/scripts/check-docs-compile.mjs
+++ b/scripts/check-docs-compile.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+
+/**
+ * Every documentation page compiles as MDX.
+ *
+ * The pages under `docs/` are not rendered by this repository. nextlyhq.com fetches them
+ * at its build and compiles them there, so a page that does not parse is green here and
+ * fails the site's next deploy. One closing tag indented under a list item is enough:
+ * the parser reads it as part of the item, and the element it should close is never
+ * closed.
+ *
+ * So the pages are compiled here, with the compiler the site's MDX pipeline is built on,
+ * and a page the compiler rejects is reported with the file, line and column the compiler
+ * names. Components are not resolved: `<Callout>` is JSX to the compiler and needs no
+ * import, which is the same as at the site. Frontmatter is taken off first, because the
+ * site's loader reads it separately and the compiler would otherwise parse the YAML as
+ * Markdown.
+ *
+ * Usage:
+ *   node scripts/check-docs-compile.mjs
+ */
+
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+
+import { compile } from "@mdx-js/mdx";
+
+/**
+ * The page body without the frontmatter block it opens with, and how many lines that
+ * block took, so a position the compiler reports can be given in the file's own lines.
+ */
+export function withoutFrontmatter(source) {
+  const match = /^---\r?\n[\s\S]*?\r?\n---\r?\n/.exec(source);
+  if (!match) return { body: source, skipped: 0 };
+  return {
+    body: source.slice(match[0].length),
+    skipped: match[0].split("\n").length - 1,
+  };
+}
+
+/**
+ * Why a page does not compile, or `null`.
+ *
+ * The compiler's own message, with its position in the FILE, so the finding points at the
+ * character the parser stopped on rather than at the page.
+ */
+export async function compileFinding(source) {
+  const { body, skipped } = withoutFrontmatter(source);
+  try {
+    await compile(body, { format: "mdx" });
+    return null;
+  } catch (error) {
+    return describeFailure(error, skipped);
+  }
+}
+
+/**
+ * The compiler's own position and message, the position moved back into the file.
+ *
+ * A parse failure is a `VFileMessage`, which carries `line`, `column` and `reason`; a
+ * failure of any other kind has none of them and is reported by its text alone.
+ */
+function describeFailure(error, skipped) {
+  const { line, column, reason } = error;
+  const where = line ? `:${line + skipped}:${column}` : "";
+  return { where, message: reason ?? String(error) };
+}
+
+/** The pages git tracks under `docs/`, which is the set the site fetches. */
+function trackedPages(repoRoot) {
+  const out = execFileSync("git", ["ls-files", "-z", "--", "docs"], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+  });
+  return out.split("\0").filter(rel => rel.endsWith(".mdx"));
+}
+
+export async function checkDocsCompile(repoRoot) {
+  const pages = trackedPages(repoRoot);
+  const findings = [];
+  for (const rel of pages) {
+    const finding = await compileFinding(
+      readFileSync(join(repoRoot, rel), "utf-8")
+    );
+    if (finding) findings.push({ file: rel, ...finding });
+  }
+  return { pages: pages.length, findings };
+}
+
+const invokedDirectly =
+  process.argv[1] && process.argv[1].endsWith("check-docs-compile.mjs");
+
+if (invokedDirectly) {
+  const { pages, findings } = await checkDocsCompile(process.cwd());
+  if (pages === 0) {
+    console.error(
+      "docs compile: git tracks no page under docs/, so nothing was compiled"
+    );
+    process.exit(1);
+  }
+  if (findings.length > 0) {
+    console.error(
+      `docs compile: ${findings.length} of ${pages} page(s) do not compile`
+    );
+    for (const { file, where, message } of findings) {
+      console.error(`  ${file}${where} — ${message}`);
+    }
+    process.exit(1);
+  }
+  console.log(`docs compile: ${pages} pages compile.`);
+}

--- a/scripts/check-docs-compile.test.mjs
+++ b/scripts/check-docs-compile.test.mjs
@@ -48,6 +48,34 @@ describe("compileFinding", () => {
   });
 });
 
+describe("components a page uses", () => {
+  it("passes a component the site registers, and HTML tags", async () => {
+    expect(
+      await compileFinding(
+        `${FRONTMATTER}<Callout>ok</Callout>\n\n<div>html</div>\n`
+      )
+    ).toBeNull();
+  });
+
+  it("reports a component the site never registered", async () => {
+    // Compiles fine; the site throws at render for it. The shape that shipped.
+    const finding = await compileFinding(
+      `${FRONTMATTER}<Warning>\nNot yet.\n</Warning>\n`
+    );
+    expect(finding).not.toBeNull();
+    expect(finding.message).toContain("<Warning>");
+    expect(finding.message).toContain("does not register");
+  });
+
+  it("does not mistake a generic in a code sample for a component", async () => {
+    expect(
+      await compileFinding(
+        `${FRONTMATTER}\`\`\`ts\nconst x: Promise<T> = f<ReturnType<F>>();\n\`\`\`\n`
+      )
+    ).toBeNull();
+  });
+});
+
 describe("the committed pages", () => {
   it("all compile, and there are pages", async () => {
     const { pages, findings } = await checkDocsCompile(process.cwd());

--- a/scripts/check-docs-compile.test.mjs
+++ b/scripts/check-docs-compile.test.mjs
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  checkDocsCompile,
+  compileFinding,
+  withoutFrontmatter,
+} from "./check-docs-compile.mjs";
+
+const FRONTMATTER = "---\ntitle: Releases\ndescription: One line.\n---\n";
+
+describe("withoutFrontmatter", () => {
+  it("takes the opening block off and counts its lines", () => {
+    expect(withoutFrontmatter(`${FRONTMATTER}# Body\n`)).toEqual({
+      body: "# Body\n",
+      skipped: 4,
+    });
+  });
+
+  it("leaves a page with none alone", () => {
+    expect(
+      withoutFrontmatter("# Body\n\n---\n\nrule, not frontmatter\n")
+    ).toEqual({
+      body: "# Body\n\n---\n\nrule, not frontmatter\n",
+      skipped: 0,
+    });
+  });
+});
+
+describe("compileFinding", () => {
+  it("is null for a page that compiles, components included", async () => {
+    expect(
+      await compileFinding(
+        `${FRONTMATTER}<Callout type="warn">\n\n1. one\n2. two\n\n</Callout>\n`
+      )
+    ).toBeNull();
+  });
+
+  it("reports a closing tag indented under a list item, at the file's own line", async () => {
+    // The shape that broke the site: the tag closes inside the list item the
+    // indentation put it in. Line 7 of the FILE, not of the body the
+    // frontmatter was taken off.
+    const finding = await compileFinding(
+      `${FRONTMATTER}<Callout type="warn">\n\n1. one\n   </Callout>\n`
+    );
+    expect(finding).not.toBeNull();
+    expect(finding.where).toBe(":8:4");
+    expect(finding.message).toContain("Expected the closing tag `</Callout>`");
+  });
+});
+
+describe("the committed pages", () => {
+  it("all compile, and there are pages", async () => {
+    const { pages, findings } = await checkDocsCompile(process.cwd());
+    expect(pages).toBeGreaterThan(50);
+    expect(findings).toEqual([]);
+  });
+});

--- a/scripts/check-docs-compile.test.mjs
+++ b/scripts/check-docs-compile.test.mjs
@@ -1,35 +1,67 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  allowedComponents,
   checkDocsCompile,
   compileFinding,
-  withoutFrontmatter,
+  frontmatterFinding,
+  splitFrontmatter,
 } from "./check-docs-compile.mjs";
 
 const FRONTMATTER = "---\ntitle: Releases\ndescription: One line.\n---\n";
+const ALLOWED = new Set(["Callout", "Tabs", "Tab"]);
+const finding = source => compileFinding(source, ALLOWED);
 
-describe("withoutFrontmatter", () => {
-  it("takes the opening block off and counts its lines", () => {
-    expect(withoutFrontmatter(`${FRONTMATTER}# Body\n`)).toEqual({
+describe("splitFrontmatter", () => {
+  it("takes the opening block off, parses it, and counts its lines", () => {
+    expect(splitFrontmatter(`${FRONTMATTER}# Body\n`)).toEqual({
       body: "# Body\n",
       skipped: 4,
+      data: { title: "Releases", description: "One line." },
     });
   });
 
   it("leaves a page with none alone", () => {
     expect(
-      withoutFrontmatter("# Body\n\n---\n\nrule, not frontmatter\n")
+      splitFrontmatter("# Body\n\n---\n\nrule, not frontmatter\n")
     ).toEqual({
       body: "# Body\n\n---\n\nrule, not frontmatter\n",
       skipped: 0,
+      data: {},
     });
+  });
+});
+
+describe("frontmatterFinding", () => {
+  it("accepts what the site's page schema accepts", () => {
+    expect(
+      frontmatterFinding({
+        title: "T",
+        description: "d",
+        icon: "i",
+        full: true,
+      })
+    ).toBeNull();
+  });
+
+  it("requires a title", () => {
+    expect(frontmatterFinding({})).toContain("no title");
+    expect(frontmatterFinding({ title: "" })).toContain("no title");
+    expect(frontmatterFinding({ title: 3 })).toContain("no title");
+  });
+
+  it("refuses a field of the wrong type", () => {
+    expect(frontmatterFinding({ title: "T", description: ["x"] })).toContain(
+      "description"
+    );
+    expect(frontmatterFinding({ title: "T", full: "yes" })).toContain("full");
   });
 });
 
 describe("compileFinding", () => {
   it("is null for a page that compiles, components included", async () => {
     expect(
-      await compileFinding(
+      await finding(
         `${FRONTMATTER}<Callout type="warn">\n\n1. one\n2. two\n\n</Callout>\n`
       )
     ).toBeNull();
@@ -37,47 +69,87 @@ describe("compileFinding", () => {
 
   it("reports a closing tag indented under a list item, at the file's own line", async () => {
     // The shape that broke the site: the tag closes inside the list item the
-    // indentation put it in. Line 7 of the FILE, not of the body the
+    // indentation put it in. Line 8 of the FILE, not of the body the
     // frontmatter was taken off.
-    const finding = await compileFinding(
+    const found = await finding(
       `${FRONTMATTER}<Callout type="warn">\n\n1. one\n   </Callout>\n`
     );
-    expect(finding).not.toBeNull();
-    expect(finding.where).toBe(":8:4");
-    expect(finding.message).toContain("Expected the closing tag `</Callout>`");
+    expect(found).not.toBeNull();
+    expect(found.where).toBe(":8:4");
+    expect(found.message).toContain("Expected the closing tag `</Callout>`");
+  });
+
+  it("reports frontmatter that is not YAML before compiling the body", async () => {
+    // The body is fine; the site's loader never gets that far.
+    const found = await finding("---\ntitle: [unterminated\n---\n# Fine\n");
+    expect(found).not.toBeNull();
+    expect(found.where).toBe(":1");
+    expect(found.message).toContain("not YAML");
+  });
+
+  it("reports frontmatter the site's schema refuses", async () => {
+    const found = await finding(
+      "---\ndescription: no title here\n---\n# Fine\n"
+    );
+    expect(found.message).toContain("no title");
   });
 });
 
 describe("components a page uses", () => {
-  it("passes a component the site registers, and HTML tags", async () => {
+  it("passes a component the contract lists, and HTML tags", async () => {
     expect(
-      await compileFinding(
-        `${FRONTMATTER}<Callout>ok</Callout>\n\n<div>html</div>\n`
-      )
+      await finding(`${FRONTMATTER}<Callout>ok</Callout>\n\n<div>html</div>\n`)
     ).toBeNull();
   });
 
-  it("reports a component the site never registered", async () => {
+  it("reports a component the contract does not list", async () => {
     // Compiles fine; the site throws at render for it. The shape that shipped.
-    const finding = await compileFinding(
+    const found = await finding(
       `${FRONTMATTER}<Warning>\nNot yet.\n</Warning>\n`
     );
-    expect(finding).not.toBeNull();
-    expect(finding.message).toContain("<Warning>");
-    expect(finding.message).toContain("does not register");
+    expect(found).not.toBeNull();
+    expect(found.message).toContain("<Warning>");
+    expect(found.message).toContain("does not list");
+  });
+
+  it("finds a component inside an MDX expression", async () => {
+    // `{cond && <Warning />}` keeps its JSX in the expression's ESTree, not
+    // in the tree's children. The Callout beside it is the control that the
+    // expression walk does not also lose what the tree walk finds.
+    const found = await finding(
+      `${FRONTMATTER}export const cond = true;\n\n{cond && <Warning />}\n\n<Callout>ok</Callout>\n`
+    );
+    expect(found).not.toBeNull();
+    expect(found.message).toContain("<Warning>");
+    expect(found.message).not.toContain("<Callout>");
+  });
+
+  it("reads a member expression's root, so <Foo.Bar> is held to Foo", async () => {
+    expect((await finding(`${FRONTMATTER}<Foo.Bar />\n`)).message).toContain(
+      "<Foo>"
+    );
   });
 
   it("does not mistake a generic in a code sample for a component", async () => {
     expect(
-      await compileFinding(
+      await finding(
         `${FRONTMATTER}\`\`\`ts\nconst x: Promise<T> = f<ReturnType<F>>();\n\`\`\`\n`
       )
     ).toBeNull();
   });
 });
 
+describe("the contract", () => {
+  it("is a list of names the docs really use, read from beside the pages", () => {
+    const allowed = allowedComponents(process.cwd());
+    expect(allowed.size).toBeGreaterThan(0);
+    for (const name of ["Callout", "Tabs", "Tab"])
+      expect(allowed.has(name)).toBe(true);
+  });
+});
+
 describe("the committed pages", () => {
-  it("all compile, and there are pages", async () => {
+  it("all compile against the contract, and there are pages", async () => {
     const { pages, findings } = await checkDocsCompile(process.cwd());
     expect(pages).toBeGreaterThan(50);
     expect(findings).toEqual([]);


### PR DESCRIPTION
**nextlyhq.com's next deploy fails on `main` as it is.** Please take this one first.

`docs/plugins/seo.mdx` (from #1741) closes a `<Callout>` with a tag indented under the last item of a numbered list:

```
3. **Pass a `skip`** to the rate limiter that does not exempt this path.
   </Callout>
```

MDX reads the indented tag as part of the list item, so the callout is never closed. Nothing in this repository renders the docs, so every check here passed. The site fetches them at its build and compiles them, and that compile fails:

```
./content/docs/plugins/seo.mdx
201:4-201:14: Expected the closing tag `</Callout>` either after the end of `listItem` (201:14)
```

Measured twice: in nextly-site #228's CI (the twins check hit it first), and locally with `next build --experimental-build-mode compile` against a fresh fetch of `main` at `cde0bd0b`. The site's last green build on its `main` predates this page; the next push there fails.

## What changes

- The tag is dedented, with a blank line ending the list first, which is the MDX form for a block element containing a list.
- **`pnpm check:docs-compile`**, in CI beside the docs-claims check: compiles every tracked page under `docs/` with `@mdx-js/mdx`, the compiler the site's fumadocs pipeline is built on. Components need no import to compile (`<Callout>` is JSX to the compiler, same as at the site); frontmatter is taken off first so the YAML is not read as Markdown; a finding names the file, line and column the compiler reports, in the file's own lines.

## Evidence

- The gate, run against the page as it is on `main`: `docs/plugins/seo.mdx:201:4 — Expected the closing tag ...`. Run against this branch: `docs compile: 66 pages compile.`
- 5 tests, including the exact shape (an indented closing tag under a list item) reported at the file's line rather than the stripped body's, and the committed pages all compiling.
- fallow pass, comment convention, `lint:scripts`, `check:docs-claims`, `test:scripts` clean.

## The dependency

`@mdx-js/mdx@3.1.1`, pinned, in root `dependencies` beside `zod`: fallow treats `scripts/` as production code and refuses a dev dependency imported there, and `zod` is the repository's precedent. Private root, so the section has no publishing meaning. `pnpm add` re-resolved two unrelated vitest peer suffixes on the way (`@types/node` 20→24, `tsx` 4.21→4.20); those were put back by hand and `pnpm install --frozen-lockfile` accepts the result, so the lockfile carries the new packages and nothing else.

No changeset: a docs fix and a check.
