### PR TITLE
test(nextly): assert the accessor's release tag, not the absence of a ban

### DIFF
--- a/packages/nextly/src/__tests__/accessors-stay-where-their-callers-are.test.ts
+++ b/packages/nextly/src/__tests__/accessors-stay-where-their-callers-are.test.ts
@@ -41,72 +41,6 @@ const initSource = readFileSync(
   "utf8"
 );
 
-/**
- * Whether a sentence forbids using the function it documents.
- *
- * A prohibition is a MODAL or IMPERATIVE negation attached to a usage verb, in
- * either voice, or one of the stock phrasings that forbid without a verb. The
- * modal is what separates a ban from a description: "must not be used by
- * plugins" forbids, "is not used until boot completes" describes what happens
- * at runtime and forbids nobody. So a bare `not` is not in the list, and
- * `cannot` is, disarmed by the verb requirement rather than by its absence:
- * "it cannot wait" describes the synchronous sibling, "callers cannot use
- * this" is exactly the sentence this docblock must never carry.
- *
- * Module-scoped and exercised directly below, because the docblock it guards
- * is clean and therefore exercises none of its branches. A predicate tested
- * only against a passing input would let every alternative in it be misspelled
- * without anything going red.
- */
-function prohibits(line: string): boolean {
-  return (
-    /\b(do not|don't|must not|should not|cannot|can't|may not|never)\s+(be\s+)?(use|used|call|called|invoke|invoked|reach for|reached for|rely on|relied on)\b/i.test(
-      line
-    ) ||
-    /\b(internal use only|not for (user|plugin|application|external)|not intended for)\b/i.test(
-      line
-    )
-  );
-}
-
-describe("what counts as forbidding a caller", () => {
-  it("catches a prohibition in either voice and any modal", () => {
-    // The positive control the docblock check cannot provide, since the real
-    // docblock is clean. Each of these must be caught, or the alternative it
-    // exercises could be misspelled with nothing going red.
-    for (const sentence of [
-      "Plugins should not call this.",
-      "Plugin callers cannot use this function.",
-      "This function cannot be used by plugin callers.",
-      "It must not be called from a plugin.",
-      "Never rely on this from a plugin.",
-      "User code may not invoke this.",
-      "Do not use this in user code.",
-      "Internal use only.",
-      "Not intended for application code.",
-      "This is not for plugin code.",
-    ]) {
-      expect(prohibits(sentence), sentence).toBe(true);
-    }
-  });
-
-  it("lets a factual negation through", () => {
-    // A description of runtime behaviour is not a ban, and a check that
-    // rejected these would refuse ordinary documentation. The difference is
-    // the modal: none of these tells anyone what they may do.
-    for (const sentence of [
-      "It cannot wait, so it asserts instead.",
-      "The cached instance is not used until boot completes.",
-      "This is not called on the request path.",
-      "The fallback is not invoked when a config is supplied.",
-      "The result is not relied on for caching.",
-      "Plugins reach for this when there is no ctx.",
-    ]) {
-      expect(prohibits(sentence), sentence).toBe(false);
-    }
-  });
-});
-
 describe("instance accessors are published where their callers can reach them", () => {
   it("publishes the async accessor from the root and NOT from runtime", async () => {
     const root = (await import("../index")) as Record<string, unknown>;
@@ -140,45 +74,20 @@ describe("instance accessors are published where their callers can reach them", 
     // The claim this file protects is an argument, and an argument lives in
     // prose. Read from source because the sentence it replaced said the
     // opposite and was wrong for as long as it stood.
+    //
+    // Asserted as a positive sentence and nothing else. Whether some other
+    // sentence in the block FORBIDS the same callers is a question about
+    // English, and a pattern asked to answer it either misses the next wording
+    // ("must never be used by") or catches a description ("is never used
+    // before boot"). The audience claim is a string, and a string is decidable.
+    // A block that named plugins and then banned them would pass here; that is
+    // a contradiction a reader sees, not a shape a test can be trusted to.
     const doc = docblockFor(
       initSource,
       "export async function getCachedNextly"
     );
 
     expect(doc).toContain("plugin code doing server work outside a route");
-  });
-
-  it("does not forbid the callers it names, however the prohibition is worded", () => {
-    // A list of forbidden phrasings is the wrong shape for this. "must not
-    // call" was covered and "should not call" was not, and the next wording
-    // nobody anticipates passes just as easily. So it is structural instead.
-    //
-    // Two properties, checked separately because either alone can be
-    // satisfied by a docblock that contradicts itself. The audience must be
-    // named, so the positive claim exists to contradict. And NO sentence may
-    // forbid use, whether or not it names who: "Internal use only." names
-    // nobody and forbids everybody, so filtering to audience sentences first
-    // would discard it unexamined.
-    const doc = docblockFor(
-      initSource,
-      "export async function getCachedNextly"
-    );
-
-    const sentences = doc
-      .replace(/^\s*\*+ ?/gm, "")
-      .split(/(?<=[.:])\s+/)
-      .map(line => line.trim())
-      .filter(line => line.length > 0);
-
-    const namesAudience = sentences.filter(line =>
-      /plugin|user code|caller/i.test(line)
-    );
-    // The control. With no audience sentence the check below has nothing to
-    // contradict, and would stay green through a docblock that never says who
-    // this is for.
-    expect(namesAudience.length).toBeGreaterThan(0);
-
-    expect(sentences.filter(prohibits)).toEqual([]);
   });
 
   it("does not claim the root avoids the Next peer dependency", () => {

--- a/packages/nextly/src/__tests__/accessors-stay-where-their-callers-are.test.ts
+++ b/packages/nextly/src/__tests__/accessors-stay-where-their-callers-are.test.ts
@@ -117,9 +117,12 @@ describe("instance accessors are published where their callers can reach them", 
     // matters, not the negation: "it cannot wait" describes the synchronous
     // sibling and forbids nothing, while "callers cannot use this" forbids
     // exactly what this docblock promises. So `cannot` stays in the list and
-    // is disarmed by the verb requirement, not by its absence.
+    // is disarmed by the verb requirement, not by its absence. The verb is
+    // matched in both voices, since "cannot be used by plugins" forbids the
+    // same thing as "plugins cannot use" and a word boundary after `use`
+    // rejects `used`.
     const prohibits = (line: string) =>
-      /\b(do not|don't|must not|should not|cannot|can't|never|not)\s+(be\s+)?(use|call|invoke|reach for|rely on)\b/i.test(
+      /\b(do not|don't|must not|should not|cannot|can't|never|not)\s+(be\s+)?(use|used|call|called|invoke|invoked|reach for|reached for|rely on|relied on)\b/i.test(
         line
       ) ||
       /\b(internal use only|not for (user|plugin|application|external)|not intended for)\b/i.test(

--- a/packages/nextly/src/__tests__/accessors-stay-where-their-callers-are.test.ts
+++ b/packages/nextly/src/__tests__/accessors-stay-where-their-callers-are.test.ts
@@ -74,20 +74,29 @@ describe("instance accessors are published where their callers can reach them", 
     // The claim this file protects is an argument, and an argument lives in
     // prose. Read from source because the sentence it replaced said the
     // opposite and was wrong for as long as it stood.
-    //
-    // Asserted as a positive sentence and nothing else. Whether some other
-    // sentence in the block FORBIDS the same callers is a question about
-    // English, and a pattern asked to answer it either misses the next wording
-    // ("must never be used by") or catches a description ("is never used
-    // before boot"). The audience claim is a string, and a string is decidable.
-    // A block that named plugins and then banned them would pass here; that is
-    // a contradiction a reader sees, not a shape a test can be trusted to.
     const doc = docblockFor(
       initSource,
       "export async function getCachedNextly"
     );
 
     expect(doc).toContain("plugin code doing server work outside a route");
+  });
+
+  it("marks the async accessor public, and never internal", () => {
+    // Whether a SENTENCE forbids the callers the block names is a question
+    // about English: a pattern asked it misses the next wording ("must never
+    // be used by") or catches a description ("is never used before boot"). The
+    // TSDoc release tag is the same statement as data. `@internal` is how this
+    // repository says "not for consumers", so the block carries `@public` and
+    // must not carry `@internal`, and a reader who adds a prose ban beside a
+    // `@public` tag has written a contradiction the tag decides.
+    const doc = docblockFor(
+      initSource,
+      "export async function getCachedNextly"
+    );
+
+    expect(doc).toMatch(/^\s*\*\s*@public\s*$/m);
+    expect(doc).not.toMatch(/@internal\b/);
   });
 
   it("does not claim the root avoids the Next peer dependency", () => {

--- a/packages/nextly/src/__tests__/accessors-stay-where-their-callers-are.test.ts
+++ b/packages/nextly/src/__tests__/accessors-stay-where-their-callers-are.test.ts
@@ -41,6 +41,72 @@ const initSource = readFileSync(
   "utf8"
 );
 
+/**
+ * Whether a sentence forbids using the function it documents.
+ *
+ * A prohibition is a MODAL or IMPERATIVE negation attached to a usage verb, in
+ * either voice, or one of the stock phrasings that forbid without a verb. The
+ * modal is what separates a ban from a description: "must not be used by
+ * plugins" forbids, "is not used until boot completes" describes what happens
+ * at runtime and forbids nobody. So a bare `not` is not in the list, and
+ * `cannot` is, disarmed by the verb requirement rather than by its absence:
+ * "it cannot wait" describes the synchronous sibling, "callers cannot use
+ * this" is exactly the sentence this docblock must never carry.
+ *
+ * Module-scoped and exercised directly below, because the docblock it guards
+ * is clean and therefore exercises none of its branches. A predicate tested
+ * only against a passing input would let every alternative in it be misspelled
+ * without anything going red.
+ */
+function prohibits(line: string): boolean {
+  return (
+    /\b(do not|don't|must not|should not|cannot|can't|may not|never)\s+(be\s+)?(use|used|call|called|invoke|invoked|reach for|reached for|rely on|relied on)\b/i.test(
+      line
+    ) ||
+    /\b(internal use only|not for (user|plugin|application|external)|not intended for)\b/i.test(
+      line
+    )
+  );
+}
+
+describe("what counts as forbidding a caller", () => {
+  it("catches a prohibition in either voice and any modal", () => {
+    // The positive control the docblock check cannot provide, since the real
+    // docblock is clean. Each of these must be caught, or the alternative it
+    // exercises could be misspelled with nothing going red.
+    for (const sentence of [
+      "Plugins should not call this.",
+      "Plugin callers cannot use this function.",
+      "This function cannot be used by plugin callers.",
+      "It must not be called from a plugin.",
+      "Never rely on this from a plugin.",
+      "User code may not invoke this.",
+      "Do not use this in user code.",
+      "Internal use only.",
+      "Not intended for application code.",
+      "This is not for plugin code.",
+    ]) {
+      expect(prohibits(sentence), sentence).toBe(true);
+    }
+  });
+
+  it("lets a factual negation through", () => {
+    // A description of runtime behaviour is not a ban, and a check that
+    // rejected these would refuse ordinary documentation. The difference is
+    // the modal: none of these tells anyone what they may do.
+    for (const sentence of [
+      "It cannot wait, so it asserts instead.",
+      "The cached instance is not used until boot completes.",
+      "This is not called on the request path.",
+      "The fallback is not invoked when a config is supplied.",
+      "The result is not relied on for caching.",
+      "Plugins reach for this when there is no ctx.",
+    ]) {
+      expect(prohibits(sentence), sentence).toBe(false);
+    }
+  });
+});
+
 describe("instance accessors are published where their callers can reach them", () => {
   it("publishes the async accessor from the root and NOT from runtime", async () => {
     const root = (await import("../index")) as Record<string, unknown>;
@@ -111,23 +177,6 @@ describe("instance accessors are published where their callers can reach them", 
     // contradict, and would stay green through a docblock that never says who
     // this is for.
     expect(namesAudience.length).toBeGreaterThan(0);
-
-    // A prohibition is a negation attached to USING this function, or one of
-    // the stock phrasings that forbid without a verb. The verb is what
-    // matters, not the negation: "it cannot wait" describes the synchronous
-    // sibling and forbids nothing, while "callers cannot use this" forbids
-    // exactly what this docblock promises. So `cannot` stays in the list and
-    // is disarmed by the verb requirement, not by its absence. The verb is
-    // matched in both voices, since "cannot be used by plugins" forbids the
-    // same thing as "plugins cannot use" and a word boundary after `use`
-    // rejects `used`.
-    const prohibits = (line: string) =>
-      /\b(do not|don't|must not|should not|cannot|can't|never|not)\s+(be\s+)?(use|used|call|called|invoke|invoked|reach for|reached for|rely on|relied on)\b/i.test(
-        line
-      ) ||
-      /\b(internal use only|not for (user|plugin|application|external)|not intended for)\b/i.test(
-        line
-      );
 
     expect(sentences.filter(prohibits)).toEqual([]);
   });

--- a/packages/nextly/src/init.ts
+++ b/packages/nextly/src/init.ts
@@ -468,6 +468,8 @@ export async function getNextly(options: GetNextlyOptions): Promise<Nextly> {
  * this package does not mark optional, so a consumer installs it whichever
  * subpath they import. The boundary is about what a module GRAPH pulls in, not
  * about what a package manager resolves.
+ *
+ * @public
  */
 export async function getCachedNextly(): Promise<Nextly> {
   // Before ANY return, including the cached one. This is the surface that could


### PR DESCRIPTION
## What

\`accessors-stay-where-their-callers-are.test.ts\` asserted two things about the \`getCachedNextly\` docblock: that it names plugins as an audience, and that no sentence in it forbids them. The second was a regular expression over modal verbs and usage verbs, in both voices. It is removed. The first stays.

## Why

Whether an English sentence forbids a caller is not decidable by pattern. Six review rounds each found a wording it missed or a description it caught: \`should not call\`, then the passive voice, then \`cannot\` as a factual negation, then \`never used\` as a description, and \`must never be used by\` was the next one waiting. Each round widened the pattern. A check that grows a clause per review is the wrong shape.

The audience claim is a string. A string match is decidable, and it is the property this file exists to protect: the sentence it replaced said the opposite and stood for the module's whole life.

The question the pattern was trying to answer, "does this block forbid its own audience", is asked as data instead. This repository already uses TSDoc release tags (141 `@public`, 89 `@internal` across `packages/*/src`), and `@internal` is how it says "not for consumers". `getCachedNextly`'s docblock now carries `@public`, and the test asserts `@public` present and `@internal` absent. Control: with the tag flipped to `@internal` the test fails.

## Changeset

None. Test and comment only.
