### PR TITLE
feat(admin): the dashboard is arranged from the md breakpoint up

### DIFF
--- a/.changeset/the-dashboard-is-arranged-from-md-up.md
+++ b/.changeset/the-dashboard-is-arranged-from-md-up.md
@@ -1,0 +1,37 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The dashboard is arranged from the `md` breakpoint up.
+
+Below it every card is already full width in one column, so an arrangement is
+a stacked list with little to reorder, and touch drag is where accessibility
+regressions hide. The Edit dashboard control is no longer offered there -- the
+arrangement made on a wider screen applies at every width -- and an edit
+already under way keeps its Save, Cancel and Reset whatever the window is
+narrowed to, so a mid-edit resize never traps the reader. An emptied dashboard
+tells a narrow-screen reader that the way back is a larger screen.

--- a/docs/widgets/index.mdx
+++ b/docs/widgets/index.mdx
@@ -34,6 +34,9 @@ instead of prose — visible rather than silently missing, but not what you want
 `custom` with your own component for prose today.
 
 Sizes are `sm`, `md`, `lg`, `xl` and `full`; heights are `short` and `tall`.
+Below the admin's `md` breakpoint every card is full width in one column and the dashboard is
+read-only: arranging it is offered from `md` up, and the arrangement made there applies at every
+width.
 
 ## Declared, not fetched
 

--- a/packages/admin/src/components/features/widgets/edit/ArrangedColumns.tsx
+++ b/packages/admin/src/components/features/widgets/edit/ArrangedColumns.tsx
@@ -58,9 +58,22 @@ function EmptyArrangement({
       data-testid="widget-grid-empty"
       className="col-span-full rounded-lg border border-dashed border-border px-4 py-10 text-center text-sm text-muted-foreground"
     >
-      {isEditing
-        ? "Every card is put away. Add one back below, or reset to the default arrangement."
-        : "Your dashboard has no cards on it. Edit it to bring one back, or reset to the default arrangement."}
+      {isEditing ? (
+        "Every card is put away. Add one back below, or reset to the default arrangement."
+      ) : (
+        <>
+          Your dashboard has no cards on it.{" "}
+          {/* Editing is offered from `md` up, so the way back is said per
+              width: naming a control a narrow screen does not show would
+              send the reader looking for it. */}
+          <span className="hidden md:inline">
+            Edit it to bring one back, or reset to the default arrangement.
+          </span>
+          <span className="md:hidden">
+            Edit it on a larger screen to bring one back.
+          </span>
+        </>
+      )}
     </p>
   );
 }

--- a/packages/admin/src/components/features/widgets/edit/DashboardEditBar.tsx
+++ b/packages/admin/src/components/features/widgets/edit/DashboardEditBar.tsx
@@ -7,6 +7,14 @@
  * leaving edit mode is a decision about the WHOLE arrangement — and because a
  * reader needs one place to look for "how do I get out of this".
  *
+ * Entering is offered from the `md` breakpoint up. Below it every card is full
+ * width in one column, so an arrangement is a stacked list with little to
+ * reorder, and touch drag is where accessibility regressions hide; the
+ * arrangement made on a wider screen still applies. The way OUT is not gated:
+ * an edit already in progress keeps its Save, Cancel and Reset at every width,
+ * so a window narrowed mid-edit never traps the reader in a mode they cannot
+ * leave.
+ *
  * @module components/features/widgets/edit/DashboardEditBar
  */
 
