### PR TITLE
test(nextly): the outbox lock suite registers its seeded collection, as a builder save does

### DIFF
--- a/packages/nextly/src/domains/webhooks/__tests__/outbox-preimage-lock.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/outbox-preimage-lock.integration.test.ts
@@ -15,6 +15,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { createAdapter } from "../../../database/factory";
+import { clearServices } from "../../../di/register";
 import { seedBuilderCollection } from "../../../plugins/__tests__/seed-builder-entity";
 import {
   createTestNextly,
@@ -114,6 +115,13 @@ for (const leg of LEGS) {
             { name: "beta", type: "text" },
           ],
         });
+        // Then boot again over the same adapter, which is what the seed helper
+        // documents and what the other two-phase suites do. Saving a
+        // collection in the Builder registers its table with the schema
+        // resolver as part of the save; seeding straight into the database
+        // does not, and a write through the ORM has no table to resolve.
+        clearServices();
+        handle = await createTestNextly({ adapter: bootAdapter });
         const h = handle.getService<CollectionsHandler>("collectionsHandler");
 
         const created = await h.createEntry(


### PR DESCRIPTION
## What

Repairs `main`'s **Integration (postgres)** and **Integration (mysql)**, both failing at `outbox-preimage-lock.integration.test.ts` › *serializes concurrent updates so neither event claims the other's field* with `expected [] to have a length of 2`.

Ledger: `finding:outbox-lock-suite-never-registered-its-collection`.

## What was true

The suite boots once, seeds its collection straight into the database with `seedBuilderCollection`, and writes through the handler. Both updates answer **500 — `Table "dc_locktestposts" not found in schema registry`**, so no `entry.updated` event is written and the assertion sees none. The suite never asserts the updates' own results, so the failure presented as a missing event rather than a refused write.

Saving a collection in the Builder registers its new table with the schema resolver as part of the save (`collection-metadata-service` calls `registerDynamicSchema`). Seeding into the database does not, and `seed-builder-entity`'s own docblock says to boot again afterwards — which the other two-phase suites (`collection-mutation-service.m2m-atomicity`, `write-path-relations-tx-visibility`, …) do and this one did not. Reads were unaffected because the read path builds its own runtime table; the ORM write path had nothing to resolve.

It surfaced now for two reasons: the legs are dialect-gated, so only pg/mysql run it, and my #1787 moved the transactional update onto the resolver — the raw statement it replaced quoted the table name itself, so an unregistered table had gone unnoticed here. The adapter's transactional **delete** has always required the resolver, so the same suite would have failed had it deleted.

## How

After seeding, `clearServices()` and boot again over the same adapter — the documented pattern, three lines.

## Verification

- The suite self-skips without a dialect URL, so **CI's `Integration (postgres)` and `(mysql)` are the oracle** — read them by name on this head. No Docker here.
- The mechanism is verified on SQLite, in a scratch probe running the same sequence (deleted; `git status` clean): **without** the second boot both updates answer that 500, `nextly_events` holds only `entry.created`, and `getEntry`/`listEntries` still succeed — the asymmetry above, measured. **With** it, both updates succeed and exactly two `entry.updated` events appear, `changedFields` `["alpha","updatedAt"]` and `["beta","updatedAt"]` — which also satisfies the property the suite exists for (neither event carries the other's field).
- Gates: nextly lint 0, check-types 0, webhooks integration on SQLite 204 passed / 8 skipped.

No changeset: test-only.
