### PR TITLE
chore(husky): refuse a push whose own packages fail check-types

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -77,14 +77,14 @@ pnpm run build
 # asking. A dependent TEST sweep is the expensive one and stays in CI, where
 # nobody is waiting on it.
 #
-# ADVISORY, not blocking. This is the one gate here whose scope is the whole
+# ADVISORY here, not blocking. This is the one gate whose scope is the whole
 # repository, so it can be red for a package the author never touched — and a
 # hook that refuses a push over someone else's broken package is a hook people
 # learn to pass `--no-verify` to, which costs every gate rather than this one.
 #
-# Reported instead, with the packages named, so an author can see at a glance
-# whether the failure is theirs. CI blocks on the same command; this is the
-# early warning, not the enforcement.
+# The packages this push CHANGES are held to it below, once the scope is
+# derived: a type error there is the author's whichever commit introduced it,
+# because the push carries it. Reported with the packages named either way.
 set +e
 pnpm turbo check-types --continue
 TYPES_STATUS=$?
@@ -131,11 +131,32 @@ elif [ -n "$GATE_FILTERS" ]; then
   pnpm turbo test --continue $GATE_FILTERS
 fi
 
+# The TYPES of the packages this push changes, blocking.
+#
+# The repo-wide run above already compiled them, and `check-types` is a cached
+# task, so this re-run replays from cache and costs seconds. What it adds is
+# the verdict: a type error in a package this push changes goes out under this
+# author's name, and one merge went red on `main` with the error printed here
+# as a note nobody read, on a day CI's queue could not report it either.
+# Failures in packages the push does not touch stay a note, for the reason
+# given above.
 if [ "$TYPES_STATUS" -ne 0 ]; then
+  if [ "$GATE_STATUS" -eq 2 ]; then
+    echo "pre-push: the diff redefines the workspace or task graph and the typecheck is red; refusing." >&2
+    exit 1
+  elif [ -n "$GATE_FILTERS" ]; then
+    # shellcheck disable=SC2086 -- one flag per line, intentionally word-split
+    if ! pnpm turbo check-types --continue $GATE_FILTERS; then
+      echo "" >&2
+      echo "pre-push: the typecheck is red in a package this push changes; refusing." >&2
+      echo "  Fix it here, or if it came in with a merge from main, fix it here anyway:" >&2
+      echo "  the push carries it." >&2
+      exit 1
+    fi
+  fi
   echo ""
-  echo "pre-push: NOTE — the repo-wide typecheck failed. Check whether the"
-  echo "  failing package is one you changed: this gate covers every package,"
-  echo "  so it can be red for someone else's work. CI blocks on it either way."
+  echo "pre-push: NOTE — the repo-wide typecheck failed outside the packages this"
+  echo "  push changes. CI blocks on it for whoever owns that package."
 fi
 
 # Last, so it is the line still on screen when the push proceeds.

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -131,24 +131,38 @@ elif [ -n "$GATE_FILTERS" ]; then
   pnpm turbo test --continue $GATE_FILTERS
 fi
 
-# The TYPES of the packages this push changes, blocking.
+# The TYPES of the packages this push AFFECTS, blocking.
 #
 # The repo-wide run above already compiled them, and `check-types` is a cached
 # task, so this re-run replays from cache and costs seconds. What it adds is
-# the verdict: a type error in a package this push changes goes out under this
-# author's name, and one merge went red on `main` with the error printed here
-# as a note nobody read, on a day CI's queue could not report it either.
-# Failures in packages the push does not touch stay a note, for the reason
-# given above.
+# the verdict: a type error this push introduces goes out under this author's
+# name, and one merge went red on `main` with the error printed here as a note
+# nobody read, on a day CI's queue could not report it either.
+#
+# "Affects" is the packages the diff changes, derived by gate-scope like the
+# test scope, AND every package that depends on them (`--filter=...<pkg>`),
+# since a shared package can stay type-correct itself and break a consumer.
+# `--only` keeps the verdict to those packages: without it the task graph also
+# pulls in their unchanged DEPENDENCIES through `^check-types`, and a red there
+# is somebody else's, the case the note below exists for. The builds those
+# dependencies would have supplied already ran above.
+#
+# Not turbo's `--affected`: it reads any root-level change as touching every
+# package, so a push that edits only `scripts/` would be refused over a red in
+# a package it never reached. gate-scope already knows which root files
+# redefine the graph (workspace list, task graph, root manifest, lockfile);
+# for those no package can be blamed and the repo-wide verdict is the one
+# that holds.
 if [ "$TYPES_STATUS" -ne 0 ]; then
   if [ "$GATE_STATUS" -eq 2 ]; then
-    echo "pre-push: the diff redefines the workspace or task graph and the typecheck is red; refusing." >&2
+    echo "pre-push: the diff redefines the workspace, task or dependency graph and the typecheck is red; refusing." >&2
     exit 1
   elif [ -n "$GATE_FILTERS" ]; then
+    AFFECTED_FILTERS=$(printf '%s\n' "$GATE_FILTERS" | sed 's/^--filter=/--filter=.../')
     # shellcheck disable=SC2086 -- one flag per line, intentionally word-split
