### PR TITLE
test(nextly): type the hook call the ordering test reads

### DIFF
--- a/packages/nextly/src/domains/collections/__tests__/collection-mutation.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/collection-mutation.test.ts
@@ -342,7 +342,7 @@ describe("CollectionEntryService — Mutation Contracts", () => {
       );
 
       const collectionPhase = mockHookRegistry.execute.mock.calls.findIndex(
-        call => call[0] === "beforeChange"
+        (call: unknown[]) => call[0] === "beforeChange"
       );
       expect(collectionPhase, "collection beforeChange ran").toBeGreaterThan(
         -1


### PR DESCRIPTION
main fails `nextly` typecheck since #1754 (`ae9e60004`, merged 11:31): `collection-mutation.test.ts:345` has an implicit `any` callback parameter, which `tsconfig.tests.json` refuses. `pnpm check-types` runs that config as its second `tsc` leg and the CI gate runs `turbo check-types`, so the required job will go red on `main` once the queue reaches it — it had not registered at the time of writing.

One-line fix: the parameter is typed as the `unknown[]` tuple it is. `check-types`, the file's 34 tests and `lint` green.

Test-only, so no changeset.