### PR TITLE
fix(nextly): name which field hooks run, rather than hiding the fields they read

### DIFF
--- a/packages/nextly/src/domains/collections/__tests__/bulk-writes-localized.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/bulk-writes-localized.integration.test.ts
@@ -479,10 +479,14 @@ describe("a bulk write on a localized collection", () => {
     // handlers for values this write never changed — and those send mail,
     // re-index, and call out.
     const fired: string[] = [];
+    // What each handler could SEE of its siblings when it ran, which is the
+    // other half: suppressing a handler must not blind the ones that do run.
+    const seen: Record<string, unknown> = {};
     const record =
       (name: string) =>
-      ({ value }: { value: unknown }) => {
+      ({ value, data }: { value: unknown; data: Record<string, unknown> }) => {
         fired.push(name);
+        seen[name] = data.metaTitle;
         return value;
       };
     process.env.DB_DIALECT = "sqlite";
@@ -535,6 +539,11 @@ describe("a bulk write on a localized collection", () => {
     );
 
     expect(fired).toEqual(["title"]);
+    // ...and the handler that DID run still saw the untouched sibling. A
+    // `title` hook deriving a search document from `metaTitle` needs it,
+    // unchanged or not, so the suppression must name which handlers run
+    // rather than take the value off the row.
+    expect(seen.title).toBe("meta");
 
     // And the untouched translation still comes back on the row, which is
     // what makes the exclusion above a hook-phase concern rather than a loss.

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -9711,45 +9711,32 @@ export class CollectionMutationService extends BaseService {
       // Field-level afterChange hooks observe the saved values (before the
       // password strip so they can see the full stored row).
       if (options.runHooks) {
-        // A field hook fires for every key PRESENT in the row it is given, so
-        // the untouched translations overlaid above — needed by the snapshot
-        // and the event, which describe the whole language — would run their
-        // `afterChange` handlers for values this write never changed. Those
-        // handlers send mail, re-index and call out, so firing them for an
-        // unchanged sibling is not a harmless extra pass.
+        // The whole language is on this row, because the snapshot and the
+        // events describe a translation rather than the one field of it that
+        // moved. Only the fields this write actually touched should have
+        // their handlers run, though: firing `afterChange` for a sibling
+        // nobody edited sends mail, re-indexes and calls out for an unchanged
+        // value.
         //
-        // Taken off for the hook phase and put back after it, rather than
-        // handed a copy: a handler's return value is written back into the
-        // row, and a copy would drop the transformations belonging to the
-        // fields this write DID set. The same remove-then-restore the field
-        // registry performs around its own snapshots.
-        const untouched = localizedUpdate
-          ? Object.keys(localizedDocument).filter(
-              name => !(name in localizedUpdate.localizedFieldValues)
-            )
-          : [];
-        const held = untouched.map(
-          name => [name, (updated as Record<string, unknown>)[name]] as const
-        );
-        for (const [name] of held) {
-          delete (updated as Record<string, unknown>)[name];
-        }
-        try {
-          await runFieldHooks({
-            kind: "collection",
-            slug: params.collectionName,
-            phase: "afterChange",
-            data: updated as Record<string, unknown>,
-            operation: "update",
-            user: params.user,
-          });
-        } finally {
-          // Restored even when a handler throws, so the response and anything
-          // read from the row afterwards still carry the whole language.
-          for (const [name, value] of held) {
-            (updated as Record<string, unknown>)[name] = value;
-          }
-        }
+        // Named rather than withheld. Removing the untouched keys from the row
+        // would suppress those handlers and also blind the ones that DO run —
+        // a `title` hook that derives a search document from `metaTitle` needs
+        // to read it, unchanged or not.
+        const touched = localizedUpdate
+          ? new Set([
+              ...Object.keys(finalData),
+              ...Object.keys(localizedUpdate.localizedFieldValues),
+            ])
+          : undefined;
+        await runFieldHooks({
+          kind: "collection",
+          slug: params.collectionName,
+          phase: "afterChange",
+          data: updated as Record<string, unknown>,
+          operation: "update",
+          user: params.user,
+          only: touched,
+        });
       }
 
       await this.redactResponseFields(

--- a/packages/nextly/src/shared/lib/field-level-registry.ts
+++ b/packages/nextly/src/shared/lib/field-level-registry.ts
@@ -761,10 +761,13 @@ async function runFieldHooksRec(
     kind: EntityKind;
     operation: "create" | "read" | "update" | "delete";
     user?: Record<string, unknown>;
-  }
+  },
+  /** Top level only; a nested row's names are its own. See {@link runFieldHooks}. */
+  only?: ReadonlySet<string>
 ): Promise<void> {
   for (const [name, entry] of Object.entries(fns)) {
     if (!(name in data)) continue;
+    if (only && !only.has(name)) continue;
     if (entry.fields) {
       for (const row of nestedRows(data[name])) {
         await runFieldHooksRec(row, entry.fields, phase, ctx);
@@ -857,13 +860,35 @@ export async function runFieldHooks(opts: {
   data: Record<string, unknown>;
   operation: "create" | "read" | "update" | "delete";
   user?: Record<string, unknown>;
+  /**
+   * Restrict WHICH fields' handlers run, without restricting what they SEE.
+   *
+   * Presence in `data` normally decides both, and for most callers that is the
+   * same question. It stops being the same question when the row carries more
+   * than the write touched: a localized update assembles the whole translation
+   * for its snapshot, and firing `afterChange` for a sibling nobody edited
+   * sends mail for an unchanged value. Withholding those keys from `data`
+   * instead would answer that at the cost of the other half — a handler that
+   * does run could no longer read its siblings, which is what a search-index
+   * or derived-value hook is for.
+   *
+   * Names at the TOP level only. A nested row's fields are its own, and the
+   * parent's gate has already decided whether its subtree runs at all.
+   */
+  only?: ReadonlySet<string>;
 }): Promise<void> {
   const fns = getFieldFunctions(opts.kind, opts.slug);
   if (!fns) return;
-  await runFieldHooksRec(opts.data, fns, opts.phase, {
-    slug: opts.slug,
-    kind: opts.kind,
-    operation: opts.operation,
-    user: opts.user,
-  });
+  await runFieldHooksRec(
+    opts.data,
+    fns,
+    opts.phase,
+    {
+      slug: opts.slug,
+      kind: opts.kind,
+      operation: opts.operation,
+      user: opts.user,
+    },
+    opts.only
+  );
 }


### PR DESCRIPTION
The last commit of #1816, which merged without it.

#1816 was squash-merged from `3f8befd40` while this commit (`c4e3b3d69`) was being pushed, so it never reached `main`. Verified by content rather than by ancestry: `only?: ReadonlySet<string>` appears twice in `c4e3b3d69` and zero times in `origin/main` or the merge commit `075870acd`, while `prepareCreateWritePayload` appears three times in both — so everything earlier in that PR did land and exactly this one commit did not. Cherry-picked onto current `main`; the patch content is identical (only blob hashes and line offsets differ).

It matters because `main` currently carries the defect this fixes.

## What it fixes

#1816 made a localized batch update assemble the whole translation onto the updated row, which the snapshot and the events need — they describe a translation rather than the one field of it that moved. But a field hook runs for every key PRESENT in the row it is handed (`runFieldHooksRec`, `if (!(name in data)) continue;`), so an `afterChange` handler on an untouched sibling started firing for a value the write never changed. Those handlers send mail, re-index and call out.

The first attempt withheld those keys from the row. That suppressed the right handlers and blinded the ones that legitimately ran: a `title` hook deriving a search document from an unchanged `metaTitle` could no longer read it. Presence was deciding two separate questions — which handlers run, and what each can see.

`runFieldHooks` now takes `only`, the set of names whose handlers should run, and leaves the row whole. Top-level names only: a nested rows fields are its own, and the parents gate has already decided whether its subtree runs.

## Evidence

One case pins both halves, because fixing either alone is what produced two review rounds:

- a patch naming one translated field fires that fields handler and no other (`fired` is exactly `["title"]`), and
- that handler still sees the sibling it did not change (`metaTitle === "meta"`).

Two break-verifications: `only: undefined` fires `metaTitle` and fails the first; withholding the keys before the call makes the second `undefined`.

Gates on this branch, after `pnpm install` (main gained `plugin-mcp`, whose node_modules were absent here) and a full rebuild: check-types 0, lint 0, unit 855 passed across 54 files (including `shared/lib`, since `field-level-registry` is shared by collections, singles and components), the localized bulk-write suite 16 passed, fallow `pass` with all four `*_introduced` at 0 over 3 changed files.

No changeset: #1816 carries the one for this work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed localized collection updates so only fields changed by a write trigger their field-level handlers.
  - Preserved untouched language-specific values while processing updates, allowing handlers for changed fields to access the complete record context.
  - Improved consistency when updating localized entries with multiple fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->