### PR TITLE
fix(admin): a builder row id is only what the list mints, and a blank field is called unnamed

### DIFF
--- a/.changeset/a-builder-row-is-what-the-list-mints.md
+++ b/.changeset/a-builder-row-is-what-the-list-mints.md
@@ -1,0 +1,38 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The schema builder's drag announcements name every field, and its row ids are
+only the ones the list mints.
+
+A field just added to the canvas has no label and no name until its author
+fills them in, and it drags in that state: it was announced as nothing at all
+("Picked up , row 2") and, beside a named field, as "and Title". It is now
+called "an unnamed field", on the announcement and on the nested drag handle
+alike. A row id that is not `row-` followed by a canonical nonnegative integer
+no longer names a row, so a drop the reorder would refuse is no longer
+announced as a move.

--- a/packages/admin/src/components/features/schema-builder/builder-field-list/NestedFieldGroup.tsx
+++ b/packages/admin/src/components/features/schema-builder/builder-field-list/NestedFieldGroup.tsx
@@ -15,6 +15,7 @@ import { CSS } from "@dnd-kit/utilities";
 
 import * as Icons from "@admin/components/icons";
 import type { LucideIcon } from "@admin/components/icons";
+import { fieldSubject } from "@admin/lib/builder/builder-announcements";
 import { packIntoRows, parseWidth } from "@admin/lib/builder/reflow";
 import type { WidthField } from "@admin/lib/builder/reflow";
 import { cn } from "@admin/lib/utils";
