### PR TITLE
fix(nextly): the list endpoints scope by the shared read decision, not by grants alone

### DIFF
--- a/.changeset/a-list-shows-what-a-reader-may-open.md
+++ b/.changeset/a-list-shows-what-a-reader-may-open.md
@@ -1,0 +1,42 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The collections and singles listings show exactly what the reader may open.
+
+Both lists scoped themselves by the stored `{slug}:read` grants alone, while
+every other read -- opening a document, the dashboard's own scope, a version
+read -- also consults the entity's code-defined `access.read`. The two
+disagreed in both directions: a collection or Single authorised entirely in
+code has no grant row, so it was left out of the list a reader could open it
+from, and on the dashboard the singles card was offered for it and then drew
+nothing; a grant the code rule refuses was listed anyway.
+
+Both listings now take the same read decision as everything else. One
+consequence for API keys: a key owned by a super admin no longer lists every
+collection and Single. It is judged on its own stamped scope, which is the rule
+every other read path already applied to it.

--- a/packages/nextly/src/api/__tests__/dashboard-read-scope.test.ts
+++ b/packages/nextly/src/api/__tests__/dashboard-read-scope.test.ts
@@ -86,8 +86,8 @@ const asMock = (fn: unknown): ReturnType<typeof vi.fn> =>
   fn as ReturnType<typeof vi.fn>;
 
 /** Two collections and one single, standing in for a real registry. */
-const COLLECTIONS = [{ slug: "posts" }, { slug: "pages" }];
-const SINGLES = [{ slug: "site-settings" }];
+const COLLECTIONS = ["posts", "pages"];
+const SINGLES = ["site-settings"];
 
 let rbac: RBACAccessControlService;
 
