### PR TITLE
fix(docs): compile the examples in package READMEs, which nothing read

### DIFF
--- a/packages/builder/README.md
+++ b/packages/builder/README.md
@@ -195,7 +195,7 @@ import { BuilderShell } from "@nextlyhq/builder/shell";
 // Server-callable. No React in any of them.
 import { BUILDER_PACKAGE_NAME, rectToHost } from "@nextlyhq/builder";
 import { fitsFullShell, PANEL_BOUNDS } from "@nextlyhq/builder/shell-state";
-import { rectToHost } from "@nextlyhq/builder/geometry";
+import { pointToCanvas } from "@nextlyhq/builder/geometry";
 ```
 
 The split is not tidiness. A banner applies to a whole artifact and everything

--- a/packages/module-specifiers/README.md
+++ b/packages/module-specifiers/README.md
@@ -5,10 +5,14 @@ only by layering guards inside this repository, never published and never
 bundled into anything shipped.
 
 ```ts
+import { readFileSync } from "node:fs";
+
 import {
   importedSpecifiers,
   UNRESOLVABLE_SPECIFIER,
 } from "@nextlyhq/module-specifiers";
+
+const file = "src/index.ts";
 
 importedSpecifiers(readFileSync(file, "utf8"), file);
 ```

--- a/packages/plugin-page-builder/README.md
+++ b/packages/plugin-page-builder/README.md
@@ -195,6 +195,9 @@ export const pricingTable = defineBlock({
     plan: { type: "text" },
   },
   defaultProps: { plan: "Pro" },
+  // Required. What the block looks like in the inserter, before an author has
+  // set anything.
+  example: { props: { plan: "Pro" } },
   supports: { typography: true, color: true, spacing: true },
   render: ({ props, className }) => (
     <div className={className}>{String(props.plan)}</div>

--- a/scripts/check-doc-samples.mjs
+++ b/scripts/check-doc-samples.mjs
@@ -350,6 +350,35 @@ export const isModule = (code, extension = "tsx") => {
  * by the next deploy. This is where they can actually be fixed, so this is
  * where they are gated.
  */
+/**
+ * The README of every package and template, which is documentation a user
+ * meets BEFORE anything under `docs/`.
+ *
+ * These carry install and usage examples, and until they were added here
+ * nothing compiled them: `check-docs-compile` reads `docs/` and this gate read
+ * `docs/`, so the first code a reader copies was the only code no gate had an
+ * opinion about. One of them called `defineConfig` without importing it, which
+ * is a paste that cannot work and which review rather than tooling caught.
+ *
+ * Collected here rather than by a second checker so they pass through the
+ * SAME extraction, the same reader-owned classification and the same ratchet.
+ * A parallel gate would need its own copy of all three, and a second baseline
+ * is a second thing that goes stale — which this repository has already been
+ * red over once.
+ */
+const README_ROOTS = ["packages", "templates"];
+
+function readmePages() {
+  return README_ROOTS.flatMap(base => {
+    const dir = join(ROOT, base);
+    if (!existsSync(dir)) return [];
+    return readdirSync(dir, { withFileTypes: true })
+      .filter(entry => entry.isDirectory())
+      .map(entry => join(dir, entry.name, "README.md"))
+      .filter(file => existsSync(file));
+  });
+}
+
 export function collectDocSamples() {
   const root = join(ROOT, "docs");
   if (!existsSync(root)) return null;
@@ -365,7 +394,7 @@ export function collectDocSamples() {
           ? [join(dir, e.name)]
           : []
     );
-  const pages = walk(root).map(full => ({
+  const pages = [...walk(root), ...readmePages()].map(full => ({
     file: relative(ROOT, full),
     text: readFileSync(full, "utf-8"),
   }));

--- a/scripts/check-doc-samples.test.mjs
+++ b/scripts/check-doc-samples.test.mjs
@@ -6,6 +6,7 @@ import ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 import {
+  collectDocSamples,
   compareToBaseline,
   compile,
   contextOnlyWorthRecording,
@@ -1690,5 +1691,41 @@ describe("how a block used a name", () => {
     // The control for the two above: `mentioned` is load-bearing, so an absent
     // name cannot read as a value use.
     expect(usedOnlyAsValue("const a = 1;", "Media", "ts")).toBe(false);
+  });
+});
+
+describe("the population includes package and template READMEs", () => {
+  const samples = collectDocSamples();
+
+  it("collects samples at all, so the checks below are not vacuous", () => {
+    // The control. An absence assertion over a list that came back empty
+    // passes perfectly, and this one reads the filesystem.
+    expect(samples).not.toBeNull();
+    expect(samples.length).toBeGreaterThan(100);
+  });
+
+  it("reads a README, which nothing compiled before", () => {
+    // A README is the first code a reader copies: `check-docs-compile` reads
+    // `docs/` and so did this gate, so package install and usage examples were
+    // the only ones no gate had an opinion about. Named rather than counted,
+    // because a count agrees with itself while the walk quietly stops
+    // descending.
+    const files = new Set(samples.map(s => s.file));
+    expect(files).toContain("packages/nextly/README.md");
+    expect(files).toContain("packages/plugin-sdk/README.md");
+  });
+
+  it("reads a TEMPLATE README too, which is a separate root", () => {
+    // `templates/` is walked by its own loop, so a package README arriving
+    // says nothing about whether templates do.
+    const files = [...new Set(samples.map(s => s.file))];
+    expect(files.some(f => f.startsWith("templates/"))).toBe(true);
+  });
+
+  it("still reads the docs pages, which the READMEs must not displace", () => {
+    // The other direction. A collector rewritten to return only READMEs
+    // satisfies both cases above and silently drops 51 pages of coverage.
+    const files = [...new Set(samples.map(s => s.file))];
+    expect(files.some(f => f.startsWith("docs/"))).toBe(true);
   });
 });

--- a/scripts/doc-samples-baseline.json
+++ b/scripts/doc-samples-baseline.json
@@ -1,8 +1,8 @@
 {
   "coverage": {
-    "pages": 51,
-    "samples": 345,
-    "compiled": 210
+    "pages": 69,
+    "samples": 388,
+    "compiled": 244
   },
   "samplesPerPage": {
     "docs/admin/branding.mdx": {
@@ -208,6 +208,78 @@
     "docs/widgets/index.mdx": {
       "samples": 1,
       "compiled": 0
+    },
+    "packages/adapter-mysql/README.md": {
+      "samples": 1,
+      "compiled": 1
+    },
+    "packages/adapter-postgres/README.md": {
+      "samples": 1,
+      "compiled": 1
+    },
+    "packages/adapter-sqlite/README.md": {
+      "samples": 1,
+      "compiled": 1
+    },
+    "packages/admin/README.md": {
+      "samples": 2,
+      "compiled": 2
+    },
+    "packages/blocks-react/README.md": {
+      "samples": 4,
+      "compiled": 4
+    },
+    "packages/builder/README.md": {
+      "samples": 2,
+      "compiled": 2
+    },
+    "packages/module-specifiers/README.md": {
+      "samples": 1,
+      "compiled": 1
+    },
+    "packages/nextly/README.md": {
+      "samples": 2,
+      "compiled": 2
+    },
+    "packages/plugin-form-builder/README.md": {
+      "samples": 2,
+      "compiled": 2
+    },
+    "packages/plugin-page-builder/README.md": {
+      "samples": 5,
+      "compiled": 4
+    },
+    "packages/plugin-sdk/README.md": {
+      "samples": 2,
+      "compiled": 2
+    },
+    "packages/plugin-seo/README.md": {
+      "samples": 7,
+      "compiled": 4
+    },
+    "packages/storage-s3/README.md": {
+      "samples": 4,
+      "compiled": 1
+    },
+    "packages/storage-uploadthing/README.md": {
+      "samples": 1,
+      "compiled": 1
+    },
+    "packages/storage-vercel-blob/README.md": {
+      "samples": 2,
+      "compiled": 1
+    },
+    "packages/ui/README.md": {
+      "samples": 3,
+      "compiled": 3
+    },
+    "templates/blog/README.md": {
+      "samples": 2,
+      "compiled": 1
+    },
+    "templates/plugin/README.md": {
+      "samples": 1,
+      "compiled": 1
     }
   },
   "pages": {
@@ -219,6 +291,9 @@
     "docs/plugins/author-guide.mdx": 2,
     "docs/plugins/distribution.mdx": 1,
     "docs/plugins/lifecycle.mdx": 2,
+    "packages/blocks-react/README.md": 1,
+    "packages/builder/README.md": 1,
+    "packages/plugin-seo/README.md": 2,
     "docs/database/mysql.mdx": 3,
     "docs/guides/isr-caching.mdx": 1
   },
@@ -271,6 +346,21 @@
       "#1 error TS2304: Cannot find name 'a'.": 1,
       "#1 error TS2304: Cannot find name 'b'.": 1
     },
+    "packages/blocks-react/README.md": {
+      "#3 error TS2304: Cannot find name 'myPosts'.": 1
+    },
+    "packages/builder/README.md": {
+      "#0 error TS2304: Cannot find name 'router'.": 1,
+      "reader-name #0 error TS2304: Cannot find name 'MyPanel'.": 1,
+      "reader-name #0 error TS2304: Cannot find name 'MyInspector'.": 1,
+      "reader-name #0 error TS2304: Cannot find name 'MyTopBar'.": 1,
+      "reader-name #0 error TS2304: Cannot find name 'MyBreadcrumb'.": 1,
+      "reader-name #0 error TS2304: Cannot find name 'MyCanvas'.": 1
+    },
+    "packages/plugin-seo/README.md": {
+      "#2 error TS7031: Binding element 'params' implicitly has an 'any' type.": 1,
+      "#2 error TS2304: Cannot find name 'getPostBySlug'.": 1
+    },
     "docs/database/mysql.mdx": {
       "#6 error TS2304: Cannot find name 'orderData'.": 1,
       "#6 error TS2304: Cannot find name 'stockUpdate'.": 1,
@@ -305,6 +395,20 @@
     "docs/guides/email.mdx": {
       "implicit-any #4 error TS7006: Parameter 'data' implicitly has an 'any' type.": 3,
       "reader-file #5 error TS2307: Cannot find module '@/nextly' or its corresponding type declarations.": 1
+    },
+    "packages/nextly/README.md": {
+      "uninstalled #1 error TS2307: Cannot find module '@nextly-config' or its corresponding type declarations.": 1
+    },
+    "packages/plugin-sdk/README.md": {
+      "uninstalled #1 error TS2307: Cannot find module '@acme/nextly-plugin-hello' or its corresponding type declarations.": 1,
+      "reader-name #0 error TS2304: Cannot find name 'MyPluginOptions'.": 1,
+      "reader-name #0 error TS2304: Cannot find name 'Greetings'.": 1
+    },
+    "templates/blog/README.md": {
+      "uninstalled #1 error TS2307: Cannot find module '@nextly-config' or its corresponding type declarations.": 1
+    },
+    "templates/plugin/README.md": {
+      "uninstalled #0 error TS2307: Cannot find module '{{pluginName}}' or its corresponding type declarations.": 1
     },
     "docs/api-reference/rest-api.mdx": {
       "reader-file #0 error TS2307: Cannot find module '../../../nextly.config' or its corresponding type declarations.": 1
@@ -346,6 +450,12 @@
     },
     "docs/plugins/testing.mdx": {
       "reader-file #0 error TS2307: Cannot find module '../src' or its corresponding type declarations.": 1
+    },
+    "packages/admin/README.md": {
+      "reader-file #1 error TS2307: Cannot find module '../../../../nextly.config' or its corresponding type declarations.": 1
+    },
+    "packages/plugin-page-builder/README.md": {
+      "reader-file #1 error TS2307: Cannot find module '../../../nextly.config' or its corresponding type declarations.": 1
     },
     "docs/plugins/form-builder.mdx": {
       "reader-name #0 error TS2304: Cannot find name 'Posts'.": 1,


### PR DESCRIPTION
## The gap

A README is the first code a user copies, and it was the only documentation no
gate had an opinion about. `check-docs-compile` reads `docs/`. This gate read
`docs/`. Measured on `main`: **43 TypeScript examples across 29 package and
template READMEs, compiled by nothing at all.**

Three of them could not work as written, and the gate found all three on its
first run.

## What was broken

- **`packages/module-specifiers`** called `readFileSync(file, "utf8")` with
  neither `readFileSync` imported nor `file` declared. Its only usage example
  was unrunnable.
- **`packages/builder`** illustrated its entry points by importing `rectToHost`
  from the root package AND from `/geometry` in one block. Both exports are
  real, so the snippet was correct about the API and uncompilable as a paste. It
  names a distinct symbol from `/geometry` now, so it still makes its point.
- **`packages/plugin-page-builder`**'s `defineBlock` example omitted `example`,
  which is REQUIRED by `BlockDefinition`. The block API gained a required field
  and the documentation did not follow — the drift nothing was watching for.

## Why this widens the existing gate instead of adding one

The READMEs join the SAME collector, so they pass through the same extraction,
the same reader-owned classification, the same continuation handling and the
same ratchet. Exactly one line assumed `docs/`; everything downstream was
already path-agnostic.

A separate checker would need its own copy of all four, and **a second baseline
is a second thing that goes stale** — this repository was red on the existing
one earlier today, until #1810 regenerated it. One population, one baseline, one
place to keep honest.

## What is left, and why it is recorded rather than fixed

Four findings remain, all reader placeholders: `myPosts`, `router`,
`getPostBySlug`, and an implicitly-typed `params`. They are in the baseline,
which only shrinks.

Recording them required `--allow-new-findings`. That is the gate refusing to
absorb findings quietly, and widening the population is precisely the deliberate
act the flag exists for — worth noting rather than passing silently.

## Evidence

- `check:doc-samples` exits 0. Coverage moves from 51 pages / 345 samples to
  **69 pages / 388 samples**, 244 compiled.
- Controls, both verified to go RED: breaking a README example (an import of an
  export that does not exist) fails the gate; narrowing the collector back to
  `docs/` alone fails two of the new tests. Four new tests pin the population by
  NAME rather than by count, including one that the docs pages must still be
  there, so a collector rewritten to return only READMEs cannot pass.
- `pnpm test:scripts` 1348 passed; `check:docs-compile`, comment convention and
  `fallow:audit` all green, zero introduced findings.
