### PR TITLE
fix(nextly): offer the collection step only where creating one would finish it

### DIFF
--- a/.changeset/a-step-offered-is-a-step-finishable.md
+++ b/.changeset/a-step-offered-is-a-step-finishable.md
@@ -1,0 +1,34 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-mcp": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The setup checklist offers "create your first collection" only to a reader who
+would be able to READ what they create. A new collection's permissions are
+seeded to the super-admin role alone, so a caller holding the definition grant
+and nothing else created the collection, gained no read on it, and found the
+step outstanding permanently -- with the card pinned to their dashboard.

--- a/.changeset/a-step-offered-is-a-step-finishable.md
+++ b/.changeset/a-step-offered-is-a-step-finishable.md
@@ -32,3 +32,7 @@ would be able to READ what they create. A new collection's permissions are
 seeded to the super-admin role alone, so a caller holding the definition grant
 and nothing else created the collection, gained no read on it, and found the
 step outstanding permanently -- with the card pinned to their dashboard.
+
+An API key stamped with a read grant is offered the step it can finish: a key
+never gains a permission, but a pre-seeded `read-<slug>` lets it create that
+collection and read it afterwards.

--- a/packages/nextly/src/auth/new-entity-access-policy.ts
+++ b/packages/nextly/src/auth/new-entity-access-policy.ts
@@ -1,5 +1,5 @@
 /**
- * Who receives a newly created entity's permissions, declared once.
+ * Who can end up able to READ a collection they create, declared once.
  *
  * 🔴 Two places need this answer and they must not each carry it. The SEEDER
  * assigns a new collection's freshly created CRUD permissions to one role. The
@@ -13,34 +13,58 @@
  * offer one that had stopped being. Neither shows up as a failure anywhere --
  * the reader just sees a checklist that is wrong about them.
  *
+ * So the recipient is named ONCE below and the predicate is computed FROM it.
+ * Sharing only the literal was not enough: a previous revision kept the
+ * membership test hard-coded as `isSuperAdmin` beside the constant, so moving
+ * the recipient would have moved the seeder and left the predicate behind.
+ *
  * @module auth/new-entity-access-policy
  */
+
+import { listRoleSlugsForUser } from "../services/lib/permissions";
 
 /**
  * The role slug a newly seeded entity's permissions are assigned to.
  *
- * Read by `PermissionSeedService.assignNewPermissionsToSuperAdmin`, which
- * performs the assignment, and by {@link wouldReadOwnNewCollection}, which
- * answers whether a given caller is on the receiving end of it.
+ * `PermissionSeedService.assignNewPermissionsToSuperAdmin` selects the role by
+ * it, and {@link wouldReadOwnNewCollection} tests membership of it.
  */
 export const NEW_ENTITY_PERMISSION_ROLE = "super-admin";
 
+/** How the caller a widget resolver holds is described to this policy. */
+export interface NewEntityAccessCaller {
+  userId: string;
+  /** An API key is judged on the scope stamped into it, never on its owner's roles. */
+  isApiKey: boolean;
+  /** The key's own stamped permission slugs. Empty for a session caller. */
+  permissions: readonly string[];
+}
+
 /**
- * Whether this caller would hold read on a collection they create.
+ * Whether this caller could end up reading a collection they create.
  *
- * Derived from the policy above rather than asserted beside it: the seeding
- * assigns to {@link NEW_ENTITY_PERMISSION_ROLE}, so the question is whether
- * this caller holds that role, and `isSuperAdmin` is the membership test for it
- * -- it resolves role inheritance, which a flat slug comparison would miss.
+ * Two routes, because two things can make a not-yet-existing collection
+ * readable, and only one of them is the seeding.
  *
- * An API KEY is never on the receiving end, whoever owns it: a key is judged on
- * the scope stamped into it when it was minted, and a role gaining a permission
- * afterwards does not widen a key that was already issued.
+ * A SESSION caller reaches it through the seeding: they hold
+ * {@link NEW_ENTITY_PERMISSION_ROLE}, so the permissions the seeder assigns
+ * land on a role they are in. Membership is read from their role slugs rather
+ * than through a named super-admin test, so the constant above is genuinely
+ * the single point of change.
+ *
+ * An API KEY reaches it a different way and must not be refused outright. A
+ * key never GAINS a grant -- it is judged on the scope stamped into it when it
+ * was minted -- but a permission may be pre-seeded, and `canReadEntity` accepts
+ * a key's exact `read-<slug>` grant once that collection exists. So a key
+ * stamped `read-reports` can finish the step by creating `reports`, and the
+ * step is finishable exactly when it carries some read grant to create into.
  */
 export async function wouldReadOwnNewCollection(
-  isSuperAdmin: (userId: string) => Promise<boolean>,
-  caller: { userId: string; isApiKey: boolean }
+  caller: NewEntityAccessCaller
 ): Promise<boolean> {
-  if (caller.isApiKey) return false;
-  return isSuperAdmin(caller.userId);
+  if (caller.isApiKey) {
+    return caller.permissions.some(slug => slug.startsWith("read-"));
+  }
+  const roles = await listRoleSlugsForUser(caller.userId);
+  return roles.includes(NEW_ENTITY_PERMISSION_ROLE);
 }

