### PR TITLE
ci: a newer main push supersedes the run in flight

### DIFF
--- a/.claude/rules/verifying-merged-work.md
+++ b/.claude/rules/verifying-merged-work.md
@@ -27,6 +27,15 @@ plus the change rather than the tree CI ran on, and the two disagree. Measured
 on one merged pull request here, the branch head reported the CI job and one
 integration leg as `success` while the merge commit had them queued.
 
+**A cancelled job on a merge commit that is no longer `main`'s head was
+superseded, not failed.** `main` groups its CI and Integration runs by branch,
+so a newer push cancels the run in flight, and a leg that overruns its budget
+FAILS rather than cancels. The script reads the base's current head and, when
+it has moved past the merge commit, reports those cancelled jobs under
+`superseded` with the head revision to read instead; they do not block. A
+cancelled job on the head itself, or a `failure` anywhere, still blocks. Judge
+`main` by its head's run, which includes every commit before it.
+
 **Know its range before trusting it.** The script's module header lists what it
 does not cover, and the four worth carrying in your head are: it snapshots
 threads and checks once rather than holding them still; `REQUIRED_CHECKS` is a

--- a/.claude/rules/verifying-merged-work.md
+++ b/.claude/rules/verifying-merged-work.md
@@ -31,10 +31,13 @@ integration leg as `success` while the merge commit had them queued.
 superseded, not failed.** `main` groups its CI and Integration runs by branch,
 so a newer push cancels the run in flight, and a leg that overruns its budget
 FAILS rather than cancels. The script reads the base's current head and, when
-it has moved past the merge commit, reports those cancelled jobs under
-`superseded` with the head revision to read instead; they do not block. A
-cancelled job on the head itself, or a `failure` anywhere, still blocks. Judge
-`main` by its head's run, which includes every commit before it.
+it has moved past the merge commit AND the head has a run of the same job,
+reports those cancelled jobs under `superseded` with the head revision to read
+instead; they do not block. The head's run is the witness: a concurrency cancel
+leaves one behind and a manual cancel does not, so a cancelled job the head
+never ran still blocks. So does a cancelled job on the head itself, and a
+`failure` anywhere. Judge `main` by its head's run, which includes every
+commit before it.
 
 **Know its range before trusting it.** The script's module header lists what it
 does not cover, and the four worth carrying in your head are: it snapshots

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,24 +12,15 @@ on:
 permissions:
   contents: read
 
-# Superseding is right for a branch under review and wrong for `main`.
-#
-# On a pull request a new push makes the previous run's verdict irrelevant, so
-# every push shares one group and cancels the last: minutes saved, nothing lost.
-#
-# On `main` every commit is a distinct artifact somebody will later ask "was that
-# green?" about, so each push gets a group of its OWN. Sharing a `github.ref`
-# group there cancelled the previous commit's run on every merge, and a REQUIRED
-# check reporting `cancelled` is indistinguishable from one that failed — which
-# trains people to merge past red.
-#
-# The group has to differ per commit rather than the cancellation merely being
-# switched off. A group holds at most one running AND one pending run, so with
-# three merges in quick succession the third displaces the second while it is
-# still queued: the middle commit ends up cancelled regardless of
-# `cancel-in-progress`. Keyed by `github.sha`, there is nothing to displace.
+# One group per branch, on `main` as on a pull request, so a newer push
+# supersedes the run in flight. `integration.yml` carries the full reasoning
+# and this workflow follows it: main was keyed per commit so every merge got a
+# verdict of its own, and the queue that produced could not drain at the merge
+# rate. A cancelled run on `main` now means one thing, superseded by a newer
+# push, and `scripts/verify-merge.mjs` reads it as such rather than as a
+# failure.
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,12 +38,32 @@ permissions:
 env:
   INTEGRATION_SUITE_BUDGET: 55m
 
