### PR TITLE
fix(ci): the hygiene gate diffs against the base branch as it is, not as it was at the last push

### DIFF
--- a/.github/workflows/code-hygiene.yml
+++ b/.github/workflows/code-hygiene.yml
@@ -90,15 +90,16 @@ jobs:
           fail-on-issues: true
           comment: false
           annotations: true
-          # The base to diff from is the base branch's CURRENT tip, named the
-          # way the envelope step below names it. Left unset, the action scopes
-          # to `pull_request.base.sha`, which GitHub records when the pull
-          # request is opened and never moves; the merge ref it audits is
-          # rebuilt against the live base, so every file the base gained while
-          # the pull request was open read as changed by it, and functions the
-          # author never touched failed the gate as introduced. On the merge
-          # ref, `origin/<base>...HEAD` has the live tip as its merge-base, so
-          # the scope is exactly the pull request.
+          # Diff from the base branch as it is now, named the way the envelope
+          # step below names it. Left unset, the action scopes to
+          # `pull_request.base.sha`, which GitHub sets when the pull request is
+          # opened or pushed to and does not move as the base branch advances;
+          # the merge ref it audits is rebuilt against the live base, so every
+          # file the base gained since the last push read as changed by the
+          # pull request, and functions its author never touched failed the
+          # gate as introduced. On the merge ref, `origin/<base>...HEAD` diffs
+          # from the merge's own base parent, so the scope is exactly the pull
+          # request.
           changed-since: origin/${{ github.base_ref }}
           # playground is a dev harness, not a published package. Excluding it
           # keeps the gate focused on the packages that ship to consumers and

--- a/.github/workflows/code-hygiene.yml
+++ b/.github/workflows/code-hygiene.yml
@@ -90,6 +90,16 @@ jobs:
           fail-on-issues: true
           comment: false
           annotations: true
+          # The base to diff from is the base branch's CURRENT tip, named the
+          # way the envelope step below names it. Left unset, the action scopes
+          # to `pull_request.base.sha`, which GitHub records when the pull
+          # request is opened and never moves; the merge ref it audits is
+          # rebuilt against the live base, so every file the base gained while
+          # the pull request was open read as changed by it, and functions the
+          # author never touched failed the gate as introduced. On the merge
+          # ref, `origin/<base>...HEAD` has the live tip as its merge-base, so
+          # the scope is exactly the pull request.
+          changed-since: origin/${{ github.base_ref }}
           # playground is a dev harness, not a published package. Excluding it
           # keeps the gate focused on the packages that ship to consumers and
           # prevents its intentional loose dependency declarations from


### PR DESCRIPTION
## What

The `Changed files` hygiene gate now diffs a pull request against the base branch **as it is now** (`origin/${{ github.base_ref }}`), not against `pull_request.base.sha`, which does not move when the base branch advances.

Ledger: `task:ci-hygiene-gate-diffs-against-current-main`, implementing `finding:fallow-ci-blames-a-pr-for-main-moving` (open since 2026-09-02; remedy named there, unowned until now).

## What was true

The fallow action, when `changed-since` is not set, scopes its audit to files changed since `github.event.pull_request.base.sha` (`action.yml` L385 → `PR_BASE_SHA`; `analyze.sh` L433-438; then `git diff <sha>...HEAD`). GitHub sets `base.sha` when the pull request is opened (the base tip then — #1804: `0121364ce`, while its branch point is `da323d583`) and again on each push (the merge-base of head and base then — #1796: `ebf8f78d9`; #1803 moved to `da323d583` after a merge of `main`, measured by a peer session). It does not follow the base branch afterwards. The job checks out `refs/pull/N/merge`, which GitHub rebuilds against the **live** base. So the diff the gate audited was "the pull request + everything `main` gained since the last push", and `--gate new-only` attributed the base's pre-existing findings to the pull request. With runs waiting 40-60 minutes in the queue today, that window was rarely empty.

Two observations on #1787 (whose `base.sha` was `c80d0da`, its merge-base at its last push, while `main` had advanced 20 commits by the time the run executed), 13:22Z (`4cb335098`) and 15:12Z (`1037dbbf3`): `verdict=fail` on CRAP in `listEntries`/`getEntry` (`collection-query-service.ts`, changed on `main` by #1642), `generateCollectionUpdate` (#1793), `saveMultiComponentsInTx` (#1788), `invalidatePermissionCache` (#1783) — the pull request's 17 files include none of those. Reproduced the mechanism locally: the same head audited with `--changed-since origin/main` (fallow 3.15.0, the repo's own) → `verdict=warn`, `changed_files_count=17`, `complexity_introduced=0`; with `--changed-since c80d0da` → the CI verdict. The job's own envelope step (`Generate audit review envelope`) already used `origin/$BASE_REF`; only the gating call did not, so the two invocations in one job measured different things.

## How

One input on the action step, `changed-since: origin/${{ github.base_ref }}`, with the reason beside it. `auto-changed-since` is documented as ignored when `changed-since` is set. On the merge ref, `origin/main...HEAD` has the live tip as its merge-base, so the scope is exactly the pull request — the same base the envelope step and the local `pnpm fallow:audit` use.

## Verification

- `pnpm test:scripts` 1344/1344 (includes `github-yaml-parses.test.mjs`, which loads every workflow).
- This pull request's own `Changed files` job ran on the fixed workflow (a `pull_request` run takes the workflow from the merge ref): its log shows `INPUT_CHANGED_SINCE: origin/main`, no "Auto-scoping analysis to files changed since PR base" notice, and `verdict=pass` on `4f81bfb79`.
- Correction to the first commit's body, which cited #1794 as passing and then failing with nothing pushed between: a push landed at 14:24Z and the failing run is on it (`3393e336e`), and the functions it names are in files #1794 changes — that example is withdrawn. The second commit also corrects the workflow comment's account of when `base.sha` is set.
- Not verified here: the action's behaviour when `origin/<base_ref>` is absent from the checkout — `actions/checkout` with `fetch-depth: 0` fetches every branch, and the envelope step in this job has relied on that ref all along.

No changeset: workflow-only.
