### PR TITLE
test(nextly): the upgrade sim admits the actor_type column the activity log gained

### DIFF
--- a/packages/nextly/src/domains/schema/pipeline/__tests__/v1-golden/upgrade-sim-045.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/v1-golden/upgrade-sim-045.integration.test.ts
@@ -344,6 +344,26 @@ const addsActivitySubjectKindColumn = (stmt: string): boolean => {
   );
 };
 
+/**
+ * The activity log gains what KIND of actor each row names.
+ *
+ * `user_id` used to be the row's only identity — a reference joined to the
+ * accounts table — so a key's own id there found no account and a key write
+ * was dropped rather than filed against a person who never made it. The kind
+ * column lets a key, an import or a job record what it is, with `user_id` set
+ * only for a `user`. NULL on rows that predate it, which were all user writes.
+ *
+ * Pinned to the table AND the column, and required to be the WHOLE statement,
+ * for the reason the erasure stamp gives: a substring match would admit a
+ * destructive clause riding through beside the additive one.
+ */
+const addsActivityActorTypeColumn = (stmt: string): boolean => {
+  const s = stmt.trim().replace(/;$/, "");
+  return /^ALTER TABLE [`"]?activity_log[`"]? ADD (COLUMN )?[`"]?actor_type[`"]?[^,]*$/i.test(
+    s
+  );
+};
+
 // Positive guard: the sim must actually create each new table (an empty first
 // pass would otherwise satisfy the additive-only check vacuously).
 const hasCreateTableFor = (stmts: string[], table: string): boolean =>
@@ -456,6 +476,7 @@ describe("existing-user upgrade sim (0.45 DDL → v1)", () => {
               addsAuditLogErasureStamp(s) ||
               addsActivityLocaleColumn(s) ||
               addsActivitySubjectKindColumn(s) ||
+              addsActivityActorTypeColumn(s) ||
               addsPreviewGenerationColumn(s),
             `phantom diff: ${s}`
           ).toBe(true);
@@ -537,6 +558,7 @@ describe("existing-user upgrade sim (0.45 DDL → v1)", () => {
               addsAuditLogErasureStamp(s) ||
               addsActivityLocaleColumn(s) ||
               addsActivitySubjectKindColumn(s) ||
+              addsActivityActorTypeColumn(s) ||
               addsPreviewGenerationColumn(s),
             `unexpected reconcile statement shape: ${s}`
           ).toBe(true);

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/v1-golden/upgrade-sim-045.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/v1-golden/upgrade-sim-045.integration.test.ts
@@ -291,6 +291,32 @@ const migratesActivityLogActor = (stmt: string): boolean => {
 };
 
 /**
+ * A predicate admitting exactly one additive column on exactly one table.
+ *
+ * Two things a looser match lets through, each of which turns the allowlist
+ * into a hole. The WHOLE statement must be the single ADD, not merely contain
+ * one: a substring match admits `ALTER TABLE t ADD c ..., DROP COLUMN d` — a
+ * destructive change riding through on the additive clause beside it. And the
+ * column name must END where the name ends: without a boundary, `actor_type`
+ * admits `actor_type_backup`, so a schema that accidentally renamed the column
+ * would push its ALTER through, apply cleanly, and leave pass 2 silent — the
+ * sim green while the column it promises was never added. The closing quote
+ * or a word boundary is required after the name for that reason.
+ *
+ * Tolerant of pg/MySQL quoting and the optional COLUMN keyword, like every
+ * predicate above.
+ */
+const addsOnlyColumn =
+  (table: string, column: string) =>
+  (stmt: string): boolean => {
+    const s = stmt.trim().replace(/;$/, "");
+    return new RegExp(
+      `^ALTER TABLE [\`"]?${escapeRegExp(table)}[\`"]? ADD (COLUMN )?[\`"]?${escapeRegExp(column)}(?:[\`"]|\\b)[^,]*$`,
+      "i"
+    ).test(s);
+  };
+
+/**
  * The auth log gains the same erasure marker the activity log has, and for the
  * same reason: `ip_address` and `user_agent` are nullable for rows that never
  * carried them, so a bare NULL cannot say whether a person was erased.
@@ -298,16 +324,10 @@ const migratesActivityLogActor = (stmt: string): boolean => {
  * Pinned to the table AND the column rather than allowing any ALTER on it, so a
  * future unintended change to `audit_log` still fails as a phantom diff.
  */
-const addsAuditLogErasureStamp = (stmt: string): boolean => {
-  const s = stmt.trim().replace(/;$/, "");
-  // The WHOLE statement must be the single ADD, not merely contain one. A
-  // substring match would admit `ALTER TABLE audit_log ADD identity_erased_at
-  // ..., DROP COLUMN ip_address` — a destructive change riding through the
-  // guard on the additive clause beside it.
-  return /^ALTER TABLE [`"]?audit_log[`"]? ADD (COLUMN )?[`"]?identity_erased_at[`"]?[^,]*$/i.test(
-    s
-  );
-};
+const addsAuditLogErasureStamp = addsOnlyColumn(
+  "audit_log",
+  "identity_erased_at"
+);
 
 /**
  * The activity log gains the LANGUAGE a mutation was made in.
@@ -322,12 +342,7 @@ const addsAuditLogErasureStamp = (stmt: string): boolean => {
  * for the reason the erasure stamp above gives: a substring match would admit a
  * destructive clause riding through beside the additive one.
  */
-const addsActivityLocaleColumn = (stmt: string): boolean => {
-  const s = stmt.trim().replace(/;$/, "");
-  return /^ALTER TABLE [`"]?activity_log[`"]? ADD (COLUMN )?[`"]?locale[`"]?[^,]*$/i.test(
-    s
-  );
-};
+const addsActivityLocaleColumn = addsOnlyColumn("activity_log", "locale");
 
 /**
  * The activity log gains what each row is ABOUT.
@@ -337,12 +352,10 @@ const addsActivityLocaleColumn = (stmt: string): boolean => {
  * settings namespace, and registry membership then reads a credential rotation
  * as a document in that collection.
  */
-const addsActivitySubjectKindColumn = (stmt: string): boolean => {
-  const s = stmt.trim().replace(/;$/, "");
-  return /^ALTER TABLE [`"]?activity_log[`"]? ADD (COLUMN )?[`"]?subject_kind[`"]?[^,]*$/i.test(
-    s
-  );
-};
+const addsActivitySubjectKindColumn = addsOnlyColumn(
+  "activity_log",
+  "subject_kind"
+);
 
 /**
  * The activity log gains what KIND of actor each row names.
@@ -357,12 +370,10 @@ const addsActivitySubjectKindColumn = (stmt: string): boolean => {
  * for the reason the erasure stamp gives: a substring match would admit a
  * destructive clause riding through beside the additive one.
  */
-const addsActivityActorTypeColumn = (stmt: string): boolean => {
-  const s = stmt.trim().replace(/;$/, "");
-  return /^ALTER TABLE [`"]?activity_log[`"]? ADD (COLUMN )?[`"]?actor_type[`"]?[^,]*$/i.test(
-    s
-  );
-};
+const addsActivityActorTypeColumn = addsOnlyColumn(
+  "activity_log",
+  "actor_type"
+);
 
 // Positive guard: the sim must actually create each new table (an empty first
 // pass would otherwise satisfy the additive-only check vacuously).
@@ -399,6 +410,32 @@ describe("existing-user upgrade sim (0.45 DDL → v1)", () => {
           1700000000,
           1700000000
         );
+      // A trail row written before the actor migration. The fixture's
+      // `activity_log` is otherwise empty, and an empty table cannot show that
+      // the migration is data-preserving: every ALTER applies cleanly to
+      // nothing, so a column that had quietly become NOT NULL, or a rebuild
+      // that dropped rows, would leave the sim green. The user is required by
+      // the cascading key the fixture still carries.
+      sqlite
+        .prepare(
+          "INSERT INTO users (id, email, created_at, updated_at) VALUES (?, ?, ?, ?)"
+        )
+        .run("u-1", "upgrader@example.com", 1700000000, 1700000000);
+      sqlite
+        .prepare(
+          `INSERT INTO activity_log
+             (id, user_id, user_name, user_email, action, collection, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run(
+          "al-1",
+          "u-1",
+          "Upgrader",
+          "upgrader@example.com",
+          "update",
+          "articles",
+          1700000000
+        );
 
       const db = drizzleSqlite({ client: sqlite });
       const kit = await getSQLiteDrizzleKit();
@@ -424,6 +461,16 @@ describe("existing-user upgrade sim (0.45 DDL → v1)", () => {
         .prepare("SELECT slug FROM dynamic_collections WHERE id = 'dc-1'")
         .get() as { slug: string } | undefined;
       expect(row?.slug).toBe("articles");
+      // The legacy trail row came through the actor migration intact, and its
+      // kind is NULL — the value the schema documents for a row written before
+      // the column existed, and the one a reader is told to read as `user`.
+      const trail = sqlite
+        .prepare(
+          "SELECT user_id, actor_type FROM activity_log WHERE id = 'al-1'"
+        )
+        .get() as { user_id: string; actor_type: string | null } | undefined;
+      expect(trail?.user_id).toBe("u-1");
+      expect(trail?.actor_type).toBeNull();
 
       // Pass 2: silence.
       const second = await kit.pushSchema(desired, db);
@@ -448,6 +495,16 @@ describe("existing-user upgrade sim (0.45 DDL → v1)", () => {
       const pool = new Pool({ connectionString: url.toString() });
       try {
         for (const stmt of fixture.statements) await pool.query(stmt);
+        // A trail row written before the actor migration; see the sqlite case
+        // for why an empty `activity_log` proves nothing about it.
+        await pool.query(
+          "INSERT INTO users (id, email) VALUES ('u-1', 'upgrader@example.com')"
+        );
+        await pool.query(
+          `INSERT INTO activity_log
+             (id, user_id, user_name, user_email, action, collection)
+           VALUES ('al-1', 'u-1', 'Upgrader', 'upgrader@example.com', 'update', 'articles')`
+        );
         const db = drizzlePg({ client: pool });
         const kit = await getPgDrizzleKit();
         const { schemaRecord } = generateRuntimeSchema(
@@ -490,6 +547,15 @@ describe("existing-user upgrade sim (0.45 DDL → v1)", () => {
         expect(first.hints).toEqual([]);
         await first.apply();
 
+        // The legacy trail row survived, with the kind the schema documents
+        // for a row that predates the column.
+        const trail = await pool.query<{
+          user_id: string;
+          actor_type: string | null;
+        }>("SELECT user_id, actor_type FROM activity_log WHERE id = 'al-1'");
+        expect(trail.rows[0]?.user_id).toBe("u-1");
+        expect(trail.rows[0]?.actor_type).toBeNull();
+
         // Pass 2: silence — the new tables round-trip with no phantom diffs.
         const second = await kit.pushSchema(desired, db, {
           schemas: ["public"],
@@ -522,6 +588,16 @@ describe("existing-user upgrade sim (0.45 DDL → v1)", () => {
         // Data that must survive the reconcile.
         await p.query(
           "INSERT INTO roles (id, name, slug, level) VALUES ('r-1', 'Upgrader', 'upgrader', 5)"
+        );
+        // A trail row written before the actor migration; see the sqlite case
+        // for why an empty `activity_log` proves nothing about it.
+        await p.query(
+          "INSERT INTO users (id, email) VALUES ('u-1', 'upgrader@example.com')"
+        );
+        await p.query(
+          `INSERT INTO activity_log
+             (id, user_id, user_name, user_email, action, collection)
+           VALUES ('al-1', 'u-1', 'Upgrader', 'upgrader@example.com', 'update', 'articles')`
         );
 
         const db = drizzleMysql({ client: pool });
@@ -590,6 +666,17 @@ describe("existing-user upgrade sim (0.45 DDL → v1)", () => {
           "SELECT slug FROM roles WHERE id = 'r-1'"
         )) as unknown as [Array<{ slug: string }>];
         expect(rows[0]?.slug).toBe("upgrader");
+        // The legacy trail row survived, with the kind the schema documents
+        // for a row that predates the column. MySQL is the dialect that could
+        // backfill an implicit value on a column that had become NOT NULL, so
+        // the null is asserted rather than the row's mere presence.
+        const [trail] = (await p.query(
+          "SELECT user_id, actor_type FROM activity_log WHERE id = 'al-1'"
+        )) as unknown as [
+          Array<{ user_id: string; actor_type: string | null }>,
+        ];
+        expect(trail[0]?.user_id).toBe("u-1");
+        expect(trail[0]?.actor_type).toBeNull();
 
         // Pass 2: silence.
         const second = await kit.pushSchema(desired, db, "nextly_upgrade_v1");

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/v1-golden/upgrade-sim-045.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/v1-golden/upgrade-sim-045.integration.test.ts
@@ -301,7 +301,11 @@ const migratesActivityLogActor = (stmt: string): boolean => {
  * admits `actor_type_backup`, so a schema that accidentally renamed the column
  * would push its ALTER through, apply cleanly, and leave pass 2 silent — the
  * sim green while the column it promises was never added. The closing quote
- * or a word boundary is required after the name for that reason.
+ * or a word boundary is required after the name for that reason. And the
+ * statement must be ONE statement: only a trailing semicolon is stripped, so a
+ * second statement after an inner one would ride through on the first —
+ * `... ADD actor_type text; DROP TABLE users` — which is why a semicolon is
+ * refused along with a comma.
  *
  * Tolerant of pg/MySQL quoting and the optional COLUMN keyword, like every
  * predicate above.
@@ -311,7 +315,7 @@ const addsOnlyColumn =
   (stmt: string): boolean => {
     const s = stmt.trim().replace(/;$/, "");
     return new RegExp(
-      `^ALTER TABLE [\`"]?${escapeRegExp(table)}[\`"]? ADD (COLUMN )?[\`"]?${escapeRegExp(column)}(?:[\`"]|\\b)[^,]*$`,
+      `^ALTER TABLE [\`"]?${escapeRegExp(table)}[\`"]? ADD (COLUMN )?[\`"]?${escapeRegExp(column)}(?:[\`"]|\\b)[^,;]*$`,
       "i"
     ).test(s);
   };

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/v1-golden/upgrade-sim-045.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/v1-golden/upgrade-sim-045.integration.test.ts
@@ -375,6 +375,32 @@ const addsActivityActorTypeColumn = addsOnlyColumn(
   "actor_type"
 );
 
+/**
+ * Every statement a v1 upgrade of the 0.45 fixture may emit on ANY dialect,
+ * beyond the dialect's own metadata reconcile.
+ *
+ * One list, read by every dialect's pass-1 check. The postgres and mysql cases
+ * used to carry a copy each, and a column added to one and not the other made
+ * the sim red on a single leg — which is how a legitimate column came to read
+ * as a phantom diff. A predicate belongs here once, and then to no dialect.
+ */
+const POST_045_ADDITIVE: ReadonlyArray<(stmt: string) => boolean> = [
+  isPost045TableStatement,
+  addsOwnerColumn,
+  addsPluginOptionsColumn,
+  addsVersionsColumn,
+  addsRevalidateColumn,
+  addsWebhooksColumn,
+  migratesActivityLogActor,
+  addsAuditLogErasureStamp,
+  addsActivityLocaleColumn,
+  addsActivitySubjectKindColumn,
+  addsActivityActorTypeColumn,
+  addsPreviewGenerationColumn,
+];
+const isPost045Additive = (stmt: string): boolean =>
+  POST_045_ADDITIVE.some(admits => admits(stmt));
+
 // Positive guard: the sim must actually create each new table (an empty first
 // pass would otherwise satisfy the additive-only check vacuously).
 const hasCreateTableFor = (stmts: string[], table: string): boolean =>
@@ -522,21 +548,7 @@ describe("existing-user upgrade sim (0.45 DDL → v1)", () => {
           schemas: ["public"],
         });
         for (const s of first.sqlStatements) {
-          expect(
-            isPost045TableStatement(s) ||
-              addsOwnerColumn(s) ||
-              addsPluginOptionsColumn(s) ||
-              addsVersionsColumn(s) ||
-              addsRevalidateColumn(s) ||
-              addsWebhooksColumn(s) ||
-              migratesActivityLogActor(s) ||
-              addsAuditLogErasureStamp(s) ||
-              addsActivityLocaleColumn(s) ||
-              addsActivitySubjectKindColumn(s) ||
-              addsActivityActorTypeColumn(s) ||
-              addsPreviewGenerationColumn(s),
-            `phantom diff: ${s}`
-          ).toBe(true);
+          expect(isPost045Additive(s), `phantom diff: ${s}`).toBe(true);
         }
         for (const t of POST_045_TABLES) {
           expect(
@@ -623,19 +635,7 @@ describe("existing-user upgrade sim (0.45 DDL → v1)", () => {
               s
             );
           expect(
-            isDefaultReconcile ||
-              isPost045TableStatement(s) ||
-              addsOwnerColumn(s) ||
-              addsPluginOptionsColumn(s) ||
-              addsVersionsColumn(s) ||
-              addsRevalidateColumn(s) ||
-              addsWebhooksColumn(s) ||
-              migratesActivityLogActor(s) ||
-              addsAuditLogErasureStamp(s) ||
-              addsActivityLocaleColumn(s) ||
-              addsActivitySubjectKindColumn(s) ||
-              addsActivityActorTypeColumn(s) ||
-              addsPreviewGenerationColumn(s),
+            isDefaultReconcile || isPost045Additive(s),
             `unexpected reconcile statement shape: ${s}`
           ).toBe(true);
         }


### PR DESCRIPTION
Test-only. Repairs the last piece of the red `main` inherited from #1735, on the two legs #1743 could not reach.

## What is red, read from the jobs

`main` at `37aa060bf`, `Integration (postgres)` and `Integration (mysql)` each fail **three** tests: the two `mutation-activity` rows (#1743 fixes those — the sqlite leg on #1753's merge ref, which contains #1743, is green) and this one:

```
upgrade-sim-045 > postgres: only additive new-table creates, then zero
  phantom diff: ALTER TABLE "activity_log" ADD COLUMN "actor_type" text;
upgrade-sim-045 > mysql: one metadata-only default reconcile, then zero
  unexpected reconcile statement shape: ALTER TABLE `activity_log` ADD `actor_type` varchar(16);
```

So once the queue drains and #1743's fix is on every merge ref, **`main` stays red on two of three integration legs**, and every open PR inherits it. Nobody owns it: the only open PR touching the sim is #1659, for `access_rules`.

## Cause

The 0.45 → v1 sim admits post-0.45 additive statements through a per-column allowlist — `addsActivityLocaleColumn`, `addsActivitySubjectKindColumn`, `addsAuditLogErasureStamp`, one whole-statement predicate each. #1735 added `actor_type` to `schemas/audit/{postgres,mysql,sqlite}.ts` and no predicate was added, so the sim correctly refused a column it had never been told about.

## The fix

`addsActivityActorTypeColumn`, mirroring its neighbours exactly: pinned to `activity_log` and to `actor_type`, and required to be the **whole** statement so a destructive clause riding beside the additive one is still refused. Added to both dialect allowlists. The docblock says why the column exists, in the schema's own terms.

## Evidence

Integration tests cannot run on this machine (no Postgres/MySQL), so the predicate was controlled directly against the **verbatim statements from the two failing jobs**, plus the negatives its docblock promises:

| input | expected | got |
|---|---|---|
| postgres statement, verbatim from job 103084653160 | admit | ✓ |
| mysql statement, verbatim from job 103094228601 | admit | ✓ |
| `… ADD COLUMN "actor_type" text, DROP COLUMN "user_id"` | refuse | ✓ |
| same column on `audit_log` | refuse | ✓ |
| `actor_name` on `activity_log` | refuse | ✓ |

The verdict is this PR's own postgres and mysql legs. The file is collected by `vitest.integration.config.ts` (`src/**/*.integration.test.ts`).

## Gates

`check-types` 0 (nextly, both tsc passes) · `lint` 0 · fallow `pass`, `changed_files_count` 1, every `*_introduced` 0. Test-only: no changeset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Database upgrades now preserve existing activity log entries and their associated user IDs.
  - Legacy activity log records remain valid when the new actor type field is introduced; existing records retain an unset actor type.

- **Tests**
  - Expanded upgrade coverage across supported database dialects to verify data preservation during migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->