### PR TITLE
fix(nextly): a trusted batch update has a trusted path

### DIFF
--- a/.changeset/a-trusted-batch-update-has-a-trusted-path.md
+++ b/.changeset/a-trusted-batch-update-has-a-trusted-path.md
@@ -1,0 +1,29 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+`updateEntries` on the collection entry service now takes `overrideAccess`, as `createEntries` already did: the collection gate, the publish-transition pre-resolve and every per-entry write skip access when it is set. Before, a trusted batch update had no trusted path and was judged as an anonymous caller, so every row was refused on a collection whose update rule wants a user.

--- a/packages/nextly/src/domains/collections/__tests__/bulk-update-override-access.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/bulk-update-override-access.integration.test.ts
@@ -147,10 +147,9 @@ describe("bulk update honours overrideAccess (integration)", () => {
       [{ id, data: { internalNote: "after" } }]
     );
     // Only what this case is about: the protected field did not change. The
-    // row itself fails here because the stripped patch is empty, and the
-    // transactional update refuses an empty patch where the ordinary one does
-    // not; that is the ledger's transactional-update-with-an-empty-patch-fails,
-    // not this flag.
+    // row itself fails here because stripping the field leaves an empty
+    // patch, and the transactional update refuses an empty patch where the
+    // ordinary one does not; that is a property of the patch, not of the flag.
     expect(unelevated.successful).toBe(0);
     let read = await handler.getEntry({
       collectionName: "pages",

--- a/packages/nextly/src/domains/collections/__tests__/bulk-update-override-access.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/bulk-update-override-access.integration.test.ts
@@ -1,0 +1,89 @@
+/**
+ * A trusted batch update has a trusted path.
+ *
+ * `createEntries` took `overrideAccess` and `updateEntries` did not, so a
+ * plugin's `updateMany(..., { as: "system" })` or a seed's batch update was
+ * judged as an anonymous caller at the collection gate and refused every row
+ * on a collection whose update rule wants a user. Asserted through a booted
+ * instance with such a rule, both ways: elevated succeeds, and the same batch
+ * without elevation is refused, so the parameter cannot be a no-op.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../../../config";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import type { CollectionEntryService } from "../../../services/collections/collection-entry-service";
+
+let current: TestNextly | undefined;
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+async function boot() {
+  current = await createTestNextly({
+    collections: [
+      defineCollection({
+        slug: "notes",
+        access: {
+          create: () => true,
+          read: () => true,
+          // Anyone signed in may update; nobody anonymous may.
+          update: ({ user }) => Boolean(user),
+        },
+        fields: [text({ name: "title" })],
+      }),
+    ],
+  });
+  // Keyed by service NAME: `ServiceMap` already maps it to its type.
+  const handler = current.getService("collectionsHandler");
+  const entries = handler.getEntryService() as CollectionEntryService;
+  const created = await handler.createEntry(
+    { collectionName: "notes", overrideAccess: true },
+    { title: "before" }
+  );
+  const id = (created.data as { id: string }).id;
+  return { handler, entries, id };
+}
+
+describe("bulk update honours overrideAccess (integration)", () => {
+  it("updates without a user when elevated", async () => {
+    const { handler, entries, id } = await boot();
+
+    const result = await entries.updateEntries(
+      { collectionName: "notes", overrideAccess: true },
+      [{ id, data: { title: "after" } }]
+    );
+
+    expect(result.errors).toEqual([]);
+    expect(result.successful).toBe(1);
+    const read = await handler.getEntry({
+      collectionName: "notes",
+      entryId: id,
+      overrideAccess: true,
+    });
+    expect((read.data as { title?: string })?.title).toBe("after");
+  });
+
+  it("still refuses the same batch without elevation", async () => {
+    // The control: an implementation that ignored the gate entirely would
+    // pass the case above. The rule wants a user and this call has none.
+    const { handler, entries, id } = await boot();
+
+    const result = await entries.updateEntries({ collectionName: "notes" }, [
+      { id, data: { title: "after" } },
+    ]);
+
+    expect(result.successful).toBe(0);
+    expect(result.failed).toBe(1);
+    const read = await handler.getEntry({
+      collectionName: "notes",
+      entryId: id,
+      overrideAccess: true,
+    });
+    expect((read.data as { title?: string })?.title).toBe("before");
+  });
+});

--- a/packages/nextly/src/domains/collections/__tests__/bulk-update-override-access.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/bulk-update-override-access.integration.test.ts
@@ -68,6 +68,114 @@ describe("bulk update honours overrideAccess (integration)", () => {
     expect((read.data as { title?: string })?.title).toBe("after");
   });
 
+  it("publishes past a refusing publish rule when elevated", async () => {
+    // Passes the collection gate (update allows everyone) so the batch reaches
+    // the transition pre-resolve, which is what must be told about the
+    // elevation; a gate-only forwarding leaves it refusing.
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "posts",
+          status: true,
+          access: {
+            create: () => true,
+            read: () => true,
+            update: () => true,
+            publish: () => false,
+          },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const handler = current.getService("collectionsHandler");
+    const entries = handler.getEntryService() as CollectionEntryService;
+    const created = await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "draft", status: "draft" }
+    );
+    const id = (created.data as { id: string }).id;
+
+    const refused = await entries.updateEntries({ collectionName: "posts" }, [
+      { id, data: { status: "published" } },
+    ]);
+    expect(refused.successful).toBe(0);
+    expect(refused.failed).toBe(1);
+
+    const elevated = await entries.updateEntries(
+      { collectionName: "posts", overrideAccess: true },
+      [{ id, data: { status: "published" } }]
+    );
+    expect(elevated.errors).toEqual([]);
+    expect(elevated.successful).toBe(1);
+    const read = await handler.getEntry({
+      collectionName: "posts",
+      entryId: id,
+      overrideAccess: true,
+    });
+    expect((read.data as { status?: string })?.status).toBe("published");
+  });
+
+  it("writes a field whose own rule refuses the caller when elevated", async () => {
+    // Passes the collection gate and the transition; only the per-entry write
+    // judges the field rule. Without the flag reaching the worker the field
+    // is dropped from the write and the row keeps its old value.
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "pages",
+          access: { create: () => true, read: () => true, update: () => true },
+          fields: [
+            text({ name: "title" }),
+            text({
+              name: "internalNote",
+              access: { update: ({ req }) => Boolean(req.user) },
+            }),
+          ],
+        }),
+      ],
+    });
+    const handler = current.getService("collectionsHandler");
+    const entries = handler.getEntryService() as CollectionEntryService;
+    const created = await handler.createEntry(
+      { collectionName: "pages", overrideAccess: true },
+      { title: "t", internalNote: "before" }
+    );
+    const id = (created.data as { id: string }).id;
+
+    const unelevated = await entries.updateEntries(
+      { collectionName: "pages" },
+      [{ id, data: { internalNote: "after" } }]
+    );
+    // Only what this case is about: the protected field did not change. The
+    // row itself fails here because the stripped patch is empty, and the
+    // transactional update refuses an empty patch where the ordinary one does
+    // not; that is the ledger's transactional-update-with-an-empty-patch-fails,
+    // not this flag.
+    expect(unelevated.successful).toBe(0);
+    let read = await handler.getEntry({
+      collectionName: "pages",
+      entryId: id,
+      overrideAccess: true,
+    });
+    expect((read.data as { internalNote?: string })?.internalNote).toBe(
+      "before"
+    );
+
+    const elevated = await entries.updateEntries(
+      { collectionName: "pages", overrideAccess: true },
+      [{ id, data: { internalNote: "after" } }]
+    );
+    expect(elevated.errors).toEqual([]);
+    read = await handler.getEntry({
+      collectionName: "pages",
+      entryId: id,
+      overrideAccess: true,
+    });
+    expect((read.data as { internalNote?: string })?.internalNote).toBe(
+      "after"
+    );
+  });
+
   it("still refuses the same batch without elevation", async () => {
     // The control: an implementation that ignored the gate entirely would
     // pass the case above. The rule wants a user and this call has none.

--- a/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
@@ -1555,8 +1555,8 @@ export class CollectionBulkService extends BaseService {
       /**
        * D35 system elevation, as on `createEntries`: the collection gate, the
        * transition pre-resolve and every per-entry write skip access. Without
-       * it a trusted batch update had no trusted path and a plugin's
-       * `updateMany(..., { as: "system" })` was judged as an anonymous caller.
+       * it a trusted batch update had no trusted path: a seed or an internal
+       * caller with no user was judged as an anonymous one at the gate.
        */
       overrideAccess?: boolean;
       authenticatedScope?: AuthenticatedScope;

--- a/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
@@ -1552,6 +1552,13 @@ export class CollectionBulkService extends BaseService {
     params: {
       collectionName: string;
       user?: UserContext;
+      /**
+       * D35 system elevation, as on `createEntries`: the collection gate, the
+       * transition pre-resolve and every per-entry write skip access. Without
+       * it a trusted batch update had no trusted path and a plugin's
+       * `updateMany(..., { as: "system" })` was judged as an anonymous caller.
+       */
+      overrideAccess?: boolean;
       authenticatedScope?: AuthenticatedScope;
     },
     entries: BulkUpdateEntry[],
@@ -1567,14 +1574,15 @@ export class CollectionBulkService extends BaseService {
     // 1. Check collection-level access FIRST (once for all entries)
     // Note: For update, we check access without document since we don't have it yet
     // Owner-only checks will be done per-entry when we fetch the document
+    const accessUser = params.overrideAccess ? undefined : params.user;
     const accessDenied =
       await this.accessService.checkCollectionAccess<BatchOperationResult>(
         params.collectionName,
         "update",
-        params.user,
+        accessUser,
         undefined,
         undefined,
-        undefined,
+        params.overrideAccess,
         undefined,
         // Judge a scoped API key on its OWN update grant, not the key owner's:
         // otherwise a super-admin-owned key without update-<slug> could
@@ -1603,7 +1611,8 @@ export class CollectionBulkService extends BaseService {
     const transitionAuth =
       await this.mutationService.resolveTransitionAuthorization({
         collectionName: params.collectionName,
-        accessUser: params.user,
+        accessUser,
+        overrideAccess: params.overrideAccess,
         authenticatedScope: params.authenticatedScope,
       });
 
@@ -2160,6 +2169,7 @@ export class CollectionBulkService extends BaseService {
       collectionName: string;
       user?: UserContext;
       authenticatedScope?: AuthenticatedScope;
+      overrideAccess?: boolean;
       /** Named so the per-item write's request facts survive the narrowing. */
       request?: Request;
     },

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -997,6 +997,7 @@ export class CollectionEntryService extends BaseService {
        */
       disableRevalidate?: boolean;
       user?: UserContext;
+      overrideAccess?: boolean;
       authenticatedScope?: AuthenticatedScope;
     },
     entries: BulkUpdateEntry[],


### PR DESCRIPTION
## What

`updateEntries` on `CollectionEntryService` and `CollectionBulkService` now takes `overrideAccess`, as `createEntries` has since D35. When set, the collection-level gate judges no user, the publish-transition pre-resolve is told, and each per-entry write skips access (the write's own params already carried the flag; it was never forwarded).

## Why

A trusted batch update had no trusted path: a plugin's system-elevated batch update or a seed was judged as an anonymous caller at the gate and refused every row on a collection whose update rule wants a user. The create path took the flag; the update path was the same method shape without it. Tracker 110, ledger `task:schema-bulk-update-override-access` (claimed with `--force` as mechanical: the sibling method is the design).

## Scope

The pooled `updateEntries` only, to match `createEntries`. Neither `createEntriesInTransaction` nor `updateEntriesInTransaction` takes the flag, and they stay alike.

## Tests

`bulk-update-override-access.integration.test.ts`: a collection whose `update` rule wants a user; an elevated batch with no user updates the row, and the same batch without elevation is refused and leaves the row untouched (the control that keeps the flag from being a no-op). Against `main`'s bulk service the elevated case fails. The three batch suites beside it pass.

Also: the pre-push hook refused my first push of this branch because the test file failed `check-types` under the tests tsconfig, which I had not run. The hook from #1781 doing what it was merged for.

Patch changeset, every package.
