### PR TITLE
fix(adapter-drizzle): an error names its operation whatever the table is called

### DIFF
--- a/.changeset/an-error-names-its-operation-whatever-the-table-is-called.md
+++ b/.changeset/an-error-names-its-operation-whatever-the-table-is-called.md
@@ -1,0 +1,29 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A database error now always carries its operation and table (`update operation failed on table '<table>': ...`). The adapter added that context only when the message did not already contain the operation's word, and a PostgreSQL or MySQL message carries the failed SQL, so any table or column whose name contained the word (a table named `int_update_table`, a column `updated_at`) left the error without it.

--- a/packages/adapter-drizzle/src/__tests__/adapter.test.ts
+++ b/packages/adapter-drizzle/src/__tests__/adapter.test.ts
@@ -334,3 +334,48 @@ describe("DrizzleAdapter", () => {
     });
   });
 });
+
+describe("the operation context on a query error", () => {
+  // `handleQueryError` is protected; exposed here to judge its message alone.
+  class ErrorProbe extends MockAdapter {
+    handle(error: unknown, operation: string, table: string) {
+      return this.handleQueryError(error, operation, table);
+    }
+  }
+  const probe = new ErrorProbe();
+
+  it("adds it when the driver's message names a table containing the operation's word", () => {
+    // A driver's message carries the failed SQL. A table named
+    // `int_update_table` put "update" in the message, which a check for the
+    // bare word read as the context already being there, so PostgreSQL and
+    // MySQL errors on such a table arrived without it.
+    const error = probe.handle(
+      new Error('Failed query: update "int_update_table" set "ghost" = $1'),
+      "update",
+      "int_update_table"
+    );
+    expect(error.message).toMatch(
+      /^update operation failed on table 'int_update_table': Failed query/
+    );
+    expect(error.message).toContain("ghost");
+  });
+
+  it("adds it when a column name contains the operation's word", () => {
+    const error = probe.handle(
+      new Error('column "updated_at" does not exist'),
+      "update",
+      "pages"
+    );
+    expect(error.message).toBe(
+      `update operation failed on table 'pages': column "updated_at" does not exist`
+    );
+  });
+
+  it("does not add it twice to an error handled on its way out twice", () => {
+    const once = probe.handle(new Error("boom"), "update", "pages");
+    const twice = probe.handle(once, "update", "pages");
+    expect(twice.message).toBe(
+      "update operation failed on table 'pages': boom"
+    );
+  });
+});

--- a/packages/adapter-drizzle/src/__tests__/adapter.test.ts
+++ b/packages/adapter-drizzle/src/__tests__/adapter.test.ts
@@ -360,6 +360,21 @@ describe("the operation context on a query error", () => {
     expect(error.message).toContain("ghost");
   });
 
+  it("adds it when the server's own message names such a relation", () => {
+    // The other shape a PostgreSQL error takes for an unknown column: no SQL,
+    // but the relation named in the server's text. SQLite's message for the
+    // same failure is `no such column: ghost`, with no table in it, which is
+    // why only that dialect kept its context.
+    const error = probe.handle(
+      new Error('column "ghost" of relation "int_update_table" does not exist'),
+      "update",
+      "int_update_table"
+    );
+    expect(error.message).toMatch(
+      /^update operation failed on table 'int_update_table': column "ghost"/
+    );
+  });
+
   it("adds it when a column name contains the operation's word", () => {
     const error = probe.handle(
       new Error('column "updated_at" does not exist'),

--- a/packages/adapter-drizzle/src/adapter.ts
+++ b/packages/adapter-drizzle/src/adapter.ts
@@ -2538,9 +2538,15 @@ export abstract class DrizzleAdapter {
   ): DatabaseError {
     const dbError = this.classifyError(error);
 
-    // Add operation context if not already present
-    if (!dbError.message.includes(operation)) {
-      dbError.message = `${operation} operation failed on table '${table}': ${dbError.message}`;
+    // Add the operation context unless THIS prefix is already on the message,
+    // which it is when an error is handled twice on its way out. Checked as
+    // the exact prefix: a driver's message carries the failed SQL, and a table
+    // or column name that merely contains the operation's word (a table named
+    // `int_update_table`, a column `updated_at`) would otherwise read as the
+    // context being present and leave the message without it.
+    const prefix = `${operation} operation failed on table '${table}': `;
+    if (!dbError.message.startsWith(prefix)) {
+      dbError.message = `${prefix}${dbError.message}`;
     }
 
     if (!dbError.table) {


### PR DESCRIPTION
## What

`main`'s Integration fails on the postgres and mysql legs since #1787 (run 34629104960 at 746a7141c):

```
× refuses a column the table does not have, naming the operation and the table
expected DatabaseError: Failed query: UPDATE "int_… to match { message: /update operation failed.*ghost/s }
```

## Root cause

Not the test. `DrizzleAdapter.handleQueryError` adds `update operation failed on table '<table>': ` only when the message does not already contain the bare word `update`. The fixture table is `int_txpg_update_table`, and the postgres and mysql messages contain the table name (the echoed statement in this run; the relation name in the server's own text for the same failure), so the check read the prefix as already present and skipped it. SQLite's message for the same failure is `no such column: ghost`, with no table in it (measured), which is why only that leg passed. So any table or column whose name contains the operation's word (`updated_at`, `*_update_*`, `inserts`, `selections`) has been losing its operation context on those dialects.

## Fix

Check for the exact prefix the method adds. That keeps what the substring check was reaching for (no double prefix when an error is handled twice on its way out) without the false positive. Renaming the fixture table would also have turned the legs green while leaving the bug in place; the unit cases pin the message shapes instead.

## Tests

`adapter.test.ts`: the prefix is added when an echoed statement names a table containing the word, when the server's message names such a relation, and when a column name contains it; it is not added twice. The first two fail on `main`. `adapter-drizzle` (184) and `adapter-sqlite` (66 unit, 12 integration) pass locally; the postgres and mysql legs run on this PR's CI.

Patch changeset, every package (the error text of a published package changes).
