### PR TITLE
fix(nextly): the setup checklist offers a reader only the steps they can finish

### DIFF
--- a/.changeset/the-checklist-offers-what-a-reader-can-do.md
+++ b/.changeset/the-checklist-offers-what-a-reader-can-do.md
@@ -1,0 +1,40 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The setup checklist offers a reader only the steps they could actually finish.
+A step is withheld where the install has observed that this reader cannot take
+it -- they may read a collection but hold `create-<slug>` on none, or they
+cannot create a collection at all -- and the "is onboarding done" question is
+answered over the steps that remain. Before, both were derived from what the
+reader may READ: an editor without a create grant had the first-entry step
+outstanding permanently, its link landing on a surface that refused them, and
+the card pinned to their dashboard for the life of their account.
+
+A finished step stays on the list whoever the reader is. It records what the
+install has done rather than offering them work, so withholding it would only
+make their progress look smaller than it is.

--- a/.changeset/the-checklist-offers-what-a-reader-can-do.md
+++ b/.changeset/the-checklist-offers-what-a-reader-can-do.md
@@ -38,3 +38,8 @@ the card pinned to their dashboard for the life of their account.
 A finished step stays on the list whoever the reader is. It records what the
 install has done rather than offering them work, so withholding it would only
 make their progress look smaller than it is.
+
+The step is decided by the same authorization a write performs, so a scoped API
+key whose collection refuses its `access.create` rule is not offered a step that
+write would refuse. The grant that authorizes creating a collection is declared
+once and read by the two routes that enforce it as well as by the checklist.

--- a/packages/nextly/src/api/collections-schema.ts
+++ b/packages/nextly/src/api/collections-schema.ts
@@ -19,6 +19,10 @@
 
 import { z } from "zod";
 
+import {
+  COLLECTION_DEFINITION_ACTION,
+  COLLECTION_DEFINITION_RESOURCE,
+} from "../auth/collection-definition-policy";
 import { getService } from "../di";
 import { calculateSchemaHash } from "../domains/schema/services/schema-hash";
 import { resolveBuilderVersions } from "../domains/versions/builder-versions";
