### PR TITLE
fix(root): one witness per exclusion rule, and every destination off the tree

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -9,7 +9,9 @@
     "AGENTS.measured.md",
     "ARCHITECTURE.md",
     "CLAUDE.md",
+    "CODE_OF_CONDUCT.md",
     "CONTRIBUTING.md",
+    "LICENSE.md",
     "SECURITY.md",
     "followup-report.md"
   ],

--- a/scripts/check-context7-index.mjs
+++ b/scripts/check-context7-index.mjs
@@ -112,13 +112,21 @@ function namedByDefaults(path) {
 }
 
 /**
- * Whether a file can witness a rule that excludes a set: it must be a file the index would
- * hold if the rule did not take. A root file is held whatever `folders` says, a hidden
- * path may be skipped unasked, and a file Context7's defaults name may be dropped by them,
- * so none of the three can show that the rule is what kept it out.
+ * How well a file witnesses a rule that excludes a set, lower first.
+ *
+ * The best witness is a file only the rule keeps out: absent, it shows the rule took. A
+ * hidden path may be skipped unasked and a file Context7's defaults name may be dropped by
+ * them, so such a file is asked only when the set holds nothing better; absent, it still
+ * shows the set is out one way or another, and retrievable, it still shows the rule did
+ * not take. A root file is held whatever `folders` says, so under that rule it can only be
+ * retrievable, and naming it in `excludeFiles` is the fix; it never witnesses that rule.
  */