--- a/packages/nextly/src/auth/new-entity-access-policy.ts
+++ b/packages/nextly/src/auth/new-entity-access-policy.ts
@@ -1,0 +1,46 @@
+/**
+ * Who receives a newly created entity's permissions, declared once.
+ *
+ * 🔴 Two places need this answer and they must not each carry it. The SEEDER
+ * assigns a new collection's freshly created CRUD permissions to one role. The
+ * dashboard's onboarding checklist asks the mirror question -- would THIS
+ * reader be able to read a collection they create -- to decide whether to offer
+ * the "create your first collection" step at all.
+ *
+ * Restated in the second, the two drift silently and in both directions: if
+ * creation began granting the creator, the checklist would go on hiding a step
+ * that had become finishable; if the assignment moved to another role, it would
+ * offer one that had stopped being. Neither shows up as a failure anywhere --
+ * the reader just sees a checklist that is wrong about them.
+ *
+ * @module auth/new-entity-access-policy
+ */
+
+/**
+ * The role slug a newly seeded entity's permissions are assigned to.
+ *
+ * Read by `PermissionSeedService.assignNewPermissionsToSuperAdmin`, which
+ * performs the assignment, and by {@link wouldReadOwnNewCollection}, which
+ * answers whether a given caller is on the receiving end of it.
+ */
+export const NEW_ENTITY_PERMISSION_ROLE = "super-admin";
+
+/**
+ * Whether this caller would hold read on a collection they create.
+ *
+ * Derived from the policy above rather than asserted beside it: the seeding
+ * assigns to {@link NEW_ENTITY_PERMISSION_ROLE}, so the question is whether
+ * this caller holds that role, and `isSuperAdmin` is the membership test for it
+ * -- it resolves role inheritance, which a flat slug comparison would miss.
+ *
+ * An API KEY is never on the receiving end, whoever owns it: a key is judged on
+ * the scope stamped into it when it was minted, and a role gaining a permission
+ * afterwards does not widen a key that was already issued.
+ */
+export async function wouldReadOwnNewCollection(
+  isSuperAdmin: (userId: string) => Promise<boolean>,
+  caller: { userId: string; isApiKey: boolean }
+): Promise<boolean> {
+  if (caller.isApiKey) return false;
+  return isSuperAdmin(caller.userId);
+}

--- a/packages/nextly/src/domains/auth/services/permission-seed-service.ts
+++ b/packages/nextly/src/domains/auth/services/permission-seed-service.ts
@@ -3,6 +3,7 @@ import { sql, eq, and } from "drizzle-orm";
 
 import type { RBACDatabaseInstance } from "@nextly/types/rbac-operations";
 
+import { NEW_ENTITY_PERMISSION_ROLE } from "../../../auth/new-entity-access-policy";
 import type { CollectedPermission } from "../../../plugins/permissions/collect-permissions";
 import { ADOPTED_LIFECYCLE_ACTIONS } from "../../../plugins/permissions/collect-permissions";
 import { SYSTEM_RESOURCES, permissionSlug } from "../../../schemas/_zod/rbac";
