### PR TITLE
fix(nextly): a lifecycle selector needs a lifecycle, and a deferral outlives nothing

### DIFF
--- a/.changeset/a-single-answers-as-one-row.md
+++ b/.changeset/a-single-answers-as-one-row.md
@@ -106,3 +106,10 @@ and a single the sync refused no longer has its migration recorded as applied
 table on the next restart. A boot also starts with nothing withheld: the
 refusals one boot recorded are its own, and a slug held over from a previous
 boot kept its source and cards hidden for the life of the process.
+
+A collection or single whose registry row was written and whose permission
+seeding then failed keeps its widget source and has its migration marked
+applied. Both registries report such an entity in `errors` as well as in
+`created`, and reading the error alone withheld a source whose stored metadata
+was in fact current -- permanently, since every later pass read the same report
+the same way.

--- a/.changeset/a-single-answers-as-one-row.md
+++ b/.changeset/a-single-answers-as-one-row.md
@@ -98,3 +98,11 @@ widget sources withheld even when the rest of its kind synced cleanly. The
 singles sync reports a per-single refusal without failing the scope, so a
 reload that refused one single had been clearing the whole deferral set and
 republishing that single's stale field list.
+
+A `next dev` reload whose metadata sync fails now withholds that kind's widget
+sources rather than publishing them over tables the apply has already moved,
+and a single the sync refused no longer has its migration recorded as applied
+-- a label that persists, so the old field list came back against the new
+table on the next restart. A boot also starts with nothing withheld: the
+refusals one boot recorded are its own, and a slug held over from a previous
+boot kept its source and cards hidden for the life of the process.

--- a/.changeset/a-single-answers-as-one-row.md
+++ b/.changeset/a-single-answers-as-one-row.md
@@ -84,3 +84,17 @@ Under `next dev`, a single whose fields you edit keeps its source and its
 status card: the reload re-marks an edited single's migration as applied from
 the sync's own report, as it already did for an edited collection, instead of
 leaving the row `pending` for the rest of the session.
+
+A widget query asking for `draft` or `published` from a source that has no
+publish lifecycle is now refused, instead of being accepted and answered as if
+no state had been named. Nothing downstream could apply such a selector, so
+the two mutually exclusive questions came back with one answer and the card
+said nothing about having been ignored. `status: "all"` is unaffected: it
+claims no lifecycle, and it is what the generated count, recent and timeline
+cards send.
+
+A single whose metadata a `next dev` reload could not store now keeps its
+widget sources withheld even when the rest of its kind synced cleanly. The
+singles sync reports a per-single refusal without failing the scope, so a
+reload that refused one single had been clearing the whole deferral set and
+republishing that single's stale field list.

