### PR TITLE
refactor(nextly): resolve the read locale chain once

### DIFF
--- a/.changeset/resolve-locale-chain-once.md
+++ b/.changeset/resolve-locale-chain-once.md
@@ -1,0 +1,39 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A collection read, a single read and an embedded component read now resolve a
+translatable field through one language chain rather than three private copies
+of the same rule.
+
+Nothing published changes for a reader: the three copies agreed, and the
+per-request `fallbackLocale` contract — `false` or `"none"` for the requested
+language alone, a named locale to fall back through that locale's own chain,
+otherwise the configured chain under the global `fallback` switch — is exactly
+what each path answered before. What changes is that a future difference in
+how a single and a collection fall back is no longer possible by omission:
+there is one place to change, and the drift the three copies invited is closed.

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -134,12 +134,8 @@ import {
   type TranslationFilterState,
 } from "../../i18n/companion-join";
 import type { SanitizedLocalizationConfig } from "../../i18n/config/types";
-import { EVERY_TRANSLATION, NO_FALLBACK } from "../../i18n/locale-selector";
-import {
-  isValidLocale,
-  resolveFallbackChain,
-  resolveRequestedLocale,
-} from "../../i18n/resolve-locale";
+import { EVERY_TRANSLATION } from "../../i18n/locale-selector";
+import { resolveLocaleChain } from "../../i18n/resolve-locale";
 import {
   resolveCompanionColumn,
   resolveCompanionSchemaReadiness,
@@ -1009,42 +1005,6 @@ export class CollectionQueryService extends BaseService {
   // ============================================================
   // i18n (M4) — companion-aware read helpers
   // ============================================================
-
-  /**
-   * Resolve the fallback chain for a read request, or `null` when localization is off.
-   * `fallbackLocale === false | "none"` disables fallback (chain = just the requested locale);
-   * otherwise the requested locale's configured chain + default locale is used (spec §8).
-   */
-  private resolveLocaleChain(
-    locale: string | undefined,
-    fallbackLocale: string | false | undefined
-  ): string[] | null {
-    // `locale=all` is handled by a separate keyed-populate path — not a single-value chain.
-    if (!this.localization || locale === EVERY_TRANSLATION) return null;
-    const requested = resolveRequestedLocale(this.localization, locale);
-    // A per-request opt-out disables fallback: return the requested language only.
-    if (fallbackLocale === false || fallbackLocale === NO_FALLBACK) {
-      return [requested];
-    }
-    // A concrete per-request fallback locale overrides the configured chain: the
-    // requested locale first, then the named fallback's own chain (deduped).
-    if (
-      typeof fallbackLocale === "string" &&
-      isValidLocale(this.localization, fallbackLocale)
-    ) {
-      const seen = new Set<string>();
-      return [
-        requested,
-        ...resolveFallbackChain(this.localization, fallbackLocale),
-      ].filter(code => (seen.has(code) ? false : (seen.add(code), true)));
-    }
-    // The global localization.fallback switch (default true) disables fallback
-    // for ordinary reads when turned off.
-    if (!this.localization.fallback) {
-      return [requested];
-    }
-    return resolveFallbackChain(this.localization, requested);
-  }
 
   /**
    * `locale=all` populate (admin/export): set each localized field to a language-keyed object
@@ -2714,7 +2674,8 @@ export class CollectionQueryService extends BaseService {
       // i18n M4: resolve the locale chain + load the companion once, so both the sort
       // block (in-query ORDER BY on a localized column) and the post-query populate reuse
       // it. `null` when localization is off or the collection isn't localized.
-      const localeChain = this.resolveLocaleChain(
+      const localeChain = resolveLocaleChain(
+        this.localization,
         params.locale,
         params.fallbackLocale
       );
@@ -3445,12 +3406,13 @@ export class CollectionQueryService extends BaseService {
    * locale-scoped search or filter describes the SAME rows the page returns.
    */
   private async localeScope(params: FilteredReadParams): Promise<{
-    localeChain: ReturnType<CollectionQueryService["resolveLocaleChain"]>;
+    localeChain: string[] | null;
     companion: Awaited<
       ReturnType<CollectionFileManager["loadCompanionSchema"]>
     > | null;
   }> {
-    const localeChain = this.resolveLocaleChain(
+    const localeChain = resolveLocaleChain(
+      this.localization,
       params.locale,
       params.fallbackLocale
     );

--- a/packages/nextly/src/domains/field-groups/services/field-group-query-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-query-service.ts
@@ -16,10 +16,9 @@ import {
   populateCompanionFieldsAllLocales,
 } from "../../i18n/companion-join";
 import type { SanitizedLocalizationConfig } from "../../i18n/config/types";
-import { EVERY_TRANSLATION, NO_FALLBACK } from "../../i18n/locale-selector";
+import { EVERY_TRANSLATION } from "../../i18n/locale-selector";
 import {
-  isValidLocale,
-  resolveFallbackChain,
+  resolveLocaleChain,
   resolveRequestedLocale,
 } from "../../i18n/resolve-locale";
 import { buildCompanionSchema } from "../../i18n/runtime/companion-io";
@@ -288,10 +287,15 @@ export class FieldGroupQueryService extends BaseService {
     // the default locale), so a default-locale read still overlays the component's companion
     // values instead of returning the omitted main-table columns.
     const requested = resolveRequestedLocale(this.localization, locale);
-    const localeChain = this.resolveComponentLocaleChain(
+    // Through the shared resolver, so a component read falls back exactly as
+    // the collection and single reads around it do. `requested` is already
+    // resolved and is never `all` here, so the chain is never null; the
+    // fallback keeps the contract this path always had rather than asserting.
+    const localeChain = resolveLocaleChain(
+      this.localization,
       requested,
       fallbackLocale
-    );
+    ) ?? [requested];
     // Resolved before the overlay runs, because inside a transaction it can only be read and the
     // read itself must not be what fails.
     const readiness = await this.companionReadiness(companion, executor);
@@ -405,34 +409,6 @@ export class FieldGroupQueryService extends BaseService {
         }
       }
     }
-  }
-
-  /**
-   * Build the fallback chain for a component read, honoring a per-request `fallbackLocale`
-   * (`false`/`"none"` disables fallback; a named locale overrides the configured chain),
-   * mirroring the collection read path so the admin's no-fallback edit mode works for
-   * embedded components too.
-   */
-  private resolveComponentLocaleChain(
-    requested: string,
-    fallbackLocale: string | false | undefined
-  ): string[] {
-    if (!this.localization) return [requested];
-    if (fallbackLocale === false || fallbackLocale === NO_FALLBACK) {
-      return [requested];
-    }
-    if (
-      typeof fallbackLocale === "string" &&
-      isValidLocale(this.localization, fallbackLocale)
-    ) {
-      const seen = new Set<string>();
-      return [
-        requested,
-        ...resolveFallbackChain(this.localization, fallbackLocale),
-      ].filter(code => (seen.has(code) ? false : (seen.add(code), true)));
-    }
-    if (this.localization.fallback === false) return [requested];
-    return resolveFallbackChain(this.localization, requested);
   }
 
   setRelationshipService(service: CollectionRelationshipService): void {

--- a/packages/nextly/src/domains/i18n/resolve-locale.test.ts
+++ b/packages/nextly/src/domains/i18n/resolve-locale.test.ts
@@ -6,6 +6,7 @@ import {
   isValidLocale,
   resolveRequestedLocale,
   resolveFallbackChain,
+  resolveLocaleChain,
 } from "./resolve-locale";
 
 const cfg = normalizeLocalization({
@@ -32,5 +33,86 @@ describe("resolve-locale", () => {
   it("resolveFallbackChain walks the chain then defaultLocale, deduped", () => {
     expect(resolveFallbackChain(cfg, "de-CH")).toEqual(["de-CH", "de", "en"]);
     expect(resolveFallbackChain(cfg, "en")).toEqual(["en"]);
+  });
+});
+
+/**
+ * The chain a READ resolves through. One function because three services
+ * asked this question with three private copies, and a copy that drifts
+ * answers a translated field differently on a collection than on a single —
+ * silently, since both copies look correct.
+ */
+describe("resolveLocaleChain", () => {
+  it("is null with no localization, and null for every-translation", () => {
+    // No single language to resolve for: the caller populates every locale
+    // keyed by code instead, and a chain would be the wrong shape.
+    expect(resolveLocaleChain(undefined, "de", undefined)).toBeNull();
+    expect(resolveLocaleChain(cfg, "all", undefined)).toBeNull();
+  });
+
+  it("follows the requested locale's configured chain by default", () => {
+    expect(resolveLocaleChain(cfg, "de-CH", undefined)).toEqual([
+      "de-CH",
+      "de",
+      "en",
+    ]);
+  });
+
+  it("resolves an unknown or absent locale to the default first", () => {
+    expect(resolveLocaleChain(cfg, "fr", undefined)).toEqual(["en"]);
+    expect(resolveLocaleChain(cfg, undefined, undefined)).toEqual(["en"]);
+  });
+
+  it("a per-request opt-out is the requested locale alone", () => {
+    // The admin editor asks for this so an untranslated field reads blank
+    // rather than showing the fallback as if it were a translation.
+    expect(resolveLocaleChain(cfg, "de-CH", false)).toEqual(["de-CH"]);
+    expect(resolveLocaleChain(cfg, "de-CH", "none")).toEqual(["de-CH"]);
+  });
+
+  it("a named per-request fallback replaces the configured chain", () => {
+    // `?locale=de-CH&fallback-locale=en`: the requested locale, then the NAMED
+    // fallback's own chain — not de-CH's configured chain through `de`.
+    expect(resolveLocaleChain(cfg, "de-CH", "en")).toEqual(["de-CH", "en"]);
+  });
+
+  it("dedupes a named fallback that is the requested locale itself", () => {
+    expect(resolveLocaleChain(cfg, "de", "de")).toEqual(["de", "en"]);
+  });
+
+  it("ignores a named fallback that is not a configured locale", () => {
+    // Falls through to the configured chain rather than binding an unknown
+    // code into the query.
+    expect(resolveLocaleChain(cfg, "de-CH", "fr")).toEqual([
+      "de-CH",
+      "de",
+      "en",
+    ]);
+  });
+
+  it("the global fallback switch off is the requested locale alone", () => {
+    const noFallback = normalizeLocalization({
+      locales: ["en", { code: "de-CH", fallbackLocale: ["de"] }, "de"],
+      defaultLocale: "en",
+      fallback: false,
+    });
+    expect(resolveLocaleChain(noFallback, "de-CH", undefined)).toEqual([
+      "de-CH",
+    ]);
+  });
+
+  it("a named per-request fallback re-enables the chain under the global switch", () => {
+    const noFallback = normalizeLocalization({
+      locales: ["en", { code: "de-CH", fallbackLocale: ["de"] }, "de"],
+      defaultLocale: "en",
+      fallback: false,
+    });
+    // The per-request name is judged BEFORE the global switch, so a caller
+    // that asks for a specific fallback gets it even where the site default is
+    // no fallback at all.
+    expect(resolveLocaleChain(noFallback, "de-CH", "en")).toEqual([
+      "de-CH",
+      "en",
+    ]);
   });
 });

--- a/packages/nextly/src/domains/i18n/resolve-locale.ts
+++ b/packages/nextly/src/domains/i18n/resolve-locale.ts
@@ -2,6 +2,7 @@ import type {
   ResolvedLocale,
   SanitizedLocalizationConfig,
 } from "./config/types";
+import { EVERY_TRANSLATION, NO_FALLBACK } from "./locale-selector";
 
 /** The application's default locale code. */
 export function getDefaultLocale(cfg: SanitizedLocalizationConfig): string {
@@ -50,4 +51,53 @@ export function resolveFallbackChain(
   visit(code);
   visit(cfg.defaultLocale);
   return chain;
+}
+
+/**
+ * The ordered languages a READ resolves a translatable field through, or
+ * `null` when there is no single language to resolve for.
+ *
+ * One function rather than one per read path. A collection read, a single
+ * read and a component read each ask this, and each once carried its own copy;
+ * the copies agreed, and agreement is not the property that matters — a copy
+ * that drifts answers a translated field differently on a single than on the
+ * collection beside it, silently, because both copies still look correct.
+ *
+ * `null` for a caller with no localization, and for `locale=all`: that read
+ * populates every locale keyed by code, which is a different shape from a
+ * chain and is handled by its own path.
+ *
+ * Otherwise, in the order the decisions are judged:
+ * - the requested locale, resolved to the default when unknown or absent;
+ * - a per-request opt-out (`false` or `"none"`) is that locale alone — the
+ *   admin editor asks for this so an untranslated field reads blank rather
+ *   than showing the fallback as if it were a translation;
+ * - a per-request NAMED fallback is the requested locale followed by that
+ *   locale's own configured chain, deduped — `?locale=de&fallback-locale=en`
+ *   falls back to `en`, not through `de`'s chain. Judged BEFORE the global
+ *   switch, so it re-enables fallback for one read on a site that has it off;
+ * - the global `fallback` switch off is the requested locale alone;
+ * - else the requested locale's configured chain, ending at the default.
+ */
+export function resolveLocaleChain(
+  cfg: SanitizedLocalizationConfig | undefined,
+  locale: string | undefined,
+  fallbackLocale: string | false | undefined
+): string[] | null {
+  if (!cfg || locale === EVERY_TRANSLATION) return null;
+  const requested = resolveRequestedLocale(cfg, locale);
+  if (fallbackLocale === false || fallbackLocale === NO_FALLBACK) {
+    return [requested];
+  }
+  if (
+    typeof fallbackLocale === "string" &&
+    isValidLocale(cfg, fallbackLocale)
+  ) {
+    const seen = new Set<string>();
+    return [requested, ...resolveFallbackChain(cfg, fallbackLocale)].filter(
+      code => (seen.has(code) ? false : (seen.add(code), true))
+    );
+  }
+  if (!cfg.fallback) return [requested];
+  return resolveFallbackChain(cfg, requested);
 }

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -92,12 +92,7 @@ import {
   populateTranslationStatus,
 } from "../../i18n/companion-join";
 import type { SanitizedLocalizationConfig } from "../../i18n/config/types";
-import { EVERY_TRANSLATION, NO_FALLBACK } from "../../i18n/locale-selector";
-import {
-  isValidLocale,
-  resolveFallbackChain,
-  resolveRequestedLocale,
-} from "../../i18n/resolve-locale";
+import { resolveLocaleChain } from "../../i18n/resolve-locale";
 import {
   buildCompanionSchema,
   splitLocalizedWrite,
@@ -1076,7 +1071,8 @@ export class SingleQueryService extends BaseService {
     );
     // The language this read resolved to, shared by both expansions below so a
     // related row and a related row inside a component are judged alike.
-    const readLocale = this.resolveLocaleChain(
+    const readLocale = resolveLocaleChain(
+      this.localization,
       options.locale,
       options.fallbackLocale
     )?.[0];
@@ -2119,7 +2115,11 @@ export class SingleQueryService extends BaseService {
     fallbackLocale: string | false | undefined,
     statusFilterValues: readonly string[] | undefined
   ): Promise<void> {
-    const localeChain = this.resolveLocaleChain(locale, fallbackLocale);
+    const localeChain = resolveLocaleChain(
+      this.localization,
+      locale,
+      fallbackLocale
+    );
     if (!localeChain) return;
     // Gate on THIS single's flag: a non-localized single has no companion table, and
     // buildCompanionSchema would otherwise classify its text fields as translatable and query a
@@ -2259,39 +2259,6 @@ export class SingleQueryService extends BaseService {
             }
           : undefined,
     });
-  }
-
-  /**
-   * Build the requested→fallback locale chain, or `null` when localization is off. A per-request
-   * `fallbackLocale === false | "none"` disables fallback (chain = just the requested locale, so an
-   * untranslated field reads empty); a per-request string re-enables the chain even when the global
-   * flag is off; otherwise the global `fallback` flag decides. Mirrors the collection read path.
-   */
-  private resolveLocaleChain(
-    locale: string | undefined,
-    fallbackLocale: string | false | undefined
-  ): string[] | null {
-    if (!this.localization || locale === EVERY_TRANSLATION) return null;
-    const requested = resolveRequestedLocale(this.localization, locale);
-    // Per-request disable wins — the admin editor passes this so untranslated fields show blank.
-    if (fallbackLocale === false || fallbackLocale === NO_FALLBACK) {
-      return [requested];
-    }
-    // A concrete per-request fallback locale overrides the configured chain: the requested
-    // locale first, then the NAMED fallback's own chain (deduped) — not the requested locale's
-    // chain. Mirrors the collection read path so `?locale=de&fallback-locale=en` falls back to en.
-    if (
-      typeof fallbackLocale === "string" &&
-      isValidLocale(this.localization, fallbackLocale)
-    ) {
-      const seen = new Set<string>();
-      return [
-        requested,
-        ...resolveFallbackChain(this.localization, fallbackLocale),
-      ].filter(code => (seen.has(code) ? false : (seen.add(code), true)));
-    }
-    if (this.localization.fallback === false) return [requested];
-    return resolveFallbackChain(this.localization, requested);
   }
 
   // ============================================================


### PR DESCRIPTION
## Summary

Three services asked one question with three private copies: which languages does this read resolve a translatable field through, and in what order. `CollectionQueryService.resolveLocaleChain`, `SingleQueryService.resolveLocaleChain` and `FieldGroupQueryService.resolveComponentLocaleChain` each held the same decision sequence over the same inputs, and each already reached into `domains/i18n/resolve-locale.ts` for the chain walk at the end of it.

They agreed today. The two `resolveLocaleChain`s differed only in spelling the global switch `!fallback` against `=== false` — moot, since the sanitized config normalizes it to a boolean — and the component copy took an already-resolved locale and answered `[requested]` rather than `null` when localization was off. Agreement is not the property that matters: a copy that drifts answers a translated field differently on a single than on the collection beside it, silently, because both copies still look correct. And the clone group fired on every locale change as a standing reminder.

`resolveLocaleChain` is now one exported function beside `resolveFallbackChain`, the home the three copies were already importing from. The three private methods are deleted; five call sites take the function; the sixth touch point — a `ReturnType<CollectionQueryService["resolveLocaleChain"]>` naming the private member — becomes the type it always denoted. The component read keeps its contract through `?? [requested]`, unreachable in practice but what that path promised. Imports that only the deleted copies used are gone with them.

Follow-up to #1642, taken here rather than widened into it. Closes `finding:resolve-locale-chain-lives-twice` (raised by @mobeenabdullah on that PR).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [x] Refactor / chore (no user-facing change)

## Related issues

Follow-up to #1642. No issue.

## Changeset

- [x] I added a changeset (or this PR only touches non-publishable code: docs, tests, internal tooling, `apps/*`)
- [x] I selected the correct semver bump (patch / minor / major)

`.changeset/resolve-locale-chain-once.md` — all published packages, `patch`, lockstep, matching how the recent refactors on `main` recorded themselves.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm check-types`
- [x] `pnpm build`
- [ ] Manually verified the change

Nine cases added to the module's existing `resolve-locale.test.ts`, one per branch of the decision, each seen red before the function existed (`resolveLocaleChain is not a function`) and green after. The fixture is built with `normalizeLocalization`, so it is the sanitized shape the function actually receives rather than a hand-assembled object.

Two cases are worth naming: a per-request fallback equal to the requested locale dedupes to that locale plus its chain, and one that is not a configured locale falls through to the configured chain rather than binding an unknown code.

On the built tree: build 19/19; `check-types` 14/14; `eslint . --max-warnings 0` clean; **1,923 unit tests across 106 files** in the i18n, collections, singles and field-group suites; **255 passed** across the i18n, field-group and singles integration suites — the one failing file being the pre-existing `custom-read-constraint` fixture, which resolves a rule module through a file URL that percent-encodes the space in this checkout path and throws before the read runs.

`fallow audit --base origin/main` answers **`pass`**: nothing introduced on any axis, and no clone group touches the three former sites.

## Checklist

- [x] I read [CONTRIBUTING](../CONTRIBUTING.md) (if it exists)
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) spec (enforced by commitlint)
- [x] I targeted the `main` branch
- [x] I updated relevant documentation

## Screenshots / recordings

Not applicable — no admin or UI surface changes.

## Notes for reviewers

**The order of the decisions is the contract, so it is written down at the function.** Requested locale resolved to the default when unknown; a per-request opt-out (`false` / `"none"`) is that locale alone; a per-request *named* fallback is the requested locale then the named one's own chain, judged **before** the global switch so it re-enables fallback for one read on a site that has it off; the global switch off is the locale alone; else the configured chain ending at the default. The tests pin each step.

**`null` versus `[requested]`.** The collection and single paths answered `null` when localization was off or the read asked for every translation; the component path answered `[requested]`. The shared function keeps the `null` contract, since a `locale=all` read populates every locale keyed by code and a chain is the wrong shape for it. The component call site adds `?? [requested]` — localization is narrowed non-null there and a component read never asks for `all`, so it never fires, but it is what that path promised and it is one token.

**Constants.** `EVERY_TRANSLATION` and `NO_FALLBACK` come from `i18n/locale-selector.ts`, which does not import `resolve-locale.ts` back, so there is no cycle. Singles no longer imports either; collections keeps `EVERY_TRANSLATION` for its own `locale=all` checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Localization**
  - Standardized locale fallback behavior across collections, single entries, and embedded components.
  - Supports configured fallback chains, request-specific fallback choices, and disabling fallback when needed.
  - Prevents duplicate locales and ignores fallback locales that are not configured.
  - Preserves “all locales” requests without applying fallback resolution.

- **Bug Fixes**
  - Improved consistency so embedded component reads now follow the same locale fallback behavior as other content reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->