### PR TITLE
fix(adapters): a query error names its operation and table on every dialect

### DIFF
--- a/.changeset/a-query-error-names-its-operation-on-every-dialect.md
+++ b/.changeset/a-query-error-names-its-operation-on-every-dialect.md
@@ -1,0 +1,35 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A database error from the adapters now says which operation failed on which
+table on every dialect. The context was attached only when the message did not
+already contain the operation's name, and on PostgreSQL and MySQL the driver's
+message quotes the failed statement — which Drizzle spells in lower case — so
+an `update`, `insert` or `delete` there, or any table or column whose name
+contains the word, arrived without it. The error still carries the table as
+before; only the message changes, and only where the context was missing.

--- a/packages/adapter-drizzle/src/__tests__/adapter.test.ts
+++ b/packages/adapter-drizzle/src/__tests__/adapter.test.ts
@@ -118,6 +118,11 @@ class MockAdapter extends DrizzleAdapter {
     return callback(ctx);
   }
 
+  /** The protected error wrapper, reachable from the tests. */
+  queryError(error: unknown, operation: string, table: string) {
+    return this.handleQueryError(error, operation, table);
+  }
+
   getCapabilities(): DatabaseCapabilities {
     return {
       dialect: "postgresql",
@@ -266,6 +271,47 @@ describe("DrizzleAdapter", () => {
       expect(result.applied).toEqual([]);
       expect(result.pending).toEqual([]);
       expect(result.current).toBeNull();
+    });
+  });
+
+  describe("a query error's context", () => {
+    const CONTEXT = "update operation failed on table 'posts'";
+
+    it("is attached to a driver message that quotes the failed statement", () => {
+      // Drizzle's own shape on PostgreSQL and MySQL: the statement, spelled in
+      // lower case, so the operation's name is in the message already.
+      const error = adapter.queryError(
+        new Error(
+          'Failed query: update "posts" set "ghost" = $1 where "id" = $2\nparams: x,1'
+        ),
+        "update",
+        "posts"
+      );
+      expect(error.message).toBe(
+        `${CONTEXT}: Failed query: update "posts" set "ghost" = $1 where "id" = $2\nparams: x,1`
+      );
+      expect(error.table).toBe("posts");
+    });
+
+    it("is attached when only a name in the message contains the operation", () => {
+      const error = adapter.queryError(
+        new Error('column "ghost" of relation "update_log" does not exist'),
+        "update",
+        "update_log"
+      );
+      expect(error.message).toBe(
+        'update operation failed on table \'update_log\': column "ghost" of relation "update_log" does not exist'
+      );
+    });
+
+    it("is attached once, however often the same error is handled", () => {
+      const first = adapter.queryError(
+        new Error("no such column: ghost"),
+        "update",
+        "posts"
+      );
+      const again = adapter.queryError(first, "update", "posts");
+      expect(again.message).toBe(`${CONTEXT}: no such column: ghost`);
     });
   });
 

