### PR TITLE
fix(admin): every sortable table takes the keyboard, and a drag names what it moves

### DIFF
--- a/.changeset/a-drag-says-what-it-is-moving.md
+++ b/.changeset/a-drag-says-what-it-is-moving.md
@@ -1,0 +1,45 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Every sortable table in the admin can be reordered from the keyboard, and a
+screen reader is told what is being moved.
+
+Two tables -- the collection fields list and the user fields page -- accepted
+only a pointer, so a keyboard user could not reorder them at all. They now use
+the same sensors as every other drag surface: Space or Enter picks a row up,
+the arrow keys move it, Space drops it, Escape puts it back.
+
+What a drag says has changed on every surface. The defaults read the
+draggable's id aloud -- "Picked up draggable item 3f9a…" -- and every id here
+is a field name or a uuid. A drag now names the thing and where it sits:
+"Picked up Title, position 1 of 4", "Title is over Body, position 3 of 4",
+"Title moved to position 3 of 4". On the dashboard the same sentences name the
+card and its column, matching what the Move buttons already say, so a card
+moved by keyboard and one moved by button sound the same. Each drag handle is
+also named after its row, so tabbing through them no longer reads as a list of
+identical buttons.

--- a/packages/admin/src/__tests__/helpers/drag.ts
+++ b/packages/admin/src/__tests__/helpers/drag.ts
@@ -1,0 +1,74 @@
+/**
+ * Driving a dnd-kit surface from the keyboard under jsdom, and hearing it.
+ *
+ * jsdom performs no layout, and dnd-kit decides what a dragged item is over
+ * by measuring nodes with `getBoundingClientRect`. Every node at 0×0 makes the
+ * first droppable "nearest" to everything, which is no geometry any surface
+ * has — so a test lays its sortable nodes out first, and from there a Space,
+ * an arrow and a Space move an item the way a keyboard user's would.
+ *
+ * @module __tests__/helpers/drag
+ */
+
+import { vi } from "vitest";
+
+/**
+ * Give each node the rectangle a rendered surface would give it: stacked in
+ * the order given, `height` apart, full `width`. Restored by
+ * `vi.restoreAllMocks()`.
+ */
+export function layOutStacked(
+  nodes: readonly Element[],
+  { height = 40, width = 600 }: { height?: number; width?: number } = {}
+): void {
+  nodes.forEach((node, index) => {
+    const top = index * height;
+    const rect = {
+      x: 0,
+      y: top,
+      top,
+      bottom: top + height,
+      left: 0,
+      right: width,
+      width,
+      height,
+      toJSON: () => ({}),
+    } satisfies DOMRect;
+    vi.spyOn(node, "getBoundingClientRect").mockReturnValue(rect);
+  });
+}
+
+/**
+ * dnd-kit's own live region.
+ *
+ * Found by the id prefix dnd-kit gives it rather than by role, so a second
+ * status region on the page can never satisfy an assertion about this one.
+ */
+export function dragRegion(): HTMLElement {
+  const region = document.querySelector<HTMLElement>('[id^="DndLiveRegion"]');
+  if (!region) throw new Error("dnd-kit rendered no live region");
+  return region;
+}
+
+/**
+ * Every sentence dnd-kit's live region speaks from now on, in order.
+ *
+ * A live region holds only its LATEST sentence, and two sentences spoken in
+ * one React batch leave only the second in the DOM — so the sequence is
+ * recorded as it lands rather than read at the end, and a test asserts what
+ * was said instead of whichever sentence won.
+ */
+export function recordDragRegion(): string[] {
+  const region = dragRegion();
+  const heard: string[] = [];
+  const observer = new MutationObserver(() => {
+    const said = region.textContent ?? "";
+    if (said && said !== heard[heard.length - 1]) heard.push(said);
+  });
+  observer.observe(region, {
+    childList: true,
+    characterData: true,
+    subtree: true,
+  });
+  return heard;
+}

