### PR TITLE
fix(root): a Context7 control is cited from its file, and every exclusion is honoured

### DIFF
--- a/scripts/check-context7-index.mjs
+++ b/scripts/check-context7-index.mjs
@@ -22,7 +22,8 @@
  *   node scripts/check-context7-index.mjs
  */
 
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 export const LIBRARY = "/nextlyhq/nextly";
@@ -78,18 +79,31 @@ function isInside(path, folders) {
 }
 
 /**
- * Why one cited path disagrees with the configuration, or `null`.
- *
- * A file must sit under a listed folder, or be the README; anything else the index cites is
- * a file it holds that the configuration never agreed to.
+ * The rules a cited path is judged by, first applicable first. An exclusion wins over an
+ * inclusion, which is the precedence Context7 documents for `excludeFolders` against
+ * `folders`; then a file must sit under a listed folder or be the README.
  */
+const CITATION_RULES = [
+  [
+    (path, config) => listField(config, "excludeFiles").includes(path),
+    path => `${path} is in excludeFiles and was indexed anyway`,
+  ],
+  [
+    (path, config) => isInside(path, listField(config, "excludeFolders")),
+    path => `${path} is under an excludeFolders entry and was indexed anyway`,
+  ],
+  [
+    (path, config) =>
+      !isInside(path, listField(config, "folders")) && !isKeptRoot(path),
+    (path, config) =>
+      `${path} is outside folders ${JSON.stringify(listField(config, "folders"))} and is not the README, and was indexed`,
+  ],
+];
+
+/** Why one cited path disagrees with the configuration, or `null`. */
 export function citationFinding(path, config) {
-  const folders = listField(config, "folders");
-  if (listField(config, "excludeFiles").includes(path)) {
-    return `${path} is in excludeFiles and was indexed anyway`;
-  }
-  if (isInside(path, folders) || isKeptRoot(path)) return null;
-  return `${path} is outside folders ${JSON.stringify(folders)} and is not the README, and was indexed`;
+  const rule = CITATION_RULES.find(([applies]) => applies(path, config));
+  return rule ? rule[1](path, config) : null;
 }
 
 /**
@@ -104,18 +118,6 @@ export function citationFindings(cited, config) {
     ];
   }
   return [...cited].map(path => citationFinding(path, config)).filter(Boolean);
-}
-
-/**
- * A sentence the index must be able to return, taken from the file rather than written
- * here, so a rewrite of the page cannot leave this comparing against words that no longer
- * exist. The first second-level heading is specific enough to belong to one page.
- */
-export function firstHeading(text, name) {
-  const match = /^##\s+(.+)$/m.exec(text);
-  if (!match)
-    throw new Error(`${name}: no second-level heading to use as a marker`);
-  return match[1].trim();
 }
 
 /** Every heading in a file, top-level and second-level, in order. */
@@ -144,19 +146,33 @@ export function probeMarker(text, corpus) {
   return candidates.find(candidate => !corpus.includes(candidate)) ?? null;
 }
 
-/** The documentation, concatenated, for deciding what a marker must not share. */
-function docsCorpus(root) {
-  const out = [];
-  const walk = dir => {
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-      const full = join(dir, entry.name);
-      if (entry.isDirectory()) walk(full);
-      else if (entry.name.endsWith(".mdx"))
-        out.push(readFileSync(full, "utf-8"));
+/** The Markdown and MDX files git tracks, which is the set Context7 can have read. */
+function trackedText(root) {
+  const out = execFileSync(
+    "git",
+    ["ls-files", "-z", "--", "*.md", "*.mdx", "**/*.md", "**/*.mdx"],
+    {
+      cwd: root,
+      encoding: "utf-8",
     }
-  };
-  walk(join(root, "docs"));
-  return out.join("\n");
+  );
+  return out.split("\0").filter(Boolean);
+}
+
+/**
+ * Everything the index may have read APART from one file, concatenated, for deciding
+ * which of that file's sentences is its own.
+ *
+ * A probe returns whatever the index holds for a topic and cannot say which file it came
+ * from, so a marker shared with any other file the index may hold would answer for the
+ * wrong one: "Quickstart" heads the root README and two package READMEs. Tracked files
+ * only, because an untracked note on one checkout is not something Context7 has read.
+ */
+function corpusExcept(root, name) {
+  return trackedText(root)
+    .filter(rel => rel !== name)
+    .map(rel => readFileSync(join(root, rel), "utf-8"))
+    .join("\n");
 }
 
 /**
@@ -192,7 +208,10 @@ async function retrievable(get, api, marker, name) {
   if (answer.status !== 200) {
     throw new Unanswerable(`probing for ${name} answered ${answer.status}`);
   }
-  return answer.body.includes(marker);
+  return {
+    found: answer.body.includes(marker),
+    cites: citedPaths(answer.body),
+  };
 }
 
 /** A JSON body, or `Unanswerable`: a truncated or non-JSON answer is no verdict either. */
@@ -204,32 +223,42 @@ function parseAnswer(body, what) {
   }
 }
 