-# Keyed per commit on `main` for the same reason as the CI workflow: a shared
-# `github.ref` group cancelled the previous commit's run on every merge, and
-# switching cancellation off is not enough — a group holds one running and one
-# pending run, so a third merge displaces the second while it is still queued.
+# One group per branch, on `main` as on a pull request, so a newer push
+# supersedes the run in flight. Keyed by `github.ref` for both: a pull request's
+# ref is its own, and every main push shares `refs/heads/main`.
+#
+# Main was keyed per commit for a while, so every merge got a verdict of its
+# own. That could not survive the merge rate: each run is three dialects for
+# twenty to thirty-five minutes, with nothing ever superseded the queue only
+# grew, and at one point fifty runs sat queued with nothing on `main` able to
+# report for over half an hour. A verdict that arrives after the next several
+# merges is not a verdict anyone acts on.
+#
+# What per-commit grouping protected against was a superseded run reading as a
+# failed one: `cancelled` and `failure` looked alike, and the habit that
+# teaches is merging past red. Two things make them distinguishable now. A leg
+# that overruns its budget FAILS rather than cancels, so on `main` a cancelled
+# run means exactly one thing, superseded by a newer push. And
+# `scripts/verify-merge.mjs` reads a cancelled job on a merge commit that is no
+# longer `main`'s head as superseded, and points at the head's run, rather than
+# counting it against the pull request.
+#
+# The group is one running plus one pending, so with three quick merges the
+# middle one is displaced before it starts. That is the intended outcome here:
+# only the newest push's verdict describes `main`, and the middle commit's
+# result is subsumed by the one that includes it.
 concurrency:
