### PR TITLE
fix(release): close the zod changeset's frontmatter

### DIFF
--- a/.changeset/one-zod-the-mcp-server-can-share.md
+++ b/.changeset/one-zod-the-mcp-server-can-share.md
@@ -1,5 +1,4 @@
 ---
-
 "@nextlyhq/adapter-drizzle": patch
 "@nextlyhq/adapter-mysql": patch
 "@nextlyhq/adapter-postgres": patch
@@ -25,6 +24,7 @@
 "@nextlyhq/telemetry": patch
 "@nextlyhq/tsconfig": patch
 "@nextlyhq/ui": patch
+---
 
 zod is 4.6 now, from 4.1. The MCP server library needs 4.2 or newer, and a
 second copy of zod beside the first would make every schema a stranger to the


### PR DESCRIPTION
## What

`.changeset/one-zod-the-mcp-server-can-share.md` (from #1784) opened its frontmatter and never closed it: the package list ran into a blank line and then the prose, with no second `---`. `@changesets/parse` refuses the file, so `pnpm changeset status` fails on every checkout of `main` and the release workflow's version step will fail on it (`release.yml` is queued on `main` right now).

This closes the frontmatter and drops the blank line after the opening marker, which is the shape every other changeset here has.

## Evidence

- Before: `pnpm changeset status` → `could not parse changeset - missing or invalid frontmatter` (index 712 of the pending set).
- After: `pnpm changeset status` exits 0 with the 25-package lockstep group plus the playground listed.
- `echo .changeset/one-zod-the-mcp-server-can-share.md | node scripts/release/check-changesets.mjs` → `Checked 1 changeset(s): all cover the group.` (the same checker CI runs on the PR's changesets).

No changeset of its own: this edits release metadata only.