### PR TITLE
test(nextly): an un-elevated batch row with its only field stripped is a no-op

### DIFF
--- a/packages/nextly/src/domains/collections/__tests__/bulk-update-override-access.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/bulk-update-override-access.integration.test.ts
@@ -146,11 +146,10 @@ describe("bulk update honours overrideAccess (integration)", () => {
       { collectionName: "pages" },
       [{ id, data: { internalNote: "after" } }]
     );
-    // Only what this case is about: the protected field did not change. The
-    // row itself fails here because stripping the field leaves an empty
-    // patch, and the transactional update refuses an empty patch where the
-    // ordinary one does not; that is a property of the patch, not of the flag.
-    expect(unelevated.successful).toBe(0);
+    // The row write is allowed and the protected field is stripped from it,
+    // leaving an empty patch, which updates the row's timestamp and nothing
+    // else. What this case is about is the field, asserted below.
+    expect(unelevated.errors).toEqual([]);
     let read = await handler.getEntry({
       collectionName: "pages",
       entryId: id,


### PR DESCRIPTION
## What

`main` fails `bulk-update-override-access.integration.test.ts`:

```
× writes a field whose own rule refuses the caller when elevated
AssertionError: expected 1 to be +0
```

## Why

Two PRs merged nine seconds apart, each green on its own base. #1801 (mine) pinned that an un-elevated batch row whose only field is stripped by a field rule *fails*, because the transactional update then issued an `UPDATE` with an empty `SET`. #1787 (another lane) fixed that underlying defect by stamping `updated_at` under its column name, so the row now succeeds as a no-op. Together, the assertion is stale.

The assertion now checks there is no error, and the case keeps the assertion it is actually about: the protected field did not change without elevation, and did with it. All 52 collections integration suites pass on `main` plus this.

## Changeset

None. Test-only.