-/** The library's search entry, once it exists and has finished indexing. */
-async function finalizedEntry(get, api) {
+/** The search results as a list, or `Unanswerable` when the answer has another shape. */
+async function searchResults(get, api) {
   const search = await get(
     `${api}/search?query=${encodeURIComponent("nextly")}`
   );
   if (search.status !== 200)
     throw new Unanswerable(`search answered ${search.status}`);
-  const entry = parseAnswer(search.body, "search").results?.find(
-    result => result.id === LIBRARY
+  const { results } = parseAnswer(search.body, "search");
+  if (!Array.isArray(results))
+    throw new Unanswerable("search answered without a list of results");
+  return results;
+}
+
+/** The library's search entry, once it exists and has finished indexing. */
+async function finalizedEntry(get, api) {
+  const entry = (await searchResults(get, api)).find(
+    result => result?.id === LIBRARY
   );
   if (!entry) {
     throw new Unanswerable(
       `${LIBRARY} is not in Context7's search results; register it first`
     );
   }
-  if (entry.state !== "finalized") {
+  if (entry.state !== "finalized")
     throw new Unanswerable(`${LIBRARY} is in state "${entry.state}"`);
-  }
   return entry;
 }
 
-/** A marker for a file, or `Unanswerable` when the file offers nothing to ask for. */
-function markerFor(root, name, corpus) {
-  const marker = probeMarker(readFileSync(join(root, name), "utf-8"), corpus);
+/** A marker for a file, or `Unanswerable` when the file offers nothing of its own to ask for. */
+export function markerFor(root, name) {
+  const marker = probeMarker(
+    readFileSync(join(root, name), "utf-8"),
+    corpusExcept(root, name)
+  );
   if (marker === null)
-    throw new Unanswerable(`${name} offers no sentence to ask for`);
+    throw new Unanswerable(`${name} offers no sentence of its own to ask for`);
   return marker;
 }
 
@@ -241,22 +270,19 @@ function markerFor(root, name, corpus) {
  * since the citation sample cannot. A control that fails is a finding, and the exclusions
  * are then not probed at all: their absences would prove nothing.
  */
-async function keptControls({ root, api, get, corpus }) {
-  const kept = [
-    [
-      DOCS_WITNESS,
-      firstHeading(
-        readFileSync(join(root, DOCS_WITNESS), "utf-8"),
-        DOCS_WITNESS
-      ),
-    ],
-    [README, markerFor(root, README, corpus)],
-  ];
+async function keptControls({ root, api, get }) {
+  const kept = [DOCS_WITNESS, README].map(name => [
+    name,
+    markerFor(root, name),
+  ]);
   const findings = [];
   for (const [name, marker] of kept) {
-    if (await retrievable(get, api, marker, name)) continue;
+    const answer = await retrievable(get, api, marker, name);
+    // The sentence must come back AND be cited from the file it was taken from: a
+    // marker answered from some other file would be a control that never looked.
+    if (answer.found && answer.cites.has(name)) continue;
     findings.push(
-      `the index cannot return "${marker}" from ${name}; an absence would prove nothing`
+      `the index cannot return "${marker}" cited from ${name}; an absence would prove nothing`
     );
   }
   return findings;
@@ -267,26 +293,27 @@ async function keptControls({ root, api, get, corpus }) {
  * that offers nothing to ask for stops the run: a "not probed" would read as a pass to
  * whoever only sees the status.
  */
-async function exclusionFindings({ root, api, get, config, corpus }) {
+async function exclusionFindings({ root, api, get, config }) {
+  const present = listField(config, "excludeFiles").filter(name =>
+    existsSync(join(root, name))
+  );
   const findings = [];
-  for (const name of listField(config, "excludeFiles")) {
-    if (!existsSync(join(root, name))) continue;
-    const marker = markerFor(root, name, corpus);
-    if (await retrievable(get, api, marker, name)) {
-      findings.push(
-        `"${marker}" from ${name} is retrievable; its exclusion did not take`
-      );
-    }
+  for (const name of present) {
+    const marker = markerFor(root, name);
+    const answer = await retrievable(get, api, marker, name);
+    if (!answer.found && !answer.cites.has(name)) continue;
+    findings.push(
+      `${name} is retrievable ("${marker}" came back, or the file was cited); its exclusion did not take`
+    );
   }
   return findings;
 }
 
 /** The findings the index earns against the configuration, given a working library. */
 async function indexFindings({ root, api, get, config, cited }) {
-  const corpus = docsCorpus(root);
   const findings = [
     ...citationFindings(cited, config),
-    ...(await keptControls({ root, api, get, corpus })),
+    ...(await keptControls({ root, api, get })),
   ];
   if (
     findings.some(finding => finding.includes("an absence would prove nothing"))
@@ -295,7 +322,7 @@ async function indexFindings({ root, api, get, config, cited }) {
   }
   return [
     ...findings,
-    ...(await exclusionFindings({ root, api, get, config, corpus })),
+    ...(await exclusionFindings({ root, api, get, config })),
   ];
 }
 

--- a/scripts/check-context7-index.test.mjs
+++ b/scripts/check-context7-index.test.mjs
@@ -1,13 +1,13 @@
 import { execFileSync, spawnSync } from "node:child_process";
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 import {
   citationFindings,
   citedPaths,
-  firstHeading,
   headings,
   LIBRARY,
+  markerFor,
   probeMarker,
   REPO_BLOB,
   Unanswerable,
@@ -50,6 +50,18 @@ describe("citationFindings", () => {
         config
       )
     ).toEqual([]);
+  });
+
+  it("reports a file under an excluded folder even when a listed folder holds it", () => {
+    expect(
+      citationFindings(new Set(["docs/internal/secret.mdx"]), {
+        folders: ["docs"],
+        excludeFolders: ["docs/internal"],
+        excludeFiles: [],
+      })
+    ).toEqual([
+      "docs/internal/secret.mdx is under an excludeFolders entry and was indexed anyway",
+    ]);
   });
 
   it("reports an excluded root file that was indexed anyway", () => {
@@ -119,22 +131,8 @@ describe("the committed configuration", () => {
   });
 });
 
-describe("firstHeading", () => {
-  it("takes the first second-level heading", () => {
-    expect(firstHeading("# T\n\ntext\n\n## First\n\n## Second\n", "x")).toBe(
-      "First"
-    );
-  });
-
-  it("refuses a page with none, rather than probing for an empty string", () => {
-    expect(() => firstHeading("# T\n\ntext\n", "x")).toThrow(
-      /no second-level heading/
-    );
-  });
-});
-
 describe("probeMarker", () => {
-  it("takes the first heading the documentation does not contain", () => {
+  it("takes the first heading nothing else contains", () => {
     const file = "# Title\n\n## Overview\n\n## Repository map\n";
     expect(headings(file)).toEqual(["Title", "Overview", "Repository map"]);
     // "Overview" is a heading a docs page also uses, so probing for it would
@@ -150,49 +148,69 @@ describe("probeMarker", () => {
     expect(probeMarker("<p>markup</p>\n- a list\n", "")).toBeNull();
   });
 
-  it("finds a marker in every committed excluded file that has headings", () => {
-    // The real files against the real docs, so the probe has something to ask
-    // for; CLAUDE.md is one line and is the known exception.
+  it("finds a marker of its own in every committed excluded file", () => {
+    // The real files against everything else git tracks, so the probe has a
+    // sentence no other file the index may hold could answer for. CLAUDE.md
+    // is one line, `@AGENTS.md`, and even that is its own.
     const config = JSON.parse(readFileSync("context7.json", "utf-8"));
-    const corpus = readdirSync("docs", { recursive: true })
-      .filter(name => String(name).endsWith(".mdx"))
-      .map(name => readFileSync(`docs/${name}`, "utf-8"))
-      .join("\n");
-    expect(corpus.length).toBeGreaterThan(10000);
-    // Every excluded file, CLAUDE.md included: its one line, `@AGENTS.md`, is a
-    // sentence the docs do not contain, so even that file can be asked for.
-    const unprobeable = config.excludeFiles.filter(
-      name => probeMarker(readFileSync(name, "utf-8"), corpus) === null
-    );
-    expect(unprobeable).toEqual([]);
+    for (const name of config.excludeFiles.filter(name => existsSync(name))) {
+      expect(markerFor(".", name), name).toEqual(expect.any(String));
+    }
+  });
+
+  it("chooses a README sentence no package README shares", () => {
+    // "Quickstart" heads the root README and two package READMEs; a probe for
+    // it could be answered from either, which is a control that never looked.
+    const marker = markerFor(".", "README.md");
+    for (const other of [
+      "packages/nextly/README.md",
+      "packages/create-nextly-app/README.md",
+    ]) {
+      expect(
+        readFileSync(other, "utf-8"),
+        `${other} shares "${marker}"`
+      ).not.toContain(marker);
+    }
   });
 });
 
 /** What the search endpoint says about the library. */
-function searchAnswer({ registered, state }) {
-  const results = registered ? [{ id: LIBRARY, state }] : [];
-  return { status: 200, body: JSON.stringify({ results }) };
-}
-
-/** What a topic query returns: the sentence, when the script says the index has it. */
-function topicAnswer(topic, topics) {
+function searchAnswer({ registered, state, results }) {
+  if (results !== undefined)
+    return { status: 200, body: JSON.stringify({ results }) };
   return {
     status: 200,
-    body: topics[topic] ? `### x\n\n${topic}\n` : "nothing\n",
+    body: JSON.stringify({
+      results: registered ? [{ id: LIBRARY, state }] : [],
+    }),
+  };
+}
+
+/**
+ * What a topic query returns: the sentence, cited from the file the script
+ * says holds it, or nothing.
+ */
+function topicAnswer(topic, topics) {
+  const from = topics[topic];
+  if (!from) return { status: 200, body: "nothing\n" };
+  return {
+    status: 200,
+    body: `### x\n\nSource: ${REPO_BLOB}main/${from}\n\n${topic}\n`,
   };
 }
 
 /**
  * A Context7 that answers from a script.
  *
- * `topics` maps a probed sentence to whether the index "returns" it; anything
- * not listed comes back empty. The real files under the repository root are
- * read for their markers, so the stand-in answers the questions the script
- * really asks.
+ * `topics` maps a probed sentence to the file the index "cites" it from;
+ * anything not listed comes back empty. The real files under the repository
+ * root are read for their markers, so the stand-in answers the questions the
+ * script really asks.
  */
 function context7({
   state = "finalized",
   registered = true,
+  results,
   cites = ["docs/index.mdx", "README.md"],
   topics = {},
   statusFor = () => 200,
@@ -203,7 +221,8 @@ function context7({
   return async url => {
     const status = statusFor(url);
     if (status !== 200) return { status, body: "" };
-    if (url.includes("/search?")) return searchAnswer({ registered, state });
+    if (url.includes("/search?"))
+      return searchAnswer({ registered, state, results });
     const topic = new URL(url).searchParams.get("topic");
     return topic === null
       ? { status: 200, body: dump }
@@ -213,30 +232,26 @@ function context7({
 
 /** The markers the script will ask for, read from the real files. */
 function realMarkers() {
-  const corpus = readdirSync("docs", { recursive: true })
-    .filter(name => String(name).endsWith(".mdx"))
-    .map(name => readFileSync(`docs/${name}`, "utf-8"))
-    .join("\n");
   const config = JSON.parse(readFileSync("context7.json", "utf-8"));
   return {
-    docs: firstHeading(
-      readFileSync("docs/getting-started/index.mdx", "utf-8"),
-      "docs"
-    ),
-    readme: probeMarker(readFileSync("README.md", "utf-8"), corpus),
+    docs: markerFor(".", "docs/getting-started/index.mdx"),
+    readme: markerFor(".", "README.md"),
     excluded: Object.fromEntries(
       config.excludeFiles
         .filter(name => existsSync(name))
-        .map(name => [name, probeMarker(readFileSync(name, "utf-8"), corpus)])
+        .map(name => [name, markerFor(".", name)])
     ),
   };
 }
 
 describe("verify", () => {
   const markers = realMarkers();
-  const kept = { [markers.docs]: true, [markers.readme]: true };
+  const kept = {
+    [markers.docs]: "docs/getting-started/index.mdx",
+    [markers.readme]: "README.md",
+  };
 
-  it("passes when the kept files come back and no excluded file does", async () => {
+  it("passes when the kept files come back cited and no excluded file does", async () => {
     const { status, lines } = await verify({
       root: ".",
       get: context7({ topics: kept }),
@@ -245,24 +260,39 @@ describe("verify", () => {
     expect(status).toBe(0);
   });
 
+  it("fails when a kept file's sentence comes back cited from somewhere else", async () => {
+    // The README's sentence answered from a package README: the marker is
+    // present, the root README is not, and the control must not clear.
+    const { status, lines } = await verify({
+      root: ".",
+      get: context7({
+        topics: { ...kept, [markers.readme]: "packages/nextly/README.md" },
+      }),
+    });
+    expect(status).toBe(1);
+    expect(lines.join("\n")).toContain("cited from README.md");
+  });
+
   it("fails when an excluded file's sentence is retrievable", async () => {
     const [name, marker] = Object.entries(markers.excluded)[0];
     const { status, lines } = await verify({
       root: ".",
-      get: context7({ topics: { ...kept, [marker]: true } }),
+      get: context7({ topics: { ...kept, [marker]: name } }),
     });
     expect(status).toBe(1);
-    expect(lines.join("\n")).toContain(`from ${name} is retrievable`);
+    expect(lines.join("\n")).toContain(`${name} is retrievable`);
   });
 
   it("fails when the README, which the configuration keeps, cannot be retrieved", async () => {
     const { status, lines } = await verify({
       root: ".",
-      get: context7({ topics: { [markers.docs]: true } }),
+      get: context7({
+        topics: { [markers.docs]: "docs/getting-started/index.mdx" },
+      }),
     });
     expect(status).toBe(1);
     expect(lines.join("\n")).toContain(
-      "from README.md; an absence would prove nothing"
+      "cited from README.md; an absence would prove nothing"
     );
   });
 
@@ -284,6 +314,19 @@ describe("verify", () => {
     expect(
       (await verify({ root: ".", get: context7({ state: "initial" }) })).status
     ).toBe(2);
+  });
+
+  it("cannot answer when the search results are not a list, or hold a null", async () => {
+    expect(
+      (await verify({ root: ".", get: context7({ results: {} }) })).status
+    ).toBe(2);
+    // A null entry is skipped rather than thrown on; the library is then simply absent.
+    const { status, lines } = await verify({
+      root: ".",
+      get: context7({ results: [null] }),
+    });
+    expect(status).toBe(2);
+    expect(lines.join("\n")).toContain("not in Context7's search results");
   });
 
   it("cannot answer when a probe gets no answer, rather than counting it as absent", async () => {


### PR DESCRIPTION
The four findings Codex left on #1758 after it merged, worked here.

- **A control's sentence must be cited from its file.** "Quickstart" heads the root README and two package READMEs, so a probe for it could be answered from a file outside the configuration and still pass the README control. A marker is now a sentence no other tracked Markdown file shares (the corpus is everything git tracks, not the docs alone), and a positive control must come back with `Source: .../README.md` in the answer, not merely the words. An excluded file is refused if its sentence comes back OR the file is cited at all.
- **`excludeFolders` is honoured.** `{ folders: ["docs"], excludeFolders: ["docs/internal"] }` accepted `docs/internal/secret.mdx` because a listed folder held it. Exclusions now come first, which is the precedence Context7 documents. The rules are a table.
- **A malformed search answer is unanswerable.** `{"results": {}}` threw a `TypeError` past the status-2 path; `[null]` did the same. Both are status 2 now.
- **The corpus is tracked files.** `git ls-files`, not a directory walk, so a contributor's untracked note cannot change a checkout's verdict.

Tests: 27 (5 new), including the cited-from-elsewhere control, the excludeFolders case, both malformed shapes, and a test that the chosen README marker appears in neither package README. fallow pass, `lint:scripts`, comment convention clean. The live script still exits 2 (`not in Context7's search results; register it first`), as it should until the library is registered.