@@ -920,7 +921,7 @@ export class PermissionSeedService extends BaseService {
       const superAdminRole = await this.db
         .select({ id: roles.id })
         .from(roles)
-        .where(eq(roles.slug, "super-admin"))
+        .where(eq(roles.slug, NEW_ENTITY_PERMISSION_ROLE))
         .limit(1)
         .then(
           (rows: unknown[]) => (rows[0] as { id: unknown } | undefined) ?? null

--- a/packages/nextly/src/domains/widgets/__tests__/onboarding.integration.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/onboarding.integration.test.ts
@@ -282,6 +282,28 @@ describe("onboarding steps against a real instance", () => {
     expect(await onboardingIsIncomplete(conditionProbe(builder))).toBe(false);
   });
 
+  it("offers it to a KEY already stamped with a read grant to create into", async () => {
+    // 🔴 A key never GAINS a grant -- it is judged on the scope stamped into
+    // it when it was minted -- but a permission may be pre-seeded, and the
+    // read decision accepts a key's exact `read-<slug>` once that collection
+    // exists. So a key holding `read-reports` finishes this step by creating
+    // `reports`, and refusing every key hid a step that WAS finishable.
+    await createTestNextly({ collections: [] }).then(t => {
+      current = t;
+      return refreshCollectionSources();
+    });
+
+    const stampedToRead: ReadCaller = {
+      user: { id: "key-2", roles: [] },
+      authenticatedScope: {
+        actorType: "apiKey",
+        permissions: ["manage-settings", "read-reports"],
+      },
+    };
+
+    expect((await stepsFor(stampedToRead)).collection).toBe(false);
+  });
+
   it("DOES offer it to a super admin, who would read what they create", async () => {
     // The must-differ half, and without it "offered to nobody" satisfies the
     // case above. The instance's FIRST user is its super admin, so this is the

--- a/packages/nextly/src/domains/widgets/__tests__/onboarding.integration.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/onboarding.integration.test.ts
@@ -245,19 +245,20 @@ describe("onboarding steps against a real instance", () => {
     expect(await onboardingIsIncomplete(conditionProbe(admin))).toBe(false);
   });
 
-  it("offers a builder the collection step and NOT the entry step", async () => {
-    // 🔴 Creating a collection is not being able to write a row in it.
-    // `seedPermissionsForCollection` assigns a new collection's CRUD
-    // permissions to `super_admin` alone, so this caller would not acquire
-    // `create-<new-slug>` -- and might not even be able to read what they
-    // made. Offering the entry step on the strength of the definition grant
-    // hands them a step they still cannot finish, which is the defect this
-    // predicate exists to prevent, moved one collection later.
+  it("offers a stamped key NEITHER step, because it could finish neither", async () => {
+    // 🔴 Holding the definition grant is not being able to finish the
+    // collection step. `seedPermissionsForCollection` assigns a new
+    // collection's CRUD permissions to `super_admin` alone, so this caller
+    // creates the collection, gains no `read-<slug>` for it, and finds the
+    // step still outstanding -- permanently. Offering it moved the defect one
+    // action later rather than fixing it.
     //
-    // The caller is a KEY stamped with the definition grant and no read grant,
-    // which is the shape that separates the two predicates: its readable set
-    // is empty while its collection answer is unambiguously yes. A session
-    // caller answers no to both and could not tell them apart.
+    // The entry step is withheld for the reason it always was: nothing
+    // readable is in reach, and the definition grant is not a substitute.
+    //
+    // A KEY is the discriminating caller: a session super admin holds the same
+    // grant AND would read what it creates, so it is still offered the step --
+    // the case below.
     await createTestNextly({
       collections: [
         defineCollection({
@@ -273,11 +274,52 @@ describe("onboarding steps against a real instance", () => {
 
     const steps = await stepsFor(builder);
 
-    expect(steps.collection).toBe(false);
+    expect(steps.collection).toBeUndefined();
     expect(steps.entry).toBeUndefined();
-    // Still incomplete: there IS something this reader can do, and the card
-    // stays until they have done it.
-    expect(await onboardingIsIncomplete(conditionProbe(builder))).toBe(true);
+    // Only the account remains, and it is already done -- so nothing is
+    // offered and the card stays off their dashboard entirely.
+    expect(Object.keys(steps)).toEqual(["account"]);
+    expect(await onboardingIsIncomplete(conditionProbe(builder))).toBe(false);
+  });
+
+  it("DOES offer it to a super admin, who would read what they create", async () => {
+    // The must-differ half, and without it "offered to nobody" satisfies the
+    // case above. The instance's FIRST user is its super admin, so this is the
+    // one caller for whom creating a collection also makes it readable -- and
+    // it is exactly the reader a fresh install has.
+    // NO collections, which is the only way the step is INCOMPLETE for a super
+    // admin: they can read every collection that exists, so any fixture with
+    // one completes the step and completion short-circuits the predicate --
+    // the test would pass without exercising it at all.
+    const t = await createTestNextly({ collections: [] });
+    current = t;
+    await refreshCollectionSources();
+
+    const users = (
+      t.nextly as unknown as {
+        users: {
+          create: (a: { data: Record<string, unknown> }) => Promise<{
+            item: { id: string };
+          }>;
+        };
+      }
+    ).users;
+    const owner = await users.create({
+      data: {
+        email: "owner@example.com",
+        password: "Password123!",
+        name: "Owner",
+        isActive: true,
+      },
+    });
+
+    const superAdmin: ReadCaller = {
+      user: { id: owner.item.id, roles: [] },
+    };
+    const steps = await stepsFor(superAdmin);
+
+    expect(steps.collection).toBe(false);
+    expect(await onboardingIsIncomplete(conditionProbe(superAdmin))).toBe(true);
   });
 
   it("offers nothing to a reader with no collection in reach and no way to make one", async () => {

--- a/packages/nextly/src/domains/widgets/condition-probe.ts
+++ b/packages/nextly/src/domains/widgets/condition-probe.ts
@@ -35,7 +35,6 @@ import {
 } from "../../auth/collection-definition-policy";
 import { wouldReadOwnNewCollection } from "../../auth/new-entity-access-policy";
 import type { ReadCaller } from "../../services/dashboard/readable-resources";
-import { isSuperAdmin } from "../../services/lib/permissions";
 
 import {
   readableCollectionSlugs,
@@ -110,9 +109,10 @@ export function conditionProbe(caller: ReadCaller): ConditionProbe {
         caller.user
       );
       if (!mayDefine) return false;
-      return wouldReadOwnNewCollection(isSuperAdmin, {
+      return wouldReadOwnNewCollection({
         userId: caller.user.id,
         isApiKey: caller.authenticatedScope?.actorType === "apiKey",
+        permissions: caller.authenticatedScope?.permissions ?? [],
       });
     })();
     return createCollection;

--- a/packages/nextly/src/domains/widgets/condition-probe.ts
+++ b/packages/nextly/src/domains/widgets/condition-probe.ts
@@ -33,6 +33,7 @@ import {
   COLLECTION_DEFINITION_ACTION,
   COLLECTION_DEFINITION_RESOURCE,
 } from "../../auth/collection-definition-policy";
+import { wouldReadOwnNewCollection } from "../../auth/new-entity-access-policy";
 import type { ReadCaller } from "../../services/dashboard/readable-resources";
 import { isSuperAdmin } from "../../services/lib/permissions";
 
@@ -94,21 +95,25 @@ export function conditionProbe(caller: ReadCaller): ConditionProbe {
     // for it, and finds the step still outstanding -- permanently, which is
     // the defect this predicate exists to prevent, moved one action later.
     //
-    // The readability half is the super-admin bypass, asked directly: it is
-    // the only thing that makes a NOT-YET-EXISTING collection readable. An API
-    // key is judged on the scope stamped into it and gains nothing when a new
-    // collection appears, which `isSuperAdmin` answers correctly for it too --
-    // a key's own user id is its owner's, and the bypass belongs to a session.
-    // So the key branch is refused explicitly rather than left to that.
+    // The readability half is DERIVED from the seeding policy rather than
+    // restated here. `wouldReadOwnNewCollection` lives beside the declaration
+    // the seeder assigns by, so if creation ever begins granting the creator --
+    // or the assignment moves to another role -- this follows instead of
+    // silently disagreeing. Asserted in one place, the two could only drift in
+    // ways nothing reports: a step hidden after it became finishable, or
+    // offered after it stopped being.
     createCollection ??= (async () => {
-      if (caller.authenticatedScope?.actorType === "apiKey") return false;
       const mayDefine = await callerMayPerform(
         caller.authenticatedScope,
         COLLECTION_DEFINITION_ACTION,
         COLLECTION_DEFINITION_RESOURCE,
         caller.user
       );
-      return mayDefine && (await isSuperAdmin(caller.user.id));
+      if (!mayDefine) return false;
+      return wouldReadOwnNewCollection(isSuperAdmin, {
+        userId: caller.user.id,
+        isApiKey: caller.authenticatedScope?.actorType === "apiKey",
+      });
     })();
     return createCollection;
   };

--- a/packages/nextly/src/domains/widgets/condition-probe.ts
+++ b/packages/nextly/src/domains/widgets/condition-probe.ts
@@ -34,6 +34,7 @@ import {
   COLLECTION_DEFINITION_RESOURCE,
 } from "../../auth/collection-definition-policy";
 import type { ReadCaller } from "../../services/dashboard/readable-resources";
+import { isSuperAdmin } from "../../services/lib/permissions";
 
 import {
   readableCollectionSlugs,
@@ -63,10 +64,11 @@ export interface ConditionProbe {
   /**
    * Whether this reader could create a COLLECTION, resolved at most once.
    *
-   * The grant is `auth/collection-definition-policy`'s, which is what the
-   * schema route and the dispatcher's definition branch both enforce, asked
-   * through the same door they ask through -- so this cannot drift from the
-   * refusal a reader would actually meet.
+   * Two halves: may they DEFINE one (the grant
+   * `auth/collection-definition-policy` names, which the schema route and the
+   * dispatcher both enforce), and would they be able to READ the result. The
+   * second is what makes the step finishable -- a new collection's permissions
+   * are seeded to `super_admin` alone.
    */
   mayCreateCollection(): Promise<boolean>;
 }
@@ -84,14 +86,30 @@ export function conditionProbe(caller: ReadCaller): ConditionProbe {
   };
 
   const mayCreateCollection = (): Promise<boolean> => {
-    // Through the same decision the entry predicate uses, and for the same
-    // reason: a key's stamped grant alone is not what a route enforces.
-    createCollection ??= callerMayPerform(
-      caller.authenticatedScope,
-      COLLECTION_DEFINITION_ACTION,
-      COLLECTION_DEFINITION_RESOURCE,
-      caller.user
-    );
+    // 🔴 May create AND would be able to READ what they created. Both halves,
+    // because the step completes when this reader can read a collection, and
+    // `seedPermissionsForCollection` assigns a new collection's CRUD
+    // permissions to `super_admin` alone. A caller holding the definition
+    // grant and nothing else creates the collection, gains no `read-<slug>`
+    // for it, and finds the step still outstanding -- permanently, which is
+    // the defect this predicate exists to prevent, moved one action later.
+    //
+    // The readability half is the super-admin bypass, asked directly: it is
+    // the only thing that makes a NOT-YET-EXISTING collection readable. An API
+    // key is judged on the scope stamped into it and gains nothing when a new
+    // collection appears, which `isSuperAdmin` answers correctly for it too --
+    // a key's own user id is its owner's, and the bypass belongs to a session.
+    // So the key branch is refused explicitly rather than left to that.
+    createCollection ??= (async () => {
+      if (caller.authenticatedScope?.actorType === "apiKey") return false;
+      const mayDefine = await callerMayPerform(
+        caller.authenticatedScope,
+        COLLECTION_DEFINITION_ACTION,
+        COLLECTION_DEFINITION_RESOURCE,
+        caller.user
+      );
+      return mayDefine && (await isSuperAdmin(caller.user.id));
+    })();
     return createCollection;
   };
 


### PR DESCRIPTION
Closes the Codex P2 raised on #1820 as it merged. Cut from `main`, not stacked.

## The defect

The collection step completes when the reader can **read** a collection, and
`seedPermissionsForCollection` assigns a new collection's CRUD permissions to
the `super_admin` role alone. So a caller holding only the definition grant was
offered "create your first collection", created it, gained no `read-<slug>` for
it, and found the step outstanding — permanently, with the card pinned to their
dashboard.

That is the same defect #1820 set out to fix, moved one action later rather than
fixed: #1820 stopped offering a step whose *action* was refused, and this stops
offering one whose *completion* the reader can never observe.

## What changed

The predicate now asks both halves: may this caller define a collection, **and**
would they be able to read the result. A scoped API key is refused outright — a
key is judged on the scope stamped into it and gains nothing when a new
collection appears.

## Evidence

Two tests, and they are a pair on purpose:

- a key stamped with the definition grant is offered **neither** step and its
  checklist reports complete, because it could finish neither;
- a session **super admin**, on an install with no collections at all, **is**
  offered it.

Without the second, "offered to nobody" would satisfy the first. The second's
fixture carries no collections deliberately: a super admin reads every
collection that exists, so any other fixture completes the step — and completion
short-circuits the predicate, which would pass without ever exercising it. That
cost me one wrong revision of this test before I noticed.

Break-verified: restoring the definition-grant-alone predicate fails the key
case by name and leaves the super-admin control green.

`check-types`, `lint`, the full `nextly` unit suite (942 files, 11971 tests) and
the seven widget integration files on sqlite all pass; fallow `pass`.