### PR TITLE
fix(blocks-engine): an exposure row reads what remains, and only a landed write counts

### DIFF
--- a/.changeset/an-exposure-row-reads-what-remains.md
+++ b/.changeset/an-exposure-row-reads-what-remains.md
@@ -1,0 +1,32 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The instance exposure view no longer reports an ancestor as cleared when only a
+descendant path was cleared, no longer counts an override on a path the resolver
+refuses to write as in force, and finds each row's winning write among its own
+node's writes rather than scanning every write per row.

--- a/packages/blocks-engine/src/resolve-instances.test.ts
+++ b/packages/blocks-engine/src/resolve-instances.test.ts
@@ -2854,6 +2854,67 @@ describe("instanceExposure", () => {
     expect(ab?.shadowedBy).toBeUndefined();
   });
 
+  it("keeps an ancestor's remaining value when a descendant is cleared", () => {
+    // `a.b` cleared deletes only `b`; the page keeps `{ a: { c: "keep" } }`.
+    // Reading the ancestor's winning write as "the sentinel, so cleared"
+    // would report `a` as gone while the page still renders its other key.
+    const nested = component(
+      [node("d1", { props: { a: { b: "base", c: "keep" } } })],
+      {
+        exposed: [
+          { ...headline, id: "parent", propPath: "a" },
+          { ...headline, id: "child", propPath: "a.b" },
+        ],
+      }
+    );
+    const node1 = instance("i1", "hero", {
+      overrides: { child: { $unset: true } },
+    });
+
+    const [parent, child] = instanceExposure(nested, node1).properties;
+
+    expect(parent?.value).toEqual({ c: "keep" });
+    expect(parent?.cleared).toBe(false);
+    expect(parent?.shadowedBy).toBe("child");
+    expect(child?.cleared).toBe(true);
+    expect(child?.value).toBeUndefined();
+
+    const rendered = resolveComponentInstances(
+      page([node1]),
+      defs({ hero: nested })
+    );
+    expect(rendered.document.nodes[0]!.props.a).toEqual({ c: "keep" });
+  });
+
+  it("does not count an override on a path the resolver refuses as in force", () => {
+    // An empty path, a doubled dot, or one over the segment limit is one the
+    // resolver declines to write. Treating its override as applied would
+    // attribute an unrendered value to the instance — and let it win a
+    // collision over a write that did land.
+    const broken = component([node("d1", { props: { text: "base" } })], {
+      exposed: [
+        { ...headline, id: "good", propPath: "text" },
+        { ...headline, id: "bad", propPath: "a..b" },
+      ],
+    });
+    const node1 = instance("i1", "hero", {
+      overrides: { good: "GOOD", bad: "BAD" },
+    });
+
+    const [good, bad] = instanceExposure(broken, node1).properties;
+
+    expect(good?.value).toBe("GOOD");
+    expect(good?.source).toBe("instance");
+    expect(bad?.source).toBe("definition");
+    expect(bad?.value).toBeUndefined();
+
+    const rendered = resolveComponentInstances(
+      page([node1]),
+      defs({ hero: broken })
+    );
+    expect(rendered.document.nodes[0]!.props).toEqual({ text: "GOOD" });
+  });
+
   it("has no path value for a visibility exposure", () => {
     // `visibility` decides whether the node is served at all; it names no prop,
     // so reading `propPath` off the definition would report an unrelated value.

--- a/packages/blocks-engine/src/resolve-instances.ts
+++ b/packages/blocks-engine/src/resolve-instances.ts
@@ -1580,9 +1580,15 @@ export function instanceExposure(
   const nodes = nodeIndex(definition.nodes);
   const applied = appliedWrites(declared, overrides);
   const props = finalProps(nodes, applied);
+  const byNode = writesByNode(applied);
 
   const properties = declared.map(property =>
-    exposedState(property, lastWriteOver(property, applied), props, nodes)
+    exposedState(
+      property,
+      lastWriteOver(property, byNode.get(property.nodeId) ?? []),
+      props,
+      nodes
+    )
   );
 
   const exposedIds = new Set(declared.map(property => property.id));
@@ -1651,6 +1657,29 @@ function finalProps(
 }
 
 /**
+ * The in-force writes grouped by the node they land on, in declaration order.
+ *
+ * A write can only reach an exposure on the SAME node, so a row's winner is
+ * found among its own node's writes rather than by scanning every write for
+ * every row — which at the documented limit of a thousand exposures, all
+ * overridden, was a million reach checks per inspector question. The cost is
+ * now the sum over nodes of rows times writes there, which is linear when
+ * exposures are spread across a definition and only approaches the old bound
+ * when a thousand of them all point at one node.
+ */
+function writesByNode(
+  applied: readonly AppliedWrite[]
+): ReadonlyMap<string, readonly AppliedWrite[]> {
+  const byNode = new Map<string, AppliedWrite[]>();
+  for (const write of applied) {
+    const list = byNode.get(write.property.nodeId) ?? [];
+    list.push(write);
+    byNode.set(write.property.nodeId, list);
+  }
+  return byNode;
+}
+
+/**
  * The last in-force write that reaches this exposure's target, if any.
  *
  * "Reaches" is the writer's notion, not string equality: on one node, a path
@@ -1703,12 +1732,18 @@ function exposedState(
   if (winner === undefined) {
     return { property, source: "definition", value, cleared: false };
   }
-  const cleared = isUnsetOverride(winner.override.value);
   const own = winner.property.id === property.id;
+  // Cleared means THIS row's own write is the sentinel. A descendant's `$unset`
+  // deletes only that key — `a.b` cleared leaves `a` holding whatever else it
+  // had — so an ancestor whose winner is a clearing descendant is superseded,
+  // not cleared, and its value is read from what remains rather than assumed
+  // gone. The value already comes from the final props, so a genuinely cleared
+  // path reads as absent without being forced to.
+  const cleared = own && isUnsetOverride(winner.override.value);
   return {
     property,
     source: winner.override.source,
-    value: cleared ? undefined : value,
+    value,
     cleared,
     ...(own ? {} : { shadowedBy: winner.property.id }),
   };
@@ -1741,8 +1776,15 @@ function inForce(
   property: ExposedProperty,
   stored: SourcedOverride | undefined
 ): SourcedOverride | undefined {
-  if (stored === undefined || property.type !== "visibility") return stored;
-  return visibilityDecision(stored.value) === undefined ? undefined : stored;
+  if (stored === undefined) return undefined;
+  if (property.type === "visibility") {
+    return visibilityDecision(stored.value) === undefined ? undefined : stored;
+  }
+  // The resolver refuses to write a path it cannot use — empty, doubled dots,
+  // over the segment limit — and leaves the node untouched. Counting such an
+  // override as in force would attribute a value to the instance that nothing
+  // rendered, and let it win a collision over a write that did.
+  return isUsablePropPath(property.propPath) ? stored : undefined;
 }
 
 /**


### PR DESCRIPTION
Three findings from the post-merge review of #1746, which landed before they were worked. All three reproduce; all three fixed here.

## A descendant's clear does not clear its ancestor

`a.b` cleared deletes only `b` — the page keeps `{ a: { c: "keep" } }`. The ancestor's winning write carried the `$unset` sentinel, so the row reported `a` as cleared while the page still rendered its other key.

`cleared` now means **this row's own write** is the sentinel. A row superseded by a clearing descendant reads its value from what remains. Oracle-checked against `resolveComponentInstances`.

## Only a write the resolver would land counts as in force

The resolver refuses paths it cannot use — empty, doubled dots, over the segment limit — and leaves the node untouched. An override on such a path was counted as in force: an unrendered value attributed to the instance, able to win a collision over a write that did land. In force now means the resolver would write it.

## Winners found per node

Each row's winning write was found by scanning every in-force write — at the documented limit of a thousand exposures all overridden, a million reach checks per inspector question. A write can only reach an exposure on the same node, so writes are grouped by node once.

**Removing that grouping changes no verdict** — all 2461 pass with and without it — which is the point: the same answer, without the quadratic scan. Residual: a thousand exposures that all target *one* node still approach the old bound, and that node's props record is itself the bottleneck there.

## What was measured

| break | what it kills |
|---|---|
| `cleared` read off the winner regardless of whose write | keeps an ancestor's remaining value when a descendant is cleared |
| unusable path counted as in force | does not count an override the resolver refuses as in force |
| per-node grouping removed | nothing — as it must, for an optimisation |

2461 passed. `fallow` pass, 0 introduced. Comment-convention clean. `changeset status` exits 0.
