### PR TITLE
chore(deps): zod 4.6, the version the MCP server library can share

### DIFF
--- a/.changeset/one-zod-the-mcp-server-can-share.md
+++ b/.changeset/one-zod-the-mcp-server-can-share.md
@@ -1,0 +1,39 @@
+---
+
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+
+zod is 4.6 now, from 4.1. The MCP server library needs 4.2 or newer, and a
+second copy of zod beside the first would make every schema a stranger to the
+other's `instanceof`; one version everywhere is what lets the coming MCP plugin
+describe its tools in the same language the rest of Nextly describes content.
+
+One behaviour moved with it. zod's JSON Schema converter now refuses a schema
+whose registrations collide on an `id` rather than emitting a shorter schema,
+which is the corruption the block document emitter already refused; the
+emitter turns that refusal into its own, so a caller still sees one error for
+one reason, and a document checked against a derivation that cannot be made is
+answered rather than thrown at.

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
   "dependencies": {
     "@mdx-js/mdx": "3.1.1",
     "js-yaml": "4.3.1",
-    "zod": "^4.1.12"
+    "zod": "^4.6.2"
   },
   "pnpm": {
     "overrides": {

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -150,7 +150,7 @@
     "tailwind-merge": "^3.4.0",
     "tailwind-variants": "^3.1.1",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^4.1.12"
+    "zod": "^4.6.2"
   },
   "repository": {
     "type": "git",

--- a/packages/nextly/package.json
+++ b/packages/nextly/package.json
@@ -332,7 +332,7 @@
     "semver": "^7.6.0",
     "server-only": "^0.0.1",
     "ws": "^8.21.1",
-    "zod": "^4.1.12"
+    "zod": "^4.6.2"
   },
   "repository": {
     "type": "git",

--- a/packages/nextly/src/plugins/codegen/__tests__/block-document.test.ts
+++ b/packages/nextly/src/plugins/codegen/__tests__/block-document.test.ts
@@ -8,7 +8,7 @@ import {
   STYLE_STATES,
   isReservedOperationName,
 } from "@nextlyhq/blocks-engine";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { blockDocumentJsonSchema, parseBlockDocument } from "../block-document";
 
@@ -482,6 +482,38 @@ describe("block document schema", () => {
         expect(parseBlockDocument(doc).success).toBe(false);
       }
     );
+  });
+
+  it("answers rather than throws when the derivation is refused before the field list exists", async () => {
+    // The field list is derived once and cached, and every test above runs
+    // against a warm cache. Cold, the corrupted emission is refused inside
+    // the check itself, and the check must turn that into the same answer a
+    // shorter emission gets: a document it cannot check, not an exception.
+    //
+    // A fresh module loaded WHILE the prototype carries `id` is the cold
+    // cache: loaded before the pollution, its load-time snapshot would refuse
+    // first and this path would never run.
+    vi.resetModules();
+    Object.defineProperty(Object.prototype, "id", {
+      value: "spoofed",
+      enumerable: false,
+      writable: true,
+      configurable: true,
+    });
+    try {
+      const polluted = await import("../block-document");
+      const result = polluted.parseBlockDocument(emptyPage());
+      expect(result.success).toBe(false);
+      expect(result.success ? [] : result.issues).toEqual([
+        "The published schema could not be derived, so this document cannot be checked against it.",
+      ]);
+    } finally {
+      delete (Object.prototype as Record<string, unknown>).id;
+    }
+    // The control: a fresh module loaded clean checks the same document.
+    vi.resetModules();
+    const clean = await import("../block-document");
+    expect(clean.parseBlockDocument(emptyPage()).success).toBe(true);
   });
 
   it("refuses once anything is added to Object.prototype at all", () => {

--- a/packages/nextly/src/plugins/codegen/block-document.ts
+++ b/packages/nextly/src/plugins/codegen/block-document.ts
@@ -623,6 +623,18 @@ function collectDeclaredFields(node: unknown, into: Set<string>): void {
   for (const value of Object.values(record)) collectDeclaredFields(value, into);
 }
 
+/** The one refusal a corrupted derivation gets, on each of the two paths. */
+const DERIVATION_FAILED_EMIT =
+  "The block document schema could not be derived, so it was not emitted.";
+const DERIVATION_FAILED_CHECK =
+  "The published schema could not be derived, so this document cannot be checked against it.";
+
+function isDerivationFailure(error: unknown): boolean {
+  return (
+    error instanceof NextlyError && error.code === "SCHEMA_DERIVATION_FAILED"
+  );
+}
+
 let declaredFieldsCache: string[] | undefined;
 
 function declaredFields(): string[] {
@@ -677,7 +689,23 @@ export type BlockDocumentShape = z.infer<typeof blockDocumentSchema>;
  * artifact is writing a document rather than reading one back out of zod.
  */
 export function blockDocumentJsonSchema(): Record<string, unknown> {
-  const schema = z.toJSONSchema(blockDocumentSchema, { io: "input" });
+  let schema: Record<string, unknown>;
+  try {
+    schema = z.toJSONSchema(blockDocumentSchema, { io: "input" });
+  } catch (error) {
+    // zod refuses the corruption itself now: with `id` on `Object.prototype`
+    // every registration reads the same id, and since 4.4 the converter
+    // reports the collision instead of emitting a shorter schema. The refusal
+    // is the same one the check below makes, so it is given the same shape;
+    // a caller then has one error to handle for one reason.
+    throw new NextlyError({
+      code: "SCHEMA_DERIVATION_FAILED",
+      publicMessage: DERIVATION_FAILED_EMIT,
+      logContext: {
+        cause: error instanceof Error ? error.message : String(error),
+      },
+    });
+  }
 
   // The emission is checked HERE rather than only where this module consumes
   // it, because publishing a corrupted schema is the worse of the two failures:
@@ -686,17 +714,18 @@ export function blockDocumentJsonSchema(): Record<string, unknown> {
   // has exited.
   //
   // What corrupts it is prototype pollution. Emitting while `Object.prototype`
-  // carries `id`, `type`, `version` and `props` returns EIGHT property names
-  // instead of 33, with every node field missing — a shorter document rather
-  // than an error, which is why nothing downstream notices.
+  // carried `id`, `type`, `version` and `props` returned EIGHT property names
+  // instead of 33 under zod 4.1, with every node field missing — a shorter
+  // document rather than an error, which is why nothing downstream noticed.
+  // The converter reports that case now; this stays for a corruption it does
+  // not, since a shorter emission is still the failure that hides.
   const emitted = new Set<string>();
   collectDeclaredFields(schema, emitted);
   const missing = NODE_REQUIRED_FIELDS.filter(field => !emitted.has(field));
   if (missing.length > 0) {
     throw new NextlyError({
       code: "SCHEMA_DERIVATION_FAILED",
-      publicMessage:
-        "The block document schema could not be derived, so it was not emitted.",
+      publicMessage: DERIVATION_FAILED_EMIT,
       logContext: {
         missing: [...missing],
         cause:
@@ -791,7 +820,15 @@ export function parseBlockDocument(value: unknown): BlockDocumentParseResult {
   // `Object.prototype`, every object in the document resolves that field
   // whether or not it holds one, so the schema would be validating values the
   // document does not contain and storage will not receive.
-  const fields = declaredFields();
+  let fields: string[];
+  try {
+    fields = declaredFields();
+  } catch (error) {
+    // The emission refused, which is a derivation failure and not this
+    // document's fault; the answer is the same as for a shorter emission.
+    if (!isDerivationFailure(error)) throw error;
+    return { success: false, issues: [DERIVATION_FAILED_CHECK] };
+  }
   // The positive control. A perturbed emission returns a SHORTER list rather
   // than an error, so "no declared field is shadowed" has to be distinguished
   // from "the list being searched was not the real one".
@@ -799,12 +836,7 @@ export function parseBlockDocument(value: unknown): BlockDocumentParseResult {
     fields.includes(field)
   );
   if (!derivationIntact) {
-    return {
-      success: false,
-      issues: [
-        "The published schema could not be derived, so this document cannot be checked against it.",
-      ],
-    };
+    return { success: false, issues: [DERIVATION_FAILED_CHECK] };
   }
 
   const shadowed = shadowedDeclaredField(fields);

--- a/packages/plugin-form-builder/package.json
+++ b/packages/plugin-form-builder/package.json
@@ -37,7 +37,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "zod": "^4.1.12"
+    "zod": "^4.6.2"
   },
   "peerDependencies": {
     "@nextlyhq/admin": "0.0.2-alpha.65",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
         specifier: ^4.3.1
         version: 4.3.1
       zod:
-        specifier: ^4.1.12
-        version: 4.1.12
+        specifier: ^4.6.2
+        version: 4.6.2
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.18.5
@@ -213,7 +213,7 @@ importers:
         version: link:../../packages/ui
       drizzle-orm:
         specifier: 1.0.0-rc.4
-        version: 1.0.0-rc.4(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@12.11.1)(effect@3.21.2)(mysql2@3.23.1(@types/node@20.19.17))(pg@8.16.3)(zod@4.1.12)
+        version: 1.0.0-rc.4(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@12.11.1)(effect@3.21.2)(mysql2@3.23.1(@types/node@20.19.17))(pg@8.16.3)(zod@4.6.2)
       mysql2:
         specifier: ^3.23.1
         version: 3.23.1(@types/node@20.19.17)
@@ -343,7 +343,7 @@ importers:
     dependencies:
       drizzle-orm:
         specifier: 1.0.0-rc.4
-        version: 1.0.0-rc.4(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@12.11.1)(effect@3.21.2)(mysql2@3.23.1(@types/node@20.19.17))(pg@8.16.3)(zod@4.1.12)
+        version: 1.0.0-rc.4(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@12.11.1)(effect@3.21.2)(mysql2@3.23.1(@types/node@20.19.17))(pg@8.16.3)(zod@4.6.2)
     devDependencies:
       '@nextlyhq/eslint-config':
         specifier: workspace:*
@@ -383,7 +383,7 @@ importers:
         version: link:../adapter-drizzle
       drizzle-orm:
         specifier: 1.0.0-rc.4
-        version: 1.0.0-rc.4(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@12.11.1)(effect@3.21.2)(mysql2@3.23.1(@types/node@24.10.0))(pg@8.16.3)(zod@4.1.12)
+        version: 1.0.0-rc.4(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@12.11.1)(effect@3.21.2)(mysql2@3.23.1(@types/node@24.10.0))(pg@8.16.3)(zod@4.6.2)
       mysql2:
         specifier: ^3.23.1
         version: 3.23.1(@types/node@24.10.0)
@@ -423,7 +423,7 @@ importers:
         version: link:../adapter-drizzle
       drizzle-orm:
         specifier: 1.0.0-rc.4
-        version: 1.0.0-rc.4(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@12.11.1)(effect@3.21.2)(mysql2@3.23.1(@types/node@24.10.0))(pg@8.16.3)(zod@4.1.12)
+        version: 1.0.0-rc.4(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@12.11.1)(effect@3.21.2)(mysql2@3.23.1(@types/node@24.10.0))(pg@8.16.3)(zod@4.6.2)
       pg:
         specifier: ^8.16.3
         version: 8.16.3
@@ -469,7 +469,7 @@ importers:
         version: 12.11.1
       drizzle-orm:
         specifier: 1.0.0-rc.4
-        version: 1.0.0-rc.4(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@12.11.1)(effect@3.21.2)(mysql2@3.23.1(@types/node@24.10.0))(pg@8.16.3)(zod@4.1.12)
+        version: 1.0.0-rc.4(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@12.11.1)(effect@3.21.2)(mysql2@3.23.1(@types/node@24.10.0))(pg@8.16.3)(zod@4.6.2)
     devDependencies:
       '@nextlyhq/eslint-config':
         specifier: workspace:*
@@ -691,8 +691,8 @@ importers:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@4.3.2)
       zod:
-        specifier: ^4.1.12
-        version: 4.1.12
+        specifier: ^4.6.2
+        version: 4.6.2
     devDependencies:
       '@nextlyhq/admin-css':
         specifier: workspace:*
@@ -1155,7 +1155,7 @@ importers:
         version: 1.0.0-rc.4
       drizzle-orm:
         specifier: 1.0.0-rc.4
-        version: 1.0.0-rc.4(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@12.11.1)(effect@3.21.2)(mysql2@3.23.1(@types/node@20.19.17))(pg@8.16.3)(zod@4.1.12)
+        version: 1.0.0-rc.4(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@12.11.1)(effect@3.21.2)(mysql2@3.23.1(@types/node@20.19.17))(pg@8.16.3)(zod@4.6.2)
       file-type:
         specifier: ^21
         version: 21.3.4
@@ -1184,8 +1184,8 @@ importers:
         specifier: ^8.21.0
         version: 8.21.1
       zod:
-        specifier: ^4.1.12
-        version: 4.1.12
+        specifier: ^4.6.2
+        version: 4.6.2
     optionalDependencies:
       better-sqlite3:
         specifier: ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0
@@ -1306,8 +1306,8 @@ importers:
         specifier: ^18.0.0 || ^19.0.0
         version: 19.2.0
       zod:
-        specifier: ^4.1.12
-        version: 4.1.12
+        specifier: ^4.6.2
+        version: 4.6.2
     devDependencies:
       '@nextlyhq/admin':
         specifier: workspace:*
@@ -9516,8 +9516,8 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  zod@4.1.12:
-    resolution: {integrity: sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==}
+  zod@4.6.2:
+    resolution: {integrity: sha512-lh5RCAGFa1Cm2hjtNwLQhSs/AsqdWnTQaBER9fEwN/88pSh7KOtJavtBx/0VlkN/uFd61SwYmljLMDAsHlvzBQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -13917,7 +13917,7 @@ snapshots:
       get-tsconfig: 4.14.0
       jiti: 2.7.0
 
-  drizzle-orm@1.0.0-rc.4(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@12.11.1)(effect@3.21.2)(mysql2@3.23.1(@types/node@20.19.17))(pg@8.16.3)(zod@4.1.12):
+  drizzle-orm@1.0.0-rc.4(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@12.11.1)(effect@3.21.2)(mysql2@3.23.1(@types/node@20.19.17))(pg@8.16.3)(zod@4.6.2):
     optionalDependencies:
       '@types/better-sqlite3': 7.6.13
       '@types/pg': 8.15.5
@@ -13925,9 +13925,9 @@ snapshots:
       effect: 3.21.2
       mysql2: 3.23.1(@types/node@20.19.17)
       pg: 8.16.3
-      zod: 4.1.12
+      zod: 4.6.2
 
-  drizzle-orm@1.0.0-rc.4(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@12.11.1)(effect@3.21.2)(mysql2@3.23.1(@types/node@24.10.0))(pg@8.16.3)(zod@4.1.12):
+  drizzle-orm@1.0.0-rc.4(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@12.11.1)(effect@3.21.2)(mysql2@3.23.1(@types/node@24.10.0))(pg@8.16.3)(zod@4.6.2):
     optionalDependencies:
       '@types/better-sqlite3': 7.6.13
       '@types/pg': 8.15.5
@@ -13935,7 +13935,7 @@ snapshots:
       effect: 3.21.2
       mysql2: 3.23.1(@types/node@24.10.0)
       pg: 8.16.3
-      zod: 4.1.12
+      zod: 4.6.2
 
   dunder-proto@1.0.1:
     dependencies:
@@ -14340,8 +14340,8 @@ snapshots:
       '@babel/parser': 7.29.7
       eslint: 9.39.1(jiti@2.7.0)
       hermes-parser: 0.25.1
-      zod: 4.1.12
-      zod-validation-error: 4.0.2(zod@4.1.12)
+      zod: 4.6.2
+      zod-validation-error: 4.0.2(zod@4.6.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -17864,10 +17864,10 @@ snapshots:
 
   yoctocolors@2.1.2: {}
 
-  zod-validation-error@4.0.2(zod@4.1.12):
+  zod-validation-error@4.0.2(zod@4.6.2):
     dependencies:
-      zod: 4.1.12
+      zod: 4.6.2
 
-  zod@4.1.12: {}
+  zod@4.6.2: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
Decision D11, Phase 5.1. The MCP server library (`@modelcontextprotocol/server@2.0.0`) peers on `zod ^4.2.0`; the workspace held 4.1.12 in four manifests (root, `nextly`, `admin`, `plugin-form-builder`; 69 files import it), and pnpm would have installed a second zod beside it for the peer, so no schema of one would satisfy the other's `instanceof`. The ranges already stated (`^4.1.12`) permitted the current release, 4.6.2; only the lockfile held it back. One zod everywhere is what lets the coming MCP plugin describe its tools in the same language the rest of Nextly describes content.

## What changes

- The four manifests state `^4.6.2`, the version tested here. **Every lockfile line that changed names zod**: the four importers, the package itself, and the peer suffixes `drizzle-orm` and `zod-validation-error` carry. `pnpm install --frozen-lockfile` is clean.
- **One behaviour moved with it.** zod 4.4+ refuses a schema whose registrations collide on an `id` in `z.toJSONSchema` ("Duplicate schema id") rather than emitting a shorter schema. That is exactly the corruption the block-document emitter already guarded after the fact (prototype pollution of `id`). The emitter turns that refusal into its own `SCHEMA_DERIVATION_FAILED`, so a caller sees one error for one reason, and `parseBlockDocument` answers "cannot be checked" rather than throwing when its field list is derived cold under the corruption; its after-the-fact guard stays for a corruption zod does not see. One test updated, one added (a fresh module loaded with the pollution present), two mutation controls red and restored.
- Changeset: `.changeset/one-zod-the-mcp-server-can-share.md`, patch across the group as every changeset here is.

## What was read before bumping

The release notes 4.2 to 4.6 name real behaviour changes; the suites are the gate and these were checked by hand: `.pick()/.omit()/.merge()` on refined objects now throw (the two `.merge()` receivers here are plain `z.object`s; the `.omit` is generated text); string `.min/.max/.length` count code points; the email regex and its JSON-Schema pattern changed (no test here asserts on either); tuple defaults; CUID tightened (unused).

## Verified

- `pnpm build` green; `pnpm lint` green after the build (before it, `import-x/no-unresolved` on `@nextlyhq/builder` is an ordering artefact); `pnpm test` green apart from the one block-document case this PR fixes; `pnpm test:integration:sqlite` 265 files green, 42 dialect-skipped.
- `pnpm check-types` is red on ONE line that is not this PR's: `collection-mutation.test.ts(345,9)` from #1754, which #1780 fixes. This branch takes it by merging `main` once #1780 lands; the CI typecheck job is red until then.
- Postgres and MySQL integration legs run in CI (Docker was hung locally).