@@ -121,9 +121,9 @@ beforeEach(() => {
       case "rbacAccessControlService":
         return rbac;
       case "collectionRegistryService":
-        return { getAllCollections: vi.fn().mockResolvedValue(COLLECTIONS) };
+        return { getAllSlugs: vi.fn().mockResolvedValue(COLLECTIONS) };
       case "singleRegistryService":
-        return { getAllSingles: vi.fn().mockResolvedValue(SINGLES) };
+        return { getAllSlugs: vi.fn().mockResolvedValue(SINGLES) };
       case "dashboardService":
         return { getStats };
       case "activityLogService":

--- a/packages/nextly/src/api/dashboard.test.ts
+++ b/packages/nextly/src/api/dashboard.test.ts
@@ -129,16 +129,10 @@ beforeEach(() => {
   containerHas.mockReturnValue(true);
   containerGet.mockImplementation((name: string) => {
     if (name === "collectionRegistryService") {
-      return {
-        getAllCollections: vi
-          .fn()
-          .mockResolvedValue([{ slug: "posts" }, { slug: "pages" }]),
-      };
+      return { getAllSlugs: vi.fn().mockResolvedValue(["posts", "pages"]) };
     }
     if (name === "singleRegistryService") {
-      return {
-        getAllSingles: vi.fn().mockResolvedValue([{ slug: "site-settings" }]),
-      };
+      return { getAllSlugs: vi.fn().mockResolvedValue(["site-settings"]) };
     }
     return serviceStub;
   });

--- a/packages/nextly/src/auth/authenticated-scope.ts
+++ b/packages/nextly/src/auth/authenticated-scope.ts
@@ -20,7 +20,7 @@ import type {
   SingleAccessControl,
 } from "../shared/types/access";
 
-import { codeAccessAllows, getRBACService } from "./entity-read-access";
+import { codeAccessAllows, getRBACService } from "./code-access";
 import type { RequestActorType } from "./request-actor";
 
 /**

--- a/packages/nextly/src/auth/code-access.ts
+++ b/packages/nextly/src/auth/code-access.ts
@@ -1,0 +1,116 @@
+/**
+ * The pieces of a read decision that every judge shares.
+ *
+ * `canReadEntity` in `entity-read-access` and the write-side gate in
+ * `authenticated-scope` both evaluate a code-defined rule against a caller and
+ * both reach the RBAC service the same way. Those two modules import each
+ * other's neighbours, so the shared parts live here, beneath both, where
+ * neither has to reach through the other to find them.
+ *
+ * @module auth/code-access
+ */
+
+import { container } from "../di/container";
+import type { RBACAccessControlService } from "../domains/auth/services/rbac-access-control-service";
+import type {
+  AccessControlContext,
+  CollectionAccessControl,
+  SingleAccessControl,
+} from "../shared/types/access";
+
+/**
+ * The resolved identity a read decision needs.
+ *
+ * `permissions` are the API key's OWN scoped grants in `{action}-{resource}`
+ * form. Note the format: `listEffectivePermissions` returns the other one
+ * (`{resource}:{action}`), and mixing them silently answers "denied" for every
+ * check. Session callers carry an empty list — their grants are resolved from
+ * the database instead.
+ */
+export interface ReadAccessCaller {
+  userId: string;
+  authMethod: "session" | "api-key";
+  /**
+   * An API key's grants in the STORED spelling (`read-posts`): what the coarse
+   * `read-{slug}` check compares against. Empty for a session caller, whose
+   * grants `checkAccess` resolves from the database.
+   */
+  permissions: string[];
+  /**
+   * The same grants in the spelling a code-defined rule reads (`posts:read`),
+   * when the caller's scope carried the rows to derive it from.
+   *
+   * 🔴 Two spellings of one list, kept apart because they are read by two
+   * different judges. `AccessControlContext.permissions` promises the
+   * `resource:action` form, and a rule written to that promise --
+   * `({ permissions }) => permissions.includes("posts:read")` -- was handed
+   * the stored form and refused a correctly scoped key. Absent when the scope
+   * never had the rows, in which case the stored slugs are what a rule gets:
+   * the honest answer, since a slug cannot be split into parts no permission
+   * row names.
+   */
+  rulePermissions?: readonly string[];
+  /** Role slugs, already normalized (session roles arrive as ids). */
+  roles: string[];
+}
+
+/**
+ * The RBAC service, or undefined before the container is initialized.
+ *
+ * Exported for `auth/authenticated-scope`, which composes the api-key and
+ * session branches of the same decision and would otherwise hold a fourth copy
+ * of this resolver. It is not part of any published surface.
+ */
+export function getRBACService(): RBACAccessControlService | undefined {
+  try {
+    if (container.has("rbacAccessControlService")) {
+      return container.get<RBACAccessControlService>(
+        "rbacAccessControlService"
+      );
+    }
+  } catch {
+    // DI container not initialized yet — the caller decides how to fall back.
+  }
+  return undefined;
+}
+
+/**
+ * Evaluate a code-defined access rule.
+ *
+ * An absent rule allows: the permission check that precedes this one is what
+ * grants access, and a rule that says nothing about an operation does not
+ * revoke it. A rule that throws denies, so a broken rule fails closed.
+ */
+export async function codeAccessAllows(
+  codeAccess: CollectionAccessControl | SingleAccessControl,
+  operation: "create" | "read" | "update" | "delete" | "publish" | "unpublish",
+  resource: string,
+  caller: ReadAccessCaller
+): Promise<boolean> {
+  const operationAccess =
+    codeAccess[
+      operation as keyof (CollectionAccessControl | SingleAccessControl)
+    ];
+
+  if (operationAccess === undefined) return true;
+  if (typeof operationAccess === "boolean") return operationAccess;
+
+  // The context carries the CALLER's roles and permissions. For an API key
+  // those are the key's own scoped values, not its owner's — which is the
+  // whole point of evaluating the rule against the key.
+  const ctx: AccessControlContext = {
+    user: { id: caller.userId },
+    roles: caller.roles,
+    // The RULE-facing spelling, which is what the context promises. The
+    // stored spelling is a fallback for a scope that never carried the rows.
+    permissions: [...(caller.rulePermissions ?? caller.permissions)],
+    operation,
+    collection: resource,
+  };
+
+  try {
+    return (await operationAccess(ctx)) === true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/nextly/src/auth/entity-read-access.ts
+++ b/packages/nextly/src/auth/entity-read-access.ts
@@ -13,33 +13,20 @@
  * @module auth/entity-read-access
  */
 
-import { container } from "../di/container";
-import type { RBACAccessControlService } from "../domains/auth/services/rbac-access-control-service";
 import { NextlyError } from "../errors/nextly-error";
 import { parsePermissionSlug } from "../plugins/routes/permission-slug";
 import type { ReadCaller } from "../services/dashboard/readable-resources";
-import type {
-  AccessControlContext,
-  CollectionAccessControl,
-  SingleAccessControl,
-} from "../shared/types/access";
 
-/**
- * The resolved identity a read decision needs.
- *
- * `permissions` are the API key's OWN scoped grants in `{action}-{resource}`
- * form. Note the format: `listEffectivePermissions` returns the other one
- * (`{resource}:{action}`), and mixing them silently answers "denied" for every
- * check. Session callers carry an empty list — their grants are resolved from
- * the database instead.
- */
-export interface ReadAccessCaller {
-  userId: string;
-  authMethod: "session" | "api-key";
-  permissions: string[];
-  /** Role slugs, already normalized (session roles arrive as ids). */
-  roles: string[];
-}
+import { ruleFacingPermissions } from "./authenticated-scope";
+import {
+  codeAccessAllows,
+  getRBACService,
+  type ReadAccessCaller,
+} from "./code-access";
+
+// The shared halves of the decision keep their old address: every reader and
+// every test that mocks this module reaches them here.
+export { codeAccessAllows, getRBACService, type ReadAccessCaller };
 
 /**
  * The same caller a read endpoint resolved, in the shape an ENTITY-LEVEL read
@@ -64,77 +51,33 @@ export interface ReadAccessCaller {
  * decision, which is the failure this module exists to prevent.
  */
 export function readAccessCaller(caller: ReadCaller): ReadAccessCaller {
-  const isApiKey = caller.authenticatedScope?.actorType === "apiKey";
+  const scope = caller.authenticatedScope;
+  if (scope?.actorType === "apiKey") {
+    return {
+      userId: caller.user.id,
+      authMethod: "api-key",
+      permissions: [...scope.permissions],
+      // Only a scope that carried the ROWS can spell a grant the way a rule
+      // reads it; one that held slugs alone is left without, and the rule
+      // gets the stored spelling as it always did.
+      ...(scope.grants
+        ? { rulePermissions: ruleFacingPermissions(scope) }
+        : {}),
+      // The key's OWN roles when authentication resolved them; a key judged
+      // on its owner's roles is the same defect as one judged on its owner's
+      // permissions, in the direction that denies.
+      roles: [...(scope.roles ?? caller.user.roles ?? [])],
+    };
+  }
   return {
     userId: caller.user.id,
-    authMethod: isApiKey ? "api-key" : "session",
+    authMethod: "session",
     // A session caller carries none here on purpose: its grants are resolved
     // from the database by `checkAccess`. Handing it the key vocabulary would
     // answer "denied" for every check.
-    permissions: isApiKey
-      ? [...(caller.authenticatedScope?.permissions ?? [])]
-      : [],
+    permissions: [],
     roles: caller.user.roles ?? [],
   };
-}
-
-/**
- * The RBAC service, or undefined before the container is initialized.
- *
- * Exported for `auth/authenticated-scope`, which composes the api-key and
- * session branches of the same decision and would otherwise hold a fourth copy
- * of this resolver. It is not part of any published surface.
- */
-export function getRBACService(): RBACAccessControlService | undefined {
-  try {
-    if (container.has("rbacAccessControlService")) {
-      return container.get<RBACAccessControlService>(
-        "rbacAccessControlService"
-      );
-    }
-  } catch {
-    // DI container not initialized yet — the caller decides how to fall back.
-  }
-  return undefined;
-}
-
-/**
- * Evaluate a code-defined access rule.
- *
- * An absent rule allows: the permission check that precedes this one is what
- * grants access, and a rule that says nothing about an operation does not
- * revoke it. A rule that throws denies, so a broken rule fails closed.
- */
-export async function codeAccessAllows(
-  codeAccess: CollectionAccessControl | SingleAccessControl,
-  operation: "create" | "read" | "update" | "delete" | "publish" | "unpublish",
-  resource: string,
-  caller: ReadAccessCaller
-): Promise<boolean> {
-  const operationAccess =
-    codeAccess[
-      operation as keyof (CollectionAccessControl | SingleAccessControl)
-    ];
-
-  if (operationAccess === undefined) return true;
-  if (typeof operationAccess === "boolean") return operationAccess;
-
-  // The context carries the CALLER's roles and permissions. For an API key
-  // those are the key's own scoped values, not its owner's — which is the
-  // whole point of evaluating the rule against the key.
-  const ctx: AccessControlContext = {
-    user: { id: caller.userId },
-    roles: caller.roles,
-    permissions: caller.permissions,
-    operation,
-    collection: resource,
-  };
-
-  try {
-    return (await operationAccess(ctx)) === true;
-  } catch {
-    return false;
-  }
 }
 
 /**

--- a/packages/nextly/src/dispatcher/handlers/__tests__/autosave-policy.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/autosave-policy.test.ts
@@ -25,7 +25,14 @@ vi.mock("../../../api/versions-access", () => ({
   resolveCurrentFields: vi.fn(async () => []),
 }));
 
-vi.mock("../../../auth/entity-read-access", () => ({
+// DERIVED from the real module rather than a closed literal: the handler
+// under test reaches this module for more than the one export replaced
+// here, and a literal that names only that export makes every other one
+// undefined the day a new caller appears.
+vi.mock("../../../auth/entity-read-access", async importOriginal => ({
+  ...(await importOriginal<
+    typeof import("../../../auth/entity-read-access")
+  >()),
   canReadEntity: vi.fn(async () => true),
 }));
 

--- a/packages/nextly/src/dispatcher/handlers/__tests__/collection-dispatcher-list-allowlist.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/collection-dispatcher-list-allowlist.test.ts
@@ -71,10 +71,11 @@ describe("listCollections resolves its allowlist before querying", () => {
     );
   });
 
-  it("passes NO allowlist for a super admin", async () => {
-    // The control in the permissive direction: a super admin sees everything,
-    // and `undefined` is how the registry is told not to filter. An empty
-    // array here would hide every collection from them.
+  it("passes NO allowlist when the decision answers with none", async () => {
+    // The control in the permissive direction: `undefined` is how the registry
+    // is told not to filter, and the dispatcher must hand it through as it is.
+    // An empty array here would hide every collection from a caller the
+    // decision chose not to scope.
     allowlistFor.mockResolvedValue(undefined);
     const listCollections = vi.fn().mockResolvedValue(serviceResult(["posts"]));
 
@@ -89,7 +90,7 @@ describe("listCollections resolves its allowlist before querying", () => {
   });
 
   it("passes an EMPTY allowlist for a reader granted nothing", async () => {
-    // 🔴 Distinct from the super-admin case above, and the distinction is the
+    // 🔴 Distinct from the unscoped case above, and the distinction is the
     // whole gate: `undefined` means "no filter", `[]` means "nothing is
     // visible". Collapsing them shows every collection to a reader with no
     // grants at all.

--- a/packages/nextly/src/dispatcher/handlers/__tests__/collection-dispatcher-list-allowlist.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/collection-dispatcher-list-allowlist.test.ts
@@ -61,9 +61,14 @@ describe("listCollections resolves its allowlist before querying", () => {
 
     const passed = listCollections.mock.calls[0][0];
     expect([...passed.slugAllowlist].sort()).toEqual(["pages", "posts"]);
-    // Asked about THIS caller, so a handler passing a constant fails here
-    // rather than merely passing something list-shaped.
-    expect(allowlistFor).toHaveBeenCalledWith("u1");
+    // Asked about THIS caller, in the shape the shared read decision takes,
+    // and about the collections registry -- so a handler passing a constant,
+    // or a bare id, or the other kind fails here rather than merely passing
+    // something list-shaped.
+    expect(allowlistFor).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "u1", authMethod: "session" }),
+      "collection"
+    );
   });
 
   it("passes NO allowlist for a super admin", async () => {

--- a/packages/nextly/src/dispatcher/handlers/__tests__/discard-working-draft-access.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/discard-working-draft-access.test.ts
@@ -25,7 +25,14 @@ vi.mock("../../../api/versions-access", () => ({
   assertDocumentUpdatable: updatableSpy,
 }));
 
-vi.mock("../../../auth/entity-read-access", () => ({
+// DERIVED from the real module rather than a closed literal: the handler
+// under test reaches this module for more than the one export replaced
+// here, and a literal that names only that export makes every other one
+// undefined the day a new caller appears.
+vi.mock("../../../auth/entity-read-access", async importOriginal => ({
+  ...(await importOriginal<
+    typeof import("../../../auth/entity-read-access")
+  >()),
   canReadEntity: canReadSpy,
 }));
 

--- a/packages/nextly/src/dispatcher/handlers/__tests__/read-access-caller.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/read-access-caller.test.ts
@@ -1,0 +1,79 @@
+/**
+ * The dispatcher's caller is read from the scope the route handler pinned,
+ * and only from the params when nothing was pinned.
+ *
+ * The params are a lossy copy of an API key: stored permission slugs, no
+ * rows, and roles only for the methods the route handler chose to serialise
+ * them for. A caller rebuilt from them answered a code rule that decides on
+ * `roles`, or checks the documented `resource:action` spelling, with an empty
+ * list and the wrong spelling — a refusal the detail route did not give.
+ *
+ * @module dispatcher/handlers/__tests__/read-access-caller.test
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { apiKeyScope } from "../../../auth/authenticated-scope";
+import { runWithCallerScope } from "../../../auth/caller-scope";
+import { readAccessCallerForDispatch } from "../read-access-caller";
+
+const GRANTS = [
+  { slug: "read-posts", resource: "posts", action: "read" },
+  { slug: "update-posts", resource: "posts", action: "update" },
+];
+const user = { id: "key-owner", roles: ["admin"] };
+
+describe("the dispatcher's read-access caller", () => {
+  it("carries the key's OWN roles from the pinned scope, whatever the params say", () => {
+    // 🔴 `listCollections` and `listSingles` are not role-aware reads, so the
+    // params never carry the key's roles and `user.roles` names its OWNER's.
+    // A rule `read: ({ roles }) => roles.includes("editor")` refused the key on
+    // the list and admitted it on the detail route.
+    const caller = runWithCallerScope(apiKeyScope(GRANTS, ["editor"]), () =>
+      readAccessCallerForDispatch({}, user)
+    );
+    expect(caller.authMethod).toBe("api-key");
+    expect(caller.roles).toEqual(["editor"]);
+  });
+
+  it("hands a rule the resource:action spelling, and the coarse check the stored one", () => {
+    // 🔴 Two spellings of one list. `AccessControlContext.permissions`
+    // promises `posts:read`; the coarse `read-{slug}` check compares against
+    // `read-posts`. Forwarding the stored slugs to the rule refused every key
+    // whose rule was written to the documented promise.
+    const caller = runWithCallerScope(apiKeyScope(GRANTS), () =>
+      readAccessCallerForDispatch({}, user)
+    );
+    expect(caller.permissions).toEqual(["read-posts", "update-posts"]);
+    expect(caller.rulePermissions).toEqual(["posts:read", "posts:update"]);
+  });
+
+  it("falls back to the params when nothing is pinned, and says so by carrying no rule spelling", () => {
+    // A direct dispatch outside the route handler. The stored slugs are all
+    // the params hold, and the caller is honest about it: no rule-facing
+    // spelling rather than one invented by splitting a slug on its hyphen.
+    const caller = readAccessCallerForDispatch(
+      {
+        _authenticatedActorType: "apiKey",
+        _authenticatedPermissions: JSON.stringify(["read-posts"]),
+      },
+      { id: "key-owner", roles: [] }
+    );
+    expect(caller.authMethod).toBe("api-key");
+    expect(caller.permissions).toEqual(["read-posts"]);
+    expect(caller.rulePermissions).toBeUndefined();
+  });
+
+  it("builds a session caller with no grants of its own", () => {
+    const caller = readAccessCallerForDispatch(
+      {},
+      { id: "u1", roles: ["editor"] }
+    );
+    expect(caller).toEqual({
+      userId: "u1",
+      authMethod: "session",
+      permissions: [],
+      roles: ["editor"],
+    });
+  });
+});

--- a/packages/nextly/src/dispatcher/handlers/__tests__/singles-list-agrees-with-the-condition.integration.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/singles-list-agrees-with-the-condition.integration.test.ts
@@ -1,0 +1,96 @@
+/**
+ * The singles listing and the `singles:present` condition answer the same
+ * reader the same way.
+ *
+ * They must, because the dashboard offers the singles card on the condition
+ * and the card then draws the listing: a reader the condition admits and the
+ * listing refuses is offered a heading over nothing, which is the empty grid
+ * slot the card's lifecycle exists to remove. The two were derived from
+ * different things — the listing from the stored `{slug}:read` grants alone,
+ * the condition from the shared read decision that also consults a Single's
+ * code-defined `access.read` — so a Single authorised entirely in code was
+ * offered and not listed.
+ *
+ * Driven against a real instance with real code rules, in both directions:
+ * a rule that admits a reader holding no grant, and a rule that refuses.
+ *
+ * @module dispatcher/handlers/__tests__/singles-list-agrees-with-the-condition.integration.test
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineSingle, text } from "../../../config";
+import { evaluateConditions } from "../../../domains/widgets/conditions";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import type { ReadCaller } from "../../../services/dashboard/readable-resources";
+import { dispatchSingles } from "../single-dispatcher";
+
+/** A reader with no roles and no stored grant. Everything it may read, code says. */
+const READER_ID = "reader-with-no-grants";
+const reader: ReadCaller = { user: { id: READER_ID, roles: [] } };
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+async function boot(): Promise<void> {
+  current = await createTestNextly({
+    singles: [
+      defineSingle({
+        slug: "homepage",
+        // Admits everyone, by code. No grant row exists for this reader.
+        access: { read: () => true, update: () => false },
+        fields: [text({ name: "headline" })],
+      }),
+      defineSingle({
+        slug: "private",
+        // Refuses everyone, by code, whatever the grants say.
+        access: { read: () => false, update: () => false },
+        fields: [text({ name: "note" })],
+      }),
+    ],
+  });
+}
+
+async function conditionHolds(): Promise<boolean> {
+  const verdicts = await evaluateConditions(
+    new Set(["singles:present"]),
+    reader
+  );
+  return verdicts.get("singles:present") === true;
+}
+
+async function listedSlugs(): Promise<string[]> {
+  const response = (await dispatchSingles(
+    "listSingles",
+    { _authenticatedUserId: READER_ID },
+    undefined
+  )) as Response;
+  expect(response.status).toBe(200);
+  const body = (await response.json()) as { items: Array<{ slug: string }> };
+  return body.items.map(item => item.slug).sort();
+}
+
+describe("the singles listing and the singles:present condition", () => {
+  it("both admit a Single that a code rule alone admits", async () => {
+    // 🔴 The reader holds no `homepage:read` grant. A listing scoped by grants
+    // answers nothing here while the condition answers yes, and the dashboard
+    // offers a card that draws an empty list.
+    await boot();
+    expect(await conditionHolds()).toBe(true);
+    expect(await listedSlugs()).toContain("homepage");
+  });
+
+  it("both refuse a Single that a code rule refuses", async () => {
+    // The must-differ half: a listing that ignored code rules could not
+    // refuse this one, and a condition that ignored them could not either.
+    await boot();
+    expect(await listedSlugs()).not.toContain("private");
+  });
+});

--- a/packages/nextly/src/dispatcher/handlers/__tests__/singles-list-agrees-with-the-condition.integration.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/singles-list-agrees-with-the-condition.integration.test.ts
@@ -110,8 +110,8 @@ async function listedSlugs(
 }
 
 /** The listing as the route handler serves an API key: scope pinned for the dispatch. */
-function listedForKey(): Promise<string[]> {
-  return runWithCallerScope(keyScope(), () =>
+function listedForKey(scope = keyScope()): Promise<string[]> {
+  return runWithCallerScope(scope, () =>
     listedSlugs({
       _authenticatedUserId: KEY_OWNER,
       _authenticatedActorType: "apiKey",
@@ -137,11 +137,32 @@ describe("the singles listing and the singles:present condition", () => {
     expect(await listedSlugs()).toContain("homepage");
   });
 
-  it("both refuse a Single that a code rule refuses", async () => {
-    // The must-differ half: a listing that ignored code rules could not
-    // refuse this one, and a condition that ignored them could not either.
+  it("both refuse a Single that a code rule refuses, with the grant HELD", async () => {
+    // 🔴 The must-differ half, and it has to be asked by a caller holding the
+    // grant: a reader with no `read-private` is refused by a grant-only
+    // listing and by the shared decision alike, so it cannot tell the two
+    // apart. This key holds exactly that grant. A listing scoped by grants
+    // lists `private` on it; the shared decision reads the code rule and
+    // refuses, on the listing and the condition alike.
     await boot();
-    expect(await listedSlugs()).not.toContain("private");
+    const privateGrant = {
+      slug: "read-private",
+      resource: "private",
+      action: "read",
+    };
+    const holdsPrivate = apiKeyScope([privateGrant]);
+    expect(await listedForKey(holdsPrivate)).not.toContain("private");
+    expect(await conditionHoldsForKey(holdsPrivate)).toBe(false);
+
+    // The control: the same grant beside one the rule admits. The listing and
+    // the condition both answer for `homepage`, so the refusal above is the
+    // rule's and not a key that sees nothing at all.
+    const holdsBoth = apiKeyScope([
+      privateGrant,
+      { slug: "read-homepage", resource: "homepage", action: "read" },
+    ]);
+    expect(await listedForKey(holdsBoth)).toEqual(["homepage"]);
+    expect(await conditionHoldsForKey(holdsBoth)).toBe(true);
   });
 });
 

--- a/packages/nextly/src/dispatcher/handlers/__tests__/singles-list-agrees-with-the-condition.integration.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/singles-list-agrees-with-the-condition.integration.test.ts
@@ -19,6 +19,8 @@
 
 import { afterEach, describe, expect, it } from "vitest";
 
+import { apiKeyScope } from "../../../auth/authenticated-scope";
+import { runWithCallerScope } from "../../../auth/caller-scope";
 import { defineSingle, text } from "../../../config";
 import { evaluateConditions } from "../../../domains/widgets/conditions";
 import {
@@ -54,9 +56,37 @@ async function boot(): Promise<void> {
         access: { read: () => false, update: () => false },
         fields: [text({ name: "note" })],
       }),
+      defineSingle({
+        slug: "editors-only",
+        // Decides on the caller's ROLES. For an API key those must be the
+        // key's own, which the list request's params never carry.
+        access: {
+          read: ({ roles }) => roles.includes("editor"),
+          update: () => false,
+        },
+        fields: [text({ name: "memo" })],
+      }),
+      defineSingle({
+        slug: "spelled-out",
+        // Decides on the documented `resource:action` spelling. A key handed
+        // its stored slugs (`read-spelled-out`) is refused here.
+        access: {
+          read: ({ permissions }) => permissions.includes("spelled-out:read"),
+          update: () => false,
+        },
+        fields: [text({ name: "body" })],
+      }),
     ],
   });
 }
+
+/** An API key holding read grants on the two rule-bearing Singles, and the editor role. */
+const KEY_GRANTS = [
+  { slug: "read-editors-only", resource: "editors-only", action: "read" },
+  { slug: "read-spelled-out", resource: "spelled-out", action: "read" },
+];
+const KEY_OWNER = "key-owner";
+const keyScope = () => apiKeyScope(KEY_GRANTS, ["editor"]);
 
 async function conditionHolds(): Promise<boolean> {
   const verdicts = await evaluateConditions(
@@ -66,15 +96,35 @@ async function conditionHolds(): Promise<boolean> {
   return verdicts.get("singles:present") === true;
 }
 
-async function listedSlugs(): Promise<string[]> {
+async function listedSlugs(
+  params: Record<string, string> = { _authenticatedUserId: READER_ID }
+): Promise<string[]> {
   const response = (await dispatchSingles(
     "listSingles",
-    { _authenticatedUserId: READER_ID },
+    params,
     undefined
   )) as Response;
   expect(response.status).toBe(200);
   const body = (await response.json()) as { items: Array<{ slug: string }> };
   return body.items.map(item => item.slug).sort();
+}
+
+/** The listing as the route handler serves an API key: scope pinned for the dispatch. */
+function listedForKey(): Promise<string[]> {
+  return runWithCallerScope(keyScope(), () =>
+    listedSlugs({
+      _authenticatedUserId: KEY_OWNER,
+      _authenticatedActorType: "apiKey",
+    })
+  );
+}
+
+async function conditionHoldsForKey(scope = keyScope()): Promise<boolean> {
+  const verdicts = await evaluateConditions(new Set(["singles:present"]), {
+    user: { id: KEY_OWNER, roles: ["admin"] },
+    authenticatedScope: scope,
+  });
+  return verdicts.get("singles:present") === true;
 }
 
 describe("the singles listing and the singles:present condition", () => {
@@ -92,5 +142,41 @@ describe("the singles listing and the singles:present condition", () => {
     // refuse this one, and a condition that ignored them could not either.
     await boot();
     expect(await listedSlugs()).not.toContain("private");
+  });
+});
+
+describe("an API key, asked the same two ways", () => {
+  it("is admitted by a rule on its OWN roles, on the listing and the condition alike", async () => {
+    // 🔴 The listing's params never carry the key's roles, and the user on
+    // them is the key's OWNER (an admin here, not an editor). Rebuilt from the
+    // params the key was refused; read from the pinned scope it is not.
+    await boot();
+    expect(await listedForKey()).toContain("editors-only");
+    expect(await conditionHoldsForKey()).toBe(true);
+  });
+
+  it("is admitted by a rule written to the documented permission spelling", async () => {
+    // 🔴 The key holds `read-spelled-out`; the rule checks
+    // `spelled-out:read`, which is what the context promises. Handed the
+    // stored spelling, the rule refused a correctly scoped key.
+    await boot();
+    expect(await listedForKey()).toContain("spelled-out");
+    // The condition's own builder, given a key holding ONLY this grant and
+    // no role: it can hold only if that builder spells the grant the way the
+    // rule reads it.
+    expect(
+      await conditionHoldsForKey(
+        apiKeyScope([
+          { slug: "read-spelled-out", resource: "spelled-out", action: "read" },
+        ])
+      )
+    ).toBe(true);
+  });
+
+  it("is still refused what its grants do not name", async () => {
+    // The control: the key holds no grant on `homepage`, and a key is judged
+    // on its own scope even though a code rule admits everyone else.
+    await boot();
+    expect(await listedForKey()).not.toContain("homepage");
   });
 });

--- a/packages/nextly/src/dispatcher/handlers/__tests__/versions-label.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/versions-label.test.ts
@@ -26,7 +26,14 @@ vi.mock("../../../api/versions-access", () => ({
   resolveSingleDocumentId: vi.fn(),
 }));
 
-vi.mock("../../../auth/entity-read-access", () => ({
+// DERIVED from the real module rather than a closed literal: the handler
+// under test reaches this module for more than the one export replaced
+// here, and a literal that names only that export makes every other one
+// undefined the day a new caller appears.
+vi.mock("../../../auth/entity-read-access", async importOriginal => ({
+  ...(await importOriginal<
+    typeof import("../../../auth/entity-read-access")
+  >()),
   canReadEntity: canReadSpy,
 }));
 

--- a/packages/nextly/src/dispatcher/handlers/__tests__/versions-restore-access.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/versions-restore-access.test.ts
@@ -24,7 +24,14 @@ vi.mock("../../../api/versions-access", () => ({
   resolveSingleDocumentId: vi.fn(),
 }));
 
-vi.mock("../../../auth/entity-read-access", () => ({
+// DERIVED from the real module rather than a closed literal: the handler
+// under test reaches this module for more than the one export replaced
+// here, and a literal that names only that export makes every other one
+// undefined the day a new caller appears.
+vi.mock("../../../auth/entity-read-access", async importOriginal => ({
+  ...(await importOriginal<
+    typeof import("../../../auth/entity-read-access")
+  >()),
   canReadEntity: canReadSpy,
 }));
 

--- a/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
@@ -113,6 +113,7 @@ import {
 } from "../helpers/validation";
 import type { MethodHandler, Params } from "../types";
 
+import { readAccessCallerFromParams } from "./read-access-caller";
 // Shared guard that centralizes required + stale schema-version validation for
 // all three entity kinds, so a stale UI save is rejected before any DDL runs.
 import { assertSchemaVersionMatch } from "./schema-version-guard";
@@ -412,15 +413,17 @@ const COLLECTIONS_METHODS: Record<
     // reading that stops at the first page, and everything past it is
     // unreachable. The singles dispatcher resolves its allowlist the same way.
     execute: async (svc, p) => {
-      const userId = p._authenticatedUserId
-        ? String(p._authenticatedUserId)
-        : undefined;
-
-      // The SHARED resolver, which the singles listing asks too. `undefined`
-      // means no filter — an unauthenticated caller, gated at the route layer,
-      // or a super admin. An empty list means nothing is visible, which the
-      // registry short-circuits to a zero-row, zero-total answer.
-      const slugAllowlist = await readableSlugAllowlist(userId);
+      // The SHARED resolver, which the singles listing asks too, handed the
+      // SAME caller every other read decision takes. `undefined` means no
+      // filter — an unauthenticated caller, gated at the route layer, or a
+      // session super admin. An empty list means nothing is visible, which
+      // the registry short-circuits to a zero-row, zero-total answer.
+      const slugAllowlist = await readableSlugAllowlist(
+        p._authenticatedUserId
+          ? readAccessCallerFromParams(p, userFromParams(p))
+          : undefined,
+        "collection"
+      );
 
       const result = await svc.listCollections({
         page: toNumber(p.page),

--- a/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
@@ -113,7 +113,7 @@ import {
 } from "../helpers/validation";
 import type { MethodHandler, Params } from "../types";
 
-import { readAccessCallerFromParams } from "./read-access-caller";
+import { readAccessCallerForDispatch } from "./read-access-caller";
 // Shared guard that centralizes required + stale schema-version validation for
 // all three entity kinds, so a stale UI save is rejected before any DDL runs.
 import { assertSchemaVersionMatch } from "./schema-version-guard";
@@ -420,7 +420,7 @@ const COLLECTIONS_METHODS: Record<
       // the registry short-circuits to a zero-row, zero-total answer.
       const slugAllowlist = await readableSlugAllowlist(
         p._authenticatedUserId
-          ? readAccessCallerFromParams(p, userFromParams(p))
+          ? readAccessCallerForDispatch(p, userFromParams(p))
           : undefined,
         "collection"
       );

--- a/packages/nextly/src/dispatcher/handlers/read-access-caller.ts
+++ b/packages/nextly/src/dispatcher/handlers/read-access-caller.ts
@@ -1,0 +1,46 @@
+/**
+ * The dispatcher's resolved identity, in the shape the shared read decision
+ * takes.
+ *
+ * `canReadEntity` and `readableEntities` are the one answer to "may this
+ * caller read that entity" — the dashboard scope, the version reads and the
+ * list endpoints all ask it, so that a collection authorised entirely in code
+ * is visible on every one of them or on none. This is the bridge from a
+ * dispatcher request to that answer, kept in one place so no handler builds
+ * its own caller and quietly asks a different question.
+ *
+ * An API key's own scoped grants arrive on the params; a session caller has
+ * none there, and `canReadEntity` resolves theirs from the database.
+ *
+ * @module dispatcher/handlers/read-access-caller
+ */
+
+import type { ReadAccessCaller } from "../../auth/entity-read-access";
+import type { UserContext } from "../../domains/singles/types";
+import type { Params } from "../types";
+
+export function readAccessCallerFromParams(
+  p: Params,
+  user: UserContext
+): ReadAccessCaller {
+  const isApiKey = p._authenticatedActorType === "apiKey";
+
+  let permissions: string[] = [];
+  if (isApiKey && p._authenticatedPermissions) {
+    try {
+      const parsed: unknown = JSON.parse(String(p._authenticatedPermissions));
+      if (Array.isArray(parsed)) permissions = parsed as string[];
+    } catch {
+      // A corrupt value must not read as a broader grant than the key holds;
+      // an empty list denies, which is the safe direction.
+      permissions = [];
+    }
+  }
+
+  return {
+    userId: user.id,
+    authMethod: isApiKey ? "api-key" : "session",
+    permissions,
+    roles: user.roles ?? [],
+  };
+}

--- a/packages/nextly/src/dispatcher/handlers/read-access-caller.ts
+++ b/packages/nextly/src/dispatcher/handlers/read-access-caller.ts
@@ -6,66 +6,33 @@
  * caller read that entity" — the dashboard scope, the version reads and the
  * list endpoints all ask it, so that a collection authorised entirely in code
  * is visible on every one of them or on none. This is the bridge from a
- * dispatcher request to that answer, kept in one place so no handler builds
+ * dispatcher request to that answer, kept as one address so no handler builds
  * its own caller and quietly asks a different question.
  *
- * 🔴 An API key is read from the scope the route handler PINNED for the
- * request, not rebuilt from the route params. The params are a lossy copy:
- * they carry the stored permission slugs and neither the key's own roles —
- * serialised only for the methods `ROLE_AWARE_READ_METHODS` names, which the
- * list reads are not — nor the grant rows a rule's `resource:action` spelling
- * is derived from. A caller rebuilt from them let a code rule deciding on
- * `roles`, or checking `permissions.includes("posts:read")`, refuse a key the
- * detail route had just admitted. The pinned scope holds all of it.
- *
- * The params remain the fallback for a transport that pins nothing — a direct
- * dispatch in a test, or one not yet wired through the route handler — and are
- * exactly as lossy there as they always were. A session caller carries no
- * grants either way; `canReadEntity` resolves theirs from the database.
+ * DERIVED, not written a third time. `readAuthenticatedScope` already owns the
+ * choice between the scope the route handler pinned for the request and the
+ * lossy reconstruction from route params, and `readAccessCaller` already turns
+ * a scope and a user into the caller the decision reads — the same conversion
+ * the dashboard makes. Repeating either here is a copy that agrees today and
+ * drifts the day one of them learns a field.
  *
  * @module dispatcher/handlers/read-access-caller
  */
 
-import { ruleFacingPermissions } from "../../auth/authenticated-scope";
-import { currentCallerScope } from "../../auth/caller-scope";
-import type { ReadAccessCaller } from "../../auth/entity-read-access";
+import {
+  readAccessCaller,
+  type ReadAccessCaller,
+} from "../../auth/entity-read-access";
 import type { UserContext } from "../../domains/singles/types";
+import { readAuthenticatedScope } from "../helpers/authenticated-actor";
 import type { Params } from "../types";
 
 export function readAccessCallerForDispatch(
   p: Params,
   user: UserContext
 ): ReadAccessCaller {
-  const pinned = currentCallerScope();
-  if (pinned?.actorType === "apiKey") {
-    return {
-      userId: user.id,
-      authMethod: "api-key",
-      permissions: [...pinned.permissions],
-      ...(pinned.grants
-        ? { rulePermissions: ruleFacingPermissions(pinned) }
-        : {}),
-      roles: [...(pinned.roles ?? user.roles ?? [])],
-    };
-  }
-
-  const isApiKey = p._authenticatedActorType === "apiKey";
-  let permissions: string[] = [];
-  if (isApiKey && p._authenticatedPermissions) {
-    try {
-      const parsed: unknown = JSON.parse(String(p._authenticatedPermissions));
-      if (Array.isArray(parsed)) permissions = parsed as string[];
-    } catch {
-      // A corrupt value must not read as a broader grant than the key holds;
-      // an empty list denies, which is the safe direction.
-      permissions = [];
-    }
-  }
-
-  return {
-    userId: user.id,
-    authMethod: isApiKey ? "api-key" : "session",
-    permissions,
-    roles: user.roles ?? [],
-  };
+  return readAccessCaller({
+    user,
+    authenticatedScope: readAuthenticatedScope(p),
+  });
 }

--- a/packages/nextly/src/dispatcher/handlers/read-access-caller.ts
+++ b/packages/nextly/src/dispatcher/handlers/read-access-caller.ts
@@ -9,22 +9,47 @@
  * dispatcher request to that answer, kept in one place so no handler builds
  * its own caller and quietly asks a different question.
  *
- * An API key's own scoped grants arrive on the params; a session caller has
- * none there, and `canReadEntity` resolves theirs from the database.
+ * 🔴 An API key is read from the scope the route handler PINNED for the
+ * request, not rebuilt from the route params. The params are a lossy copy:
+ * they carry the stored permission slugs and neither the key's own roles —
+ * serialised only for the methods `ROLE_AWARE_READ_METHODS` names, which the
+ * list reads are not — nor the grant rows a rule's `resource:action` spelling
+ * is derived from. A caller rebuilt from them let a code rule deciding on
+ * `roles`, or checking `permissions.includes("posts:read")`, refuse a key the
+ * detail route had just admitted. The pinned scope holds all of it.
+ *
+ * The params remain the fallback for a transport that pins nothing — a direct
+ * dispatch in a test, or one not yet wired through the route handler — and are
+ * exactly as lossy there as they always were. A session caller carries no
+ * grants either way; `canReadEntity` resolves theirs from the database.
  *
  * @module dispatcher/handlers/read-access-caller
  */
 
+import { ruleFacingPermissions } from "../../auth/authenticated-scope";
+import { currentCallerScope } from "../../auth/caller-scope";
 import type { ReadAccessCaller } from "../../auth/entity-read-access";
 import type { UserContext } from "../../domains/singles/types";
 import type { Params } from "../types";
 
-export function readAccessCallerFromParams(
+export function readAccessCallerForDispatch(
   p: Params,
   user: UserContext
 ): ReadAccessCaller {
-  const isApiKey = p._authenticatedActorType === "apiKey";
+  const pinned = currentCallerScope();
+  if (pinned?.actorType === "apiKey") {
+    return {
+      userId: user.id,
+      authMethod: "api-key",
+      permissions: [...pinned.permissions],
+      ...(pinned.grants
+        ? { rulePermissions: ruleFacingPermissions(pinned) }
+        : {}),
+      roles: [...(pinned.roles ?? user.roles ?? [])],
+    };
+  }
 
+  const isApiKey = p._authenticatedActorType === "apiKey";
   let permissions: string[] = [];
   if (isApiKey && p._authenticatedPermissions) {
     try {

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -114,7 +114,7 @@ import {
 } from "../helpers/validation";
 import type { MethodHandler, Params } from "../types";
 
-import { readAccessCallerFromParams } from "./read-access-caller";
+import { readAccessCallerForDispatch } from "./read-access-caller";
 import { assertSchemaVersionMatch } from "./schema-version-guard";
 import {
   assertLabelRequestValid,
@@ -487,7 +487,7 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
       // zero-row, zero-total response.
       const user = authenticatedSingleUser(p);
       const slugAllowlist = await readableSlugAllowlist(
-        user ? readAccessCallerFromParams(p, user) : undefined,
+        user ? readAccessCallerForDispatch(p, user) : undefined,
         "single"
       );
 

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -114,6 +114,7 @@ import {
 } from "../helpers/validation";
 import type { MethodHandler, Params } from "../types";
 
+import { readAccessCallerFromParams } from "./read-access-caller";
 import { assertSchemaVersionMatch } from "./schema-version-guard";
 import {
   assertLabelRequestValid,
@@ -476,17 +477,19 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
         }
       }
 
-      const userId = p._authenticatedUserId
-        ? String(p._authenticatedUserId)
-        : undefined;
-
       // Resolved BEFORE the registry call, through the SHARED resolver the
-      // collections listing asks too. Super admins and unauthenticated callers
-      // (gated at the route layer) pass through with `undefined`, which means
-      // "no filter"; an authenticated non-super-admin gets an explicit list,
-      // possibly empty, which the registry short-circuits to a zero-row,
-      // zero-total response.
-      const slugAllowlist = await readableSlugAllowlist(userId);
+      // collections listing asks too, and handed the SAME caller every other
+      // read decision takes -- so a Single a code rule admits is listed here
+      // exactly when the dashboard offers a card for it. Session super admins
+      // and unauthenticated callers (gated at the route layer) pass through
+      // with `undefined`, which means "no filter"; anyone else gets an
+      // explicit list, possibly empty, which the registry short-circuits to a
+      // zero-row, zero-total response.
+      const user = authenticatedSingleUser(p);
+      const slugAllowlist = await readableSlugAllowlist(
+        user ? readAccessCallerFromParams(p, user) : undefined,
+        "single"
+      );
 
       const result = await svc.registry.listSingles({
         source: p.source as "code" | "ui" | "built-in" | undefined,

--- a/packages/nextly/src/dispatcher/handlers/versions-methods.ts
+++ b/packages/nextly/src/dispatcher/handlers/versions-methods.ts
@@ -49,7 +49,7 @@ import { stripPasswordFieldValues } from "../../shared/lib/password-fields";
 import { readAuthenticatedScope } from "../helpers/authenticated-actor";
 import type { Params } from "../types";
 
-import { readAccessCallerFromParams } from "./read-access-caller";
+import { readAccessCallerForDispatch } from "./read-access-caller";
 
 /** Page size when the caller does not ask for one. */
 const DEFAULT_LIMIT = 25;
@@ -447,7 +447,7 @@ export async function setVersionLabelForDocument(
   assertPositiveInteger(args.versionNo, "versionNo");
   const { provided, label } = readLabelFromBody(args.body);
 
-  const caller = readAccessCallerFromParams(args.params, args.user);
+  const caller = readAccessCallerForDispatch(args.params, args.user);
 
   if (!(await canReadEntity(args.slug, caller))) {
     throw NextlyError.notFound({
@@ -536,7 +536,7 @@ export async function restoreVersionForDocument(
     request?: Request;
   }
 ): Promise<{ restoredFrom: number; droppedFields: string[] }> {
-  const caller = readAccessCallerFromParams(args.params, args.user);
+  const caller = readAccessCallerForDispatch(args.params, args.user);
 
   if (!(await canReadEntity(args.slug, caller))) {
     // "Not found" rather than "forbidden", matching the document gate below: a
@@ -610,7 +610,7 @@ export async function discardWorkingDraftForDocument(
     locale?: string | null;
   }
 ): Promise<unknown> {
-  const caller = readAccessCallerFromParams(args.params, args.user);
+  const caller = readAccessCallerForDispatch(args.params, args.user);
 
   // Read gate first: the route authorized this as an update, not a read, so a
   // caller who cannot read the document is refused here — as "not found" so the
@@ -686,7 +686,7 @@ export async function autosaveForDocument(
     locale?: string | null;
   }
 ): Promise<unknown> {
-  const caller = readAccessCallerFromParams(args.params, args.user);
+  const caller = readAccessCallerForDispatch(args.params, args.user);
 
   if (!(await canReadEntity(args.slug, caller))) {
     throw NextlyError.notFound({
@@ -850,7 +850,7 @@ export async function autosaveForDocument(
 export async function getAutosaveForDocument(
   args: Omit<VersionMethodArgs, "locale"> & { params: Params }
 ): Promise<unknown> {
-  const caller = readAccessCallerFromParams(args.params, args.user);
+  const caller = readAccessCallerForDispatch(args.params, args.user);
 
   if (!(await canReadEntity(args.slug, caller))) {
     throw NextlyError.notFound({

--- a/packages/nextly/src/dispatcher/handlers/versions-methods.ts
+++ b/packages/nextly/src/dispatcher/handlers/versions-methods.ts
@@ -21,10 +21,7 @@ import {
   tryResolveCurrentFields,
 } from "../../api/versions-access";
 import type { AuthenticatedScope } from "../../auth/authenticated-scope";
-import {
-  canReadEntity,
-  type ReadAccessCaller,
-} from "../../auth/entity-read-access";
+import { canReadEntity } from "../../auth/entity-read-access";
 import type { RequestActor } from "../../auth/request-actor";
 import type { FieldConfig } from "../../collections/fields/types";
 import { getService } from "../../di";
@@ -51,6 +48,8 @@ import type { VersionScopeKind } from "../../schemas/versions/types";
 import { stripPasswordFieldValues } from "../../shared/lib/password-fields";
 import { readAuthenticatedScope } from "../helpers/authenticated-actor";
 import type { Params } from "../types";
+
+import { readAccessCallerFromParams } from "./read-access-caller";
 
 /** Page size when the caller does not ask for one. */
 const DEFAULT_LIMIT = 25;
@@ -333,38 +332,6 @@ export async function getVersionDiffForDocument(
     modifiedOnly: args.modifiedOnly,
     authenticatedScope: args.authenticatedScope,
   });
-}
-
-/**
- * The resolved identity, as the shared read decision needs it.
- *
- * An API key's own scoped grants arrive on the params; a session caller has
- * none there, and `canReadEntity` resolves theirs from the database.
- */
-function readAccessCallerFromParams(
-  p: Params,
-  user: UserContext
-): ReadAccessCaller {
-  const isApiKey = p._authenticatedActorType === "apiKey";
-
-  let permissions: string[] = [];
-  if (isApiKey && p._authenticatedPermissions) {
-    try {
-      const parsed: unknown = JSON.parse(String(p._authenticatedPermissions));
-      if (Array.isArray(parsed)) permissions = parsed as string[];
-    } catch {
-      // A corrupt value must not read as a broader grant than the key holds;
-      // an empty list denies, which is the safe direction.
-      permissions = [];
-    }
-  }
-
-  return {
-    userId: user.id,
-    authMethod: isApiKey ? "api-key" : "session",
-    permissions,
-    roles: user.roles ?? [],
-  };
 }
 
 /**

--- a/packages/nextly/src/services/lib/__tests__/registered-content-snapshot.test.ts
+++ b/packages/nextly/src/services/lib/__tests__/registered-content-snapshot.test.ts
@@ -27,13 +27,13 @@ vi.mock("../../../di/container", () => ({
 
 import { registeredContentSnapshot } from "../registered-content-slugs";
 
-const collections = { getAllCollections: vi.fn() };
-const singles = { getAllSingles: vi.fn() };
+const collections = { getAllSlugs: vi.fn() };
+const singles = { getAllSlugs: vi.fn() };
 
 beforeEach(() => {
   vi.clearAllMocks();
-  collections.getAllCollections.mockResolvedValue([{ slug: "posts" }]);
-  singles.getAllSingles.mockResolvedValue([{ slug: "site-settings" }]);
+  collections.getAllSlugs.mockResolvedValue(["posts"]);
+  singles.getAllSlugs.mockResolvedValue(["site-settings"]);
   containerHas.mockReturnValue(true);
   containerGet.mockImplementation((name: string) => {
     if (name === "collectionRegistryService") return collections;
@@ -67,7 +67,7 @@ describe("enumerating the content registries", () => {
   it("IS degraded when a registered registry cannot answer", async () => {
     // The case the flag exists for: a registered registry that throws has said
     // nothing about how much it holds, so its empty result is a floor.
-    collections.getAllCollections.mockRejectedValue(new Error("pool timeout"));
+    collections.getAllSlugs.mockRejectedValue(new Error("pool timeout"));
 
     const snapshot = await registeredContentSnapshot();
 

--- a/packages/nextly/src/services/lib/readable-slug-allowlist.test.ts
+++ b/packages/nextly/src/services/lib/readable-slug-allowlist.test.ts
@@ -7,66 +7,109 @@
  * rows, and a caller that treats them alike shows a reader with no grants the
  * entire install.
  *
+ * And the list is DERIVED from the shared read decision, not from the stored
+ * grants: a slug the decision admits is listed whether or not a grant row
+ * exists for it, and a slug it refuses is not listed whatever the grants say.
+ *
  * @module services/lib/readable-slug-allowlist.test
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const isSuperAdmin = vi.fn();
-const listEffectivePermissions = vi.fn();
+import type { ReadAccessCaller } from "../../auth/entity-read-access";
 
-// The two collaborators are stubbed; the resolver under test is the real one.
-// It lives in its own module precisely so this substitution works — a function
+const isSuperAdmin = vi.fn();
+const readableEntities = vi.fn();
+const registeredSlugsOfKind = vi.fn();
+
+// The collaborators are stubbed; the resolver under test is the real one. It
+// lives in its own module precisely so this substitution works — a function
 // calling its neighbours through module-local references cannot have them
 // replaced, and the test would then drive the real permission service.
-vi.mock("./permissions", () => ({ isSuperAdmin, listEffectivePermissions }));
+vi.mock("./permissions", () => ({ isSuperAdmin }));
+vi.mock("../../auth/entity-read-access", () => ({ readableEntities }));
+vi.mock("./registered-content-slugs", () => ({ registeredSlugsOfKind }));
 
 const { readableSlugAllowlist } = await import("./readable-slug-allowlist");
 
+const session: ReadAccessCaller = {
+  userId: "u1",
+  authMethod: "session",
+  permissions: [],
+  roles: ["editor"],
+};
+const apiKey: ReadAccessCaller = {
+  userId: "u1",
+  authMethod: "api-key",
+  permissions: ["read-posts"],
+  roles: [],
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
+  isSuperAdmin.mockResolvedValue(false);
+  registeredSlugsOfKind.mockResolvedValue({
+    slugs: ["posts", "secrets", "notes"],
+    reachable: true,
+  });
 });
 
 describe("which slugs a caller may read", () => {
-  it("answers UNDEFINED for a super admin, which means no filter", async () => {
+  it("answers UNDEFINED for a session super admin, which means no filter", async () => {
     isSuperAdmin.mockResolvedValue(true);
-
-    await expect(readableSlugAllowlist("admin")).resolves.toBeUndefined();
-    // The grants are never read: a super admin's answer does not depend on
-    // them, and asking would be a query per listing for a decided outcome.
-    expect(listEffectivePermissions).not.toHaveBeenCalled();
+    expect(await readableSlugAllowlist(session, "collection")).toBeUndefined();
+    // Nothing else was asked: the bypass is the whole answer.
+    expect(readableEntities).not.toHaveBeenCalled();
   });
 
   it("answers UNDEFINED for no caller at all", async () => {
-    // Unauthenticated callers are gated at the route layer; reaching here with
-    // no id is not a licence to filter by an empty set.
-    await expect(readableSlugAllowlist(undefined)).resolves.toBeUndefined();
-    expect(isSuperAdmin).not.toHaveBeenCalled();
+    expect(await readableSlugAllowlist(undefined, "single")).toBeUndefined();
+    expect(readableEntities).not.toHaveBeenCalled();
   });
 
-  it("answers an EMPTY LIST for a caller granted no reads", async () => {
-    // 🔴 Distinct from `undefined`, and this is the whole gate. Returning
-    // `undefined` here would mean "no filter" and hand every collection and
-    // single in the install to a caller holding none.
-    isSuperAdmin.mockResolvedValue(false);
-    listEffectivePermissions.mockResolvedValue(["media:write", "users:update"]);
-
-    await expect(readableSlugAllowlist("u1")).resolves.toEqual([]);
-  });
-
-  it("keeps only the READ half of each grant, de-duplicated", async () => {
-    // A write grant is not a read grant, and the resource is the half before
-    // the colon. Passing pairs through whole would filter on strings no slug
-    // column ever holds, which reads as "this caller may see nothing".
-    isSuperAdmin.mockResolvedValue(false);
-    listEffectivePermissions.mockResolvedValue([
-      "posts:read",
-      "pages:read",
-      "posts:read",
-      "posts:delete",
+  it("does NOT bypass for an API key, however privileged its owner", async () => {
+    // 🔴 The owner's standing is not the key's. `canReadEntity` judges a key on
+    // its own stamped scope, and a bypass here would make a read-only key
+    // issued by an administrator equivalent to their whole account on the two
+    // endpoints that list the most.
+    isSuperAdmin.mockResolvedValue(true);
+    readableEntities.mockResolvedValue(new Set(["posts"]));
+    expect(await readableSlugAllowlist(apiKey, "collection")).toEqual([
+      "posts",
     ]);
+    expect(readableEntities).toHaveBeenCalledWith(
+      ["posts", "secrets", "notes"],
+      apiKey
+    );
+  });
 
-    const allowlist = await readableSlugAllowlist("u1");
+  it("lists exactly what the shared read decision admits, in registry order", async () => {
+    // Neither a grant row nor its absence is consulted here: the decision is
+    // `readableEntities`' alone, and this returns its verdict as a list.
+    readableEntities.mockResolvedValue(new Set(["notes", "posts"]));
+    expect(await readableSlugAllowlist(session, "collection")).toEqual([
+      "posts",
+      "notes",
+    ]);
+  });
 
-    expect([...(allowlist ?? [])].sort()).toEqual(["pages", "posts"]);
+  it("asks about the registry of the KIND being listed", async () => {
+    readableEntities.mockResolvedValue(new Set());
+    await readableSlugAllowlist(session, "single");
+    expect(registeredSlugsOfKind).toHaveBeenCalledWith("single");
+  });
+
+  it("answers an EMPTY LIST for a caller admitted to nothing", async () => {
+    readableEntities.mockResolvedValue(new Set());
+    expect(await readableSlugAllowlist(session, "collection")).toEqual([]);
+  });
+
+  it("answers an EMPTY LIST when the registry could not be enumerated", async () => {
+    // 🔴 Fails CLOSED. A registry that could not be reached is not "no
+    // content", and it is not "every row" either -- it is an access decision
+    // with no candidates, and admitting nothing is the safe direction. The
+    // decision itself is not even asked, so it cannot answer from a floor.
+    registeredSlugsOfKind.mockResolvedValue({ slugs: [], reachable: false });
+    expect(await readableSlugAllowlist(session, "single")).toEqual([]);
+    expect(readableEntities).not.toHaveBeenCalled();
   });
 });

--- a/packages/nextly/src/services/lib/readable-slug-allowlist.test.ts
+++ b/packages/nextly/src/services/lib/readable-slug-allowlist.test.ts
@@ -10,6 +10,8 @@
  * And the list is DERIVED from the shared read decision, not from the stored
  * grants: a slug the decision admits is listed whether or not a grant row
  * exists for it, and a slug it refuses is not listed whatever the grants say.
+ * That includes the super-admin bypass, which the decision composes and this
+ * module does not restate.
  *
  * @module services/lib/readable-slug-allowlist.test
  */
@@ -17,7 +19,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ReadAccessCaller } from "../../auth/entity-read-access";
 
-const isSuperAdmin = vi.fn();
 const readableEntities = vi.fn();
 const registeredSlugsOfKind = vi.fn();
 
@@ -25,8 +26,14 @@ const registeredSlugsOfKind = vi.fn();
 // lives in its own module precisely so this substitution works — a function
 // calling its neighbours through module-local references cannot have them
 // replaced, and the test would then drive the real permission service.
-vi.mock("./permissions", () => ({ isSuperAdmin }));
 vi.mock("../../auth/entity-read-access", () => ({ readableEntities }));
+// The control for the bypass case: the permission service, were it asked,
+// would call every session here a super admin. The module under test must not
+// ask it -- a bypass restated here would answer "no filter" before the shared
+// decision ran, and this stub is what makes that restatement observable.
+vi.mock("./permissions", () => ({
+  isSuperAdmin: vi.fn().mockResolvedValue(true),
+}));
 vi.mock("./registered-content-slugs", () => ({ registeredSlugsOfKind }));
 
 const { readableSlugAllowlist } = await import("./readable-slug-allowlist");
@@ -46,7 +53,6 @@ const apiKey: ReadAccessCaller = {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  isSuperAdmin.mockResolvedValue(false);
   registeredSlugsOfKind.mockResolvedValue({
     slugs: ["posts", "secrets", "notes"],
     reachable: true,
@@ -54,16 +60,30 @@ beforeEach(() => {
 });
 
 describe("which slugs a caller may read", () => {
-  it("answers UNDEFINED for a session super admin, which means no filter", async () => {
-    isSuperAdmin.mockResolvedValue(true);
-    expect(await readableSlugAllowlist(session, "collection")).toBeUndefined();
-    // Nothing else was asked: the bypass is the whole answer.
-    expect(readableEntities).not.toHaveBeenCalled();
-  });
-
   it("answers UNDEFINED for no caller at all", async () => {
     expect(await readableSlugAllowlist(undefined, "single")).toBeUndefined();
     expect(readableEntities).not.toHaveBeenCalled();
+  });
+
+  it("asks the shared decision about EVERY session caller, a super admin included", async () => {
+    // 🔴 No bypass is decided here. `canReadEntity` hands a session whole to
+    // `checkAccess`, which admits a super admin before it reads a rule or a
+    // grant, so a super admin is answered with every registered slug by the
+    // same machinery that answers everyone else -- and a second bypass in
+    // this module was a second super-admin path for the lists alone, one a
+    // change to the shared bypass would leave behind. Asserted as the LIST the
+    // decision returned rather than as "no filter": the two spellings reach
+    // the registry differently, and only this one came from the decision.
+    readableEntities.mockResolvedValue(new Set(["posts", "secrets", "notes"]));
+    expect(await readableSlugAllowlist(session, "collection")).toEqual([
+      "posts",
+      "secrets",
+      "notes",
+    ]);
+    expect(readableEntities).toHaveBeenCalledWith(
+      ["posts", "secrets", "notes"],
+      session
+    );
   });
 
   it("does NOT bypass for an API key, however privileged its owner", async () => {
@@ -71,7 +91,6 @@ describe("which slugs a caller may read", () => {
     // its own stamped scope, and a bypass here would make a read-only key
     // issued by an administrator equivalent to their whole account on the two
     // endpoints that list the most.
-    isSuperAdmin.mockResolvedValue(true);
     readableEntities.mockResolvedValue(new Set(["posts"]));
     expect(await readableSlugAllowlist(apiKey, "collection")).toEqual([
       "posts",

--- a/packages/nextly/src/services/lib/readable-slug-allowlist.ts
+++ b/packages/nextly/src/services/lib/readable-slug-allowlist.ts
@@ -7,6 +7,16 @@
  * into a WHERE clause so the row COUNT describes the same set as the rows —
  * which is the property that breaks when a caller filters the page instead.
  *
+ * 🔴 Derived from `readableEntities`, the same decision the dashboard scope
+ * and every version read take, and NOT from the stored `{slug}:read` grants.
+ * It used to be the grants alone, and that answered a different question
+ * from the rest of the read path in both directions: a Single authorised
+ * entirely by its code-defined `access.read` has no grant row to find, so the
+ * list dropped an entity the caller could open and the dashboard offered a
+ * card over an empty list; and a grant the code rule refuses was listed
+ * anyway. `api/dashboard.ts` made this move for the dashboard first, for the
+ * same reasons, and the list endpoints are the last readers that had not.
+ *
  * Its own module rather than a member of `permissions`, because that is what
  * makes it testable: a function calling its neighbours through module-local
  * references cannot have them substituted, so a test would exercise the real
@@ -14,7 +24,13 @@
  *
  * @module services/lib/readable-slug-allowlist
  */
-import { isSuperAdmin, listEffectivePermissions } from "./permissions";
+import {
+  readableEntities,
+  type ReadAccessCaller,
+} from "../../auth/entity-read-access";
+
+import { isSuperAdmin } from "./permissions";
+import { registeredSlugsOfKind } from "./registered-content-slugs";
 
 /**
  * `undefined` for no filter, `[]` for nothing visible, or the readable slugs.
@@ -22,27 +38,33 @@ import { isSuperAdmin, listEffectivePermissions } from "./permissions";
  * The three answers are distinct and collapsing any two is a defect:
  *
  * - `undefined` — no filter. An unauthenticated caller, gated at the route
- *   layer, and a super admin, who may see everything.
- * - `[]` — nothing is visible. A caller holding no read grant at all. Returned
- *   as an empty list rather than as `undefined`, because the registries read
- *   the difference: one means "every row", the other means "no rows".
- * - a non-empty list — exactly the resources this caller may read.
+ *   layer, and a SESSION super admin, who may see everything.
+ * - `[]` — nothing is visible. A caller the decision admits to nothing, and
+ *   also a registry that could not be enumerated: an access decision fails
+ *   closed, because admitting nothing is safe and admitting everything is not.
+ *   Returned as an empty list rather than as `undefined`, because the
+ *   registries read the difference: one means "every row", the other "no
+ *   rows".
+ * - a non-empty list — exactly the resources of `kind` this caller may read.
  *
- * Derived from the `{resource}:{action}` pairs the permission service already
- * publishes, so a change to how a grant is spelled reaches both endpoints.
+ * An API key takes the long way even when a super admin owns it. Its owner's
+ * standing is not the key's: `canReadEntity` judges a key on its own stamped
+ * scope, and a super-admin bypass applied here would make a read-only key
+ * issued by an administrator equivalent to their whole account on the two
+ * endpoints that list the most.
  */
 export async function readableSlugAllowlist(
-  userId: string | undefined
+  caller: ReadAccessCaller | undefined,
+  kind: "collection" | "single"
 ): Promise<string[] | undefined> {
-  if (!userId) return undefined;
-  if (await isSuperAdmin(userId)) return undefined;
+  if (!caller) return undefined;
+  if (caller.authMethod === "session" && (await isSuperAdmin(caller.userId))) {
+    return undefined;
+  }
 
-  const permissionPairs = await listEffectivePermissions(userId);
-  return Array.from(
-    new Set(
-      permissionPairs
-        .filter(pair => pair.endsWith(":read"))
-        .map(pair => pair.split(":")[0])
-    )
-  );
+  const registry = await registeredSlugsOfKind(kind);
+  if (!registry.reachable) return [];
+
+  const readable = await readableEntities(registry.slugs, caller);
+  return registry.slugs.filter(slug => readable.has(slug));
 }

--- a/packages/nextly/src/services/lib/readable-slug-allowlist.ts
+++ b/packages/nextly/src/services/lib/readable-slug-allowlist.ts
@@ -29,7 +29,6 @@ import {
   type ReadAccessCaller,
 } from "../../auth/entity-read-access";
 
-import { isSuperAdmin } from "./permissions";
 import { registeredSlugsOfKind } from "./registered-content-slugs";
 
 /**
@@ -38,7 +37,7 @@ import { registeredSlugsOfKind } from "./registered-content-slugs";
  * The three answers are distinct and collapsing any two is a defect:
  *
  * - `undefined` — no filter. An unauthenticated caller, gated at the route
- *   layer, and a SESSION super admin, who may see everything.
+ *   layer, and nobody else.
  * - `[]` — nothing is visible. A caller the decision admits to nothing, and
  *   also a registry that could not be enumerated: an access decision fails
  *   closed, because admitting nothing is safe and admitting everything is not.
@@ -47,20 +46,22 @@ import { registeredSlugsOfKind } from "./registered-content-slugs";
  *   rows".
  * - a non-empty list — exactly the resources of `kind` this caller may read.
  *
- * An API key takes the long way even when a super admin owns it. Its owner's
- * standing is not the key's: `canReadEntity` judges a key on its own stamped
- * scope, and a super-admin bypass applied here would make a read-only key
- * issued by an administrator equivalent to their whole account on the two
- * endpoints that list the most.
+ * A super admin is not a case here. The shared decision already composes the
+ * bypass -- `canReadEntity` delegates a session whole to `checkAccess`, which
+ * admits a super admin before it consults a rule or a grant -- so a session
+ * super admin is answered with every registered slug by the same machinery
+ * that answers everyone else. Deciding the bypass here as well was a second
+ * super-admin path for the list endpoints alone, one the dashboard scope and
+ * the version reads did not share, and a change to what the bypass means
+ * would have split the lists from them again. It also keeps a key honest: an
+ * API key is judged on its own stamped scope whoever owns it, and there is no
+ * shortcut here for a bypass to leak through.
  */
 export async function readableSlugAllowlist(
   caller: ReadAccessCaller | undefined,
   kind: "collection" | "single"
 ): Promise<string[] | undefined> {
   if (!caller) return undefined;
-  if (caller.authMethod === "session" && (await isSuperAdmin(caller.userId))) {
-    return undefined;
-  }
 
   const registry = await registeredSlugsOfKind(kind);
   if (!registry.reachable) return [];

--- a/packages/nextly/src/services/lib/registered-content-slugs.ts
+++ b/packages/nextly/src/services/lib/registered-content-slugs.ts
@@ -23,7 +23,7 @@
 import { container } from "../../di/container";
 
 /** A registry's slugs, and whether they are all of them. */
-interface RegistryRead {
+export interface RegistryRead {
   slugs: string[];
   reachable: boolean;
 }
@@ -81,6 +81,19 @@ function singleSlugs(): Promise<RegistryRead> {
   return registryRead<{
     getAllSingles: () => Promise<Array<{ slug: string }>>;
   }>("singleRegistryService", registry => registry.getAllSingles());
+}
+
+/**
+ * The slugs of ONE kind, with whether that registry answered.
+ *
+ * For a caller that lists a single kind and must fail closed only when the
+ * registry it lists from is the one that could not be reached: a collections
+ * outage is not a reason to hide every single.
+ */
+export function registeredSlugsOfKind(
+  kind: "collection" | "single"
+): Promise<RegistryRead> {
+  return kind === "single" ? singleSlugs() : collectionSlugs();
 }
 
 /**

--- a/packages/nextly/src/services/lib/registered-content-slugs.ts
+++ b/packages/nextly/src/services/lib/registered-content-slugs.ts
@@ -51,17 +51,18 @@ export interface RegistryRead {
  * for every caller rather than only the one asking about degradation. Ask `has`
  * for absence, then let anything after it count as failure.
  */
-async function registryRead<T>(
-  service: string,
-  enumerate: (registry: T) => Promise<Array<{ slug: string }>>
-): Promise<RegistryRead> {
+async function registryRead(service: string): Promise<RegistryRead> {
   // Absent: this install registers no content of that kind, and that is a whole
   // answer rather than a shortfall.
   if (!container.has(service)) return { slugs: [], reachable: true };
   try {
-    const registry = container.get<T>(service);
-    const entries = await enumerate(registry);
-    return { slugs: entries.map(entry => String(entry.slug)), reachable: true };
+    // The slug-only projection, not the records. Every caller here wants the
+    // names as candidates and nothing else, and the full read deserializes
+    // each record's fields JSON -- the whole registry materialized to learn
+    // what it is called.
+    const registry = container.get<SlugRegistry>(service);
+    const slugs = await registry.getAllSlugs();
+    return { slugs: slugs.map(slug => String(slug)), reachable: true };
   } catch {
     // Registered and unable to answer -- a construction failure inside the
     // factory included. Contribute nothing, and SAY that it is a floor.
@@ -69,18 +70,19 @@ async function registryRead<T>(
   }
 }
 
+/** The one method a registry needs for this: its names, and nothing else. */
+interface SlugRegistry {
+  getAllSlugs: () => Promise<string[]>;
+}
+
 /** The registered collection slugs, or none when the registry is unreachable. */
 function collectionSlugs(): Promise<RegistryRead> {
-  return registryRead<{
-    getAllCollections: () => Promise<Array<{ slug: string }>>;
-  }>("collectionRegistryService", registry => registry.getAllCollections());
+  return registryRead("collectionRegistryService");
 }
 
 /** The registered single slugs, or none when the registry is unreachable. */
 function singleSlugs(): Promise<RegistryRead> {
-  return registryRead<{
-    getAllSingles: () => Promise<Array<{ slug: string }>>;
-  }>("singleRegistryService", registry => registry.getAllSingles());
+  return registryRead("singleRegistryService");
 }
 
 /**

--- a/packages/nextly/src/shared/__tests__/base-registry-service.slugs.test.ts
+++ b/packages/nextly/src/shared/__tests__/base-registry-service.slugs.test.ts
@@ -1,0 +1,78 @@
+/**
+ * The registry's names, read without its records.
+ *
+ * Shared by both content registries and tested here for the same reason the
+ * schema-sync predicate is: a caller that wants the slugs as candidates reads
+ * every registry the same way, and the property is what the ADAPTER is asked
+ * for -- one column of every row -- rather than what comes back.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { NextlyError } from "../../errors/nextly-error";
+import {
+  BaseRegistryService,
+  type BaseRegistryRecord,
+} from "../base-registry-service";
+
+/** A concrete registry over a recording adapter. */
+class ProbeRegistry extends BaseRegistryService<BaseRegistryRecord> {
+  protected readonly registryTableName = "probe_registry";
+  protected readonly resourceType = "Probe";
+  protected readonly tableNamePrefix = "probe_";
+  protected getSearchColumns(): string[] {
+    return [];
+  }
+  protected deserializeRecord(record: BaseRegistryRecord): BaseRegistryRecord {
+    return record;
+  }
+}
+
+function registryOver(select: ReturnType<typeof vi.fn>): ProbeRegistry {
+  return new ProbeRegistry(
+    // The error path reads the dialect off the adapter's capabilities to name
+    // the driver failure; nothing else of the adapter is touched here.
+    { select, getCapabilities: () => ({ dialect: "sqlite" }) } as never,
+    { debug() {}, info() {}, warn() {}, error() {} } as never
+  );
+}
+
+describe("BaseRegistryService.getAllSlugs", () => {
+  it("asks the adapter for the slug column alone, over every row", async () => {
+    // 🔴 The projection is the property. A read of the whole record
+    // deserializes each row's fields JSON, so a caller that only wanted the
+    // names materialized the whole registry on every request -- and the
+    // returned list looks identical either way, which is why the assertion is
+    // on the query rather than on the answer alone.
+    const select = vi
+      .fn()
+      .mockResolvedValue([{ slug: "posts" }, { slug: "pages" }]);
+
+    expect(await registryOver(select).getAllSlugs()).toEqual([
+      "posts",
+      "pages",
+    ]);
+
+    expect(select).toHaveBeenCalledTimes(1);
+    const [table, options] = select.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(table).toBe("probe_registry");
+    expect(options.columns).toEqual(["slug"]);
+    // No page and no filter: the candidates are every row, or the allowlist
+    // built from them silently drops whatever a page boundary cut off.
+    expect(options.limit).toBeUndefined();
+    expect(options.where).toBeUndefined();
+  });
+
+  it("reports a driver failure as the registry failing, not as an empty registry", async () => {
+    // An empty answer from a failed read is the direction that widens an
+    // access decision built on it; the caller distinguishes a throw from a
+    // floor, so the throw has to reach it in the package's own error shape.
+    const select = vi.fn().mockRejectedValue(new Error("pool timeout"));
+
+    await expect(registryOver(select).getAllSlugs()).rejects.toSatisfy(
+      (error: unknown) => NextlyError.is(error)
+    );
+  });
+});

--- a/packages/nextly/src/shared/base-registry-service.ts
+++ b/packages/nextly/src/shared/base-registry-service.ts
@@ -268,6 +268,29 @@ export abstract class BaseRegistryService<
   }
 
   /**
+   * Every registered slug, as a slug-only projection.
+   *
+   * For a caller that needs the registry as a CANDIDATE LIST -- names to
+   * authorize one by one, a scope to bound a cross-entity read by -- and
+   * nothing else about the records. `getAllRecords` selects and deserializes
+   * every column, the fields JSON included, so a caller that wanted the names
+   * alone materialized the whole registry on every request, ahead of the
+   * paginated query it was scoping.
+   */
+  async getAllSlugs(): Promise<string[]> {
+    try {
+      const rows = await this.adapter.select<{ slug: string }>(
+        await this.resolveRegistryTableName(),
+        { columns: ["slug"] }
+      );
+      return rows.map(row => row.slug);
+    } catch (error) {
+      if (NextlyError.is(error)) throw error;
+      throw NextlyError.fromDatabaseError(toDbError(this.dialect, error));
+    }
+  }
+
+  /**
    * List records with pagination, search, and total count.
    */
   protected async listRecords(


### PR DESCRIPTION
Follow-up to #1756, from the Codex P2 that arrived after it merged — and the reviewer was right about the mechanism where my own filed finding was wrong.

## The divergence

The admin's singles card fetches `/admin/api/singles`, which goes through the dispatcher's `listSingles`, scoped by `readableSlugAllowlist` — the stored `{slug}:read` grants, **alone**. The `singles:present` condition that decides whether to offer the card goes through `canReadEntity`, which also consults the Single's code-defined `access.read`. So a reader admitted by a code rule and holding no grant row got the card offered and an empty list under it: the reserved grid slot #1756 had just removed, back as a heading over nothing. The collections listing had the same derivation and the same two failures — a code-only collection missing from the list a reader could open it from, and a grant the code rule refuses listed anyway.

`api/dashboard.ts` already replaced this exact slug filter with `canReadEntity` (#1384) and documents both failures in its own words. The two list endpoints were the last readers that had not made the move.

## The fix

`readableSlugAllowlist(caller, kind)` now takes the caller in the shape the shared decision reads and the kind being listed, and answers from `readableEntities` over that registry's slugs. Its documented three answers stand — `undefined` (no caller / session super admin), `[]` (nothing admitted), a list — with one addition: `[]` for a registry that could not be enumerated, because an access decision fails closed and the decision is not even asked.

The dispatcher-side caller builder that `versions-methods.ts` carried privately is now `read-access-caller.ts`, shared by the three handlers, so none can quietly ask a different question.

## One behaviour change beyond the divergence, named

**An API key owned by a super admin no longer lists every collection and Single.** The old allowlist checked `isSuperAdmin(userId)` on the key's *owner* and returned "no filter". `canReadEntity` states in its own docblock that a super admin does not bypass an API key's scope — a read-only key issued by an administrator must not be equivalent to their account — and every other read path already applied that. The two endpoints that list the most were the exception. This tightens them to the rule.

## Evidence

The integration test asks the **listing and the condition about the same reader** — no roles, no grants — on a real instance with real code rules:

| Single | code rule | condition | listing |
|---|---|---|---|
| `homepage` | admits | true | listed |
| `private` | refuses | — | not listed |

| break | test killed |
|---|---|
| grants-only derivation written back | `both admit a Single that a code rule alone admits` |
| decision skipped (registry slugs returned unfiltered) | `both refuse a Single that a code rule refuses` |

Unit tests cover the three answers, the API-key non-bypass (the decision is asked; `readableEntities` receives the key's own scope), fail-closed on an unreachable registry (the decision is not asked), and that the dispatcher hands the allowlist a `ReadAccessCaller` and the right kind rather than a bare id.

Gates on this exact tree (`main` @ `9f5252716`): `nextly` 11,912 unit; integration (sqlite) across `dispatcher`, `domains/singles`, `domains/widgets`, `domains/collections`, `api`, `auth`, `services` — 30+ files green; `check-types` incl. tests; `lint`; `check:comments`; `changeset status` 26.

This touches the access layer for two list endpoints. It follows the repo's own precedent, but it deserves the access-data review lens, and I'd rather it get a second pair of eyes than merge on my word alone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Collection and Single listings now consistently honor configured access rules, including code-defined permissions.
  * API-key access is evaluated using the key’s assigned permissions rather than the account owner’s privileges.
  * Unavailable content registries now fail closed, preventing inaccessible content from appearing.
  * Session super administrators continue to receive unrestricted access where applicable.
* **Tests**
  * Added coverage confirming listing results match access-condition evaluations for the same reader.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->