### PR TITLE
test(nextly): count the stripped batch row as processed, not just error-free

### DIFF
--- a/packages/nextly/src/domains/collections/__tests__/bulk-update-override-access.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/bulk-update-override-access.integration.test.ts
@@ -148,8 +148,12 @@ describe("bulk update honours overrideAccess (integration)", () => {
     );
     // The row write is allowed and the protected field is stripped from it,
     // leaving an empty patch, which updates the row's timestamp and nothing
-    // else. What this case is about is the field, asserted below.
+    // else. Counted, not just error-free: a row skipped without being
+    // accounted for would also report no errors.
     expect(unelevated.errors).toEqual([]);
+    expect(unelevated.successful).toBe(1);
+    expect(unelevated.failed).toBe(0);
+    expect(unelevated.ids).toEqual([id]);
     let read = await handler.getEntry({
       collectionName: "pages",
       entryId: id,


### PR DESCRIPTION
## What

Review on #1806, after it merged: the stripped un-elevated row asserted only `errors: []`, which a row skipped without being accounted for would also satisfy. The case now asserts `successful: 1`, `failed: 0` and the row's id, so it proves the row was processed as a no-op.

## Changeset

None. Test-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened coverage for bulk updates to protected fields, verifying successful processing, absence of failures and errors, and inclusion of the affected entry identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->