### PR TITLE
fix(release): close the super-admin key changeset's frontmatter

### DIFF
--- a/.changeset/a-super-admins-key-copies-the-catalogue.md
+++ b/.changeset/a-super-admins-key-copies-the-catalogue.md
@@ -1,5 +1,4 @@
 ---
-
 "@nextlyhq/adapter-drizzle": patch
 "@nextlyhq/adapter-mysql": patch
 "@nextlyhq/adapter-postgres": patch
@@ -25,6 +24,7 @@
 "@nextlyhq/telemetry": patch
 "@nextlyhq/tsconfig": patch
 "@nextlyhq/ui": patch
+---
 
 An API key created by a Super Admin copies the permission catalogue rather
 than the role's rows. A Super Admin's power is a bypass, and the role only


### PR DESCRIPTION
## What

Second instance of #1791, one commit later: `.changeset/a-super-admins-key-copies-the-catalogue.md` (landed in `cd9554690`) opened its frontmatter and never closed it — the package list runs into a blank line and the prose with no second `---`. `@changesets/parse` refuses the file, so `pnpm changeset status` fails on `main` and `release.yml`'s version step will fail on it.

Closing marker added after the 25th package line; the blank after the opening marker removed — the shape every other changeset has. One line.

#1794 edits this file's prose further down (from line 45); the hunks do not overlap, so it merges either way. If that branch also closes the frontmatter, its rebase conflicts on this one line — resolve to either, they are identical.

## Evidence

- `echo .changeset/a-super-admins-key-copies-the-catalogue.md | node scripts/release/check-changesets.mjs` → `Checked 1 changeset(s): all cover the group.`
- Scanned every `.changeset/*.md` on `origin/main` for fewer than two `---` lines: this was the only one left after #1791.

No changeset of its own: this edits release metadata only.