-function canWitness(path) {
-  return !isRoot(path) && !isHidden(path) && !namedByDefaults(path);
+const PREFERRED = 0;
+const FALLBACK = 1;
+const NEVER = null;
+
+function witnessRank(path) {
+  return isHidden(path) || namedByDefaults(path) ? FALLBACK : PREFERRED;
 }
 
 /**
@@ -138,7 +146,10 @@ const EXCLUSION_RULES = [
     applies: (path, config) =>
       listField(config, "excludeFiles").includes(basename(path)),
     indexed: path => `${path} is in excludeFiles and was indexed anyway`,
-    set: path => (isHidden(path) ? null : `excludeFiles entry ${basename(path)}`),
+    set: path => `excludeFiles entry ${basename(path)}`,
+    // The entry names the file, so the root one is the witness and a file of
+    // the same name elsewhere stands in only when there is no root one.
+    rank: path => (isRoot(path) ? PREFERRED : witnessRank(path)),
   },
   {
     applies: (path, config) =>
@@ -146,9 +157,8 @@ const EXCLUSION_RULES = [
     indexed: path =>
       `${path} is under an excludeFolders entry and was indexed anyway`,
     set: (path, config) =>
-      canWitness(path)
-        ? `excludeFolders entry ${folderOf(path, listField(config, "excludeFolders"))}`
-        : null,
+      `excludeFolders entry ${folderOf(path, listField(config, "excludeFolders"))}`,
+    rank: witnessRank,
   },
   {
     applies: (path, config) =>
@@ -156,9 +166,8 @@ const EXCLUSION_RULES = [
     indexed: (path, config) =>
       `${path} is outside folders ${JSON.stringify(listField(config, "folders"))} and is not the README, and was indexed`,
     set: (path, config) =>
-      canWitness(path)
-        ? `folders ${JSON.stringify(listField(config, "folders"))}`
-        : null,
+      `folders ${JSON.stringify(listField(config, "folders"))}`,
+    rank: path => (isRoot(path) ? NEVER : witnessRank(path)),
   },
 ];
 
@@ -344,24 +353,29 @@ export function markerFor(corpus, name) {
  * One tracked file for each set the configuration excludes, with a sentence of its own.
  *
  * A rule takes for its whole set or for none of it, so one file answers for the set, where
- * the sample of citations can miss a small folder entirely. The files are taken in git's
- * order and the first with a sentence of its own is the witness; a set whose files all
- * share every sentence cannot be probed and says so rather than passing. A set with no
- * tracked file excludes nothing, and one with no file that could witness it (all root,
- * hidden, or named by Context7's defaults) offers no probe that could fail; neither is
- * probed.
+ * the sample of citations can miss a small folder entirely. The files are taken by rank,
+ * then in git's order, and the first with a sentence of its own is the witness; a set whose
+ * files all share every sentence cannot be probed and says so rather than passing. A set
+ * with no tracked file excludes nothing, and one whose files can never witness it (root
+ * files under the folders rule) is the citation rule's business; neither is probed.
  */
 export function witnesses(corpus, config) {
   const sets = new Map();
   for (const name of corpus.keys()) {
-    const set = excludingRule(name, config)?.set(name, config);
-    if (!set) continue;
+    const rule = excludingRule(name, config);
+    const rank = rule?.rank(name);
+    if (!rule || rank === NEVER) continue;
+    const set = rule.set(name, config);
     if (!sets.has(set)) sets.set(set, []);
-    sets.get(set).push(name);
+    sets.get(set).push({ name, rank });
   }
-  return [...sets].map(([set, names]) => ({
+  return [...sets].map(([set, files]) => ({
     set,
-    ...witnessOf(corpus, set, names),
+    ...witnessOf(
+      corpus,
+      set,
+      files.sort((a, b) => a.rank - b.rank).map(file => file.name)
+    ),
   }));
 }
 

--- a/scripts/check-context7-index.mjs
+++ b/scripts/check-context7-index.mjs
@@ -83,13 +83,14 @@ function isHidden(path) {
   return path.split("/").some(segment => segment.startsWith("."));
 }
 
-function isInside(path, folders) {
-  return folders.some(folder => path.startsWith(`${folder}/`));
-}
-
-/** The listed folder a path sits under. */
+/** The listed folder a path sits under, or none. */
 function folderOf(path, folders) {
   return folders.find(folder => path.startsWith(`${folder}/`));
+}
+
+/** Whether a path sits under one of the folders: the same lookup, read as a yes or no. */
+function isInside(path, folders) {
+  return folderOf(path, folders) !== undefined;
 }
 
 /**

--- a/scripts/check-context7-index.mjs
+++ b/scripts/check-context7-index.mjs
@@ -23,8 +23,8 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { readFileSync } from "node:fs";
+import { basename, join } from "node:path";
 
 export const LIBRARY = "/nextlyhq/nextly";
 /** Overridable so a test can point the script at a port nothing listens on. */
@@ -66,44 +66,110 @@ function listField(config, name) {
  * The one root file the configuration means to keep.
  *
  * Context7 reads every root Markdown file whatever `folders` says, and the configuration
- * names the rest to exclude them. A cited root file that is neither the README nor named
- * there, such as a CHANGELOG Context7's defaults are trusted to drop, is a file the index
- * holds that the configuration never agreed to.
+ * names the rest to exclude them; its own default exclusions apply only to a configuration
+ * that names none, so nothing is trusted to them. A cited root file that is neither the
+ * README nor named is a file the index holds that the configuration never agreed to.
  */
 function isKeptRoot(path) {
   return path === README;
+}
+
+function isRoot(path) {
+  return !path.includes("/");
+}
+
+/** Whether a path has a segment a crawler may skip unasked: `.changeset/`, `.github/`. */
+function isHidden(path) {
+  return path.split("/").some(segment => segment.startsWith("."));
 }
 
 function isInside(path, folders) {
   return folders.some(folder => path.startsWith(`${folder}/`));
 }
 
+/** The listed folder a path sits under. */
+function folderOf(path, folders) {
+  return folders.find(folder => path.startsWith(`${folder}/`));
+}
+
 /**
- * The rules a cited path is judged by, first applicable first. An exclusion wins over an
- * inclusion, which is the precedence Context7 documents for `excludeFolders` against
- * `folders`; then a file must sit under a listed folder or be the README.
+ * What Context7 excludes on its own when a configuration names nothing. Its documentation
+ * leaves open whether these also apply to a configuration that names exclusions, so a
+ * file they name cannot witness a rule: its absence could be theirs. Read broader than
+ * the documented patterns on purpose; a candidate skipped is only the next one chosen.
  */
-const CITATION_RULES = [
-  [
-    (path, config) => listField(config, "excludeFiles").includes(path),
-    path => `${path} is in excludeFiles and was indexed anyway`,
-  ],
-  [
-    (path, config) => isInside(path, listField(config, "excludeFolders")),
-    path => `${path} is under an excludeFolders entry and was indexed anyway`,
-  ],
-  [
-    (path, config) =>
+const DEFAULT_FILES = /^(?:changelog\.mdx?|license\.md|code_of_conduct\.md)$/i;
+const DEFAULT_FOLDERS =
+  /archive|deprecated|legacy|previous|outdated|superseded|^old$|^zh-|^i18n$/i;
+
+function namedByDefaults(path) {
+  const segments = path.split("/");
+  return (
+    DEFAULT_FILES.test(segments.at(-1)) ||
+    segments.slice(0, -1).some(segment => DEFAULT_FOLDERS.test(segment))
+  );
+}
+
+/**
+ * Whether a file can witness a rule that excludes a set: it must be a file the index would
+ * hold if the rule did not take. A root file is held whatever `folders` says, a hidden
+ * path may be skipped unasked, and a file Context7's defaults name may be dropped by them,
+ * so none of the three can show that the rule is what kept it out.
+ */
+function canWitness(path) {
+  return !isRoot(path) && !isHidden(path) && !namedByDefaults(path);
+}
+
+/**
+ * The rules a path is excluded by, first applicable first. An exclusion wins over an
+ * inclusion, which is the precedence Context7 documents for `excludeFolders` against
+ * `folders`; then a file must sit under a listed folder or be the README. An `excludeFiles`
+ * entry is a filename, not a path, and takes a file of that name anywhere in the tree.
+ *
+ * Each rule says what a cited path under it means, and names the set it excludes, so that
+ * one tracked file of the set can be probed to show the rule took. A rule that excludes
+ * files by name is witnessed by one of them, the root file first in git's order; a rule
+ * that excludes a folder or everything outside the listed ones, by a file it would
+ * otherwise hold.
+ */
+const EXCLUSION_RULES = [
+  {
+    applies: (path, config) =>
+      listField(config, "excludeFiles").includes(basename(path)),
+    indexed: path => `${path} is in excludeFiles and was indexed anyway`,
+    set: path => (isHidden(path) ? null : `excludeFiles entry ${basename(path)}`),
+  },
+  {
+    applies: (path, config) =>
+      isInside(path, listField(config, "excludeFolders")),
+    indexed: path =>
+      `${path} is under an excludeFolders entry and was indexed anyway`,
+    set: (path, config) =>
+      canWitness(path)
+        ? `excludeFolders entry ${folderOf(path, listField(config, "excludeFolders"))}`
+        : null,
+  },
+  {
+    applies: (path, config) =>
       !isInside(path, listField(config, "folders")) && !isKeptRoot(path),
-    (path, config) =>
+    indexed: (path, config) =>
       `${path} is outside folders ${JSON.stringify(listField(config, "folders"))} and is not the README, and was indexed`,
-  ],
+    set: (path, config) =>
+      canWitness(path)
+        ? `folders ${JSON.stringify(listField(config, "folders"))}`
+        : null,
+  },
 ];
+
+/** The first rule that excludes a path, or `null` when the configuration keeps it. */
+function excludingRule(path, config) {
+  return EXCLUSION_RULES.find(rule => rule.applies(path, config)) ?? null;
+}
 
 /** Why one cited path disagrees with the configuration, or `null`. */
 export function citationFinding(path, config) {
-  const rule = CITATION_RULES.find(([applies]) => applies(path, config));
-  return rule ? rule[1](path, config) : null;
+  const rule = excludingRule(path, config);
+  return rule ? rule.indexed(path, config) : null;
 }
 
 /**
@@ -134,16 +200,17 @@ function markerLines(text) {
 }
 
 /**
- * A sentence of a file that no documentation page contains.
+ * A sentence of a file that none of the other texts contains.
  *
  * The probe asks the index for the sentence and reads the answer, so a heading the docs
  * also use would find the docs: "Overview" and "packages" both do. Headings are tried
  * first, then any line of prose, which is what a one-line `CLAUDE.md` has. `null` means
  * the file offers nothing to ask for, and the caller must not read that as a pass.
  */
-export function probeMarker(text, corpus) {
+export function probeMarker(text, others) {
   const candidates = [...headings(text), ...markerLines(text)];
-  return candidates.find(candidate => !corpus.includes(candidate)) ?? null;
+  const shared = candidate => others.some(other => other.includes(candidate));
+  return candidates.find(candidate => !shared(candidate)) ?? null;
 }
 
 /** The Markdown and MDX files git tracks, which is the set Context7 can have read. */
@@ -160,19 +227,28 @@ function trackedText(root) {
 }
 
 /**
- * Everything the index may have read APART from one file, concatenated, for deciding
- * which of that file's sentences is its own.
+ * The text of every tracked Markdown file, by path, read once for a run.
  *
  * A probe returns whatever the index holds for a topic and cannot say which file it came
  * from, so a marker shared with any other file the index may hold would answer for the
- * wrong one: "Quickstart" heads the root README and two package READMEs. Tracked files
- * only, because an untracked note on one checkout is not something Context7 has read.
+ * wrong one: "Quickstart" heads the root README and two package READMEs. Every marker is
+ * therefore chosen against everything else here, and a run chooses one per kept control
+ * and per excluded set, so the tree is read once and each choice reads the same map.
+ * Tracked files only, because an untracked note on one checkout is not something Context7
+ * has read.
  */
-function corpusExcept(root, name) {
-  return trackedText(root)
-    .filter(rel => rel !== name)
-    .map(rel => readFileSync(join(root, rel), "utf-8"))
-    .join("\n");
+export function readCorpus(root) {
+  return new Map(
+    trackedText(root).map(name => [
+      name,
+      readFileSync(join(root, name), "utf-8"),
+    ])
+  );
+}
+
+/** Every text of the corpus but one file's: what a marker for that file must not share. */
+function othersOf(corpus, name) {
+  return [...corpus].filter(([other]) => other !== name).map(([, text]) => text);
 }
 
 /**
@@ -251,15 +327,52 @@ async function finalizedEntry(get, api) {
   return entry;
 }
 
-/** A marker for a file, or `Unanswerable` when the file offers nothing of its own to ask for. */
-export function markerFor(root, name) {
-  const marker = probeMarker(
-    readFileSync(join(root, name), "utf-8"),
-    corpusExcept(root, name)
-  );
+/** A marker for a tracked file, or `Unanswerable` when it offers nothing of its own to ask for. */
+export function markerFor(corpus, name) {
+  if (!corpus.has(name))
+    throw new Unanswerable(
+      `${name} is not tracked, so the index cannot have read it`
+    );
+  const marker = probeMarker(corpus.get(name), othersOf(corpus, name));
   if (marker === null)
     throw new Unanswerable(`${name} offers no sentence of its own to ask for`);
   return marker;
+}
+
+/**
+ * One tracked file for each set the configuration excludes, with a sentence of its own.
+ *
+ * A rule takes for its whole set or for none of it, so one file answers for the set, where
+ * the sample of citations can miss a small folder entirely. The files are taken in git's
+ * order and the first with a sentence of its own is the witness; a set whose files all
+ * share every sentence cannot be probed and says so rather than passing. A set with no
+ * tracked file excludes nothing, and one with no file that could witness it (all root,
+ * hidden, or named by Context7's defaults) offers no probe that could fail; neither is
+ * probed.
+ */
+export function witnesses(corpus, config) {
+  const sets = new Map();
+  for (const name of corpus.keys()) {
+    const set = excludingRule(name, config)?.set(name, config);
+    if (!set) continue;
+    if (!sets.has(set)) sets.set(set, []);
+    sets.get(set).push(name);
+  }
+  return [...sets].map(([set, names]) => ({
+    set,
+    ...witnessOf(corpus, set, names),
+  }));
+}
+
+/** The first of a set's files that offers a sentence of its own, with that sentence. */
+function witnessOf(corpus, set, names) {
+  for (const name of names) {
+    const marker = probeMarker(corpus.get(name), othersOf(corpus, name));
+    if (marker !== null) return { name, marker };
+  }
+  throw new Unanswerable(
+    `no file of ${set} offers a sentence of its own to ask for`
+  );
 }
 
 /**
@@ -270,10 +383,10 @@ export function markerFor(root, name) {
  * since the citation sample cannot. A control that fails is a finding, and the exclusions
  * are then not probed at all: their absences would prove nothing.
  */
-async function keptControls({ root, api, get }) {
+async function keptControls({ corpus, api, get }) {
   const kept = [DOCS_WITNESS, README].map(name => [
     name,
-    markerFor(root, name),
+    markerFor(corpus, name),
   ]);
   const findings = [];
   for (const [name, marker] of kept) {
@@ -289,31 +402,28 @@ async function keptControls({ root, api, get }) {
 }
 
 /**
- * Every excluded file, probed for a sentence of its own. Not a sample of them, and one
- * that offers nothing to ask for stops the run: a "not probed" would read as a pass to
- * whoever only sees the status.
+ * Every set the configuration excludes, probed through its witness for a sentence of its
+ * own. Not a sample of the sets: each rule gets its probe, and a witness that offers
+ * nothing to ask for stops the run, since a "not probed" would read as a pass to whoever
+ * only sees the status.
  */
-async function exclusionFindings({ root, api, get, config }) {
-  const present = listField(config, "excludeFiles").filter(name =>
-    existsSync(join(root, name))
-  );
+async function exclusionFindings({ corpus, api, get, config }) {
   const findings = [];
-  for (const name of present) {
-    const marker = markerFor(root, name);
+  for (const { set, name, marker } of witnesses(corpus, config)) {
     const answer = await retrievable(get, api, marker, name);
     if (!answer.found && !answer.cites.has(name)) continue;
     findings.push(
-      `${name} is retrievable ("${marker}" came back, or the file was cited); its exclusion did not take`
+      `${name} is retrievable ("${marker}" came back, or the file was cited); ${set} did not take`
     );
   }
   return findings;
 }
 
 /** The findings the index earns against the configuration, given a working library. */
-async function indexFindings({ root, api, get, config, cited }) {
+async function indexFindings({ corpus, api, get, config, cited }) {
   const findings = [
     ...citationFindings(cited, config),
-    ...(await keptControls({ root, api, get })),
+    ...(await keptControls({ corpus, api, get })),
   ];
   if (
     findings.some(finding => finding.includes("an absence would prove nothing"))
@@ -322,7 +432,7 @@ async function indexFindings({ root, api, get, config, cited }) {
   }
   return [
     ...findings,
-    ...(await exclusionFindings({ root, api, get, config })),
+    ...(await exclusionFindings({ corpus, api, get, config })),
   ];
 }
 
@@ -366,9 +476,10 @@ export async function verify({ root, api = API, get = fetchText }) {
       throw new Unanswerable(`${LIBRARY} answered ${dump.status}`);
     const cited = citedPaths(dump.body);
 
+    const corpus = readCorpus(root);
     return report(
       cited,
-      await indexFindings({ root, api, get, config, cited })
+      await indexFindings({ corpus, api, get, config, cited })
     );
   } catch (error) {
     if (error instanceof Unanswerable) {

--- a/scripts/check-context7-index.test.mjs
+++ b/scripts/check-context7-index.test.mjs
@@ -9,10 +9,15 @@ import {
   LIBRARY,
   markerFor,
   probeMarker,
+  readCorpus,
   REPO_BLOB,
   Unanswerable,
   verify,
+  witnesses,
 } from "./check-context7-index.mjs";
+
+/** The tracked Markdown, read once for every test that chooses a marker from it. */
+const corpus = readCorpus(".");
 
 /** A dump in the shape Context7 returns, measured on /upstash/context7. */
 const dump = (...paths) =>
@@ -70,8 +75,20 @@ describe("citationFindings", () => {
     ).toEqual(["AGENTS.md is in excludeFiles and was indexed anyway"]);
   });
 
+  it("reads an excludeFiles entry as a filename, wherever the file sits", () => {
+    // Context7 documents the entry as a name, not a path, so a package's
+    // AGENTS.md is excluded by the same entry as the root one.
+    expect(
+      citationFindings(new Set(["packages/nextly/AGENTS.md"]), config)
+    ).toEqual([
+      "packages/nextly/AGENTS.md is in excludeFiles and was indexed anyway",
+    ]);
+  });
+
   it("reports a root file that is neither the README nor excluded", () => {
-    // A CHANGELOG Context7's defaults are trusted to drop, cited anyway.
+    // A root file the configuration never named, cited anyway. Context7's
+    // default exclusions do not cover it: they apply only to a configuration
+    // that names no exclusions of its own.
     expect(citationFindings(new Set(["CHANGELOG.md"]), config)).toEqual([
       'CHANGELOG.md is outside folders ["docs"] and is not the README, and was indexed',
     ]);
@@ -103,20 +120,20 @@ describe("the committed configuration", () => {
     })
       .split("\n")
       .filter(name => name.endsWith(".md") && !name.includes("/"));
-    // Excluded by Context7's defaults, per its documentation.
-    const defaults = new Set([
-      "CHANGELOG.md",
-      "LICENSE.md",
-      "CODE_OF_CONDUCT.md",
-    ]);
+    // Nothing is left to Context7's default exclusions: per its documentation
+    // they apply only to a configuration that names no exclusions of its own,
+    // and this one does, so a LICENSE or CODE_OF_CONDUCT is indexed unless
+    // named here.
     const forReaders = new Set(["README.md"]);
     const unaccounted = rootMarkdown.filter(
-      name =>
-        !config.excludeFiles.includes(name) &&
-        !defaults.has(name) &&
-        !forReaders.has(name)
+      name => !config.excludeFiles.includes(name) && !forReaders.has(name)
     );
     expect(unaccounted).toEqual([]);
+  });
+
+  it("names its exclusions as filenames, which is what Context7 matches", () => {
+    const config = JSON.parse(readFileSync("context7.json", "utf-8"));
+    expect(config.excludeFiles.filter(name => name.includes("/"))).toEqual([]);
   });
 
   it("keeps the README, which is the one root file meant to be indexed", () => {
@@ -137,15 +154,15 @@ describe("probeMarker", () => {
     expect(headings(file)).toEqual(["Title", "Overview", "Repository map"]);
     // "Overview" is a heading a docs page also uses, so probing for it would
     // find the docs and report the exclusion as broken.
-    expect(probeMarker(file, "## Overview\n\n## Title of a page")).toBe(
+    expect(probeMarker(file, ["## Overview\n", "## Title of a page"])).toBe(
       "Repository map"
     );
   });
 
   it("falls back to a line of prose, and reports nothing when every line is shared", () => {
-    expect(probeMarker("@AGENTS.md\n", "")).toBe("@AGENTS.md");
-    expect(probeMarker("## Setup\n", "## Setup")).toBeNull();
-    expect(probeMarker("<p>markup</p>\n- a list\n", "")).toBeNull();
+    expect(probeMarker("@AGENTS.md\n", [])).toBe("@AGENTS.md");
+    expect(probeMarker("## Setup\n", ["## Setup"])).toBeNull();
+    expect(probeMarker("<p>markup</p>\n- a list\n", [])).toBeNull();
   });
 
   it("finds a marker of its own in every committed excluded file", () => {
@@ -153,15 +170,19 @@ describe("probeMarker", () => {
     // sentence no other file the index may hold could answer for. CLAUDE.md
     // is one line, `@AGENTS.md`, and even that is its own.
     const config = JSON.parse(readFileSync("context7.json", "utf-8"));
-    for (const name of config.excludeFiles.filter(name => existsSync(name))) {
-      expect(markerFor(".", name), name).toEqual(expect.any(String));
+    for (const name of config.excludeFiles.filter(name => corpus.has(name))) {
+      expect(markerFor(corpus, name), name).toEqual(expect.any(String));
     }
+  });
+
+  it("refuses a file git does not track, which the index cannot have read", () => {
+    expect(() => markerFor(corpus, "NOTES.md")).toThrow(Unanswerable);
   });
 
   it("chooses a README sentence no package README shares", () => {
     // "Quickstart" heads the root README and two package READMEs; a probe for
     // it could be answered from either, which is a control that never looked.
-    const marker = markerFor(".", "README.md");
+    const marker = markerFor(corpus, "README.md");
     for (const other of [
       "packages/nextly/README.md",
       "packages/create-nextly-app/README.md",
@@ -234,15 +255,117 @@ function context7({
 function realMarkers() {
   const config = JSON.parse(readFileSync("context7.json", "utf-8"));
   return {
-    docs: markerFor(".", "docs/getting-started/index.mdx"),
-    readme: markerFor(".", "README.md"),
+    docs: markerFor(corpus, "docs/getting-started/index.mdx"),
+    readme: markerFor(corpus, "README.md"),
     excluded: Object.fromEntries(
       config.excludeFiles
-        .filter(name => existsSync(name))
-        .map(name => [name, markerFor(".", name)])
+        .filter(name => corpus.has(name))
+        .map(name => [name, markerFor(corpus, name)])
     ),
+    witnesses: witnesses(corpus, config),
   };
 }
+
+describe("witnesses", () => {
+  const files = new Map([
+    ["README.md", "# Nextly\n\nThe README, kept.\n"],
+    ["CHANGELOG.md", "# Changelog\n\nA root file nothing names.\n"],
+    [".changeset/note.md", "A hidden note outside the docs.\n"],
+    ["AGENTS.md", "# Agents\n\nThe root agent file.\n"],
+    ["packages/nextly/AGENTS.md", "# Agents\n\nThe package agent file.\n"],
+    ["docs/index.mdx", "# Overview\n\nA docs page, kept.\n"],
+    ["docs/internal/shared.mdx", "# Overview\n"],
+    ["docs/internal/secret.mdx", "# Overview\n\nA sentence of the internal page.\n"],
+    ["docs/private/notes.mdx", "# Overview\n\nThe private page.\n"],
+    ["docs/archive/old.mdx", "# Overview\n\nThe archived page.\n"],
+    ["apps/playground/CHANGELOG.md", "# playground\n\nThe app's changelog.\n"],
+    ["packages/legacy/README.md", "# legacy\n\nA README under a folder Context7 drops on its own.\n"],
+    ["packages/nextly/README.md", "# Nextly\n\nThe package README, outside the docs.\n"],
+  ]);
+  const config = {
+    folders: ["docs"],
+    excludeFolders: ["docs/internal", "docs/private", "docs/archive", "docs/absent"],
+    excludeFiles: ["AGENTS.md"],
+  };
+
+  it("chooses one file per excluded set, the first in git's order with a sentence of its own", () => {
+    expect(witnesses(files, config)).toEqual([
+      // The root file witnesses the name, before the package's copy.
+      {
+        set: "excludeFiles entry AGENTS.md",
+        name: "AGENTS.md",
+        marker: "The root agent file.",
+      },
+      // `shared.mdx` has nothing of its own, so the next file of the folder witnesses it.
+      {
+        set: "excludeFolders entry docs/internal",
+        name: "docs/internal/secret.mdx",
+        marker: "A sentence of the internal page.",
+      },
+      {
+        set: "excludeFolders entry docs/private",
+        name: "docs/private/notes.mdx",
+        marker: "The private page.",
+      },
+      {
+        set: 'folders ["docs"]',
+        name: "packages/nextly/README.md",
+        marker: "The package README, outside the docs.",
+      },
+    ]);
+  });
+
+  it("never lets a root file, a hidden path or a default-excluded file witness the folders rule", () => {
+    // Context7 holds root Markdown whatever `folders` says, may skip a hidden
+    // path unasked, and may drop a CHANGELOG or a `legacy` folder on its own:
+    // none of those absences could show the rule took. All four sort before
+    // the package README, so the order alone would pick one of them.
+    const names = witnesses(files, config).map(witness => witness.name);
+    for (const name of [
+      "CHANGELOG.md",
+      ".changeset/note.md",
+      "apps/playground/CHANGELOG.md",
+      "packages/legacy/README.md",
+    ]) {
+      expect(names).not.toContain(name);
+    }
+  });
+
+  it("probes nothing for an excluded folder that holds no tracked file, or none that could witness", () => {
+    // `docs/absent` excludes nothing. `docs/archive` is a folder Context7 drops
+    // on its own, so its file's absence could be the defaults' doing and no
+    // probe of it could show the entry took.
+    const sets = witnesses(files, config).map(witness => witness.set);
+    expect(sets).not.toContain("excludeFolders entry docs/absent");
+    expect(sets).not.toContain("excludeFolders entry docs/archive");
+  });
+
+  it("stops rather than passes when a set offers nothing to ask for", () => {
+    const shared = new Map([
+      ["docs/index.mdx", "# Overview\n"],
+      ["docs/internal/a.mdx", "# Overview\n"],
+    ]);
+    expect(() =>
+      witnesses(shared, { folders: ["docs"], excludeFolders: ["docs/internal"] })
+    ).toThrow(Unanswerable);
+  });
+
+  it("finds a witness for every set the committed configuration excludes", () => {
+    // Every excludeFiles entry is witnessed by its root file, and the folders
+    // rule by a file the index would hold without it: not a changeset under
+    // `.changeset/`, and not the playground's CHANGELOG, which sorts first.
+    const config = JSON.parse(readFileSync("context7.json", "utf-8"));
+    const found = witnesses(corpus, config);
+    for (const name of config.excludeFiles) {
+      expect(found).toContainEqual(
+        expect.objectContaining({ set: `excludeFiles entry ${name}`, name })
+      );
+    }
+    const folders = found.find(witness => witness.set === 'folders ["docs"]');
+    expect(folders.name).toContain("/");
+    expect(folders.name).not.toMatch(/^\.|changelog/i);
+  });
+});
 
 describe("verify", () => {
   const markers = realMarkers();
@@ -280,7 +403,26 @@ describe("verify", () => {
       get: context7({ topics: { ...kept, [marker]: name } }),
     });
     expect(status).toBe(1);
-    expect(lines.join("\n")).toContain(`${name} is retrievable`);
+    expect(lines.join("\n")).toContain(
+      `${name} is retrievable ("${marker}" came back, or the file was cited); excludeFiles entry ${name} did not take`
+    );
+  });
+
+  it("fails when a file outside the listed folders is retrievable", async () => {
+    // The folders rule, witnessed by one file it keeps out. The citation
+    // sample cannot see this: a file it happens not to cite is not a file
+    // the index does not hold.
+    const { name, marker } = markers.witnesses.find(
+      witness => witness.set === 'folders ["docs"]'
+    );
+    const { status, lines } = await verify({
+      root: ".",
+      get: context7({ topics: { ...kept, [marker]: name } }),
+    });
+    expect(status).toBe(1);
+    expect(lines.join("\n")).toContain(
+      `${name} is retrievable ("${marker}" came back, or the file was cited); folders ["docs"] did not take`
+    );
   });
 
   it("fails when the README, which the configuration keeps, cannot be retrieved", async () => {

--- a/scripts/check-context7-index.test.mjs
+++ b/scripts/check-context7-index.test.mjs
@@ -298,12 +298,21 @@ describe("witnesses", () => {
   };
 
   it("chooses one file per excluded set, the first in git's order with a sentence of its own", () => {
-    expect(witnesses(files, config)).toEqual([
+    const bySet = (a, b) => a.set.localeCompare(b.set);
+    expect(witnesses(files, config).sort(bySet)).toEqual([
       // The root file witnesses the name, before the package's copy.
       {
         set: "excludeFiles entry AGENTS.md",
         name: "AGENTS.md",
         marker: "The root agent file.",
+      },
+      // `docs/archive` holds only a file Context7's defaults may drop, so that
+      // file stands in: absent, the folder is out one way or another; present,
+      // the entry did not take.
+      {
+        set: "excludeFolders entry docs/archive",
+        name: "docs/archive/old.mdx",
+        marker: "The archived page.",
       },
       // `shared.mdx` has nothing of its own, so the next file of the folder witnesses it.
       {
@@ -321,17 +330,16 @@ describe("witnesses", () => {
         name: "packages/nextly/README.md",
         marker: "The package README, outside the docs.",
       },
-    ]);
+    ].sort(bySet));
   });
 
-  it("never lets a root file, a hidden path or a default-excluded file witness the folders rule", () => {
-    // Context7 holds root Markdown whatever `folders` says, may skip a hidden
-    // path unasked, and may drop a CHANGELOG or a `legacy` folder on its own:
-    // none of those absences could show the rule took. All four sort before
-    // the package README, so the order alone would pick one of them.
+  it("prefers a file only the rule keeps out over one a crawler might drop anyway", () => {
+    // Context7 may skip a hidden path unasked and may drop a CHANGELOG or a
+    // `legacy` folder on its own, so such a file's absence could be their
+    // doing. All three sort before the package README, so the order alone
+    // would pick one of them; the rank does not.
     const names = witnesses(files, config).map(witness => witness.name);
     for (const name of [
-      "CHANGELOG.md",
       ".changeset/note.md",
       "apps/playground/CHANGELOG.md",
       "packages/legacy/README.md",
@@ -340,13 +348,25 @@ describe("witnesses", () => {
     }
   });
 
-  it("probes nothing for an excluded folder that holds no tracked file, or none that could witness", () => {
-    // `docs/absent` excludes nothing. `docs/archive` is a folder Context7 drops
-    // on its own, so its file's absence could be the defaults' doing and no
-    // probe of it could show the entry took.
-    const sets = witnesses(files, config).map(witness => witness.set);
-    expect(sets).not.toContain("excludeFolders entry docs/absent");
-    expect(sets).not.toContain("excludeFolders entry docs/archive");
+  it("never lets a root file witness the folders rule, and probes nothing when only root files are outside", () => {
+    // Context7 holds root Markdown whatever `folders` says, so such a file can
+    // only ever be retrievable, and naming it in excludeFiles is the fix. It
+    // sorts first, so the order alone would pick it.
+    expect(witnesses(files, config).map(witness => witness.name)).not.toContain(
+      "CHANGELOG.md"
+    );
+    const onlyRoot = new Map([
+      ["README.md", "# Nextly\n\nThe README, kept.\n"],
+      ["CHANGELOG.md", "# Changelog\n\nA root file nothing names.\n"],
+      ["docs/index.mdx", "# Overview\n\nA docs page, kept.\n"],
+    ]);
+    expect(witnesses(onlyRoot, { folders: ["docs"] })).toEqual([]);
+  });
+
+  it("probes nothing for an excluded folder that holds no tracked file", () => {
+    expect(
+      witnesses(files, config).map(witness => witness.set)
+    ).not.toContain("excludeFolders entry docs/absent");
   });
 
   it("stops rather than passes when a set offers nothing to ask for", () => {

--- a/scripts/check-context7-index.test.mjs
+++ b/scripts/check-context7-index.test.mjs
@@ -58,12 +58,18 @@ describe("citationFindings", () => {
   });
 
   it("reports a file under an excluded folder even when a listed folder holds it", () => {
+    // A folder is a path segment: the sibling `docs/internal-notes` shares
+    // the prefix and is not under the entry.
+    const config = {
+      folders: ["docs"],
+      excludeFolders: ["docs/internal"],
+      excludeFiles: [],
+    };
     expect(
-      citationFindings(new Set(["docs/internal/secret.mdx"]), {
-        folders: ["docs"],
-        excludeFolders: ["docs/internal"],
-        excludeFiles: [],
-      })
+      citationFindings(
+        new Set(["docs/internal/secret.mdx", "docs/internal-notes/note.mdx"]),
+        config
+      )
     ).toEqual([
       "docs/internal/secret.mdx is under an excludeFolders entry and was indexed anyway",
     ]);
@@ -274,6 +280,9 @@ describe("witnesses", () => {
     ["AGENTS.md", "# Agents\n\nThe root agent file.\n"],
     ["packages/nextly/AGENTS.md", "# Agents\n\nThe package agent file.\n"],
     ["docs/index.mdx", "# Overview\n\nA docs page, kept.\n"],
+    // A sibling that shares the entry's prefix and sorts before it in git's
+    // order: a prefix read without its slash would make it the witness.
+    ["docs/internal-notes/note.mdx", "# Overview\n\nA page of the sibling folder, kept.\n"],
     ["docs/internal/shared.mdx", "# Overview\n"],
     ["docs/internal/secret.mdx", "# Overview\n\nA sentence of the internal page.\n"],
     ["docs/private/notes.mdx", "# Overview\n\nThe private page.\n"],

--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -130,7 +130,18 @@ const context7Finding = (check, message) => ({
  * no description leaves nothing to follow; and a description that merely differs from the
  * core package's is the drift that lets the others happen unnoticed. `undefined` is the
  * untracked file, `null` the unreadable one.
+ *
+ * Last, the exclusions are held to the shapes their readers understand. Context7 matches
+ * `excludeFiles` by filename, so an entry with a path in it excludes nothing; and the
+ * index verifier, `check-context7-index`, reads `excludeFolders` as plain paths, so a
+ * glob there is a rule it could never witness.
  */
+const listOf = value =>
+  Array.isArray(value) ? value.filter(entry => typeof entry === "string") : [];
+const pathEntries = value => listOf(value).filter(entry => entry.includes("/"));
+const patternEntries = value =>
+  listOf(value).filter(entry => /[*?[]|^\.\/|\/$/.test(entry));
+
 const CONTEXT7_RULES = [
   [
     config => config === undefined,
@@ -176,11 +187,27 @@ const CONTEXT7_RULES = [
         `description differs from packages/${CORE_PACKAGE}/package.json; one sentence says what this is`
       ),
   ],
+  [
+    config => pathEntries(config.excludeFiles).length > 0,
+    config =>
+      context7Finding(
+        "context7-exclusion",
+        `excludeFiles names ${pathEntries(config.excludeFiles).join(", ")} with a path; Context7 matches the field by filename, so an entry with a slash excludes nothing`
+      ),
+  ],
+  [
+    config => patternEntries(config.excludeFolders).length > 0,
+    config =>
+      context7Finding(
+        "context7-exclusion",
+        `excludeFolders names ${patternEntries(config.excludeFolders).join(", ")} as a pattern; check-context7-index reads plain paths, docs/archive, and cannot witness a pattern`
+      ),
+  ],
 ];
 
 export function context7Findings(config, coreDescription) {
   const rule = CONTEXT7_RULES.find(([applies]) => applies(config, coreDescription));
-  return rule ? rule[1]() : null;
+  return rule ? rule[1](config) : null;
 }
 
 /**
@@ -503,23 +530,11 @@ const REPO_LINK = /github\.com\/nextlyhq\/nextly\/(?:blob|tree|raw)\/([^\s)\]"'`
 
 const HEX_REF = /^[0-9a-f]{7,40}$/i;
 
-/**
- * Every link destination a file holds, read off its syntax tree.
- *
- * Read off the tree rather than matched in the text, because the text has no end of
- * spellings: `[x](../y.mdx "title")`, `[x](<../y.mdx>)`, a bare `[x](y.mdx)`, and a
- * reference definition `[x]: ../y.mdx` are four the patterns this replaced had learned one
- * at a time, and a fenced sample, an inline code span and an MDX comment were three places
- * the same patterns had to be taught not to look. A `link` node is a rendered link and a
- * `code` node is not, by construction.
- *
- * Frontmatter is taken off first, the way the site's loader takes it off, or the compiler
- * would read the YAML as Markdown. A page the compiler cannot parse yields no links; the
- * compile check reports that page on its own.
- */
-/** Whether a syntax-tree node carries a link destination. */
+/** The syntax-tree nodes that carry a destination: a link, an image, a reference definition. */
+const DESTINATION_NODES = new Set(["link", "image", "definition"]);
+
 function hasDestination(node) {
-  return node.type === "link" || node.type === "definition";
+  return DESTINATION_NODES.has(node.type);
 }
 
 /** Every node under one, itself included, in document order. */
@@ -527,26 +542,68 @@ function nodesOf(node) {
   return [node, ...(node.children ?? []).flatMap(nodesOf)];
 }
 
+/**
+ * Every destination a file holds, read off its syntax tree, with the node that holds it.
+ *
+ * Read off the tree rather than matched in the text, because the text has no end of
+ * spellings: `[x](../y.mdx "title")`, `[x](<../y.mdx>)`, a bare `[x](y.mdx)`, and a
+ * reference definition `[x]: ../y.mdx` are four the patterns this replaced had learned one
+ * at a time, and a fenced sample, an inline code span and an MDX comment were three places
+ * the same patterns had to be taught not to look. A `link` node is a rendered link and a
+ * `code` node is not, by construction. An `image` is a destination too: the patterns saw
+ * `![d](./x.png)` only because it shares `](` with a link, and the tree names it outright.
+ *
+ * Frontmatter is taken off first, the way the site's loader takes it off, or the compiler
+ * would read the YAML as Markdown. A page the compiler cannot parse, or whose frontmatter
+ * is not YAML, yields no destinations; the compile check reports that page on its own.
+ */
 async function linkDestinations(text, mdx) {
   const links = [];
-  const { body, skipped } = splitFrontmatter(text);
-  const collect = () => tree => {
+  const collect = skipped => () => tree => {
     for (const node of nodesOf(tree).filter(hasDestination)) {
-      links.push({ url: node.url, line: (node.position?.start.line ?? 0) + skipped });
+      links.push({
+        url: node.url,
+        type: node.type,
+        line: (node.position?.start.line ?? 0) + skipped,
+      });
     }
   };
   try {
-    await compile(body, { format: mdx ? "mdx" : "md", remarkPlugins: [collect] });
+    const { body, skipped } = splitFrontmatter(text);
+    await compile(body, { format: mdx ? "mdx" : "md", remarkPlugins: [collect(skipped)] });
   } catch {
     return [];
   }
   return links;
 }
 
+/**
+ * How a finding names a destination, by the node that carries it: what the page does with
+ * it, and what the site needs instead. A page is linked by its URL and source by its
+ * GitHub URL; an image has nothing served beside the page, so any relative one is a path.
+ */
+const DESTINATION_WORDING = {
+  link: {
+    verb: "links to",
+    remedy: "a page is linked by its URL, /docs/..., and source by its GitHub URL",
+    relativeIsPath: url => /^\.\.?\//.test(url) || /\.mdx?(?:[#?]|$)/i.test(url),
+  },
+  image: {
+    verb: "embeds",
+    remedy: "the site serves no file beside a page, so an image is embedded by its URL",
+    relativeIsPath: () => true,
+  },
+};
+
+/** The wording for a destination's node; a definition reads as the link it defines. */
+function wordingFor(type) {
+  return DESTINATION_WORDING[type] ?? DESTINATION_WORDING.link;
+}
+
 /** A destination written as a path from the file rather than as a URL. */
-function isFilePath(url) {
+function isFilePath(url, type) {
   if (/^(?:[a-z][a-z0-9+.-]*:|\/|#)/i.test(url)) return false;
-  return /^\.\.?\//.test(url) || /\.mdx?(?:[#?]|$)/i.test(url);
+  return wordingFor(type).relativeIsPath(url);
 }
 
 /**
@@ -962,22 +1019,23 @@ async function internalLinks(repoRoot, tracked, findings) {
     } catch {
       continue;
     }
-    for (const { url, line } of await linkDestinations(text, rel.endsWith(".mdx"))) {
+    for (const { url, type, line } of await linkDestinations(text, rel.endsWith(".mdx"))) {
+      const { verb, remedy } = wordingFor(type);
       if (url.startsWith("/docs/") && !resolves(url)) {
         findings.push({
           check: "internal-docs-link",
           file: rel,
           line,
-          message: `links to ${url}, which is not a docs page`,
+          message: `${verb} ${url}, which is not a docs page`,
         });
       }
       // Only a published page: a README linking `./CONTRIBUTING.md` is a link GitHub renders.
-      if (pages.has(rel) && isFilePath(url)) {
+      if (pages.has(rel) && isFilePath(url, type)) {
         findings.push({
           check: "internal-docs-link",
           file: rel,
           line,
-          message: `links to ${url} as a file path; a page is linked by its URL, /docs/..., and source by its GitHub URL`,
+          message: `${verb} ${url} as a file path; ${remedy}`,
         });
       }
     }

--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -697,6 +697,17 @@ function wordingFor(type) {
   return DESTINATION_WORDING[type] ?? DESTINATION_WORDING.link;
 }
 
+/**
+ * The documentation route: its root, or anything under it.
+ *
+ * The boundary matters because the two wordings disagree about the root. A
+ * LINK to `/docs` is right, and `resolves` says so. An IMAGE there is wrong
+ * whatever answers, and a prefix test for `/docs/` never asked about the root
+ * at all, so `<img src="/docs">` was accepted by a rule that refuses
+ * `/docs/anything`. `/docsomething` is a different route and is not this one.
+ */
+const isDocsRoute = url => /^\/docs(?:[/#?]|$)/.test(url);
+
 /** A destination written as a path from the file rather than as a URL. */
 function isFilePath(url, type) {
   if (/^(?:[a-z][a-z0-9+.-]*:|\/|#)/i.test(url)) return false;
@@ -1101,7 +1112,9 @@ async function internalLinks(repoRoot, tracked, findings) {
   // package's README.mdx has GitHub as its surface and its own link rules.
   const pages = new Set(tracked.filter(rel => rel.startsWith("docs/") && rel.endsWith(".mdx")));
   const resolves = target => {
-    const path = target.split("#")[0].replace(/\/+$/, "");
+    // The query goes with the fragment: neither names a page, and the route
+    // root reached with either is still the route root.
+    const path = target.split(/[#?]/)[0].replace(/\/+$/, "");
     if (path === "/docs") return true;
     const rel = `docs${path.slice("/docs".length)}`;
     return pages.has(`${rel}.mdx`) || pages.has(`${rel}/index.mdx`);
@@ -1118,7 +1131,7 @@ async function internalLinks(repoRoot, tracked, findings) {
     }
     for (const { url, type, line } of await linkDestinations(text, rel.endsWith(".mdx"))) {
       const { verb, remedy, docsUrlFinding } = wordingFor(type);
-      const docsUrl = url.startsWith("/docs/") ? docsUrlFinding(resolves(url)) : null;
+      const docsUrl = isDocsRoute(url) ? docsUrlFinding(resolves(url)) : null;
       if (docsUrl) {
         findings.push({
           check: "internal-docs-link",

--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -138,9 +138,11 @@ const context7Finding = (check, message) => ({
  */
 const listOf = value =>
   Array.isArray(value) ? value.filter(entry => typeof entry === "string") : [];
-const pathEntries = value => listOf(value).filter(entry => entry.includes("/"));
+// Either separator: Context7 sees a filename, git supplies POSIX paths, and a
+// backslash satisfies neither.
+const pathEntries = value => listOf(value).filter(entry => /[\\/]/.test(entry));
 const patternEntries = value =>
-  listOf(value).filter(entry => /[*?[]|^\.\/|\/$/.test(entry));
+  listOf(value).filter(entry => /[*?[\\]|^\.\/|\/$/.test(entry));
 
 const CONTEXT7_RULES = [
   [
@@ -537,6 +539,26 @@ function hasDestination(node) {
   return DESTINATION_NODES.has(node.type);
 }
 
+/**
+ * What a destination is, for the wording and the rule it is held to.
+ *
+ * A definition carries no kind of its own: `[pic]: diagram.png` is an image when
+ * `![d][pic]` uses it and a link when `[d][pic]` does. Read as an image whenever an
+ * image reference uses it, since that is the reading under which a relative
+ * destination is broken.
+ */
+function destinationKind(node, imageIds) {
+  if (node.type === "definition" && imageIds.has(node.identifier)) return "image";
+  return node.type;
+}
+
+/** The identifiers every image reference in a tree uses. */
+function imageReferenceIds(nodes) {
+  return new Set(
+    nodes.filter(node => node.type === "imageReference").map(node => node.identifier)
+  );
+}
+
 /** Every node under one, itself included, in document order. */
 function nodesOf(node) {
   return [node, ...(node.children ?? []).flatMap(nodesOf)];
@@ -554,27 +576,41 @@ function nodesOf(node) {
  * `![d](./x.png)` only because it shares `](` with a link, and the tree names it outright.
  *
  * Frontmatter is taken off first, the way the site's loader takes it off, or the compiler
- * would read the YAML as Markdown. A page the compiler cannot parse, or whose frontmatter
- * is not YAML, yields no destinations; the compile check reports that page on its own.
+ * would read the YAML as Markdown. A block that is not YAML is left in and read as
+ * Markdown instead, a rule and a paragraph, so the links after it are still read: the
+ * compile check reports a docs page's frontmatter, but a README is not a docs page and
+ * this is the only check that reads its links. A page the compiler cannot parse yields no
+ * destinations; the compile check reports that one.
  */
 async function linkDestinations(text, mdx) {
   const links = [];
   const collect = skipped => () => tree => {
-    for (const node of nodesOf(tree).filter(hasDestination)) {
+    const nodes = nodesOf(tree);
+    const imageIds = imageReferenceIds(nodes);
+    for (const node of nodes.filter(hasDestination)) {
       links.push({
         url: node.url,
-        type: node.type,
+        type: destinationKind(node, imageIds),
         line: (node.position?.start.line ?? 0) + skipped,
       });
     }
   };
+  const { body, skipped } = frontmatterOrMarkdown(text);
   try {
-    const { body, skipped } = splitFrontmatter(text);
     await compile(body, { format: mdx ? "mdx" : "md", remarkPlugins: [collect(skipped)] });
   } catch {
     return [];
   }
   return links;
+}
+
+/** The text with its frontmatter taken off, or the whole text when the block is not YAML. */
+function frontmatterOrMarkdown(text) {
+  try {
+    return splitFrontmatter(text);
+  } catch {
+    return { body: text, skipped: 0 };
+  }
 }
 
 /**
@@ -587,11 +623,15 @@ const DESTINATION_WORDING = {
     verb: "links to",
     remedy: "a page is linked by its URL, /docs/..., and source by its GitHub URL",
     relativeIsPath: url => /^\.\.?\//.test(url) || /\.mdx?(?:[#?]|$)/i.test(url),
+    // A docs URL is right when a page answers there.
+    docsUrlFinding: resolves => (resolves ? null : "which is not a docs page"),
+    // Nothing under /docs is an image, whatever answers there.
   },
   image: {
     verb: "embeds",
     remedy: "the site serves no file beside a page, so an image is embedded by its URL",
     relativeIsPath: () => true,
+    docsUrlFinding: () => "which is where pages are served, not files",
   },
 };
 
@@ -1020,13 +1060,14 @@ async function internalLinks(repoRoot, tracked, findings) {
       continue;
     }
     for (const { url, type, line } of await linkDestinations(text, rel.endsWith(".mdx"))) {
-      const { verb, remedy } = wordingFor(type);
-      if (url.startsWith("/docs/") && !resolves(url)) {
+      const { verb, remedy, docsUrlFinding } = wordingFor(type);
+      const docsUrl = url.startsWith("/docs/") ? docsUrlFinding(resolves(url)) : null;
+      if (docsUrl) {
         findings.push({
           check: "internal-docs-link",
           file: rel,
           line,
-          message: `${verb} ${url}, which is not a docs page`,
+          message: `${verb} ${url}, ${docsUrl}`,
         });
       }
       // Only a published page: a README linking `./CONTRIBUTING.md` is a link GitHub renders.

--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -136,10 +136,16 @@ const context7Finding = (check, message) => ({
  * nothing; and the index verifier, `check-context7-index`, reads `excludeFolders` as
  * plain paths, so a pattern there is a rule it could never witness. What is accepted is
  * named rather than what is refused: a list of the metacharacters a pattern may use has
- * no end, and the names in this repository are plain.
+ * no end, and the names in this repository are plain. A field that is present and not a
+ * list of strings is refused first: normalised to an empty list it would read as "nothing
+ * excluded" here while the operator meant the opposite.
  */
-const listOf = value =>
-  Array.isArray(value) ? value.filter(entry => typeof entry === "string") : [];
+const LIST_FIELDS = ["folders", "excludeFolders", "excludeFiles"];
+const isStringList = value =>
+  Array.isArray(value) && value.every(entry => typeof entry === "string");
+const malformedLists = config =>
+  LIST_FIELDS.filter(name => name in config && !isStringList(config[name]));
+const listOf = value => (isStringList(value) ? value : []);
 /** A filename as Context7 matches one, and as git spells one segment of a path. */
 const LITERAL_NAME = /^[A-Za-z0-9._-]+$/;
 const isLiteralName = entry =>
@@ -192,6 +198,14 @@ const CONTEXT7_RULES = [
       context7Finding(
         "context7-description",
         `description differs from packages/${CORE_PACKAGE}/package.json; one sentence says what this is`
+      ),
+  ],
+  [
+    config => malformedLists(config).length > 0,
+    config =>
+      context7Finding(
+        "context7-exclusion",
+        `${malformedLists(config).join(", ")} must be a list of strings; read as empty, the field would exclude nothing`
       ),
   ],
   [
@@ -545,13 +559,17 @@ const DESTINATION_NODES = new Set(["link", "image", "definition"]);
  * each by the attribute that carries it. Only a literal string is read; an expression is a
  * value the page computes, which a scan of the source cannot know.
  */
-const JSX_DESTINATIONS = { img: ["src", "image"], a: ["href", "link"] };
+const JSX_DESTINATIONS = new Map([
+  ["img", ["src", "image"]],
+  ["a", ["href", "link"]],
+]);
 const JSX_NODES = new Set(["mdxJsxFlowElement", "mdxJsxTextElement"]);
 
 /** The destination a JSX element carries, as `{ url, type }`, or `null`. */
 function jsxDestination(node) {
-  if (!JSX_NODES.has(node.type) || !(node.name in JSX_DESTINATIONS)) return null;
-  const [attribute, type] = JSX_DESTINATIONS[node.name];
+  const carried = JSX_NODES.has(node.type) ? JSX_DESTINATIONS.get(node.name) : undefined;
+  if (!carried) return null;
+  const [attribute, type] = carried;
   const found = (node.attributes ?? []).find(
     candidate => candidate.type === "mdxJsxAttribute" && candidate.name === attribute
   );
@@ -624,10 +642,23 @@ async function linkDestinations(text, mdx) {
   const { body, skipped } = frontmatterOrMarkdown(text);
   try {
     await compile(body, { format: mdx ? "mdx" : "md", remarkPlugins: [collect(skipped)] });
-  } catch {
+  } catch (error) {
+    // A parse failure is the compiler's, carries its position, and is the
+    // compile check's to report. Anything else is this scan's own failure, and
+    // read as "no destinations" it would pass every link on the page.
+    if (!isParseFailure(error)) throw error;
     return [];
   }
   return links;
+}
+
+/**
+ * Whether a compile error is the parser refusing the page, as against a fault in a plugin.
+ * The parser's message carries the position and a `reason`, which is what the compile
+ * check reports; its `name` is the position, so it is not the thing to test.
+ */
+function isParseFailure(error) {
+  return typeof error?.reason === "string" && "line" in error;
 }
 
 /** The text with its frontmatter taken off, or the whole text when the block is not YAML. */

--- a/scripts/check-docs-claims.mjs
+++ b/scripts/check-docs-claims.mjs
@@ -132,17 +132,22 @@ const context7Finding = (check, message) => ({
  * untracked file, `null` the unreadable one.
  *
  * Last, the exclusions are held to the shapes their readers understand. Context7 matches
- * `excludeFiles` by filename, so an entry with a path in it excludes nothing; and the
- * index verifier, `check-context7-index`, reads `excludeFolders` as plain paths, so a
- * glob there is a rule it could never witness.
+ * `excludeFiles` by filename, so an entry that is not one, a path or a pattern, excludes
+ * nothing; and the index verifier, `check-context7-index`, reads `excludeFolders` as
+ * plain paths, so a pattern there is a rule it could never witness. What is accepted is
+ * named rather than what is refused: a list of the metacharacters a pattern may use has
+ * no end, and the names in this repository are plain.
  */
 const listOf = value =>
   Array.isArray(value) ? value.filter(entry => typeof entry === "string") : [];
-// Either separator: Context7 sees a filename, git supplies POSIX paths, and a
-// backslash satisfies neither.
-const pathEntries = value => listOf(value).filter(entry => /[\\/]/.test(entry));
-const patternEntries = value =>
-  listOf(value).filter(entry => /[*?[\\]|^\.\/|\/$/.test(entry));
+/** A filename as Context7 matches one, and as git spells one segment of a path. */
+const LITERAL_NAME = /^[A-Za-z0-9._-]+$/;
+const isLiteralName = entry =>
+  LITERAL_NAME.test(entry) && entry !== "." && entry !== "..";
+/** A path as git supplies one: literal names joined by `/`. */
+const isLiteralPath = entry => entry.split("/").every(isLiteralName);
+const notFilenames = value => listOf(value).filter(entry => !isLiteralName(entry));
+const notPaths = value => listOf(value).filter(entry => !isLiteralPath(entry));
 
 const CONTEXT7_RULES = [
   [
@@ -190,19 +195,19 @@ const CONTEXT7_RULES = [
       ),
   ],
   [
-    config => pathEntries(config.excludeFiles).length > 0,
+    config => notFilenames(config.excludeFiles).length > 0,
     config =>
       context7Finding(
         "context7-exclusion",
-        `excludeFiles names ${pathEntries(config.excludeFiles).join(", ")} with a path; Context7 matches the field by filename, so an entry with a slash excludes nothing`
+        `excludeFiles names ${notFilenames(config.excludeFiles).join(", ")}, which is not a filename; Context7 matches the field by filename, so a path or a pattern excludes nothing`
       ),
   ],
   [
-    config => patternEntries(config.excludeFolders).length > 0,
+    config => notPaths(config.excludeFolders).length > 0,
     config =>
       context7Finding(
         "context7-exclusion",
-        `excludeFolders names ${patternEntries(config.excludeFolders).join(", ")} as a pattern; check-context7-index reads plain paths, docs/archive, and cannot witness a pattern`
+        `excludeFolders names ${notPaths(config.excludeFolders).join(", ")}, which is not a plain path; check-context7-index reads plain paths, docs/archive, and cannot witness a pattern`
       ),
   ],
 ];
@@ -535,8 +540,26 @@ const HEX_REF = /^[0-9a-f]{7,40}$/i;
 /** The syntax-tree nodes that carry a destination: a link, an image, a reference definition. */
 const DESTINATION_NODES = new Set(["link", "image", "definition"]);
 
+/**
+ * The JSX a page may write a destination into: an `<img>` is an image and an `<a>` a link,
+ * each by the attribute that carries it. Only a literal string is read; an expression is a
+ * value the page computes, which a scan of the source cannot know.
+ */
+const JSX_DESTINATIONS = { img: ["src", "image"], a: ["href", "link"] };
+const JSX_NODES = new Set(["mdxJsxFlowElement", "mdxJsxTextElement"]);
+
+/** The destination a JSX element carries, as `{ url, type }`, or `null`. */
+function jsxDestination(node) {
+  if (!JSX_NODES.has(node.type) || !(node.name in JSX_DESTINATIONS)) return null;
+  const [attribute, type] = JSX_DESTINATIONS[node.name];
+  const found = (node.attributes ?? []).find(
+    candidate => candidate.type === "mdxJsxAttribute" && candidate.name === attribute
+  );
+  return typeof found?.value === "string" ? { url: found.value, type } : null;
+}
+
 function hasDestination(node) {
-  return DESTINATION_NODES.has(node.type);
+  return DESTINATION_NODES.has(node.type) || jsxDestination(node) !== null;
 }
 
 /**
@@ -574,6 +597,8 @@ function nodesOf(node) {
  * the same patterns had to be taught not to look. A `link` node is a rendered link and a
  * `code` node is not, by construction. An `image` is a destination too: the patterns saw
  * `![d](./x.png)` only because it shares `](` with a link, and the tree names it outright.
+ * So is an `<img src>` or an `<a href>` written as JSX, which compiles and renders
+ * whatever its attribute says; a literal one is read, an expression is left to the page.
  *
  * Frontmatter is taken off first, the way the site's loader takes it off, or the compiler
  * would read the YAML as Markdown. A block that is not YAML is left in and read as
@@ -588,9 +613,10 @@ async function linkDestinations(text, mdx) {
     const nodes = nodesOf(tree);
     const imageIds = imageReferenceIds(nodes);
     for (const node of nodes.filter(hasDestination)) {
+      const jsx = jsxDestination(node);
       links.push({
-        url: node.url,
-        type: destinationKind(node, imageIds),
+        url: jsx ? jsx.url : node.url,
+        type: jsx ? jsx.type : destinationKind(node, imageIds),
         line: (node.position?.start.line ?? 0) + skipped,
       });
     }

--- a/scripts/check-docs-claims.test.mjs
+++ b/scripts/check-docs-claims.test.mjs
@@ -1229,6 +1229,28 @@ describe("internal-docs-link", () => {
     ]);
   });
 
+  it("refuses an image at the docs route ROOT, which a prefix test never asked about", async () => {
+    // `/docs` is a page, so a LINK there is right and `resolves` says so; an
+    // image there is wrong for the same reason `/docs/b` is, and a
+    // `startsWith("/docs/")` guard skipped the root entirely. The query and
+    // fragment forms are the same route reached three ways. The link beside
+    // each one is the control that the root stays a valid link destination,
+    // and `/docsguide` that a different route is untouched.
+    const page = [
+      '![a](/docs) ![b](/docs#intro) ![c](/docs?v=2) ![d](/docsguide.png)',
+      "[e](/docs) [f](/docs#intro) [g](/docs?v=2)",
+      "",
+    ].join("\n");
+    const findings = await findingsFor({ "docs/a.mdx": page });
+    expect(
+      findings.filter(f => f.check === "internal-docs-link").map(f => f.message)
+    ).toEqual([
+      "embeds /docs, which is where pages are served, not files",
+      "embeds /docs#intro, which is where pages are served, not files",
+      "embeds /docs?v=2, which is where pages are served, not files",
+    ]);
+  });
+
   it("reads a reference-style image as an image, by the reference that uses its definition", async () => {
     // `[pic]: diagram.png` is an image when `![d][pic]` uses it, and the link
     // heuristic would let a bare `diagram.png` through. The link reference

--- a/scripts/check-docs-claims.test.mjs
+++ b/scripts/check-docs-claims.test.mjs
@@ -301,6 +301,45 @@ describe("context7", () => {
     expect(checks).not.toContain("context7-description");
     expect(checks).not.toContain("context7-unreadable");
     expect(checks).not.toContain("retired-category");
+    expect(checks).not.toContain("context7-exclusion");
+  });
+
+  it("fires on an excludeFiles entry written as a path, which excludes nothing", async () => {
+    // Context7 matches the field by filename. The entry beside it is the
+    // control that a plain name passes.
+    const withPath = JSON.stringify({
+      projectTitle: "Nextly",
+      description: SENTENCE,
+      folders: ["docs"],
+      excludeFiles: ["AGENTS.md", "docs/internal/notes.md"],
+    });
+    const findings = await findingsFor({
+      "packages/nextly/package.json": core(SENTENCE),
+      "context7.json": withPath,
+    });
+    const exclusion = findings.filter(f => f.check === "context7-exclusion");
+    expect(exclusion).toHaveLength(1);
+    expect(exclusion[0].message).toContain("docs/internal/notes.md");
+    expect(exclusion[0].message).not.toContain("AGENTS.md");
+  });
+
+  it("fires on an excludeFolders pattern, which the index verifier cannot witness", async () => {
+    for (const entry of ["**/internal", "./build", "docs/old/"]) {
+      const withPattern = JSON.stringify({
+        projectTitle: "Nextly",
+        description: SENTENCE,
+        folders: ["docs"],
+        excludeFolders: ["docs/archive", entry],
+      });
+      const findings = await findingsFor({
+        "packages/nextly/package.json": core(SENTENCE),
+        "context7.json": withPattern,
+      });
+      const exclusion = findings.filter(f => f.check === "context7-exclusion");
+      expect(exclusion.map(f => f.message), entry).toEqual([
+        expect.stringContaining(`excludeFolders names ${entry} as a pattern`),
+      ]);
+    }
   });
 });
 
@@ -1132,6 +1171,41 @@ describe("internal-docs-link", () => {
         "docs/b.mdx": "# b\n",
       })
     ).not.toContain("internal-docs-link");
+  });
+
+  it("fires on an image embedded by a file path or at a docs URL, and says it is an image", async () => {
+    // The site serves nothing beside a page, so a bare `diagram.png` is as
+    // broken as `./diagram.png`; and `/docs/...` is where pages are, not
+    // files. The two absolute images are the control that an image by URL
+    // passes.
+    const page = [
+      "![d](./missing.png) ![e](diagram.png) ![f](/docs/nope)",
+      "![ok](https://example.com/x.png) ![ok](/images/x.png)",
+      "",
+    ].join("\n");
+    const findings = await findingsFor({ "docs/a.mdx": page });
+    expect(
+      findings.filter(f => f.check === "internal-docs-link").map(f => f.message)
+    ).toEqual([
+      "embeds ./missing.png as a file path; the site serves no file beside a page, so an image is embedded by its URL",
+      "embeds diagram.png as a file path; the site serves no file beside a page, so an image is embedded by its URL",
+      "embeds /docs/nope, which is not a docs page",
+    ]);
+  });
+
+  it("yields no links for a page whose frontmatter is not YAML, and keeps running", async () => {
+    // The compile check reports that page; this one must neither report its
+    // links nor stop the whole run on it. The second page is the control
+    // that the run went on past it.
+    const checks = await checksFor({
+      "docs/a.mdx": "---\ntitle: [unterminated\n---\n\nSee [gone](/docs/nope).\n",
+      "docs/b.mdx": "See [gone](/docs/nope).\n",
+    });
+    expect(checks).toContain("internal-docs-link");
+    const findings = await findingsFor({
+      "docs/a.mdx": "---\ntitle: [unterminated\n---\n\nSee [gone](/docs/nope).\n",
+    });
+    expect(findings.filter(f => f.check === "internal-docs-link")).toEqual([]);
   });
 });
 

--- a/scripts/check-docs-claims.test.mjs
+++ b/scripts/check-docs-claims.test.mjs
@@ -305,13 +305,14 @@ describe("context7", () => {
   });
 
   it("fires on an excludeFiles entry written as a path, which excludes nothing", async () => {
-    // Context7 matches the field by filename. The entry beside it is the
-    // control that a plain name passes.
+    // Context7 matches the field by filename, and either separator makes a
+    // path: a backslash is not a filename either. The entry beside them is
+    // the control that a plain name passes.
     const withPath = JSON.stringify({
       projectTitle: "Nextly",
       description: SENTENCE,
       folders: ["docs"],
-      excludeFiles: ["AGENTS.md", "docs/internal/notes.md"],
+      excludeFiles: ["AGENTS.md", "docs/internal/notes.md", "docs\\internal\\draft.md"],
     });
     const findings = await findingsFor({
       "packages/nextly/package.json": core(SENTENCE),
@@ -319,12 +320,14 @@ describe("context7", () => {
     });
     const exclusion = findings.filter(f => f.check === "context7-exclusion");
     expect(exclusion).toHaveLength(1);
-    expect(exclusion[0].message).toContain("docs/internal/notes.md");
+    expect(exclusion[0].message).toContain("docs/internal/notes.md, docs\\internal\\draft.md");
     expect(exclusion[0].message).not.toContain("AGENTS.md");
   });
 
   it("fires on an excludeFolders pattern, which the index verifier cannot witness", async () => {
-    for (const entry of ["**/internal", "./build", "docs/old/"]) {
+    // A glob, a root anchor, a trailing slash, and a backslash path, which
+    // git's POSIX paths never match.
+    for (const entry of ["**/internal", "./build", "docs/old/", "docs\\internal"]) {
       const withPattern = JSON.stringify({
         projectTitle: "Nextly",
         description: SENTENCE,
@@ -1175,37 +1178,57 @@ describe("internal-docs-link", () => {
 
   it("fires on an image embedded by a file path or at a docs URL, and says it is an image", async () => {
     // The site serves nothing beside a page, so a bare `diagram.png` is as
-    // broken as `./diagram.png`; and `/docs/...` is where pages are, not
-    // files. The two absolute images are the control that an image by URL
-    // passes.
+    // broken as `./diagram.png`; and `/docs/...` is where pages are served,
+    // not files, so an image there is wrong whether a page answers (`/docs/b`
+    // does) or not. The two absolute images are the control that an image by
+    // URL passes.
     const page = [
-      "![d](./missing.png) ![e](diagram.png) ![f](/docs/nope)",
+      "![d](./missing.png) ![e](diagram.png) ![f](/docs/nope) ![g](/docs/b)",
       "![ok](https://example.com/x.png) ![ok](/images/x.png)",
       "",
     ].join("\n");
-    const findings = await findingsFor({ "docs/a.mdx": page });
+    const findings = await findingsFor({ "docs/a.mdx": page, "docs/b.mdx": "# b\n" });
     expect(
       findings.filter(f => f.check === "internal-docs-link").map(f => f.message)
     ).toEqual([
       "embeds ./missing.png as a file path; the site serves no file beside a page, so an image is embedded by its URL",
       "embeds diagram.png as a file path; the site serves no file beside a page, so an image is embedded by its URL",
-      "embeds /docs/nope, which is not a docs page",
+      "embeds /docs/nope, which is where pages are served, not files",
+      "embeds /docs/b, which is where pages are served, not files",
     ]);
   });
 
-  it("yields no links for a page whose frontmatter is not YAML, and keeps running", async () => {
-    // The compile check reports that page; this one must neither report its
-    // links nor stop the whole run on it. The second page is the control
-    // that the run went on past it.
-    const checks = await checksFor({
-      "docs/a.mdx": "---\ntitle: [unterminated\n---\n\nSee [gone](/docs/nope).\n",
-      "docs/b.mdx": "See [gone](/docs/nope).\n",
-    });
-    expect(checks).toContain("internal-docs-link");
+  it("reads a reference-style image as an image, by the reference that uses its definition", async () => {
+    // `[pic]: diagram.png` is an image when `![d][pic]` uses it, and the link
+    // heuristic would let a bare `diagram.png` through. The link reference
+    // beside it is the control that a definition a link uses keeps link wording.
+    const page = [
+      "![d][pic] and [g][guide]",
+      "",
+      "[pic]: diagram.png",
+      "[guide]: guide.mdx",
+      "",
+    ].join("\n");
+    const findings = await findingsFor({ "docs/a.mdx": page });
+    expect(
+      findings.filter(f => f.check === "internal-docs-link").map(f => f.message.split(";")[0])
+    ).toEqual([
+      "embeds diagram.png as a file path",
+      "links to guide.mdx as a file path",
+    ]);
+  });
+
+  it("keeps reading links past frontmatter that is not YAML, in a README as in a page", async () => {
+    // The compile check reports a docs page's frontmatter, but nothing else
+    // reads a README's links, so the block is read as Markdown and the link
+    // after it is still held. The line is the file's own, since nothing was
+    // taken off.
     const findings = await findingsFor({
+      "README.md": "---\ntitle: [unterminated\n---\n\nSee [gone](/docs/nope).\n",
       "docs/a.mdx": "---\ntitle: [unterminated\n---\n\nSee [gone](/docs/nope).\n",
     });
-    expect(findings.filter(f => f.check === "internal-docs-link")).toEqual([]);
+    const links = findings.filter(f => f.check === "internal-docs-link");
+    expect(links.map(f => `${f.file}:${f.line}`)).toEqual(["README.md:5", "docs/a.mdx:5"]);
   });
 });
 

--- a/scripts/check-docs-claims.test.mjs
+++ b/scripts/check-docs-claims.test.mjs
@@ -312,7 +312,7 @@ describe("context7", () => {
       projectTitle: "Nextly",
       description: SENTENCE,
       folders: ["docs"],
-      excludeFiles: ["AGENTS.md", "docs/internal/notes.md", "docs\\internal\\draft.md"],
+      excludeFiles: ["AGENTS.md", "docs/internal/notes.md", "docs\\internal\\draft.md", "*.md"],
     });
     const findings = await findingsFor({
       "packages/nextly/package.json": core(SENTENCE),
@@ -320,14 +320,23 @@ describe("context7", () => {
     });
     const exclusion = findings.filter(f => f.check === "context7-exclusion");
     expect(exclusion).toHaveLength(1);
-    expect(exclusion[0].message).toContain("docs/internal/notes.md, docs\\internal\\draft.md");
+    expect(exclusion[0].message).toContain("docs/internal/notes.md, docs\\internal\\draft.md, *.md");
     expect(exclusion[0].message).not.toContain("AGENTS.md");
   });
 
   it("fires on an excludeFolders pattern, which the index verifier cannot witness", async () => {
-    // A glob, a root anchor, a trailing slash, and a backslash path, which
-    // git's POSIX paths never match.
-    for (const entry of ["**/internal", "./build", "docs/old/", "docs\\internal"]) {
+    // Named by what is accepted, not by the metacharacters refused: a glob, a
+    // brace set, an extglob, a root anchor, a trailing slash, a parent segment,
+    // and a backslash path, which git's POSIX paths never match.
+    for (const entry of [
+      "**/internal",
+      "docs/{archive,legacy}",
+      "docs/@(archive|legacy)",
+      "./build",
+      "docs/old/",
+      "docs/../secret",
+      "docs\\internal",
+    ]) {
       const withPattern = JSON.stringify({
         projectTitle: "Nextly",
         description: SENTENCE,
@@ -340,7 +349,7 @@ describe("context7", () => {
       });
       const exclusion = findings.filter(f => f.check === "context7-exclusion");
       expect(exclusion.map(f => f.message), entry).toEqual([
-        expect.stringContaining(`excludeFolders names ${entry} as a pattern`),
+        expect.stringContaining(`excludeFolders names ${entry}, which is not a plain path`),
       ]);
     }
   });
@@ -1216,6 +1225,25 @@ describe("internal-docs-link", () => {
       "embeds diagram.png as a file path",
       "links to guide.mdx as a file path",
     ]);
+  });
+
+  it("reads a destination written as JSX, an <img src> as an image and an <a href> as a link", async () => {
+    // Both compile and render whatever the attribute says, so a file path in
+    // either is as broken as in Markdown. The expression-valued src is the
+    // control that only a literal is read, and the absolute one that an image
+    // by URL passes.
+    const page = [
+      'export const path = "./computed.png";',
+      "",
+      '<img src="./missing.png" alt="d" /> and <a href="../guide.mdx">guide</a>',
+      "",
+      '<img src={path} alt="e" /> <img src="/images/x.png" alt="ok" />',
+      "",
+    ].join("\n");
+    const findings = await findingsFor({ "docs/a.mdx": page });
+    expect(
+      findings.filter(f => f.check === "internal-docs-link").map(f => `${f.line} ${f.message.split(";")[0]}`)
+    ).toEqual(["3 embeds ./missing.png as a file path", "3 links to ../guide.mdx as a file path"]);
   });
 
   it("keeps reading links past frontmatter that is not YAML, in a README as in a page", async () => {

--- a/scripts/check-docs-claims.test.mjs
+++ b/scripts/check-docs-claims.test.mjs
@@ -304,6 +304,28 @@ describe("context7", () => {
     expect(checks).not.toContain("context7-exclusion");
   });
 
+  it("refuses an exclusion field that is not a list of strings rather than reading it as empty", async () => {
+    for (const [field, value] of [
+      ["excludeFiles", [42]],
+      ["excludeFolders", "docs/internal"],
+      ["folders", { docs: true }],
+    ]) {
+      const findings = await findingsFor({
+        "packages/nextly/package.json": core(SENTENCE),
+        "context7.json": JSON.stringify({
+          projectTitle: "Nextly",
+          description: SENTENCE,
+          folders: ["docs"],
+          [field]: value,
+        }),
+      });
+      expect(
+        findings.filter(f => f.check === "context7-exclusion").map(f => f.message),
+        field
+      ).toEqual([expect.stringContaining(`${field} must be a list of strings`)]);
+    }
+  });
+
   it("fires on an excludeFiles entry written as a path, which excludes nothing", async () => {
     // Context7 matches the field by filename, and either separator makes a
     // path: a backslash is not a filename either. The entry beside them is
@@ -1244,6 +1266,19 @@ describe("internal-docs-link", () => {
     expect(
       findings.filter(f => f.check === "internal-docs-link").map(f => `${f.line} ${f.message.split(";")[0]}`)
     ).toEqual(["3 embeds ./missing.png as a file path", "3 links to ../guide.mdx as a file path"]);
+  });
+
+  it("reads past an element named like an Object.prototype key, and a page that does not parse yields nothing", async () => {
+    // `<toString>` is an intrinsic element with a name every plain object
+    // answers `in` for; the lookup must not find a destination carrier there,
+    // and must not throw inside the compiler, where the catch would read a
+    // fault of this scan as the page not compiling and pass every link in it.
+    const findings = await findingsFor({
+      "docs/a.mdx": "<toString>x</toString> <constructor>y</constructor>\n\nSee [gone](/docs/nope).\n",
+      "docs/b.mdx": "<Callout>\n\n1. one\n   </Callout>\n\nSee [gone](/docs/nope).\n",
+    });
+    const links = findings.filter(f => f.check === "internal-docs-link");
+    expect(links.map(f => f.file)).toEqual(["docs/a.mdx"]);
   });
 
   it("keeps reading links past frontmatter that is not YAML, in a README as in a page", async () => {


### PR DESCRIPTION
Follow-up to #1764 and #1767, which merged with five Codex findings open between them. Four were real and are fixed here; one is answered on its thread. Two more things were found while verifying them against Context7's documentation.

## check-context7-index

**One witness per exclusion rule** (#1764, `excludeFolders`). The active probes covered only `excludeFiles`; an `excludeFolders` entry, or the `folders` list itself, was checked against the capped citation sample alone, and a small folder can sit outside any sample. The rule table that judges cited paths now also names the set each rule excludes, and `witnesses(corpus, config)` probes one tracked file per set: each `excludeFiles` name (its root file first), each `excludeFolders` entry, and the `folders` rule. A rule takes for its whole set or not at all, so one file answers for it.

A witness has to be a file the index would hold if the rule did not take, so three kinds cannot serve: a root file (held whatever `folders` says), a hidden path such as `.changeset/x.md` (a crawler may skip it unasked), and a file Context7's own defaults name, `CHANGELOG.md`, a `legacy` folder (their docs leave open whether the defaults also apply to a configuration that names exclusions, and ours does). Without the third exclusion the `folders` witness here would have been `apps/playground/CHANGELOG.md`, a control that could never fail. A set with no file that can witness it is skipped rather than probed; a set whose files all share every sentence stops the run with exit 2.

**The corpus is read once** (#1764, performance). `markerFor` rebuilt the tracked corpus with `git ls-files` and a full reread for every probe, forty megabytes each. `readCorpus(root)` reads it once into a map and every marker is chosen against `othersOf(corpus, name)`. The test suite went from 46 s to 1.7 s; the probe count per run went from 9 to 12 (three more sets witnessed).

**Two findings against the configuration itself**, from reading Context7's `library-owners` documentation while verifying the above:

- `excludeFiles` is matched **by filename anywhere in the tree**, not by path. The citation rule now reads it that way (`packages/nextly/AGENTS.md` is excluded by the same entry as the root one), and `check-docs-claims` refuses an entry with a slash in it, which would exclude nothing.
- The default exclusions (`CHANGELOG.md`, `LICENSE.md`, `CODE_OF_CONDUCT.md`, ...) apply "if you don't specify `excludeFiles` or `excludeFolders`". This configuration specifies both, so root `LICENSE.md` and `CODE_OF_CONDUCT.md` were being indexed. Both are named now, and the test that allowed the defaults to account for them no longer does.

`check-docs-claims` also refuses an `excludeFolders` glob (`**/internal`, `./build`, a trailing slash): the verifier reads plain paths and could not witness a pattern.

## check-docs-claims

**Images are destinations** (#1767). The text patterns caught `![d](./missing.png)` only because it shares `](` with a link; the tree scan dropped `image` nodes. They are read now, with their own wording: a relative image is a file path whatever its spelling (the site serves nothing beside a page), and `/docs/...` is where pages are, not files. Measured: no Markdown image exists in the 1,312 tracked files today (the 21 `<img>` are shields.io badges in package READMEs), so this is coverage kept rather than a page fixed.

**Malformed frontmatter no longer stops the run** (#1767). `splitFrontmatter` threw outside the `try`, so a page with YAML the loader refuses would have ended `runChecks` with a stack trace. It is inside now and the page yields no destinations; the compile check reports it.

**Unreferenced definitions stay in scope** (#1767, answered on the thread rather than changed). A `definition` is a destination the author wrote, and one pointing at a missing page or a file path is a defect whether a reference uses it yet or not; the remedy is the same. Measured: 5 definitions across the tracked files, none unreferenced.

## Verified

- `check-context7-index.test.mjs` 36/36 in 1.7 s; `check-docs-claims.test.mjs` 217/217.
- `node scripts/check-docs-claims.mjs` exit 0, no findings; `check-docs-compile` 66 pages; `check-context7-index` exit 2 (unregistered, as expected).
- Nine mutation controls, each red on the named test and restored: image nodes dropped; frontmatter split moved back outside the `try`; each new config rule disabled; `canWitness` without the defaults filter, and without the root/hidden filters; `excludeFiles` matched by path again; `witnessOf` returning a null marker instead of refusing; `exclusionFindings` skipping the `folders` set.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved documentation link validation for images, reference-style links, JSX links, and pages with incomplete frontmatter.
  - Added clearer reporting for invalid Context7 file and folder exclusion entries.
  - Expanded Context7 index checks to detect files outside configured folders and verify all exclusion rules.

- **Tests**
  - Added coverage for exclusion formats, image destinations, link classification, and exclusion-rule witnesses.

- **Chores**
  - Updated Context7 exclusions to include `CODE_OF_CONDUCT.md` and `LICENSE.md`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->