--- a/packages/admin/src/components/features/content/SortableFieldsTable.test.tsx
+++ b/packages/admin/src/components/features/content/SortableFieldsTable.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * The fields table can be reordered from the keyboard, and says what it is
+ * doing about the FIELD rather than its key.
+ *
+ * Driven through the real `DndContext`, with the rows laid out the way a
+ * table lays them out — see `__tests__/helpers/drag` for why jsdom needs
+ * telling. From there a Space, an arrow and a Space reorder the list the way
+ * a keyboard user's would, and the live region says what theirs would say.
+ *
+ * @module components/features/content/SortableFieldsTable.test
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  dragRegion,
+  layOutStacked,
+  recordDragRegion,
+} from "@admin/__tests__/helpers/drag";
+import type { FieldConfig } from "@admin/types/ui/collection";
+
+import { SortableFieldsTable } from "./SortableFieldsTable";
+
+const FIELDS: FieldConfig[] = [
+  { name: "title", label: "Title", type: "text" },
+  { name: "slug", label: "Slug", type: "text" },
+  { name: "body", label: "Body", type: "richtext" },
+];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function draw() {
+  const onReorder = vi.fn();
+  const view = render(
+    <SortableFieldsTable
+      fields={FIELDS}
+      onReorder={onReorder}
+      onEdit={vi.fn()}
+      onDeleteRequest={vi.fn()}
+    />
+  );
+  layOutStacked(Array.from(document.querySelectorAll("tbody tr")));
+  return { ...view, onReorder };
+}
+
+describe("the fields table", () => {
+  it("names each handle after its field, so a keyboard user knows which row they hold", () => {
+    // 🔴 Every handle used to be "Drag handle". Tabbing through was N identical
+    // buttons with nothing to say which field was which.
+    draw();
+    expect(
+      screen.getByRole("button", { name: "Drag to reorder Title" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Drag to reorder Body" })
+    ).toBeInTheDocument();
+  });
+
+  it("picks a field up from the keyboard and says so by label and position", async () => {
+    // 🔴 Two things, and one press proves both. The drag begins only if a
+    // KeyboardSensor is attached -- a pointer-only table ignores the key -- and
+    // the sentence names "Slug", not the sortable key, because the table
+    // supplied its own announcements in place of dnd-kit's "Picked up
+    // draggable item slug."
+    draw();
+    const heard = recordDragRegion();
+    const handle = screen.getByRole("button", { name: "Drag to reorder Slug" });
+    handle.focus();
+    fireEvent.keyDown(handle, { code: "Space", key: " " });
+
+    await waitFor(() =>
+      expect(heard).toContain("Picked up Slug, position 2 of 3.")
+    );
+    // Nothing it said, before or after, was dnd-kit's default.
+    expect(heard.join(" ")).not.toContain("draggable item");
+  });
+
+  it("reorders the fields from the keyboard: Space, arrow, Space", async () => {
+    // 🔴 The whole of WCAG 2.1.1 for this table, end to end. Every step is
+    // spoken: the pick-up, the row it is over once the arrow moves it, and
+    // the landing -- and the drop reaches `onReorder` with the moved list.
+    const { onReorder } = draw();
+    const heard = recordDragRegion();
+    const handle = screen.getByRole("button", { name: "Drag to reorder Slug" });
+    handle.focus();
+    fireEvent.keyDown(handle, { code: "Space", key: " " });
+    await waitFor(() =>
+      expect(heard).toContain("Picked up Slug, position 2 of 3.")
+    );
+
+    fireEvent.keyDown(handle, { code: "ArrowDown", key: "ArrowDown" });
+    await waitFor(() =>
+      expect(heard).toContain("Slug is over Body, position 3 of 3.")
+    );
+
+    fireEvent.keyDown(handle, { code: "Space", key: " " });
+    await waitFor(() =>
+      expect(heard).toContain("Slug moved to position 3 of 3.")
+    );
+    expect(onReorder).toHaveBeenCalledTimes(1);
+    expect(
+      onReorder.mock.calls[0][0].map((f: { name: string }) => f.name)
+    ).toEqual(["title", "body", "slug"]);
+  });
+
+  it("says where a cancelled drag returned to", async () => {
+    draw();
+    const heard = recordDragRegion();
+    const handle = screen.getByRole("button", { name: "Drag to reorder Slug" });
+    handle.focus();
+    fireEvent.keyDown(handle, { code: "Space", key: " " });
+    await waitFor(() => expect(heard.length).toBeGreaterThan(0));
+
+    fireEvent.keyDown(handle, { code: "Escape", key: "Escape" });
+
+    await waitFor(() =>
+      expect(dragRegion().textContent).toContain(
+        "Dragging cancelled. Slug returned to position 2 of 3."
+      )
+    );
+  });
+});

--- a/packages/admin/src/components/features/content/SortableFieldsTable.tsx
+++ b/packages/admin/src/components/features/content/SortableFieldsTable.tsx
@@ -1,10 +1,4 @@
-import {
-  DndContext,
-  closestCenter,
-  useSensor,
-  useSensors,
-  PointerSensor,
-} from "@dnd-kit/core";
+import { DndContext, closestCenter } from "@dnd-kit/core";
 import type { DragEndEvent } from "@dnd-kit/core";
 import {
   SortableContext,
@@ -15,6 +9,11 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import { Badge, Button } from "@nextlyhq/ui";
 
+import {
+  positionInList,
+  sortableAnnouncements,
+  useSortableSensors,
+} from "@admin/components/features/entries/fields/structured/field-array-helpers";
 import { Edit, Trash } from "@admin/components/icons";
 import type {
   FieldConfig,
@@ -58,7 +57,9 @@ function SortableFieldRow({
           {...attributes}
           {...listeners}
           tabIndex={0}
-          aria-label="Drag handle"
+          // Named per ROW. Every handle labelled alike is N identical buttons to
+          // a reader moving by keyboard, with nothing to say which field is which.
+          aria-label={`Drag to reorder ${field.label}`}
         >
           <svg
             width="16"
@@ -123,11 +124,18 @@ export function SortableFieldsTable({
   onEdit,
   onDeleteRequest,
 }: SortableFieldsTableProps) {
-  const sensors = useSensors(
-    useSensor(PointerSensor, {
-      activationConstraint: { distance: 8 },
-    })
-  );
+  // Pointer AND keyboard, from the one hook every sortable surface shares. A
+  // pointer-only `useSensors` here is what left this table unreachable from
+  // the keyboard.
+  const sensors = useSortableSensors();
+
+  // Said about the FIELD rather than its name-as-id: a reader hears "Picked up
+  // Title, position 1 of 4", not the sortable key.
+  const names = fields.map(f => f.name);
+  const announcements = sortableAnnouncements({
+    describe: ({ id }) => fields.find(f => f.name === id)?.label,
+    place: ({ id }) => positionInList(names, id),
+  });
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
@@ -148,11 +156,9 @@ export function SortableFieldsTable({
         sensors={sensors}
         collisionDetection={closestCenter}
         onDragEnd={handleDragEnd}
+        accessibility={{ announcements }}
       >
-        <SortableContext
-          items={fields.map(f => f.name)}
-          strategy={verticalListSortingStrategy}
-        >
+        <SortableContext items={names} strategy={verticalListSortingStrategy}>
           <table className="w-full divide-y divide-border">
             <thead className="bg-primary/5">
               <tr>

--- a/packages/admin/src/components/features/entries/fields/structured/field-array-helpers.tsx
+++ b/packages/admin/src/components/features/entries/fields/structured/field-array-helpers.tsx
@@ -16,9 +16,12 @@ import {
   PointerSensor,
   useSensor,
   useSensors,
+  type Announcements,
+  type DataRef,
   type DragEndEvent,
   type SensorDescriptor,
   type SensorOptions,
+  type UniqueIdentifier,
 } from "@dnd-kit/core";
 import {
   SortableContext,
@@ -180,11 +183,20 @@ export interface UseSortableFieldArrayResult {
  * @param move - Function from useFieldArray to move items between indices
  * @returns Sensors and drag end callback
  */
-export function useSortableFieldArray<T extends { id: string }>(
-  items: T[],
-  move: (oldIndex: number, newIndex: number) => void
-): UseSortableFieldArrayResult {
-  const sensors = useSensors(
+/**
+ * The sensors every sortable surface in the admin drags with.
+ *
+ * Pointer AND keyboard, always together. A surface that builds its own
+ * `useSensors` reaches for the pointer and stops, and the keyboard gap that
+ * leaves is invisible to anyone testing with a mouse — two tables shipped that
+ * way. One hook makes the pair the only thing there is to reach for.
+ *
+ * The 8px activation distance keeps a click on a row from starting a drag,
+ * and `sortableKeyboardCoordinates` is what turns an arrow key into a move
+ * to the neighbouring item rather than a move by a fixed number of pixels.
+ */
+export function useSortableSensors(): SensorDescriptor<SensorOptions>[] {
+  return useSensors(
     useSensor(PointerSensor, {
       activationConstraint: {
         distance: 8,
@@ -194,6 +206,103 @@ export function useSortableFieldArray<T extends { id: string }>(
       coordinateGetter: sortableKeyboardCoordinates,
     })
   );
+}
+
+/**
+ * One draggable or droppable as an announcement sees it: an id, and the data
+ * its `useSortable`/`useDroppable` call attached. Both of dnd-kit's `Active`
+ * and `Over` carry these, so one shape describes either end of a drag.
+ */
+export interface AnnouncedItem {
+  id: UniqueIdentifier;
+  data: DataRef;
+}
+
+/**
+ * What a surface knows about the things it sorts.
+ *
+ * `describe` names an item — a field's label, a card's title. `place` says
+ * where it sits, in words the surface owns: "position 2 of 5" for a list,
+ * "column 1 of 3, position 2 of 4" for the grid. Either may answer
+ * `undefined` for an id it does not know, and the sentence is built around
+ * the gap rather than from it.
+ */
+export interface SortableAnnouncementModel {
+  describe: (item: AnnouncedItem) => string | undefined;
+  place?: (item: AnnouncedItem) => string | undefined;
+}
+
+/** The subject of a sentence when a surface cannot name an item. */
+const UNNAMED = "the item";
+
+/**
+ * What a screen reader hears during a drag, said about the THING being moved.
+ *
+ * 🔴 dnd-kit's defaults read the draggable's ID aloud — "Picked up draggable
+ * item 3f9a…" — and every sortable here is keyed by a field name, a placement
+ * id or a uuid, so a reader moving a row by keyboard was told nothing they
+ * could act on. The wording lives here ONCE so a field row and a dashboard
+ * card are announced in the same sentences, and each surface supplies only
+ * what it knows: a name for an id and, where it has one, the place it sits.
+ *
+ * `onDragEnd` names the landing. A surface that already announces its own
+ * landing through a live region of its own overrides it to return
+ * `undefined`, so a drop is not read twice — the dashboard grid does this,
+ * because its button path speaks the same landing sentence and the two ways
+ * of moving a card must sound the same.
+ */
+export function sortableAnnouncements(
+  model: SortableAnnouncementModel
+): Announcements {
+  const name = (item: AnnouncedItem) => model.describe(item) ?? UNNAMED;
+  const at = (item: AnnouncedItem) => model.place?.(item);
+  const withPlace = (item: AnnouncedItem, sentence: string) => {
+    const place = at(item);
+    return place === undefined ? `${sentence}.` : `${sentence}, ${place}.`;
+  };
+  return {
+    onDragStart: ({ active }) => withPlace(active, `Picked up ${name(active)}`),
+    onDragOver: ({ active, over }) => {
+      if (over === null) return `${name(active)} is no longer over a list.`;
+      // The first thing a picked-up item is over is ITSELF, and dnd-kit reports
+      // that as a hover like any other. Said aloud it would overwrite the
+      // pick-up sentence with "Slug is over Slug" -- so it is not said, and
+      // the pick-up stands until the item reaches something else.
+      if (over.id === active.id) return undefined;
+      return withPlace(over, `${name(active)} is over ${name(over)}`);
+    },
+    onDragEnd: ({ active, over }) => {
+      if (over === null) return `${name(active)} was dropped. Nothing moved.`;
+      return `${name(active)} moved to ${at(over) ?? name(over)}.`;
+    },
+    onDragCancel: ({ active }) => {
+      const place = at(active);
+      return place === undefined
+        ? `Dragging cancelled. ${name(active)} is where it was.`
+        : `Dragging cancelled. ${name(active)} returned to ${place}.`;
+    },
+  };
+}
+
+/**
+ * Where an id sits in a single ordered list, as a phrase.
+ *
+ * The `place` a flat sortable list hands to {@link sortableAnnouncements}.
+ * One-based, because a reader is told "position 1 of 5" and not "index 0".
+ */
+export function positionInList(
+  ids: readonly UniqueIdentifier[],
+  id: UniqueIdentifier
+): string | undefined {
+  const index = ids.indexOf(id);
+  return index === -1 ? undefined : `position ${index + 1} of ${ids.length}`;
+}
+
+export function useSortableFieldArray<T extends { id: string }>(
+  items: T[],
+  move: (oldIndex: number, newIndex: number) => void
+): UseSortableFieldArrayResult {
+  const sensors = useSortableSensors();
 
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {

--- a/packages/admin/src/components/features/entries/fields/structured/sortable-announcements.test.tsx
+++ b/packages/admin/src/components/features/entries/fields/structured/sortable-announcements.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * What a drag says, and that every sortable surface can be driven by keyboard.
+ *
+ * The sentences are asserted by shape and by subject: they must name the thing
+ * being moved, never its id, and they must say where it is in the words the
+ * surface supplied. The sensors are asserted by membership, because a surface
+ * that reaches for the pointer alone looks finished to anyone testing with a
+ * mouse.
+ *
+ * @module components/features/entries/fields/structured/sortable-announcements.test
+ */
+
+import {
+  KeyboardSensor,
+  PointerSensor,
+  type Active,
+  type Over,
+} from "@dnd-kit/core";
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  positionInList,
+  sortableAnnouncements,
+  useSortableSensors,
+  type AnnouncedItem,
+} from "./field-array-helpers";
+
+/**
+ * The two ends of a drag as dnd-kit hands them to an announcement.
+ *
+ * The builder reads only the id and the data; the rects are the part no
+ * sentence uses, and they are shaped differently on each end, which is why
+ * there are two of these.
+ */
+function active(id: string, data: Record<string, unknown> = {}): Active {
+  return {
+    id,
+    data: { current: data },
+    rect: { current: { initial: null, translated: null } },
+  };
+}
+const NOWHERE = { top: 0, left: 0, right: 0, bottom: 0, width: 0, height: 0 };
+function over(id: string, data: Record<string, unknown> = {}): Over {
+  return { id, data: { current: data }, rect: NOWHERE, disabled: false };
+}
+
+const ROWS = ["title", "slug", "body"];
+const LABELS: Record<string, string> = {
+  title: "Title",
+  slug: "Slug",
+  body: "Body",
+};
+
+const model = {
+  describe: ({ id }: AnnouncedItem) => LABELS[String(id)],
+  place: ({ id }: AnnouncedItem) => positionInList(ROWS, id),
+};
+
+describe("what a drag says", () => {
+  const say = sortableAnnouncements(model);
+
+  it("names the row and its position on pick-up", () => {
+    expect(say.onDragStart({ active: active("title") })).toBe(
+      "Picked up Title, position 1 of 3."
+    );
+  });
+
+  it("names the row it is over, with the position a drop there would take", () => {
+    expect(
+      say.onDragOver({ active: active("title"), over: over("body") })
+    ).toBe("Title is over Body, position 3 of 3.");
+  });
+
+  it("says nothing while the item is over itself", () => {
+    // 🔴 The first hover dnd-kit reports after pick-up is the item over its own
+    // slot. Spoken, "Slug is over Slug" replaces the pick-up sentence a beat
+    // after it was said; unspoken, the pick-up stands until the item reaches
+    // a different row.
+    expect(
+      say.onDragOver({ active: active("slug"), over: over("slug") })
+    ).toBeUndefined();
+  });
+
+  it("says when it has left the list", () => {
+    expect(say.onDragOver({ active: active("title"), over: null })).toBe(
+      "Title is no longer over a list."
+    );
+  });
+
+  it("names the landing by position", () => {
+    expect(say.onDragEnd({ active: active("title"), over: over("slug") })).toBe(
+      "Title moved to position 2 of 3."
+    );
+  });
+
+  it("says nothing moved on a drop outside the list", () => {
+    expect(say.onDragEnd({ active: active("title"), over: null })).toBe(
+      "Title was dropped. Nothing moved."
+    );
+  });
+
+  it("says where a cancelled drag went back to", () => {
+    expect(say.onDragCancel({ active: active("slug"), over: null })).toBe(
+      "Dragging cancelled. Slug returned to position 2 of 3."
+    );
+  });
+
+  it("never reads an id aloud", () => {
+    // 🔴 The defect this replaces. dnd-kit's defaults say "Picked up draggable
+    // item <id>", and every id here is a field name, a placement id or a
+    // uuid. An id the surface cannot name is called "the item" rather than
+    // spoken.
+    const unknown = active("3f9a2c1e-7b4d-4e0a-9c8f-1d2e3f4a5b6c");
+    const heard = [
+      say.onDragStart({ active: unknown }),
+      say.onDragOver({ active: unknown, over: over("title") }),
+      say.onDragEnd({ active: unknown, over: null }),
+      say.onDragCancel({ active: unknown, over: null }),
+    ].join(" ");
+    expect(heard).not.toContain("3f9a2c1e");
+    expect(heard).toContain("the item");
+  });
+
+  it("drops the place clause when the surface has none to give", () => {
+    // A surface may know names and not positions -- a grid whose model is
+    // columns, say. The sentence closes cleanly rather than trailing a comma.
+    const nameOnly = sortableAnnouncements({ describe: model.describe });
+    expect(nameOnly.onDragStart({ active: active("title") })).toBe(
+      "Picked up Title."
+    );
+    expect(nameOnly.onDragCancel({ active: active("title"), over: null })).toBe(
+      "Dragging cancelled. Title is where it was."
+    );
+    expect(
+      nameOnly.onDragEnd({ active: active("title"), over: over("slug") })
+    ).toBe("Title moved to Slug.");
+  });
+});
+
+describe("where an id sits in a list", () => {
+  it("is one-based, as a reader counts", () => {
+    expect(positionInList(ROWS, "title")).toBe("position 1 of 3");
+    expect(positionInList(ROWS, "body")).toBe("position 3 of 3");
+  });
+
+  it("is nothing for an id the list does not hold", () => {
+    expect(positionInList(ROWS, "author")).toBeUndefined();
+  });
+});
+
+describe("the sensors every sortable surface drags with", () => {
+  it("include the keyboard, not only the pointer", () => {
+    // 🔴 Two tables shipped with a pointer-only `useSensors` of their own,
+    // and nobody testing with a mouse could tell. Asserted by membership,
+    // because jsdom performs no layout and a keyboard move cannot be
+    // observed by its effect here -- only by the sensor that would cause it.
+    const { result } = renderHook(() => useSortableSensors());
+    const kinds = result.current.map(descriptor => descriptor.sensor);
+    expect(kinds).toContain(KeyboardSensor);
+    expect(kinds).toContain(PointerSensor);
+  });
+});

--- a/packages/admin/src/components/features/widgets/WidgetGrid.tsx
+++ b/packages/admin/src/components/features/widgets/WidgetGrid.tsx
@@ -167,6 +167,7 @@ export function WidgetGrid() {
     moveColumn,
     hasArrangement,
     sensors,
+    announcements,
     handleDragEnd,
   } = useDashboardArrangement(declared, layout, announceColumn);
 
@@ -276,6 +277,7 @@ export function WidgetGrid() {
         // of one column resolves to its neighbour.
         collisionDetection={closestCorners}
         onDragEnd={handleDragEnd}
+        accessibility={{ announcements }}
       >
         <ArrangedColumns
           columns={columns}

--- a/packages/admin/src/components/features/widgets/edit/__tests__/WidgetGrid.edit.test.tsx
+++ b/packages/admin/src/components/features/widgets/edit/__tests__/WidgetGrid.edit.test.tsx
@@ -3,11 +3,18 @@
  * and what happens when the arrangement is not there.
  */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { act, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { layOutStacked, recordDragRegion } from "@admin/__tests__/helpers/drag";
 import { protectedApi } from "@admin/lib/api/protectedApi";
 import { registerCoreComponent } from "@admin/lib/plugins/component-registry-internal";
 import type { AdminBranding } from "@admin/types/branding";
@@ -268,6 +275,76 @@ describe("moving a card without a drag", () => {
     expect(screen.getAllByTestId("widget-move-down")[0]).toHaveAttribute(
       "aria-label",
       "Move Widget core/a down, currently position 1 of 3"
+    );
+  });
+});
+
+describe("moving a card from the keyboard", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /** Enters edit mode and gives the three cells the geometry a column has. */
+  async function beginKeyboardEditing() {
+    renderGrid();
+    await beginEditing();
+    layOutStacked(
+      ["core/a", "core/b", "core/c"].map(id =>
+        screen.getByTestId(`widget-cell-${id}`)
+      ),
+      { height: 200, width: 400 }
+    );
+  }
+
+  it("says which card was picked up, and where it sits, by title", async () => {
+    // 🔴 dnd-kit's default reads the placement id aloud -- "Picked up
+    // draggable item p2" -- which names nothing a reader can see. The card is
+    // named by TITLE and placed in the same column-and-position terms the
+    // Move buttons announce a landing in, so a keyboard drag and a button
+    // move describe the same dashboard.
+    await beginKeyboardEditing();
+    const heard = recordDragRegion();
+    const handle = screen.getByRole("button", {
+      name: "Drag to reorder Widget core/b",
+    });
+    handle.focus();
+    fireEvent.keyDown(handle, { code: "Space", key: " " });
+
+    await waitFor(() =>
+      expect(heard).toContain(
+        "Picked up Widget core/b, column 1 of 3, position 2 of 3."
+      )
+    );
+    expect(heard.join(" ")).not.toContain("draggable item");
+    // The grid's OWN region is for landings. A pick-up is not one.
+    expect(screen.getByTestId("widget-grid-live").textContent).not.toMatch(
+      /Widget core\/b/
+    );
+  });
+
+  it("does not read a drop twice: dnd-kit is silent on landing, the grid speaks", async () => {
+    // 🔴 The grid already announces where a card landed, in the sentence its
+    // Move buttons use, so a keyboard drop spoken by dnd-kit as well would be
+    // heard twice in two wordings. Dropped in place here so no landing is
+    // due at all: the grid's region has nothing to say, and dnd-kit's must
+    // not fill the silence with a landing of its own.
+    await beginKeyboardEditing();
+    const heard = recordDragRegion();
+    const handle = screen.getByRole("button", {
+      name: "Drag to reorder Widget core/b",
+    });
+    handle.focus();
+    fireEvent.keyDown(handle, { code: "Space", key: " " });
+    // `aria-pressed` exists only while the card is held; its arrival is the
+    // pick-up, its removal the drop. Waited on both rather than on silence,
+    // which is true before anything has happened.
+    await waitFor(() => expect(handle).toHaveAttribute("aria-pressed", "true"));
+
+    fireEvent.keyDown(handle, { code: "Space", key: " " });
+    await waitFor(() => expect(handle).not.toHaveAttribute("aria-pressed"));
+    expect(heard.join(" ")).not.toMatch(/moved to|was dropped/);
+    expect(screen.getByTestId("widget-grid-live").textContent).not.toMatch(
+      /moved to/
     );
   });
 });

--- a/packages/admin/src/components/features/widgets/edit/useDashboardArrangement.ts
+++ b/packages/admin/src/components/features/widgets/edit/useDashboardArrangement.ts
@@ -12,14 +12,18 @@
  * @module components/features/widgets/edit/useDashboardArrangement
  */
 
-import type { DragEndEvent } from "@dnd-kit/core";
+import type { Announcements, DragEndEvent } from "@dnd-kit/core";
 import { DEFAULT_COLUMN_COUNT } from "nextly/config";
 import { useCallback, useMemo } from "react";
 
 import type { UseDashboardLayoutResult } from "@admin/hooks/queries/useDashboardLayout";
 import type { DashboardWidget } from "@admin/types/dashboard/widgets";
 
-import { useSortableFieldArray } from "../../entries/fields/structured/field-array-helpers";
+import {
+  sortableAnnouncements,
+  useSortableSensors,
+  type AnnouncedItem,
+} from "../../entries/fields/structured/field-array-helpers";
 import {
   columnFromDropData,
   dropSide,
@@ -112,9 +116,18 @@ export interface DashboardArrangement {
    * and the whole of any outage.
    */
   hasArrangement: boolean;
-  sortableItems: Array<{ id: string }>;
-  sensors: ReturnType<typeof useSortableFieldArray>["sensors"];
-  handleDragEnd: ReturnType<typeof useSortableFieldArray>["handleDragEnd"];
+  sensors: ReturnType<typeof useSortableSensors>;
+  handleDragEnd: (event: DragEndEvent) => void;
+  /**
+   * What a screen reader hears while a card is being dragged.
+   *
+   * Pick-up, hover and cancel are spoken here, about the card by title and
+   * in column-and-position terms. The LANDING is deliberately not: the grid
+   * speaks that through its own live region, in the same sentence the Move
+   * buttons use, so a card moved by keyboard and one moved by button sound
+   * identical and no drop is read twice.
+   */
+  announcements: Announcements;
 }
 
 export function useDashboardArrangement(
@@ -218,11 +231,6 @@ export function useDashboardArrangement(
     [visible, columnCount]
   );
 
-  const sortableItems = useMemo(
-    () => visible.map(row => ({ id: row.placementId })),
-    [visible]
-  );
-
   /** The placements the grid actually draws, which is what a position counts. */
   const renderedIds = useMemo(
     () => new Set(visible.map(row => row.placementId)),
@@ -233,16 +241,60 @@ export function useDashboardArrangement(
   // Two implementations of "where does this land" agree until one is edited,
   // and a grid whose drag and whose buttons disagreed would be impossible to
   // reason about from either.
-  // `useSortableFieldArray` hands back INDICES into the list it was given, and
-  // that list is the filtered view. They are turned into placement ids here,
-  // once, so the editor never sees a position that means something different to
-  // it than it did to the grid.
-  // Only the SENSORS are borrowed. `useSortableFieldArray` resolves a drop to a
-  // pair of indices into one list, which cannot express a column: an index says
-  // where in a sequence a card landed and says nothing about which column it
-  // landed in. The sensors are the half that is genuinely shared -- a pointer
-  // and a keyboard sensor, configured identically wherever this admin drags.
-  const { sensors } = useSortableFieldArray(sortableItems, () => {});
+  // The sensors alone are shared with every other sortable surface. The
+  // drop is NOT: a flat list resolves a drop to a pair of indices, which
+  // cannot express a column, so this hook keeps its own `handleDragEnd` below.
+  const sensors = useSortableSensors();
+
+  /**
+   * A card or a column as the announcements see it.
+   *
+   * 🔴 A column is recognised from the droppable's DATA, exactly as the drop
+   * handler recognises it, so the sentence a reader hears while hovering
+   * describes the same target the release will act on. Recognising it from
+   * the shape of the id instead would let a card named like a column be
+   * announced as one.
+   */
+  const describeItem = useCallback(
+    (item: AnnouncedItem): string | undefined => {
+      const column = columnFromDropData(item.data.current);
+      if (column !== undefined) return `column ${column + 1} of ${columnCount}`;
+      return visible.find(row => row.placementId === String(item.id))?.widget
+        .title;
+    },
+    [visible, columnCount]
+  );
+
+  /**
+   * Where a card sits, in the same terms the landing is announced in.
+   *
+   * Read from the DRAWN columns, the buckets the grid renders from, so the
+   * position a reader is told on pick-up counts the cards they can see.
+   */
+  const placeItem = useCallback(
+    (item: AnnouncedItem): string | undefined => {
+      const id = String(item.id);
+      const column = columns.findIndex(bucket =>
+        bucket.some(row => row.placementId === id)
+      );
+      if (column === -1) return undefined;
+      const position =
+        columns[column].findIndex(row => row.placementId === id) + 1;
+      return `column ${column + 1} of ${columnCount}, position ${position} of ${columns[column].length}`;
+    },
+    [columns, columnCount]
+  );
+
+  const announcements = useMemo<Announcements>(
+    () => ({
+      ...sortableAnnouncements({ describe: describeItem, place: placeItem }),
+      // The landing is spoken by `announceLanding` below, through the grid's
+      // own live region and in the Move buttons' sentence. Spoken here as
+      // well, a keyboard drop would be read twice in two wordings.
+      onDragEnd: () => undefined,
+    }),
+    [describeItem, placeItem]
+  );
 
   /**
    * Say where a card ended up, in the terms the reader can verify.
@@ -379,8 +431,8 @@ export function useDashboardArrangement(
     moveWithinColumn,
     moveColumn,
     hasArrangement,
-    sortableItems,
     sensors,
+    announcements,
     handleDragEnd,
   };
 }

--- a/packages/admin/src/pages/dashboard/users/fields/index.tsx
+++ b/packages/admin/src/pages/dashboard/users/fields/index.tsx
@@ -1,13 +1,6 @@
 "use client";
 
-import {
-  closestCenter,
-  DndContext,
-  PointerSensor,
-  useSensor,
-  useSensors,
-  type DragEndEvent,
-} from "@dnd-kit/core";
+import { closestCenter, DndContext, type DragEndEvent } from "@dnd-kit/core";
 import {
   arrayMove,
   SortableContext,
@@ -43,6 +36,11 @@ import {
 import type React from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+import {
+  positionInList,
+  sortableAnnouncements,
+  useSortableSensors,
+} from "@admin/components/features/entries/fields/structured/field-array-helpers";
 import { UserBreadcrumbs } from "@admin/components/features/user-management/breadcrumbs";
 import {
   AlertTriangle,
@@ -365,7 +363,7 @@ function SortableFieldRow({
             {...attributes}
             {...listeners}
             tabIndex={0}
-            aria-label="Drag to reorder"
+            aria-label={`Drag to reorder ${field.label}`}
             onClick={e => e.stopPropagation()}
           >
             <GripVertical className="h-4 w-4" />
@@ -513,12 +511,10 @@ function UserFieldsTable() {
     UserFieldDefinitionRecord[] | null
   >(null);
 
-  // DnD sensors
-  const sensors = useSensors(
-    useSensor(PointerSensor, {
-      activationConstraint: { distance: 8 },
-    })
-  );
+  // Pointer AND keyboard, from the hook every sortable surface shares. The
+  // pointer-only pair this replaced left the table unreachable from the
+  // keyboard.
+  const sensors = useSortableSensors();
 
   // Fetch fields
   const { data, isLoading, isError, error } = useUserFields();
@@ -568,6 +564,15 @@ function UserFieldsTable() {
     const start = page * pageSize;
     return filteredFields.slice(start, start + pageSize);
   }, [filteredFields, page, pageSize]);
+
+  // Said about the FIELD, and placed within the PAGE the reader is looking
+  // at -- the same list the sortable context holds -- rather than within every
+  // field the install has, most of which are not on screen.
+  const pageIds = paginatedFields.map(f => f.id);
+  const announcements = sortableAnnouncements({
+    describe: ({ id }) => paginatedFields.find(f => f.id === id)?.label,
+    place: ({ id }) => positionInList(pageIds, id),
+  });
 
   // Reset page when search changes
   useEffect(() => {
@@ -753,6 +758,7 @@ function UserFieldsTable() {
             sensors={sensors}
             collisionDetection={closestCenter}
             onDragEnd={handleDragEnd}
+            accessibility={{ announcements }}
           >
             <Table aria-label="User fields table" className="min-w-max">
               <TableHeader className="bg-[var(--nx-table-header-bg)]">
@@ -780,7 +786,7 @@ function UserFieldsTable() {
               {/* Custom fields (draggable) */}
               <TableBody>
                 <SortableContext
-                  items={paginatedFields.map(f => f.id)}
+                  items={pageIds}
                   strategy={verticalListSortingStrategy}
                 >
                   {paginatedFields.map(field => (


### PR DESCRIPTION
Phase 2.7 of the dashboard widgets: keyboard reordering on every sortable surface, and drag announcements that name the thing being moved.

## What was wrong

**Two tables could not be reordered from the keyboard at all.** `SortableFieldsTable` (collection fields) and the user-fields page each built a pointer-only `useSensors` of their own, while every other drag surface takes its sensors from `useSortableFieldArray`, which pairs the pointer with a `KeyboardSensor`. Nobody testing with a mouse could tell. That is WCAG 2.1.1, failed on two shipped screens.

**Every surface read a uuid aloud.** No `DndContext` in the admin passed `accessibility.announcements`, so all of them used dnd-kit's defaults — `"Picked up draggable item " + active.id` — and every sortable here is keyed by a field name, a placement id or a uuid. A screen-reader user rearranging the dashboard heard *"Draggable item p2 was moved over droppable area p3."*

**Every drag handle had the same name.** `aria-label="Drag handle"` on every row: tabbing through was N identical buttons.

## What changes

- **`useSortableSensors`** — the pointer+keyboard pair gets its own hook; all four surfaces use it. The grid no longer reaches it through `useSortableFieldArray(items, () => {})` with a `move` it never wanted, and the `sortableItems` that existed only to feed that call is gone.
- **`sortableAnnouncements`** — the wording lives once. Each surface supplies a name for an id and, where it has one, the place it sits: `"Picked up Title, position 1 of 4."`, `"Title is over Body, position 3 of 4."`, `"Title moved to position 3 of 4."`, `"Dragging cancelled. Title returned to position 1 of 4."` An id the surface cannot name is called "the item", never spoken.
- **The grid** places a card as `"column 1 of 3, position 2 of 4"` — derived from the same drawn buckets its landing announcement already counts from, and a column droppable is recognised from its **data** the way the drop handler recognises it, so the hover sentence describes the target the release will act on. dnd-kit's `onDragEnd` is silenced on the grid: the Move buttons already announce a landing through the grid's own live region, and a keyboard drop spoken by both would be heard twice in two wordings.
- **The self-hover is not spoken.** The first hover dnd-kit reports after pick-up is the item over its own slot. Said aloud, `"Slug is over Slug"` replaced the pick-up sentence a beat later — and under React's batching the pick-up never reached the DOM at all. This came out of the test, not the design.
- **Handles are named per row**: `Drag to reorder Title`, matching what the grid already did.

## Evidence

The table test lays its rows out (dnd-kit measures with `getBoundingClientRect`, and jsdom gives every row 0×0, which is no geometry any table has) and drives a **complete keyboard reorder through the real `DndContext`**: Space → `"Picked up Slug, position 2 of 3."`, ArrowDown → `"Slug is over Body, position 3 of 3."`, Space → `"Slug moved to position 3 of 3."`, and `onReorder` receives `[title, body, slug]`. The live region's sentences are recorded as they land, because a region holds only its latest.

Six breaks, each named by exactly the tests that should fail:

| break | tests killed |
|---|---|
| `KeyboardSensor` removed from the shared hook | membership test + all three keyboard table tests |
| table passes no announcements | the three wording tests (defaults read the id) |
| self-hover guard removed | unit case + pick-up + full reorder (batching swallows the pick-up) |
| dnd-kit allowed to announce the grid's landing | `does not read a drop twice` |
| grid passes no announcements | both grid keyboard tests |
| grid's place derivation emptied | `says which card was picked up, and where it sits` |

Gates: 4,239 admin tests, `check-types` (tests included), `lint`, `check:comments`, `changeset status` (26). The users-fields page has no component test and its e2e spec does not reach the handle; its change is the same wiring as the tested table, and I am saying so rather than implying coverage.

## Surfaced, filed, not fixed here

The two tables still have **no single-pointer alternative** to dragging. `WidgetEditControls.tsx` states in as many words that a `KeyboardSensor` satisfies WCAG 2.1.1 and not 2.2 SC 2.5.7, which is why the grid carries Move up / Move down beside its handle. The tables need the same pair — a row-toolbar design change, filed as `finding:sortable-tables-have-no-single-pointer-alternative`.