### PR TITLE
test(nextly): type the hook-order callback so check-types passes on main

### DIFF
--- a/packages/nextly/src/domains/collections/__tests__/collection-mutation.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/collection-mutation.test.ts
@@ -341,8 +341,10 @@ describe("CollectionEntryService — Mutation Contracts", () => {
         { title: "Ordered Post" }
       );
 
+      // The registry mock is an untyped record, so its call list is too;
+      // the parameter is named as what a recorded call is.
       const collectionPhase = mockHookRegistry.execute.mock.calls.findIndex(
-        call => call[0] === "beforeChange"
+        (call: unknown[]) => call[0] === "beforeChange"
       );
       expect(collectionPhase, "collection beforeChange ran").toBeGreaterThan(
         -1


### PR DESCRIPTION
## What

`main` fails `pnpm --filter nextly check-types` since #1754:

```
src/domains/collections/__tests__/collection-mutation.test.ts(345,9): error TS7006: Parameter 'call' implicitly has an 'any' type.
```

The hook registry mock is an untyped record, so `.mock.calls` is `any` and the `findIndex` callback's parameter had no type. It is now typed as what a recorded call is, `unknown[]`.

## Why it reached main

The pre-push hook runs the repo-wide `check-types` but reports a failure as a NOTE rather than refusing, because the repo-wide check can be red for another lane's work. CI would have blocked, but its queue cannot drain (#1778), so the note was the only signal. #1781 makes the hook refuse a type error in the packages a push affects.

## Changeset

None. Test-only.
