### PR TITLE
fix(blocks-engine): an exposure is cleared when its target was erased, and a cleared value is absent

### DIFF
--- a/.changeset/a-cleared-exposure-is-one-whose-target-was-erased.md
+++ b/.changeset/a-cleared-exposure-is-one-whose-target-was-erased.md
@@ -1,0 +1,32 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+An exposure row reports itself cleared when the winning clear erases its
+target — at its own path or an ancestor's, by any exposure — never when the
+clear is below it, and a cleared row's value is always absent rather than the
+clear sentinel.

--- a/packages/blocks-engine/src/resolve-instances.test.ts
+++ b/packages/blocks-engine/src/resolve-instances.test.ts
@@ -2915,6 +2915,72 @@ describe("instanceExposure", () => {
     expect(rendered.document.nodes[0]!.props).toEqual({ text: "GOOD" });
   });
 
+  it("reports a cleared visibility as cleared with NO value, not the sentinel", () => {
+    // The winning write on a visibility row IS the `$unset` object. Handing
+    // that back as `value` breaks the promise that a cleared row has none —
+    // and a control drawn from it would show an object where it expects blank.
+    const gated = component([node("d1")], {
+      exposed: [{ ...headline, propPath: "", type: "visibility" }],
+    });
+    const node1 = instance("i1", "hero", {
+      overrides: { headline: { $unset: true } },
+    });
+
+    const [state] = instanceExposure(gated, node1).properties;
+
+    expect(state?.cleared).toBe(true);
+    expect(state?.value).toBeUndefined();
+  });
+
+  it("marks a row cleared when an ANCESTOR path was cleared by another exposure", () => {
+    // Clearing `a` removes `a.b` with it. The child row's value is gone
+    // because somebody deliberately removed it, and reporting that as merely
+    // superseded would make the removal indistinguishable from a definition
+    // that never held `a.b` at all.
+    const nested = component([node("d1", { props: { a: { b: "base" } } })], {
+      exposed: [
+        { ...headline, id: "parent", propPath: "a" },
+        { ...headline, id: "child", propPath: "a.b" },
+      ],
+    });
+    const node1 = instance("i1", "hero", {
+      overrides: { parent: { $unset: true } },
+    });
+
+    const [parent, child] = instanceExposure(nested, node1).properties;
+
+    expect(parent?.cleared).toBe(true);
+    expect(child?.cleared).toBe(true);
+    expect(child?.value).toBeUndefined();
+    expect(child?.shadowedBy).toBe("parent");
+
+    const rendered = resolveComponentInstances(
+      page([node1]),
+      defs({ hero: nested })
+    );
+    expect(rendered.document.nodes[0]!.props).toEqual({});
+  });
+
+  it("marks a row cleared when the SAME path was cleared by another exposure", () => {
+    const twoPointers = component([node("d1", { props: { text: "base" } })], {
+      exposed: [
+        { ...headline, id: "first" },
+        { ...headline, id: "second" },
+      ],
+    });
+    const node1 = instance("i1", "hero", {
+      overrides: { first: "MINE", second: { $unset: true } },
+    });
+
+    const [first, second] = instanceExposure(twoPointers, node1).properties;
+
+    expect(second?.cleared).toBe(true);
+    // The earlier row's target was erased by the later clear.
+    expect(first?.cleared).toBe(true);
+    expect(first?.value).toBeUndefined();
+    expect(first?.shadowedBy).toBe("second");
+  });
+
   it("has no path value for a visibility exposure", () => {
     // `visibility` decides whether the node is served at all; it names no prop,
     // so reading `propPath` off the definition would report an unrelated value.

--- a/packages/blocks-engine/src/resolve-instances.ts
+++ b/packages/blocks-engine/src/resolve-instances.ts
@@ -1733,20 +1733,45 @@ function exposedState(
     return { property, source: "definition", value, cleared: false };
   }
   const own = winner.property.id === property.id;
-  // Cleared means THIS row's own write is the sentinel. A descendant's `$unset`
-  // deletes only that key — `a.b` cleared leaves `a` holding whatever else it
-  // had — so an ancestor whose winner is a clearing descendant is superseded,
-  // not cleared, and its value is read from what remains rather than assumed
-  // gone. The value already comes from the final props, so a genuinely cleared
-  // path reads as absent without being forced to.
-  const cleared = own && isUnsetOverride(winner.override.value);
+  // Cleared means the winning `$unset` ERASES this row's target — whichever
+  // exposure wrote it. A clear at the row's own path or at an ancestor deletes
+  // what the row reads (clearing `a` removes `a.b` with it), so the row is
+  // cleared even when another exposure did the clearing; reporting it as
+  // merely superseded would make a deliberate removal indistinguishable from
+  // a definition that holds nothing. A clear BELOW the row is the one case
+  // that does not erase it: `a.b` cleared leaves `a` holding whatever else it
+  // had, so the ancestor reads what remains rather than being assumed gone.
+  const cleared =
+    isUnsetOverride(winner.override.value) &&
+    erasesTarget(winner.property, property);
   return {
     property,
     source: winner.override.source,
-    value,
+    // Normalised to `undefined` when cleared, which the contract promises. For
+    // a prop row the final props already read as absent; for a `visibility`
+    // row the winning value IS the sentinel, and handing that object to a
+    // caller expecting a blank would be the contract broken on exactly the
+    // rows a clear is most likely to reach.
+    value: cleared ? undefined : value,
     cleared,
     ...(own ? {} : { shadowedBy: winner.property.id }),
   };
+}
+
+/**
+ * True when clearing `writer`'s target deletes what `row` reads.
+ *
+ * On one node, a `visibility` exposure erases every other visibility exposure
+ * on it, and a prop path erases itself and everything beneath it. It does NOT
+ * erase its ancestors, which is the asymmetry {@link reachesSameTarget} has no
+ * reason to carry: reaching is symmetric, erasing is not.
+ */
+function erasesTarget(writer: ExposedProperty, row: ExposedProperty): boolean {
+  if (writer.nodeId !== row.nodeId) return false;
+  if (writer.type === "visibility" || row.type === "visibility") {
+    return writer.type === row.type;
+  }
+  return isPathPrefix(writer.propPath, row.propPath);
 }
 
 /** The value a row shows: the final props at its path, or a visibility decision. */


### PR DESCRIPTION
Two follow-ups from the post-merge review of #1763, both about what `cleared` means. Both reproduce; both fixed.

## A cleared value is absent, never the sentinel

A `visibility` row's winning write **is** the `$unset` object. Reading `value` straight off the winning write handed that object back while `cleared` said true — the contract broken on exactly the rows a clear is most likely to reach. A cleared row's value is now always `undefined`.

## Cleared means the target was erased, whichever exposure did it

`cleared` meant "this row's own write is the sentinel". That left a row whose target **another** exposure erased — a clear at the same path, or at an ancestor, since clearing `a` removes `a.b` with it — reporting an absent value and `cleared: false`, indistinguishable from a definition that never held it.

Cleared now means the winning clear **erases this row's target**. The one clear that does not erase a row is one *below* it, so an ancestor whose descendant was cleared still reads what remains. That asymmetry is why erasure is its own relation rather than the symmetric reach test reused — the break case for that is the ancestor test from #1763.

## What was measured

| break | what it kills |
|---|---|
| sentinel handed back as `value` | cleared visibility has no value |
| cleared only for the row's own write | ancestor-cleared and same-path-cleared rows |
| erasure made symmetric | ancestor keeps its remaining value |

2464 passed. `fallow` pass, 0 introduced. `changeset status` exits 0.
