### PR TITLE
fix(root): check a staged changeset at commit time

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -37,4 +37,8 @@ else
   echo "  CI will still run the scan on your PR."
 fi
 
-npx lint-staged
+# Serially, not in parallel. `.changeset/*.md` matches two globs in
+# lint-staged.config.mjs -- prettier, which rewrites the file, and the
+# changeset checker, which reads it -- and run at once the checker can read a
+# file prettier is halfway through writing.
+npx lint-staged --concurrent false

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -4,4 +4,14 @@ export default {
     `prettier --write ${files.map((f) => JSON.stringify(f)).join(' ')}`,
   ],
   '*.{json,css,scss,md}': 'prettier --write',
+  // A changeset is read by the release, and a malformed one — a frontmatter
+  // that never closes, a package missing from the lockstep group — fails
+  // `changeset version` for everybody once it is on main. The same checker
+  // CI runs on a pull request's changesets runs here on the staged ones, so
+  // the refusal reaches the author at commit time rather than after a merge
+  // that happened while CI was still queued. Two such files landed on main
+  // in one afternoon that way.
+  '.changeset/*.md': (files) => [
+    `node scripts/release/check-changesets.mjs ${files.map((f) => JSON.stringify(f)).join(' ')}`,
+  ],
 }


### PR DESCRIPTION
## What

Two changesets whose frontmatter never closed reached `main` this afternoon (#1784's, repaired in #1791; then `cd9554690`'s, repaired in #1795). Each broke `pnpm changeset status` for every checkout of `main` and would have failed the release's version step. CI's `Changeset covers the lockstep group` step refuses exactly these files — both merged while CI was still queued, so the gate ran after the merge.

The same checker, `scripts/release/check-changesets.mjs`, now runs from lint-staged on any staged `.changeset/*.md`, so the refusal reaches the author at commit time regardless of the CI queue. `.husky/pre-commit` runs lint-staged with `--concurrent false`: the changeset glob and the prettier glob both match those files, and run in parallel the checker can read a file prettier is halfway through writing.

## Evidence

Through the real hook, on this branch:

- staged a changeset with an unclosed frontmatter → `git commit` refused: `✖ .changeset/zz-probe-malformed.md: the frontmatter is missing or has a line this cannot read...`
- staged a copy of an existing well-formed changeset → `git commit` succeeded with `Checked 1 changeset(s): all cover the group.` (probe commit reset and the file removed before this push)

CI-only/tooling change — no changeset.