@@ -241,7 +245,11 @@ export const POST = withErrorHandler(async (request: Request) => {
 
   // Authorise: only super-admins or users with manage-settings permission
   // may create new collections (matches the frontend route guard).
-  await requireRoutePermission(request, "manage", "settings");
+  await requireRoutePermission(
+    request,
+    COLLECTION_DEFINITION_ACTION,
+    COLLECTION_DEFINITION_RESOURCE
+  );
 
   const body = await request.json();
 

--- a/packages/nextly/src/auth/collection-definition-policy.ts
+++ b/packages/nextly/src/auth/collection-definition-policy.ts
@@ -1,0 +1,38 @@
+/**
+ * Which grant authorizes a collection DEFINITION change, declared once.
+ *
+ * Creating, renaming or dropping a collection is DDL, and it is authorized
+ * differently from writing a row in one: an editor holding `update-posts` may
+ * not redefine `posts`, and a caller holding this grant may have no access to
+ * any collection's rows.
+ *
+ * 🔴 Three places need the answer and they must not each carry it. Two are the
+ * routes that ENFORCE it -- the standalone schema endpoint and the dispatcher's
+ * definition-mutation branch -- and the third is the dashboard's onboarding
+ * checklist, which asks whether to OFFER the reader a "create your first
+ * collection" step at all. Restated in the third, the checklist would go on
+ * asking for a grant the routes had stopped requiring, and the failure is
+ * silent in both directions: a step offered whose endpoint refuses it, or a
+ * step hidden from someone allowed to take it.
+ *
+ * Split into its parts as well as the slug because the two consumers spell the
+ * same fact differently: `requirePermission`/`requireRoutePermission` take an
+ * action and a resource, while a permission-table lookup wants the joined
+ * `{action}-{resource}`. Deriving the slug here keeps the join from being a
+ * fourth place the policy is written.
+ *
+ * @module auth/collection-definition-policy
+ */
+
+/** The action half, as the route guards spell it. */
+export const COLLECTION_DEFINITION_ACTION = "manage";
+
+/** The resource half, as the route guards spell it. */
+export const COLLECTION_DEFINITION_RESOURCE = "settings";
+
+/**
+ * The same policy as a permission slug, for a caller that looks one up rather
+ * than guarding a route with it.
+ */
+export const COLLECTION_DEFINITION_PERMISSION =
+  `${COLLECTION_DEFINITION_ACTION}-${COLLECTION_DEFINITION_RESOURCE}` as const;

--- a/packages/nextly/src/domains/widgets/__tests__/onboarding.integration.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/onboarding.integration.test.ts
@@ -245,18 +245,19 @@ describe("onboarding steps against a real instance", () => {
     expect(await onboardingIsIncomplete(conditionProbe(admin))).toBe(false);
   });
 
-  it("offers the first-entry step to a builder with no collection in reach yet", async () => {
-    // 🔴 The empty-list case, which the grant walk cannot answer on its own:
-    // with nothing readable there is no `create-<slug>` to find, and reading
-    // that absence as a refusal is a different claim from having observed one.
-    // So the step follows the next question along -- could this reader make
-    // the collection the entry would go in?
+  it("offers a builder the collection step and NOT the entry step", async () => {
+    // 🔴 Creating a collection is not being able to write a row in it.
+    // `seedPermissionsForCollection` assigns a new collection's CRUD
+    // permissions to `super_admin` alone, so this caller would not acquire
+    // `create-<new-slug>` -- and might not even be able to read what they
+    // made. Offering the entry step on the strength of the definition grant
+    // hands them a step they still cannot finish, which is the defect this
+    // predicate exists to prevent, moved one collection later.
     //
-    // The caller is a KEY carrying `manage-settings` and no read grant, which
-    // is the only shape that can tell the two apart: it reads nothing, so the
-    // walk is empty, while the collection answer is unambiguously yes. A
-    // session caller cannot discriminate here -- both branches answer false
-    // for it, so the same test passed with this composition removed.
+    // The caller is a KEY stamped with the definition grant and no read grant,
+    // which is the shape that separates the two predicates: its readable set
+    // is empty while its collection answer is unambiguously yes. A session
+    // caller answers no to both and could not tell them apart.
     await createTestNextly({
       collections: [
         defineCollection({
@@ -273,7 +274,9 @@ describe("onboarding steps against a real instance", () => {
     const steps = await stepsFor(builder);
 
     expect(steps.collection).toBe(false);
-    expect(steps.entry).toBe(false);
+    expect(steps.entry).toBeUndefined();
+    // Still incomplete: there IS something this reader can do, and the card
+    // stays until they have done it.
     expect(await onboardingIsIncomplete(conditionProbe(builder))).toBe(true);
   });
 
@@ -309,6 +312,72 @@ describe("onboarding steps against a real instance", () => {
     // to offer and the card is not put on their dashboard at all.
     expect(Object.keys(steps)).toEqual(["account"]);
     expect(await onboardingIsIncomplete(conditionProbe(admin))).toBe(false);
+  });
+
+  it("withholds the entry step from a KEY the collection's own create rule refuses", async () => {
+    // 🔴 The two decisions disagree for exactly this caller. A bare permission
+    // check reads the key's stamped `create-<slug>` and stops; the WRITE also
+    // evaluates the collection's code-defined `access.create` against that
+    // scope. Gated on the bare check, this key is told it may create -- and
+    // the step it is offered is refused by the write it links to, which is the
+    // defect the predicate exists to prevent.
+    await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: ARCHIVE,
+          access: {
+            read: () => true,
+            // Refuses the key, whatever the key is stamped with.
+            create: () => false,
+            update: () => true,
+          },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    }).then(t => {
+      current = t;
+      return refreshCollectionSources();
+    });
+
+    const stamped: ReadCaller = {
+      user: { id: "key-1", roles: [] },
+      authenticatedScope: {
+        actorType: "apiKey",
+        permissions: [`read-${ARCHIVE}`, `create-${ARCHIVE}`],
+      },
+    };
+
+    const steps = await stepsFor(stamped);
+    expect(steps.entry).toBeUndefined();
+  });
+
+  it("offers it to the same KEY when the rule admits it", async () => {
+    // The must-differ half, and it has to be the same fixture with the one
+    // rule flipped: a predicate that refused every key -- or never ran --
+    // would satisfy the case above on its own.
+    await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: ARCHIVE,
+          access: { read: () => true, create: () => true, update: () => true },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    }).then(t => {
+      current = t;
+      return refreshCollectionSources();
+    });
+
+    const stamped: ReadCaller = {
+      user: { id: "key-1", roles: [] },
+      authenticatedScope: {
+        actorType: "apiKey",
+        permissions: [`read-${ARCHIVE}`, `create-${ARCHIVE}`],
+      },
+    };
+
+    const steps = await stepsFor(stamped);
+    expect(steps.entry).toBe(false);
   });
 
   // No case asserts that the condition agrees with the steps it reports.

--- a/packages/nextly/src/domains/widgets/__tests__/onboarding.integration.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/onboarding.integration.test.ts
@@ -25,10 +25,28 @@ import { onboardingIsIncomplete, onboardingSteps } from "../onboarding";
 const NOTES = "notes";
 /** A collection whose rows the reader under test may NOT read. */
 const SECRETS = "secrets";
+/** A collection the reader may read, whose create rule the case decides. */
+const ARCHIVE = "archive";
 
 /** An admin: the reader onboarding actually meets, and one who may read all. */
 const admin: ReadCaller = {
   user: { id: "admin-1", roles: ["admin"] },
+};
+
+/**
+ * A key stamped to create collections and to read none of them.
+ *
+ * A key rather than a session, because `callerHoldsPermission` judges a key on
+ * its OWN stamped grants and a session through the RBAC tables -- and this
+ * instance seeds no role holding `manage-settings`, so a session caller answers
+ * "no" to both halves of the composition under test and cannot separate them.
+ */
+const builder: ReadCaller = {
+  user: { id: "builder-1", roles: [] },
+  authenticatedScope: {
+    actorType: "apiKey",
+    permissions: ["manage-settings"],
+  },
 };
 
 type WriteHandler = {
@@ -87,6 +105,32 @@ async function boot(): Promise<TestNextly> {
   // The same call `POST /api/dashboard/query` makes before resolving anything:
   // publish the collection sources from the LIVE registry. Boot does not, and
   // the steps read that registry to know which collections exist.
+  await refreshCollectionSources();
+  return t;
+}
+
+/**
+ * One collection this reader may READ and may not CREATE in, and nothing else.
+ *
+ * Its own boot because the shared fixture grants `create` on `notes`: with a
+ * creatable collection in reach the reader CAN take the first-entry step, so
+ * that fixture cannot tell a per-step predicate from no predicate at all.
+ */
+async function bootReadOnly(mayCreate: boolean): Promise<TestNextly> {
+  const t = await createTestNextly({
+    collections: [
+      defineCollection({
+        slug: ARCHIVE,
+        access: {
+          read: () => true,
+          create: () => mayCreate,
+          update: () => true,
+        },
+        fields: [text({ name: "title" })],
+      }),
+    ],
+  });
+  current = t;
   await refreshCollectionSources();
   return t;
 }
@@ -154,6 +198,117 @@ describe("onboarding steps against a real instance", () => {
 
     expect((await stepsFor(admin)).entry).toBe(false);
     expect(await onboardingIsIncomplete(conditionProbe(admin))).toBe(true);
+  });
+
+  it("withholds the first-entry step from a reader who may create in nothing", async () => {
+    // 🔴 The defect this pair exists for. Derived from what the reader may
+    // READ, the step was outstanding for such a reader permanently: they
+    // cannot write the row that would complete it, its link lands on a surface
+    // that refuses them, and `onboarding:incomplete` therefore stayed true for
+    // the life of their account -- pinning the card to their dashboard with an
+    // action that always fails.
+    //
+    // Absent from the list rather than present-and-disabled: a step nobody can
+    // take is not a task, and both WooCommerce's task list and SAP's guided
+    // setup hide rather than grey out.
+    await bootReadOnly(false);
+    const steps = await stepsFor(admin);
+
+    expect(steps.entry).toBeUndefined();
+    // The aggregate follows from the list, which is the point of deriving it:
+    // with no step this reader can act on, there is nothing to offer them.
+    expect(await onboardingIsIncomplete(conditionProbe(admin))).toBe(false);
+  });
+
+  it("offers it when the same collection admits a create", async () => {
+    // The must-differ half, and it has to be the SAME fixture with one rule
+    // flipped. A case that merely booted the shared fixture would differ in
+    // the collection set too, so a predicate that hid the step for any reason
+    // at all -- or one that never ran -- would satisfy the pair.
+    await bootReadOnly(true);
+    const steps = await stepsFor(admin);
+
+    expect(steps.entry).toBe(false);
+    expect(await onboardingIsIncomplete(conditionProbe(admin))).toBe(true);
+  });
+
+  it("keeps a FINISHED step a reader could not have taken", async () => {
+    // The asymmetry, asserted rather than left to the docblock. A finished
+    // step is a fact about the install, not an offer -- so it stays on the
+    // list and shows the reader how far the install has come. Only an
+    // unfinished step has to be actionable.
+    const t = await bootReadOnly(false);
+    await write(t, ARCHIVE, { title: "written by someone else" });
+    const steps = await stepsFor(admin);
+
+    expect(steps.entry).toBe(true);
+    expect(await onboardingIsIncomplete(conditionProbe(admin))).toBe(false);
+  });
+
+  it("offers the first-entry step to a builder with no collection in reach yet", async () => {
+    // 🔴 The empty-list case, which the grant walk cannot answer on its own:
+    // with nothing readable there is no `create-<slug>` to find, and reading
+    // that absence as a refusal is a different claim from having observed one.
+    // So the step follows the next question along -- could this reader make
+    // the collection the entry would go in?
+    //
+    // The caller is a KEY carrying `manage-settings` and no read grant, which
+    // is the only shape that can tell the two apart: it reads nothing, so the
+    // walk is empty, while the collection answer is unambiguously yes. A
+    // session caller cannot discriminate here -- both branches answer false
+    // for it, so the same test passed with this composition removed.
+    await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: SECRETS,
+          access: { read: () => false, create: () => true, update: () => true },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    }).then(t => {
+      current = t;
+      return refreshCollectionSources();
+    });
+
+    const steps = await stepsFor(builder);
+
+    expect(steps.collection).toBe(false);
+    expect(steps.entry).toBe(false);
+    expect(await onboardingIsIncomplete(conditionProbe(builder))).toBe(true);
+  });
+
+  it("offers nothing to a reader with no collection in reach and no way to make one", async () => {
+    // 🔴 The empty-list case, which the grant walk cannot answer on its own:
+    // with nothing readable there is no `create-<slug>` to find, and reading
+    // that absence as a refusal is a different claim from having observed one.
+    // So the step follows the next question along -- could this reader make
+    // the collection the entry would go in -- and this caller cannot.
+    //
+    // The must-differ half is `sees a declared collection, and no content yet`,
+    // where the same caller IS offered the entry step because a creatable
+    // collection is in reach. A predicate answering "no" unconditionally would
+    // fail that one.
+    await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: SECRETS,
+          access: { read: () => false, create: () => true, update: () => true },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    }).then(t => {
+      current = t;
+      return refreshCollectionSources();
+    });
+
+    const steps = await stepsFor(admin);
+
+    expect(steps.collection).toBeUndefined();
+    expect(steps.entry).toBeUndefined();
+    // Only the account remains, and it is already done -- so there is nothing
+    // to offer and the card is not put on their dashboard at all.
+    expect(Object.keys(steps)).toEqual(["account"]);
+    expect(await onboardingIsIncomplete(conditionProbe(admin))).toBe(false);
   });
 
   // No case asserts that the condition agrees with the steps it reports.

--- a/packages/nextly/src/domains/widgets/condition-probe.ts
+++ b/packages/nextly/src/domains/widgets/condition-probe.ts
@@ -28,10 +28,11 @@
  * @module domains/widgets/condition-probe
  */
 
+import { callerMayPerform } from "../../auth/authenticated-scope";
 import {
-  callerHoldsPermission,
-  readAccessCaller,
-} from "../../auth/entity-read-access";
+  COLLECTION_DEFINITION_ACTION,
+  COLLECTION_DEFINITION_RESOURCE,
+} from "../../auth/collection-definition-policy";
 import type { ReadCaller } from "../../services/dashboard/readable-resources";
 
 import {
@@ -40,16 +41,6 @@ import {
   readerHasContent,
   readerMayCreateEntry,
 } from "./reader-content";
-
-/**
- * The permission `POST /api/collections/schema` requires to create a collection.
- *
- * Named here rather than spelled at the call site so the two cannot drift: if
- * that endpoint's guard changes, this is the one place that has to follow, and
- * a reader offered a step whose endpoint refuses them is the defect the
- * per-step predicate exists to prevent.
- */
-const COLLECTION_CREATE_PERMISSION = "manage-settings";
 
 /** What every condition evaluator is handed. */
 export interface ConditionProbe {
@@ -62,22 +53,20 @@ export interface ConditionProbe {
   /** Whether this reader can see any row at all, resolved at most once. */
   hasContent(): Promise<boolean>;
   /**
-   * Whether this reader could write a first entry at all, resolved at most once.
+   * Whether this reader could write a first entry, resolved at most once.
    *
-   * Two routes, and the answer is whichever applies: a collection they can
-   * already read and hold `create-<slug>` on, or -- with none in reach -- the
-   * ability to make one to put the entry in. Answering the first alone would
-   * withhold the step from an administrator on a fresh install, who has no
-   * collection yet and is precisely the reader about to make one.
+   * One question: is there a collection they can read and hold `create-<slug>`
+   * on? With none in reach the answer is no -- the ability to create a
+   * COLLECTION is not a substitute, for the reason the implementation gives.
    */
   mayCreateEntry(): Promise<boolean>;
   /**
    * Whether this reader could create a COLLECTION, resolved at most once.
    *
-   * `manage-settings` is what the schema endpoint requires, asked through the
-   * same door it asks through, so this cannot drift from the refusal a reader
-   * would actually meet. Unlike the entry answer there is no "could not ask"
-   * case: the permission is the whole question and it is always decidable.
+   * The grant is `auth/collection-definition-policy`'s, which is what the
+   * schema route and the dispatcher's definition branch both enforce, asked
+   * through the same door they ask through -- so this cannot drift from the
+   * refusal a reader would actually meet.
    */
   mayCreateCollection(): Promise<boolean>;
 }
@@ -95,9 +84,13 @@ export function conditionProbe(caller: ReadCaller): ConditionProbe {
   };
 
   const mayCreateCollection = (): Promise<boolean> => {
-    createCollection ??= callerHoldsPermission(
-      COLLECTION_CREATE_PERMISSION,
-      readAccessCaller(caller)
+    // Through the same decision the entry predicate uses, and for the same
+    // reason: a key's stamped grant alone is not what a route enforces.
+    createCollection ??= callerMayPerform(
+      caller.authenticatedScope,
+      COLLECTION_DEFINITION_ACTION,
+      COLLECTION_DEFINITION_RESOURCE,
+      caller.user
     );
     return createCollection;
   };
@@ -121,15 +114,22 @@ export function conditionProbe(caller: ReadCaller): ConditionProbe {
       // From the same memo `hasContent` reads, for the same reason: the create
       // decision is taken over the collections this reader can read, and
       // resolving that list twice is the duplication this module removes.
+      // 🔴 NOT composed with `mayCreateCollection`. Being able to create a
+      // collection is not being able to write a row in it: seeding a new
+      // collection's CRUD permissions assigns them to `super_admin` alone
+      // (`seedPermissionsForCollection`), so a caller holding the definition
+      // grant and nothing else does not acquire `create-<new-slug>` -- and may
+      // not even be able to READ the collection they just made. Offering the
+      // entry step on that basis hands them a step they still cannot finish,
+      // which is the defect the predicate exists to prevent, moved one
+      // collection later.
+      //
+      // So with nothing in reach the step is not offered. A step is offered
+      // only where the install can point at a way for THIS reader to finish
+      // it, and "they might be granted something on a collection that does not
+      // exist yet" is not one.
       createEntry ??= readableSlugs().then(resolved =>
-        // 🔴 With NOTHING in reach there is no create grant to find, and an
-        // empty walk answering "no" would be an absence read as a refusal.
-        // The honest question then is the next one along: could this reader
-        // make the collection the entry would go in? That is what an
-        // administrator on a fresh install does, in that order.
-        resolved.length === 0
-          ? mayCreateCollection()
-          : readerMayCreateEntry(caller, resolved)
+        readerMayCreateEntry(caller, resolved)
       );
       return createEntry;
     },

--- a/packages/nextly/src/domains/widgets/condition-probe.ts
+++ b/packages/nextly/src/domains/widgets/condition-probe.ts
@@ -28,13 +28,28 @@
  * @module domains/widgets/condition-probe
  */
 
+import {
+  callerHoldsPermission,
+  readAccessCaller,
+} from "../../auth/entity-read-access";
 import type { ReadCaller } from "../../services/dashboard/readable-resources";
 
 import {
   readableCollectionSlugs,
   readableSingleSlugs,
   readerHasContent,
+  readerMayCreateEntry,
 } from "./reader-content";
+
+/**
+ * The permission `POST /api/collections/schema` requires to create a collection.
+ *
+ * Named here rather than spelled at the call site so the two cannot drift: if
+ * that endpoint's guard changes, this is the one place that has to follow, and
+ * a reader offered a step whose endpoint refuses them is the defect the
+ * per-step predicate exists to prevent.
+ */
+const COLLECTION_CREATE_PERMISSION = "manage-settings";
 
 /** What every condition evaluator is handed. */
 export interface ConditionProbe {
@@ -46,16 +61,45 @@ export interface ConditionProbe {
   readableSingles(): Promise<string[]>;
   /** Whether this reader can see any row at all, resolved at most once. */
   hasContent(): Promise<boolean>;
+  /**
+   * Whether this reader could write a first entry at all, resolved at most once.
+   *
+   * Two routes, and the answer is whichever applies: a collection they can
+   * already read and hold `create-<slug>` on, or -- with none in reach -- the
+   * ability to make one to put the entry in. Answering the first alone would
+   * withhold the step from an administrator on a fresh install, who has no
+   * collection yet and is precisely the reader about to make one.
+   */
+  mayCreateEntry(): Promise<boolean>;
+  /**
+   * Whether this reader could create a COLLECTION, resolved at most once.
+   *
+   * `manage-settings` is what the schema endpoint requires, asked through the
+   * same door it asks through, so this cannot drift from the refusal a reader
+   * would actually meet. Unlike the entry answer there is no "could not ask"
+   * case: the permission is the whole question and it is always decidable.
+   */
+  mayCreateCollection(): Promise<boolean>;
 }
 
 export function conditionProbe(caller: ReadCaller): ConditionProbe {
   let slugs: Promise<string[]> | undefined;
   let singles: Promise<string[]> | undefined;
   let content: Promise<boolean> | undefined;
+  let createEntry: Promise<boolean> | undefined;
+  let createCollection: Promise<boolean> | undefined;
 
   const readableSlugs = (): Promise<string[]> => {
     slugs ??= readableCollectionSlugs(caller);
     return slugs;
+  };
+
+  const mayCreateCollection = (): Promise<boolean> => {
+    createCollection ??= callerHoldsPermission(
+      COLLECTION_CREATE_PERMISSION,
+      readAccessCaller(caller)
+    );
+    return createCollection;
   };
 
   return {
@@ -73,5 +117,22 @@ export function conditionProbe(caller: ReadCaller): ConditionProbe {
       );
       return content;
     },
+    mayCreateEntry: () => {
+      // From the same memo `hasContent` reads, for the same reason: the create
+      // decision is taken over the collections this reader can read, and
+      // resolving that list twice is the duplication this module removes.
+      createEntry ??= readableSlugs().then(resolved =>
+        // 🔴 With NOTHING in reach there is no create grant to find, and an
+        // empty walk answering "no" would be an absence read as a refusal.
+        // The honest question then is the next one along: could this reader
+        // make the collection the entry would go in? That is what an
+        // administrator on a fresh install does, in that order.
+        resolved.length === 0
+          ? mayCreateCollection()
+          : readerMayCreateEntry(caller, resolved)
+      );
+      return createEntry;
+    },
+    mayCreateCollection,
   };
 }

--- a/packages/nextly/src/domains/widgets/onboarding.ts
+++ b/packages/nextly/src/domains/widgets/onboarding.ts
@@ -47,6 +47,9 @@
 import type { ConditionProbe } from "./condition-probe";
 import type { OnboardingStep } from "./onboarding-steps";
 
+/** A step no permission gates, as a predicate the walk below can call alike. */
+const ALWAYS = (): Promise<boolean> => Promise.resolve(true);
+
 /**
  * Every step, with the reader's progress through it.
  *
@@ -68,12 +71,42 @@ export async function onboardingSteps(
   // guaranteed-empty pass over an empty list.
   const hasContent = slugs.length > 0 && (await probe.hasContent());
 
-  return [
-    // True by construction: an unauthenticated caller never reaches this.
-    { id: "account", complete: true },
-    { id: "collection", complete: slugs.length > 0 },
-    { id: "entry", complete: hasContent },
+  const candidates: Array<
+    OnboardingStep & { offered: () => Promise<boolean> }
+  > = [
+    // True by construction: an unauthenticated caller never reaches this,
+    // and no permission gates having made the account one is already using.
+    { id: "account", complete: true, offered: ALWAYS },
+    {
+      id: "collection",
+      complete: slugs.length > 0,
+      offered: () => probe.mayCreateCollection(),
+    },
+    {
+      id: "entry",
+      complete: hasContent,
+      offered: () => probe.mayCreateEntry(),
+    },
   ];
+
+  const offered: OnboardingStep[] = [];
+  for (const { offered: mayPerform, ...step } of candidates) {
+    // 🔴 Asked only of an INCOMPLETE step, and the asymmetry is the design
+    // rather than an optimisation that leaked into the semantics. A finished
+    // step is a fact about the install's history, and history is not an offer:
+    // withholding it would shorten a reader's list by the very rows that show
+    // them how far the install has come. An UNFINISHED step is an offer, and
+    // an offer the reader cannot accept is the defect -- the link lands on a
+    // surface that refuses them, and `onboardingIsIncomplete` below stays true
+    // for as long as their account exists, pinning the card to their dashboard
+    // permanently.
+    //
+    // It is also what keeps a settled install off this path entirely: with
+    // every step complete no permission decision is taken at all, so the
+    // steady state costs nothing.
+    if (step.complete || (await mayPerform())) offered.push(step);
+  }
+  return offered;
 }
 
 /**
@@ -89,6 +122,14 @@ export async function onboardingSteps(
  * settles it. Left exhaustive because the same call draws the card, and the two
  * paths sharing one implementation is worth more than one skipped count on a
  * request that is about to make the same one.
+ *
+ * Reader-scoped through the steps themselves, which is what `onboardingSteps`
+ * filtering buys: a step this reader cannot perform is not in the list, so it
+ * cannot hold the condition true. Scoped any other way -- an aggregate taken
+ * over every step that EXISTS -- a reader who may read a collection and create
+ * nothing in it would have this answer true for the life of their account,
+ * with the card pinned to their dashboard offering an action that always
+ * fails. That is the opposite of what the lifecycle was built for.
  */
 export async function onboardingIsIncomplete(
   probe: ConditionProbe

--- a/packages/nextly/src/domains/widgets/reader-content.ts
+++ b/packages/nextly/src/domains/widgets/reader-content.ts
@@ -27,9 +27,9 @@
  * @module domains/widgets/reader-content
  */
 
+import { callerMayPerform } from "../../auth/authenticated-scope";
 import {
   authorizationGroups,
-  callerHoldsPermission,
   readAccessCaller,
 } from "../../auth/entity-read-access";
 import { requireNextly } from "../../direct-api/nextly";
@@ -107,10 +107,13 @@ export async function readableSingleSlugs(
  * collection instead); answering it here would make this function two questions
  * wearing one name.
  *
- * Decided through {@link callerHoldsPermission}, the same door `requirePermission`
- * uses, so the answer agrees with what the create itself would say. Deriving it
- * from the stored grant rows instead would disagree in both directions, exactly
- * as {@link readableEntities} documents for reads.
+ * 🔴 Decided through {@link callerMayPerform}, not through the bare permission
+ * check beside it. For a scoped API KEY the two disagree: the bare check reads
+ * the stamped grant and stops, while a real write also evaluates the
+ * collection's code-defined `access.create` against that scope. A key stamped
+ * `create-<slug>` whose code rule refuses it would therefore have been told it
+ * may create -- and the step it was offered is refused by the write, which is
+ * the defect this predicate exists to prevent, wearing a different hat.
  *
  * Short-circuits on the first grant, and walks in {@link authorizationGroups}
  * order otherwise: one decision, then bounded groups, so a cold per-user cache
@@ -120,13 +123,14 @@ export async function readerMayCreateEntry(
   caller: ReadCaller,
   readable: readonly string[]
 ): Promise<boolean> {
-  const access = readAccessCaller(caller);
   for (const group of authorizationGroups(readable)) {
     // `allSettled`, as the read decision beside it: a lookup that threw has
     // told us nothing, and nothing must not read as a grant. The slug counts
     // as refused and the rest of the set still answers.
     const settled = await Promise.allSettled(
-      group.map(slug => callerHoldsPermission(`create-${slug}`, access))
+      group.map(slug =>
+        callerMayPerform(caller.authenticatedScope, "create", slug, caller.user)
+      )
     );
     if (settled.some(result => result.status === "fulfilled" && result.value)) {
       return true;

--- a/packages/nextly/src/domains/widgets/reader-content.ts
+++ b/packages/nextly/src/domains/widgets/reader-content.ts
@@ -27,7 +27,11 @@
  * @module domains/widgets/reader-content
  */
 
-import { readAccessCaller } from "../../auth/entity-read-access";
+import {
+  authorizationGroups,
+  callerHoldsPermission,
+  readAccessCaller,
+} from "../../auth/entity-read-access";
 import { requireNextly } from "../../direct-api/nextly";
 import type { FindArgs } from "../../direct-api/types/collections";
 import type { ReadCaller } from "../../services/dashboard/readable-resources";
@@ -90,6 +94,45 @@ export async function readableSingleSlugs(
   return (
     (await readableSlugAllowlist(readAccessCaller(caller), "single")) ?? []
   );
+}
+
+/**
+ * Whether this reader could create an entry in ANY collection they can read.
+ *
+ * Answers the grants ALONE: `false` means this reader holds `create-<slug>` on
+ * none of the collections named. An empty `readable` is therefore `false` too,
+ * and that is not the same statement as "cannot write a first entry" -- with
+ * nothing in reach there was no grant to find. The caller composes that case
+ * (see `ConditionProbe.mayCreateEntry`, which asks whether they could make a
+ * collection instead); answering it here would make this function two questions
+ * wearing one name.
+ *
+ * Decided through {@link callerHoldsPermission}, the same door `requirePermission`
+ * uses, so the answer agrees with what the create itself would say. Deriving it
+ * from the stored grant rows instead would disagree in both directions, exactly
+ * as {@link readableEntities} documents for reads.
+ *
+ * Short-circuits on the first grant, and walks in {@link authorizationGroups}
+ * order otherwise: one decision, then bounded groups, so a cold per-user cache
+ * is populated once rather than missed by every member of the first fan-out.
+ */
+export async function readerMayCreateEntry(
+  caller: ReadCaller,
+  readable: readonly string[]
+): Promise<boolean> {
+  const access = readAccessCaller(caller);
+  for (const group of authorizationGroups(readable)) {
+    // `allSettled`, as the read decision beside it: a lookup that threw has
+    // told us nothing, and nothing must not read as a grant. The slug counts
+    // as refused and the rest of the set still answers.
+    const settled = await Promise.allSettled(
+      group.map(slug => callerHoldsPermission(`create-${slug}`, access))
+    );
+    if (settled.some(result => result.status === "fulfilled" && result.value)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -101,6 +101,10 @@ import {
 import { postWidgetQuery } from "./api/widget-query";
 import { apiKeyScopeFrom } from "./auth/authenticated-scope";
 import { runWithCallerScope } from "./auth/caller-scope";
+import {
+  COLLECTION_DEFINITION_ACTION,
+  COLLECTION_DEFINITION_RESOURCE,
+} from "./auth/collection-definition-policy";
 import { readAccessTokenCookie } from "./auth/cookies/access-token-cookie";
 import type { SanitizedNextlyConfig } from "./collections/config/define-config";
 import { container } from "./di/container";
@@ -866,8 +870,16 @@ async function resolveAuthorization(
       const slug = routeParams?.collectionName || "";
       return requireCollectionAccess(req, "read", slug);
     }
-    // Definition mutations (create/update/delete collection) → manage-settings
-    return requirePermission(req, "manage", "settings");
+    // Definition mutations (create/update/delete collection). The grant is
+    // declared once, in `auth/collection-definition-policy`, because the
+    // onboarding checklist asks the same question to decide whether to OFFER
+    // the step -- and a copy there would go on asking for a grant this route
+    // had stopped requiring.
+    return requirePermission(
+      req,
+      COLLECTION_DEFINITION_ACTION,
+      COLLECTION_DEFINITION_RESOURCE
+    );
   }
 
   // --- Singles endpoints ---


### PR DESCRIPTION
Closes the Codex P2 raised on #1723 after it merged, which the follow-up there
deliberately deferred: a wrong answer on an authorization path is worse than
the defect, and it was too much to bolt onto a five-fix PR written in one pass.

## The defect

`onboardingSteps` derived both detected steps from what the reader may READ. A
reader holding `read-<slug>` and no `create-<slug>` therefore had the
first-entry step outstanding permanently — they cannot write the row that would
complete it, and the step's link sends them to a surface `requireCollectionAccess`
refuses. Because `onboarding:incomplete` is derived from the same steps, it
stayed true for the life of their account, pinning the checklist to their
dashboard with an action that always fails.

The population is narrower than it sounds: the seeded editor role can create,
so this reaches custom read-only roles rather than the defaults. It is still the
opposite of what the card's lifecycle was built for.

## What changed

Each step carries a host-side predicate, and a step the install has observed
this reader cannot take leaves the list entirely.

- **`entry`** — do they hold `create-<slug>` on any collection they can read?
  Asked through `callerHoldsPermission`, the same door `requirePermission` uses,
  so the answer cannot drift from the refusal they would actually meet. It
  short-circuits on the first grant and walks in `authorizationGroups` order
  otherwise, so a cold per-user cache is missed once rather than by every member
  of the first fan-out.
- **`collection`** — do they hold `manage-settings`, which is what
  `POST /api/collections/schema` requires? Named in one place so the two cannot
  drift apart.
- **`account`** — no predicate. Nothing gates having made the account you are
  already using.

Hidden, not disabled: WooCommerce's task list and SAP's guided setup both hide,
and a greyed row is still a row the aggregate has to count. The aggregate is
derived from what remains, so it is reader-scoped by construction rather than by
a second rule that could disagree with the first.

## Two decisions worth flagging

**The predicate is asked of an unfinished step only.** A finished step records
what the install has done rather than offering the reader work, so withholding
it would shorten their list by exactly the rows showing their progress. It also
means a settled install takes no permission decision here at all — the steady
state costs nothing.

**An empty readable list is not a refusal.** With no collection in reach there
is no `create-<slug>` to find, so the entry step follows the next question
along: could this reader make the collection the entry would go in? Answering
the grant walk alone would have withheld the step from an administrator on a
fresh install — the one reader about to follow that roadmap.

## Evidence

Three break-verifications, each failing the intended test by name:

- offering every step unconditionally fails `withholds the first-entry step from
  a reader who may create in nothing`, alone;
- dropping the completion clause fails `keeps a FINISHED step a reader could not
  have taken` and `sees a declared collection, and no content yet`;
- reading an empty readable list as a refusal fails `offers the first-entry step
  to a builder with no collection in reach yet`.

That last test was **wrong on its first attempt and is worth naming**: written
with the shared session caller it passed with the composition removed, because
that caller answers false to both branches. It needed a key stamped with
`manage-settings` and no read grant — the only caller shape that can separate
them — and the note is in the test so the next reader does not undo it.

`pnpm check-types`, `pnpm lint`, the full `nextly` unit suite (939 files, 11937
tests) and the seven widget integration files on sqlite all pass; fallow reports
`pass` with 0 introduced dead code and 0 introduced duplication.