-  group: integration-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  group: integration-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/scripts/verify-merge.mjs
+++ b/scripts/verify-merge.mjs
@@ -268,9 +268,20 @@ export function gateVerdict({
   coderabbitReviewCount,
   approvalCount = 0,
   supersededBy = null,
+  supersedingRuns = [],
 }) {
   const blockers = [];
   const superseded = [];
+  // The job names the superseding head has a run for. A cancelled job counts
+  // as superseded only when the head is running or ran the SAME job: that run
+  // is the witness that a concurrency group cancelled this one. Without it, a
+  // cancellation somebody made by hand on a commit that was then merged past
+  // would read as superseded and stop blocking.
+  const witnessed = new Set(
+    (Array.isArray(supersedingRuns) ? supersedingRuns : [])
+      .map(run => run?.name)
+      .filter(name => typeof name === "string")
+  );
 
   if (typeof tip !== "string" || tip.length === 0) {
     blockers.push({ kind: "no-tip", detail: "no head revision to merge" });
@@ -315,7 +326,11 @@ export function gateVerdict({
       // rather than cancels. The verdict that describes `main` is the head's,
       // and this one is subsumed by it. Reported, never a blocker; a cancelled
       // job on the head itself is still exactly what it looks like.
-      if (job.conclusion === "cancelled" && supersededBy) {
+      if (
+        job.conclusion === "cancelled" &&
+        supersededBy &&
+        witnessed.has(job.name)
+      ) {
         superseded.push(job.name);
         continue;
       }
@@ -1153,6 +1168,28 @@ export function main(argv) {
     }
   }
 
+  // The head's own runs, read only when there is a head to read. These are the
+  // witnesses: a cancelled job here is filed as superseded only if the head
+  // has a run of the same name, which is what a concurrency cancel leaves
+  // behind and a manual cancel does not.
+  let supersedingRuns = [];
+  if (supersededBy) {
+    try {
+      supersedingRuns = flatPages(
+        ghJson([
+          "api",
+          "--paginate",
+          "--slurp",
+          `repos/${REPO}/commits/${supersededBy}/check-runs?per_page=100`,
+        ]),
+        "check-runs",
+        pageWrapping("check_runs")
+      ).flatMap(page => page.check_runs ?? []);
+    } catch {
+      supersedingRuns = [];
+    }
+  }
+
   // Only read before it is needed. Rewrite reachability answers whether a merge
   // took the whole branch, which an open pull request has not yet asked — so
   // querying it there lets an unrelated endpoint failure refuse a verdict the
@@ -1397,6 +1434,7 @@ export function main(argv) {
     coderabbitReviewCount: coderabbit,
     approvalCount: countWriteAccessApprovals(reviews),
     supersededBy,
+    supersedingRuns,
   });
 
   // Nothing is printed until the freshness read below has decided. Emitting the

--- a/scripts/verify-merge.mjs
+++ b/scripts/verify-merge.mjs
@@ -267,8 +267,10 @@ export function gateVerdict({
   codexReviewedSha,
   coderabbitReviewCount,
   approvalCount = 0,
+  supersededBy = null,
 }) {
   const blockers = [];
+  const superseded = [];
 
   if (typeof tip !== "string" || tip.length === 0) {
     blockers.push({ kind: "no-tip", detail: "no head revision to merge" });
@@ -307,6 +309,16 @@ export function gateVerdict({
       });
     }
     for (const job of blockingJobs(checkRuns)) {
+      // A cancelled job on a merge commit that is no longer the base's head
+      // was superseded: `main` groups its runs by branch, so a newer push
+      // cancels the one in flight, and a leg that overran its budget FAILS
+      // rather than cancels. The verdict that describes `main` is the head's,
+      // and this one is subsumed by it. Reported, never a blocker; a cancelled
+      // job on the head itself is still exactly what it looks like.
+      if (job.conclusion === "cancelled" && supersededBy) {
+        superseded.push(job.name);
+        continue;
+      }
       blockers.push({
         kind: "job-not-green",
         detail: `${job.name} (${job.status}/${job.conclusion ?? "-"})`,
@@ -344,6 +356,10 @@ export function gateVerdict({
     // rather than raise the bar for any. Surfacing it states the gap instead of
     // hiding it behind a green verdict or making the gate unusable.
     maintainerApproval: approvalCount > 0 ? "approved" : "none",
+    // Reported, never a blocker: which jobs this revision never finished
+    // because a newer push to the base superseded it, and the revision whose
+    // run answers for it instead.
+    superseded: superseded.length > 0 ? { jobs: superseded, by: supersededBy } : null,
   };
 }
 
@@ -353,6 +369,11 @@ export function formatVerdict(verdict) {
   lines.push(verdict.mergeable ? "GATE PASSED" : "GATE BLOCKED");
   for (const blocker of verdict.blockers)
     lines.push(`  - ${blocker.kind}: ${blocker.detail}`);
+  if (verdict.superseded) {
+    lines.push(
+      `  ~ superseded: ${verdict.superseded.jobs.join(", ")} cancelled because ${verdict.superseded.by.slice(0, 9)} pushed to the base afterwards; read that revision's run (not a blocker)`
+    );
+  }
   if (verdict.secondReviewer !== "reviewed") {
     lines.push(
       `  ! second reviewer: ${verdict.secondReviewer} (not a blocker; not coverage either)`
@@ -1114,6 +1135,24 @@ export function main(argv) {
   // the merge reports on a tree nobody has.
   const subject = merged ? meta.mergeSha : tip;
 
+  // The base's CURRENT head, read only after a merge. A merge commit that is no
+  // longer that head has been superseded: the base's workflows group runs by
+  // branch, so a newer push cancels the run in flight, and the cancelled jobs
+  // on this revision are answered by the head's run rather than counted as
+  // failures here. Null when this revision still IS the head, or when the base
+  // cannot be read, in which case a cancelled job stays exactly what it looks
+  // like and the gate errs toward blocking.
+  let supersededBy = null;
+  if (merged && subject) {
+    try {
+      const baseHead = ghJson(["api", `repos/${REPO}/commits/${meta.baseRef}`]);
+      const headSha = typeof baseHead?.sha === "string" ? baseHead.sha : null;
+      if (headSha && headSha !== subject) supersededBy = headSha;
+    } catch {
+      supersededBy = null;
+    }
+  }
+
   // Only read before it is needed. Rewrite reachability answers whether a merge
   // took the whole branch, which an open pull request has not yet asked — so
   // querying it there lets an unrelated endpoint failure refuse a verdict the
@@ -1357,6 +1396,7 @@ export function main(argv) {
     codexReviewedSha: reviewedSha,
     coderabbitReviewCount: coderabbit,
     approvalCount: countWriteAccessApprovals(reviews),
+    supersededBy,
   });
 
   // Nothing is printed until the freshness read below has decided. Emitting the

--- a/scripts/verify-merge.test.mjs
+++ b/scripts/verify-merge.test.mjs
@@ -56,6 +56,16 @@ const forcePush = { event: "head_ref_force_pushed" };
 const commented = { event: "commented" };
 const green = name => ({ name, status: "completed", conclusion: "success" });
 const queued = name => ({ name, status: "queued", conclusion: null });
+const cancelled = name => ({
+  name,
+  status: "completed",
+  conclusion: "cancelled",
+});
+/** Every required job green except the named one, which was cancelled. */
+const allGreenExceptCancelled = name =>
+  REQUIRED.map(check =>
+    check.name === name ? cancelled(check.name) : green(check.name)
+  );
 /** The one check whose ABSENCE means no build ran. Fixtures must name it. */
 const CI = "Lint / Typecheck / Test / Build";
 /** A real 40-character object name; the gate refuses anything shorter as a tip. */
@@ -487,6 +497,59 @@ describe("gateVerdict", () => {
 
     expect(verdict.mergeable).toBe(false);
     expect(verdict.blockers.map(b => b.kind)).toContain("job-not-green");
+  });
+
+  it("reports a cancelled job as superseded when the base moved past it", () => {
+    // `main` groups its runs by branch, so a newer push cancels the run in
+    // flight, and a leg that overruns its budget FAILS rather than cancels. A
+    // cancelled job on a merge commit that is no longer the head therefore
+    // means one thing: the head's run answers for it. Reported, not a blocker.
+    const HEAD = "aa11bb22cc33dd44ee55ff6677889900aabbccdd";
+    const verdict = gateVerdict({
+      ...passing,
+      checkRuns: allGreenExceptCancelled("Integration (postgres)"),
+      supersededBy: HEAD,
+    });
+
+    expect(verdict.mergeable).toBe(true);
+    expect(verdict.blockers).toEqual([]);
+    expect(verdict.superseded).toEqual({
+      jobs: ["Integration (postgres)"],
+      by: HEAD,
+    });
+  });
+
+  it("still blocks on a cancelled job when this revision IS the head", () => {
+    // The control that keeps the case above honest. With nothing pushed after
+    // it, a cancelled job was not superseded by anything, and treating it as
+    // fine would be the merge-past-red the per-commit grouping once guarded.
+    const verdict = gateVerdict({
+      ...passing,
+      checkRuns: allGreenExceptCancelled("Integration (postgres)"),
+      supersededBy: null,
+    });
+
+    expect(verdict.mergeable).toBe(false);
+    expect(verdict.blockers.map(b => b.kind)).toContain("job-not-green");
+    expect(verdict.superseded).toBeNull();
+  });
+
+  it("does not let supersession excuse a job that FAILED", () => {
+    // Only `cancelled` is the superseded shape. A failure on a superseded
+    // commit is still a failure the head inherited, and the head's own run
+    // will say so; hiding it here would be the same red passed twice.
+    const verdict = gateVerdict({
+      ...passing,
+      checkRuns: REQUIRED.map(check =>
+        check.name === "Integration (mysql)"
+          ? { name: check.name, status: "completed", conclusion: "failure" }
+          : green(check.name)
+      ),
+      supersededBy: "aa11bb22cc33dd44ee55ff6677889900aabbccdd",
+    });
+
+    expect(verdict.mergeable).toBe(false);
+    expect(verdict.superseded).toBeNull();
   });
 
   it("blocks when NO jobs reported at all", () => {

--- a/scripts/verify-merge.test.mjs
+++ b/scripts/verify-merge.test.mjs
@@ -509,6 +509,9 @@ describe("gateVerdict", () => {
       ...passing,
       checkRuns: allGreenExceptCancelled("Integration (postgres)"),
       supersededBy: HEAD,
+      // The witness: the head is running the same job, which is what a
+      // concurrency cancel leaves behind.
+      supersedingRuns: [queued("Integration (postgres)")],
     });
 
     expect(verdict.mergeable).toBe(true);
@@ -517,6 +520,24 @@ describe("gateVerdict", () => {
       jobs: ["Integration (postgres)"],
       by: HEAD,
     });
+  });
+
+  it("still blocks a cancelled job the head has no run of", () => {
+    // The case supersession alone cannot explain. A run somebody cancelled by
+    // hand on a commit that was later merged past has a newer head and no
+    // witness: the head never ran that job. Filing it as superseded would let
+    // a manual cancel stop blocking, so without the witness it stays what it
+    // looks like.
+    const verdict = gateVerdict({
+      ...passing,
+      checkRuns: allGreenExceptCancelled("Integration (postgres)"),
+      supersededBy: "aa11bb22cc33dd44ee55ff6677889900aabbccdd",
+      supersedingRuns: [green(CI)],
+    });
+
+    expect(verdict.mergeable).toBe(false);
+    expect(verdict.blockers.map(b => b.kind)).toContain("job-not-green");
+    expect(verdict.superseded).toBeNull();
   });
 
   it("still blocks on a cancelled job when this revision IS the head", () => {


### PR DESCRIPTION
## Why main cannot report

The Integration and CI workflows key their concurrency group on `main` **by commit**, so no push there ever supersedes another. Every merge runs to completion — Integration is 3 dialects × 20–35 min — and at the current merge rate the queue can only grow.

Measured at 07:46Z: **50 runs queued across all workflows, 7 in progress**, Integration runs from 07:12Z still going, and nothing on `main` had reported for over half an hour. That included #1761, the commit that fixed the failure everyone was waiting to see fixed. Every open PR read as BLOCKED meanwhile.

## This reverses #688, on purpose

#688 chose per-commit grouping deliberately, and its concern was real: a shared group cancelled 5 of 8 main runs, and a required check reporting `cancelled` looked the same as one that failed — which trains people to merge past red.

Two things make them distinguishable now, and both are what let this change be made rather than wished for:

1. **A leg that overruns its budget fails rather than cancels** (#1744). So on `main`, `cancelled` means exactly one thing: superseded by a newer push.
2. **`verify-merge.mjs` reads the base's current head after a merge.** A cancelled job on a merge commit the base has moved past is reported under `superseded`, naming the head revision whose run answers for it, and does not block. A cancelled job on the head itself still blocks. A `failure` anywhere still blocks; supersession excuses nothing that actually failed.

The middle of three quick merges is displaced before it starts, which #688 counted as a lost verdict. Here it is the intended outcome: the newest push's run includes that commit and is the one that describes `main`.

## What changed

- `integration.yml`, `ci.yml`: `group: …-${{ github.ref }}` for both events. Comments record the decision and the reasoning.
- `scripts/verify-merge.mjs`: `gateVerdict` takes `supersededBy`; the call site reads `repos/…/commits/<base>` after a merge. Reported the way `secondReviewer` and `maintainerApproval` already are: never a blocker.
- `.claude/rules/verifying-merged-work.md`: how to read a cancelled job now.

Three tests: superseded is reported not blocked; cancelled on HEAD still blocks; failure on a superseded commit still blocks. The first fails with the branch removed.

Coordinated with the session that owns #1744's budget guard; the verify-merge interaction was their catch. CI-only, no changeset. scripts 1,281 · lint 0 · comments 0.