--- a/packages/nextly/src/di/__tests__/register-widgets.test.ts
+++ b/packages/nextly/src/di/__tests__/register-widgets.test.ts
@@ -16,6 +16,10 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { CORE_WIDGETS } from "../../domains/widgets/core-widgets";
+import {
+  deferredEntities,
+  setDeferredEntities,
+} from "../../domains/widgets/deferred-entities";
 
 import {
   clearWidgets,
@@ -112,6 +116,26 @@ describe("resetWidgetRegistries", () => {
     // The control: the source core DOES republish is still answerable, so this
     // cannot pass by clearing everything and registering nothing.
     expect(systemResolver(RELEASES_SOURCE_ID)).toBeDefined();
+  });
+
+  it("drops the previous boot's deferred entities, for both kinds", () => {
+    // 🔴 A refusal is a statement about the reloads of ONE process, and this
+    // store outlives that process's services. Left standing across a
+    // `clearServices()` / `registerServices()` pair, a slug the last boot
+    // deferred withheld its source and every generated card for good: only a
+    // later reload replaces a kind's set, and this boot has no reason to run
+    // one. Both kinds asserted, because the store is keyed by kind and a reset
+    // that took one of them would leave the other answering for a boot that is
+    // over.
+    setDeferredEntities("collection", ["posts"]);
+    setDeferredEntities("single", ["settings"]);
+    expect([...deferredEntities("collection")]).toEqual(["posts"]);
+    expect([...deferredEntities("single")]).toEqual(["settings"]);
+
+    resetWidgetRegistries();
+
+    expect([...deferredEntities("collection")]).toEqual([]);
+    expect([...deferredEntities("single")]).toEqual([]);
   });
 
   it("drops the previous boot's widgets and leaves core's own", () => {

--- a/packages/nextly/src/di/__tests__/register-widgets.test.ts
+++ b/packages/nextly/src/di/__tests__/register-widgets.test.ts
@@ -118,24 +118,24 @@ describe("resetWidgetRegistries", () => {
     expect(systemResolver(RELEASES_SOURCE_ID)).toBeDefined();
   });
 
-  it("drops the previous boot's deferred entities, for both kinds", () => {
-    // 🔴 A refusal is a statement about the reloads of ONE process, and this
-    // store outlives that process's services. Left standing across a
-    // `clearServices()` / `registerServices()` pair, a slug the last boot
-    // deferred withheld its source and every generated card for good: only a
-    // later reload replaces a kind's set, and this boot has no reason to run
-    // one. Both kinds asserted, because the store is keyed by kind and a reset
-    // that took one of them would leave the other answering for a boot that is
-    // over.
+  it("leaves the deferral store alone, because it has not synced anything yet", () => {
+    // 🔴 The reset runs BEFORE the boot syncs any metadata, so clearing here
+    // would publish "nothing is withheld" on the strength of work that has not
+    // happened -- and the boot's own sync can then fail and be CAUGHT, leaving
+    // the registry exactly as stale as the previous reload found it while the
+    // set says otherwise.
+    //
+    // Each kind replaces its own set from its own sync path instead, once that
+    // sync has succeeded (`publishBootDeferrals` in `di/register`), which
+    // clears a previous boot's refusal on the pass that earns the right to and
+    // retains it when the sync throws.
     setDeferredEntities("collection", ["posts"]);
     setDeferredEntities("single", ["settings"]);
-    expect([...deferredEntities("collection")]).toEqual(["posts"]);
-    expect([...deferredEntities("single")]).toEqual(["settings"]);
 
     resetWidgetRegistries();
 
-    expect([...deferredEntities("collection")]).toEqual([]);
-    expect([...deferredEntities("single")]).toEqual([]);
+    expect([...deferredEntities("collection")]).toEqual(["posts"]);
+    expect([...deferredEntities("single")]).toEqual(["settings"]);
   });
 
   it("drops the previous boot's widgets and leaves core's own", () => {

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -94,6 +94,7 @@ import type { ResolvedWebhookRetentionConfig } from "../domains/webhooks/retenti
 import type { WebhookDeliveryQueryService } from "../domains/webhooks/services/webhook-delivery-query-service";
 import type { WebhookEndpointService } from "../domains/webhooks/services/webhook-endpoint-service";
 import { publishStoredWebhookRecordingPolicies } from "../domains/webhooks/stored-recording-policy";
+import type { DeferrableEntityKind } from "../domains/widgets/deferred-entities";
 import { NextlyError } from "../errors/nextly-error";
 import { getEventBus } from "../events/event-bus";
 import type { FieldGroupConfig } from "../field-groups/config/types";
@@ -107,6 +108,7 @@ import { registerCollectionHooks } from "../hooks/register-collection-hooks";
 import { registerSingleHooks } from "../hooks/register-single-hooks";
 import { createSanitizationHook } from "../hooks/sanitization-hooks";
 import { openBootMigrationsGate } from "../init/boot-migrations-gate";
+import { unwrittenSlugs } from "../init/sync-outcome";
 import type { PluginPermission, PluginRole } from "../plugins/contributions";
 import { getCoreVersion } from "../plugins/core-version";
 import { warnUndescribedPlugins } from "../plugins/describe-check";
@@ -1878,6 +1880,32 @@ function registerCodeDefinedAccess(
   }
 }
 
+/**
+ * Replace one kind's deferral set from a boot sync that actually RAN.
+ *
+ * 🔴 Called only after the sync resolved, never from the reset that precedes
+ * it. `resetWidgetRegistries` runs before any metadata has been synced, so
+ * clearing there would publish "nothing is withheld" on the strength of work
+ * that has not happened -- and the sync can then fail and be caught, leaving
+ * the registry as stale as the previous reload found it while the set says
+ * otherwise. Replacing it HERE means a previous boot's refusal is cleared by
+ * the pass that earned the right to clear it, and retained when the sync
+ * throws, because this line is never reached.
+ *
+ * The set is the slugs whose registry WRITE did not land -- not everything the
+ * sync reported an error for. A slug that errored AFTER its row was written
+ * has current metadata, and withholding its source would hide a working card.
+ */
+async function publishBootDeferrals(
+  kind: DeferrableEntityKind,
+  syncResult: unknown
+): Promise<void> {
+  const { setDeferredEntities } = await import(
+    "../domains/widgets/deferred-entities"
+  );
+  setDeferredEntities(kind, unwrittenSlugs(syncResult));
+}
+
 async function syncCodeFirstCollections(
   adapter: DrizzleAdapter,
   logger: Logger,
@@ -1964,6 +1992,11 @@ async function syncCodeFirstCollections(
   logger.info?.(
     `Collections registered: ${syncResult.created.length} created, ${syncResult.updated.length} updated, ${syncResult.unchanged.length} unchanged`
   );
+
+  // This boot has now spoken for the collections: whatever a previous boot's
+  // reload refused is either fixed or reported here, so its set is replaced
+  // rather than inherited.
+  await publishBootDeferrals("collection", syncResult);
 
   // On a fresh database the dynamic_collections table hasn't been created
   // by migrations yet, so every sync fails with "does not exist". That's
@@ -2527,12 +2560,16 @@ async function syncCodeFirstSingles(
     logger.info?.(
       `Singles registered: ${singleSyncResult.created.length} created, ${singleSyncResult.updated.length} updated, ${singleSyncResult.unchanged.length} unchanged`
     );
+    // The singles' half of the same statement, on the path where their sync
+    // actually ran.
+    await publishBootDeferrals("single", singleSyncResult);
     // Expose the live code-first snapshot (for function/structured defaults)
-    // only for singles that synced: a failed slug's serialized metadata did not
-    // advance, so it is kept off the snapshot and falls back to those fields.
-    const failedSingleSlugs = new Set(
-      singleSyncResult.errors.map(entry => entry.slug)
-    );
+    // only for singles that synced. Narrowed to the writes that did NOT land:
+    // a slug the sync pushed onto `created` or `updated` before its permission
+    // seeding threw appears in `errors` too, and its row is current -- keeping
+    // its PRIOR snapshot there would pair new fields with stale metadata, the
+    // very thing this option exists to prevent.
+    const failedSingleSlugs = new Set(unwrittenSlugs(singleSyncResult));
     singleRegistry.setCodeFirstSingles(transformedConfig.singles, {
       keepPriorFor: failedSingleSlugs,
     });

--- a/packages/nextly/src/di/registrations/register-widgets.ts
+++ b/packages/nextly/src/di/registrations/register-widgets.ts
@@ -41,7 +41,6 @@ import { registerReleasesWidgetSource } from "../../domains/releases/releases-wi
 import { registerVersionsWidgetSource } from "../../domains/versions/versions-widget-source";
 import { setContributedWidgets } from "../../domains/widgets/canonical";
 import { CORE_WIDGETS } from "../../domains/widgets/core-widgets";
-import { clearDeferredEntities } from "../../domains/widgets/deferred-entities";
 import { clearWidgets, registerWidget } from "../../domains/widgets/registry";
 import { clearSources } from "../../domains/widgets/sources";
 import { clearSystemResolvers } from "../../domains/widgets/system-sources";
@@ -60,13 +59,18 @@ export function resetWidgetRegistries(
   // and ready to answer again the moment anything republished that id through
   // the generic `registerSource` door.
   clearSystemResolvers();
-  // The third `globalThis` store this registration owns. It records which
-  // entities a RELOAD found to disagree with their tables, which is a fact
-  // about the boot that made the observation -- this boot re-syncs its own
-  // metadata, so it starts with nothing withheld. Left standing, a slug one
-  // boot deferred kept its source and cards hidden for the life of the
-  // process, because only a later reload ever replaces a kind's set.
-  clearDeferredEntities();
+  // 🔴 The deferral store is NOT cleared here, and that is deliberate. It
+  // records which entities a reload found to disagree with their tables, and
+  // this function runs BEFORE the boot has synced any metadata -- so clearing
+  // here publishes "nothing is withheld" on the strength of work that has not
+  // happened yet. The boot's own sync can then fail and be caught, leaving the
+  // registry exactly as stale as the previous reload found it while the set
+  // says otherwise.
+  //
+  // Each kind replaces its own set from its own sync path instead, once that
+  // sync has actually succeeded -- which clears a previous boot's refusal on
+  // the pass that earns the right to, and retains it when the sync fails. See
+  // `publishBootDeferrals` in `di/register`.
 
   // The OTHER channel a widget arrives by. A contribution never passes through
   // `registerWidget`, so without this the server's canonical set holds core's

--- a/packages/nextly/src/di/registrations/register-widgets.ts
+++ b/packages/nextly/src/di/registrations/register-widgets.ts
@@ -41,6 +41,7 @@ import { registerReleasesWidgetSource } from "../../domains/releases/releases-wi
 import { registerVersionsWidgetSource } from "../../domains/versions/versions-widget-source";
 import { setContributedWidgets } from "../../domains/widgets/canonical";
 import { CORE_WIDGETS } from "../../domains/widgets/core-widgets";
+import { clearDeferredEntities } from "../../domains/widgets/deferred-entities";
 import { clearWidgets, registerWidget } from "../../domains/widgets/registry";
 import { clearSources } from "../../domains/widgets/sources";
 import { clearSystemResolvers } from "../../domains/widgets/system-sources";
@@ -59,6 +60,13 @@ export function resetWidgetRegistries(
   // and ready to answer again the moment anything republished that id through
   // the generic `registerSource` door.
   clearSystemResolvers();
+  // The third `globalThis` store this registration owns. It records which
+  // entities a RELOAD found to disagree with their tables, which is a fact
+  // about the boot that made the observation -- this boot re-syncs its own
+  // metadata, so it starts with nothing withheld. Left standing, a slug one
+  // boot deferred kept its source and cards hidden for the life of the
+  // process, because only a later reload ever replaces a kind's set.
+  clearDeferredEntities();
 
   // The OTHER channel a widget arrives by. A contribution never passes through
   // `registerWidget`, so without this the server's canonical set holds core's

--- a/packages/nextly/src/domains/widgets/__tests__/query.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/query.test.ts
@@ -30,6 +30,11 @@ beforeEach(() => {
     label: "Posts",
     kind: "collection",
     supports: ["count", "list"],
+    // Declared, because the queries below select lifecycle states. The `status`
+    // FIELD beside it does not imply the capability -- a collection with the
+    // lifecycle off may declare an ordinary user field of that name, and the
+    // two are indistinguishable in `fields`.
+    lifecycleStatus: true,
     fields: [
       { name: "title", type: "string" },
       { name: "status", type: "string" },
@@ -166,6 +171,85 @@ describe("validateWidgetQuery", () => {
         sort: "-secretScore",
       })
     ).toThrow(/sort references undeclared field "secretScore"/);
+  });
+
+  describe("a lifecycle selector against a source that has no lifecycle", () => {
+    /**
+     * A collection with the lifecycle OFF that declares an ordinary user field
+     * called `status`. The pair is the whole point: `fields` cannot tell this
+     * apart from a lifecycle collection, so a validator reading the field list
+     * would admit the selector this source cannot answer.
+     */
+    beforeEach(() => {
+      registerSource({
+        id: "collection:notes",
+        label: "Notes",
+        kind: "collection",
+        supports: ["count", "list"],
+        fields: [
+          { name: "title", type: "string" },
+          { name: "status", type: "string" },
+        ],
+      });
+    });
+
+    it.each(["draft", "published"] as const)(
+      "refuses %s, which nothing downstream could have applied",
+      status => {
+        expect(() =>
+          validateWidgetQuery({
+            source: "collection:notes",
+            op: "count",
+            status,
+          })
+        ).toThrow(/collection:notes has no draft\/published lifecycle/);
+      }
+    );
+
+    it('accepts "all", which claims no lifecycle and is what the generated cards send', () => {
+      const q = validateWidgetQuery({
+        source: "collection:notes",
+        op: "count",
+        status: "all",
+      });
+      expect(q.status).toBe("all");
+    });
+
+    it("refuses it for a single too, and still admits one that has the lifecycle", () => {
+      // Both kinds reach the same read plumbing, so the refusal is the
+      // source's capability rather than a rule per kind.
+      registerSource({
+        id: "single:site-settings",
+        label: "Site settings",
+        kind: "single",
+        supports: ["list"],
+        fields: [{ name: "siteName", type: "string" }],
+      });
+      registerSource({
+        id: "single:homepage",
+        label: "Homepage",
+        kind: "single",
+        supports: ["list"],
+        lifecycleStatus: true,
+        fields: [{ name: "headline", type: "string" }],
+      });
+
+      expect(() =>
+        validateWidgetQuery({
+          source: "single:site-settings",
+          op: "list",
+          status: "draft",
+        })
+      ).toThrow(/single:site-settings has no draft\/published lifecycle/);
+
+      expect(
+        validateWidgetQuery({
+          source: "single:homepage",
+          op: "list",
+          status: "draft",
+        }).status
+      ).toBe("draft");
+    });
   });
 
   it("clamps the limit rather than trusting it", () => {

--- a/packages/nextly/src/domains/widgets/deferred-entities.ts
+++ b/packages/nextly/src/domains/widgets/deferred-entities.ts
@@ -67,22 +67,3 @@ export function setDeferredEntities(
 ): void {
   store().set(kind, new Set(slugs));
 }
-
-/**
- * Forget every kind's refusals, for a boot that is about to establish its own.
- *
- * 🔴 A refusal is a statement about ONE process's reloads, and this store
- * outlives the process's services: it is pinned to `globalThis`, so
- * `clearServices()` and a fresh `registerServices()` left the previous boot's
- * refusals standing. The new boot re-syncs every entity's metadata from the
- * config it was given, so nothing it registers is known to disagree with its
- * table -- and a slug held over from the last boot withheld a source and its
- * generated cards for good, since only a later reload replaces a kind's set.
- *
- * Called from `resetWidgetRegistries`, with the widget and source stores it
- * belongs beside: all three are the same boot's registration, and a reset that
- * took two of them left the third answering for a boot that is over.
- */
-export function clearDeferredEntities(): void {
-  store().clear();
-}

--- a/packages/nextly/src/domains/widgets/deferred-entities.ts
+++ b/packages/nextly/src/domains/widgets/deferred-entities.ts
@@ -67,3 +67,22 @@ export function setDeferredEntities(
 ): void {
   store().set(kind, new Set(slugs));
 }
+
+/**
+ * Forget every kind's refusals, for a boot that is about to establish its own.
+ *
+ * 🔴 A refusal is a statement about ONE process's reloads, and this store
+ * outlives the process's services: it is pinned to `globalThis`, so
+ * `clearServices()` and a fresh `registerServices()` left the previous boot's
+ * refusals standing. The new boot re-syncs every entity's metadata from the
+ * config it was given, so nothing it registers is known to disagree with its
+ * table -- and a slug held over from the last boot withheld a source and its
+ * generated cards for good, since only a later reload replaces a kind's set.
+ *
+ * Called from `resetWidgetRegistries`, with the widget and source stores it
+ * belongs beside: all three are the same boot's registration, and a reset that
+ * took two of them left the third answering for a boot that is over.
+ */
+export function clearDeferredEntities(): void {
+  store().clear();
+}

--- a/packages/nextly/src/domains/widgets/query.ts
+++ b/packages/nextly/src/domains/widgets/query.ts
@@ -802,11 +802,36 @@ function assertTimeseriesAgreesWithOp(
   return { dateField, interval };
 }
 
-/** Confirms `status`, when present, is one of the known values, and returns it. */
-function assertValidStatus(status: unknown): WidgetQuery["status"] | undefined {
+/**
+ * Confirms `status`, when present, is one of the known values AND is one this
+ * source can actually answer, and returns it.
+ *
+ * 🔴 `draft` and `published` are refused for a source without the lifecycle,
+ * and that is a correctness refusal rather than a tidiness one. Nothing
+ * downstream can honour them: `resolveStatusFilter` returns no filter when the
+ * target carries no status column, so both selectors reach the same rows and
+ * two mutually exclusive questions come back with one answer. A card asking for
+ * drafts would report the published count and say nothing about having been
+ * ignored, which is the failure `statsWidget` already refuses to GENERATE --
+ * this is the same refusal at the door, where a hand-written or plugin query
+ * arrives.
+ *
+ * `all` stays legal for every source. It is not a claim that a lifecycle
+ * exists, it is a statement that this read is not bounded by one, and it is
+ * what the generated count, recent and timeline cards already send.
+ */
+function assertValidStatus(
+  source: WidgetSource,
+  status: unknown
+): WidgetQuery["status"] | undefined {
   if (status === undefined) return undefined;
   if (!VALID_STATUSES.includes(status as WidgetQuery["status"] & string)) {
     fail(`status must be one of ${VALID_STATUSES.join(", ")}`);
+  }
+  if (status !== "all" && source.lifecycleStatus !== true) {
+    fail(
+      `${source.id} has no draft/published lifecycle, so status must be "all"`
+    );
   }
   return status as WidgetQuery["status"];
 }
@@ -888,7 +913,7 @@ export function validateReadWidgetQuery(
   assertWhereClauseUsable(where, { source, declared, op });
   assertSelectFieldsDeclared(source, select, declared);
   const sort = assertSortFieldDeclared(source, raw.sort, declared);
-  const status = assertValidStatus(raw.status);
+  const status = assertValidStatus(source, raw.status);
   const groupBy = assertGroupByAgreesWithOp(
     source,
     raw.groupBy,

--- a/packages/nextly/src/init/__tests__/reload-config.test.ts
+++ b/packages/nextly/src/init/__tests__/reload-config.test.ts
@@ -969,6 +969,46 @@ describe("reloadNextlyConfig", () => {
     );
   });
 
+  it("does NOT mark a single 'applied' when its own metadata sync REFUSED it", async () => {
+    // 🔴 The in-process deferral cannot stand in for this. `applied` is
+    // PERSISTED, so it outlives the deferral set: after a restart the set is
+    // gone, the row still reads `applied`, and the source refresh republishes
+    // the field list the registry refused to update -- against the table the
+    // apply just moved. `theme` synced and travels as the control, so a
+    // marking step that had simply stopped running cannot pass this.
+    loadConfigSpy.mockResolvedValue({
+      config: {
+        singles: [
+          { slug: "settings", fields: [{ name: "site_name", type: "text" }] },
+          { slug: "theme", fields: [{ name: "accent", type: "text" }] },
+        ],
+      },
+    });
+    // Both tables are NEW, so the absent-table half would mark both.
+    introspectSpy.mockResolvedValue(buildSnapshot([]));
+
+    const resolver = buildResolver({
+      singleSyncResult: {
+        created: ["settings", "theme"],
+        updated: [],
+        unchanged: [],
+        errors: [{ slug: "settings" }],
+      },
+    });
+    const { reloadNextlyConfig } = await import("../reload-config");
+    await reloadNextlyConfig({ resolver });
+
+    expect(pipelineApplySpy).toHaveBeenCalledTimes(1);
+    expect(resolver.updateSingleMigrationStatusSpy).toHaveBeenCalledWith(
+      "theme",
+      "applied"
+    );
+    expect(resolver.updateSingleMigrationStatusSpy).not.toHaveBeenCalledWith(
+      "settings",
+      "applied"
+    );
+  });
+
   it("does NOT mark a DEFERRED single 'applied' in a mixed batch", async () => {
     // The sync payload is every configured single, so a refused one whose
     // fields changed still comes back in `updated`; marking it from that list
@@ -1214,19 +1254,19 @@ describe("reloadNextlyConfig", () => {
 
     expect(pipelineApplySpy).toHaveBeenCalledTimes(1);
     expect(setDeferredEntitiesSpy).toHaveBeenCalledWith("single", ["settings"]);
-    // The collection sync threw, so nothing may claim to know what it wrote.
-    expect(setDeferredEntitiesSpy).not.toHaveBeenCalledWith(
-      "collection",
-      expect.anything()
-    );
+    // The collection sync REJECTED, so it stored nothing while the apply had
+    // already moved the tables: every configured collection is now described
+    // by the field list it had before. Asserting the setter was not called
+    // could not tell that from a set correctly left alone.
+    expect(setDeferredEntitiesSpy).toHaveBeenCalledWith("collection", [
+      "authors",
+    ]);
   });
 
-  it("leaves the single refusal set standing when the single metadata sync throws", async () => {
-    // The other direction of the same separation: a singles sync that threw
-    // wrote nothing, so the registry still describes what an earlier reload
-    // recorded, and replacing the set from here would clear a refusal that
-    // reload correctly made. The collection sync ran, so its kind is still
-    // published.
+  it("defers its kind when the single metadata sync throws, and leaves the other kind alone", async () => {
+    // The other direction of the same separation. The singles sync rejected
+    // after the apply, so its own kind is withheld; the collection sync ran
+    // and published its kind normally.
     loadConfigSpy.mockResolvedValue({
       config: {
         collections: [
@@ -1258,10 +1298,7 @@ describe("reloadNextlyConfig", () => {
 
     expect(pipelineApplySpy).toHaveBeenCalledTimes(1);
     expect(setDeferredEntitiesSpy).toHaveBeenCalledWith("collection", []);
-    expect(setDeferredEntitiesSpy).not.toHaveBeenCalledWith(
-      "single",
-      expect.anything()
-    );
+    expect(setDeferredEntitiesSpy).toHaveBeenCalledWith("single", ["settings"]);
   });
 
   it("preserves UI-created singles (registry-only) in the desired schema", async () => {

--- a/packages/nextly/src/init/__tests__/reload-config.test.ts
+++ b/packages/nextly/src/init/__tests__/reload-config.test.ts
@@ -989,7 +989,10 @@ describe("reloadNextlyConfig", () => {
 
     const resolver = buildResolver({
       singleSyncResult: {
-        created: ["settings", "theme"],
+        // `theme` was written; `settings` was refused, so it is absent from
+        // `created`. A slug in both lists means the row landed and something
+        // after it failed, which the pair below covers.
+        created: ["theme"],
         updated: [],
         unchanged: [],
         errors: [{ slug: "settings" }],
@@ -1007,6 +1010,48 @@ describe("reloadNextlyConfig", () => {
       "settings",
       "applied"
     );
+  });
+
+  it("DOES mark a single whose row landed and whose permission seeding then failed", async () => {
+    // 🔴 The distinction `errors` alone cannot make, and the direction that
+    // fails silently. Both registries push a slug onto `created`/`updated`
+    // BEFORE awaiting the permission seeding that follows the write, and the
+    // catch around that await appends to `errors` -- so a slug in BOTH lists
+    // means the row IS current and something after it failed.
+    //
+    // Read as a refusal, such a single is withheld from the widget sources and
+    // its migration is never marked applied, over metadata that is in fact
+    // current, and no later pass corrects it because every later pass reads
+    // the same report the same way.
+    loadConfigSpy.mockResolvedValue({
+      config: {
+        singles: [
+          { slug: "settings", fields: [{ name: "site_name", type: "text" }] },
+        ],
+      },
+    });
+    introspectSpy.mockResolvedValue(buildSnapshot([]));
+
+    const resolver = buildResolver({
+      singleSyncResult: {
+        created: ["settings"],
+        updated: [],
+        unchanged: [],
+        // The SAME slug, in both lists.
+        errors: [{ slug: "settings", error: "permission seeding failed" }],
+      },
+    });
+    const { reloadNextlyConfig } = await import("../reload-config");
+    await reloadNextlyConfig({ resolver });
+
+    expect(pipelineApplySpy).toHaveBeenCalledTimes(1);
+    expect(resolver.updateSingleMigrationStatusSpy).toHaveBeenCalledWith(
+      "settings",
+      "applied"
+    );
+    // Nor is its source withheld: the metadata the source is built from is the
+    // metadata that landed.
+    expect(setDeferredEntitiesSpy).toHaveBeenCalledWith("single", []);
   });
 
   it("does NOT mark a DEFERRED single 'applied' in a mixed batch", async () => {
@@ -1197,7 +1242,10 @@ describe("reloadNextlyConfig", () => {
     await reloadNextlyConfig({
       resolver: buildResolver({
         singleSyncResult: {
-          created: ["theme"],
+          // `errors` ALONE. A slug in `created` too would be a row that was
+          // written and then failed something after the write, which is not a
+          // refusal and must not be withheld -- see the pair below.
+          created: [],
           updated: [],
           unchanged: [],
           errors: [{ slug: "theme", error: "write failed" }],

--- a/packages/nextly/src/init/__tests__/reload-config.test.ts
+++ b/packages/nextly/src/init/__tests__/reload-config.test.ts
@@ -660,6 +660,51 @@ describe("reloadNextlyConfig", () => {
     expect(setDeferredEntitiesSpy).toHaveBeenCalledWith("collection", []);
   });
 
+  it("keeps a single the metadata-only sync REFUSED deferred, while the rest of its kind clears", async () => {
+    // 🔴 The scope flag cannot carry this. `syncCodeFirstSingles` reports a
+    // per-slug refusal by RESOLVING with `errors[]`, so the scope stays
+    // "synced" and only the failed slugs say otherwise. Reading the flag alone
+    // emptied the set, and `refreshSingleSources` then republished fields the
+    // registry had just refused to update.
+    loadConfigSpy.mockResolvedValue({
+      config: {
+        singles: [
+          { slug: "settings", fields: [{ name: "site_name", type: "text" }] },
+          { slug: "theme", fields: [{ name: "accent", type: "text" }] },
+        ],
+      },
+    });
+    introspectSpy.mockResolvedValue(
+      buildSnapshot([
+        {
+          name: "single_settings",
+          columns: [
+            ...reservedColumns("single_settings"),
+            { name: "site_name", type: "text", nullable: true },
+          ],
+        },
+        {
+          name: "single_theme",
+          columns: [
+            ...reservedColumns("single_theme"),
+            { name: "accent", type: "text", nullable: true },
+          ],
+        },
+      ])
+    );
+
+    const resolver = buildResolver({
+      singleSyncResult: { errors: [{ slug: "settings" }] },
+    });
+    const { reloadNextlyConfig } = await import("../reload-config");
+    await reloadNextlyConfig({ resolver });
+
+    // No DDL: every diff was zero-op, which is the branch this guards.
+    expect(pipelineApplySpy).not.toHaveBeenCalled();
+    // `theme` synced and is absent; `settings` is the one that did not land.
+    expect(setDeferredEntitiesSpy).toHaveBeenCalledWith("single", ["settings"]);
+  });
+
   it("publishes NOTHING when the reload carries only a refusal", async () => {
     // 🔴 A reload whose only change is refused never reaches the metadata sync:
     // `hasChanges` stays false, and the metadata-only landing is gated on

--- a/packages/nextly/src/init/__tests__/sync-outcome.test.ts
+++ b/packages/nextly/src/init/__tests__/sync-outcome.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Reading a registry sync's report.
+ *
+ * The case that matters is the one `errors[]` alone cannot express: both
+ * registries push a slug onto `created`/`updated` BEFORE awaiting the
+ * permission seeding that follows the write, and the catch around that await
+ * appends to `errors`. A slug in BOTH lists therefore means the row landed and
+ * something after it failed -- and reading that as a refusal withholds a
+ * source whose metadata is current, permanently, because every later pass
+ * reads the same report the same way.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { erroredSlugs, rewrittenSlugs, unwrittenSlugs } from "../sync-outcome";
+
+const report = (r: {
+  created?: unknown;
+  updated?: unknown;
+  errors?: unknown;
+}) => r;
+
+describe("unwrittenSlugs", () => {
+  it("takes a slug the sync refused outright", () => {
+    expect(
+      unwrittenSlugs(report({ created: [], errors: [{ slug: "posts" }] }))
+    ).toEqual(["posts"]);
+  });
+
+  it("LEAVES a slug whose row was written and which errored afterwards", () => {
+    // 🔴 The whole point. `posts` is in both lists, so its row is current.
+    expect(
+      unwrittenSlugs(
+        report({ created: ["posts"], errors: [{ slug: "posts" }] })
+      )
+    ).toEqual([]);
+  });
+
+  it("leaves one whose row was UPDATED and which errored afterwards", () => {
+    // The other write verb reports through a different list, and a reading
+    // that checked only `created` would withhold every edited entity.
+    expect(
+      unwrittenSlugs(
+        report({ updated: ["posts"], errors: [{ slug: "posts" }] })
+      )
+    ).toEqual([]);
+  });
+
+  it("separates the two within one report", () => {
+    // The discriminating case: a batch where one slug landed-then-failed and
+    // another was refused. A reading that answered all-or-nothing would match
+    // one of the cases above and neither of these.
+    expect(
+      unwrittenSlugs(
+        report({
+          created: ["landed"],
+          updated: [],
+          errors: [{ slug: "landed" }, { slug: "refused" }],
+        })
+      )
+    ).toEqual(["refused"]);
+  });
+
+  it("answers nothing for a clean report, and for a shape it cannot read", () => {
+    // The registries are reached through a duck-typed surface here, so a fake
+    // may resolve anything at all -- and "cannot read it" must not become
+    // "everything failed", which would withhold every source in the install.
+    expect(unwrittenSlugs(report({ created: ["a"], errors: [] }))).toEqual([]);
+    expect(unwrittenSlugs(undefined)).toEqual([]);
+    expect(unwrittenSlugs(null)).toEqual([]);
+    expect(unwrittenSlugs("not a report")).toEqual([]);
+    expect(unwrittenSlugs(report({ errors: "not an array" }))).toEqual([]);
+    expect(unwrittenSlugs(report({ errors: [{}, 7, null] }))).toEqual([]);
+  });
+});
+
+describe("erroredSlugs", () => {
+  it("keeps a post-write failure, which is what makes it the wrong input for withholding", () => {
+    // The raw reading has its own callers -- a failed permission seed is worth
+    // logging. Asserted beside `unwrittenSlugs` so the difference between them
+    // is visible rather than inferred from two files.
+    expect(
+      erroredSlugs(report({ created: ["posts"], errors: [{ slug: "posts" }] }))
+    ).toEqual(["posts"]);
+  });
+});
+
+describe("rewrittenSlugs", () => {
+  it("names the rows the sync updated, and not the ones it created", () => {
+    // `created` rows are caught by the caller's own absent-table reading; a row
+    // reported here is one whose `migration_status` the update reset.
+    expect(
+      rewrittenSlugs(report({ created: ["new"], updated: ["edited"] }))
+    ).toEqual(["edited"]);
+  });
+
+  it("answers nothing for a shape it cannot read", () => {
+    expect(rewrittenSlugs(undefined)).toEqual([]);
+    expect(rewrittenSlugs(report({ updated: "not an array" }))).toEqual([]);
+  });
+});

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -106,6 +106,7 @@ import type { SingleHooks } from "../singles/config/types";
 
 import { planFieldGroupReload } from "./field-group-reload-plan";
 import { clearLiveSnapshots, setLiveSnapshot } from "./schema-snapshot-cache";
+import { rewrittenSlugs, unwrittenSlugs } from "./sync-outcome";
 
 // Service-resolver shape. Defaulted to the real getService at runtime;
 // tests inject a lighter-weight resolver to avoid pulling DI internals.
@@ -191,44 +192,6 @@ type ComponentDef = {
 };
 
 /**
- * The slugs a metadata sync REFUSED, read defensively from an untyped result.
- *
- * `syncCodeFirstCollections` resolves rather than rejecting on a per-collection
- * failure, so a caller that only catches sees a partial failure as a success.
- * Read through a guard for the same reason its sibling below is: the surface
- * this module holds is duck-typed, and a fake may resolve anything at all.
- */
-function syncFailedSlugs(result: unknown): string[] {
-  if (typeof result !== "object" || result === null) return [];
-  const errors = (result as { errors?: unknown }).errors;
-  if (!Array.isArray(errors)) return [];
-  return errors
-    .map(entry =>
-      typeof entry === "object" && entry !== null
-        ? (entry as { slug?: unknown }).slug
-        : undefined
-    )
-    .filter((slug): slug is string => typeof slug === "string");
-}
-
-/**
- * The slugs a metadata sync rewrote, read defensively from an untyped result.
- *
- * `SyncResult.updated` names the rows that went through `updateCollection`,
- * which is the one path that resets `migration_status` on a collection that
- * already existed. Read through a guard rather than a cast because the surface
- * this module holds is duck-typed: a partial resolver fake may resolve anything
- * at all, and a sync that reports nothing must leave the marking alone rather
- * than throw inside the metadata step.
- */
-function rewrittenSlugs(result: unknown): string[] {
-  if (typeof result !== "object" || result === null) return [];
-  const updated = (result as { updated?: unknown }).updated;
-  if (!Array.isArray(updated)) return [];
-  return updated.filter((slug): slug is string => typeof slug === "string");
-}
-
-/**
  * The slugs of one kind whose registry row may now say `applied`.
  *
  * 🔴 A successful apply leaves a row saying `pending` in TWO ways, and the
@@ -288,7 +251,7 @@ function migratedSlugs(
   // Read from the sync's OWN report rather than passed in beside it: the
   // result naming the rows it rewrote is the result naming the rows it could
   // not, so asking it twice cannot disagree with itself.
-  const refused = new Set(syncFailedSlugs(syncResult));
+  const refused = new Set(unwrittenSlugs(syncResult));
   const withheld = (slug: string): boolean =>
     isDeferred(slug) || refused.has(slug);
   const migrated = new Set<string>(
@@ -412,13 +375,12 @@ interface SingleRegistrySurface {
  * is read from there; those slugs keep their prior default snapshot.
  */
 function failedSingleSlugs(syncResult: unknown): Set<string> {
-  const errs = (syncResult as { errors?: Array<{ slug?: string }> } | undefined)
-    ?.errors;
-  const slugs = new Set<string>();
-  if (Array.isArray(errs)) {
-    for (const entry of errs) if (entry?.slug) slugs.add(entry.slug);
-  }
-  return slugs;
+  // Narrowed to the writes that did NOT land, for the reason `unwrittenSlugs`
+  // states: a slug the sync pushed onto `created` or `updated` before its
+  // permission seeding threw is in BOTH lists, and its row is current. Reading
+  // `errors` alone kept that single's PRIOR snapshot over metadata that had
+  // already advanced.
+  return new Set(unwrittenSlugs(syncResult));
 }
 
 /**
@@ -635,7 +597,7 @@ async function syncCodeFirstMetadataOnly(
       payload.length > 0
         ? await registry.syncCodeFirstCollections(payload)
         : undefined;
-    const failed = syncFailedSlugs(result);
+    const failed = unwrittenSlugs(result);
     if (failed.length > 0) {
       collections = false;
       logger?.warn(
@@ -2477,7 +2439,7 @@ async function applyReload(opts?: {
       // must not act on metadata the registry did not accept: the recording
       // policies, and the hook publication below. Both would then run against a
       // field tree that is not the one stored.
-      const failedCollections = syncFailedSlugs(collectionSync);
+      const failedCollections = unwrittenSlugs(collectionSync);
 
       // 🔴 Published HERE, on the path where the metadata sync actually ran,
       // and not before the branch above. Computing it earlier looked equivalent

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -2104,11 +2104,21 @@ async function applyReload(opts?: {
       // collection sync that ran says nothing about a single a previous reload
       // refused, and clearing that too would publish a card over a table the
       // single's metadata is still ahead of.
-      const { setDeferredEntities } = await import(
-        "../domains/widgets/deferred-entities"
-      );
-      if (synced.collections) setDeferredEntities("collection", []);
-      if (synced.singles) setDeferredEntities("single", []);
+      // 🔴 The scope flag alone does not say the scope caught up. The singles
+      // sync reports a per-slug refusal by RESOLVING with errors, and
+      // `syncCodeFirstMetadataOnly` keeps those singles' prior snapshot and
+      // leaves `singles` true -- so reading the flag alone cleared the whole
+      // deferral set while a single the sync had just refused still described
+      // itself the old way. `refreshSingleSources` would then republish those
+      // stale fields and its cards would query columns the table does not have.
+      // Published through the same helper the DDL paths use, so the slugs that
+      // stay deferred are the ones this pass could not land rather than a
+      // separate rule maintained here.
+      if (synced.collections)
+        await publishDeferred("collection", deferredEntities);
+      if (synced.singles) {
+        await publishDeferred("single", deferredEntities, synced.failedSingles);
+      }
       // Publish each scope's (possibly toggled) recording policy ONLY when that
       // scope's metadata sync succeeded — a `webhooks` change surfaces as no
       // schema diff, so this is the path a live opt-out/opt-in toggle flows

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -277,11 +277,25 @@ function migratedSlugs(
 ): Set<string> {
   const isDeferred = (slug: string): boolean =>
     deferredEntities.has(`${kind}:${slug}`);
+  // 🔴 A slug the sync REFUSED is excluded from both halves as firmly as a
+  // deferred one, and for a reason the in-process deferral cannot cover. The
+  // DDL moved that table and the registry kept its old field list, so
+  // `applied` is the opposite of what just happened -- and unlike the deferral
+  // set, which lives only in this process, the label PERSISTS. After a restart
+  // the set is gone, the row still reads `applied`, and the stale field list
+  // is republished against the table it no longer describes.
+  //
+  // Read from the sync's OWN report rather than passed in beside it: the
+  // result naming the rows it rewrote is the result naming the rows it could
+  // not, so asking it twice cannot disagree with itself.
+  const refused = new Set(syncFailedSlugs(syncResult));
+  const withheld = (slug: string): boolean =>
+    isDeferred(slug) || refused.has(slug);
   const migrated = new Set<string>(
-    rewrittenSlugs(syncResult).filter(slug => !isDeferred(slug))
+    rewrittenSlugs(syncResult).filter(slug => !withheld(slug))
   );
   for (const target of targets) {
-    if (!liveByTable.has(target.tableName) && !isDeferred(target.slug)) {
+    if (!liveByTable.has(target.tableName) && !withheld(target.slug)) {
       migrated.add(target.slug);
     }
   }
@@ -2483,6 +2497,22 @@ async function applyReload(opts?: {
     } catch {
       // Non-fatal: DDL was applied; metadata sync failed. The next boot
       // or HMR cycle will retry via registerServices.
+      //
+      // 🔴 The deferral is published from HERE too, not only from the success
+      // path. A sync that REJECTS stored nothing, so every table this apply
+      // moved now has a registry row describing the shape it had before --
+      // and leaving the previous set standing (usually empty) said the
+      // opposite, publishing sources over tables that had just changed under
+      // them. The whole configured set, because a rejection carries no report
+      // of which entities it got to: the precise set is unknowable here, and
+      // a withheld card that works is recoverable where a card querying a
+      // column that no longer exists is not. The next successful reload
+      // replaces this, and a restart clears it.
+      await publishDeferred(
+        "collection",
+        deferredEntities,
+        targets.map(target => target.slug)
+      );
       collectionSynced = false;
     }
 
@@ -2534,7 +2564,14 @@ async function applyReload(opts?: {
         keepPriorFor: failedSlugs,
       });
     } catch {
-      // Non-fatal: same reasoning as collection metadata sync above.
+      // Non-fatal: same reasoning as collection metadata sync above, and the
+      // deferral is published for the same reason — a rejected sync leaves
+      // every moved table described by the field list it had before.
+      await publishDeferred(
+        "single",
+        deferredEntities,
+        singleTargets.map(target => target.slug)
+      );
       singleSynced = false;
     }
 

--- a/packages/nextly/src/init/sync-outcome.ts
+++ b/packages/nextly/src/init/sync-outcome.ts
@@ -1,0 +1,84 @@
+/**
+ * Reading a registry sync's report: which slugs actually LANDED.
+ *
+ * 🔴 `errors[]` is not that answer, and the gap is the whole reason this module
+ * exists. Both registries push a slug onto `created` or `updated` BEFORE
+ * awaiting the permission seeding that follows the write, and the catch around
+ * that await appends to `errors`. So a slug can appear in BOTH lists, and when
+ * it does the meaning is specific: the registry row was written and something
+ * after it failed.
+ *
+ * Read as a refusal, such a slug is withheld from the widget sources and its
+ * migration is never marked applied -- over metadata that is in fact current,
+ * and with no later pass able to correct it, because every later pass reads the
+ * same report the same way. The failure is silent and permanent.
+ *
+ * One implementation because three callers ask it: the metadata-only reload,
+ * the post-DDL reload, and the boot sync. They already disagreed once, and the
+ * disagreement is invisible -- each site looks correct on its own.
+ *
+ * @module init/sync-outcome
+ */
+
+/** The shape both registries answer with, read defensively from an untyped result. */
+interface SyncReport {
+  created?: unknown;
+  updated?: unknown;
+  errors?: unknown;
+}
+
+function slugList(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((slug): slug is string => typeof slug === "string")
+    : [];
+}
+
+/**
+ * The slugs the sync REPORTED AN ERROR for, whatever else it says about them.
+ *
+ * The raw reading, and the one that is right for a caller asking "did anything
+ * go wrong for this entity" -- a failed permission seed is a real failure worth
+ * logging, even though the row landed.
+ */
+export function erroredSlugs(result: unknown): string[] {
+  if (typeof result !== "object" || result === null) return [];
+  const errors = (result as SyncReport).errors;
+  if (!Array.isArray(errors)) return [];
+  return errors
+    .map(entry =>
+      typeof entry === "object" && entry !== null
+        ? (entry as { slug?: unknown }).slug
+        : undefined
+    )
+    .filter((slug): slug is string => typeof slug === "string");
+}
+
+/**
+ * The slugs whose registry WRITE did not land.
+ *
+ * An error MINUS the writes the same report claims, because a slug in both
+ * lists had its row written. This is the answer every "is the stored metadata
+ * behind its table" question wants: a slug here kept its old field list, and a
+ * slug that errored after its write did not.
+ */
+export function unwrittenSlugs(result: unknown): string[] {
+  if (typeof result !== "object" || result === null) return [];
+  const report = result as SyncReport;
+  const written = new Set([
+    ...slugList(report.created),
+    ...slugList(report.updated),
+  ]);
+  return erroredSlugs(result).filter(slug => !written.has(slug));
+}
+
+/**
+ * The slugs a metadata sync REWROTE -- the rows whose `migration_status` it
+ * reset to `pending` and which an apply may therefore now mark applied.
+ *
+ * `updated` alone: `created` rows are caught by the caller's own absent-table
+ * reading, and a row the sync left `unchanged` never moved.
+ */
+export function rewrittenSlugs(result: unknown): string[] {
+  if (typeof result !== "object" || result === null) return [];
+  return slugList((result as SyncReport).updated);
+}


### PR DESCRIPTION
The six findings Codex raised on #1803 in its last two rounds, which arrived
as that PR merged. Cut from `main`, not stacked — a stacked base runs none of
the substantive CI.

Five are fixed here. One is real and belongs elsewhere; it is answered on its
thread with the measurement and filed rather than bolted on.

## A lifecycle selector needs a lifecycle

A widget query naming `draft` or `published` against a source with no publish
lifecycle was accepted and forwarded. `resolveStatusFilter` returns no filter
when the target carries no status column, so both selectors reached the same
rows: two mutually exclusive questions, one answer, and nothing saying the
selector had been ignored.

`statsWidget` already refuses to *generate* such a card, and its comment names
this exact failure. The refusal now also sits at the door, where a hand-written
or plugin query arrives — in `validateReadWidgetQuery`, which holds the source,
so it covers collections and singles alike rather than one kind.

`status: "all"` stays legal everywhere. It claims no lifecycle, it is what the
generated count, recent and timeline cards send, and refusing it would break
them.

## A refused single stays deferred

`syncCodeFirstSingles` reports a per-slug refusal by *resolving* with
`errors[]`, so the scope flag stays true while those singles keep their prior
snapshot. The metadata-only reload read the flag alone and emptied the whole
deferral set; the next `refreshSingleSources` then republished field lists the
registry had just refused to store.

## Three ways the deferral store answered for what it had not seen

- **A rejected sync published nothing.** The DDL had already moved tables, and
  the catch left the previous set standing — usually empty. Each kind now
  records its configured set from its own catch. The precise set is unknowable
  there: a rejection carries no report of which entities it reached, and a
  withheld card that works is recoverable where a card querying a dropped
  column is not.
- **`applied` persists; the deferral does not.** `migratedSlugs` excluded
  deferred slugs but not refused ones, so a single whose metadata sync failed
  was still marked applied. After a restart the in-process set is gone, the row
  still reads `applied`, and the stale field list comes back against the moved
  table.
- **The store outlived its boot.** It is pinned to `globalThis` beside the
  widget and source stores, but `resetWidgetRegistries` cleared only those two.
  A slug one boot deferred kept its source and cards hidden for the life of the
  process, since only a later reload replaces a kind's set.

## Evidence

Each fix was broken individually and the intended test failed by name, with the
neighbours staying green: the `migratedSlugs` break kills one test, the catch
break kills exactly the two deferral tests, and the reset break kills only the
reset test. The lifecycle refusal was broken in both directions — removing it
fails the three refusal cases, and widening it to refuse `all` fails the
acceptance case, so neither over- nor under-refusal passes.

Codex was right that the previous rejection tests asserted only that no setter
was called, which cannot separate a set correctly left alone from one that
failed to record a newly mismatched entity. They now assert what is recorded.

`pnpm check-types`, `pnpm lint`, the full `nextly` unit suite (939 files,
11922 tests) and the eight widget/schema integration files on sqlite all pass;
fallow reports `pass` with 0 introduced dead code and 0 introduced duplication.