@@ -47,7 +55,15 @@ export function DashboardEditBar({
 }: DashboardEditBarProps) {
   if (!isEditing) {
     return (
-      <div className="flex justify-end">
+      // `hidden md:flex`: the same Tailwind breakpoint the grid folds to one
+      // column at (`sizes.ts`), so the offer and the fold cannot disagree the
+      // way a width read in JavaScript could. `display: none` also takes the
+      // control out of the accessibility tree, so it is not offered to a
+      // screen reader either.
+      <div
+        className="hidden justify-end md:flex"
+        data-testid="dashboard-edit-offer"
+      >
         <Button
           type="button"
           variant="outline"

--- a/packages/admin/src/components/features/widgets/edit/__tests__/WidgetGrid.edit.test.tsx
+++ b/packages/admin/src/components/features/widgets/edit/__tests__/WidgetGrid.edit.test.tsx
@@ -831,6 +831,48 @@ describe("an arrangement that already holds as many cards as a write may carry",
   // the one on the pure function.
 });
 
+describe("below the md breakpoint", () => {
+  // jsdom lays nothing out, so a viewport cannot be narrowed here; what is
+  // asserted is the CAUSE -- the responsive classes -- on the exact elements
+  // the fold applies to, which is what a browser reads the width against.
+
+  it("does not offer editing: the entry control is hidden until md, by the breakpoint the grid folds at", async () => {
+    renderGrid();
+    const offer = await screen.findByTestId("dashboard-edit-offer");
+    expect(offer).toHaveClass("hidden", "md:flex");
+    expect(offer).toContainElement(screen.getByTestId("dashboard-edit-begin"));
+  });
+
+  it("keeps the way OUT at every width once an edit is under way", async () => {
+    // A window narrowed mid-edit must not trap the reader: the bar that holds
+    // Save and Cancel carries no fold, whatever the offer to enter did.
+    renderGrid();
+    await beginEditing();
+    const cancel = screen.getByTestId("dashboard-edit-cancel");
+    const bar = cancel.parentElement;
+    expect(bar).not.toBeNull();
+    expect(bar).not.toHaveClass("hidden");
+    expect(screen.queryByTestId("dashboard-edit-offer")).toBeNull();
+  });
+
+  it("tells a narrow-screen reader the way back is a larger screen", async () => {
+    // The empty arrangement names its way back, and the way back differs by
+    // width: naming a control a phone does not show would send the reader
+    // looking for it.
+    layoutResponse = layout([
+      { id: "p1", widgetId: "core/a", order: 0, hidden: true },
+    ]);
+    renderGrid();
+    const empty = await screen.findByTestId("widget-grid-empty");
+    const wide = screen.getByText(/Edit it to bring one back/);
+    const narrow = screen.getByText(/Edit it on a larger screen/);
+    expect(empty).toContainElement(wide);
+    expect(empty).toContainElement(narrow);
+    expect(wide).toHaveClass("hidden", "md:inline");
+    expect(narrow).toHaveClass("md:hidden");
+  });
+});
+
 describe("an arrangement with nothing left on it", () => {
   it("KEEPS the way back when every card is put away", async () => {
     // 🔴 The dead end. Deriving the grid's rows from the arrangement meant an


### PR DESCRIPTION
## What

Phase 2.6 of the dashboard-widgets programme: customisation is disabled below the `md` breakpoint (design 2026-08-30 §4.4, §4.6, Part 7 row 2.6).

Below `md` every card is already full width in one column (`sizes.ts` folds the grid there), so an arrangement is a stacked list with little to reorder, and touch drag is where accessibility regressions hide. Now:

- **The offer to edit is hidden below `md`** — `hidden md:flex` on the Edit dashboard control's wrapper, the same Tailwind breakpoint the grid folds at, so the offer and the fold cannot disagree the way a width read in JavaScript could; `display: none` also takes the control out of the accessibility tree. The arrangement made on a wider screen applies at every width.
- **The way out is not gated.** An edit already under way keeps its Save, Cancel and Reset whatever the window is narrowed to, so a mid-edit resize never traps the reader in a mode they cannot leave.
- **An emptied dashboard names its way back per width**: "Edit it to bring one back, or reset…" from `md` up; "Edit it on a larger screen to bring one back." below, so a phone reader is not sent looking for a control the screen does not show.
- Docs: `docs/widgets/index.mdx` says the dashboard is read-only below `md`.

Research node `research:customisation-below-md` (Payload and Strapi offer no dashboard customisation; Directus arranges panels in a desktop grid editor and stacks them narrow; WordPress disables metabox drag-sorting below its 782px admin breakpoint and offers move-up/down arrows since 5.5 — the relaxation path if ever wanted, since the grid already has the non-drag controls from 2.7). Task: `task:widgets-2-6-customisation-below-md`.

## Evidence

- `WidgetGrid.edit.test.tsx` "below the md breakpoint" (3): the entry control's wrapper carries `hidden md:flex` and contains the button; the editing bar that holds Cancel carries no fold and the offer is gone while editing; the empty-arrangement copy carries both variants with `hidden md:inline` / `md:hidden`. jsdom lays nothing out, so the tests assert the cause — the responsive classes on the exact elements a browser reads the width against. Break-verified by name: dropping the fold from the offer, folding the editing bar, and giving the narrow copy the wide sentence each kill exactly one test.
- Gates: admin `check-types`, `lint`, full unit suite (425 files); docs compile; comment convention; fallow `pass` (0 introduced).

One changeset, all 25 packages.