### PR TITLE
refactor(nextly): one tail for every transactional write wrapper

### DIFF
--- a/.changeset/one-tail-for-every-transactional-write.md
+++ b/.changeset/one-tail-for-every-transactional-write.md
@@ -1,0 +1,29 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+`createEntryInTransaction`, `updateEntryInTransaction` and `deleteEntryInTransaction` on the collection service share one tail: collect what the write left for `withTransaction`, then convert a failed envelope. A failed transactional create now carries the collection in its log context and a failed transactional delete now logs a warning, as the update already did. Nothing on the wire changes.

--- a/packages/nextly/src/domains/collections/services/collection-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-service.ts
@@ -327,6 +327,49 @@ export class CollectionService extends BaseService {
   }
 
   /**
+   * The tail every `*InTransaction` wrapper shares: collect what the write left
+   * for `withTransaction` to flush after commit, then turn a failed envelope
+   * into the error it came from and hand back the data of a successful one.
+   *
+   * Collected BEFORE the success check, and that ordering is the contract. The
+   * mutation layer sets the intent only once the row is written and carries it
+   * even on a hook-failure result, so a caller that commits despite the failure
+   * still busts the tags; a genuine rollback drops the collector unflushed, so
+   * collecting first is always safe.
+   *
+   * Every failure goes through the converter, including the code-less 404 and
+   * 403 that used to short-circuit to a factory: the converter answers those
+   * with the same generic error, the identifiers stay in the log context and
+   * never reach the wire, and short-circuiting only meant those two outcomes
+   * arrived without the failure they came from.
+   */
+  private settleTxWrite<T>(
+    tx: TransactionContext,
+    result: Parameters<CollectionService["mapLegacyErrorToNextlyError"]>[0] & {
+      revalidationIntent?: RevalidationIntent;
+      eventRecorded?: boolean;
+    },
+    failure: { message: string; logContext: Record<string, unknown> }
+  ): T {
+    this.collectTxIntent(tx, result.revalidationIntent);
+    this.collectTxEvent(tx, result.eventRecorded);
+    this.collectTxCommittedWrite(tx, result.success);
+
+    if (!result.success) {
+      this.logger.warn(failure.message, {
+        ...failure.logContext,
+        message: result.message,
+        statusCode: result.statusCode,
+      });
+      throw this.mapLegacyErrorToNextlyError(result, {
+        entity: "entry",
+        ...failure.logContext,
+      });
+    }
+    return result.data as T;
+  }
+
+  /**
    * Register dynamic collection schemas for runtime use.
    *
    * This should be called during app initialization to register
@@ -921,30 +964,17 @@ export class CollectionService extends BaseService {
       data
     );
 
-    // Collect before the success check. The mutation layer sets the intent only
-    // once the row is written and carries it even on a hook-failure result, so a
-    // caller that commits despite the failure still busts the tags; a genuine
-    // rollback drops the collector unflushed, so collecting here is always safe.
-    // withTransaction flushes what was collected once the transaction commits.
-    this.collectTxIntent(tx, result.revalidationIntent);
-    this.collectTxEvent(tx, result.eventRecorded);
-    this.collectTxCommittedWrite(tx, result.success);
-
-    if (!result.success) {
-      this.logger.warn("Entry creation in transaction failed", {
-        collectionName,
-        message: result.message,
-        statusCode: result.statusCode,
-      });
-      throw this.mapLegacyErrorToNextlyError(result);
-    }
+    const entry = this.settleTxWrite<CollectionEntry>(tx, result, {
+      message: "Entry creation in transaction failed",
+      logContext: { collectionName },
+    });
 
     this.logger.info("Entry created in transaction", {
       collectionName,
-      entryId: (result.data as CollectionEntry | null)?.id,
+      entryId: entry?.id,
     });
 
-    return result.data as CollectionEntry;
+    return entry;
   }
 
   /**
@@ -984,36 +1014,17 @@ export class CollectionService extends BaseService {
       data
     );
 
-    // Collect before the success check, so a caller that commits despite a
-    // post-write hook failure still busts the tags (see createEntryInTransaction).
-    this.collectTxIntent(tx, result.revalidationIntent);
-    this.collectTxEvent(tx, result.eventRecorded);
-    this.collectTxCommittedWrite(tx, result.success);
-
-    if (!result.success) {
-      // Every failure goes through the converter, including the code-less 404
-      // and 403 that used to short-circuit to a factory here. The converter
-      // answers those with the same generic error -- the identifiers stay in
-      // the log context and never reach the wire -- and short-circuiting only
-      // meant those two outcomes arrived without the failure they came from.
-      this.logger.warn("Entry update in transaction failed", {
-        collectionName,
-        entryId,
-        message: result.message,
-      });
-      throw this.mapLegacyErrorToNextlyError(result, {
-        entity: "entry",
-        collectionName,
-        entryId,
-      });
-    }
+    const entry = this.settleTxWrite<CollectionEntry>(tx, result, {
+      message: "Entry update in transaction failed",
+      logContext: { collectionName, entryId },
+    });
 
     this.logger.info("Entry updated in transaction", {
       collectionName,
       entryId,
     });
 
-    return result.data as CollectionEntry;
+    return entry;
   }
 
   /**
@@ -1049,24 +1060,10 @@ export class CollectionService extends BaseService {
       ...forwardedFromContext(context),
     });
 
-    // Collect before the success check, so a caller that commits despite a
-    // post-delete hook failure still busts the tags (see createEntryInTransaction).
-    this.collectTxIntent(tx, result.revalidationIntent);
-    this.collectTxEvent(tx, result.eventRecorded);
-    this.collectTxCommittedWrite(tx, result.success);
-
-    if (!result.success) {
-      // Every failure goes through the converter, including the code-less 404
-      // and 403 that used to short-circuit to a factory here. The converter
-      // answers those with the same generic error -- the identifiers stay in
-      // the log context and never reach the wire -- and short-circuiting only
-      // meant those two outcomes arrived without the failure they came from.
-      throw this.mapLegacyErrorToNextlyError(result, {
-        entity: "entry",
-        collectionName,
-        entryId,
-      });
-    }
+    this.settleTxWrite<unknown>(tx, result, {
+      message: "Entry deletion in transaction failed",
+      logContext: { collectionName, entryId },
+    });
 
     this.logger.info("Entry deleted in transaction", {
       collectionName,


### PR DESCRIPTION
## What

`createEntryInTransaction`, `updateEntryInTransaction` and `deleteEntryInTransaction` on `CollectionService` each ended with the same block: collect the revalidation intent, the outbox event and the committed write for `withTransaction` to flush after commit, then convert a failed envelope into the error it came from. Measured on `main` before this, the create and update bodies were 66.7% similar by difflib, and a one-line addition in #1654 tipped them over Fallow's clone threshold. One private method, `settleTxWrite`, holds the tail now.

## What had to survive

The collect-before-success-check ordering, and its reason, which the create wrapper carried as a comment and the other two referenced. The mutation layer sets the intent only once the row is written and carries it even on a hook-failure result, so a caller that commits despite the failure still busts the tags; a rollback drops the collector unflushed. The ordering is inside the one method, with that paragraph on it.

## What changes at the edges, log context only

- A failed transactional create's error now carries `entity: "entry"` and the collection in its log context, as update and delete already did.
- A failed transactional delete now logs a warning, as create and update already did.
- The update warning now includes the status code, as create's already did.

Nothing on the wire changes. The 21 suites that reach these wrappers (unit and integration) pass. Patch changeset, every package.

Closes the ledger's `transactional-write-tails-are-three-copies`.
