### PR TITLE
fix(docs): a locale sample stops posing as a continuation, and the sample baseline catches up

### DIFF
--- a/docs/plugins/services.mdx
+++ b/docs/plugins/services.mdx
@@ -48,7 +48,7 @@ site's default, which is what every call has always meant.
 
 ```ts
 // A French visitor's page reads French content.
-const page = await ctx.services.collections.findEntryById("pages", id, {
+const frenchPage = await ctx.services.collections.findEntryById("pages", id, {
   as: "system",
   locale: "fr",
 });

--- a/scripts/doc-samples-baseline.json
+++ b/scripts/doc-samples-baseline.json
@@ -1,7 +1,7 @@
 {
   "coverage": {
-    "pages": 50,
-    "samples": 343,
+    "pages": 51,
+    "samples": 345,
     "compiled": 210
   },
   "samplesPerPage": {
@@ -186,7 +186,7 @@
       "compiled": 4
     },
     "docs/plugins/services.mdx": {
-      "samples": 4,
+      "samples": 5,
       "compiled": 0
     },
     "docs/plugins/testing.mdx": {
@@ -204,6 +204,10 @@
     "docs/webhooks/retention.mdx": {
       "samples": 2,
       "compiled": 1
+    },
+    "docs/widgets/index.mdx": {
+      "samples": 1,
+      "compiled": 0
     }
   },
   "pages": {


### PR DESCRIPTION
## What

Repairs `main`'s **Lint / Typecheck / Test / Build** (and so the blocking **CI gate**), red at the *Doc samples compile* step since the first run after my #1769.

Ledger: `task:doc-sample-baseline-catches-up`, fixing `finding:doc-samples-gate-red-since-1769`; research `research:doc-sample-continuation-match`.

## What was true on `main`

- The job was cancelled or skipped on every `main` push from #1769 (`4de79a213`) until `0121364ce`, its first completed run: `check:doc-samples` refused because more samples were checked than the baseline records — then **only** `docs/plugins/services.mdx`, samples 4 → 5, compiled 0 → 1. By `746a7141c`, #1782's new `docs/widgets/index.mdx` joined it.
- The rewrite the gate asks for (`--write-baseline`) refused too: it would have recorded three new diagnostics on `services.mdx` — `ctx`, `slug`, `someId` in the *Querying* fence.
- Why those appeared: the checker compiles a fence that mentions a name an earlier fence declared as that fence's **continuation**. #1769's locale sample declared `const page`; the *Querying* fence contains `pagination: { limit: 20, page: 1 }`; the key matched, the *Querying* fence compiled with the locale sample's names, and its placeholders — never compiled before — became findings.

## How

- The locale sample's variable is `frenchPage`. The *Querying* fence no longer matches, `services.mdx` compiles 0 fences again and records no diagnostics. The fix is to the sample, as the gate's own message asks, not an `--allow-new-findings` recording of an artefact.
- The baseline is then rewritten with **no override flags** and records only coverage gained: pages 50 → 51, samples 343 → 345, `services.mdx` 4 → 5, `docs/widgets/index.mdx` added.

## Verification

- Before (on `746a7141c`, the control): `pnpm check:doc-samples` exit 1 with exactly CI's message. After: exit 0; again after the commit hook ran.
- `pnpm test:scripts` 1344/1344 (the checker's own tests), `check:docs-claims` 0, `check:docs-compile` 0 (66 pages).
- For the checker's owner, noted in the research node rather than changed here: a use that is an object key still counts as mentioning an earlier `const` of the same spelling, so this can happen again.

No changeset: docs and a CI baseline only. `Integration (postgres)`/`(mysql)` stay red on this PR until #1807 lands — that is `main`'s other red, and it does not gate here.