--- a/packages/adapter-drizzle/src/adapter.ts
+++ b/packages/adapter-drizzle/src/adapter.ts
@@ -2538,9 +2538,16 @@ export abstract class DrizzleAdapter {
   ): DatabaseError {
     const dbError = this.classifyError(error);
 
-    // Add operation context if not already present
-    if (!dbError.message.includes(operation)) {
-      dbError.message = `${operation} operation failed on table '${table}': ${dbError.message}`;
+    // Add operation context if not already present — asked of the context
+    // this method writes, not of the operation's bare name. A driver message
+    // that quotes the failed statement names the operation already (Drizzle's
+    // `Failed query: update "posts" set …` on PostgreSQL and MySQL, whose
+    // statements it spells in lower case), and so does any table or column
+    // whose name contains the word; neither says which operation failed on
+    // which table.
+    const context = `${operation} operation failed on table '${table}'`;
+    if (!dbError.message.includes(context)) {
+      dbError.message = `${context}: ${dbError.message}`;
     }
 
     if (!dbError.table) {


### PR DESCRIPTION
## What

Repairs `main`'s red **Integration (postgres)** and **Integration (mysql)** legs, which my #1787 turned red, by fixing the adapter behaviour the failing assertion caught: a query error now carries its operation-and-table context on every dialect.

Ledger: `task:query-errors-carry-their-context`, fixing `finding:query-error-context-skipped-on-pg-mysql`; research `research:query-error-context-check`.

## What was true on `main` (`95cfddac3`)

- Both legs fail one test from #1787: `adapter-{postgres,mysql}/…/transaction-update-writes-the-table.integration.test.ts` › *refuses a column the table does not have, naming the operation and the table*. Received: a `DatabaseError` with `table: "int_txpg_update_table"` and message `Failed query: UPDATE "int_txpg_update_table" …`; expected `/update operation failed.*ghost/s`. #1787's merge commit had these legs **skipped** by the newer-push rule, so the next push to `main` was their first run; the twins self-skip locally (no Docker here), so the SQLite twin was the only one I ran. That is on me.
- The cause is in `DrizzleAdapter.handleQueryError`: it prefixes `<op> operation failed on table '<t>': ` only `if (!message.includes(operation))` — a proxy for "the context is not there yet". The table's *name* contains `update`, so the proxy said yes.
- It is wider than this test. Drizzle spells its statements in lower case (`pg-core/dialect.js`: `delete from`, `update … set`, `insert into`; `mysql-core` the same) and wraps a driver error as `Failed query: <sql>\nparams: …` (`errors.js`). So on PostgreSQL and MySQL the message names the operation for **every** query-builder statement, and the context has effectively never been attached there.

## How

`handleQueryError` now asks whether the context *it writes* is present — `message.includes("<op> operation failed on table '<t>'")` — rather than whether the operation's bare name appears. Same method, same shape, attached once however often one error is handled (`classifyError` returns an existing `DatabaseError` unchanged, so a re-handled error must not stack the prefix).

Who reads the message: `git grep 'operation failed'` finds only the three twin assertions; no product code parses it, and nextly maps a `DatabaseError` to its public response by kind (`NextlyError.fromDatabaseError`), never by driver text. So this changes diagnostic text only, on PostgreSQL and MySQL, where the context was missing.

## Verification

- Three base-class tests in `adapter-drizzle/src/__tests__/adapter.test.ts` (they run everywhere, unlike the pg/mysql twins): a Drizzle-shaped lower-case statement message gets the context; a message where only a *name* contains the operation gets it; handling the same error twice attaches it once.
- **Break-verified**: restoring the bare-word check fails exactly the first two (2/21); "always prefix" fails exactly the third (1/21). Restored: 21/21.
- Gates at `c42424c95` (main `746a7141c` merged in): adapter-drizzle, -sqlite, -postgres, -mysql lint 0 and check-types 0 (after rebuilding adapter-drizzle's dist); unit 184 / 66 / 87 / 47; SQLite integration twin 35/35; `pnpm exec fallow audit --changed-since origin/main --gate new-only` (3.15.0) pass, 0 introduced.
- nextly's **full** SQLite integration suite, run on `95cfddac3` + this change: 1,654 passed, 1 failed — `bulk-update-override-access` › *writes a field whose own rule refuses the caller when elevated*, which `main`'s own SQLite leg fails identically at `95cfddac3` (the unmodified control; job 103352224752). It is the other half of #1787's fallout — the tx path now bumps `updated_at`, so a patch whose only field is stripped is no longer empty — and the wt-forms lane fixed it on `main` in #1806; merged in here, that file passes 4/4.
- Why both halves matter: `main`'s pg/mysql legs stop at the adapter twins before reaching nextly's suite, so they stay red until this lands even with #1806 in.
- The pg/mysql twins are the real oracle and run only in CI: read `Integration (postgres)` and `Integration (mysql)` by name on this head.

One changeset (all 25 packages, patch).