-    if ! pnpm turbo check-types --continue $GATE_FILTERS; then
+    if ! pnpm turbo check-types --continue --only $AFFECTED_FILTERS; then
       echo "" >&2
-      echo "pre-push: the typecheck is red in a package this push changes; refusing." >&2
+      echo "pre-push: the typecheck is red in a package this push changes or one that depends on it; refusing." >&2
       echo "  Fix it here, or if it came in with a merge from main, fix it here anyway:" >&2
       echo "  the push carries it." >&2
       exit 1
@@ -156,7 +170,7 @@ if [ "$TYPES_STATUS" -ne 0 ]; then
   fi
   echo ""
   echo "pre-push: NOTE — the repo-wide typecheck failed outside the packages this"
-  echo "  push changes. CI blocks on it for whoever owns that package."
+  echo "  push affects. CI blocks on it for whoever owns that package."
 fi
 
 # Last, so it is the line still on screen when the push proceeds.

--- a/scripts/gate-scope.mjs
+++ b/scripts/gate-scope.mjs
@@ -252,12 +252,21 @@ function missingWorkspaceDir(path, roots) {
  * entry detaches a directory that still exists, and the only changed path is
  * the YAML itself, so nothing names the workspace that just lost its gate.
  * `turbo.jsonc` defines the tasks every workspace runs, so a filtered run
- * exercises the new definition for one package and none of the others.
+ * exercises the new definition for one package and none of the others. The
+ * root manifest and the lockfile define the DEPENDENCY graph: a transitive
+ * upgrade changes what every package compiles against while touching no path
+ * inside any of them, so a diff that reaches only the lockfile derives an
+ * empty scope and the packages it broke are never gated.
+ *
+ * Root paths only. A package's own `package.json` is that package's change and
+ * scopes to it like any other file under its root.
  */
 const ROOT_WIDE_FILES = new Set([
   "pnpm-workspace.yaml",
   "turbo.json",
   "turbo.jsonc",
+  "package.json",
+  "pnpm-lock.yaml",
 ]);
 
 /**

--- a/scripts/gate-scope.test.mjs
+++ b/scripts/gate-scope.test.mjs
@@ -171,6 +171,21 @@ describe("a change that redefines the graph for every package", () => {
     expect(rootWideChanges(["turbo.jsonc"])).toEqual(["turbo.jsonc"]);
   });
 
+  it("refuses for the dependency graph: the root manifest and the lockfile", () => {
+    // A transitive upgrade changes what every package compiles against while
+    // touching no path inside any of them. Narrowed, that diff derives an
+    // empty scope and the packages it broke are never gated.
+    expect(rootWideChanges(["pnpm-lock.yaml"])).toEqual(["pnpm-lock.yaml"]);
+    expect(rootWideChanges(["package.json"])).toEqual(["package.json"]);
+  });
+
+  it("scopes a package's own manifest to that package", () => {
+    // The root manifest is root-wide by its PATH, not its name: a workspace's
+    // manifest is that workspace's change, and reading every `package.json` as
+    // graph-wide would make a dependency bump in one plugin test everything.
+    expect(rootWideChanges(["packages/plugin-seo/package.json"])).toEqual([]);
+  });
+
   it("says so in the report as well as in the refusal", () => {
     // The two audiences are separate: one is spliced into a command, the other
     // is read by a person, and a person following the report must not be told


### PR DESCRIPTION
## What

The pre-push hook runs the repo-wide `check-types` and, by design, only prints a NOTE when it fails: the whole-repo scope can be red for a package the author never touched, and a hook that refuses over someone else's breakage teaches `--no-verify`.

That stays. What changes: the packages the push AFFECTS are held to `check-types` with a re-run that replays from turbo's cache and costs seconds. "Affects" is the packages `scripts/gate-scope.mjs` derives from the diff (the same scope the test gate uses) plus every package that depends on them (`--filter=...<pkg>`), with `--only` so their unchanged dependencies stay out of the verdict. A type error there is refused; one outside stays a note.

Root `package.json` and `pnpm-lock.yaml` join gate-scope's graph-wide set beside `pnpm-workspace.yaml` and `turbo.jsonc`: a dependency change cannot be attributed to a package, so both the test gate and the type verdict run unfiltered for it (exit 2). Root paths only; a workspace's own manifest scopes to that workspace.

Turbo's `--affected` was tried first and measured: it reads any root-level change, `scripts/` included, as touching all 27 packages, which would refuse a scripts-only push over a red in a package it never reached. The derived filters do not.

## Why now

#1754 merged with an implicit `any` in a test file. The hook printed the error as a note; CI, which blocks on it, could not report because its queue cannot drain (#1778). `main` has been red on `check-types` since (#1780 fixes the line). A gate whose only enforcement was elsewhere had no enforcement that day.

## Verified

The block was run directly against the real turbo task with `main`'s current `nextly` error present: a push scoped to `@nextlyhq/plugin-seo` runs 1 package and continues with the note (its unchanged dependency's red does not block); a push scoped to `@nextlyhq/blocks-engine` runs 14 packages, reaches `nextly` as a dependent, and is refused; no package touched notes and continues; graph redefined and red refuses; types green is silent. This branch's own pushes exercised the note path live, once with `.husky` alone and once with `scripts/` changed.

CI-only, no changeset.