@@ -165,7 +166,7 @@ function NestedFieldRow({
         {!readOnly && (
           <button
             type="button"
-            aria-label={`Reorder ${field.name}`}
+            aria-label={`Reorder ${fieldSubject(field)}`}
             className="text-muted-foreground select-none cursor-grab text-xs"
             {...attributes}
             {...listeners}

--- a/packages/admin/src/components/features/schema-builder/builder-field-list/__tests__/NestedFieldGroup.test.tsx
+++ b/packages/admin/src/components/features/schema-builder/builder-field-list/__tests__/NestedFieldGroup.test.tsx
@@ -74,6 +74,34 @@ describe("NestedFieldGroup", () => {
     expect(onEdit).toHaveBeenCalledWith("c1");
   });
 
+  it("names each child's handle for what the child is called, or that it is unnamed", () => {
+    // 🔴 The handle read `field.name`, so a child just added -- no label and
+    // no name yet -- had a handle called "Reorder " and a drag that announced
+    // nothing. It now says the same subject the announcement says: the label
+    // the card shows, else the name, else that the field is unnamed.
+    renderInDnd(
+      <NestedFieldGroup
+        parentField={{
+          id: "p1",
+          name: "heroSections",
+          label: "Hero Sections",
+          type: "repeater",
+          validation: {},
+          fields: [childField("c1", "title"), childField("c2", "", "")],
+        }}
+        onEditField={noop}
+        onDeleteField={noop}
+        onDuplicateField={noop}
+        onAddInsideParent={noop}
+      />
+    );
+    expect(
+      screen
+        .getAllByRole("button", { name: /^Reorder / })
+        .map(handle => handle.getAttribute("aria-label"))
+    ).toEqual(["Reorder Title Field", "Reorder an unnamed field"]);
+  });
+
   it("calls onAddInsideParent with the parent's id when +Add is clicked", async () => {
     const onAdd = vi.fn();
     renderInDnd(

--- a/packages/admin/src/lib/builder/builder-announcements.ts
+++ b/packages/admin/src/lib/builder/builder-announcements.ts
@@ -26,9 +26,23 @@ import {
 } from "./builder-rows";
 import { findFieldById, findParentContainerId } from "./field-transformers";
 
+/**
+ * What a field is called when spoken: its label, else its name, else that
+ * it has neither yet.
+ *
+ * A field just added to the canvas has an empty label AND an empty name until
+ * its author fills them in, and it is draggable in that state. Read as
+ * `label || name` it was announced as nothing at all -- "Picked up , row 2" --
+ * and a row holding one was "and Title". The fallback is a description rather
+ * than a placeholder name, so it cannot be mistaken for a field called that.
+ */
+export function fieldSubject(field: BuilderField): string {
+  return field.label || field.name || "an unnamed field";
+}
+
 /** "Title", or "First name and Last name" for a row holding two fields. */
 function labelsOf(fields: readonly BuilderField[]): string {
-  const labels = fields.map(f => f.label || f.name);
+  const labels = fields.map(fieldSubject);
   if (labels.length <= 1) return labels[0] ?? "an empty row";
   return `${labels.slice(0, -1).join(", ")} and ${labels[labels.length - 1]}`;
 }
@@ -45,7 +59,7 @@ export function builderAnnouncements(
       return row ? labelsOf(row.map(item => item._field)) : undefined;
     }
     const field = findFieldById([...fields], String(id));
-    return field ? field.label || field.name : undefined;
+    return field ? fieldSubject(field) : undefined;
   };
 
   const place = ({ id }: AnnouncedItem): string | undefined => {

--- a/packages/admin/src/lib/builder/builder-rows.test.ts
+++ b/packages/admin/src/lib/builder/builder-rows.test.ts
@@ -10,7 +10,7 @@
  * @module lib/builder/builder-rows.test
  */
 
-import type { Active } from "@dnd-kit/core";
+import type { Active, Over } from "@dnd-kit/core";
 import { describe, expect, it } from "vitest";
 
 import type { BuilderField } from "@admin/components/features/schema-builder/types";
@@ -77,8 +77,19 @@ describe("the rows the builder draws", () => {
 
   it("round-trips a row id", () => {
     expect(builderRowIndex(builderRowId(3))).toBe(3);
+    expect(builderRowIndex(builderRowId(0))).toBe(0);
     expect(builderRowIndex("field_abc")).toBeUndefined();
     expect(builderRowIndex("row-x")).toBeUndefined();
+  });
+
+  it("names a row only for the ids the list mints", () => {
+    // 🔴 `Number()` read `row--1` as -1 and `row-1.5` as a fraction. Each
+    // sat below the acceptance rule's upper bound, so a drop was announced as
+    // a move while the reorder's own range check refused it. Only a canonical
+    // nonnegative integer -- what `builderRowId` writes -- names a row.
+    for (const id of ["row--1", "row-1.5", "row-01", "row-", "row-1e2"]) {
+      expect(builderRowIndex(id), id).toBeUndefined();
+    }
   });
 });
 
@@ -102,6 +113,14 @@ describe("what a drag on the canvas says", () => {
     data: { current: undefined },
     rect: { current: { initial: null, translated: null } },
   });
+  // A droppable carries a resolved rect where a draggable carries a ref to
+  // one; the sentences read neither, so both are empty here.
+  const over = (id: string): Over => ({
+    id,
+    data: { current: undefined },
+    rect: { width: 0, height: 0, top: 0, left: 0, right: 0, bottom: 0 },
+    disabled: false,
+  });
 
   it("names every field in a row, and places the row among the rows drawn", () => {
     // Two half-width fields share row 1; the hidden field takes none; the
@@ -121,6 +140,33 @@ describe("what a drag on the canvas says", () => {
     );
   });
 
+  it("says a field with no label and no name yet is unnamed, rather than nothing", () => {
+    // 🔴 A field just added to the canvas has both empty until its author
+    // fills them in, and it drags in that state. Read as `label || name` it
+    // was announced as "Picked up , row 2" and, beside a named field, as
+    // "and Title".
+    const blank = field("new_1", { name: "", label: "", width: "50%" });
+    const speak = builderAnnouncements([
+      field("title", { label: "Title", width: "50%" }),
+      blank,
+      field("new_2", { name: "", label: "" }),
+      field("gallery", {
+        type: "repeater",
+        label: "Gallery",
+        fields: [field("new_3", { name: "", label: "" })],
+      } as Partial<BuilderField>),
+    ]);
+    expect(speak.onDragStart({ active: at("row-0") })).toBe(
+      "Picked up Title and an unnamed field, row 1 of 3."
+    );
+    expect(speak.onDragStart({ active: at("row-1") })).toBe(
+      "Picked up an unnamed field, row 2 of 3."
+    );
+    expect(speak.onDragStart({ active: at("new_3") })).toBe(
+      "Picked up an unnamed field, position 1 of 1."
+    );
+  });
+
   it("says a drop the handler refuses moved nothing", () => {
     // 🔴 A nested field released over a field in ANOTHER container is refused
     // by the drop handler, and the generic landing sentence said "moved to"
@@ -134,13 +180,13 @@ describe("what a drag on the canvas says", () => {
       } as Partial<BuilderField>),
     ];
     const speak = builderAnnouncements(withTwoContainers);
-    expect(speak.onDragEnd({ active: at("credit"), over: at("note") })).toBe(
+    expect(speak.onDragEnd({ active: at("credit"), over: over("note") })).toBe(
       "Credit cannot move there. Nothing moved."
     );
     // The accepted case keeps its landing sentence.
-    expect(speak.onDragEnd({ active: at("credit"), over: at("caption") })).toBe(
-      "Credit moved to position 1 of 2."
-    );
+    expect(
+      speak.onDragEnd({ active: at("credit"), over: over("caption") })
+    ).toBe("Credit moved to position 1 of 2.");
   });
 
   it("never reads a row id or a field id aloud", () => {
@@ -180,5 +226,9 @@ describe("which drops the canvas accepts", () => {
 
   it("refuses a row index the canvas does not draw", () => {
     expect(builderDropAccepted(fields, "row-0", "row-9")).toBe(false);
+    // Below the count too: a negative index passes `< count` and is refused
+    // by the reorder, so accepting it here announces a move that never
+    // happens.
+    expect(builderDropAccepted(fields, "row-0", "row--1")).toBe(false);
   });
 });

--- a/packages/admin/src/lib/builder/builder-rows.ts
+++ b/packages/admin/src/lib/builder/builder-rows.ts
@@ -56,11 +56,18 @@ export function builderRowId(index: number): string {
   return `row-${index}`;
 }
 
-/** The row index a sortable id names, or undefined for any other id. */
+/**
+ * The row index a sortable id names, or undefined for any other id.
+ *
+ * Only the ids `builderRowId` mints -- `row-` and a canonical nonnegative
+ * integer -- name a row. `Number()` alone read `row--1` as -1 and `row-1.5`
+ * as a fraction, and each passed the acceptance rule's upper bound while the
+ * reorder refused it, so the announcement described a move the handler had
+ * just declined.
+ */
 export function builderRowIndex(id: string): number | undefined {
-  if (!id.startsWith("row-")) return undefined;
-  const index = Number(id.slice("row-".length));
-  return Number.isNaN(index) ? undefined : index;
+  const match = /^row-(0|[1-9][0-9]*)$/.exec(id);
+  return match ? Number(match[1]) : undefined;
 }
 
 /**


### PR DESCRIPTION
## What

Follow-up to #1776, which merged while its last review round was being worked. Two findings from that round, both on the schema builder canvas:

**A row id is only what the list mints.** `builderRowIndex` read `row--1` as `-1` and `row-1.5` as a fraction: each sat below `builderDropAccepted`'s upper bound, so a drop was announced as a move while `reorderRows`' own range check refused it. Only `row-` followed by a canonical nonnegative integer — what `builderRowId` writes — names a row now.

**A field with no label and no name yet is called unnamed.** A field just added to the canvas has both empty until its author fills them in, and it drags in that state. Read as `label || name` it was announced as nothing at all (`Picked up , row 2`) and, beside a named field, as `and Title`. `fieldSubject` is now what a field is called when spoken — its label, else its name, else "an unnamed field" — and the nested drag handle says the same subject rather than a bare `field.name`.

Also fixes the announcement test's drop-target fixture, which was typed as an `Active` where dnd-kit's `onDragEnd` takes an `Over` (`disabled` missing) — `pnpm --filter @nextlyhq/admin check-types` was red on #1776's head.

## Evidence

- `builder-rows.test.ts`: `row--1`, `row-1.5`, `row-01`, `row-`, `row-1e2` name no row; `builderDropAccepted(fields, "row-0", "row--1")` is false; a blank field is announced as "an unnamed field" alone, in a row beside "Title", and as a nested child.
- `NestedFieldGroup.test.tsx`: the handles read `Reorder Title Field` and `Reorder an unnamed field`.
- Break-verified: the parser back on `Number()` fails two cases; the subject back on `label || name` fails one.
- Gates on this branch: admin `check-types`, `lint`, full suite (425 files, 4263 tests), `check:comments`, fallow `pass`.

One changeset, all 25 packages.